### PR TITLE
PR4: ArchitectureSignature v0 指標を追加

### DIFF
--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -143,6 +143,9 @@ def totalFanout {C : Type u} (G : ArchGraph C)
 Coarse Nat-valued average fanout used by the initial signature.
 
 For an empty component universe, Lean's natural-number division gives `0`.
+Because this is integer division, sparse graphs can also round down to `0`;
+future signatures may prefer `totalFanout`, `maxFanout`, or another fanout-risk
+normalization.
 -/
 def averageFanoutOfFinite {C : Type u} (G : ArchGraph C)
     [DecidableRel G.edge] (components : List C) : Nat :=
@@ -156,7 +159,12 @@ def boundedDepthFrom {C : Type u} (G : ArchGraph C)
       maxNatList (components.map (fun d =>
         if decide (G.edge c d) then boundedDepthFrom G components fuel d + 1 else 0))
 
-/-- Maximum bounded dependency-chain depth over the supplied finite universe. -/
+/--
+Maximum bounded dependency-chain depth over the supplied finite universe.
+
+On cyclic graphs this is a fuel-bounded measurement, not a true global depth.
+Cycle risk is represented separately by `hasCycle`.
+-/
 def maxDepthOfFinite {C : Type u} (G : ArchGraph C)
     [DecidableRel G.edge] (components : List C) : Nat :=
   maxNatList (components.map (fun c => boundedDepthFrom G components components.length c))

--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -1,4 +1,8 @@
+import Formal.Arch.Graph
+
 namespace Formal.Arch
+
+universe u
 
 /--
 Initial architecture signature.
@@ -44,6 +48,196 @@ theorem riskLE_trans {a b c : ArchitectureSignature}
   rcases hbc with ⟨k1, k2, k3, k4, k5, k6⟩
   exact ⟨Nat.le_trans h1 k1, Nat.le_trans h2 k2, Nat.le_trans h3 k3,
     Nat.le_trans h4 k4, Nat.le_trans h5 k5, Nat.le_trans h6 k6⟩
