### PR TITLE
sig0-extractor の外部利用向け検証を強化する

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -19,3 +19,13 @@ jobs:
 
       - name: Build
         run: lake build
+
+  sig0-extractor:
+    name: sig0-extractor cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test sig0 extractor
+        run: cargo test --manifest-path tools/sig0-extractor/Cargo.toml

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -868,6 +868,13 @@ Lean status の区分:
   `components`, `edges`, `metricStatus` に基づく tooling-side evidence であり、
   Lean witness そのものではない。core 4 軸の `metricStatus` も測定済み metadata として
   extractor output に含める。
+- `sig0-extractor` の外部利用向け hardening は
+  [#137](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/137)
+  で README の再現手順、representative fixture、CLI integration test、CI 上の
+  `cargo test --manifest-path tools/sig0-extractor/Cargo.toml` として追加する。
+  JSON contract では `metricStatus.measured = false` と placeholder 0 / optional
+  `null` を区別し、Lean status は `empirical hypothesis` / tooling implementation
+  である。
 
 Stabilization / Audit 時点で残す後続タスク:
 
@@ -877,8 +884,6 @@ Stabilization / Audit 時点で残す後続タスク:
   empirical pilot を小規模 repository で実施する。
 - [#136](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/136):
   Lean refinement 候補を整理し、必要最小限だけ証明する。
-- [#137](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/137):
-  `sig0-extractor` tooling を外部利用向けに hardening する。
 
 `LocalReplacementContract` 風の packaging theorem は
 [#118](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/118)

--- a/tools/sig0-extractor/README.md
+++ b/tools/sig0-extractor/README.md
@@ -6,6 +6,49 @@ Lean status: `empirical hypothesis` / tooling output.
 
 ## Usage
 
+fixture を使った最小再現例は次である。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
+  --root tools/sig0-extractor/tests/fixtures/minimal \
+  --policy tools/sig0-extractor/tests/fixtures/minimal/policy_measured_zero.json \
+  --runtime-edges tools/sig0-extractor/tests/fixtures/minimal/runtime_edges.json \
+  --out .lake/sig0-fixture.json
+```
+
+代表的な出力 contract は次の形になる。
+
+```json
+{
+  "schemaVersion": "sig0-extractor-v0",
+  "componentKind": "lean-module",
+  "policies": {
+    "policyId": "minimal-measured-zero",
+    "schemaVersion": "signature-policy-v0"
+  },
+  "metricStatus": {
+    "boundaryViolationCount": {
+      "measured": true,
+      "source": "policy:minimal-measured-zero"
+    },
+    "runtimePropagation": {
+      "measured": true,
+      "source": "runtime-edge-projection-v0"
+    }
+  },
+  "runtimeDependencyGraph": {
+    "projectionRule": "runtime-edge-projection-v0",
+    "edgeKind": "runtime"
+  }
+}
+```
+
+policy を渡さない場合、`boundaryViolationCount` と
+`abstractionViolationCount` の値は placeholder の `0` になるが、
+`metricStatus.<axis>.measured = false` なので違反なしとは読まない。
+runtime edge evidence を渡さない場合も、dataset 側の `runtimePropagation` は
+未評価の `null` として残る。
+
 ```bash
 cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
   --root . \
@@ -34,6 +77,28 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate \
 `metricStatus` から duplicate-free component list, local edge closure, external target,
 policy metric status を検査する。report は tooling-side evidence であり、
 `ComponentUniverse` の Lean witness そのものではない。
+
+fixture 出力を検証する例:
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate \
+  --input .lake/sig0-fixture.json \
+  --out .lake/sig0-fixture-validation.json \
+  --universe-mode local-only
+```
+
+pass する場合の要点は次である。
+
+```json
+{
+  "schemaVersion": "component-universe-validation-report-v0",
+  "summary": {
+    "result": "pass",
+    "failedCheckCount": 0,
+    "notMeasuredCheckCount": 0
+  }
+}
+```
 
 repository root を測定する場合、`.git`, `.lake`, `.elan`, `target`, root 直下の
 `tools` は scan 対象から除外する。これは extractor 自身の fixture や build artifact
@@ -82,6 +147,52 @@ PR metadata の `pullRequest.mergeCommit` が必須である。
 runtime edge evidence がない Sig0 JSON では `runtimePropagation` は `null` のままで、
 測定済み 0 とは扱わない。
 
+fixture metadata を使った dataset 生成例:
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
+  --root tools/sig0-extractor/tests/fixtures/minimal \
+  --out .lake/sig0-before.json
+
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
+  --root tools/sig0-extractor/tests/fixtures/minimal \
+  --policy tools/sig0-extractor/tests/fixtures/minimal/policy_measured_zero.json \
+  --runtime-edges tools/sig0-extractor/tests/fixtures/minimal/runtime_edges.json \
+  --out .lake/sig0-after.json
+
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- dataset \
+  --before .lake/sig0-before.json \
+  --after .lake/sig0-after.json \
+  --pr-metadata tools/sig0-extractor/tests/fixtures/minimal/pr_metadata.json \
+  --after-role head \
+  --out .lake/empirical-dataset-v0.json
+```
+
+この例では before 側の policy / runtime graph が未評価なので、after 側が測定済みでも
+次のように delta は `null` になる。
+
+```json
+{
+  "deltaSignatureSigned": {
+    "boundaryViolationCount": null,
+    "runtimePropagation": null
+  },
+  "metricDeltaStatus": {
+    "boundaryViolationCount": {
+      "comparable": false,
+      "beforeMeasured": false,
+      "afterMeasured": true
+    }
+  },
+  "analysisMetadata": {
+    "runtimeMetrics": {
+      "runtimeGraphMeasured": true,
+      "runtimeEdgeEvidenceCount": 2
+    }
+  }
+}
+```
+
 workflow 単位の `RelationComplexityObservation` を候補 evidence JSON から生成する場合は
 次を使う。
 
@@ -100,3 +211,18 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- relation-complexity
 同じ evidence item 内の同一 tag は 1 回だけ数える。`application-owned` と
 `application-configured` は counting candidate とし、`framework-generated` や
 未対応 framework の候補は `excludedEvidence` に理由を残す。
+
+fixture の代表出力では `constraints = 1`, `compensations = 1`,
+`failureTransitions = 1` なので、`relationComplexity = 3` になる。
+
+## Test and CI
+
+ローカル検証は次で行う。
+
+```bash
+cargo test --manifest-path tools/sig0-extractor/Cargo.toml
+```
+
+CI では GitHub Actions の `sig0-extractor cargo test` job が同じコマンドを実行する。
+Lean theorem ではなく tooling contract の再現性を確認するため、fixtures と CLI test で
+policy, runtime edge projection, relation complexity, dataset conversion を通す。

--- a/tools/sig0-extractor/src/lib.rs
+++ b/tools/sig0-extractor/src/lib.rs
@@ -332,6 +332,7 @@ pub struct AnalysisMetadata {
     pub exclusion_reasons: Vec<String>,
     pub primary_cost_record: Option<String>,
     pub relation_complexity_components: Option<RelationComplexityComponents>,
+    pub runtime_metrics: Option<RuntimeMetrics>,
     pub alternate_signature_after: Option<Box<SignatureSnapshot>>,
 }
 
@@ -343,9 +344,28 @@ impl Default for AnalysisMetadata {
             exclusion_reasons: Vec::new(),
             primary_cost_record: None,
             relation_complexity_components: None,
+            runtime_metrics: None,
             alternate_signature_after: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeMetrics {
+    pub runtime_graph_measured: bool,
+    pub runtime_edge_evidence_count: Option<usize>,
+    pub runtime_pair_count: Option<usize>,
+    pub runtime_fanout: Option<usize>,
+    pub unprotected_runtime_propagation_radius: Option<usize>,
+    pub circuit_breaker_coverage_ratio: Option<f64>,
+    pub protected_pair_count: Option<usize>,
+    pub partial_pair_count: Option<usize>,
+    pub unprotected_pair_count: Option<usize>,
+    pub unknown_coverage_pair_count: Option<usize>,
+    pub failure_mode_taxonomy_version: Option<String>,
+    pub coverage_policy_version: Option<String>,
+    pub confidence_threshold: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/sig0-extractor/tests/cli.rs
+++ b/tools/sig0-extractor/tests/cli.rs
@@ -1,0 +1,164 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal")
+}
+
+fn temp_dir(test_name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("sig0-extractor-{test_name}-{nanos}"));
+    fs::create_dir_all(&dir).expect("temp dir is created");
+    dir
+}
+
+fn run_sig0(args: &[&str]) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sig0-extractor"))
+        .args(args)
+        .output()
+        .expect("sig0-extractor command runs");
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn read_json(path: &Path) -> Value {
+    let contents = fs::read_to_string(path).expect("json output is readable");
+    serde_json::from_str(&contents).expect("json output parses")
+}
+
+#[test]
+fn cli_extracts_policy_runtime_fixture_contract() {
+    let root = fixture_root();
+    let out_dir = temp_dir("extract");
+    let out = out_dir.join("sig0.json");
+
+    run_sig0(&[
+        "--root",
+        root.to_str().expect("fixture path is utf-8"),
+        "--policy",
+        root.join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--runtime-edges",
+        root.join("runtime_edges.json")
+            .to_str()
+            .expect("runtime path is utf-8"),
+        "--out",
+        out.to_str().expect("output path is utf-8"),
+    ]);
+
+    let json = read_json(&out);
+    assert_eq!(json["schemaVersion"], "sig0-extractor-v0");
+    assert_eq!(json["policies"]["policyId"], "minimal-measured-zero");
+    assert_eq!(
+        json["metricStatus"]["boundaryViolationCount"]["measured"],
+        true
+    );
+    assert_eq!(json["metricStatus"]["runtimePropagation"]["measured"], true);
+    assert_eq!(
+        json["runtimeDependencyGraph"]["projectionRule"],
+        "runtime-edge-projection-v0"
+    );
+    assert_eq!(
+        json["runtimeEdgeEvidence"][0]["evidenceLocation"]["path"],
+        "runtime/routes.json"
+    );
+}
+
+#[test]
+fn cli_dataset_fixture_keeps_unmeasured_deltas_null() {
+    let root = fixture_root();
+    let out_dir = temp_dir("dataset");
+    let before = out_dir.join("before.json");
+    let after = out_dir.join("after.json");
+    let dataset = out_dir.join("dataset.json");
+
+    run_sig0(&[
+        "--root",
+        root.to_str().expect("fixture path is utf-8"),
+        "--out",
+        before.to_str().expect("before path is utf-8"),
+    ]);
+    run_sig0(&[
+        "--root",
+        root.to_str().expect("fixture path is utf-8"),
+        "--policy",
+        root.join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--runtime-edges",
+        root.join("runtime_edges.json")
+            .to_str()
+            .expect("runtime path is utf-8"),
+        "--out",
+        after.to_str().expect("after path is utf-8"),
+    ]);
+    run_sig0(&[
+        "dataset",
+        "--before",
+        before.to_str().expect("before path is utf-8"),
+        "--after",
+        after.to_str().expect("after path is utf-8"),
+        "--pr-metadata",
+        root.join("pr_metadata.json")
+            .to_str()
+            .expect("metadata path is utf-8"),
+        "--out",
+        dataset.to_str().expect("dataset path is utf-8"),
+    ]);
+
+    let json = read_json(&dataset);
+    assert_eq!(json["schemaVersion"], "empirical-signature-dataset-v0");
+    assert_eq!(
+        json["deltaSignatureSigned"]["boundaryViolationCount"],
+        Value::Null
+    );
+    assert_eq!(
+        json["deltaSignatureSigned"]["runtimePropagation"],
+        Value::Null
+    );
+    assert_eq!(
+        json["metricDeltaStatus"]["boundaryViolationCount"]["comparable"],
+        false
+    );
+    assert_eq!(
+        json["analysisMetadata"]["runtimeMetrics"]["runtimeGraphMeasured"],
+        true
+    );
+}
+
+#[test]
+fn cli_relation_complexity_fixture_outputs_observation() {
+    let root = fixture_root();
+    let out_dir = temp_dir("relation");
+    let out = out_dir.join("relation-complexity.json");
+
+    run_sig0(&[
+        "relation-complexity",
+        "--input",
+        root.join("relation_complexity_candidates.json")
+            .to_str()
+            .expect("relation path is utf-8"),
+        "--out",
+        out.to_str().expect("output path is utf-8"),
+    ]);
+
+    let json = read_json(&out);
+    assert_eq!(json["schemaVersion"], "relation-complexity-observation/v0");
+    assert_eq!(json["relationComplexity"], 3);
+    assert_eq!(
+        json["measurementUniverse"]["ruleSetVersion"],
+        "relation-complexity-rules/v0"
+    );
+}

--- a/tools/sig0-extractor/tests/fixtures/minimal/pr_metadata.json
+++ b/tools/sig0-extractor/tests/fixtures/minimal/pr_metadata.json
@@ -1,0 +1,60 @@
+{
+  "repository": {
+    "owner": "example",
+    "name": "service",
+    "defaultBranch": "main"
+  },
+  "pullRequest": {
+    "number": 42,
+    "author": "alice",
+    "createdAt": "2026-04-01T00:00:00Z",
+    "mergedAt": "2026-04-02T00:00:00Z",
+    "baseCommit": "base-sha",
+    "headCommit": "head-sha",
+    "mergeCommit": "merge-sha",
+    "labels": ["feature", "architecture-signature"],
+    "isBotGenerated": false
+  },
+  "prMetrics": {
+    "changedFiles": 2,
+    "changedLinesAdded": 20,
+    "changedLinesDeleted": 5,
+    "changedComponents": ["Formal", "Formal.Arch.A"],
+    "reviewCommentCount": 1,
+    "reviewThreadCount": 1,
+    "reviewRoundCount": 1,
+    "firstReviewLatencyHours": 2.0,
+    "approvalLatencyHours": 6.0,
+    "mergeLatencyHours": 12.0
+  },
+  "issueIncidentLinks": [],
+  "analysisMetadata": {
+    "signatureAfterCommitRole": "head",
+    "excludedFromPrimaryAnalysis": false,
+    "exclusionReasons": [],
+    "primaryCostRecord": null,
+    "relationComplexityComponents": {
+      "constraints": 1,
+      "compensations": 1,
+      "projections": 0,
+      "failureTransitions": 1,
+      "idempotencyRequirements": 0
+    },
+    "runtimeMetrics": {
+      "runtimeGraphMeasured": true,
+      "runtimeEdgeEvidenceCount": 2,
+      "runtimePairCount": 2,
+      "runtimeFanout": 2,
+      "unprotectedRuntimePropagationRadius": null,
+      "circuitBreakerCoverageRatio": 0.5,
+      "protectedPairCount": 1,
+      "partialPairCount": 0,
+      "unprotectedPairCount": 0,
+      "unknownCoveragePairCount": 1,
+      "failureModeTaxonomyVersion": "fixture-v0",
+      "coveragePolicyVersion": "fixture-coverage-v0",
+      "confidenceThreshold": null
+    },
+    "alternateSignatureAfter": null
+  }
+}


### PR DESCRIPTION
## 概要

Closes #137

`sig0-extractor` を外部利用しやすくするため、fixture ベースの再現手順、CLI integration test、CI 上の Rust test job、dataset metadata contract を強化しました。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/sig0-extractor/README.md`: policy / runtime edge / validate / dataset / relation complexity の fixture 実行例と出力例を追加
- `docs/proof_obligations.md`: #137 の tooling hardening と Lean status を反映

## 実施したテスト

- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
