### PR TITLE
hasCycleBoolとHasClosedWalkの同値を証明

### DIFF
--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -222,6 +222,31 @@ theorem hasCycleBool_complete_of_bounded_return_walk {C : Type u} {G : ArchGraph
   exact ⟨d, (U.edgeClosed hEdge).2, by
     simp [decide_eq_true hEdge, reachesWithin_complete_of_walk U w hLen]⟩
 
+/--
+A nonempty closed walk is detected by the cycle indicator under a finite
+component universe.
+-/
+theorem hasCycleBool_complete_of_hasClosedWalk {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G)
+    (h : HasClosedWalk G) : hasCycleBool G U.components = true := by
+  rcases h with ⟨c, w, hLen⟩
+  rcases edge_reachable_of_closed_walk w hLen with ⟨d, hEdge, hReach⟩
+  rw [hasCycleBool, List.any_eq_true]
+  refine ⟨c, (U.edgeClosed hEdge).1, ?_⟩
+  rw [List.any_eq_true]
+  exact ⟨d, (U.edgeClosed hEdge).2, by
+    simp [decide_eq_true hEdge,
+      reachesWithin_complete_of_reachable_under_universe U hReach]⟩
+
+/--
+Correctness of the executable cycle indicator under a finite component
+universe.
+-/
+theorem hasCycleBool_correct_under_finite_universe {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G) :
+    hasCycleBool G U.components = true ↔ HasClosedWalk G :=
+  ⟨hasClosedWalk_of_hasCycleBool, hasCycleBool_complete_of_hasClosedWalk U⟩
+
 end ArchitectureSignature
 
 end Formal.Arch

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -308,14 +308,16 @@ Lean status:
   propositional `Reachable G c d` to executable bounded search over
   `ComponentUniverse.components` with `components.length` fuel. This resolves
   Issue #7.
+- Proved: `hasCycleBool_complete_of_hasClosedWalk` and
+  `hasCycleBool_correct_under_finite_universe` connect the executable cycle
+  indicator with `HasClosedWalk` under a finite `ComponentUniverse`. This
+  resolves Issue #8.
 - Defined only: `ComponentUniverse` is still a proof-carrying measurement
   universe, not a parser or extractor for real codebases.
 - Future proof obligation: connect SCC-size counts to equivalence classes of
   mutual `Reachable`, and decide whether `FiniteArchGraph` should become a
   bundled graph-plus-universe structure.
-- Future proof obligation: prove
-  `hasCycleBool ↔ HasClosedWalk` under a finite universe, and max-depth
-  correctness on acyclic finite graphs.
+- Future proof obligation: prove max-depth correctness on acyclic finite graphs.
 
 ## 実証研究で検証する仮説
 


### PR DESCRIPTION
## 概要

Issue #8 に対応し、有限 `ComponentUniverse` のもとで executable cycle indicator `hasCycleBool G U.components = true` と `HasClosedWalk G` の同値を証明しました。

## 変更内容

- `ArchitectureSignature.hasCycleBool_complete_of_hasClosedWalk` を追加しました。
- `ArchitectureSignature.hasCycleBool_correct_under_finite_universe` を追加しました。
- `edge_reachable_of_closed_walk` と #7 の `reachesWithin_complete_of_reachable_under_universe` を接続して、closed walk から `hasCycleBool` への completeness を証明しました。
- `docs/proof_obligations.md` の Lean status を更新し、Issue #8 を proved に移しました。

## 確認

- `lake build` 成功
- `git diff --check` 成功
- hidden / bidirectional Unicode scan で検出なし
- `axiom`, `admit`, `sorry`, `unsafe` scan で検出なし

Closes #8