### PR TITLE
weightedSccRisk の counting rule を追加する

### DIFF
--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -244,6 +244,63 @@ def sccExcessSizeOfFinite {C : Type u} (G : ArchGraph C)
   sccMaxSizeOfFinite G components - 1
 
 /--
+SCC excess around one component.
+
+Singleton SCCs contribute zero risk by Nat subtraction. This is the local
+building block for weighted SCC risk.
+-/
+def sccExcessAt {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) (c : C) : Nat :=
+  sccSizeAt G components c - 1
+
+/--
+Weighted SCC risk contribution of one component.
+
+The weight is supplied by the caller. Lean only treats it as a natural-number
+importance factor; evidence used to extract that weight belongs to empirical
+tooling rather than this graph-level metric.
+-/
+def weightedSccContributionAt {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) (weight : C → Nat) (c : C) : Nat :=
+  weight c * sccExcessAt G components c
+
+/--
+Signature v1 weighted SCC risk over a finite measurement universe.
+
+The counting rule sums each measured component's weight multiplied by its local
+SCC excess. Non-cyclic singleton SCCs therefore contribute zero risk, while
+larger mutually reachable classes can be emphasized by caller-supplied weights.
+Duplicates in `components` are counted as repeated measurements, matching the
+rest of the finite executable metrics.
+-/
+def weightedSccRiskOfFinite {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C) (weight : C → Nat) : Nat :=
+  (components.map (fun c => weightedSccContributionAt G components weight c)).sum
+
+/-- Zero weights make weighted SCC risk zero for any measured graph. -/
+theorem weightedSccRiskOfFinite_zero_weight {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge] (components : List C) :
+    weightedSccRiskOfFinite G components (fun _ => 0) = 0 := by
+  have h : ∀ xs : List C, (xs.map (fun _ => 0)).sum = 0 := by
+    intro xs
+    induction xs with
+    | nil => rfl
+    | cons _ xs ih => simp [ih]
+  simpa [weightedSccRiskOfFinite, weightedSccContributionAt] using h components
+
+/--
+With unit weights, weighted SCC risk is the sum of local SCC excess values.
+-/
+theorem weightedSccRiskOfFinite_unit_weight {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge] (components : List C) :
+    weightedSccRiskOfFinite G components (fun _ => 1) =
+      (components.map (fun c => sccExcessAt G components c)).sum := by
+  simp [weightedSccRiskOfFinite, weightedSccContributionAt]
+
+/--
 Signature v1 core local fanout concentration metric.
 
 Unlike v0 `fanoutRiskOfFinite`, this records the largest per-component outgoing
@@ -434,6 +491,29 @@ def v1OfFinite {C : Type u} (G : ArchGraph C)
   relationComplexity := none
   empiricalChangeCost := none
 
+/--
+Build a Signature v1 value with the Lean executable weighted SCC axis populated.
+
+The caller supplies component weights explicitly. This keeps weight extraction
+or calibration outside the Lean graph core while still making the counting rule
+executable.
+-/
+def v1OfFiniteWithWeightedSccRisk {C : Type u} (G : ArchGraph C)
+    [DecidableEq C] [DecidableRel G.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed]
+    (weight : C → Nat) :
+    ArchitectureSignatureV1 where
+  core := v1CoreOfFinite G components boundaryAllowed abstractionAllowed
+  weightedSccRisk := some (weightedSccRiskOfFinite G components weight)
+  projectionSoundnessViolation := none
+  lspViolationCount := none
+  nilpotencyIndex := none
+  runtimePropagation := none
+  relationComplexity := none
+  empiricalChangeCost := none
+
 namespace Examples
 
 /-- One-component graph with no dependency edges. -/
@@ -483,6 +563,15 @@ instance : DecidableRel boolForwardGraph.edge := by
   change Decidable (c = false ∧ d = true)
   infer_instance
 
+/-- Two-component graph whose components are mutually reachable. -/
+def boolCycleGraph : ArchGraph Bool where
+  edge c d := c ≠ d
+
+instance : DecidableRel boolCycleGraph.edge := by
+  intro c d
+  change Decidable (c ≠ d)
+  infer_instance
+
 /-- A single measured dependency contributes one unit of fanout risk. -/
 theorem v0_boolForward :
     v0OfFinite boolForwardGraph [false, true] (fun _ _ => True) (fun _ _ => True) =
@@ -529,6 +618,28 @@ theorem v1Core_boolForward :
     sccExcessSizeOfFinite boolForwardGraph [false, true] = 0 ∧
       maxFanoutOfFinite boolForwardGraph [false, true] = 1 ∧
       reachableConeSizeOfFinite boolForwardGraph [false, true] = 1 := by
