### PR TITLE
docs の現状反映と索引を整備

### DIFF
--- a/docs/aat_v2_overview.md
+++ b/docs/aat_v2_overview.md
@@ -95,9 +95,9 @@ Sig0(A) =
 
 `maxDepth` は初期 Lean 実装では bounded max depth として扱う。循環グラフ上の真の大域 depth ではなく、有限 universe による fuel-bounded measurement である。循環リスクは `hasCycle` の別軸で扱う。
 
-`sccMaxSize` は初期指標として残すが、将来的には非循環成分を 0 risk にするため `sccExcessSize = sccMaxSize - 1` への正規化を検討する。`fanoutRisk : Nat` は v0 では `totalFanout` として定義し、疎なグラフでも測定 universe 内に依存辺があれば 0 に丸め落ちないようにする。`maxFanout` は局所集中を表す別軸として、Signature v1 以降で追加を検討する。
+`sccMaxSize` は v0 互換の説明用指標として残すが、v1 core では非循環 singleton SCC を 0 risk にするため `sccExcessSize = sccMaxSize - 1` へ正規化する。`fanoutRisk : Nat` は v0 では `totalFanout` として定義し、疎なグラフでも測定 universe 内に依存辺があれば 0 に丸め落ちないようにする。`maxFanout` は局所集中を表す v1 core 軸、`reachableConeSize` は変更波及の到達範囲を表す v1 core 軸として追加済みである。
 
-Lean PR4 では、有限な component list を測定 universe とする executable v0 metrics を定義する。Lean PR5 では、その list に `Nodup`, coverage, edge-closedness を持たせる `ComponentUniverse` を追加し、bounded reachability と `Walk` / `Reachable` の基本的な正当性 bridge を証明する。現在の `ComponentUniverse` は full universe なので edge-closedness は coverage から導けるが、将来 closed measurement sub-universe を扱う余地を残すため明示フィールドとして保持する。これは実コードベース抽出器の完全性を主張するものではない。SCC count と相互到達可能性の同値類との接続は、次の proof obligation として残す。
+Lean 側では、有限な component list を測定 universe とする executable v0 metrics と、その list に `Nodup`, coverage, edge-closedness を持たせる `ComponentUniverse` を定義済みである。bounded reachability と `Walk` / `Reachable` の bridge、cycle indicator correctness、SCC count と相互到達可能性 class size の bridge、v1 core 派生 metric の主要 bridge は証明済みである。現在の `ComponentUniverse` は full universe なので edge-closedness は coverage から導けるが、将来 closed measurement sub-universe を扱う余地を残すため明示フィールドとして保持する。これは実コードベース抽出器の完全性を主張するものではない。
 
 発展シグネチャ `Sig1(A)` では、解析的・実証的な軸を追加する。
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2,11 +2,15 @@
 
 このディレクトリには、全体方針から切り出した個別 design / protocol 文書を置く。
 
-- [Sig0 extractor v0 設計](sig0_extractor_design.md)
-- [Signature 実証プロトコル](empirical_protocol.md)
-- [ArchitectureSignature v1 後半戦まとめ](signature_v1_wrapup.md)
-- [relationComplexity 設計](relation_complexity_design.md)
-- [runtimePropagation 設計](runtime_propagation_design.md)
-- [Projection soundness と exact projection の使い分け](projection_exact_soundness.md)
-- [Observation bridge と projection bridge の関係](observation_projection_bridge.md)
-- [spectral radius bridge 設計](spectral_radius_bridge.md)
+## 文書一覧
+
+| 文書 | 区分 | 用途 |
+| --- | --- | --- |
+| [Sig0 extractor v0 設計](sig0_extractor_design.md) | tooling design / empirical hypothesis | Lean module import graph から Signature v0 JSON を作る最小 extractor と、Lean `ComponentUniverse` との責務境界を整理する。 |
+| [Signature 実証プロトコル](empirical_protocol.md) | empirical protocol | Signature と PR / issue / incident metadata を結合し、変更波及・レビューコスト・障害修正との関係を検証する手順を固定する。 |
+| [ArchitectureSignature v1 後半戦まとめ](signature_v1_wrapup.md) | Lean schema / design decision | v0 互換軸、v1 core、optional extension axis の責務境界をまとめる。 |
+| [relationComplexity 設計](relation_complexity_design.md) | tooling design / empirical hypothesis | 状態遷移代数層の複雑度を workflow observation として測る方針を整理する。 |
+| [runtimePropagation 設計](runtime_propagation_design.md) | Lean executable metric / tooling boundary | 0/1 `RuntimeDependencyGraph` 上の propagation radius と runtime metadata の境界を整理する。 |
+| [Projection soundness と exact projection の使い分け](projection_exact_soundness.md) | Lean bridge design | `ProjectionSound` で足りる主張と `ProjectionExact` が必要な refinement を分ける。 |
+| [Observation bridge と projection bridge の関係](observation_projection_bridge.md) | Lean bridge design / future proof obligation | projection bridge と observation bridge を局所契約層で並列に扱う方針を整理する。 |
+| [spectral radius bridge 設計](spectral_radius_bridge.md) | Lean bridge / empirical boundary | `rho(A)` の構造的 theorem と変更・障害コストの empirical claim を分離する。 |

--- a/docs/design/sig0_extractor_design.md
+++ b/docs/design/sig0_extractor_design.md
@@ -158,6 +158,15 @@ boundary / abstraction policy が未指定の場合の最小例:
 `averageFanout` 由来の名前が残る場合でも、extractor v0 の出力では `fanoutRisk` を
 正規の列名にし、必要なら Lean 側 field との mapping を adapter で明示する。
 
+実装上、`components` は repository 内で検出した Lean source file に対応する local
+module component だけを列挙する。一方で、`edges` と executable graph metric は
+import target に現れる外部 module も graph node として扱う。たとえば `Mathlib.*` import
+は `components` には入らないが、edge target としては残る。このため extractor v0 の
+`fanoutRisk` は tooling output 上の unique import edge count であり、Lean の
+`ComponentUniverse` にそのまま渡した finite component list 上の `totalFanout` と
+同一視しない。Lean 側へ接続する場合は、local-only projection か external dependency
+node を含む測定 universe を別途明示する。
+
 `nilpotencyIndex`, `rho(A)`, `runtimePropagation`, `relationComplexity`,
 `empiricalChangeCost` は v0 extractor の対象外である。これらは matrix bridge、
 runtime dependency extraction、state transition algebra、実証プロトコルの後続課題に
@@ -207,10 +216,13 @@ policy file は v0 の対象外である。そのため `boundaryViolationCount`
 
 ## 後続 Issue への分割
 
-この設計から、後続実装は次の単位に分けられる。
+この設計のうち、Issue #51 では次を実装済みである。
 
 - Lean module import graph を抽出し、component / edge JSON を出力する CLI を作る。
 - JSON output から `hasCycle`, `sccMaxSize`, `maxDepth`, `fanoutRisk` を計算する。
+
+残る後続実装は次の単位に分けられる。
+
 - boundary / abstraction policy file の最小 schema を設計し、violation count を出す。
 - extractor output と `ComponentUniverse` の責務境界を検査する validation report を出す。
 - 複数 repository に対する signature 時系列と PR metadata を結合する実証 protocol を作る。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -21,6 +21,7 @@ File: `Formal/Arch/Graph.lean`
 | `Walk.vertices` | `def` | walk が通る頂点列。 | `defined only` |
 | `Walk.vertices_length` | `theorem` | `vertices` と `length` の基本関係。 | `proved` |
 | `SimpleWalk` | `structure` | 頂点重複のない walk。 | `defined only` |
+| `Path` | `abbrev` | 現時点では `SimpleWalk` の別名。bounded reachability で使う path representative。 | `defined only` |
 | `SimpleWalk.vertices_length` | `theorem` | simple walk の頂点列と長さの基本関係。 | `proved` |
 
 ## Reachability
@@ -90,7 +91,9 @@ File: `Formal/Arch/Projection.lean`
 | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- |
 | `InterfaceProjection` | `structure` | 具象 component から抽象 component への射影。 | `defined only` |
+| `AbstractGraph` | `abbrev` | 射影先の抽象依存グラフ。 | `defined only` |
 | `ProjectedDeps` | `def` | 具象依存を抽象依存へ写した関係。 | `defined only` |
+| `RespectsProjection` | `def` | すべての具象依存 edge が抽象 edge として表現されること。 | `defined only` |
 | `ProjectionSound` | `abbrev` | 具象依存が抽象依存へ sound に写ること。 | `defined only` |
 | `projectionSoundnessViolationEdges` | `def` | 有限な測定 universe 上で、abstract edge に写らない concrete edge のリスト。 | `defined only` |
 | `mem_projectionSoundnessViolationEdges_iff` | `theorem` | projection soundness violation edge の membership が、測定対象 concrete edge かつ projected abstract edge 不在であることと一致する。 | `proved` |
@@ -106,8 +109,13 @@ File: `Formal/Arch/Projection.lean`
 | `projectionSound_of_projectionExact` | `theorem` | exact projection から soundness を得る。 | `proved` |
 | `projectionComplete_of_projectionExact` | `theorem` | exact projection から completeness を得る。 | `proved` |
 | `dipCompatible_of_strongDIPCompatible` | `theorem` | strong DIP compatible なら DIP compatible。 | `proved` |
+| `respectsProjection_id` | `theorem` | identity projection は元の graph を respect する。 | `proved` |
+| `quotientWellDefined_id` | `theorem` | identity projection は quotient well-defined。 | `proved` |
 | `dipCompatible_id` | `theorem` | identity projection は DIP compatible。 | `proved` |
+| `projectionComplete_id` | `theorem` | identity projection は complete。 | `proved` |
+| `projectionExact_id` | `theorem` | identity projection は exact。 | `proved` |
 | `strongDIPCompatible_id` | `theorem` | identity projection は strong DIP compatible。 | `proved` |
+| `mapReachable` | `def` | projection soundness の下で具象到達可能性を抽象到達可能性へ写す。 | `proved` |
 
 ## Observation / LSP
 
@@ -200,9 +208,15 @@ File: `Formal/Arch/Finite.lean`
 | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- |
 | `ComponentUniverse` | `structure` | finite measurement universe with proofs。 | `defined only` |
+| `ComponentUniverse.edgeClosed_of_covers` | `theorem` | full coverage universe では edge-closedness が coverage から従う。 | `proved` |
 | `ComponentUniverse.full` | `def` | full coverage universe を作る。 | `defined only` |
 | `ComponentUniverse.v0` | `def` | universe から v0 signature を計算する。 | `defined only` |
 | `FiniteArchGraph` | `structure` | `ArchGraph` と `ComponentUniverse` を束ねる構造。 | `defined only` |
+| `FiniteArchGraph.ofComponentUniverse` | `def` | 既存の graph と component universe を `FiniteArchGraph` として束ねる。 | `defined only` |
+| `FiniteArchGraph.components` | `def` | bundled component universe の測定 component list を読む。 | `defined only` |
+| `FiniteArchGraph.nodup_components` | `theorem` | `FiniteArchGraph.components` が duplicate-free であること。 | `proved` |
+| `FiniteArchGraph.covers_components` | `theorem` | `FiniteArchGraph.components` が全 component を cover すること。 | `proved` |
+| `FiniteArchGraph.edgeClosed_components` | `theorem` | `FiniteArchGraph` の edge が component universe 内に閉じていること。 | `proved` |
 | `FiniteArchGraph.v0` | `def` | finite graph から v0 signature を計算する。 | `defined only` |
 | `ComponentUniverse.reachable_exists_bounded_path` | `theorem` | finite universe 上で reachable なら bounded simple path がある。 | `proved` |
 | `reachableBool_eq_true_iff` | `theorem` | executable reachable boolean と propositional reachable の接続。 | `proved` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -624,10 +624,10 @@ per component, per KLOC などの正規化は raw count を置き換えない将
 この規約の Lean status は `empirical hypothesis` / tooling design であり、
 Lean theorem ではない。
 
-v1 core に追加・正規化する候補:
+v1 core / extension に追加・正規化した軸:
 
 - `sccExcessSize = sccMaxSize - 1`: 非循環 singleton SCC を 0 risk として扱うための循環リスク軸。
