### PR TITLE
fanoutRisk と測定依存辺数の対応を証明する

### DIFF
--- a/Formal/Arch/Finite.lean
+++ b/Formal/Arch/Finite.lean
@@ -492,6 +492,17 @@ theorem sccMaxSizeOfFinite_eq_max_mutualReachableClassSize_under_universe
     sccSizeAt_eq_mutualReachableClassSize_under_universe U]
 
 /--
+Under a finite component universe, v0 `fanoutRiskOfFinite` counts exactly the
+measured dependency edges inside the universe.
+-/
+theorem fanoutRiskOfFinite_eq_measuredDependencyEdges_length_under_universe
+    {C : Type u} {G : ArchGraph C} [DecidableRel G.edge]
+    (U : ComponentUniverse G) :
+    fanoutRiskOfFinite G U.components =
+      (measuredDependencyEdges G U.components).length := by
+  exact fanoutRiskOfFinite_eq_measuredDependencyEdges_length G U.components
+
+/--
 An edge followed by a bounded return walk is detected by the cycle indicator
 under a finite component universe.
 -/

--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -140,6 +140,36 @@ def totalFanout {C : Type u} (G : ArchGraph C)
   (components.map (fun c => fanout G components c)).sum
 
 /--
+Measured dependency edges over the supplied finite component list.
+
+The list is measurement-universe based: duplicates in `components` intentionally
+produce duplicate measured pairs, matching the executable v0 metrics.
+-/
+def measuredDependencyEdges {C : Type u} (G : ArchGraph C)
+    [DecidableRel G.edge] (components : List C) : List (C × C) :=
+  components.flatMap (fun c =>
+    (components.filter (fun d => decide (G.edge c d))).map (fun d => (c, d)))
+
+/--
+Membership in `measuredDependencyEdges` is exactly being an edge whose source
+and target are both in the supplied measurement list.
+-/
+theorem mem_measuredDependencyEdges_iff {C : Type u} {G : ArchGraph C}
+    [DecidableRel G.edge] {components : List C} {edge : C × C} :
+    edge ∈ measuredDependencyEdges G components ↔
+      edge.1 ∈ components ∧ edge.2 ∈ components ∧ G.edge edge.1 edge.2 := by
+  rcases edge with ⟨c, d⟩
+  simp [measuredDependencyEdges]
+
+/--
+The total fanout metric is exactly the number of measured dependency edges.
+-/
+theorem totalFanout_eq_measuredDependencyEdges_length {C : Type u}
+    (G : ArchGraph C) [DecidableRel G.edge] (components : List C) :
+    totalFanout G components = (measuredDependencyEdges G components).length := by
+  simp [totalFanout, measuredDependencyEdges, fanout, countWhere]
+
+/--
 Fanout risk for Signature v0.
 
 The v0 signature uses total outgoing dependency count rather than Nat-valued
@@ -150,6 +180,15 @@ shape axis without changing this total propagation-load axis.
 def fanoutRiskOfFinite {C : Type u} (G : ArchGraph C)
     [DecidableRel G.edge] (components : List C) : Nat :=
   totalFanout G components
+
+/--
+The v0 fanout risk is exactly the number of measured dependency edges.
+-/
+theorem fanoutRiskOfFinite_eq_measuredDependencyEdges_length {C : Type u}
+    (G : ArchGraph C) [DecidableRel G.edge] (components : List C) :
+    fanoutRiskOfFinite G components =
+      (measuredDependencyEdges G components).length := by
+  simp [fanoutRiskOfFinite, totalFanout_eq_measuredDependencyEdges_length]
 
 /--
 Legacy coarse Nat-valued average fanout.

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -138,7 +138,11 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.sccSizeAt` | `def` | component 周辺の相互到達 class size。 | `defined only` |
 | `ArchitectureSignature.sccMaxSizeOfFinite` | `def` | finite universe 上の最大 SCC サイズ。 | `defined only` |
 | `ArchitectureSignature.totalFanout` | `def` | finite universe 上の総 fanout。 | `defined only` |
+| `ArchitectureSignature.measuredDependencyEdges` | `def` | finite component list 上で測定される依存辺ペア。 | `defined only` |
+| `ArchitectureSignature.mem_measuredDependencyEdges_iff` | `theorem` | 測定依存辺リストの membership が list 内の graph edge と一致すること。 | `proved` |
+| `ArchitectureSignature.totalFanout_eq_measuredDependencyEdges_length` | `theorem` | `totalFanout` が測定依存辺数と一致すること。 | `proved` |
 | `ArchitectureSignature.fanoutRiskOfFinite` | `def` | v0 の fanout risk。現在は `totalFanout`。 | `defined only` |
+| `ArchitectureSignature.fanoutRiskOfFinite_eq_measuredDependencyEdges_length` | `theorem` | v0 `fanoutRisk` が測定依存辺数と一致すること。 | `proved` |
 | `ArchitectureSignature.maxDepthOfFinite` | `def` | finite universe 上の bounded max depth。 | `defined only` |
 | `ArchitectureSignature.v0OfFinite` | `def` | finite universe から v0 signature を計算する。 | `defined only` |
 | `ArchitectureSignature.v0_unitNoEdge` | `theorem` | 辺なし unit graph の v0 計算例。 | `proved` |
@@ -169,6 +173,7 @@ File: `Formal/Arch/Finite.lean`
 | `reachesWithin_eq_reachableBool_under_universe` | `theorem` | bounded reachability と executable reachability の一致。 | `proved` |
 | `sccSizeAt_eq_mutualReachableClassSize_under_universe` | `theorem` | SCC size executable metric と相互到達 class size の接続。 | `proved` |
 | `sccMaxSizeOfFinite_eq_max_mutualReachableClassSize_under_universe` | `theorem` | max SCC metric と相互到達 class size 最大値の接続。 | `proved` |
+| `fanoutRiskOfFinite_eq_measuredDependencyEdges_length_under_universe` | `theorem` | finite universe 下で v0 `fanoutRisk` が測定依存辺数と一致すること。 | `proved` |
 | `hasClosedWalk_of_hasCycleBool` | `theorem` | executable cycle indicator から closed walk を得る。 | `proved` |
 | `hasCycleBool_complete_of_hasClosedWalk` | `theorem` | closed walk から executable cycle indicator を得る。 | `proved` |
 | `hasCycleBool_correct_under_finite_universe` | `theorem` | finite universe 下の cycle indicator correctness。 | `proved` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -454,12 +454,13 @@ Lean status:
   metric. Signature v0 uses `fanoutRiskOfFinite = totalFanout`, resolving the
   design decision tracked by
   [Issue #11](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/11).
-
-`future proof obligation`:
-
-- Prove graph-level correctness facts for `fanoutRiskOfFinite` under a finite
-  `ComponentUniverse`, such as equivalence with the number of measured
-  dependency edges.
+- `measuredDependencyEdges` lists the dependency pairs measured by the supplied
+  finite component list. `fanoutRiskOfFinite_eq_measuredDependencyEdges_length`
+  and
+  `fanoutRiskOfFinite_eq_measuredDependencyEdges_length_under_universe` prove
+  that Signature v0 `fanoutRisk` is exactly the number of measured dependency
+  edges. This resolves
+  [Issue #64](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/64).
 
 #### Signature v1 軸設計
 


### PR DESCRIPTION
## 概要

Closes #64

- `measuredDependencyEdges` を追加し、finite component list 上で測定される依存辺ペアを明示しました。
- `fanoutRiskOfFinite` / `totalFanout` が測定依存辺数と一致することを証明しました。
- `docs/proof_obligations.md` と Lean 定義・定理索引の status を更新しました。

## 証明した定理

- `ArchitectureSignature.mem_measuredDependencyEdges_iff`
- `ArchitectureSignature.totalFanout_eq_measuredDependencyEdges_length`
- `ArchitectureSignature.fanoutRiskOfFinite_eq_measuredDependencyEdges_length`
- `ArchitectureSignature.fanoutRiskOfFinite_eq_measuredDependencyEdges_length_under_universe`

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/formal/lean_theorem_index.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている