### PR TITLE
ArchitectureSignature v1 後半戦を整理する

### DIFF
--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -129,6 +129,9 @@ Lean 側の v1 output schema は、v0 互換軸を含む `ArchitectureSignatureV
 `none` は未評価を意味し、risk 0 とは解釈しない。これにより、Lean で測定済みの
 core axis と、extractor / empirical tooling 側で後から埋める extension axis を
 同じ schema 上で区別できる。
+この後半戦の統合方針は
+[ArchitectureSignature v1 後半戦まとめ](design/signature_v1_wrapup.md)
+に分離する。
 
 `sccMaxSize` は v0 互換の説明用指標として残し、v1 の循環リスクでは `sccExcessSizeOfFinite = sccMaxSizeOfFinite - 1` を優先する。Lean では finite universe 下で `sccExcessSizeOfFinite` が graph-level mutual-reachability class size 最大値から 1 を引いた値と一致することを証明済みである。`weightedSccRiskOfFinite` は `weight : C -> Nat` を入力として、各 component の `weight c * (sccSizeAt G components c - 1)` を合計する executable metric である。重みの由来や calibration は empirical / extractor tooling 側に残し、Lean core では counting rule だけを扱う。
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -4,5 +4,6 @@
 
 - [Sig0 extractor v0 設計](sig0_extractor_design.md)
 - [Signature 実証プロトコル](empirical_protocol.md)
+- [ArchitectureSignature v1 後半戦まとめ](signature_v1_wrapup.md)
 - [relationComplexity 設計](relation_complexity_design.md)
 - [runtimePropagation 設計](runtime_propagation_design.md)

--- a/docs/design/signature_v1_wrapup.md
+++ b/docs/design/signature_v1_wrapup.md
@@ -1,0 +1,49 @@
+# ArchitectureSignature v1 後半戦まとめ
+
+このメモは Issue #83 の完了条件を整理するための wrap-up である。
+Signature v1 は v0 の置き換えではなく、v0 の安定軸を内側に含む多軸診断として扱う。
+
+## v1 schema の固定方針
+
+Lean 側の出力 schema は、次の 2 層に分ける。
+
+- `ArchitectureSignatureV1Core`: v0 signature と、Lean core で直接測定できる v1 派生軸を保持する。
+- `ArchitectureSignatureV1`: core に加えて、未評価または tooling / empirical 側で埋める extension axis を `Option Nat` で保持する。
+
+`Option Nat` の `none` は未評価を表し、risk 0 とは解釈しない。
+この規約は extractor output の `metricStatus.measured = false` と同じ意味を持つ。
+
+## 軸構成
+
+| 軸 | Lean 側の扱い | Lean status |
+| --- | --- | --- |
+| v0 互換軸 | `ArchitectureSignature` として保持する | `defined only` / `proved` |
+| `sccExcessSize` | `sccMaxSizeOfFinite - 1` として計算し、mutual-reachability class size 最大値との bridge を証明済み | `defined only` / `proved` |
+| `maxFanout` | source ごとの measured dependency edges 数の最大値として計算する | `defined only` / `proved` |
+| `reachableConeSize` | strict reachable cone size の最大値として計算する | `defined only` / `proved` |
+| `weightedSccRisk` | 明示的な `weight : C -> Nat` が渡された場合だけ extension axis を埋める | `defined only` / `proved` |
+| `projectionSoundnessViolation` | projection bridge の measured soundness violation count として扱う | `defined only` / `proved` |
+| `lspViolationCount` | behavioral extension の measured pair count として扱う | `defined only` / `proved` |
+| `nilpotencyIndex` | finite `ComponentUniverse` 上の matrix bridge entry point から埋める | `defined only` / `proved` |
+| `runtimePropagation` | 0/1 `RuntimeDependencyGraph` 上の propagation radius として計算する | `defined only` / `empirical hypothesis` |
+| `relationComplexity` | workflow observation から作る empirical extension として扱う | `empirical hypothesis` |
+| `empiricalChangeCost` | 実データ検証の目的変数として扱う | `empirical hypothesis` |
+
+## 子 Issue の反映
+
+| Issue | 決定内容 | 反映先 |
+| --- | --- | --- |
+| #87 | `ArchitectureSignatureV1Core` / `ArchitectureSignatureV1` の 2 層 schema に固定する | `Formal/Arch/Signature.lean`, `docs/proof_obligations.md`, `docs/aat_v2_overview.md` |
+| #84 | `weightedSccRisk` は component weight を入力にした SCC excess contribution の合計とする | `Formal/Arch/Signature.lean`, `docs/proof_obligations.md`, `docs/aat_v2_overview.md` |
+| #85 | `nilpotencyIndex` は matrix bridge 由来の optional extension axis とし、`rho(A)` とは分離する | `Formal/Arch/Matrix.lean`, `docs/proof_obligations.md`, `docs/aat_v2_overview.md` |
+| #86 | `runtimePropagation` は初期 metric を `runtimePropagationRadius` に固定し、runtime metadata は tooling 側に残す | `Formal/Arch/Signature.lean`, `docs/design/runtime_propagation_design.md`, `docs/proof_obligations.md` |
+
+## 残る境界
+
+次の主張は Signature v1 schema には場所を持つが、Lean core の全称定理としてはまだ扱わない。
+
+- `rho(A)` は行列解析を含むため、spectral bridge の後続 proof obligation とする。
+- runtime edge metadata, timeout budget, retry policy, circuit breaker coverage は extractor / empirical tooling 側に残す。
+- `relationComplexity` と `empiricalChangeCost` は実証プロトコル上の観測・目的変数として扱う。
+
+これにより、v1 は「測定済みの 0」と「未評価」を混同せず、Lean proof と empirical validation の責務境界を保ったまま拡張できる。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -593,6 +593,13 @@ v0 signature を内側に持ち、`sccExcessSize`, `maxFanout`,
 `v1CoreOfFinite` と `v1OfFinite` は finite component list からこの schema を
 構成する executable entry point である。
 
+Issue [#83](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/83)
+では、v1 後半戦の子 Issue #87, #84, #85, #86 の決定を統合し、
+v0 互換軸、Lean core、matrix bridge、runtime / empirical extension の責務境界を
+整理した。まとめは
+[ArchitectureSignature v1 後半戦まとめ](design/signature_v1_wrapup.md)
+に分離する。
+
 Issue [#84](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/84)
 では、`weightedSccRisk` の Lean 側 counting rule を固定した。入力は
 `weight : C -> Nat` であり、`weightedSccRiskOfFinite G components weight` は
@@ -704,6 +711,11 @@ Lean status の区分:
   [#86](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/86)
   で扱う。初期設計は
   [runtime_propagation_design.md](design/runtime_propagation_design.md)
+  に分離する。
+- Signature v1 後半戦の統合整理は
+  [#83](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/83)
+  で扱う。完了時のまとめは
+  [signature_v1_wrapup.md](design/signature_v1_wrapup.md)
   に分離する。
 
 Bridge theorem naming policy:


### PR DESCRIPTION
## 概要

Closes #83

ArchitectureSignature v1 後半戦の統合整理として、v1 schema、Lean status、extractor / empirical 側の責務境界をまとめる design メモを追加しました。`ArchitectureSignatureV1Core` と `ArchitectureSignatureV1` の 2 層 schema、および #84 #85 #86 #87 の決定内容を docs から辿れるようにしています。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/design/signature_v1_wrapup.md`
- `docs/design/README.md`
- `docs/aat_v2_overview.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている