### PR TITLE
Projection soundness と exact projection の使い分けを整理

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,3 +7,4 @@
 - [ArchitectureSignature v1 後半戦まとめ](signature_v1_wrapup.md)
 - [relationComplexity 設計](relation_complexity_design.md)
 - [runtimePropagation 設計](runtime_propagation_design.md)
+- [Projection soundness と exact projection の使い分け](projection_exact_soundness.md)

--- a/docs/design/projection_exact_soundness.md
+++ b/docs/design/projection_exact_soundness.md
@@ -1,0 +1,91 @@
+# Projection soundness と exact projection の使い分け
+
+このメモは Issue #82 の設計整理である。`ProjectionSound` だけで十分な主張と、
+`ProjectionExact` / `StrongDIPCompatible` が必要な主張を分ける。
+
+## 方針
+
+`ProjectionSound` は、具体依存が抽象グラフに漏れなく写ることを表す。したがって、
+具象グラフから抽象グラフへの forward preservation を言う主張では soundness だけで
+十分である。
+
+`ProjectionComplete` は、抽象グラフ上の辺が何らかの具体依存に由来することを表す。
+したがって、抽象グラフの辺を具体世界へ戻して読む主張や、抽象グラフに余分な辺が
+ないことを要求する主張では completeness が必要である。
+
+`ProjectionExact` は `ProjectionSound` と `ProjectionComplete` の組であり、
+`StrongDIPCompatible` は `ProjectionExact` に `RepresentativeStable` を加えた
+exact-projection refinement として扱う。現行 Lean の `DIPCompatible` は
+`ProjectionSound` と `RepresentativeStable` を要求する strong operational
+formalization であり、`StrongDIPCompatible` の別名ではない。
+
+## soundness-only で扱う主張
+
+次の主張は、抽象グラフに余分な辺が存在しても壊れない。
+
+- 具体依存が抽象依存として表現されること。
+- `ProjectionSound` なら `projectionSoundnessViolation = 0` になること。
+- 測定 universe が concrete edge を閉じている場合に、violation 0 から
+  `ProjectionSound` を復元すること。
+- `mapReachable` のように、具象到達可能性を抽象到達可能性へ送る bridge。
+- Signature v1 の `projectionSoundnessViolation` 軸。
+
+`projectionSoundnessViolation` は soundness violation count であり、
+`ProjectionComplete` の欠如は測らない。したがって、この軸は
+`ProjectionExact` の代替ではなく、projection bridge の片側だけを測る
+executable metric である。
+
+## exact projection が必要な主張
+
+次の主張では、抽象グラフ上の辺が具体依存に由来することを使うため、
+`ProjectionComplete` または `ProjectionExact` が必要である。
+
+- 抽象依存を具体依存 witness へ戻す主張。
+- 抽象グラフが、具体依存から誘導される商グラフと同じ辺集合を持つという主張。
+- 抽象グラフ上で見つかった循環や経路が、具体依存の witness を持つという主張。
+- 「抽象グラフに余分な設計上の依存がない」という診断。
+- `StrongDIPCompatible` から `DIPCompatible` へ降りる refinement の説明。
+
+ただし、exact projection が成り立っても、抽象グラフ自体の非循環性や
+`Decomposable` は従わない。抽象層の循環を排除するには Layered などの大域構造制約が
+別途必要である。
+
+## Lean theorem statement 候補
+
+既存の Lean では次が証明済みである。
+
+- `projectionSound_of_projectionExact`
+- `projectionComplete_of_projectionExact`
+- `dipCompatible_of_strongDIPCompatible`
+- `projectionSoundnessViolation_eq_zero_of_projectionSound`
+- `projectionSound_of_projectionSoundnessViolation_eq_zero`
+
+後続で追加するなら、次の方向を別 Issue に分ける。
+
+```text
+ProjectionComplete G π GA ->
+  GA.edge a b ->
+  exists c d, π.expose c = a and π.expose d = b and G.edge c d
+```
+
+これは定義の展開補題であり、抽象辺を具体 witness へ戻す bridge の入口になる。
+
+```text
+ProjectionExact G π GA ->
+  GA.edge a b <->
+    exists c d, π.expose c = a and π.expose d = b and G.edge c d
+```
+
+これは exact projection を「抽象辺集合と投影された具体辺集合の一致」として読む
+bridge theorem である。
+
+抽象循環や抽象経路を具体 witness へ持ち上げる theorem は、上の edge-level bridge の
+後続に置く。これは path / walk 側の構造を使うため、projection bridge だけの Issue には
+混ぜない。
+
+## Issue #82 の結論
+
+Issue #82 では、`projectionSoundnessViolation` を soundness-only metric として固定し、
+exact projection は抽象辺を具体依存由来として読むための refinement として分離する。
+`DIPCompatible` と `StrongDIPCompatible` の使い分けは
+[設計原則の分類](../design_principle_classification.md) と整合する。

--- a/docs/design/signature_v1_wrapup.md
+++ b/docs/design/signature_v1_wrapup.md
@@ -22,7 +22,7 @@ Lean 側の出力 schema は、次の 2 層に分ける。
 | `maxFanout` | source ごとの measured dependency edges 数の最大値として計算する | `defined only` / `proved` |
 | `reachableConeSize` | strict reachable cone size の最大値として計算する | `defined only` / `proved` |
 | `weightedSccRisk` | 明示的な `weight : C -> Nat` が渡された場合だけ extension axis を埋める | `defined only` / `proved` |
-| `projectionSoundnessViolation` | projection bridge の measured soundness violation count として扱う | `defined only` / `proved` |
+| `projectionSoundnessViolation` | projection bridge の measured soundness violation count として扱い、exact projection とは分離する | `defined only` / `proved` |
 | `lspViolationCount` | behavioral extension の measured pair count として扱う | `defined only` / `proved` |
 | `nilpotencyIndex` | finite `ComponentUniverse` 上の matrix bridge entry point から埋める | `defined only` / `proved` |
 | `runtimePropagation` | 0/1 `RuntimeDependencyGraph` 上の propagation radius として計算する | `defined only` / `empirical hypothesis` |
@@ -43,6 +43,8 @@ Lean 側の出力 schema は、次の 2 層に分ける。
 次の主張は Signature v1 schema には場所を持つが、Lean core の全称定理としてはまだ扱わない。
 
 - `rho(A)` は行列解析を含むため、spectral bridge の後続 proof obligation とする。
+- `projectionSoundnessViolation` は soundness-only metric であり、`ProjectionComplete`
+  の欠如や exact projection gap は別 refinement として扱う。
 - runtime edge metadata, timeout budget, retry policy, circuit breaker coverage は extractor / empirical tooling 側に残す。
 - `relationComplexity` と `empiricalChangeCost` は実証プロトコル上の観測・目的変数として扱う。
 

--- a/docs/design_principle_classification.md
+++ b/docs/design_principle_classification.md
@@ -144,3 +144,5 @@ Dependencies:
 この段階では、旧 `AbstractCycleComponent` は完全な `DIPCompatible` 反例ではなく、`DIP-direction-only counterexample` として位置づける。より強い Lean 例では、`RespectsProjection`, `QuotientWellDefined`, `DIPCompatible`, `LSPCompatible` を満たしながら、抽象層循環により `¬ Decomposable` となる形を用意する。
 
 `DIPCompatible` は、現行 Lean では単なる具象から抽象への依存方向制約ではなく、`ProjectionSound` と `RepresentativeStable` を合わせた strong operational formalization である。`StrongDIPCompatible` はこれに `ProjectionComplete` を加えた exact-projection refinement として扱う。したがって、DIP 系の局所契約が満たされることと、抽象層そのものが非循環・層化可能であることは別の不変量である。
+
+この使い分けの詳細は [Projection soundness と exact projection の使い分け](design/projection_exact_soundness.md) に置く。Signature v1 の `projectionSoundnessViolation` は soundness-only metric であり、`StrongDIPCompatible` が要求する exact projection 全体を測るものではない。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -323,6 +323,13 @@ DIPCompatible =
 `StrongDIPCompatible` は、`DIPCompatible` の別名ではなく exact-projection refinement として扱う。つまり、
 `ProjectionSound` に加えて `ProjectionComplete` も要求し、抽象グラフ上の辺が何らかの具体依存に由来することまで固定する。
 
+Issue [#82](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/82)
+では、`ProjectionSound` だけで十分な主張と exact projection が必要な主張を
+[Projection soundness と exact projection の使い分け](design/projection_exact_soundness.md)
+に分離した。Signature v1 の `projectionSoundnessViolation` は soundness-only
+metric として固定し、`ProjectionComplete` の欠如や exact projection gap は別の
+refinement として扱う。
+
 Lean status:
 
 - `defined only`: `ProjectionSound`, `ProjectionComplete`, `ProjectionExact`,
@@ -337,8 +344,9 @@ Lean status:
 
 今後の proof obligation:
 
-- exact projection が必要な場面と soundness だけで十分な場面を、設計原則分類と
-  Signature v1 の projection bridge 軸で分ける。
+- exact projection の edge-level bridge theorem を追加する場合は、
+  `ProjectionExact G π GA` から `GA.edge a b` と
+  `exists c d, π.expose c = a ∧ π.expose d = b ∧ G.edge c d` の同値を切る。
 - SOLID 不完全性反例では、DIP 風の依存方向や `DIPCompatible` を満たしても、
   抽象層の循環から `¬ Decomposable` が起こり得ることを Layered とは別軸として扱う。
 
@@ -631,6 +639,10 @@ soundness 側だけを測るため、`ProjectionComplete` まで要求する exa
 とは分けて扱う。Lean では、`ProjectionSound` なら violation が 0 になること、
 また測定 universe が concrete edge を閉じている場合には violation 0 から
 `ProjectionSound` が得られることを証明済みである。
+Issue [#82](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/82)
+で、この軸は soundness-only metric として固定した。`ProjectionComplete` の欠如や
+exact projection gap はこの count では測らず、抽象辺を具体依存 witness へ戻して読む
+refinement として別に扱う。
 
 Issue [#65](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/65)
 では、behavioral extension の最小 Lean bridge を追加した。`observationalDivergence`


### PR DESCRIPTION
## 概要

Closes #82

`ProjectionSound` だけで十分な主張と、`ProjectionExact` / `StrongDIPCompatible` が必要な主張を docs 上で分離しました。
Signature v1 の `projectionSoundnessViolation` は soundness-only metric として固定し、exact projection gap は別 refinement として扱う方針を明記しています。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/design/projection_exact_soundness.md`
- `docs/design/README.md`
- `docs/design/signature_v1_wrapup.md`
- `docs/design_principle_classification.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
