### PR TITLE
PR5: finite universe bridge を追加

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -9,4 +9,4 @@ import Formal.Arch.Observation
 import Formal.Arch.LSP
 import Formal.Arch.SolidCounterexample
 import Formal.Arch.Signature
-
+import Formal.Arch.Finite

--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -10,7 +10,9 @@ A finite measurement universe for an architecture graph.
 
 `components` is the executable list used by v0 metrics. `nodup`, `covers`, and
 `edgeClosed` make explicit which assumptions are needed before list-based
-metrics are treated as graph-level facts.
+metrics are treated as graph-level facts. In this full-universe version,
+`edgeClosed` follows from `covers`; it remains explicit to leave room for future
+closed measurement sub-universes.
 -/
 structure ComponentUniverse {C : Type u} (G : ArchGraph C) where
   components : List C
@@ -116,7 +118,7 @@ theorem reachesWithin_complete_of_walk {C : Type u} {G : ArchGraph C}
 An edge followed by a bounded return walk is detected by the cycle indicator
 under a finite component universe.
 -/
-theorem hasCycleBool_complete_of_edge_walk {C : Type u} {G : ArchGraph C}
+theorem hasCycleBool_complete_of_bounded_return_walk {C : Type u} {G : ArchGraph C}
     [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G)
     {c d : C} (hEdge : G.edge c d) (w : Walk G d c)
     (hLen : w.length ≤ U.components.length) :

--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -1,0 +1,132 @@
+import Formal.Arch.Layering
+import Formal.Arch.Signature
+
+namespace Formal.Arch
+
+universe u
+
+/--
+A finite measurement universe for an architecture graph.
+
+`components` is the executable list used by v0 metrics. `nodup`, `covers`, and
+`edgeClosed` make explicit which assumptions are needed before list-based
+metrics are treated as graph-level facts.
+-/
+structure ComponentUniverse {C : Type u} (G : ArchGraph C) where
+  components : List C
+  nodup : components.Nodup
+  covers : ∀ c : C, c ∈ components
+  edgeClosed : ∀ {c d : C}, G.edge c d → c ∈ components ∧ d ∈ components
+
+namespace ComponentUniverse
+
+/-- Build the v0 signature using the finite universe's component list. -/
+def v0 {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignature :=
+  ArchitectureSignature.v0OfFinite G U.components boundaryAllowed abstractionAllowed
+
+end ComponentUniverse
+
+namespace ArchitectureSignature
+
+/--
+Bounded Boolean reachability is sound with respect to propositional
+`Reachable`.
+
+This theorem does not need a finite-universe coverage assumption: any successful
+bounded search exposes a concrete chain of graph edges.
+-/
+theorem reachesWithin_sound {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] {components : List C} :
+    ∀ {fuel : Nat} {c d : C},
+      reachesWithin G components fuel c d = true → Reachable G c d := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro c d h
+      by_cases hEq : c = d
+      · cases hEq
+        exact Reachable.refl c
+      · simp [reachesWithin, hEq] at h
+  | succ fuel ih =>
+      intro c d h
+      by_cases hEq : c = d
+      · cases hEq
+        exact Reachable.refl c
+      · simp [reachesWithin, hEq, List.any_eq_true] at h
+        rcases h with ⟨next, _hMem, hEdge, hRest⟩
+        exact Reachable.step hEdge (ih hRest)
+
+/-- A true cycle indicator gives a generating edge followed by reachability back. -/
+theorem edge_reachable_of_hasCycleBool {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] {components : List C}
+    (h : hasCycleBool G components = true) :
+    ∃ c d : C, G.edge c d ∧ Reachable G d c := by
+  simp [hasCycleBool, List.any_eq_true] at h
+  rcases h with ⟨c, _hc, d, _hd, hEdge, hReach⟩
+  exact ⟨c, d, hEdge, reachesWithin_sound hReach⟩
+
+/-- A true cycle indicator gives a nonempty closed walk. -/
+theorem hasClosedWalk_of_hasCycleBool {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] {components : List C}
+    (h : hasCycleBool G components = true) : HasClosedWalk G := by
+  rcases edge_reachable_of_hasCycleBool h with ⟨c, d, hEdge, hReach⟩
+  exact hasClosedWalk_of_edge_reachable hEdge hReach
+
+/--
+A concrete walk of length at most `fuel` is found by bounded Boolean
+reachability, assuming the finite universe contains edge targets.
+-/
+theorem reachesWithin_complete_of_walk {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G) :
+    ∀ {c d : C} (w : Walk G c d) {fuel : Nat},
+      w.length ≤ fuel → reachesWithin G U.components fuel c d = true := by
+  intro c d w
+  induction w with
+  | nil c =>
+      intro fuel _hLen
+      cases fuel <;> simp [reachesWithin]
+  | @cons c d e hEdge rest ih =>
+      intro fuel hLen
+      cases fuel with
+      | zero =>
+          cases hLen
+      | succ fuel =>
+          by_cases hEq : c = e
+          · cases hEq
+            simp [reachesWithin]
+          · have hRest : rest.length ≤ fuel := by
+              exact Nat.le_of_succ_le_succ (by
+                simpa [Walk.length, Nat.succ_eq_add_one] using hLen)
+            have hAny :
+                U.components.any
+                    (fun next =>
+                      decide (G.edge c next) &&
+                        reachesWithin G U.components fuel next e) = true := by
+              rw [List.any_eq_true]
+              exact ⟨d, (U.edgeClosed hEdge).2, by
+                simp [decide_eq_true hEdge, ih hRest]⟩
+            simp [reachesWithin, hEq, hAny]
+
+/--
+An edge followed by a bounded return walk is detected by the cycle indicator
+under a finite component universe.
+-/
+theorem hasCycleBool_complete_of_edge_walk {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G)
+    {c d : C} (hEdge : G.edge c d) (w : Walk G d c)
+    (hLen : w.length ≤ U.components.length) :
+    hasCycleBool G U.components = true := by
+  rw [hasCycleBool, List.any_eq_true]
+  refine ⟨c, (U.edgeClosed hEdge).1, ?_⟩
+  rw [List.any_eq_true]
+  exact ⟨d, (U.edgeClosed hEdge).2, by
+    simp [decide_eq_true hEdge, reachesWithin_complete_of_walk U w hLen]⟩
+
+end ArchitectureSignature
+
+end Formal.Arch

--- a/README.md
+++ b/README.md
@@ -34,4 +34,6 @@ The initial formalization includes:
 - observation, observation factorization, and LSP compatibility;
 - local-contract and abstract-layer-cycle counterexamples;
 - architecture signatures with componentwise risk order and executable v0
-  finite-list metrics.
+  finite-list metrics;
+- a proof-carrying finite component universe for bridging executable metrics to
+  `Walk` and `Reachable`.

--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -95,7 +95,7 @@ Sig0(A) =
 
 `sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`averageFanout : Nat` は初期の粗い足場であり、Nat 除算で丸められるため、PR4 以降で `fanoutRisk = totalFanout` または `maxFanout` への置き換えを検討する。
 
-Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。これは実コードベース抽出器の完全性を主張するものではない。抽出された component list の重複排除・完全性、および SCC 計算との正当性接続は、将来の有限グラフ表現で扱う。
+Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。Lean PR5 では、その list に `Nodup`, coverage, edge-closedness を持たせる `ComponentUniverse` を追加し、bounded reachability と `Walk` / `Reachable` の基本的な正当性 bridge を証明する。これは実コードベース抽出器の完全性を主張するものではない。SCC count と相互到達可能性の同値類との接続は、次の proof obligation として残す。
 
 発展シグネチャ `Sig1(A)` では、解析的・実証的な軸を追加する。
 

--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -95,7 +95,7 @@ Sig0(A) =
 
 `sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`averageFanout : Nat` は初期の粗い足場であり、Nat 除算で丸められるため、PR4 以降で `fanoutRisk = totalFanout` または `maxFanout` への置き換えを検討する。
 
-Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。Lean PR5 では、その list に `Nodup`, coverage, edge-closedness を持たせる `ComponentUniverse` を追加し、bounded reachability と `Walk` / `Reachable` の基本的な正当性 bridge を証明する。これは実コードベース抽出器の完全性を主張するものではない。SCC count と相互到達可能性の同値類との接続は、次の proof obligation として残す。
+Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。Lean PR5 では、その list に `Nodup`, coverage, edge-closedness を持たせる `ComponentUniverse` を追加し、bounded reachability と `Walk` / `Reachable` の基本的な正当性 bridge を証明する。現在の `ComponentUniverse` は full universe なので edge-closedness は coverage から導けるが、将来 closed measurement sub-universe を扱う余地を残すため明示フィールドとして保持する。これは実コードベース抽出器の完全性を主張するものではない。SCC count と相互到達可能性の同値類との接続は、次の proof obligation として残す。
 
 発展シグネチャ `Sig1(A)` では、解析的・実証的な軸を追加する。
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -284,16 +284,16 @@ Lean status:
 - Defined: executable v0 metrics over a supplied finite component list:
   `hasCycleBool`, bounded SCC size, bounded max depth, Nat-valued average fanout,
   boundary violation count, abstraction violation count, and `v0OfFinite`.
-- Defined only: the supplied component list is treated as the measurement universe.
-  There is not yet a Lean proof that it is duplicate-free or complete for a
-  semantic codebase.
-- Future proof obligation: introduce `ComponentUniverse` or `FiniteArchGraph`
-  with no-duplicate and edge-closedness invariants, then connect finite bounded
-  reachability/SCC metrics to `Walk` and `Reachable`.
-- Future proof obligation: prove correctness lemmas such as
-  `reachesWithin_sound`, `reachesWithin_complete_under_universe`,
-  `hasCycleBool_correct_under_finite_universe`, and
-  `sccSizeAt_correct_under_finite_universe`.
+- Defined: `ComponentUniverse` packages the executable component list with
+  `Nodup`, coverage, and edge-closedness assumptions.
+- Proved: `reachesWithin_sound`, `hasClosedWalk_of_hasCycleBool`,
+  `reachesWithin_complete_of_walk`, and
+  `hasCycleBool_complete_of_edge_walk`.
+- Defined only: `ComponentUniverse` is still a proof-carrying measurement
+  universe, not a parser or extractor for real codebases.
+- Future proof obligation: connect SCC-size counts to equivalence classes of
+  mutual `Reachable`, and decide whether `FiniteArchGraph` should become a
+  bundled graph-plus-universe structure.
 
 ## 実証研究で検証する仮説
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -286,14 +286,21 @@ Lean status:
   boundary violation count, abstraction violation count, and `v0OfFinite`.
 - Defined: `ComponentUniverse` packages the executable component list with
   `Nodup`, coverage, and edge-closedness assumptions.
-- Proved: `reachesWithin_sound`, `hasClosedWalk_of_hasCycleBool`,
-  `reachesWithin_complete_of_walk`, and
-  `hasCycleBool_complete_of_edge_walk`.
+- Note: the current `ComponentUniverse` is a full universe, so edge-closedness
+  follows from coverage. It remains an explicit field to leave room for future
+  closed measurement sub-universes.
+- Proved: `reachesWithin_sound`, `edge_reachable_of_hasCycleBool`,
+  `hasClosedWalk_of_hasCycleBool`, `reachesWithin_complete_of_walk`, and
+  `hasCycleBool_complete_of_bounded_return_walk`.
 - Defined only: `ComponentUniverse` is still a proof-carrying measurement
   universe, not a parser or extractor for real codebases.
 - Future proof obligation: connect SCC-size counts to equivalence classes of
   mutual `Reachable`, and decide whether `FiniteArchGraph` should become a
   bundled graph-plus-universe structure.
+- Future proof obligation: prove
+  `reachesWithin_complete_of_reachable_under_universe`,
+  `hasCycleBool ↔ HasClosedWalk` under a finite universe, and max-depth
+  correctness on acyclic finite graphs.
 
 ## 実証研究で検証する仮説
 


### PR DESCRIPTION
## 概要
- ComponentUniverse を追加し、有限 component list に Nodup, coverage, edge-closedness を明示
- PR4 の v0OfFinite を proof-carrying universe から呼ぶ ComponentUniverse.v0 を追加
- reachesWithin / hasCycleBool と Reachable / Walk / HasClosedWalk の基本 bridge を証明
- docs に PR5 の Lean status と残る proof obligation を反映

## 証明したこと
- reachesWithin_sound
- edge_reachable_of_hasCycleBool
- hasClosedWalk_of_hasCycleBool
- reachesWithin_complete_of_walk
- hasCycleBool_complete_of_edge_walk

## 残したこと
- SCC-size count と mutual Reachable equivalence class の正当性接続
- FiniteArchGraph を bundled graph-plus-universe として導入するかの判断

## 検証
- lake build
- lake exe aatv2
- git diff --check