### PR TITLE
Sig0 extractorでComponentUniverse validation reportを生成する

### DIFF
--- a/docs/design/component_universe_validation_report.md
+++ b/docs/design/component_universe_validation_report.md
@@ -1,11 +1,15 @@
 # ComponentUniverse validation report v0
 
-Lean status: `empirical hypothesis` / tooling design.
+Lean status: `empirical hypothesis` / tooling implementation.
 
 この文書は Issue [#109](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/109)
 の設計メモである。目的は、Sig0 / v1 extractor output と Lean の
 `ComponentUniverse` の責務境界を検査する validation report の最小 schema と CLI
 contract を固定することである。
+
+Issue [#116](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/116)
+で、Sig0 extractor output を入力にこの report を生成する
+`sig0-extractor validate --input ...` を実装した。
 
 ここで定義する report は Lean theorem ではない。extractor が現実コードベースから
 作った JSON graph を、Lean 側の proof-carrying measurement universe に渡せる形へ

--- a/docs/design/sig0_extractor_design.md
+++ b/docs/design/sig0_extractor_design.md
@@ -238,7 +238,8 @@ Issue #115 では `--policy` で
 - extractor output と `ComponentUniverse` の責務境界を検査する validation report の
   schema と CLI contract は
   [ComponentUniverse validation report v0](component_universe_validation_report.md)
-  で固定した。後続実装ではこの report を生成する。
+  で固定し、Issue #116 で `sig0-extractor validate --input ...` として実装した。
+  同時に core 4 軸の `metricStatus` も測定済み metadata として出力するようにした。
 - 複数 repository に対する signature 時系列と PR metadata を結合する empirical dataset
   schema は [empirical dataset v0 schema](empirical_dataset_schema.md) で固定した。
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -824,6 +824,12 @@ Lean status の区分:
   [component_universe_validation_report.md](design/component_universe_validation_report.md)
   に分離する。これは `Nodup`, coverage, edge-closedness に対応する JSON-level
   tooling evidence であり、`ComponentUniverse` の Lean witness そのものではない。
+- Sig0 extractor output から上記 validation report を生成する CLI は
+  [#116](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/116)
+  で `sig0-extractor validate --input ...` として実装済みである。report は入力 JSON の
+  `components`, `edges`, `metricStatus` に基づく tooling-side evidence であり、
+  Lean witness そのものではない。core 4 軸の `metricStatus` も測定済み metadata として
+  extractor output に含める。
 
 残る後続タスク:
 

--- a/tools/sig0-extractor/README.md
+++ b/tools/sig0-extractor/README.md
@@ -16,6 +16,21 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
 `--policy` を省略すると boundary / abstraction policy は未評価の placeholder として
 出力される。`--out` を省略すると JSON は stdout に出力される。
 
+既存 Sig0 JSON から `ComponentUniverse` 境界に対応する validation report を生成する場合は
+次を使う。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate \
+  --input .lake/sig0.json \
+  --out .lake/sig0-validation.json \
+  --universe-mode local-only
+```
+
+`validate` は source file を再 scan せず、入力 JSON の `components`, `edges`,
+`metricStatus` から duplicate-free component list, local edge closure, external target,
+policy metric status を検査する。report は tooling-side evidence であり、
+`ComponentUniverse` の Lean witness そのものではない。
+
 repository root を測定する場合、`.git`, `.lake`, `.elan`, `target`, root 直下の
 `tools` は scan 対象から除外する。これは extractor 自身の fixture や build artifact
 を Lean module import graph に混ぜないための v0 の実装仕様である。
@@ -27,7 +42,12 @@ repository root を測定する場合、`.git`, `.lake`, `.elan`, `target`, root
 - `components`: Lean source file から得た module component。
 - `edges`: `source depends on target` の import edge。これは `ArchGraph.edge source target` に対応する。
 - `signature`: import graph から計算した `hasCycle`, `sccMaxSize`, `maxDepth`, `fanoutRisk` と、policy 評価に基づく violation count。
-- `metricStatus`: `boundaryViolationCount` / `abstractionViolationCount` が測定済みか、placeholder 欠損値かを記録する。
+- `metricStatus`: 各 signature 軸が測定済みか、placeholder 欠損値かを記録する。
 - `policyViolations`: policy 評価で検出した unique dependency edge 単位の evidence。違反がなければ省略される。
 
 この CLI は `ComponentUniverse` の完全な witness を生成したとは主張しない。duplicate-free component list, edge closure, coverage などの証明付き universe は Lean 側の別責務として扱う。
+
+validation report の出力 schema は
+`schemaVersion: "component-universe-validation-report-v0"` の単一 JSON document である。
+`summary.result` は `pass`, `warn`, `fail` のいずれかで、`fail` の場合だけ CLI の終了コードは
+`1` になる。入力 JSON を読めない、または report を生成できない場合の終了コードは `2` である。

--- a/tools/sig0-extractor/src/lib.rs
+++ b/tools/sig0-extractor/src/lib.rs
@@ -9,6 +9,8 @@ use walkdir::{DirEntry, WalkDir};
 
 pub const SCHEMA_VERSION: &str = "sig0-extractor-v0";
 pub const COMPONENT_KIND: &str = "lean-module";
+pub const VALIDATION_REPORT_SCHEMA_VERSION: &str = "component-universe-validation-report-v0";
+pub const DEFAULT_UNIVERSE_MODE: &str = "local-only";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,6 +91,72 @@ pub struct PolicyViolation {
     pub relation_ids: Option<Vec<String>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentUniverseValidationReport {
+    pub schema_version: String,
+    pub input: ValidationInput,
+    pub universe_mode: String,
+    pub summary: ValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub root: String,
+    pub component_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationSummary {
+    pub result: String,
+    pub component_count: usize,
+    pub local_edge_count: usize,
+    pub external_edge_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+    pub not_measured_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationCheck {
+    pub id: String,
+    pub title: String,
+    pub result: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<ValidationExample>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metric: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lean_boundary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationExample {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ImportEdge {
     source: String,
@@ -132,6 +200,12 @@ pub fn extract_sig0_with_policy(
     let mut signature = compute_signature(&components, &edges);
 
     let mut metric_status = BTreeMap::new();
+    for axis in ["hasCycle", "sccMaxSize", "maxDepth", "fanoutRisk"] {
+        metric_status.insert(
+            axis.to_string(),
+            measured_status("sig0-extractor:import-graph"),
+        );
+    }
     metric_status.insert(
         "boundaryViolationCount".to_string(),
         MetricStatus {
@@ -242,6 +316,395 @@ pub fn extract_sig0_with_policy(
         metric_status,
         policy_violations,
     })
+}
+
+pub fn validate_component_universe_report(
+    document: &Sig0Document,
+    input_path: &str,
+    universe_mode: &str,
+) -> Result<ComponentUniverseValidationReport, Box<dyn Error>> {
+    if !matches!(universe_mode, "local-only" | "closed-with-external") {
+        return Err(format!("unsupported universe mode: {universe_mode}").into());
+    }
+
+    let component_ids: BTreeSet<String> = document
+        .components
+        .iter()
+        .map(|component| component.id.clone())
+        .collect();
+    let local_roots = component_roots(&component_ids);
+    let external_edges = external_edges(document, &component_ids, &local_roots);
+    let local_edge_count = document
+        .edges
+        .iter()
+        .filter(|edge| component_ids.contains(&edge.source) && component_ids.contains(&edge.target))
+        .count();
+
+    let mut checks = Vec::new();
+
+    checks.push(check_schema_version(&document.schema_version));
+    checks.push(check_component_id_nodup(&document.components));
+    checks.push(check_component_path_nodup(&document.components));
+    checks.push(check_edge_endpoint_resolved(
+        &document.edges,
+        &component_ids,
+        &local_roots,
+    ));
+    checks.push(check_edge_closure_local(
+        &document.edges,
+        &component_ids,
+        &local_roots,
+    ));
+    checks.push(check_external_edge_targets(&external_edges, universe_mode));
+    checks.push(check_metric_status_complete(&document.metric_status));
+    checks.push(check_metric_measured(
+        "boundary-policy-status",
+        "boundary violation metric is measured",
+        "boundaryViolationCount",
+        &document.metric_status,
+    ));
+    checks.push(check_metric_measured(
+        "abstraction-policy-status",
+        "abstraction violation metric is measured",
+        "abstractionViolationCount",
+        &document.metric_status,
+    ));
+    checks.push(validation_check(
+        "extractor-warning-status",
+        "extractor output has no warnings",
+        "pass",
+    ));
+
+    let failed_check_count = count_checks(&checks, "fail");
+    let warning_check_count = count_checks(&checks, "warn");
+    let not_measured_check_count = count_checks(&checks, "not_measured");
+    let result = if failed_check_count > 0 {
+        "fail"
+    } else if warning_check_count > 0 || not_measured_check_count > 0 {
+        "warn"
+    } else {
+        "pass"
+    };
+
+    let mut warnings = Vec::new();
+    if universe_mode == "local-only" && !external_edges.is_empty() {
+        warnings.push("local-only universe excludes external import targets".to_string());
+    }
+
+    Ok(ComponentUniverseValidationReport {
+        schema_version: VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: ValidationInput {
+            schema_version: document.schema_version.clone(),
+            path: input_path.to_string(),
+            root: document.root.clone(),
+            component_kind: document.component_kind.clone(),
+        },
+        universe_mode: universe_mode.to_string(),
+        summary: ValidationSummary {
+            result: result.to_string(),
+            component_count: document.components.len(),
+            local_edge_count,
+            external_edge_count: external_edges.len(),
+            failed_check_count,
+            warning_check_count,
+            not_measured_check_count,
+        },
+        checks,
+        warnings,
+    })
+}
+
+fn count_checks(checks: &[ValidationCheck], result: &str) -> usize {
+    checks.iter().filter(|check| check.result == result).count()
+}
+
+fn validation_check(id: &str, title: &str, result: &str) -> ValidationCheck {
+    ValidationCheck {
+        id: id.to_string(),
+        title: title.to_string(),
+        result: result.to_string(),
+        reason: None,
+        count: None,
+        examples: Vec::new(),
+        metric: None,
+        lean_boundary: None,
+    }
+}
+
+fn check_schema_version(schema_version: &str) -> ValidationCheck {
+    let mut check = validation_check(
+        "schema-version-supported",
+        "input schema version is supported",
+        if schema_version == SCHEMA_VERSION {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!("unsupported schemaVersion: {schema_version}"));
+    }
+    check
+}
+
+fn check_component_id_nodup(components: &[Component]) -> ValidationCheck {
+    let duplicate_ids = duplicates(components.iter().map(|component| component.id.as_str()));
+    let mut check = validation_check(
+        "component-id-nodup",
+        "component ids are duplicate-free",
+        if duplicate_ids.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    check.lean_boundary = Some("Nodup-like JSON evidence only".to_string());
+    if !duplicate_ids.is_empty() {
+        check.reason = Some("duplicate component ids found".to_string());
+        check.count = Some(duplicate_ids.len());
+        check.examples = duplicate_ids
+            .into_iter()
+            .take(5)
+            .map(|component_id| ValidationExample {
+                component_id: Some(component_id),
+                path: None,
+                source: None,
+                target: None,
+                evidence: None,
+            })
+            .collect();
+    }
+    check
+}
+
+fn check_component_path_nodup(components: &[Component]) -> ValidationCheck {
+    let duplicate_paths = duplicates(components.iter().map(|component| component.path.as_str()));
+    let mut check = validation_check(
+        "component-path-nodup",
+        "component paths are duplicate-free",
+        if duplicate_paths.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !duplicate_paths.is_empty() {
+        check.reason = Some("duplicate component paths found".to_string());
+        check.count = Some(duplicate_paths.len());
+        check.examples = duplicate_paths
+            .into_iter()
+            .take(5)
+            .map(|path| ValidationExample {
+                component_id: None,
+                path: Some(path),
+                source: None,
+                target: None,
+                evidence: None,
+            })
+            .collect();
+    }
+    check
+}
+
+fn check_edge_endpoint_resolved(
+    edges: &[Edge],
+    component_ids: &BTreeSet<String>,
+    local_roots: &BTreeSet<String>,
+) -> ValidationCheck {
+    let unresolved = unresolved_edges(edges, component_ids, local_roots);
+    let mut check = validation_check(
+        "edge-endpoint-resolved",
+        "edge endpoints are local components or external nodes",
+        if unresolved.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !unresolved.is_empty() {
+        check.reason = Some("edge endpoint is not covered by the selected universe".to_string());
+        check.count = Some(unresolved.len());
+        check.examples = unresolved.into_iter().take(5).collect();
+    }
+    check
+}
+
+fn check_edge_closure_local(
+    edges: &[Edge],
+    component_ids: &BTreeSet<String>,
+    local_roots: &BTreeSet<String>,
+) -> ValidationCheck {
+    let open_edges: Vec<ValidationExample> = edges
+        .iter()
+        .filter(|edge| {
+            component_ids.contains(&edge.source)
+                && is_local_like(&edge.target, local_roots)
+                && !component_ids.contains(&edge.target)
+        })
+        .map(edge_example)
+        .collect();
+    let mut check = validation_check(
+        "edge-closure-local",
+        "local dependency edges are closed over selected universe",
+        if open_edges.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    check.lean_boundary = Some("edge-closedness candidate for local-only projection".to_string());
+    if !open_edges.is_empty() {
+        check.reason = Some("local-like dependency target is missing from components".to_string());
+        check.count = Some(open_edges.len());
+        check.examples = open_edges.into_iter().take(5).collect();
+    }
+    check
+}
+
+fn check_external_edge_targets(
+    external_edges: &[ValidationExample],
+    universe_mode: &str,
+) -> ValidationCheck {
+    let has_external_edges = !external_edges.is_empty();
+    let result = if universe_mode == "local-only" && has_external_edges {
+        "warn"
+    } else {
+        "pass"
+    };
+    let mut check = validation_check(
+        "external-edge-targets",
+        "external import targets are outside selected universe",
+        result,
+    );
+    check.lean_boundary =
+        Some("not a ComponentUniverse witness for the full import graph".to_string());
+    if has_external_edges {
+        check.count = Some(external_edges.len());
+        check.examples = external_edges.iter().take(5).cloned().collect();
+    }
+    check
+}
+
+fn check_metric_status_complete(metric_status: &BTreeMap<String, MetricStatus>) -> ValidationCheck {
+    let expected_axes = [
+        "hasCycle",
+        "sccMaxSize",
+        "maxDepth",
+        "fanoutRisk",
+        "boundaryViolationCount",
+        "abstractionViolationCount",
+    ];
+    let missing: Vec<&str> = expected_axes
+        .iter()
+        .copied()
+        .filter(|axis| !metric_status.contains_key(*axis))
+        .collect();
+    let mut check = validation_check(
+        "metric-status-complete",
+        "signature axes have metric status entries",
+        if missing.is_empty() { "pass" } else { "warn" },
+    );
+    if !missing.is_empty() {
+        check.reason = Some(format!(
+            "missing metricStatus entries: {}",
+            missing.join(", ")
+        ));
+        check.count = Some(missing.len());
+    }
+    check
+}
+
+fn check_metric_measured(
+    id: &str,
+    title: &str,
+    metric: &str,
+    metric_status: &BTreeMap<String, MetricStatus>,
+) -> ValidationCheck {
+    let status = metric_status.get(metric);
+    let measured = status.is_some_and(|status| status.measured);
+    let mut check = validation_check(id, title, if measured { "pass" } else { "not_measured" });
+    check.metric = Some(metric.to_string());
+    if !measured {
+        check.reason = Some(
+            status
+                .and_then(|status| status.reason.clone())
+                .unwrap_or_else(|| "metricStatus entry is missing".to_string()),
+        );
+    }
+    check
+}
+
+fn duplicates<'a>(values: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for value in values {
+        *counts.entry(value).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .filter_map(|(value, count)| (count > 1).then(|| value.to_string()))
+        .collect()
+}
+
+fn component_roots(component_ids: &BTreeSet<String>) -> BTreeSet<String> {
+    component_ids
+        .iter()
+        .filter_map(|id| id.split('.').next())
+        .filter(|root| !root.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn unresolved_edges(
+    edges: &[Edge],
+    component_ids: &BTreeSet<String>,
+    local_roots: &BTreeSet<String>,
+) -> Vec<ValidationExample> {
+    edges
+        .iter()
+        .filter(|edge| {
+            edge.source.is_empty()
+                || edge.target.is_empty()
+                || (!component_ids.contains(&edge.source)
+                    && is_local_like(&edge.source, local_roots))
+                || (!component_ids.contains(&edge.target)
+                    && is_local_like(&edge.target, local_roots))
+        })
+        .map(edge_example)
+        .collect()
+}
+
+fn external_edges(
+    document: &Sig0Document,
+    component_ids: &BTreeSet<String>,
+    local_roots: &BTreeSet<String>,
+) -> Vec<ValidationExample> {
+    document
+        .edges
+        .iter()
+        .filter(|edge| {
+            (!component_ids.contains(&edge.source) && !is_local_like(&edge.source, local_roots))
+                || (!component_ids.contains(&edge.target)
+                    && !is_local_like(&edge.target, local_roots))
+        })
+        .map(edge_example)
+        .collect()
+}
+
+fn is_local_like(component_id: &str, local_roots: &BTreeSet<String>) -> bool {
+    component_id
+        .split('.')
+        .next()
+        .is_some_and(|root| local_roots.contains(root))
+}
+
+fn edge_example(edge: &Edge) -> ValidationExample {
+    ValidationExample {
+        component_id: None,
+        path: None,
+        source: Some(edge.source.clone()),
+        target: Some(edge.target.clone()),
+        evidence: Some(edge.evidence.clone()),
+    }
 }
 
 fn measured_status(source: &str) -> MetricStatus {
@@ -923,6 +1386,13 @@ import Should.Not.Appear
         assert_eq!(document.signature.boundary_violation_count, 0);
         assert_eq!(document.signature.abstraction_violation_count, 0);
         assert!(
+            document
+                .metric_status
+                .get("hasCycle")
+                .expect("hasCycle status")
+                .measured
+        );
+        assert!(
             !document
                 .metric_status
                 .get("boundaryViolationCount")
@@ -999,6 +1469,137 @@ import Should.Not.Appear
                     .as_ref()
                     .is_some_and(|relations| relations == &vec!["formal-api".to_string()])
         }));
+    }
+
+    #[test]
+    fn validates_minimal_fixture_with_tooling_boundary_warnings() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal");
+        let policy = root.join("policy_measured_zero.json");
+        let document = extract_sig0_with_policy(&root, Some(&policy)).expect("fixture extracts");
+
+        let report =
+            validate_component_universe_report(&document, ".lake/sig0.json", DEFAULT_UNIVERSE_MODE)
+                .expect("report validates");
+
+        assert_eq!(report.schema_version, VALIDATION_REPORT_SCHEMA_VERSION);
+        assert_eq!(report.universe_mode, DEFAULT_UNIVERSE_MODE);
+        assert_eq!(report.summary.component_count, 3);
+        assert_eq!(report.summary.local_edge_count, 3);
+        assert_eq!(report.summary.external_edge_count, 0);
+        assert_eq!(report.summary.failed_check_count, 0);
+        assert_eq!(report.summary.warning_check_count, 0);
+        assert_eq!(report.summary.not_measured_check_count, 0);
+        assert_eq!(report.summary.result, "pass");
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| { check.id == "metric-status-complete" && check.result == "pass" })
+        );
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| { check.id == "boundary-policy-status" && check.result == "pass" })
+        );
+        assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn validation_report_detects_duplicate_and_uncovered_local_target() {
+        let mut metric_status = BTreeMap::new();
+        metric_status.insert(
+            "boundaryViolationCount".to_string(),
+            unmeasured_status("policy file not provided".to_string()),
+        );
+        metric_status.insert(
+            "abstractionViolationCount".to_string(),
+            unmeasured_status("policy file not provided".to_string()),
+        );
+        let document = Sig0Document {
+            schema_version: SCHEMA_VERSION.to_string(),
+            root: ".".to_string(),
+            component_kind: COMPONENT_KIND.to_string(),
+            components: vec![
+                Component {
+                    id: "Formal".to_string(),
+                    path: "Formal.lean".to_string(),
+                },
+                Component {
+                    id: "Formal".to_string(),
+                    path: "FormalDuplicate.lean".to_string(),
+                },
+            ],
+            edges: vec![Edge {
+                source: "Formal".to_string(),
+                target: "Formal.Arch.Missing".to_string(),
+                kind: "import".to_string(),
+                evidence: "import Formal.Arch.Missing".to_string(),
+            }],
+            policies: Policies {
+                boundary_allowed: Vec::new(),
+                abstraction_allowed: Vec::new(),
+                policy_id: None,
+                schema_version: None,
+                boundary_group_count: None,
+                abstraction_relation_count: None,
+            },
+            signature: Signature {
+                has_cycle: 0,
+                scc_max_size: 1,
+                max_depth: 1,
+                fanout_risk: 1,
+                boundary_violation_count: 0,
+                abstraction_violation_count: 0,
+            },
+            metric_status,
+            policy_violations: Vec::new(),
+        };
+
+        let report =
+            validate_component_universe_report(&document, ".lake/sig0.json", DEFAULT_UNIVERSE_MODE)
+                .expect("report validates");
+
+        assert_eq!(report.summary.result, "fail");
+        assert_eq!(report.summary.failed_check_count, 3);
+        assert!(report.checks.iter().any(|check| {
+            check.id == "component-id-nodup" && check.result == "fail" && check.count == Some(1)
+        }));
+        assert!(report.checks.iter().any(|check| {
+            check.id == "edge-endpoint-resolved" && check.result == "fail" && check.count == Some(1)
+        }));
+        assert!(report.checks.iter().any(|check| {
+            check.id == "edge-closure-local" && check.result == "fail" && check.count == Some(1)
+        }));
+    }
+
+    #[test]
+    fn validation_report_warns_about_external_targets_in_local_only_mode() {
+        let mut document = extract_sig0(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/minimal")
+                .as_path(),
+        )
+        .expect("fixture extracts");
+        document.edges.push(Edge {
+            source: "Formal".to_string(),
+            target: "Mathlib.Data.List.Basic".to_string(),
+            kind: "import".to_string(),
+            evidence: "import Mathlib.Data.List.Basic".to_string(),
+        });
+
+        let report =
+            validate_component_universe_report(&document, ".lake/sig0.json", DEFAULT_UNIVERSE_MODE)
+                .expect("report validates");
+
+        assert_eq!(report.summary.external_edge_count, 1);
+        assert!(report.checks.iter().any(|check| {
+            check.id == "external-edge-targets" && check.result == "warn" && check.count == Some(1)
+        }));
+        assert_eq!(
+            report.warnings,
+            vec!["local-only universe excludes external import targets".to_string()]
+        );
     }
 
     #[test]

--- a/tools/sig0-extractor/src/main.rs
+++ b/tools/sig0-extractor/src/main.rs
@@ -2,13 +2,20 @@ use std::error::Error;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::process::ExitCode;
 
-use clap::Parser;
-use sig0_extractor::extract_sig0_with_policy;
+use clap::{Parser, Subcommand};
+use sig0_extractor::{
+    DEFAULT_UNIVERSE_MODE, Sig0Document, extract_sig0_with_policy,
+    validate_component_universe_report,
+};
 
 #[derive(Debug, Parser)]
 #[command(version, about = "Extract Sig0 input from Lean module imports")]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// Repository root to scan.
     #[arg(long, default_value = ".")]
     root: PathBuf,
@@ -22,11 +29,68 @@ struct Args {
     policy: Option<PathBuf>,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let args = Args::parse();
-    let document = extract_sig0_with_policy(&args.root, args.policy.as_deref())?;
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Validate an existing Sig0 extractor JSON document.
+    Validate {
+        /// Input Sig0 extractor JSON path.
+        #[arg(long)]
+        input: PathBuf,
 
-    match args.out {
+        /// Output validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+
+        /// Universe mode for edge closure checks.
+        #[arg(long, default_value = DEFAULT_UNIVERSE_MODE)]
+        universe_mode: String,
+    },
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run() -> Result<ExitCode, Box<dyn Error>> {
+    let args = Args::parse();
+
+    match args.command {
+        Some(Command::Validate {
+            input,
+            out,
+            universe_mode,
+        }) => {
+            let file = File::open(&input)?;
+            let document: Sig0Document = serde_json::from_reader(file)?;
+            let report = validate_component_universe_report(
+                &document,
+                &input.display().to_string(),
+                &universe_mode,
+            )?;
+            let failed = report.summary.result == "fail";
+            write_json(out, &report)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        None => {
+            let document = extract_sig0_with_policy(&args.root, args.policy.as_deref())?;
+            write_json(args.out, &document)?;
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}
+
+fn write_json<T: serde::Serialize>(out: Option<PathBuf>, value: &T) -> Result<(), Box<dyn Error>> {
+    match out {
         Some(path) => {
             if let Some(parent) = path.parent() {
                 if !parent.as_os_str().is_empty() {
@@ -34,16 +98,15 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
             let mut file = File::create(path)?;
-            serde_json::to_writer_pretty(&mut file, &document)?;
+            serde_json::to_writer_pretty(&mut file, value)?;
             writeln!(file)?;
         }
         None => {
             let stdout = io::stdout();
             let mut handle = stdout.lock();
-            serde_json::to_writer_pretty(&mut handle, &document)?;
+            serde_json::to_writer_pretty(&mut handle, value)?;
             writeln!(handle)?;
         }
     }
-
     Ok(())
 }


### PR DESCRIPTION
## 概要

Closes #116

Sig0 extractor output から `ComponentUniverse` 境界に対応する validation report を生成する `validate` サブコマンドを追加した。

- `component-universe-validation-report-v0` の JSON report を生成
- duplicate component、local edge closure、external target、metricStatus completeness、policy metric status を検査
- core 4 軸の `metricStatus` を extractor output に測定済み metadata として追加
- report が Lean witness ではなく tooling-side evidence であることを docs / README に反映

## 証明した定理

- なし

## 編集したドキュメント

- `tools/sig0-extractor/README.md`
- `docs/design/component_universe_validation_report.md`
- `docs/design/sig0_extractor_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml`
- [x] `cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- --root tools/sig0-extractor/tests/fixtures/minimal --policy tools/sig0-extractor/tests/fixtures/minimal/policy_measured_zero.json --out /tmp/sig0-fixture-policy.json`
- [x] `cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate --input /tmp/sig0-fixture-policy.json --out /tmp/sig0-validation-policy.json`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