-- `weightedSccRisk`: SCC の大きさや重要度を重みづけする将来の executable metric。
+- `weightedSccRisk`: SCC の大きさや重要度を重みづけする executable extension metric。
 - `maxFanout`: 局所的な依存集中を表す executable metric。
 - `reachableConeSize`: 変更波及の到達範囲を表す executable metric。
 - `projectionSoundnessViolation`: 抽象射影に反する具体依存を数える projection bridge 軸。
@@ -754,23 +754,28 @@ Lean status の区分:
 | `relationComplexity` | 状態遷移代数層の設計に依存する | `empirical hypothesis` |
 | `empiricalChangeCost` | 実データで検証する目的変数 | `empirical hypothesis` |
 
-後続 Issue への分割:
+完了済み・設計整理済みの項目:
 
 - adjacency matrix と `rho(A)` の解析的拡張は
   [#94](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/94)
   と [#95](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/95)
-  に分割して扱う。
+  に分割し、finite DAG で `rho(A)=0`、finite closed walk で `rho(A)>0`
+  になる bridge theorem を証明済みである。
 - 静的依存と実行時依存の分離は
   [#33](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/33)
-  で扱う。
-- 実コードベースからの Sig0 / v1 core 抽出 tooling は
+  で `StaticDependencyGraph`, `RuntimeDependencyGraph`,
+  `ArchitectureDependencyGraphs` の role alias / bundle として定義済みである。
+- 最小 Sig0 extractor CLI は
+  [#51](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/51)
+  で `tools/sig0-extractor/` に実装済みである。
+- 実コードベースからの Sig0 / v1 core 抽出 tooling の設計境界は
   [#34](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/34)
-  で扱う。最小 Sig0 extractor の v0 設計は
+  で扱う。最小 Sig0 extractor の v0 設計と現在の実装境界は
   [sig0_extractor_design.md](design/sig0_extractor_design.md)
   に分離する。
 - 実証プロトコルと empirical cost 軸は
   [#35](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/35)
-  で扱う。初期 protocol は
+  で扱う。初期 protocol 設計は
   [empirical_protocol.md](design/empirical_protocol.md)
   に分離する。
 - `relationComplexity` は
@@ -780,14 +785,27 @@ Lean status の区分:
   に分離する。
 - `runtimePropagation` の最小 metric と extractor 境界は
   [#86](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/86)
-  で扱う。初期設計は
+  で `runtimePropagationOfFinite` と
+  `v1OfFiniteWithRuntimePropagation` を定義済みである。初期設計は
   [runtime_propagation_design.md](design/runtime_propagation_design.md)
   に分離する。
 - Signature v1 後半戦の統合整理は
   [#83](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/83)
-  で扱う。完了時のまとめは
+  で完了し、まとめは
   [signature_v1_wrapup.md](design/signature_v1_wrapup.md)
   に分離する。
+
+残る後続タスク:
+
+- boundary / abstraction policy file の最小 schema を設計し、tooling 側で
+  violation count を測れるようにする。
+- extractor output と Lean の `ComponentUniverse` の責務境界を検査する
+  validation report を設計する。
+- v1 core / extension output と PR metadata を結合する empirical dataset を作る。
+- `ProjectionExact` から抽象 edge と投影された具体 edge 集合の一致を読む
+  edge-level bridge theorem を追加するか判断する。
+- `DIPCompatible G π GA` と `ObservationFactorsThrough π O` を束ねる
+  `LocalReplacementContract` 風の packaging theorem を追加するか判断する。
 
 Bridge theorem naming policy:
 


### PR DESCRIPTION
## 概要

Closes #101

docs の現状確認に基づき、Lean 実装済みの内容とドキュメントの軽微なズレを整理する。

- v1 core metric と `ComponentUniverse` 周辺の説明を現状に合わせる
- Sig0 extractor v0 と Lean finite universe の責務境界を明記する
- Lean 定義・定理索引に主要 API を追加する
- `proof_obligations.md` で完了済み項目と残タスクを分ける
- `docs/design/README.md` を区分つきの案内表にする

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat_v2_overview.md`
- `docs/design/README.md`
- `docs/design/sig0_extractor_design.md`
- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

`axiom` / `sorry` scan は docs の方針説明だけに一致し、Lean source への混入はない。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている