### PR TITLE
docs: Lean module 階層整理方針を固定する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 ## Lean 形式化
 
 - [Lean 定義・定理索引](formal/lean_theorem_index.md): 現在 Lean に存在する主要な定義・定理の索引。
+- [Lean module 階層整理方針](formal/lean_module_organization.md): `Formal/Arch` 以下の責務分類、移動判断基準、当面の配置ルール。
 
 Lean で証明済みの構造的事実、定義のみの概念、将来の証明義務、実証仮説は混同しない。
 

--- a/docs/formal/lean_module_organization.md
+++ b/docs/formal/lean_module_organization.md
@@ -1,0 +1,92 @@
+# Lean module 階層整理方針
+
+Lean status: `defined only` / module organization / docs and API design.
+
+この文書は Issue [#138](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/138)
+の設計決定である。現時点では `Formal/Arch` 以下のファイル移動は行わず、責務分類と
+当面の配置ルールを明文化する。実際の import path 変更は、必要になった時点で単独の
+follow-up Issue / PR に分割し、`lake build` を通して進める。
+
+## 現行 module の責務分類
+
+| 責務層 | 現行 module | 役割 |
+| --- | --- | --- |
+| Core graph theory | `Graph`, `Reachability` | `ArchGraph`, `Walk`, `SimpleWalk` / `Path`, `Reachable` を定義する最小基盤。 |
+| Structural invariants | `Layering`, `Decomposable`, `Finite` | `StrictLayered`, `Acyclic`, `FinitePropagation`, finite `ComponentUniverse`, finite graph bridge theorem を扱う。 |
+| Category / projection | `Category`, `ThinCategory`, `Projection` | thin category と抽象射影、DIP / projection soundness / exactness を扱う。 |
+| Behavior | `Observation`, `LSP`, `LocalReplacement` | 観測同値、LSP、projection bridge と observation bridge を束ねる局所置換契約を扱う。 |
+| Metrics / matrix | `Signature`, `Matrix` | Architecture Signature v0/v1、finite executable metrics、adjacency matrix / nilpotence / spectral bridge を扱う。 |
+| Examples / counterexamples | `SolidCounterexample` | SOLID-style local contract だけでは `Decomposable` が従わない反例を保持する。 |
+
+この分類は reader-facing な責務整理であり、現時点の Lean import path は
+`Formal.Arch.<Module>` の flat layout のまま維持する。
+
+## 変更しない判断
+
+短期的には `Formal/Arch` 直下の flat layout を維持する。理由は次の通り。
+
+- module 数はまだ少なく、`Formal.lean` と `docs/formal/lean_theorem_index.md` で入口を把握できる。
+- file move は import path を変え、下流 import、docs link、theorem index の同時更新を要求する。
+- 現在の主要課題は theorem / docs / empirical tooling の安定化であり、階層移動そのものは新しい theorem を増やさない。
+- `Formal.Arch.Signature` と `Formal.Arch.Matrix` は多くの前提 module を参照するため、移動 PR の blast radius が相対的に大きい。
+
+したがって Issue #138 では、移動を実施せず、責務分類・移動判断基準・配置ルールを固定する。
+
+## 将来移動する判断基準
+
+次のいずれかが起きた場合に、subdirectory 化を follow-up Issue として検討する。
+
+- `Formal/Arch` 直下の module が増え、theorem index の reader-facing section と import path の対応が分かりにくくなった。
+- core graph theory と metric / empirical bridge の依存方向を import path でも明示する必要が出た。
+- paper-ready research note で、Lean API の提示順と module path の対応が読者の理解を妨げる。
+- downstream code が `Formal.Arch` 全体 import ではなく特定責務層だけを import する需要を持つ。
+
+移動する場合の候補は次である。
+
+| 将来 path 候補 | 対象 module |
+| --- | --- |
+| `Formal/Arch/Core` | `Graph`, `Reachability`, `Layering`, `Decomposable`, `Finite` |
+| `Formal/Arch/Category` | `Category`, `ThinCategory`, `Projection` |
+| `Formal/Arch/Behavior` | `Observation`, `LSP`, `LocalReplacement` |
+| `Formal/Arch/Metrics` | `Signature`, `Matrix` |
+| `Formal/Arch/Examples` | `SolidCounterexample` |
+
+ただし `Projection` は category / behavior / metrics の境界にある。移動時は、
+projection soundness を category-side abstraction bridge として置くか、
+behavior と同じ local-contract 層へ置くかをその PR で明示する。
+
+## import path 変更の影響範囲
+
+実際に file move する PR では、少なくとも次を同時に更新する。
+
+- `Formal.lean`: public import entry point の順序と path。
+- moved Lean files: `import Formal.Arch.<Module>` 参照。
+- `docs/formal/lean_theorem_index.md`: `File:` / `Files:` の path と section name。
+- `docs/proof_obligations.md`: theorem 名や file path を含む説明。
+- `docs/aat_v2_overview.md` と `docs/design/*.md`: Lean module path を参照する箇所。
+- downstream imports: repository 内の `Formal.Arch.<Module>` import と、必要なら README の例。
+
+file move PR は docs-only PR と混ぜない。移動 PR では Lean の定義や theorem statement を
+原則として変更せず、path 更新と `lake build` に焦点を絞る。
+
+## 当面の命名・配置ルール
+
+- graph の基礎構造は `Graph` / `Reachability` に置く。
+- `Decomposable G := StrictLayered G` は `Decomposable` に置き、acyclicity,
+  finite propagation, nilpotence, spectral conditions を定義へ混ぜない。
+- finite universe と graph-level bridge theorem は `Finite` に置く。
+- Signature の executable metric 定義は `Signature` に置き、graph-level correctness theorem は
+  必要に応じて `Finite` または該当 bridge module に置く。
+- adjacency matrix / nilpotence / spectral radius の bridge は `Matrix` に置く。
+- projection / DIP の定義と theorem は `Projection` に置く。
+- observation / LSP / local replacement は `Observation`, `LSP`, `LocalReplacement` に分ける。
+- counterexample は theorem の補助例であっても、reader-facing example として
+  `SolidCounterexample` に隔離する。
+- 新規 module を追加する場合は、`Formal.lean`、`docs/formal/lean_theorem_index.md`、
+  必要なら `docs/proof_obligations.md` を同じ PR で更新する。
+
+## #138 の結論
+
+Issue #138 では、現行 layout を維持する。subdirectory 化は今すぐ行わない。
+ただし、この文書の責務分類を当面の reader-facing module map とし、将来の file move は
+単独 Issue / PR で扱う。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -6,6 +6,9 @@
 
 この索引は手動管理である。Lean 定義・定理を追加、削除、rename する PR では、研究上参照する主要 API に影響がある場合にこの文書も更新する。
 
+`Formal/Arch` 以下の責務分類、file move の判断基準、当面の配置ルールは
+[Lean module 階層整理方針](lean_module_organization.md) に分離する。
+
 ## Graph / Walk
 
 File: `Formal/Arch/Graph.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -879,12 +879,16 @@ Stabilization / Audit 時点で残す後続タスク:
   Lean refinement 候補を整理し、必要最小限だけ証明する。
 - [#137](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/137):
   `sig0-extractor` tooling を外部利用向けに hardening する。
-- [#138](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/138):
-  `Formal/Arch` 以下の module 階層整理方針を決める。
 
 `LocalReplacementContract` 風の packaging theorem は
 [#118](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/118)
 で実装済みであり、この台帳では未解決タスクとして扱わない。
+
+`Formal/Arch` 以下の module 階層整理方針は
+[#138](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/138)
+で [Lean module 階層整理方針](formal/lean_module_organization.md) に固定する。
+現時点では file move を行わず、責務分類と当面の配置ルールを reader-facing な
+module map として扱う。
 
 Bridge theorem naming policy:
 


### PR DESCRIPTION
## 概要

Closes #138

`Formal/Arch` 以下の Lean module 階層整理方針を docs として固定しました。

- `docs/formal/lean_module_organization.md` を新設し、現行 module の責務分類を整理
- 現時点では file move せず flat layout を維持する判断を明記
- 将来 subdirectory 化する判断基準と import path 変更時の影響範囲を明記
- 当面の命名・配置ルールを明文化
- `docs/README.md`, `docs/formal/lean_theorem_index.md`, `docs/proof_obligations.md` から方針文書へ参照を追加

## 証明した定理

- なし

## 編集したドキュメント

- `docs/formal/lean_module_organization.md`
- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`
- `docs/README.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