+  native_decide
+
+/-- Acyclic singleton SCCs contribute zero weighted SCC risk. -/
+theorem weightedSccRisk_boolForward :
+    weightedSccRiskOfFinite boolForwardGraph [false, true]
+      (fun c => if c then 3 else 2) = 0 := by
+  native_decide
+
+/--
+In a two-component cycle, each component contributes its supplied weight once.
+-/
+theorem weightedSccRisk_boolCycle :
+    weightedSccRiskOfFinite boolCycleGraph [false, true]
+      (fun c => if c then 3 else 2) = 5 := by
+  native_decide
+
+/-- The weighted SCC entry point populates only the weighted SCC extension axis. -/
+theorem v1Schema_boolCycle_weightedScc :
+    (v1OfFiniteWithWeightedSccRisk boolCycleGraph [false, true]
+      (fun _ _ => True) (fun _ _ => True)
+      (fun c => if c then 3 else 2)).weightedSccRisk =
+      some 5 := by
   native_decide
 
 end Examples

--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -130,7 +130,7 @@ Lean 側の v1 output schema は、v0 互換軸を含む `ArchitectureSignatureV
 core axis と、extractor / empirical tooling 側で後から埋める extension axis を
 同じ schema 上で区別できる。
 
-`sccMaxSize` は v0 互換の説明用指標として残し、v1 の循環リスクでは `sccExcessSizeOfFinite = sccMaxSizeOfFinite - 1` を優先する。Lean では finite universe 下で `sccExcessSizeOfFinite` が graph-level mutual-reachability class size 最大値から 1 を引いた値と一致することを証明済みである。`weightedSccRisk` は SCC の大きさや重要度を重みづけする将来の executable metric とする。
+`sccMaxSize` は v0 互換の説明用指標として残し、v1 の循環リスクでは `sccExcessSizeOfFinite = sccMaxSizeOfFinite - 1` を優先する。Lean では finite universe 下で `sccExcessSizeOfFinite` が graph-level mutual-reachability class size 最大値から 1 を引いた値と一致することを証明済みである。`weightedSccRiskOfFinite` は `weight : C -> Nat` を入力として、各 component の `weight c * (sccSizeAt G components c - 1)` を合計する executable metric である。重みの由来や calibration は empirical / extractor tooling 側に残し、Lean core では counting rule だけを扱う。
 
 `fanoutRisk` は #11 の設計判断に従い `totalFanout` として残す。`maxFanoutOfFinite` は局所的な依存集中、`reachableConeSizeOfFinite` は変更波及の到達範囲を表す別軸として扱う。これらは v0 record を置き換えるのではなく、有限な測定 universe 上の v1 core 派生 metric として追加する。Lean では finite universe 下で `maxFanoutOfFinite` が source ごとの measured dependency edges 数の最大値と一致し、`reachableConeSizeOfFinite` が source 自身を除く graph-level reachable cone size の最大値と一致することを証明済みである。
 

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -163,6 +163,11 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.fanoutRiskOfFinite` | `def` | v0 の fanout risk。現在は `totalFanout`。 | `defined only` |
 | `ArchitectureSignature.fanoutRiskOfFinite_eq_measuredDependencyEdges_length` | `theorem` | v0 `fanoutRisk` が測定依存辺数と一致すること。 | `proved` |
 | `ArchitectureSignature.sccExcessSizeOfFinite` | `def` | v1 core の SCC excess metric。`sccMaxSizeOfFinite - 1`。 | `defined only` |
+| `ArchitectureSignature.sccExcessAt` | `def` | component ごとの SCC excess metric。`sccSizeAt - 1`。 | `defined only` |
+| `ArchitectureSignature.weightedSccContributionAt` | `def` | component ごとの `weight * sccExcessAt`。 | `defined only` |
+| `ArchitectureSignature.weightedSccRiskOfFinite` | `def` | finite universe 上で重み付き SCC excess contribution を合計する v1 metric。 | `defined only` |
+| `ArchitectureSignature.weightedSccRiskOfFinite_zero_weight` | `theorem` | すべての component weight が 0 なら weighted SCC risk も 0。 | `proved` |
+| `ArchitectureSignature.weightedSccRiskOfFinite_unit_weight` | `theorem` | unit weight では weighted SCC risk が component ごとの SCC excess の和になること。 | `proved` |
 | `ArchitectureSignature.maxFanoutOfFinite` | `def` | v1 core の局所 fanout 最大値 metric。 | `defined only` |
 | `ArchitectureSignature.maxFanoutOfFinite_eq_max_measuredDependencyEdgesFromSource_length` | `theorem` | `maxFanoutOfFinite` が source ごとの測定依存辺数の最大値であること。 | `proved` |
 | `ArchitectureSignature.reachableConeSizeAt` | `def` | v1 core の component ごとの strict bounded reachable cone size。 | `defined only` |
