### PR TITLE
ArchitectureSignature v1の軸構成を整理

### DIFF
--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -103,13 +103,34 @@ Lean PR4 では、有限な component list を測定 universe とする executab
 
 ```text
 Sig1(A) =
-  < rho(A),
-    poleRadius,
-    weightedSccRisk,
-    relationComplexity,
-    runtimePropagation,
-    empiricalChangeCost >
+  < decompositionRisk,
+    propagationRisk,
+    boundaryRisk,
+    abstractionRisk,
+    behavioralRisk,
+    stateTransitionRisk,
+    runtimeRisk,
+    empiricalCost >
 ```
+
+v1 は v0 を置き換える巨大な単一構造ではなく、v0 の安定軸を内側に含む多軸診断として設計する。まず `hasCycle`, `sccMaxSize`, `maxDepth`, `fanoutRisk`, `boundaryViolationCount`, `abstractionViolationCount` は v0 互換の executable metric として残す。その上で、次の順序で拡張する。
+
+| 段階 | 軸 | 代表指標 | Lean status |
+| --- | --- | --- | --- |
+| v1 core | 分解可能性・循環リスク | `sccExcessSize`, `weightedSccRisk` | executable metric / future proof obligation |
+| v1 core | 変更波及・依存伝播 | `maxFanout`, `reachableConeSize`, `fanoutRisk = totalFanout` | executable metric / future proof obligation |
+| matrix bridge | 行列的伝播 | `nilpotencyIndex`, `rho(A)` | future proof obligation |
+| projection bridge | 境界・抽象化 | `boundaryViolationCount`, `abstractionViolationCount`, `projectionSoundnessViolation` | defined only / future proof obligation |
+| behavioral extension | 観測可能性 | `observationalDivergence`, `lspViolationCount` | defined only / future proof obligation |
+| empirical extension | 状態遷移・実行時・実証コスト | `relationComplexity`, `runtimePropagation`, `empiricalChangeCost` | empirical hypothesis |
+
+`sccMaxSize` は v0 互換の説明用指標として残し、v1 の循環リスクでは `sccExcessSize = sccMaxSize - 1` を優先する。`weightedSccRisk` は SCC の大きさや重要度を重みづけする将来の executable metric とする。
+
+`fanoutRisk` は #11 の設計判断に従い `totalFanout` として残す。`maxFanout` は局所的な依存集中、`reachableConeSize` は変更波及の到達範囲を表す別軸として扱う。
+
+`nilpotencyIndex` と `rho(A)` は adjacency matrix 導入後の bridge 軸である。`nilpotencyIndex` は DAG / 層化 / 冪零性との Lean theorem を目標にする。一方で `rho(A)` は実数・行列解析を含むため、初期 v1 では executable / empirical 側の候補に留め、Lean proof は後続課題に分離する。
+
+`runtimePropagation`, `relationComplexity`, `empiricalChangeCost` は実コードや運用データの抽出設計に依存するため、Lean の全称定理としては扱わない。これらは Signature v1 の最終候補軸だが、初期実装では empirical hypothesis として分離する。
 
 単一スコア化は補助的な集約に留める。研究の中心は、多軸シグネチャ間のリスク順序と、各軸がどの不変量の破れを表すかの説明に置く。
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -31,11 +31,12 @@ design / tooling 系の Issue は、上の status を補助する作業として
 | [#8](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/8) | closed | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | `hasCycleBool` と `HasClosedWalk` の有限 universe 上の同値を証明する。 |
 | [#9](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/9) | open | 1. Finite Universe Bridge | docs index | [GitHub Issues 索引](#github-issues-索引) | この文書を GitHub Issues への索引として更新する。 |
 | [#10](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/10) | open | 6. Projection / Observation Invariants | `defined only` / design | [5. DIP は射影整合性である](#5-dip-は射影整合性である), [6. LSP は観測関手による同値性である](#6-lsp-は観測関手による同値性である) | `DIPCompatible` と `StrongDIPCompatible` の役割分担を整理する。 |
-| [#11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11) | open | 4. Signature v0 Stabilization | `defined only` / design decided | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ), [fanout とレビューコスト](#3-fanout-とレビューコスト) | `fanoutRisk = totalFanout` として v0 の fanout 軸を安定化する。 |
-| [#23](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/23) | open | 5. Layering Equivalence | `proved` | [2. 分解可能性の基礎定理](#2-分解可能性の基礎定理) | 有限非循環グラフから `StrictLayered` を構成する。 |
+| [#11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11) | closed | 4. Signature v0 Stabilization | `defined only` / design decided | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ), [fanout とレビューコスト](#3-fanout-とレビューコスト) | `fanoutRisk = totalFanout` として v0 の fanout 軸を安定化する。 |
+| [#23](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/23) | closed | 5. Layering Equivalence | `proved` | [2. 分解可能性の基礎定理](#2-分解可能性の基礎定理) | 有限非循環グラフから `StrictLayered` を構成する。 |
 | [#24](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/24) | closed | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | acyclic finite graph 上の `maxDepth` correctness を証明する。 |
 | [#25](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/25) | closed | 3. Cycle, SCC and Depth Correctness | `proved` | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ) | SCC サイズ指標と相互到達可能性の同値類を接続する。 |
 | [#26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26) | open | 7. Path and Matrix Foundations | `future proof obligation` / design | [2. 分解可能性の基礎定理](#2-分解可能性の基礎定理), [解析的指標は発展課題として扱う](#解析的指標は発展課題として扱う) | adjacency matrix と DAG / nilpotence / spectral bridge を設計する。 |
+| [#32](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/32) | open | 4. Signature v0 Stabilization | `defined only` / design decided | [7. Architecture Signature は半順序を持つ](#7-architecture-signature-は半順序を持つ), [Signature v1 軸設計](#signature-v1-軸設計) | ArchitectureSignature v1 の軸構成を整理する。 |
 
 ## Lean で証明する命題
 
@@ -387,6 +388,58 @@ Lean status:
 - Prove graph-level correctness facts for `fanoutRiskOfFinite` under a finite
   `ComponentUniverse`, such as equivalence with the number of measured
   dependency edges.
+
+#### Signature v1 軸設計
+
+Issue [#32](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/32)
+では、v1 を v0 の単純な置き換えではなく、v0 の安定軸を含む多軸診断として扱う。
+
+v0 に残す軸:
+
+- `hasCycle`
+- `sccMaxSize`
+- `maxDepth`
+- `fanoutRisk = totalFanout`
+- `boundaryViolationCount`
+- `abstractionViolationCount`
+
+v1 core に追加・正規化する候補:
+
+- `sccExcessSize = sccMaxSize - 1`: 非循環 singleton SCC を 0 risk として扱うための循環リスク軸。
+- `weightedSccRisk`: SCC の大きさや重要度を重みづけする将来の executable metric。
+- `maxFanout`: 局所的な依存集中を表す executable metric。
+- `reachableConeSize`: 変更波及の到達範囲を表す executable metric。
+- `projectionSoundnessViolation`: 抽象射影に反する具体依存を数える projection bridge 軸。
+
+Lean status の区分:
+
+| 軸 | 扱い | Lean status |
+| --- | --- | --- |
+| `sccExcessSize`, `maxFanout`, `reachableConeSize` | 有限 universe 上の計算として定義し、graph-level facts は theorem として証明する | `defined only` -> `future proof obligation` |
+| `weightedSccRisk` | 重み関数つき executable metric として設計する | `defined only` |
+| `nilpotencyIndex` | adjacency matrix 導入後に DAG / 層化 / 冪零性と接続する | `future proof obligation` |
+| `rho(A)` | 行列解析上の伝播増幅指標として扱う | `future proof obligation` / `empirical hypothesis` |
+| `runtimePropagation` | 実行時依存抽出に依存する | `empirical hypothesis` |
+| `relationComplexity` | 状態遷移代数層の設計に依存する | `empirical hypothesis` |
+| `empiricalChangeCost` | 実データで検証する目的変数 | `empirical hypothesis` |
+
+後続 Issue への分割:
+
+- adjacency matrix, `nilpotencyIndex`, `rho(A)` は
+  [#26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
+  で扱う。
+- 静的依存と実行時依存の分離は
+  [#33](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/33)
+  で扱う。
+- 実コードベースからの Sig0 / v1 core 抽出 tooling は
+  [#34](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/34)
+  で扱う。
+- 実証プロトコルと empirical cost 軸は
+  [#35](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/35)
+  で扱う。
+- `relationComplexity` は
+  [#36](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/36)
+  で扱う。
 
 Bridge theorem naming policy:
 

--- a/docs/research_goal.md
+++ b/docs/research_goal.md
@@ -144,6 +144,8 @@ Sig(A) =
 | 分散収束・ログ整合性 | 分散状態は前提条件のもとで収束するか。 | `consensusPreconditionRisk`, `divergenceWindow`, `replicationLagRisk` |
 | 実証的コスト | 指標は実際の変更・障害コストと関係するか。 | `empiricalChangeCost`, `reviewCost`, `incidentRepairCost` |
 
+Signature v1 では、これらを一度にすべて Lean 構造へ入れない。まず v0 の安定軸を保持し、分解可能性・依存伝播・境界・抽象化の executable metric を v1 core とする。`nilpotencyIndex` と `rho(A)` は adjacency matrix bridge の後続軸、`relationComplexity`, `runtimePropagation`, `empiricalChangeCost` は empirical extraction と実証プロトコル側の軸として分離する。
+
 ## 利用イメージ
 
 完成時には、設計改善の前後を次のように比較できる。


### PR DESCRIPTION
## 概要

Issue #32 に対応し、ArchitectureSignature v1 の軸構成を設計として整理しました。

v1 は v0 の置き換えではなく、v0 の安定軸を含む多軸診断として扱います。分解可能性・依存伝播・境界・抽象化を v1 core とし、`nilpotencyIndex` / `rho(A)` は adjacency matrix bridge、`relationComplexity` / `runtimePropagation` / `empiricalChangeCost` は empirical 側の軸として分離しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat_v2_overview.md`
- `docs/research_goal.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [ ] `lake build`（docs-only で Lean ソースと import 未変更のため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている

Closes #32
