### PR TITLE
DIP互換な抽象層循環反例を明示する

### DIFF
--- a/Formal/Arch/SolidCounterexample.lean
+++ b/Formal/Arch/SolidCounterexample.lean
@@ -236,6 +236,14 @@ inductive abstractEdge : Port → Port → Prop where
 def abstractGraph : AbstractGraph Port where
   edge := abstractEdge
 
+/-- The abstract port-level cycle itself is not decomposable. -/
+theorem abstractGraph_not_decomposable : ¬ Decomposable abstractGraph := by
+  intro h
+  rcases h with ⟨layer, hLayer⟩
+  have h1 : layer Port.payment < layer Port.order := hLayer abstractEdge.order_payment
+  have h2 : layer Port.order < layer Port.payment := hLayer abstractEdge.payment_order
+  exact Nat.lt_asymm h1 h2
+
 /-- Every concrete edge is represented at the abstract level. -/
 theorem projectionSound : ProjectionSound graph projection abstractGraph := by
   intro c d h
@@ -290,6 +298,22 @@ theorem not_decomposable : ¬ Decomposable graph := by
   have h1 : layer paymentPort < layer orderPort := hLayer edge.orderPort_paymentPort
   have h2 : layer orderPort < layer paymentPort := hLayer edge.paymentPort_orderPort
   exact Nat.lt_asymm h1 h2
+
+/--
+The strong operational DIP condition and non-decomposability hold together in
+the abstract-layer-cycle example.
+-/
+theorem dipCompatible_and_not_decomposable :
+    DIPCompatible graph projection abstractGraph ∧ ¬ Decomposable graph :=
+  ⟨dipCompatible, not_decomposable⟩
+
+/--
+Even exact projection plus representative stability does not by itself exclude
+the abstract-layer cycle.
+-/
+theorem strongDIPCompatible_and_not_decomposable :
+    StrongDIPCompatible graph projection abstractGraph ∧ ¬ Decomposable graph :=
+  ⟨strongDIPCompatible, not_decomposable⟩
 
 end StrongAbstractCycleComponent
 

--- a/docs/design_principle_classification.md
+++ b/docs/design_principle_classification.md
@@ -141,7 +141,7 @@ Dependencies:
 
 この例では、具象 `OrderAdapter` / `PaymentAdapter` は抽象 `OrderPort` / `PaymentPort` へ依存しており、具象への逆向き依存はない。それでも抽象層 `OrderPort <-> PaymentPort` が循環しているため、`Decomposable` は従わない。狙いは、DIP 風の依存方向を保っても、大域的な抽象層の循環を排除するには Layered などの別原則が必要であることを示すことである。
 
-この段階では、旧 `AbstractCycleComponent` は完全な `DIPCompatible` 反例ではなく、`DIP-direction-only counterexample` として位置づける。より強い Lean 例では、`RespectsProjection`, `QuotientWellDefined`, `DIPCompatible`, `LSPCompatible` を満たしながら、抽象層循環により `¬ Decomposable` となる形を用意する。
+旧 `AbstractCycleComponent` は完全な `DIPCompatible` 反例ではなく、`DIP-direction-only counterexample` として位置づける。より強い Lean 例 `StrongAbstractCycleComponent` では、`ProjectionSound`, `ProjectionComplete`, `RepresentativeStable`, `DIPCompatible`, `StrongDIPCompatible`, `LSPCompatible` を満たしながら、抽象層循環により `¬ Decomposable` となることを証明済みである。
 
 `DIPCompatible` は、現行 Lean では単なる具象から抽象への依存方向制約ではなく、`ProjectionSound` と `RepresentativeStable` を合わせた strong operational formalization である。`StrongDIPCompatible` はこれに `ProjectionComplete` を加えた exact-projection refinement として扱う。したがって、DIP 系の局所契約が満たされることと、抽象層そのものが非循環・層化可能であることは別の不変量である。
 

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -295,15 +295,21 @@ File: `Formal/Arch/SolidCounterexample.lean`
 
 | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- |
-| `TwoCycle.not_decomposable` | `theorem` | 2点循環グラフが decomposable でないこと。 | `proved` |
-| `PaymentCycle.not_decomposable` | `theorem` | 局所契約風データを持つ循環例が decomposable でないこと。 | `proved` |
-| `AbstractCycle.not_decomposable` | `theorem` | 抽象層循環例が decomposable でないこと。 | `proved` |
-| `StrongAbstractCycle.lspCompatible` | `theorem` | 強い抽象層循環例が LSP compatible であること。 | `proved` |
-| `StrongAbstractCycle.projectionSound` | `theorem` | 強い抽象層循環例の projection soundness。 | `proved` |
-| `StrongAbstractCycle.projectionComplete` | `theorem` | 強い抽象層循環例の projection completeness。 | `proved` |
-| `StrongAbstractCycle.dipCompatible` | `theorem` | 強い抽象層循環例が DIP compatible であること。 | `proved` |
-| `StrongAbstractCycle.strongDIPCompatible` | `theorem` | 強い抽象層循環例が strong DIP compatible であること。 | `proved` |
-| `StrongAbstractCycle.not_decomposable` | `theorem` | strong DIP / LSP 互換でも decomposable は従わないこと。 | `proved` |
+| `TwoCycleComponent.not_decomposable` | `theorem` | 2点循環グラフが decomposable でないこと。 | `proved` |
+| `PaymentComponent.not_decomposable` | `theorem` | 局所契約風データを持つ循環例が decomposable でないこと。 | `proved` |
+| `AbstractCycleComponent.not_decomposable` | `theorem` | 抽象層循環例が decomposable でないこと。 | `proved` |
+| `StrongAbstractCycleComponent.observation_factors` | `theorem` | 強い抽象層循環例の observation factorization。 | `proved` |
+| `StrongAbstractCycleComponent.lspCompatible` | `theorem` | 強い抽象層循環例が LSP compatible であること。 | `proved` |
+| `StrongAbstractCycleComponent.abstractGraph_not_decomposable` | `theorem` | 抽象 port-level cycle graph が decomposable でないこと。 | `proved` |
+| `StrongAbstractCycleComponent.projectionSound` | `theorem` | 強い抽象層循環例の projection soundness。 | `proved` |
+| `StrongAbstractCycleComponent.projectionComplete` | `theorem` | 強い抽象層循環例の projection completeness。 | `proved` |
+| `StrongAbstractCycleComponent.projectionExact` | `theorem` | 強い抽象層循環例の exact projection。 | `proved` |
+| `StrongAbstractCycleComponent.representativeStable` | `theorem` | 強い抽象層循環例の representative stability。 | `proved` |
+| `StrongAbstractCycleComponent.dipCompatible` | `theorem` | 強い抽象層循環例が DIP compatible であること。 | `proved` |
+| `StrongAbstractCycleComponent.strongDIPCompatible` | `theorem` | 強い抽象層循環例が strong DIP compatible であること。 | `proved` |
+| `StrongAbstractCycleComponent.not_decomposable` | `theorem` | strong DIP / LSP 互換でも decomposable は従わないこと。 | `proved` |
+| `StrongAbstractCycleComponent.dipCompatible_and_not_decomposable` | `theorem` | DIP compatible と `¬ Decomposable` が同時に成立すること。 | `proved` |
+| `StrongAbstractCycleComponent.strongDIPCompatible_and_not_decomposable` | `theorem` | strong DIP compatible と `¬ Decomposable` が同時に成立すること。 | `proved` |
 
 ## 現在 Lean に入れていないもの
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -380,15 +380,22 @@ Lean status:
   `dipCompatible_of_strongDIPCompatible`,
   `mem_projectionSoundnessViolationEdges_iff`,
   `projectionSoundnessViolation_eq_zero_of_projectionSound`,
-  `projectionSound_of_projectionSoundnessViolation_eq_zero`
+  `projectionSound_of_projectionSoundnessViolation_eq_zero`,
+  `StrongAbstractCycleComponent.abstractGraph_not_decomposable`,
+  `StrongAbstractCycleComponent.dipCompatible_and_not_decomposable`,
+  `StrongAbstractCycleComponent.strongDIPCompatible_and_not_decomposable`
+
+Issue [#81](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/81)
+では、DIP 風の依存方向だけでなく `DIPCompatible` /
+`StrongDIPCompatible` を満たしても、抽象層の循環から
+`¬ Decomposable` が起こり得ることを証明済みである。
+これは Layered とは別軸の局所契約 invariant として扱う。
 
 今後の proof obligation:
 
 - exact projection の edge-level bridge theorem を追加する場合は、
   `ProjectionExact G π GA` から `GA.edge a b` と
   `exists c d, π.expose c = a ∧ π.expose d = b ∧ G.edge c d` の同値を切る。
-- SOLID 不完全性反例では、DIP 風の依存方向や `DIPCompatible` を満たしても、
-  抽象層の循環から `¬ Decomposable` が起こり得ることを Layered とは別軸として扱う。
 
 ### 6. LSP は観測関手による同値性である
 


### PR DESCRIPTION
## 概要

Closes #81

`StrongAbstractCycleComponent` で、抽象 port-level cycle 自体が decomposable でないことと、`DIPCompatible` / `StrongDIPCompatible` と `¬ Decomposable` が同時に成立することを明示した。あわせて proof obligations と theorem index を、Issue #81 の Lean status が `proved` であることに合わせて更新した。

## 証明した定理

- `StrongAbstractCycleComponent.abstractGraph_not_decomposable`
- `StrongAbstractCycleComponent.dipCompatible_and_not_decomposable`
- `StrongAbstractCycleComponent.strongDIPCompatible_and_not_decomposable`

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/design_principle_classification.md`
- `docs/formal/lean_theorem_index.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/SolidCounterexample.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