+
+/-- Risk order is antisymmetric. -/
+theorem riskLE_antisymm {a b : ArchitectureSignature}
+    (hab : a ≤ b) (hba : b ≤ a) : a = b := by
+  rcases a with ⟨a1, a2, a3, a4, a5, a6⟩
+  rcases b with ⟨b1, b2, b3, b4, b5, b6⟩
+  rcases hab with ⟨h1, h2, h3, h4, h5, h6⟩
+  rcases hba with ⟨k1, k2, k3, k4, k5, k6⟩
+  have e1 : a1 = b1 := Nat.le_antisymm h1 k1
+  have e2 : a2 = b2 := Nat.le_antisymm h2 k2
+  have e3 : a3 = b3 := Nat.le_antisymm h3 k3
+  have e4 : a4 = b4 := Nat.le_antisymm h4 k4
+  have e5 : a5 = b5 := Nat.le_antisymm h5 k5
+  have e6 : a6 = b6 := Nat.le_antisymm h6 k6
+  cases e1
+  cases e2
+  cases e3
+  cases e4
+  cases e5
+  cases e6
+  rfl
+
+/-- Convert a Boolean predicate into the 0/1 risk convention. -/
+def boolRisk (b : Bool) : Nat :=
+  if b then 1 else 0
+
+/-- Maximum of a finite list of natural-number measurements. -/
+def maxNatList (xs : List Nat) : Nat :=
+  xs.foldl Nat.max 0
+
+/-- Count entries satisfying a Boolean predicate. -/
+def countWhere {α : Type u} (xs : List α) (p : α → Bool) : Nat :=
+  (xs.filter p).length
+
+/--
+All ordered component pairs from a finite component universe.
+
+The list is intentionally allowed to contain duplicates when `components`
+contains duplicates; v0 metrics treat the supplied list as the measurement
+universe.
+-/
+def componentPairs {C : Type u} (components : List C) : List (C × C) :=
+  components.flatMap (fun c => components.map (fun d => (c, d)))
+
+/-- Bounded reachability search over a supplied finite component universe. -/
+def reachesWithin {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) : Nat → C → C → Bool
+  | 0, c, d => decide (c = d)
+  | fuel + 1, c, d =>
+      decide (c = d) ||
+        components.any (fun next =>
+          decide (G.edge c next) && reachesWithin G components fuel next d)
+
+/--
+Cycle indicator over a finite component universe.
+
+A cycle is detected as an edge followed by bounded reachability back to the
+source.
+-/
+def hasCycleBool {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) : Bool :=
+  components.any (fun c =>
+    components.any (fun d =>
+      decide (G.edge c d) && reachesWithin G components components.length d c))
+
+/-- Number of supplied components mutually reachable with `c`, using bounded search. -/
+def sccSizeAt {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) (c : C) : Nat :=
+  countWhere components (fun d =>
+    reachesWithin G components components.length c d &&
+      reachesWithin G components components.length d c)
+
+/-- Maximum bounded SCC size over the supplied component universe. -/
+def sccMaxSizeOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) : Nat :=
+  maxNatList (components.map (fun c => sccSizeAt G components c))
+
+/-- Outgoing dependency count for one component within the supplied universe. -/
+def fanout {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) (c : C) : Nat :=
+  countWhere components (fun d => decide (G.edge c d))
+
+/-- Total outgoing dependency count over the supplied finite universe. -/
+def totalFanout {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) : Nat :=
+  (components.map (fun c => fanout G components c)).sum
+
+/--
+Coarse Nat-valued average fanout used by the initial signature.
+
+For an empty component universe, Lean's natural-number division gives `0`.
+-/
+def averageFanoutOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) : Nat :=
+  totalFanout G components / components.length
+
+/-- Bounded longest dependency-chain depth from one component. -/
+def boundedDepthFrom {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) : Nat → C → Nat
+  | 0, _ => 0
+  | fuel + 1, c =>
+      maxNatList (components.map (fun d =>
+        if decide (G.edge c d) then boundedDepthFrom G components fuel d + 1 else 0))
+
+/-- Maximum bounded dependency-chain depth over the supplied finite universe. -/
+def maxDepthOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) : Nat :=
+  maxNatList (components.map (fun c => boundedDepthFrom G components components.length c))
+
+/-- Count dependency edges that violate a supplied boundary policy. -/
+def boundaryViolationCountOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge]
+    (components : List C) (boundaryAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] : Nat :=
+  countWhere (componentPairs components) (fun pair =>
+    decide (G.edge pair.1 pair.2) && ! decide (boundaryAllowed pair.1 pair.2))
+
+/-- Count dependency edges that violate a supplied abstraction policy. -/
+def abstractionViolationCountOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge]
+    (components : List C) (abstractionAllowed : C → C → Prop)
+    [DecidableRel abstractionAllowed] : Nat :=
+  countWhere (componentPairs components) (fun pair =>
+    decide (G.edge pair.1 pair.2) && ! decide (abstractionAllowed pair.1 pair.2))
+
+/--
+Build the initial v0 signature from a finite component universe and two local
+edge policies.
+
+This is an executable metric definition, not yet a proof that the supplied list
+is duplicate-free or contains every semantic component of a larger codebase.
+-/
+def v0OfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignature where
+  hasCycle := boolRisk (hasCycleBool G components)
+  sccMaxSize := sccMaxSizeOfFinite G components
+  maxDepth := maxDepthOfFinite G components
+  averageFanout := averageFanoutOfFinite G components
+  boundaryViolationCount := boundaryViolationCountOfFinite G components boundaryAllowed
+  abstractionViolationCount := abstractionViolationCountOfFinite G components abstractionAllowed
+
+namespace Examples
+
+/-- One-component graph with no dependency edges. -/
+def unitNoEdgeGraph : ArchGraph Unit where
+  edge _ _ := False
+
+/-- One-component graph with a self dependency. -/
+def unitSelfLoopGraph : ArchGraph Unit where
+  edge _ _ := True
+
+instance : DecidableRel unitNoEdgeGraph.edge := by
+  intro c d
+  exact isFalse (by intro h; exact h)
+
+instance : DecidableRel unitSelfLoopGraph.edge := by
+  intro c d
+  exact isTrue trivial
+
+/-- The no-edge graph has no cycle and zero fanout/depth risk. -/
+theorem v0_unitNoEdge :
+    v0OfFinite unitNoEdgeGraph [()] (fun _ _ => True) (fun _ _ => True) =
+      { hasCycle := 0
+        sccMaxSize := 1
+        maxDepth := 0
+        averageFanout := 0
+        boundaryViolationCount := 0
+        abstractionViolationCount := 0 } := by
+  rfl
+
+/-- A self dependency is detected as a 0/1 cycle risk. -/
+theorem v0_unitSelfLoop :
+    v0OfFinite unitSelfLoopGraph [()] (fun _ _ => True) (fun _ _ => True) =
+      { hasCycle := 1
+        sccMaxSize := 1
+        maxDepth := 1
+        averageFanout := 1
+        boundaryViolationCount := 0
+        abstractionViolationCount := 0 } := by
+  rfl
+
+end Examples
 
 end ArchitectureSignature
 

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ The initial formalization includes:
 - projection soundness/completeness/exactness and strong operational DIP;
 - observation, observation factorization, and LSP compatibility;
 - local-contract and abstract-layer-cycle counterexamples;
-- architecture signatures with componentwise risk order.
-
+- architecture signatures with componentwise risk order and executable v0
+  finite-list metrics.

