### PR TITLE
有限Universe上のbounded pathを証明

### DIFF
--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -31,6 +31,87 @@ def v0 {C : Type u} {G : ArchGraph C}
     ArchitectureSignature :=
   ArchitectureSignature.v0OfFinite G U.components boundaryAllowed abstractionAllowed
 
+/-- If `a` occurs in `l` and `a ≠ b`, then `a` still occurs after erasing `b`. -/
+private theorem mem_erase_of_ne_of_mem {C : Type u} [DecidableEq C]
+    {a b : C} {l : List C} (hne : a ≠ b) (hmem : a ∈ l) :
+    a ∈ l.erase b := by
+  induction l with
+  | nil =>
+      cases hmem
+  | cons c cs ih =>
+      by_cases hcb : c = b
+      · subst c
+        simp [List.erase_cons_head, hne] at hmem ⊢
+        exact hmem
+      · rw [List.erase_cons_tail]
+        · simp at hmem ⊢
+          cases hmem with
+          | inl hca => exact Or.inl hca
+          | inr hincs => exact Or.inr (ih hincs)
+        · simp [hcb]
+
+/--
+A duplicate-free list included in another duplicate-free list cannot be longer
+than that containing list.
+-/
+private theorem length_le_of_nodup_subset {C : Type u} [DecidableEq C]
+    {xs ys : List C} (hxs : xs.Nodup) (hys : ys.Nodup)
+    (hSub : ∀ a, a ∈ xs → a ∈ ys) : xs.length ≤ ys.length := by
+  revert ys
+  induction xs with
+  | nil =>
+      intro ys _hys _hSub
+      simp
+  | cons x xs ih =>
+      intro ys hys hSub
+      have hxNot : x ∉ xs := (List.nodup_cons.mp hxs).1
+      have hxsNodup : xs.Nodup := (List.nodup_cons.mp hxs).2
+      have hxMem : x ∈ ys := hSub x (by simp)
+      have hSubErase : ∀ a, a ∈ xs → a ∈ ys.erase x := by
+        intro a ha
+        exact mem_erase_of_ne_of_mem
+          (by
+            intro h
+            exact hxNot (by simpa [h] using ha))
+          (hSub a (by simp [ha]))
+      have ihLen : xs.length ≤ (ys.erase x).length :=
+        ih hxsNodup (List.Nodup.erase x hys) hSubErase
+      have hEraseLen : (ys.erase x).length = ys.length - 1 :=
+        List.length_erase_of_mem hxMem
+      have hPos : 0 < ys.length := List.length_pos_of_mem hxMem
+      have hSucc : xs.length + 1 ≤ (ys.erase x).length + 1 :=
+        Nat.succ_le_succ ihLen
+      calc
+        (x :: xs).length = xs.length + 1 := rfl
+        _ ≤ (ys.erase x).length + 1 := hSucc
+        _ = ys.length := by omega
+
+/--
+Every simple walk over a component universe is bounded by the universe list
+length.
+-/
+theorem simpleWalk_length_le_components_length {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] (U : ComponentUniverse G) {c d : C}
+    (p : SimpleWalk G c d) : p.length ≤ U.components.length := by
+  have hVerticesLen : p.vertices.length ≤ U.components.length :=
+    length_le_of_nodup_subset p.nodup_vertices U.nodup
+      (fun a _ha => U.covers a)
+  have hWalkLen : p.length ≤ p.vertices.length := by
+    rw [SimpleWalk.vertices_length]
+    exact Nat.le_succ p.length
+  exact Nat.le_trans hWalkLen hVerticesLen
+
+/--
+Reachability over a finite component universe has a simple path representative
+whose length is bounded by `components.length`.
+-/
+theorem reachable_exists_bounded_path {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] (U : ComponentUniverse G) {c d : C}
+    (h : Reachable G c d) :
+    ∃ p : Path G c d, p.length ≤ U.components.length := by
+  rcases Reachable.exists_path h with ⟨p, _⟩
+  exact ⟨p, simpleWalk_length_le_components_length U p⟩
+
 end ComponentUniverse
 
 namespace ArchitectureSignature

--- a/Formal/Arch/Graph.lean
+++ b/Formal/Arch/Graph.lean
@@ -39,6 +39,41 @@ theorem vertices_length {C : Type u} {G : ArchGraph C} {c d : C}
   | cons hEdge rest ih =>
       simp [vertices, length, ih]
 
+/-- Suffix of a walk starting at a vertex already visited by the walk. -/
+noncomputable def suffixFrom {C : Type u} [DecidableEq C] {G : ArchGraph C}
+    {x c d : C} : (w : Walk G c d) → x ∈ w.vertices → Walk G x d
+  | nil c, hMem => by
+      have hx : x = c := by
+        simpa [vertices] using hMem
+      cases hx
+      exact nil x
+  | @cons _ G c next d hEdge rest, hMem => by
+      by_cases hx : x = c
+      · cases hx
+        exact cons hEdge rest
+      · have hTail : x ∈ rest.vertices := by
+          simpa [vertices, hx] using hMem
+        exact suffixFrom rest hTail
+
+/-- The vertices of a walk suffix form a sublist of the original walk vertices. -/
+theorem suffixFrom_vertices_sublist {C : Type u} [DecidableEq C]
+    {G : ArchGraph C} {x c d : C} (w : Walk G c d)
+    (hMem : x ∈ w.vertices) : (suffixFrom w hMem).vertices.Sublist w.vertices := by
+  induction w with
+  | nil c =>
+      have hx : x = c := by
+        simpa [vertices] using hMem
+      cases hx
+      simp [suffixFrom]
+  | @cons c next d hEdge rest ih =>
+      by_cases hx : x = c
+      · cases hx
+        simp [suffixFrom]
+      · have hTail : x ∈ rest.vertices := by
+          simpa [vertices, hx] using hMem
+        have hSub := ih hTail
+        simpa [suffixFrom, hx, vertices] using hSub.cons c
+
 end Walk
 
 /--