@@ -173,6 +178,7 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.ArchitectureSignatureV1` | `structure` | v1 core と optional extension axis を束ねる output schema。 | `defined only` |
 | `ArchitectureSignature.v1CoreOfFinite` | `def` | finite universe から v1 core signature を計算する。 | `defined only` |
 | `ArchitectureSignature.v1OfFinite` | `def` | finite universe から v1 schema を作り、未評価 extension axis を `none` にする。 | `defined only` |
+| `ArchitectureSignature.v1OfFiniteWithWeightedSccRisk` | `def` | 明示的な component weight から `weightedSccRisk` を埋めた v1 schema を作る。 | `defined only` |
 | `ArchitectureSignature.v0_unitNoEdge` | `theorem` | 辺なし unit graph の v0 計算例。 | `proved` |
 | `ArchitectureSignature.v0_unitSelfLoop` | `theorem` | self-loop unit graph の v0 計算例。 | `proved` |
 | `ArchitectureSignature.v0_boolForward` | `theorem` | bool forward graph の v0 計算例。 | `proved` |
@@ -180,6 +186,9 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.v1CoreSchema_unitNoEdge` | `theorem` | 辺なし unit graph の v1 core schema 計算例。 | `proved` |
 | `ArchitectureSignature.v1Schema_unitNoEdge_unmeasured` | `theorem` | 未評価 v1 extension axis が `none` に残る計算例。 | `proved` |
 | `ArchitectureSignature.v1Core_boolForward` | `theorem` | bool forward graph の v1 core 計算例。 | `proved` |
+| `ArchitectureSignature.weightedSccRisk_boolForward` | `theorem` | 非循環 bool forward graph では weighted SCC risk が 0 になる計算例。 | `proved` |
+| `ArchitectureSignature.weightedSccRisk_boolCycle` | `theorem` | 2 component cycle では各 component の重みが 1 回ずつ寄与する計算例。 | `proved` |
+| `ArchitectureSignature.v1Schema_boolCycle_weightedScc` | `theorem` | weighted SCC entry point が `weightedSccRisk` extension axis を埋める計算例。 | `proved` |
 
 ## Finite Universe / Bridge Theorems
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -574,6 +574,16 @@ v0 signature を内側に持ち、`sccExcessSize`, `maxFanout`,
 `v1CoreOfFinite` と `v1OfFinite` は finite component list からこの schema を
 構成する executable entry point である。
 
+Issue [#84](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/84)
+では、`weightedSccRisk` の Lean 側 counting rule を固定した。入力は
+`weight : C -> Nat` であり、`weightedSccRiskOfFinite G components weight` は
+測定 universe 上の各 component について
+`weight c * (sccSizeAt G components c - 1)` を合計する。Nat subtraction により
+singleton SCC は 0 risk になり、component importance など重みの抽出根拠や
+calibration は empirical / extractor tooling 側に残す。Lean では
+`v1OfFiniteWithWeightedSccRisk` により、重みが明示的に渡された場合だけ
+`ArchitectureSignatureV1.weightedSccRisk` を `some` で埋める。
+
 Issue [#62](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/62)
 では、projection bridge の最小 Lean 定義を追加した。`projectionSoundnessViolation`
 は `components : List C` に現れる concrete edge `(c, d)` のうち、
@@ -626,7 +636,7 @@ Lean status の区分:
 | `reachableConeSize` | 有限 universe 上の計算として定義済み。graph-level strict reachable cone size 最大値との bridge を証明済み | `defined only` / `proved` |
 | `maxFanout` | 有限 universe 上の計算として定義済み。source ごとの measured dependency edges との bridge を証明済み | `defined only` / `proved` |
 | `ArchitectureSignatureV1Core`, `ArchitectureSignatureV1` | v0 を内側に含む v1 output schema。未評価 extension axis は `Option Nat` で保持する | `defined only` |
-| `weightedSccRisk` | 重み関数つき executable metric として設計する | `defined only` |
+| `weightedSccRisk` | `weight : C -> Nat` を入力し、各 component の重み付き SCC excess を合計する executable metric。重みの由来は empirical / extractor tooling 側に残す | `defined only` / `proved` |
 | `projectionSoundnessViolation` | 具象依存が抽象依存へ sound に写らない measured edge を数える | `defined only` / `proved` |
 | `observationalDivergence`, `lspViolationCount` | 観測差分と measured LSP violation pair を数える behavioral extension | `defined only` / `proved` |
 | `nilpotencyIndex` | adjacency matrix 導入後に DAG / 層化 / 冪零性と接続する | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #84

`weightedSccRisk` の Lean 側 counting rule を、明示的な `weight : C -> Nat` を受け取って各 component の `weight c * (sccSizeAt G components c - 1)` を合計する executable metric として追加しました。重みの由来や calibration は empirical / extractor tooling 側に残し、Lean core では counting rule と schema への投入点だけを扱います。

## 証明した定理

- `ArchitectureSignature.weightedSccRiskOfFinite_zero_weight`
- `ArchitectureSignature.weightedSccRiskOfFinite_unit_weight`
- `ArchitectureSignature.weightedSccRisk_boolForward`
- `ArchitectureSignature.weightedSccRisk_boolCycle`
- `ArchitectureSignature.v1Schema_boolCycle_weightedScc`

## 編集したドキュメント

- `docs/aat_v2_overview.md`
- `docs/proof_obligations.md`
- `docs/formal/lean_theorem_index.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている