### PR TITLE
spectral radius bridge の設計方針を整理する

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,3 +8,4 @@
 - [relationComplexity 設計](relation_complexity_design.md)
 - [runtimePropagation 設計](runtime_propagation_design.md)
 - [Projection soundness と exact projection の使い分け](projection_exact_soundness.md)
+- [spectral radius bridge 設計](spectral_radius_bridge.md)

--- a/docs/design/spectral_radius_bridge.md
+++ b/docs/design/spectral_radius_bridge.md
@@ -1,0 +1,77 @@
+# spectral radius bridge 設計
+
+Lean status: `future proof obligation` / design decision.
+
+Issue [#79](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/79)
+の設計判断として、`rho(A)` は既存の `NatMatrix` bridge や
+`nilpotencyIndex` axis には混ぜず、mathlib 依存を持つ解析的拡張として分離する。
+
+## 決定
+
+既存 Lean core は、有限 `ComponentUniverse` 上の自然数値 adjacency power を使う。
+
+```text
+NatMatrix C := C -> C -> Nat
+adjacencyPowerEntry U k c d
+AdjacencyNilpotent U
+```
+
+これは `A^k` の entry と長さ `k` の `Walk` の存在を接続するための
+count-preserving bridge であり、`Decomposable` の定義には入れない。
+
+spectral radius 側では、この `NatMatrix` を直接拡張せず、有限 list を添字化した
+正方行列へ写す別の bridge を置く。
+
+```text
+SpectralIndex U := Fin U.components.length
+spectralAdjacencyMatrix U : Matrix (SpectralIndex U) (SpectralIndex U) Complex
+rho(A) := spectral radius of A over Complex
+```
+
+係数体は最初から `Complex` とする。実数非負行列として始めると、固有値や
+spectral radius の標準補題で結局 `Complex` 化が必要になるためである。
+
+このリポジトリの現在の `lakefile.toml` は mathlib 依存を持たない。したがって
+`rho(A)` bridge theorem の実装 PR では、mathlib を導入するか、mathlib 依存を持つ
+別パッケージに切り出すかを最初に決める。#79 では Lean core に半端な独自
+spectral radius 定義を追加しない。
+
+## theorem statement の分割
+
+`rho(A)` に関する theorem は、次の 2 つに分割する。
+
+1. `DAG -> rho(A) = 0`
+2. `cycle -> rho(A) > 0`
+
+同一 Issue で扱わない。前者は nilpotence から spectral radius 0 への標準線形代数
+補題に依存する。後者は非空閉 walk から正の spectral radius を得る補題に依存し、
+Perron-Frobenius 型の事実や trace / diagonal entry の評価が必要になる可能性がある。
+
+後続 Issue:
+
+- [#94](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/94):
+  `DAG` / adjacency nilpotence から `rho(A) = 0` への bridge theorem。
+- [#95](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/95):
+  cycle / closed walk から `rho(A) > 0` への bridge theorem。
+
+## empirical claim との分離
+
+`rho(A)` を変更波及や障害伝播の増幅指標として読む主張は
+`empirical hypothesis` とする。Lean theorem が扱うのは有限 adjacency matrix の
+構造的事実だけであり、障害修正コスト、変更コスト、運用リスクとの相関は
+実証プロトコル側で検証する。
+
+したがって Signature v1 では、現時点で次の境界を維持する。
+
+| 軸 | 扱い | Lean status |
+| --- | --- | --- |
+| `nilpotencyIndex` | finite `ComponentUniverse` 上の executable matrix bridge axis | `defined only` / `proved` |
+| `rho(A)` | mathlib-backed spectral bridge の後続候補 | `future proof obligation` |
+| `rho(A)` と変更・障害コストの関係 | 実データで検証する研究仮説 | `empirical hypothesis` |
+
+## Lean core へ入れないもの
+
+- `Decomposable` の定義への spectral condition の混入。
+- `ArchitectureSignatureV1.nilpotencyIndex` への `rho(A)` の混入。
+- mathlib なしの独自 spectral radius 定義。
+- 実証上の増幅解釈を Lean theorem として主張すること。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -122,8 +122,8 @@ Lean status:
 - `DAG <-> Nilpotent adjacency matrix`: `proved` for finite
   `ComponentUniverse` natural-number adjacency powers,
   [Issue #55](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/55)
-- `DAG -> rho(A) = 0`: [Issue #26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
-- `cycle -> rho(A) > 0`: [Issue #26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
+- `DAG -> rho(A) = 0`: [Issue #94](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/94)
+- `cycle -> rho(A) > 0`: [Issue #95](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/95)
 
 #### Matrix bridge 設計
 
@@ -174,14 +174,23 @@ Issue [#85](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/85
 `ArchitectureSignature.v1OfComponentUniverseWithNilpotencyIndex` は、この値を
 `ArchitectureSignatureV1.nilpotencyIndex` に埋める entry point である。
 
+Issue [#79](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/79)
+では、`rho(A)` bridge を mathlib-backed な解析的拡張として分離する方針にした。
+対象行列は `ComponentUniverse.components` を `Fin U.components.length` で添字化した
+`Complex` 係数の正方行列とし、既存の `NatMatrix` は walk count / nilpotence
+bridge として維持する。詳細は
+[spectral radius bridge 設計](design/spectral_radius_bridge.md) に分離する。
+
 当面は次の status に分ける。
 
 - `DAG <-> Nilpotent adjacency matrix`: `proved` for finite `ComponentUniverse`
   natural-number adjacency powers
 - `nilpotencyIndex`: executable metric / proved acyclic bridge for finite
   `ComponentUniverse`
-- `DAG -> rho(A) = 0`: `future proof obligation`, matrix bridge 後の解析的拡張
-- `cycle -> rho(A) > 0`: `future proof obligation`, matrix bridge 後の解析的拡張
+- `DAG -> rho(A) = 0`: `future proof obligation`,
+  [Issue #94](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/94)
+- `cycle -> rho(A) > 0`: `future proof obligation`,
+  [Issue #95](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/95)
 - spectral radius を変更波及や障害伝播の増幅指標として使う主張:
   `empirical hypothesis`
 
@@ -699,8 +708,9 @@ Lean status の区分:
 後続 Issue への分割:
 
 - adjacency matrix と `rho(A)` の解析的拡張は
-  [#26](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/26)
-  で扱う。
+  [#94](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/94)
+  と [#95](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/95)
+  に分割して扱う。
 - 静的依存と実行時依存の分離は
   [#33](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/33)
   で扱う。


### PR DESCRIPTION
## 概要

Closes #79

- `rho(A)` を既存の `NatMatrix` / `nilpotencyIndex` axis に混ぜず、mathlib-backed な解析的拡張として分離する方針を明文化しました。
- 対象行列を `Fin U.components.length` 添字の `Complex` 係数正方行列として扱う設計にしました。
- 後続 proof obligation を `DAG -> rho(A) = 0` の #94 と `cycle -> rho(A) > 0` の #95 に分割しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/design/spectral_radius_bridge.md`
- `docs/design/README.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 該当なし
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 該当なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている