### PR TITLE
AGENTS.mdを日本語化し運用ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,49 @@
-# Repository Guidelines
+# リポジトリ運用ガイド
 
-## Project Structure
+## 言語と GitHub 運用
 
-- The Lean library root is `Formal.lean`.
-- Core formalization lives under `Formal/Arch`.
-- Research notes live under `docs`.
-- `Main.lean` provides the executable target `aatv2`.
-- Build configuration is `lakefile.toml`; the Lean version is pinned by
-  `lean-toolchain`.
+- ユーザーへの応答は日本語で行う。
+- コミットメッセージは日本語で書く。
+- Pull Request のタイトルと本文は日本語で書く。
+- GitHub Issue のタイトルと本文は日本語で書く。
+- Lean の識別子、ファイル名、コマンド名、定理名、既存の英語技術用語を引用する場合は、名前をそのまま残してよい。必要に応じて日本語で補足する。
 
-## Build Commands
+## プロジェクト構成
 
-- `lake build`: build all targets.
-- `lake build Formal`: build the Lean library only.
-- `lake exe aatv2`: run the executable target.
-- `lake env lean Formal/Arch/Layering.lean`: type-check one file.
+- Lean ライブラリの root は `Formal.lean`。
+- 中核となる形式化は `Formal/Arch` 以下に置く。
+- 研究ノートは `docs` 以下に置く。
+- `Main.lean` は実行ターゲット `aatv2` を提供する。
+- build 設定は `lakefile.toml`。
+- Lean バージョンは `lean-toolchain` で固定する。
 
-## Formalization Policy
+## Build コマンド
 
-- Do not introduce `axiom`, `admit`, `sorry`, or `unsafe` without explicit
-  discussion.
-- Keep definitions small and grow equivalences as theorems.
-- `Decomposable` currently means `StrictLayered`; acyclicity, finite
-  propagation, nilpotence, and spectral conditions should remain separate
-  theorems or future proof obligations.
-- `ComponentCategory` is thin and intentionally forgets path counts and walk
-  lengths. Quantitative metrics should use `Walk`, `Path`, adjacency matrices,
-  or a future free-category construction.
+- `lake build`: すべてのターゲットを build する。
+- `lake build Formal`: Lean ライブラリだけを build する。
+- `lake exe aatv2`: 実行ターゲットを実行する。
+- `lake env lean Formal/Arch/Layering.lean`: 単一ファイルを type-check する。
 
-## Documentation Policy
+## 形式化ポリシー
 
-- When changing a research claim in `docs`, keep the corresponding Lean status
-  clear: proved, defined only, future proof obligation, or empirical hypothesis.
-- Keep Lean-proved claims separate from empirical validation claims.
+- 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入しない。
+- 定義は小さく保ち、同値性や対応関係は定理として育てる。
+- 現在の `Decomposable` は `StrictLayered` を意味する。
+- acyclicity, finite propagation, nilpotence, spectral conditions は `Decomposable` の定義に混ぜない。これらは別個の定理または将来の proof obligation として扱う。
+- `ComponentCategory` は thin category であり、path count や walk length を意図的に忘れる。
+- 定量指標は `Walk`, `Path`, adjacency matrix, または将来の free-category construction 側で扱う。
+
+## ドキュメントポリシー
+
+- `docs` の研究主張を変更する場合は、対応する Lean status を明確にする。
+- Lean status は、proved, defined only, future proof obligation, empirical hypothesis を区別する。
+- Lean で証明済みの主張と、実証研究で検証する主張を混同しない。
+- `proof_obligations.md` は GitHub Issues への索引としても使う。
+
+## タスク管理
+
+- 未解決課題は GitHub Issues で管理する。
+- Issue は研究の依存構造に沿って milestone に割り当てる。
+- Issue の label は `type:*`, `area:*`, `priority:*`, `status:*` を使って整理する。
+- empirical extractor や実証研究の Issue は Lean proof の進行をブロックしないように扱う。
 


### PR DESCRIPTION
## 概要
- AGENTS.md 全体を日本語に書き直しました
- ユーザー応答、コミットメッセージ、PR、Issue を日本語で作成するルールを追加しました
- 既存のプロジェクト構成、build、形式化、ドキュメント方針は内容を保ったまま日本語化しました

## 確認
- git diff --check