### PR TITLE
reachableからbounded searchへの完全性を証明

### DIFF
--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -196,6 +196,18 @@ theorem reachesWithin_complete_of_walk {C : Type u} {G : ArchGraph C}
             simp [reachesWithin, hEq, hAny]
 
 /--
+Under a finite component universe, propositional reachability is complete for
+the executable bounded search at `components.length` fuel.
+-/
+theorem reachesWithin_complete_of_reachable_under_universe
+    {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G)
+    {c d : C} (h : Reachable G c d) :
+    reachesWithin G U.components U.components.length c d = true := by
+  rcases ComponentUniverse.reachable_exists_bounded_path U h with ⟨p, hLen⟩
+  exact reachesWithin_complete_of_walk U p.walk hLen
+
+/--
 An edge followed by a bounded return walk is detected by the cycle indicator
 under a finite component universe.
 -/

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -304,18 +304,18 @@ Lean status:
 - Proved: `ComponentUniverse.reachable_exists_bounded_path` shows that
   `Reachable G c d` over a finite `ComponentUniverse` has a `Path G c d` whose
   length is bounded by `components.length`. This resolves Issue #6.
+- Proved: `reachesWithin_complete_of_reachable_under_universe` connects
+  propositional `Reachable G c d` to executable bounded search over
+  `ComponentUniverse.components` with `components.length` fuel. This resolves
+  Issue #7.
 - Defined only: `ComponentUniverse` is still a proof-carrying measurement
   universe, not a parser or extractor for real codebases.
 - Future proof obligation: connect SCC-size counts to equivalence classes of
   mutual `Reachable`, and decide whether `FiniteArchGraph` should become a
   bundled graph-plus-universe structure.
 - Future proof obligation: prove
-  `reachesWithin_complete_of_reachable_under_universe`,
   `hasCycleBool ↔ HasClosedWalk` under a finite universe, and max-depth
   correctness on acyclic finite graphs.
-- Future proof obligation: use
-  `ComponentUniverse.reachable_exists_bounded_path` to prove
-  `reachesWithin_complete_of_reachable_under_universe`.
 
 ## 実証研究で検証する仮説
 


### PR DESCRIPTION
## 概要

Issue #7 に対応し、有限 `ComponentUniverse` のもとで `Reachable G c d` なら `reachesWithin G U.components U.components.length c d = true` となる完全性定理を追加しました。

## 変更内容

- `ArchitectureSignature.reachesWithin_complete_of_reachable_under_universe` を追加しました。
- #6 で追加した `ComponentUniverse.reachable_exists_bounded_path` を使い、`Reachable` から bounded `Path` を取り出して executable bounded search に接続しました。
- `docs/proof_obligations.md` の Lean status を更新し、Issue #7 を proved に移しました。

## 確認

- `lake build` 成功
- `git diff --check` 成功
- hidden / bidirectional Unicode scan で検出なし
- `axiom`, `admit`, `sorry`, `unsafe` scan で検出なし

Closes #7