### PR TITLE
ProjectionExact の edge-level bridge theorem を追加

### DIFF
--- a/Formal/Arch/Projection.lean
+++ b/Formal/Arch/Projection.lean
@@ -139,6 +139,32 @@ theorem projectionComplete_of_projectionExact {C : Type u} {A : Type v}
     (h : ProjectionExact G π GA) : ProjectionComplete G π GA :=
   h.2
 
+/-- Projection completeness turns an abstract edge into a concrete edge witness. -/
+theorem projectedConcreteEdge_of_projectionComplete {C : Type u} {A : Type v}
+    {G : ArchGraph C} {π : InterfaceProjection C A} {GA : AbstractGraph A}
+    (h : ProjectionComplete G π GA) {a b : A} (hEdge : GA.edge a b) :
+    ∃ c d : C, π.expose c = a ∧ π.expose d = b ∧ G.edge c d :=
+  h hEdge
+
+/--
+Exact projection identifies abstract edges with projected concrete edge
+witnesses.
+-/
+theorem abstractEdge_iff_projectedConcreteEdge_of_projectionExact
+    {C : Type u} {A : Type v}
+    {G : ArchGraph C} {π : InterfaceProjection C A} {GA : AbstractGraph A}
+    (h : ProjectionExact G π GA) {a b : A} :
+    GA.edge a b ↔
+      ∃ c d : C, π.expose c = a ∧ π.expose d = b ∧ G.edge c d := by
+  constructor
+  · intro hEdge
+    exact projectedConcreteEdge_of_projectionComplete
+      (projectionComplete_of_projectionExact h) hEdge
+  · rintro ⟨c, d, hc, hd, hEdge⟩
+    have hAbstract : GA.edge (π.expose c) (π.expose d) :=
+      projectionSound_of_projectionExact h hEdge
+    simpa [hc, hd] using hAbstract
+
 /--
 The quotient is well-defined when representatives of the same abstraction
 induce the same abstract outgoing dependency predicate.

--- a/docs/design/projection_exact_soundness.md
+++ b/docs/design/projection_exact_soundness.md
@@ -59,8 +59,10 @@ executable metric である。
 - `dipCompatible_of_strongDIPCompatible`
 - `projectionSoundnessViolation_eq_zero_of_projectionSound`
 - `projectionSound_of_projectionSoundnessViolation_eq_zero`
+- `projectedConcreteEdge_of_projectionComplete`
+- `abstractEdge_iff_projectedConcreteEdge_of_projectionExact`
 
-後続で追加するなら、次の方向を別 Issue に分ける。
+Issue #107 では、次の片方向 witness theorem を追加した。
 
 ```text
 ProjectionComplete G π GA ->
@@ -69,6 +71,8 @@ ProjectionComplete G π GA ->
 ```
 
 これは定義の展開補題であり、抽象辺を具体 witness へ戻す bridge の入口になる。
+
+同じ Issue #107 では、次の exact projection edge-level bridge theorem も追加した。
 
 ```text
 ProjectionExact G π GA ->

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -108,6 +108,8 @@ File: `Formal/Arch/Projection.lean`
 | `StrongDIPCompatible` | `def` | `DIPCompatible` に `ProjectionComplete` を加えた強い互換性。 | `defined only` |
 | `projectionSound_of_projectionExact` | `theorem` | exact projection から soundness を得る。 | `proved` |
 | `projectionComplete_of_projectionExact` | `theorem` | exact projection から completeness を得る。 | `proved` |
+| `projectedConcreteEdge_of_projectionComplete` | `theorem` | completeness から抽象 edge の具体 edge witness を得る。 | `proved` |
+| `abstractEdge_iff_projectedConcreteEdge_of_projectionExact` | `theorem` | exact projection の下で抽象 edge と投影された具体 edge witness が同値。 | `proved` |
 | `dipCompatible_of_strongDIPCompatible` | `theorem` | strong DIP compatible なら DIP compatible。 | `proved` |
 | `respectsProjection_id` | `theorem` | identity projection は元の graph を respect する。 | `proved` |
 | `quotientWellDefined_id` | `theorem` | identity projection は quotient well-defined。 | `proved` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -377,6 +377,8 @@ Lean status:
   `projectionSoundnessViolationEdges`, `projectionSoundnessViolation`
 - `proved`: `projectionSound_of_projectionExact`,
   `projectionComplete_of_projectionExact`,
+  `projectedConcreteEdge_of_projectionComplete`,
+  `abstractEdge_iff_projectedConcreteEdge_of_projectionExact`,
   `dipCompatible_of_strongDIPCompatible`,
   `mem_projectionSoundnessViolationEdges_iff`,
   `projectionSoundnessViolation_eq_zero_of_projectionSound`,
@@ -391,11 +393,13 @@ Issue [#81](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/81
 `¬ Decomposable` が起こり得ることを証明済みである。
 これは Layered とは別軸の局所契約 invariant として扱う。
 
-今後の proof obligation:
-
-- exact projection の edge-level bridge theorem を追加する場合は、
-  `ProjectionExact G π GA` から `GA.edge a b` と
-  `exists c d, π.expose c = a ∧ π.expose d = b ∧ G.edge c d` の同値を切る。
+Issue [#107](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/107)
+では、exact projection の edge-level bridge theorem を追加する判断を採用した。
+`abstractEdge_iff_projectedConcreteEdge_of_projectionExact` により、
+`ProjectionExact G π GA` から `GA.edge a b` と
+`exists c d, π.expose c = a ∧ π.expose d = b ∧ G.edge c d` の同値を読める。
+片方向の witness 取り出しは
+`projectedConcreteEdge_of_projectionComplete` として切り出した。
 
 ### 6. LSP は観測関手による同値性である
 
@@ -818,8 +822,6 @@ Lean status の区分:
 
 残る後続タスク:
 
-- `ProjectionExact` から抽象 edge と投影された具体 edge 集合の一致を読む
-  edge-level bridge theorem を追加するか判断する。
 - `DIPCompatible G π GA` と `ObservationFactorsThrough π O` を束ねる
   `LocalReplacementContract` 風の packaging theorem を追加するか判断する。
 


### PR DESCRIPTION
## 概要

Closes #107

`ProjectionExact` を抽象 edge 集合と投影された具体 edge witness の一致として読めるように、edge-level bridge theorem を追加しました。`projectionSoundnessViolation` は引き続き soundness-only metric として扱い、exact projection gap とは分けています。

## 証明した定理

- `projectedConcreteEdge_of_projectionComplete`
- `abstractEdge_iff_projectedConcreteEdge_of_projectionExact`

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/design/projection_exact_soundness.md`
- `docs/formal/lean_theorem_index.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/Projection.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている