### PR TITLE
fanoutリスク軸をtotalFanoutに安定化

### DIFF
--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -11,13 +11,13 @@ Every field is normalized as a risk axis: larger values mean greater structural
 risk on that axis. `hasCycle` is a 0/1 risk indicator.
 
 Future refinements may replace `sccMaxSize` with `sccExcessSize = sccMaxSize - 1`
-and `averageFanout` with `fanoutRisk` or `maxFanout`.
+and may split `fanoutRisk` into more refined propagation metrics.
 -/
 structure ArchitectureSignature where
   hasCycle : Nat
   sccMaxSize : Nat
   maxDepth : Nat
-  averageFanout : Nat
+  fanoutRisk : Nat
   boundaryViolationCount : Nat
   abstractionViolationCount : Nat
   deriving DecidableEq, Repr
@@ -29,7 +29,7 @@ def RiskLE (a b : ArchitectureSignature) : Prop :=
   a.hasCycle ≤ b.hasCycle ∧
   a.sccMaxSize ≤ b.sccMaxSize ∧
   a.maxDepth ≤ b.maxDepth ∧
-  a.averageFanout ≤ b.averageFanout ∧
+  a.fanoutRisk ≤ b.fanoutRisk ∧
   a.boundaryViolationCount ≤ b.boundaryViolationCount ∧
   a.abstractionViolationCount ≤ b.abstractionViolationCount
 
@@ -140,12 +140,24 @@ def totalFanout {C : Type u} (G : ArchGraph C)
   (components.map (fun c => fanout G components c)).sum
 
 /--
-Coarse Nat-valued average fanout used by the initial signature.
+Fanout risk for Signature v0.
+
+The v0 signature uses total outgoing dependency count rather than Nat-valued
+average fanout, so sparse graphs with at least one measured dependency do not
+round down to zero risk. A future signature can add `maxFanout` as a separate
+shape axis without changing this total propagation-load axis.
+-/
+def fanoutRiskOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) : Nat :=
+  totalFanout G components
+
+/--
+Legacy coarse Nat-valued average fanout.
 
 For an empty component universe, Lean's natural-number division gives `0`.
-Because this is integer division, sparse graphs can also round down to `0`;
-future signatures may prefer `totalFanout`, `maxFanout`, or another fanout-risk
-normalization.
+Because this is integer division, sparse graphs can also round down to `0`.
+It is kept as a derived executable metric, but Signature v0 uses
+`fanoutRiskOfFinite`.
 -/
 def averageFanoutOfFinite {C : Type u} (G : ArchGraph C)
     [DecidableRel G.edge] (components : List C) : Nat :=
@@ -201,7 +213,7 @@ def v0OfFinite {C : Type u} (G : ArchGraph C)
   hasCycle := boolRisk (hasCycleBool G components)
   sccMaxSize := sccMaxSizeOfFinite G components
   maxDepth := maxDepthOfFinite G components
-  averageFanout := averageFanoutOfFinite G components
+  fanoutRisk := fanoutRiskOfFinite G components
   boundaryViolationCount := boundaryViolationCountOfFinite G components boundaryAllowed
   abstractionViolationCount := abstractionViolationCountOfFinite G components abstractionAllowed
 
@@ -229,7 +241,7 @@ theorem v0_unitNoEdge :
       { hasCycle := 0
         sccMaxSize := 1
         maxDepth := 0
-        averageFanout := 0
+        fanoutRisk := 0
         boundaryViolationCount := 0
         abstractionViolationCount := 0 } := by
   rfl
@@ -240,10 +252,30 @@ theorem v0_unitSelfLoop :
       { hasCycle := 1
         sccMaxSize := 1
         maxDepth := 1
-        averageFanout := 1
+        fanoutRisk := 1
         boundaryViolationCount := 0
         abstractionViolationCount := 0 } := by
   rfl
