### PR TITLE
有限非循環グラフの maxDepth 正当性を証明

### DIFF
--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -5,6 +5,24 @@ namespace Formal.Arch
 
 universe u
 
+/-- A vertex listed in a walk is reachable from the walk source. -/
+theorem reachable_of_mem_walk_vertices {C : Type u} {G : ArchGraph C}
+    {x c d : C} (w : Walk G c d) (hMem : x ∈ w.vertices) :
+    Reachable G c x := by
+  induction w with
+  | nil c =>
+      have hx : x = c := by
+        simpa [Walk.vertices] using hMem
+      simpa [hx] using (Reachable.refl c : Reachable G c c)
+  | @cons c next d hEdge rest ih =>
+      have hMem' : x = c ∨ x ∈ rest.vertices := by
+        simpa [Walk.vertices] using hMem
+      cases hMem' with
+      | inl hx =>
+          simpa [hx] using (Reachable.refl c : Reachable G c c)
+      | inr hTail =>
+          exact Reachable.step hEdge (ih hTail)
+
 /--
 A finite measurement universe for an architecture graph.
 
@@ -101,6 +119,35 @@ theorem simpleWalk_length_le_components_length {C : Type u} {G : ArchGraph C}
     exact Nat.le_succ p.length
   exact Nat.le_trans hWalkLen hVerticesLen
 
+/-- In an acyclic graph, every walk visits each vertex at most once. -/
+theorem walk_vertices_nodup_of_acyclic {C : Type u} {G : ArchGraph C}
+    (hAcyclic : Acyclic G) :
+    ∀ {c d : C} (w : Walk G c d), w.vertices.Nodup
+  | _, _, Walk.nil _ => by
+      simp [Walk.vertices]
+  | _, _, @Walk.cons _ _ src _ _ hEdge rest => by
+      have hRest : rest.vertices.Nodup :=
+        walk_vertices_nodup_of_acyclic hAcyclic rest
+      have hFresh : src ∉ rest.vertices := by
+        intro hMem
+        exact hAcyclic hEdge (reachable_of_mem_walk_vertices rest hMem)
+      simpa [Walk.vertices] using List.nodup_cons.mpr ⟨hFresh, hRest⟩
+
+/--
+Every walk in an acyclic finite component universe is bounded by the universe
+size.
+-/
+theorem walk_length_le_components_length_of_acyclic {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] (U : ComponentUniverse G) (hAcyclic : Acyclic G)
+    {c d : C} (w : Walk G c d) : w.length ≤ U.components.length := by
+  have hVerticesLen : w.vertices.length ≤ U.components.length :=
+    length_le_of_nodup_subset (walk_vertices_nodup_of_acyclic hAcyclic w)
+      U.nodup (fun a _ha => U.covers a)
+  have hWalkLen : w.length ≤ w.vertices.length := by
+    rw [Walk.vertices_length]
+    exact Nat.le_succ w.length
+  exact Nat.le_trans hWalkLen hVerticesLen
+
 /--
 Reachability over a finite component universe has a simple path representative
 whose length is bounded by `components.length`.
@@ -115,6 +162,58 @@ theorem reachable_exists_bounded_path {C : Type u} {G : ArchGraph C}
 end ComponentUniverse
 
 namespace ArchitectureSignature
