### PR TITLE
EdgeSubset の保存定理を追加する

### DIFF
--- a/Formal/Arch/Decomposable.lean
+++ b/Formal/Arch/Decomposable.lean
@@ -29,6 +29,11 @@ theorem decomposable_finitePropagation {C : Type u} {G : ArchGraph C}
     (h : Decomposable G) : FinitePropagation G :=
   finitePropagation_of_strictLayered h
 
+/-- Decomposability is preserved by deleting dependency edges. -/
+theorem decomposable_of_edgeSubset {C : Type u} {H G : ArchGraph C}
+    (hSubset : EdgeSubset H G) (h : Decomposable G) : Decomposable H :=
+  strictLayered_of_edgeSubset hSubset h
+
 /-- Four-layer example used as the first positive decomposability witness. -/
 inductive FourLayerComponent where
   | ui
@@ -68,4 +73,3 @@ theorem decomposable : Decomposable graph :=
 end FourLayerComponent
 
 end Formal.Arch
-

--- a/Formal/Arch/Graph.lean
+++ b/Formal/Arch/Graph.lean
@@ -11,6 +11,28 @@ structure ArchGraph (C : Type u) where
   edge : C → C → Prop
 
 /--
+`EdgeSubset H G` means every dependency edge of `H` is also present in `G`.
+This is the graph-level relation used for dependency deletion and subgraph
+preservation theorems.
+-/
+def EdgeSubset {C : Type u} (H G : ArchGraph C) : Prop :=
+  ∀ {c d : C}, H.edge c d → G.edge c d
+
+namespace EdgeSubset
+
+/-- Every graph is an edge subset of itself. -/
+theorem refl {C : Type u} (G : ArchGraph C) : EdgeSubset G G :=
+  fun hEdge => hEdge
+
+/-- Edge subset inclusion is transitive. -/
+theorem trans {C : Type u} {G₁ G₂ G₃ : ArchGraph C}
+    (h₁₂ : EdgeSubset G₁ G₂) (h₂₃ : EdgeSubset G₂ G₃) :
+    EdgeSubset G₁ G₃ :=
+  fun hEdge => h₂₃ (h₁₂ hEdge)
+
+end EdgeSubset
+
+/--
 Static dependencies such as imports, type references, inheritance, and package
 dependencies.
 
@@ -55,6 +77,21 @@ namespace Walk
 def length {C : Type u} {G : ArchGraph C} {c d : C} : Walk G c d → Nat
   | nil _ => 0
   | cons _ rest => rest.length + 1
+
+/-- An edge subset turns every walk in the smaller graph into a walk in the larger graph. -/
+def map_edgeSubset {C : Type u} {H G : ArchGraph C} (hSubset : EdgeSubset H G) :
+    ∀ {c d : C}, Walk H c d → Walk G c d
+  | _, _, nil c => nil c
+  | _, _, cons hEdge rest => cons (hSubset hEdge) (map_edgeSubset hSubset rest)
+
+/-- Mapping a walk along an edge subset preserves its length. -/
+theorem length_map_edgeSubset {C : Type u} {H G : ArchGraph C}
+    (hSubset : EdgeSubset H G) :
+    ∀ {c d : C} (w : Walk H c d),
+      (map_edgeSubset hSubset w).length = w.length
+  | _, _, nil _ => rfl
+  | _, _, cons _ rest => by
+      simp [map_edgeSubset, length, length_map_edgeSubset hSubset rest]
 
 /-- Vertices visited by a walk, including both endpoints. -/
 def vertices {C : Type u} {G : ArchGraph C} {c d : C} : Walk G c d → List C

--- a/Formal/Arch/Layering.lean
+++ b/Formal/Arch/Layering.lean
@@ -31,6 +31,19 @@ def WalkAcyclic {C : Type u} (G : ArchGraph C) : Prop :=
 def FinitePropagation {C : Type u} (G : ArchGraph C) : Prop :=
   ∃ bound : C → Nat, ∀ {c d : C} (w : Walk G c d), w.length ≤ bound c
 
+/-- Strict layering is preserved when dependency edges are deleted. -/
+theorem strictLayering_of_edgeSubset {C : Type u} {H G : ArchGraph C}
+    (hSubset : EdgeSubset H G) {layer : Layering C}
+    (hLayer : StrictLayering G layer) : StrictLayering H layer :=
+  fun hEdge => hLayer (hSubset hEdge)
+
+/-- Strictly layered graphs remain strictly layered under edge subset restriction. -/
+theorem strictLayered_of_edgeSubset {C : Type u} {H G : ArchGraph C}
+    (hSubset : EdgeSubset H G) (hLayered : StrictLayered G) :
+    StrictLayered H := by
+  rcases hLayered with ⟨layer, hLayer⟩
+  exact ⟨layer, strictLayering_of_edgeSubset hSubset hLayer⟩
+
 /-- A strict layer assignment is monotone along reachability. -/
 theorem layer_le_of_reachable {C : Type u} {G : ArchGraph C} {layer : Layering C}
     (hLayer : StrictLayering G layer) :
@@ -52,6 +65,13 @@ theorem strictLayered_acyclic {C : Type u} {G : ArchGraph C}
     (h : StrictLayered G) : Acyclic G := by
   rcases h with ⟨layer, hLayer⟩
   exact acyclic_of_strictLayering hLayer
+
+/-- Acyclic graphs remain acyclic under edge subset restriction. -/
+theorem acyclic_of_edgeSubset {C : Type u} {H G : ArchGraph C}
+    (hSubset : EdgeSubset H G) (hAcyclic : Acyclic G) :
+    Acyclic H := by
+  intro c d hEdge hReach
+  exact hAcyclic (hSubset hEdge) (Reachable.map_edgeSubset hSubset hReach)
 
 /-- A nonempty closed walk exposes one generating edge followed by reachability back. -/
 theorem edge_reachable_of_closed_walk {C : Type u} {G : ArchGraph C}

--- a/Formal/Arch/Reachability.lean
+++ b/Formal/Arch/Reachability.lean
@@ -26,6 +26,12 @@ def trans {C : Type u} {G : ArchGraph C} {a b c : C} :
   | refl _, h₂ => h₂
   | step h hd, h₂ => step h (trans hd h₂)
 
+/-- An edge subset turns reachability in the smaller graph into reachability in the larger graph. -/
+def map_edgeSubset {C : Type u} {H G : ArchGraph C} (hSubset : EdgeSubset H G) :
+    ∀ {c d : C}, Reachable H c d → Reachable G c d
+  | _, _, refl c => refl c
+  | _, _, step hEdge hRest => step (hSubset hEdge) (map_edgeSubset hSubset hRest)
+
 /-- Walks imply reachability, but reachability forgets walk length and count. -/
 def of_walk {C : Type u} {G : ArchGraph C} {c d : C} :
     Walk G c d → Reachable G c d

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -16,11 +16,16 @@ File: `Formal/Arch/Graph.lean`
 | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- |
 | `ArchGraph` | `structure` | component 間の依存辺 `edge : C -> C -> Prop` を持つ基本グラフ。 | `defined only` |
+| `EdgeSubset` | `def` | 依存削除・部分グラフ化を、片方の graph の全 edge がもう片方に含まれる関係として表す。 | `defined only` |
+| `EdgeSubset.refl` | `theorem` | 任意 graph は自身の edge subset である。 | `proved` |
+| `EdgeSubset.trans` | `theorem` | edge subset 関係は推移的である。 | `proved` |
 | `StaticDependencyGraph` | `abbrev` | 静的依存を表す graph role。 | `defined only` |
 | `RuntimeDependencyGraph` | `abbrev` | 実行時依存を表す graph role。 | `defined only` |
 | `ArchitectureDependencyGraphs` | `structure` | 静的依存と実行時依存を同時に保持する薄い構造。 | `defined only` |
 | `Walk` | `inductive` | 長さを保持する依存 walk。 | `defined only` |
 | `Walk.length` | `def` | walk の長さ。 | `defined only` |
+| `Walk.map_edgeSubset` | `def` | edge subset に沿って小さい graph の walk を大きい graph の walk へ写す。 | `proved` |
+| `Walk.length_map_edgeSubset` | `theorem` | edge subset に沿って写した walk の長さは保存される。 | `proved` |
 | `Walk.vertices` | `def` | walk が通る頂点列。 | `defined only` |
 | `Walk.vertices_length` | `theorem` | `vertices` と `length` の基本関係。 | `proved` |
 | `SimpleWalk` | `structure` | 頂点重複のない walk。 | `defined only` |
@@ -37,6 +42,7 @@ File: `Formal/Arch/Reachability.lean`
 | `Reachable.refl'` | `theorem` | 任意 component は自身へ到達可能。 | `proved` |
 | `Reachable.of_edge` | `theorem` | 依存辺から到達可能性を得る。 | `proved` |
 | `Reachable.trans` | `def` | 到達可能性の推移性。 | `proved` |
+| `Reachable.map_edgeSubset` | `def` | edge subset に沿って小さい graph の reachability を大きい graph の reachability へ写す。 | `proved` |
 | `Reachable.of_walk` | `def` | `Walk` から `Reachable` を得る。 | `proved` |
 | `Reachable.of_simpleWalk` | `def` | `SimpleWalk` から `Reachable` を得る。 | `proved` |
 | `Reachable.exists_path` | `theorem` | 到達可能なら simple path が存在する。 | `proved` |
@@ -54,9 +60,12 @@ File: `Formal/Arch/Layering.lean`
 | `HasClosedWalk` | `def` | 閉 walk を持つこと。 | `defined only` |
 | `WalkAcyclic` | `def` | 非自明な閉 walk が存在しないこと。 | `defined only` |
 | `FinitePropagation` | `def` | 任意 component からの walk 長に上界があること。 | `defined only` |
+| `strictLayering_of_edgeSubset` | `theorem` | edge subset restriction は特定の strict layer assignment を保存する。 | `proved` |
+| `strictLayered_of_edgeSubset` | `theorem` | edge subset restriction は `StrictLayered` を保存する。 | `proved` |
 | `layer_le_of_reachable` | `theorem` | strict layering 下で reachable な依存先の layer は増えない。 | `proved` |
 | `acyclic_of_strictLayering` | `theorem` | strict layering は acyclicity を与える。 | `proved` |
 | `strictLayered_acyclic` | `theorem` | `StrictLayered -> Acyclic`。 | `proved` |
+| `acyclic_of_edgeSubset` | `theorem` | edge subset restriction は `Acyclic` を保存する。 | `proved` |
 | `walkAcyclic_of_acyclic` | `theorem` | `Acyclic -> WalkAcyclic`。 | `proved` |
 | `acyclic_of_walkAcyclic` | `theorem` | `WalkAcyclic -> Acyclic`。 | `proved` |
 | `acyclic_iff_walkAcyclic` | `theorem` | acyclicity と walk acyclicity の同値。 | `proved` |
@@ -72,6 +81,7 @@ File: `Formal/Arch/Decomposable.lean`
 | `decomposable_iff_strictLayered` | `theorem` | `Decomposable G <-> StrictLayered G`。 | `proved` |
 | `decomposable_acyclic` | `theorem` | `Decomposable -> Acyclic`。 | `proved` |
 | `decomposable_finitePropagation` | `theorem` | `Decomposable -> FinitePropagation`。 | `proved` |
+| `decomposable_of_edgeSubset` | `theorem` | edge subset restriction は `Decomposable` を保存する。 | `proved` |
 | `FourLayerExample.decomposable` | `theorem` | 4層例が decomposable であること。 | `proved` |
 
 ## Thin Category

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -58,6 +58,10 @@ Decomposable G := StrictLayered G
 
 - `StrictLayered -> Acyclic`: `proved`
 - `StrictLayered -> FinitePropagation`: `proved`
+- Edge deletion / subgraph preservation:
+  `EdgeSubset`, `strictLayered_of_edgeSubset`, `acyclic_of_edgeSubset`,
+  and `decomposable_of_edgeSubset` are `proved`,
+  [Issue #161](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/161)
 - `Acyclic + finite vertices -> StrictLayered`: `proved`, [Issue #23](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/23)
 - `Acyclic <-> WalkAcyclic`: `proved`
 - `DAG <-> Nilpotent adjacency matrix`: `proved` for finite
@@ -111,6 +115,8 @@ Lean status:
 - `defined only`: `Decomposable G := StrictLayered G`
 - `proved`: `StrictLayered -> Acyclic`
 - `proved`: `StrictLayered -> FinitePropagation`
+- `proved`: `EdgeSubset` preserves `StrictLayered`, `Acyclic`, and
+  `Decomposable`, [Issue #161](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/161)
 - `proved`: Layered な4層例が `Decomposable` であること
 - `proved`: 2点循環グラフが `Decomposable` でないこと
 - `proved`: `ComponentUniverse.strictLayered_of_acyclic` and


### PR DESCRIPTION
## 概要

Closes #161

依存削除・部分グラフ化を表す `EdgeSubset` を追加し、edge subset restriction が walk / reachability / layering / acyclicity / decomposability を保存することを Lean theorem として証明しました。

## 証明した定理

- `EdgeSubset.refl`
- `EdgeSubset.trans`
- `Walk.length_map_edgeSubset`
- `Reachable.map_edgeSubset`
- `strictLayering_of_edgeSubset`
- `strictLayered_of_edgeSubset`
- `acyclic_of_edgeSubset`
- `decomposable_of_edgeSubset`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