+
+/-- Two-component graph with one dependency edge. -/
+def boolForwardGraph : ArchGraph Bool where
+  edge c d := c = false ∧ d = true
+
+instance : DecidableRel boolForwardGraph.edge := by
+  intro c d
+  change Decidable (c = false ∧ d = true)
+  infer_instance
+
+/-- A single measured dependency contributes one unit of fanout risk. -/
+theorem v0_boolForward :
+    v0OfFinite boolForwardGraph [false, true] (fun _ _ => True) (fun _ _ => True) =
+      { hasCycle := 0
+        sccMaxSize := 1
+        maxDepth := 1
+        fanoutRisk := 1
+        boundaryViolationCount := 0
+        abstractionViolationCount := 0 } := by
+  native_decide
 
 end Examples
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lean では、定義が明確で全称命題として扱える構造的事実を
 
 4. **Signature v0 Stabilization**
    - `ArchitectureSignature` v0 の各軸を安定化する。
-   - `averageFanout` を `totalFanout`, `maxFanout`, `fanoutRisk` のどれに寄せるか決める。
+   - `fanoutRisk` を `totalFanout` として扱い、`maxFanout` は将来の局所集中軸として分離する。
 
 5. **Layering Equivalence**
    - `Acyclic + finite vertices -> StrictLayered` を証明する。

--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -86,7 +86,7 @@ Sig0(A) =
   < hasCycle,
     sccMaxSize,
     maxDepth,
-    averageFanout,
+    fanoutRisk,
     boundaryViolationCount,
     abstractionViolationCount >
 ```
@@ -95,7 +95,7 @@ Sig0(A) =
 
 `maxDepth` は初期 Lean 実装では bounded max depth として扱う。循環グラフ上の真の大域 depth ではなく、有限 universe による fuel-bounded measurement である。循環リスクは `hasCycle` の別軸で扱う。
 
-`sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`averageFanout : Nat` は初期の粗い足場であり、Nat 除算で丸められるため、PR4 以降で `fanoutRisk = totalFanout` または `maxFanout` への置き換えを検討する。
+`sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`fanoutRisk : Nat` は v0 では `totalFanout` として定義し、疎なグラフでも測定 universe 内に依存辺があれば 0 に丸め落ちないようにする。`maxFanout` は局所集中を表す別軸として、Signature v1 以降で追加を検討する。
 
 Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。Lean PR5 では、その list に `Nodup`, coverage, edge-closedness を持たせる `ComponentUniverse` を追加し、bounded reachability と `Walk` / `Reachable` の基本的な正当性 bridge を証明する。現在の `ComponentUniverse` は full universe なので edge-closedness は coverage から導けるが、将来 closed measurement sub-universe を扱う余地を残すため明示フィールドとして保持する。これは実コードベース抽出器の完全性を主張するものではない。SCC count と相互到達可能性の同値類との接続は、次の proof obligation として残す。
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -31,7 +31,7 @@ design / tooling 系の Issue は、上の status を補助する作業として
 | [#8](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/8) | closed | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | `hasCycleBool` と `HasClosedWalk` の有限 universe 上の同値を証明する。 |
 | [#9](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/9) | open | 1. Finite Universe Bridge | docs index | [GitHub Issues 索引](#github-issues-索引) | この文書を GitHub Issues への索引として更新する。 |
 | [#10](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/10) | open | 6. Projection / Observation Invariants | `defined only` / design | [5. DIP は射影整合性である](#5-dip-は射影整合性である), [6. LSP は観測関手による同値性である](#6-lsp-は観測関手による同値性である) | `DIPCompatible` と `StrongDIPCompatible` の役割分担を整理する。 |
-| [#11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11) | open | 4. Signature v0 Stabilization | `defined only` / design | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ), [fanout とレビューコスト](#3-fanout-とレビューコスト) | `averageFanout` を `totalFanout` / `maxFanout` / `fanoutRisk` のどれに寄せるか決める。 |
+| [#11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11) | open | 4. Signature v0 Stabilization | `defined only` / design decided | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ), [fanout とレビューコスト](#3-fanout-とレビューコスト) | `fanoutRisk = totalFanout` として v0 の fanout 軸を安定化する。 |
 | [#23](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/23) | open | 5. Layering Equivalence | `proved` | [2. 分解可能性の基礎定理](#2-分解可能性の基礎定理) | 有限非循環グラフから `StrictLayered` を構成する。 |
 | [#24](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/24) | closed | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | acyclic finite graph 上の `maxDepth` correctness を証明する。 |
 | [#25](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/25) | closed | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | SCC サイズ指標と相互到達可能性の同値類を接続する。 |
@@ -312,7 +312,7 @@ Sig(A) <=risk Sig(B)
 - `hasCycle` は 0/1 の risk indicator として扱う。
 - `sccMaxSize` は将来的に `sccExcessSize = sccMaxSize - 1` として正規化することを検討する。
 - `maxDepth` は PR4 では bounded max depth であり、循環グラフ上の真の大域 depth ではない。循環リスクは `hasCycle` で別軸として扱う。
-- `averageFanout : Nat` は初期の粗い足場であり、Nat 除算で丸められる。PR4 以降で `fanoutRisk = totalFanout` または `maxFanout` への置き換えを検討する。
+- `fanoutRisk : Nat` は v0 では `totalFanout` として扱う。Nat-valued average fanout は丸め落ちるため Signature 本体から外し、`maxFanout` は局所集中を表す将来軸として分離する。
 - `nilpotencyIndex?` は初期 Lean 実装には入れず、adjacency matrix 導入後の発展指標として扱う。
 
 Lean status:
@@ -354,8 +354,9 @@ Lean status:
 `defined only`:
 
 - Executable v0 metrics over a supplied finite component list:
-  `hasCycleBool`, bounded SCC size, bounded max depth, Nat-valued average fanout,
-  boundary violation count, abstraction violation count, and `v0OfFinite`.
+  `hasCycleBool`, bounded SCC size, bounded max depth, total-fanout
+  `fanoutRisk`, boundary violation count, abstraction violation count, and
+  `v0OfFinite`.
 - `ComponentUniverse` packages the executable component list with `Nodup`,
   coverage, and edge-closedness assumptions. The current `ComponentUniverse` is
   a full universe, so edge-closedness follows from coverage. It remains an
@@ -376,15 +377,16 @@ Lean status:
 - `ComponentUniverse` is still a proof-carrying measurement universe, not a
   parser or extractor for real codebases. `FiniteArchGraph` is only the bundled
   Lean representation of a graph with such a universe.
-- `averageFanout : Nat` remains an initial coarse metric. Its replacement or
-  normalization is tracked by
+- `averageFanoutOfFinite : Nat` remains only as a legacy derived executable
+  metric. Signature v0 uses `fanoutRiskOfFinite = totalFanout`, resolving the
+  design decision tracked by
   [Issue #11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11).
 
 `future proof obligation`:
 
-- Stabilize the fanout risk axis after the `averageFanout` design decision;
-  design tracking:
-  [Issue #11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11).
+- Prove graph-level correctness facts for `fanoutRiskOfFinite` under a finite
+  `ComponentUniverse`, such as equivalence with the number of measured
+  dependency edges.
 
 Bridge theorem naming policy:
 
@@ -452,7 +454,7 @@ sccMaxSize が大きいほど、障害修正時間が長くなる。
 仮説:
 
 ```text