+
+/-- Folding `Nat.max` never decreases its accumulator. -/
+private theorem acc_le_foldl_max (xs : List Nat) (acc : Nat) :
+    acc ≤ xs.foldl Nat.max acc := by
+  induction xs generalizing acc with
+  | nil =>
+      exact Nat.le_refl _
+  | cons x xs ih =>
+      exact Nat.le_trans (Nat.le_max_left acc x) (ih (Nat.max acc x))
+
+/-- Every element of a finite list is bounded by a `Nat.max` fold. -/
+private theorem le_foldl_max_of_mem {n acc : Nat} :
+    ∀ {xs : List Nat}, n ∈ xs → n ≤ xs.foldl Nat.max acc := by
+  intro xs hMem
+  induction xs generalizing n acc with
+  | nil =>
+      cases hMem
+  | cons x xs ih =>
+      simp at hMem
+      cases hMem with
+      | inl hn =>
+          subst n
+          exact Nat.le_trans (Nat.le_max_right acc x)
+            (acc_le_foldl_max xs (Nat.max acc x))
+      | inr hTail =>
+          exact ih (acc := Nat.max acc x) hTail
+
+/-- Every element of a finite list is bounded by `maxNatList`. -/
+private theorem le_maxNatList_of_mem {xs : List Nat} {n : Nat}
+    (hMem : n ∈ xs) : n ≤ maxNatList xs := by
+  simpa [maxNatList] using (le_foldl_max_of_mem (acc := 0) hMem)
+
+private theorem foldl_max_le_of_forall_le {bound : Nat} :
+    ∀ (xs : List Nat) (acc : Nat),
+      acc ≤ bound → (∀ n, n ∈ xs → n ≤ bound) →
+        xs.foldl Nat.max acc ≤ bound := by
+  intro xs
+  induction xs with
+  | nil =>
+      intro acc hAcc _hAll
+      exact hAcc
+  | cons x xs ih =>
+      intro acc hAcc hAll
+      apply ih
+      · exact (Nat.max_le).2 ⟨hAcc, hAll x (by simp)⟩
+      · intro n hn
+        exact hAll n (by simp [hn])
+
+private theorem maxNatList_le_of_forall_le {xs : List Nat} {bound : Nat}
+    (hAll : ∀ n, n ∈ xs → n ≤ bound) : maxNatList xs ≤ bound := by
+  simpa [maxNatList] using
+    foldl_max_le_of_forall_le xs 0 (Nat.zero_le bound) hAll
 
 /--
 Bounded Boolean reachability is sound with respect to propositional
@@ -246,6 +345,175 @@ theorem hasCycleBool_correct_under_finite_universe {C : Type u} {G : ArchGraph C
     [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G) :
     hasCycleBool G U.components = true ↔ HasClosedWalk G :=
   ⟨hasClosedWalk_of_hasCycleBool, hasCycleBool_complete_of_hasClosedWalk U⟩
+
+/-- `bound` is a global upper bound for all dependency-walk lengths. -/
+def IsGlobalWalkDepthBound {C : Type u} (G : ArchGraph C) (bound : Nat) : Prop :=
+  ∀ {c d : C} (w : Walk G c d), w.length ≤ bound
+
+/--
+`depth` is the least natural-number upper bound for all dependency-walk
+lengths.
+-/
+def IsExactGlobalWalkDepth {C : Type u} (G : ArchGraph C) (depth : Nat) : Prop :=
+  IsGlobalWalkDepthBound G depth ∧
+    ∀ bound : Nat, IsGlobalWalkDepthBound G bound → depth ≤ bound
+
+/--
+The bounded DFS depth covers every concrete walk whose length fits in the fuel.
+-/
+theorem walk_length_le_boundedDepthFrom_of_walk {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G) :
+    ∀ {fuel : Nat} {c d : C} (w : Walk G c d),
+      w.length ≤ fuel → w.length ≤ boundedDepthFrom G U.components fuel c
+  | 0, _, _, Walk.nil _, _ => by
+      simp [Walk.length, boundedDepthFrom]
+  | 0, _, _, Walk.cons _ _, hLen => by
+      cases hLen
+  | fuel + 1, _, _, Walk.nil _, _ => by
+      simp [Walk.length]
+  | fuel + 1, _, _, Walk.cons (c := src) (d := next) hEdge rest, hLen => by
+      have hRestLen : rest.length ≤ fuel := by
+        exact Nat.le_of_succ_le_succ (by
+          simpa [Walk.length, Nat.succ_eq_add_one] using hLen)
+      have hRestDepth :
+          rest.length ≤ boundedDepthFrom G U.components fuel next :=
+        walk_length_le_boundedDepthFrom_of_walk U rest hRestLen
+      have hMeasureMem :
+          boundedDepthFrom G U.components fuel next + 1 ∈
+            U.components.map (fun d =>
+              if decide (G.edge src d) then
+                boundedDepthFrom G U.components fuel d + 1
+              else
+                0) := by
+        exact List.mem_map.mpr
+          ⟨next, (U.edgeClosed hEdge).2, by
+            simp [decide_eq_true hEdge]⟩
+      have hMeasureLe :
+          boundedDepthFrom G U.components fuel next + 1 ≤
+            maxNatList (U.components.map (fun d =>
+              if decide (G.edge src d) then
+                boundedDepthFrom G U.components fuel d + 1
+              else
+                0)) :=
+        le_maxNatList_of_mem hMeasureMem
+      have hWalkLe :
+          (Walk.cons hEdge rest).length ≤
+            boundedDepthFrom G U.components fuel next + 1 := by
+        simpa [Walk.length, Nat.succ_eq_add_one] using
+          Nat.succ_le_succ hRestDepth
+      exact Nat.le_trans hWalkLe (by
+        simpa [boundedDepthFrom] using hMeasureLe)
+
+/--
+If `bound` is a walk-depth bound from `c`, bounded DFS from `c` never reports a
+larger depth.
+-/
+theorem boundedDepthFrom_le_of_walk_depth_bound {C : Type u}
+    {G : ArchGraph C} [DecidableRel G.edge] {components : List C}
+    {bound : Nat} :
+    ∀ {fuel : Nat} {c : C},
+      (∀ {d : C} (w : Walk G c d), w.length ≤ bound) →
+        boundedDepthFrom G components fuel c ≤ bound
+  | 0, _ => by
+      intro _hBound
+      simp [boundedDepthFrom]
+  | fuel + 1, c => by
+      intro hBound
+      simp only [boundedDepthFrom]
+      apply maxNatList_le_of_forall_le
+      intro n hn
+      rcases List.mem_map.mp hn with ⟨next, _hMem, hEq⟩
+      by_cases hEdge : G.edge c next
+      · have hNextBound :
+            ∀ {terminal : C} (walk : Walk G next terminal),
+              walk.length ≤ bound - 1 := by
+          intro terminal walk
+          have hCons :
+              (Walk.cons hEdge walk).length ≤ bound :=
+            hBound (Walk.cons hEdge walk)
+          have hCons' : walk.length + 1 ≤ bound := by
+            simpa [Walk.length, Nat.succ_eq_add_one] using hCons
+          omega
+        have hDepth :
+            boundedDepthFrom G components fuel next ≤ bound - 1 :=
+          boundedDepthFrom_le_of_walk_depth_bound hNextBound
+        have hPositive : 0 < bound := by
+          have hOne : (Walk.cons hEdge (Walk.nil next)).length ≤ bound :=
+            hBound (Walk.cons hEdge (Walk.nil next))
+          have hOne' : 1 ≤ bound := by
+            simpa [Walk.length] using hOne
+          omega
+        subst n
+        have hStep :
+            boundedDepthFrom G components fuel next + 1 ≤ bound := by
+          omega
+        simpa [hEdge] using hStep
+      · subst n
+        simp [hEdge]
+
+/--
+If `bound` is a graph-level walk-depth bound, bounded DFS never reports a
+larger depth.
+-/
+theorem boundedDepthFrom_le_of_global_walk_depth_bound {C : Type u}
+    {G : ArchGraph C} [DecidableRel G.edge] {components : List C}
+    {bound : Nat} (hBound : IsGlobalWalkDepthBound G bound) :
+    ∀ {fuel : Nat} {c : C},
+      boundedDepthFrom G components fuel c ≤ bound := by
+  intro fuel c
+  exact boundedDepthFrom_le_of_walk_depth_bound
+    (fun w => hBound w)
+
+/--
+Under a finite acyclic component universe, `maxDepthOfFinite` bounds every
+walk length.
+-/
+theorem maxDepthOfFinite_is_global_walk_depth_bound_of_acyclic {C : Type u}
+    {G : ArchGraph C} [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) (hAcyclic : Acyclic G) :
+    IsGlobalWalkDepthBound G (maxDepthOfFinite G U.components) := by
+  intro c d w
+  have hFuel : w.length ≤ U.components.length :=
+    ComponentUniverse.walk_length_le_components_length_of_acyclic U hAcyclic w
+  have hDepth :
+      w.length ≤ boundedDepthFrom G U.components U.components.length c :=
+    walk_length_le_boundedDepthFrom_of_walk U w hFuel
+  have hSourceMem :
+      boundedDepthFrom G U.components U.components.length c ∈
+        U.components.map (fun c =>
+          boundedDepthFrom G U.components U.components.length c) := by
+    exact List.mem_map.mpr ⟨c, U.covers c, rfl⟩
+  have hMax :
+      boundedDepthFrom G U.components U.components.length c ≤
+        maxDepthOfFinite G U.components := by
+    simpa [maxDepthOfFinite] using le_maxNatList_of_mem hSourceMem
+  exact Nat.le_trans hDepth hMax
+
+/--
+Any graph-level walk-depth bound is also an upper bound for
+`maxDepthOfFinite`.
+-/
+theorem maxDepthOfFinite_le_of_global_walk_depth_bound {C : Type u}
+    {G : ArchGraph C} [DecidableRel G.edge] {components : List C}
+    {bound : Nat} (hBound : IsGlobalWalkDepthBound G bound) :
+    maxDepthOfFinite G components ≤ bound := by
+  simp only [maxDepthOfFinite]
+  apply maxNatList_le_of_forall_le
+  intro n hn
+  rcases List.mem_map.mp hn with ⟨c, _hMem, hEq⟩
+  subst n
+  exact boundedDepthFrom_le_of_global_walk_depth_bound hBound
+
+/--
+Correctness of `maxDepthOfFinite` on acyclic finite component universes:
+it is the least upper bound of all concrete dependency-walk lengths.
+-/
+theorem maxDepthOfFinite_correct_of_acyclic {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) (hAcyclic : Acyclic G) :
+    IsExactGlobalWalkDepth G (maxDepthOfFinite G U.components) := by
+  exact ⟨maxDepthOfFinite_is_global_walk_depth_bound_of_acyclic U hAcyclic,
+    fun _ hBound => maxDepthOfFinite_le_of_global_walk_depth_bound hBound⟩
 
 end ArchitectureSignature
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -33,7 +33,7 @@ design / tooling 系の Issue は、上の status を補助する作業として
 | [#10](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/10) | open | 6. Projection / Observation Invariants | `defined only` / design | [5. DIP は射影整合性である](#5-dip-は射影整合性である), [6. LSP は観測関手による同値性である](#6-lsp-は観測関手による同値性である) | `DIPCompatible` と `StrongDIPCompatible` の役割分担を整理する。 |
 | [#11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11) | open | 4. Signature v0 Stabilization | `defined only` / design | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ), [fanout とレビューコスト](#3-fanout-とレビューコスト) | `averageFanout` を `totalFanout` / `maxFanout` / `fanoutRisk` のどれに寄せるか決める。 |
 | [#23](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/23) | open | 5. Layering Equivalence | `future proof obligation` | [2. 分解可能性の基礎定理](#2-分解可能性の基礎定理) | 有限非循環グラフから `StrictLayered` を構成する。 |
-| [#24](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/24) | open | 3. Cycle, SCC and Depth Correctness | `future proof obligation` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | acyclic finite graph 上の `maxDepth` correctness を証明する。 |
+| [#24](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/24) | open | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | acyclic finite graph 上の `maxDepth` correctness を証明する。 |
 | [#25](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/25) | open | 3. Cycle, SCC and Depth Correctness | `future proof obligation` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | SCC サイズ指標と相互到達可能性の同値類を接続する。 |
 | [#26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26) | open | 7. Path and Matrix Foundations | `future proof obligation` / design | [2. 分解可能性の基礎定理](#2-分解可能性の基礎定理), [解析的指標は発展課題として扱う](#解析的指標は発展課題として扱う) | adjacency matrix と DAG / nilpotence / spectral bridge を設計する。 |
 
@@ -335,6 +335,13 @@ Lean status:
   `hasCycleBool_correct_under_finite_universe` connect the executable cycle
   indicator with `HasClosedWalk` under a finite `ComponentUniverse`. This
   resolves [Issue #8](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/8).
+- `walk_length_le_components_length_of_acyclic`,
+  `maxDepthOfFinite_is_global_walk_depth_bound_of_acyclic`,
+  `maxDepthOfFinite_le_of_global_walk_depth_bound`, and
+  `maxDepthOfFinite_correct_of_acyclic` show that, under an acyclic finite
+  `ComponentUniverse`, executable `maxDepthOfFinite` is the least upper bound
+  of all concrete dependency-walk lengths. This resolves
+  [Issue #24](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/24).
 
 `defined only`:
 
@@ -367,8 +374,6 @@ Lean status:
 - Decide whether `FiniteArchGraph` should become a bundled graph-plus-universe
   structure; design tracking:
   [Issue #3](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/3).
-- Prove max-depth correctness on acyclic finite graphs; tracking:
-  [Issue #24](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/24).
 - Stabilize the fanout risk axis after the `averageFanout` design decision;
   design tracking:
   [Issue #11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11).


### PR DESCRIPTION
## 概要

Issue #24 に対応しました。

## 変更内容

- 非循環グラフの walk が重複頂点を持たず、有限 ComponentUniverse のサイズで長さを上から抑えられることを証明しました。
- boundedDepthFrom / maxDepthOfFinite と graph-level の walk depth bound を接続し、非循環有限 universe 上で maxDepthOfFinite が全 dependency-walk 長の最小上界になることを証明しました。
- docs/proof_obligations.md の #24 Lean status を proved に更新しました。

## 確認

- `lake build` 成功
- `git diff --check` 成功
- hidden / bidirectional Unicode scan で検出なし
- `axiom` / `admit` / `sorry` / `unsafe` scan で検出なし

Closes #24