### PR TITLE
docs: Lean 実装と台帳の棚卸しを反映する

### DIFF
--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -163,10 +163,15 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.riskLE_refl` | `theorem` | risk order の反射性。 | `proved` |
 | `ArchitectureSignature.riskLE_trans` | `theorem` | risk order の推移性。 | `proved` |
 | `ArchitectureSignature.riskLE_antisymm` | `theorem` | risk order の反対称性。 | `proved` |
+| `ArchitectureSignature.boolRisk` | `def` | `Bool` を 0/1 risk convention へ写す補助関数。 | `defined only` |
+| `ArchitectureSignature.maxNatList` | `def` | finite metric list の最大値を取る補助関数。 | `defined only` |
+| `ArchitectureSignature.countWhere` | `def` | Boolean predicate を満たす list 要素数を数える補助関数。 | `defined only` |
+| `ArchitectureSignature.componentPairs` | `def` | finite component list 上の ordered pair 測定 universe。 | `defined only` |
 | `ArchitectureSignature.reachesWithin` | `def` | fuel-bounded reachability。 | `defined only` |
 | `ArchitectureSignature.hasCycleBool` | `def` | executable cycle indicator。 | `defined only` |
 | `ArchitectureSignature.sccSizeAt` | `def` | component 周辺の相互到達 class size。 | `defined only` |
 | `ArchitectureSignature.sccMaxSizeOfFinite` | `def` | finite universe 上の最大 SCC サイズ。 | `defined only` |
+| `ArchitectureSignature.fanout` | `def` | component ごとの outgoing dependency count。 | `defined only` |
 | `ArchitectureSignature.totalFanout` | `def` | finite universe 上の総 fanout。 | `defined only` |
 | `ArchitectureSignature.measuredDependencyEdgesFromSource` | `def` | source component 固定で測定される依存辺ペア。 | `defined only` |
 | `ArchitectureSignature.mem_measuredDependencyEdgesFromSource_iff` | `theorem` | source 固定の測定依存辺 membership が selected source からの graph edge と一致すること。 | `proved` |
@@ -186,7 +191,11 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.maxFanoutOfFinite_eq_max_measuredDependencyEdgesFromSource_length` | `theorem` | `maxFanoutOfFinite` が source ごとの測定依存辺数の最大値であること。 | `proved` |
 | `ArchitectureSignature.reachableConeSizeAt` | `def` | v1 core の component ごとの strict bounded reachable cone size。 | `defined only` |
 | `ArchitectureSignature.reachableConeSizeOfFinite` | `def` | v1 core の最大 strict bounded reachable cone size。 | `defined only` |
+| `ArchitectureSignature.averageFanoutOfFinite` | `def` | legacy coarse Nat-valued average fanout。Signature v0 では使わない派生 metric。 | `defined only` |
+| `ArchitectureSignature.boundedDepthFrom` | `def` | component ごとの fuel-bounded dependency-chain depth。 | `defined only` |
 | `ArchitectureSignature.maxDepthOfFinite` | `def` | finite universe 上の bounded max depth。 | `defined only` |
+| `ArchitectureSignature.boundaryViolationCountOfFinite` | `def` | supplied boundary policy に反する測定依存辺数。 | `defined only` |
+| `ArchitectureSignature.abstractionViolationCountOfFinite` | `def` | supplied abstraction policy に反する測定依存辺数。 | `defined only` |
 | `ArchitectureSignature.v0OfFinite` | `def` | finite universe から v0 signature を計算する。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1Core` | `structure` | v0 signature と Lean-measured v1 core axis を束ねる schema。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1` | `structure` | v1 core と optional extension axis を束ねる output schema。 | `defined only` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -869,10 +869,22 @@ Lean status の区分:
   Lean witness そのものではない。core 4 軸の `metricStatus` も測定済み metadata として
   extractor output に含める。
 
-残る後続タスク:
+Stabilization / Audit 時点で残す後続タスク:
 
-- `DIPCompatible G π GA` と `ObservationFactorsThrough π O` を束ねる
-  `LocalReplacementContract` 風の packaging theorem を追加するか判断する。
+- [#134](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/134):
+  paper-ready research note を作成する。
+- [#135](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/135):
+  empirical pilot を小規模 repository で実施する。
+- [#136](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/136):
+  Lean refinement 候補を整理し、必要最小限だけ証明する。
+- [#137](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/137):
+  `sig0-extractor` tooling を外部利用向けに hardening する。
+- [#138](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/138):
+  `Formal/Arch` 以下の module 階層整理方針を決める。
+
+`LocalReplacementContract` 風の packaging theorem は
+[#118](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/118)
+で実装済みであり、この台帳では未解決タスクとして扱わない。
 
 Bridge theorem naming policy:
 


### PR DESCRIPTION
## 概要

Closes #141

Lean 実装・docs・Issue 台帳の棚卸しとして、`docs/formal/lean_theorem_index.md` と `docs/proof_obligations.md` の軽微な drift を修正しました。

- Signature v0 / v1 周辺の主要 executable helper / metric を theorem index に追加
- `LocalReplacementContract` packaging theorem を未解決タスクから外し、#118 で実装済みであることを明記
- Stabilization / Audit 時点で残す後続タスクを #134, #135, #136, #137, #138 に整理

## 証明した定理

- なし

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