-averageFanout または最大 fanout が大きいほど、レビューコストが増える。
+fanoutRisk または最大 fanout が大きいほど、レビューコストが増える。
 ```
 
 測定候補:
@@ -533,6 +535,6 @@ G_runtime
 
 スペクトル半径、最近極、形式的ゼータ関数、discounted propagation resolvent は重要だが、初期実装では中心に置かない。
 
-まずは `hasCycle`, `sccMaxSize`, `maxDepth`, `averageFanout`, `boundaryViolationCount`, `abstractionViolationCount` のような、抽出・説明・検証が容易な指標を優先する。
+まずは `hasCycle`, `sccMaxSize`, `maxDepth`, `fanoutRisk`, `boundaryViolationCount`, `abstractionViolationCount` のような、抽出・説明・検証が容易な指標を優先する。
 
 なお、これらの定量指標には thin category だけでは不足する情報がある。経路数・経路長・walk 数を扱う場合は、`Reachable` ではなく `Walk`, `Path`, adjacency matrix, または `FreeCategoryOfGraph` 側で定義する。


### PR DESCRIPTION
## 概要

Issue #11 に対応しました。

## 変更内容

- ArchitectureSignature v0 の fanout 軸を averageFanout から fanoutRisk に変更
- fanoutRiskOfFinite を totalFanout として定義し、疎なグラフでの Nat 除算の丸め落ちを回避
- README と docs の Signature v0 / proof obligations の記述を更新

## 確認

- lake build 成功
- git diff --check 成功
- hidden / bidirectional Unicode scan で検出なし
- axiom / admit / sorry / unsafe scan で検出なし

Closes #11