@@ -90,6 +125,14 @@ def vertices {C : Type u} {G : ArchGraph C} {c d : C}
 theorem vertices_length {C : Type u} {G : ArchGraph C} {c d : C}
     (p : SimpleWalk G c d) : p.vertices.length = p.length + 1 :=
   Walk.vertices_length p.walk
+
+/-- Suffix of a simple walk starting at a vertex already visited by it. -/
+noncomputable def suffixFrom {C : Type u} [DecidableEq C] {G : ArchGraph C}
+    {x c d : C} (p : SimpleWalk G c d) (hMem : x ∈ p.vertices) :
+    SimpleWalk G x d where
+  walk := Walk.suffixFrom p.walk hMem
+  nodup_vertices :=
+    p.nodup_vertices.sublist (Walk.suffixFrom_vertices_sublist p.walk hMem)
 
 end SimpleWalk
 

--- a/Formal/Arch/Reachability.lean
+++ b/Formal/Arch/Reachability.lean
@@ -42,6 +42,21 @@ def of_path {C : Type u} {G : ArchGraph C} {c d : C}
     (p : Path G c d) : Reachable G c d :=
   of_simpleWalk p
 
+/--
+Reachability admits a simple path representative.
+
+If adding a new leading edge would repeat the source, the construction keeps
+the already-simple suffix starting at that repeated source instead.
+-/
+theorem exists_path {C : Type u} [DecidableEq C] {G : ArchGraph C} :
+    ∀ {c d : C}, Reachable G c d → ∃ _ : Path G c d, True
+  | _, _, Reachable.refl c => ⟨SimpleWalk.nil c, trivial⟩
+  | c, _e, Reachable.step (d := d) hEdge hRest => by
+      rcases exists_path hRest with ⟨p, _⟩
+      by_cases hMem : c ∈ p.vertices
+      · exact ⟨SimpleWalk.suffixFrom p hMem, trivial⟩
+      · exact ⟨SimpleWalk.cons hEdge p hMem, trivial⟩
+
 end Reachable
 
 end Formal.Arch

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -297,6 +297,13 @@ Lean status:
   definition level: `Walk` remains the length/count-preserving object, while
   `Path` / `SimpleWalk` marks the no-repeated-vertices representative needed
   for future path-shortening.
+- Proved: `Reachable.exists_path` constructs a `Path` / `SimpleWalk`
+  representative from propositional reachability. If a leading edge would
+  repeat a vertex, the construction keeps the simple suffix starting at that
+  vertex.
+- Proved: `ComponentUniverse.reachable_exists_bounded_path` shows that
+  `Reachable G c d` over a finite `ComponentUniverse` has a `Path G c d` whose
+  length is bounded by `components.length`. This resolves Issue #6.
 - Defined only: `ComponentUniverse` is still a proof-carrying measurement
   universe, not a parser or extractor for real codebases.
 - Future proof obligation: connect SCC-size counts to equivalence classes of
@@ -306,9 +313,9 @@ Lean status:
   `reachesWithin_complete_of_reachable_under_universe`,
   `hasCycleBool ↔ HasClosedWalk` under a finite universe, and max-depth
   correctness on acyclic finite graphs.
-- Future proof obligation: prove a path-shortening theorem from arbitrary
-  `Walk` / `Reachable` evidence to a bounded `Path` under a finite
-  `ComponentUniverse`, with the length bound tied to `components.length`.
+- Future proof obligation: use
+  `ComponentUniverse.reachable_exists_bounded_path` to prove
+  `reachesWithin_complete_of_reachable_under_universe`.
 
 ## 実証研究で検証する仮説
 


### PR DESCRIPTION
## 概要

Issue #6 に対応し、有限 `ComponentUniverse` 上で `Reachable G c d` から長さが `components.length` 以下の `Path G c d` を得る theorem を追加しました。

## 変更内容

- `Walk.suffixFrom` と `SimpleWalk.suffixFrom` を追加しました。
- `Reachable.exists_path` を追加し、到達可能性から単純な `Path` / `SimpleWalk` 代表を構成しました。
- `ComponentUniverse.simpleWalk_length_le_components_length` を追加しました。
- `ComponentUniverse.reachable_exists_bounded_path` を追加しました。
- `proof_obligations.md` で Issue #6 の Lean status を proved に更新しました。

## 確認

- `lake build` 成功
- `git diff --check` 成功
- hidden / bidirectional Unicode scan で検出なし

Closes #6