--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -93,6 +93,8 @@ Sig0(A) =
 
 `sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`averageFanout : Nat` は初期の粗い足場であり、PR4 以降で `fanoutRisk` または `maxFanout` への改名を検討する。
 
+Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。これは実コードベース抽出器の完全性を主張するものではない。抽出された component list の重複排除・完全性、および SCC 計算との正当性接続は、将来の有限グラフ表現で扱う。
+
 発展シグネチャ `Sig1(A)` では、解析的・実証的な軸を追加する。
 
 ```text

--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -91,7 +91,9 @@ Sig0(A) =
 
 `hasCycle` は 0/1 のリスク指標として扱う。`nilpotencyIndex?` は初期 Lean 版の `ArchitectureSignature` にはまだ入れず、adjacency matrix 導入後の発展指標として扱う。
 
-`sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`averageFanout : Nat` は初期の粗い足場であり、PR4 以降で `fanoutRisk` または `maxFanout` への改名を検討する。
+`maxDepth` は初期 Lean 実装では bounded max depth として扱う。循環グラフ上の真の大域 depth ではなく、有限 universe による fuel-bounded measurement である。循環リスクは `hasCycle` の別軸で扱う。
+
+`sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`averageFanout : Nat` は初期の粗い足場であり、Nat 除算で丸められるため、PR4 以降で `fanoutRisk = totalFanout` または `maxFanout` への置き換えを検討する。
 
 Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。これは実コードベース抽出器の完全性を主張するものではない。抽出された component list の重複排除・完全性、および SCC 計算との正当性接続は、将来の有限グラフ表現で扱う。
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -274,7 +274,8 @@ Sig(A) <=risk Sig(B)
 
 - `hasCycle` は 0/1 の risk indicator として扱う。
 - `sccMaxSize` は将来的に `sccExcessSize = sccMaxSize - 1` として正規化することを検討する。
-- `averageFanout : Nat` は初期の粗い足場であり、PR4 以降で `fanoutRisk` または `maxFanout` への改名を検討する。
+- `maxDepth` は PR4 では bounded max depth であり、循環グラフ上の真の大域 depth ではない。循環リスクは `hasCycle` で別軸として扱う。
+- `averageFanout : Nat` は初期の粗い足場であり、Nat 除算で丸められる。PR4 以降で `fanoutRisk = totalFanout` または `maxFanout` への置き換えを検討する。
 - `nilpotencyIndex?` は初期 Lean 実装には入れず、adjacency matrix 導入後の発展指標として扱う。
 
 Lean status:
@@ -286,9 +287,13 @@ Lean status:
 - Defined only: the supplied component list is treated as the measurement universe.
   There is not yet a Lean proof that it is duplicate-free or complete for a
   semantic codebase.
-- Future proof obligation: connect finite bounded reachability/SCC metrics to a
-  dedicated finite graph representation with coverage and no-duplicate
-  invariants.
+- Future proof obligation: introduce `ComponentUniverse` or `FiniteArchGraph`
+  with no-duplicate and edge-closedness invariants, then connect finite bounded
+  reachability/SCC metrics to `Walk` and `Reachable`.
+- Future proof obligation: prove correctness lemmas such as
+  `reachesWithin_sound`, `reachesWithin_complete_under_universe`,
+  `hasCycleBool_correct_under_finite_universe`, and
+  `sccSizeAt_correct_under_finite_universe`.
 
 ## 実証研究で検証する仮説
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -256,7 +256,8 @@ ObservationFactorsThrough π O -> LSPCompatible π O
 
 ```text
 ArchitectureSignature
-SignatureLE
+RiskLE
+v0OfFinite
 ```
 
 意味:
@@ -275,6 +276,19 @@ Sig(A) <=risk Sig(B)
 - `sccMaxSize` は将来的に `sccExcessSize = sccMaxSize - 1` として正規化することを検討する。
 - `averageFanout : Nat` は初期の粗い足場であり、PR4 以降で `fanoutRisk` または `maxFanout` への改名を検討する。
 - `nilpotencyIndex?` は初期 Lean 実装には入れず、adjacency matrix 導入後の発展指標として扱う。
+
+Lean status:
+
+- Proved: componentwise risk order is reflexive, transitive, and antisymmetric.
+- Defined: executable v0 metrics over a supplied finite component list:
+  `hasCycleBool`, bounded SCC size, bounded max depth, Nat-valued average fanout,
+  boundary violation count, abstraction violation count, and `v0OfFinite`.
+- Defined only: the supplied component list is treated as the measurement universe.
+  There is not yet a Lean proof that it is duplicate-free or complete for a
+  semantic codebase.
+- Future proof obligation: connect finite bounded reachability/SCC metrics to a
+  dedicated finite graph representation with coverage and no-duplicate
+  invariants.
 
 ## 実証研究で検証する仮説
 


### PR DESCRIPTION
## 概要
- architecture signature 向けの有限リストベース v0 指標定義を追加
- componentwise risk order の antisymmetry を証明
- Lean status と将来の有限グラフ proof obligation を文書化

## 検証
- lake build
- lake exe aatv2
- git diff --check