### PR TITLE
docs/design README の Lean status を同期する

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,5 +15,5 @@
 | [relationComplexity 設計](relation_complexity_design.md) | tooling design / empirical hypothesis | 状態遷移代数層の複雑度を workflow observation として測る方針を整理する。 |
 | [runtimePropagation 設計](runtime_propagation_design.md) | Lean executable metric / tooling boundary | 0/1 `RuntimeDependencyGraph` 上の propagation radius と runtime metadata の境界を整理する。 |
 | [Projection soundness と exact projection の使い分け](projection_exact_soundness.md) | Lean bridge design | `ProjectionSound` で足りる主張と `ProjectionExact` が必要な refinement を分ける。 |
-| [Observation bridge と projection bridge の関係](observation_projection_bridge.md) | Lean bridge design / future proof obligation | projection bridge と observation bridge を局所契約層で並列に扱う方針を整理する。 |
+| [Observation bridge と projection bridge の関係](observation_projection_bridge.md) | Lean bridge design / proved packaging | projection bridge と observation bridge を局所契約層で並列に扱い、`LocalReplacementContract` の包装定理との接続を整理する。 |
 | [spectral radius bridge 設計](spectral_radius_bridge.md) | Lean bridge / empirical boundary | `rho(A)` の構造的 theorem と変更・障害コストの empirical claim を分離する。 |


### PR DESCRIPTION
## 概要

Closes #139
Refs #133

`docs/design/README.md` の Observation bridge 項目を、#118 反映後の `LocalReplacementContract` packaging theorem の状態に合わせて更新する。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/design/README.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている