### PR TITLE
隣接行列ブリッジで DAG と冪零性を接続する

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -10,3 +10,4 @@ import Formal.Arch.LSP
 import Formal.Arch.SolidCounterexample
 import Formal.Arch.Signature
 import Formal.Arch.Finite
+import Formal.Arch.Matrix

--- a/Formal/Arch/Matrix.lean
+++ b/Formal/Arch/Matrix.lean
@@ -1,0 +1,315 @@
+import Formal.Arch.Finite
+
+namespace Formal.Arch
+
+universe u
+
+/-- A finite-universe matrix with natural-number entries. -/
+abbrev NatMatrix (C : Type u) := C → C → Nat
+
+namespace NatMatrix
+
+/-- Identity matrix over a component type. -/
+def id {C : Type u} [DecidableEq C] : NatMatrix C :=
+  fun c d => if c = d then 1 else 0
+
+/--
+Matrix multiplication where the finite summation range is provided by a
+proof-carrying component universe.
+-/
+def mul {C : Type u} {G : ArchGraph C} (U : ComponentUniverse G)
+    (A B : NatMatrix C) : NatMatrix C :=
+  fun c d => (U.components.map (fun mid => A c mid * B mid d)).sum
+
+/-- Matrix powers over the finite component universe. -/
+def pow {C : Type u} {G : ArchGraph C} [DecidableEq C]
+    (U : ComponentUniverse G) (A : NatMatrix C) : Nat → NatMatrix C
+  | 0 => id
+  | k + 1 => mul U A (pow U A k)
+
+end NatMatrix
+
+/-- The 0/1 adjacency matrix of an architecture graph. -/
+def adjacencyMatrix {C : Type u} (G : ArchGraph C) [DecidableRel G.edge] :
+    NatMatrix C :=
+  fun c d => if G.edge c d then 1 else 0
+
+/-- The `(c,d)` entry of `A^k` for the graph adjacency matrix. -/
+def adjacencyPowerEntry {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) (k : Nat) (c d : C) : Nat :=
+  NatMatrix.pow U (adjacencyMatrix G) k c d
+
+/--
+Adjacency-matrix nilpotence as eventual zero of all sufficiently large powers.
+
+This avoids adding nilpotence to `Decomposable`; it is a bridge property over a
+finite measurement universe.
+-/
+def AdjacencyNilpotent {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge] (U : ComponentUniverse G) : Prop :=
+  ∃ cutoff : Nat, ∀ {k : Nat} {c d : C},
+    cutoff ≤ k → adjacencyPowerEntry U k c d = 0
+
+namespace Walk
+
+/-- Concatenate two walks. -/
+def append {C : Type u} {G : ArchGraph C} {a b c : C} :
+    Walk G a b → Walk G b c → Walk G a c
+  | nil _, tail => tail
+  | cons hEdge rest, tail => cons hEdge (append rest tail)
+
+/-- Length is additive under walk concatenation. -/
+theorem length_append {C : Type u} {G : ArchGraph C}
+    {a b c : C} (w1 : Walk G a b) (w2 : Walk G b c) :
+    (append w1 w2).length = w1.length + w2.length := by
+  induction w1 with
+  | nil a =>
+      simp [append, length]
+  | cons hEdge rest ih =>
+      simp [append, length, ih, Nat.add_assoc]
+      omega
+
+/-- Repeat a closed walk `n` times. -/
+def repeatClosed {C : Type u} {G : ArchGraph C} {c : C} :
+    Nat → Walk G c c → Walk G c c
+  | 0, _ => nil c
+  | n + 1, w => append w (repeatClosed n w)
+
+/-- Repeating a closed walk multiplies its length. -/
+theorem length_repeatClosed {C : Type u} {G : ArchGraph C}
+    {c : C} (n : Nat) (w : Walk G c c) :
+    (repeatClosed n w).length = n * w.length := by
+  induction n with
+  | zero =>
+      simp [repeatClosed, length]
+  | succ n ih =>
+      rw [repeatClosed, length_append, ih, Nat.succ_mul]
+      omega
+
+end Walk
+
+private theorem zero_lt_sum_iff_exists_pos :
+    ∀ xs : List Nat, 0 < xs.sum ↔ ∃ n, n ∈ xs ∧ 0 < n
+  | [] => by
+      simp
+  | x :: xs => by
+      rw [List.sum_cons]
+      constructor
+      · intro h
+        by_cases hx : 0 < x
+        · exact ⟨x, by simp, hx⟩
+        · have hxs : 0 < xs.sum := by omega
+          rcases (zero_lt_sum_iff_exists_pos xs).mp hxs with ⟨n, hn, hpos⟩
+          exact ⟨n, by simp [hn], hpos⟩
+      · rintro ⟨n, hn, hpos⟩
+        simp at hn
+        cases hn with
+        | inl hn =>
+            subst n
+            omega
+        | inr hn =>
+            have hxs : 0 < xs.sum :=
+              (zero_lt_sum_iff_exists_pos xs).mpr ⟨n, hn, hpos⟩
+            omega
+
+private theorem zero_lt_sum_map_iff_exists_pos {C : Type u}
+    (components : List C) (f : C → Nat) :
+    0 < (components.map f).sum ↔ ∃ c, c ∈ components ∧ 0 < f c := by
+  rw [zero_lt_sum_iff_exists_pos]
+  constructor
+  · rintro ⟨n, hn, hpos⟩
+    rcases List.mem_map.mp hn with ⟨c, hc, rfl⟩
+    exact ⟨c, hc, hpos⟩
+  · rintro ⟨c, hc, hpos⟩
+    exact ⟨f c, List.mem_map.mpr ⟨c, hc, rfl⟩, hpos⟩
+
+/--
+The graph adjacency entry is positive exactly when the corresponding edge
+exists.
+-/
+theorem adjacencyMatrix_pos_iff {C : Type u} {G : ArchGraph C}
+    [DecidableRel G.edge] {c d : C} :
+    0 < adjacencyMatrix G c d ↔ G.edge c d := by
+  by_cases hEdge : G.edge c d
+  · simp [adjacencyMatrix, hEdge]
+  · simp [adjacencyMatrix, hEdge]
+
+/--
+The `(c,d)` entry of `A^k` is positive exactly when there is a walk from `c`
+to `d` with length `k`.
+-/
+theorem adjacencyPowerEntry_pos_iff_walk_length {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) :
+    ∀ {k : Nat} {c d : C},
+      0 < adjacencyPowerEntry U k c d ↔
+        ∃ w : Walk G c d, w.length = k := by
+  intro k
+  induction k with
+  | zero =>
+      intro c d
+      constructor
+      · intro hPos
+        by_cases hEq : c = d
+        · subst d
+          exact ⟨Walk.nil c, rfl⟩
+        · simp [adjacencyPowerEntry, NatMatrix.pow, NatMatrix.id, hEq] at hPos
+      · rintro ⟨w, hLen⟩
+        cases w with
+        | nil c =>
+            simp [adjacencyPowerEntry, NatMatrix.pow, NatMatrix.id]
+        | cons hEdge rest =>
+            simp [Walk.length] at hLen
+  | succ k ih =>
+      intro c d
+      constructor
+      · intro hPos
+        have hExists :
+            ∃ mid, mid ∈ U.components ∧
+              0 <
+                adjacencyMatrix G c mid *
+                  adjacencyPowerEntry U k mid d := by
+          simpa [adjacencyPowerEntry, NatMatrix.pow, NatMatrix.mul]
+            using
+              (zero_lt_sum_map_iff_exists_pos U.components
+                (fun mid =>
+                  adjacencyMatrix G c mid *
+                    adjacencyPowerEntry U k mid d)).mp hPos
+        rcases hExists with ⟨mid, _hMem, hTerm⟩
+        have hEdgeAndRest :
+            G.edge c mid ∧ 0 < adjacencyPowerEntry U k mid d := by
+          by_cases hEdge : G.edge c mid
+          · have hRestPos :
+                0 < adjacencyPowerEntry U k mid d := by
+              simpa [adjacencyMatrix, hEdge] using hTerm
+            exact ⟨hEdge, hRestPos⟩
+          · simp [adjacencyMatrix, hEdge] at hTerm
+        rcases hEdgeAndRest with ⟨hEdge, hRestPos⟩
+        rcases (ih (c := mid) (d := d)).mp hRestPos with ⟨rest, hRestLen⟩
+        exact ⟨Walk.cons hEdge rest, by
+          simp [Walk.length, hRestLen]⟩
+      · rintro ⟨w, hLen⟩
+        cases w with
+        | nil c =>
+            simp [Walk.length] at hLen
+        | @cons c mid d hEdge rest =>
+            have hRestLen : rest.length = k := by
+              simpa [Walk.length, Nat.succ_eq_add_one] using hLen
+            have hRestPos :
+                0 < adjacencyPowerEntry U k mid d :=
+              (ih (c := mid) (d := d)).mpr ⟨rest, hRestLen⟩
+            have hTerm :
+                0 <
+                  adjacencyMatrix G c mid *
+                    adjacencyPowerEntry U k mid d := by
+              simpa [adjacencyMatrix, hEdge] using hRestPos
+            have hMem : mid ∈ U.components := (U.edgeClosed hEdge).2
+            have hSum :
+                0 <
+                  (U.components.map
+                    (fun x =>
+                      adjacencyMatrix G c x *
+                        adjacencyPowerEntry U k x d)).sum :=
+              (zero_lt_sum_map_iff_exists_pos U.components
+                (fun x =>
+                  adjacencyMatrix G c x *
+                    adjacencyPowerEntry U k x d)).mpr
+                ⟨mid, hMem, hTerm⟩
+            simpa [adjacencyPowerEntry, NatMatrix.pow, NatMatrix.mul] using hSum
+
+/--
+Finite acyclicity forces sufficiently large adjacency powers to be zero.
+-/
+theorem adjacencyNilpotent_of_acyclic {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) (hAcyclic : Acyclic G) :
+    AdjacencyNilpotent U := by
+  refine ⟨U.components.length + 1, ?_⟩
+  intro k c d hCutoff
+  by_cases hZero : adjacencyPowerEntry U k c d = 0
+  · exact hZero
+  · have hPos : 0 < adjacencyPowerEntry U k c d := Nat.pos_of_ne_zero hZero
+    rcases (adjacencyPowerEntry_pos_iff_walk_length U).mp hPos with ⟨w, hLen⟩
+    have hBound :
+        w.length ≤ U.components.length :=
+      ComponentUniverse.walk_length_le_components_length_of_acyclic U hAcyclic w
+    omega
+
+/--
+If all sufficiently large adjacency powers are zero, then there is no nonempty
+closed walk.
+-/
+theorem walkAcyclic_of_adjacencyNilpotent {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) (hNil : AdjacencyNilpotent U) :
+    WalkAcyclic G := by
+  intro hClosed
+  rcases hNil with ⟨cutoff, hZero⟩
+  rcases hClosed with ⟨c, w, hLen⟩
+  let repeated : Walk G c c := Walk.repeatClosed (cutoff + 1) w
+  have hRepeatedLen :
+      repeated.length = (cutoff + 1) * w.length :=
+    Walk.length_repeatClosed (cutoff + 1) w
+  have hOne : 1 ≤ w.length := hLen
+  have hCutoffLe : cutoff ≤ repeated.length := by
+    have hLeMul : cutoff + 1 ≤ (cutoff + 1) * w.length := by
+      simpa using Nat.mul_le_mul_left (cutoff + 1) hOne
+    rw [hRepeatedLen]
+    exact Nat.le_trans (Nat.le_succ cutoff) hLeMul
+  have hEntryPos :
+      0 < adjacencyPowerEntry U repeated.length c c :=
+    (adjacencyPowerEntry_pos_iff_walk_length U).mpr ⟨repeated, rfl⟩
+  have hEntryZero :
+      adjacencyPowerEntry U repeated.length c c = 0 :=
+    hZero hCutoffLe
+  omega
+
+/-- On a finite component universe, adjacency nilpotence implies acyclicity. -/
+theorem acyclic_of_adjacencyNilpotent {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) (hNil : AdjacencyNilpotent U) :
+    Acyclic G :=
+  acyclic_of_walkAcyclic (walkAcyclic_of_adjacencyNilpotent U hNil)
+
+/--
+On a finite component universe, adjacency nilpotence is equivalent to
+walk-level acyclicity.
+-/
+theorem adjacencyNilpotent_iff_walkAcyclic {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) :
+    AdjacencyNilpotent U ↔ WalkAcyclic G :=
+  ⟨walkAcyclic_of_adjacencyNilpotent U,
+    fun hWalkAcyclic =>
+      adjacencyNilpotent_of_acyclic U (acyclic_of_walkAcyclic hWalkAcyclic)⟩
+
+/--
+On a finite component universe, adjacency nilpotence is equivalent to the
+graph-level acyclicity predicate.
+-/
+theorem adjacencyNilpotent_iff_acyclic {C : Type u} {G : ArchGraph C}
+    [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) :
+    AdjacencyNilpotent U ↔ Acyclic G :=
+  ⟨acyclic_of_adjacencyNilpotent U, adjacencyNilpotent_of_acyclic U⟩
+
+namespace FiniteArchGraph
+
+/-- Finite acyclic architecture graphs have nilpotent adjacency matrices. -/
+theorem adjacencyNilpotent_of_acyclic {C : Type u} [DecidableEq C]
+    (FG : FiniteArchGraph C) [DecidableRel FG.graph.edge]
+    (hAcyclic : Acyclic FG.graph) :
+    AdjacencyNilpotent FG.componentUniverse :=
+  Formal.Arch.adjacencyNilpotent_of_acyclic FG.componentUniverse hAcyclic
+
+/-- Nilpotent adjacency matrices rule out cycles in finite architecture graphs. -/
+theorem acyclic_of_adjacencyNilpotent {C : Type u} [DecidableEq C]
+    (FG : FiniteArchGraph C) [DecidableRel FG.graph.edge]
+    (hNil : AdjacencyNilpotent FG.componentUniverse) :
+    Acyclic FG.graph :=
+  Formal.Arch.acyclic_of_adjacencyNilpotent FG.componentUniverse hNil
+
+end FiniteArchGraph
+
+end Formal.Arch

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -176,6 +176,33 @@ File: `Formal/Arch/Finite.lean`
 | `ComponentUniverse.strictLayered_of_acyclic` | `theorem` | finite acyclic graph から strict layering を構成する。 | `proved` |
 | `FiniteArchGraph.strictLayered_of_acyclic` | `theorem` | `FiniteArchGraph` 入口で finite acyclic graph から strict layering を得る。 | `proved` |
 
+## Matrix Bridge
+
+File: `Formal/Arch/Matrix.lean`
+
+| Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- |
+| `NatMatrix` | `abbrev` | finite universe の list-sum で冪を計算する自然数 entry の行列表現。 | `defined only` |
+| `NatMatrix.id` | `def` | 単位行列。 | `defined only` |
+| `NatMatrix.mul` | `def` | `ComponentUniverse.components` 上で和を取る行列積。 | `defined only` |
+| `NatMatrix.pow` | `def` | finite universe 上の行列冪。 | `defined only` |
+| `adjacencyMatrix` | `def` | `ArchGraph` の 0/1 adjacency matrix。 | `defined only` |
+| `adjacencyPowerEntry` | `def` | adjacency matrix の `A^k` entry。 | `defined only` |
+| `AdjacencyNilpotent` | `def` | 十分大きい adjacency matrix 冪がすべて 0 になること。 | `defined only` |
+| `Walk.append` | `def` | walk の連結。 | `defined only` |
+| `Walk.length_append` | `theorem` | walk 連結で長さが加法的になる。 | `proved` |
+| `Walk.repeatClosed` | `def` | 閉 walk の繰り返し。 | `defined only` |
+| `Walk.length_repeatClosed` | `theorem` | 閉 walk の繰り返しで長さが乗法的になる。 | `proved` |
+| `adjacencyMatrix_pos_iff` | `theorem` | adjacency entry が正であることと辺の存在が一致する。 | `proved` |
+| `adjacencyPowerEntry_pos_iff_walk_length` | `theorem` | `A^k` entry が正であることと長さ `k` の walk の存在が一致する。 | `proved` |
+| `adjacencyNilpotent_of_acyclic` | `theorem` | finite acyclic graph では adjacency matrix が冪零になる。 | `proved` |
+| `walkAcyclic_of_adjacencyNilpotent` | `theorem` | adjacency nilpotence から非空閉 walk が存在しないことを得る。 | `proved` |
+| `acyclic_of_adjacencyNilpotent` | `theorem` | adjacency nilpotence から graph-level acyclicity を得る。 | `proved` |
+| `adjacencyNilpotent_iff_walkAcyclic` | `theorem` | finite universe 上で adjacency nilpotence と `WalkAcyclic` が一致する。 | `proved` |
+| `adjacencyNilpotent_iff_acyclic` | `theorem` | finite universe 上で adjacency nilpotence と `Acyclic` が一致する。 | `proved` |
+| `FiniteArchGraph.adjacencyNilpotent_of_acyclic` | `theorem` | `FiniteArchGraph` 入口で acyclicity から adjacency nilpotence を得る。 | `proved` |
+| `FiniteArchGraph.acyclic_of_adjacencyNilpotent` | `theorem` | `FiniteArchGraph` 入口で adjacency nilpotence から acyclicity を得る。 | `proved` |
+
 ## SOLID Counterexamples
 
 File: `Formal/Arch/SolidCounterexample.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -55,7 +55,9 @@ Decomposable G := StrictLayered G
 - `StrictLayered -> FinitePropagation`: `proved`
 - `Acyclic + finite vertices -> StrictLayered`: `proved`, [Issue #23](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/23)
 - `Acyclic <-> WalkAcyclic`: `proved`
-- `DAG <-> Nilpotent adjacency matrix`: `future proof obligation`, [Issue #26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
+- `DAG <-> Nilpotent adjacency matrix`: `proved` for finite
+  `ComponentUniverse` natural-number adjacency powers,
+  [Issue #55](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/55)
 
 ### 1. 依存グラフから thin category が生成される
 
@@ -112,7 +114,9 @@ Lean status:
 
 発展段階で検討すること:
 
-- `DAG <-> Nilpotent adjacency matrix`: [Issue #26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
+- `DAG <-> Nilpotent adjacency matrix`: `proved` for finite
+  `ComponentUniverse` natural-number adjacency powers,
+  [Issue #55](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/55)
 - `DAG -> rho(A) = 0`: [Issue #26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
 - `cycle -> rho(A) > 0`: [Issue #26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
 
@@ -140,9 +144,18 @@ count-preserving object として使う。これは `Reachable` や
 
 `rho(A)` などの spectral condition は、実数・複素数上の行列解析と
 Perron-Frobenius 型の補題を要するため、初期 Lean bridge では証明対象にしない。
+Issue [#55](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/55)
+で、Lean 側には `NatMatrix`, `adjacencyMatrix`, `adjacencyPowerEntry`,
+`AdjacencyNilpotent` を導入した。`adjacencyPowerEntry_pos_iff_walk_length`
+により、`A^k` の entry が正であることと長さ `k` の walk の存在が一致する。
+また `adjacencyNilpotent_iff_walkAcyclic` と
+`adjacencyNilpotent_iff_acyclic` により、有限 `ComponentUniverse` 上では
+adjacency nilpotence / `WalkAcyclic` / `Acyclic` が一致する。
+
 当面は次の status に分ける。
 
-- `DAG <-> Nilpotent adjacency matrix`: `future proof obligation`
+- `DAG <-> Nilpotent adjacency matrix`: `proved` for finite `ComponentUniverse`
+  natural-number adjacency powers
 - `DAG -> rho(A) = 0`: `future proof obligation`, matrix bridge 後の解析的拡張
 - `cycle -> rho(A) > 0`: `future proof obligation`, matrix bridge 後の解析的拡張
 - spectral radius を変更波及や障害伝播の増幅指標として使う主張:


### PR DESCRIPTION
## 概要

Closes #55

有限 ComponentUniverse 上の自然数 entry 行列表現として NatMatrix を追加し、ArchGraph の 0/1 adjacency matrix とその冪を定義しました。A^k entry が正であることと長さ k の Walk の存在を接続し、finite universe 上で adjacency nilpotence / WalkAcyclic / Acyclic が一致することを証明しました。

## 証明した定理

- Walk.length_append
- Walk.length_repeatClosed
- adjacencyMatrix_pos_iff
- adjacencyPowerEntry_pos_iff_walk_length
- adjacencyNilpotent_of_acyclic
- walkAcyclic_of_adjacencyNilpotent
- acyclic_of_adjacencyNilpotent
- adjacencyNilpotent_iff_walkAcyclic
- adjacencyNilpotent_iff_acyclic
- FiniteArchGraph.adjacencyNilpotent_of_acyclic
- FiniteArchGraph.acyclic_of_adjacencyNilpotent

## 編集したドキュメント

- docs/proof_obligations.md
- docs/formal/lean_theorem_index.md

## 実施したテスト

- [x] lake build
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [x] axiom / admit / sorry / unsafe scan

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている