### PR TITLE
PathとSimpleWalkの定義を追加

### DIFF
--- a/Formal/Arch/Graph.lean
+++ b/Formal/Arch/Graph.lean
@@ -25,7 +25,72 @@ def length {C : Type u} {G : ArchGraph C} {c d : C} : Walk G c d → Nat
   | nil _ => 0
   | cons _ rest => rest.length + 1
 
+/-- Vertices visited by a walk, including both endpoints. -/
+def vertices {C : Type u} {G : ArchGraph C} {c d : C} : Walk G c d → List C
+  | nil c => [c]
+  | cons (c := c) _ rest => c :: rest.vertices
+
+/-- A walk with `n` edges visits `n + 1` vertices, counting repetitions. -/
+theorem vertices_length {C : Type u} {G : ArchGraph C} {c d : C}
+    (w : Walk G c d) : w.vertices.length = w.length + 1 := by
+  induction w with
+  | nil c =>
+      rfl
+  | cons hEdge rest ih =>
+      simp [vertices, length, ih]
+
 end Walk
 
-end Formal.Arch
+/--
+A simple walk is a walk whose visited vertex list has no duplicates.
 
+This keeps the existing `Walk` as the count-preserving object and adds only the
+extra no-repeated-vertices invariant needed for future path-shortening lemmas.
+-/
+structure SimpleWalk {C : Type u} (G : ArchGraph C) (c d : C) where
+  walk : Walk G c d
+  nodup_vertices : walk.vertices.Nodup
+
+/--
+Path is the canonical no-repeated-vertices representative used by bounded
+reachability arguments.
+
+At this stage it is an alias for `SimpleWalk`; future work may add additional
+path-specific API without changing the underlying invariant.
+-/
+abbrev Path {C : Type u} (G : ArchGraph C) (c d : C) := SimpleWalk G c d
+
+namespace SimpleWalk
+
+/-- The zero-length simple walk at a component. -/
+def nil {C : Type u} {G : ArchGraph C} (c : C) : SimpleWalk G c c where
+  walk := Walk.nil c
+  nodup_vertices := by
+    simp [Walk.vertices]
+
+/-- Add one fresh source vertex to the front of a simple walk. -/
+def cons {C : Type u} {G : ArchGraph C} {c d e : C}
+    (hEdge : G.edge c d) (rest : SimpleWalk G d e)
+    (hFresh : c ∉ rest.walk.vertices) : SimpleWalk G c e where
+  walk := Walk.cons hEdge rest.walk
+  nodup_vertices := by
+    simpa [Walk.vertices] using List.nodup_cons.mpr ⟨hFresh, rest.nodup_vertices⟩
+
+/-- Number of generating dependency edges used by a simple walk. -/
+def length {C : Type u} {G : ArchGraph C} {c d : C}
+    (p : SimpleWalk G c d) : Nat :=
+  p.walk.length
+
+/-- Vertices visited by a simple walk. -/
+def vertices {C : Type u} {G : ArchGraph C} {c d : C}
+    (p : SimpleWalk G c d) : List C :=
+  p.walk.vertices
+
+/-- A simple walk has the same edge/vertex count relation as its underlying walk. -/
+theorem vertices_length {C : Type u} {G : ArchGraph C} {c d : C}
+    (p : SimpleWalk G c d) : p.vertices.length = p.length + 1 :=
+  Walk.vertices_length p.walk
+
+end SimpleWalk
+
+end Formal.Arch

--- a/Formal/Arch/Reachability.lean
+++ b/Formal/Arch/Reachability.lean
@@ -32,6 +32,16 @@ def of_walk {C : Type u} {G : ArchGraph C} {c d : C} :
   | Walk.nil _ => Reachable.refl _
   | Walk.cons h rest => Reachable.step h (of_walk rest)
 
+/-- Simple walks imply reachability through their underlying walk. -/
+def of_simpleWalk {C : Type u} {G : ArchGraph C} {c d : C}
+    (p : SimpleWalk G c d) : Reachable G c d :=
+  of_walk p.walk
+
+/-- Paths imply reachability through their underlying simple walk. -/
+def of_path {C : Type u} {G : ArchGraph C} {c d : C}
+    (p : Path G c d) : Reachable G c d :=
+  of_simpleWalk p
+
 end Reachable
 
 end Formal.Arch

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -292,6 +292,11 @@ Lean status:
 - Proved: `reachesWithin_sound`, `edge_reachable_of_hasCycleBool`,
   `hasClosedWalk_of_hasCycleBool`, `reachesWithin_complete_of_walk`, and
   `hasCycleBool_complete_of_bounded_return_walk`.
+- Defined: `SimpleWalk` packages a `Walk` with `walk.vertices.Nodup`, and
+  `Path` is currently an alias for `SimpleWalk`. This resolves Issue #5 at the
+  definition level: `Walk` remains the length/count-preserving object, while
+  `Path` / `SimpleWalk` marks the no-repeated-vertices representative needed
+  for future path-shortening.
 - Defined only: `ComponentUniverse` is still a proof-carrying measurement
   universe, not a parser or extractor for real codebases.
 - Future proof obligation: connect SCC-size counts to equivalence classes of
@@ -301,6 +306,9 @@ Lean status:
   `reachesWithin_complete_of_reachable_under_universe`,
   `hasCycleBool ↔ HasClosedWalk` under a finite universe, and max-depth
   correctness on acyclic finite graphs.
+- Future proof obligation: prove a path-shortening theorem from arbitrary
+  `Walk` / `Reachable` evidence to a bounded `Path` under a finite
+  `ComponentUniverse`, with the length bound tied to `components.length`.
 
 ## 実証研究で検証する仮説
 


### PR DESCRIPTION
## 概要

Issue #5 に対応し、bounded reachability correctness の前提になる `Path` / `SimpleWalk` の定義を追加しました。

## 変更内容

- `Walk.vertices` を追加し、walk が訪問する頂点列を明示しました。
- `SimpleWalk` を `Walk` と `walk.vertices.Nodup` を持つ構造として導入しました。
- `Path` を現時点では `SimpleWalk` の別名として定義しました。
- `Reachable.of_simpleWalk` / `Reachable.of_path` を追加しました。
- `proof_obligations.md` に Issue #5 の Lean status と、今後の path-shortening proof obligation を追記しました。

## 確認

- `lake build` 成功
- `git diff --check` 成功
- hidden / bidirectional Unicode scan で検出なし

Closes #5