### PR TITLE
Architecture Signature diff MVPを実装する

### DIFF
--- a/docs/design/signature_snapshot_store_schema.md
+++ b/docs/design/signature_snapshot_store_schema.md
@@ -293,3 +293,50 @@ measured 0 と unmeasured `null` の規約を両方で維持できる。
 
 この例では `boundaryViolationCount = 0` は測定済み 0 である。一方、
 `runtimePropagation = null` は未評価であり、runtime risk 0 ではない。
+
+## Diff report MVP
+
+Issue [#156](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/156)
+では、snapshot store record 同士を比較する tooling output として
+`signature-diff-report-v0` を追加する。これは Lean theorem ではなく、週次監視や
+PR attribution のための empirical report である。
+
+```text
+SignatureDiffReportV0 =
+  schemaVersion: "signature-diff-report-v0"
+  before: SnapshotDiffEndpoint
+  after: SnapshotDiffEndpoint
+  comparisonStatus: SnapshotComparisonStatus
+  deltaSignatureSigned: NullableSignatureIntVector
+  metricDeltaStatus: MetricDeltaStatus
+  worsenedAxes: List SignatureAxisChange
+  improvedAxes: List SignatureAxisChange
+  unchangedAxes: List SignatureAxisChange
+  unmeasuredAxes: List UnmeasuredAxisDelta
+  evidenceDiff: SnapshotEvidenceDiff
+  attribution: SnapshotDiffAttribution
+```
+
+`deltaSignatureSigned` と `metricDeltaStatus` は empirical dataset v0 と同じ規約を使う。
+before / after のどちらかで未評価の軸、または optional extension axis が `null` の軸は
+`unmeasuredAxes` に理由を残し、主要 diff の数値比較には入れない。
+
+`comparisonStatus.primaryDiffEligible = false` になる代表例は次である。
+
+- before または after の `validationSummary.result` が `fail` または `not_run`。
+- `extractor.name`, `extractor.version`, `extractor.ruleSetVersion` が一致しない。
+- `policy.policyId` または `policy.version` が一致しない。
+
+`evidenceDiff` は raw Sig0 extractor JSON が before / after ともに与えられた場合だけ
+component / edge / policy violation の追加・削除を保持する。snapshot record 単体には
+raw edge list を持たせないため、raw JSON がない場合は `available = false` とし、
+Signature axis diff だけを report する。
+
+`attribution` は v0 では PR metadata に基づく原因候補である。after revision SHA が
+`pullRequest.headCommit` または `pullRequest.mergeCommit` と一致するか、PR の
+`changedComponents` が `evidenceDiff` の追加・削除 component と重なるかを使って
+confidence を出す。これは因果証明ではなく、調査開始点を提示する ranking である。
+
+CLI の再現手順は
+[`tools/sig0-extractor/README.md`](../../tools/sig0-extractor/README.md) の
+`Snapshot diff MVP` を参照する。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -866,6 +866,14 @@ Lean status の区分:
   `validationSummary.result = fail` の snapshot は主要 diff から除外し、測定済み 0 と
   未評価 `null` を混同しない。Lean status は `empirical hypothesis` / tooling schema
   である。
+- Architecture Signature の時系列 diff / PR attribution MVP は
+  [#156](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/156)
+  で `sig0-extractor snapshot` と `sig0-extractor signature-diff` として実装済みである。
+  `signature-diff-report-v0` は悪化・改善・変化なし・未評価の軸を分け、raw Sig0 JSON
+  がある場合は増えた component / edge / policy violation を report する。PR metadata
+  を渡した場合の attribution は changed components と after revision SHA に基づく
+  confidence 付き原因候補であり、因果証明ではない。Lean status は
+  `empirical hypothesis` / tooling implementation である。
 - RelationComplexityObservation extractor rule set v0 は
   [#124](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/124)
   で `sig0-extractor relation-complexity --input ...` として実装済みである。

--- a/tools/sig0-extractor/README.md
+++ b/tools/sig0-extractor/README.md
@@ -247,6 +247,89 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- relation-complexity
 fixture の代表出力では `constraints = 1`, `compensations = 1`,
 `failureTransitions = 1` なので、`relationComplexity = 3` になる。
 
+## Snapshot diff MVP
+
+週次 scan や任意期間比較では、まず Sig0 output と validation report から
+`signature-snapshot-store-v0` record を作り、2 つの snapshot を
+`signature-diff-report-v0` に比較する。この workflow は Lean theorem ではなく、
+empirical / tooling output である。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
+  --root . \
+  --policy signature-policy.json \
+  --out .lake/signature-current/sig0.json
+
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate \
+  --input .lake/signature-current/sig0.json \
+  --out .lake/signature-current/validation.json \
+  --universe-mode local-only
+
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- snapshot \
+  --input .lake/signature-current/sig0.json \
+  --validation-report .lake/signature-current/validation.json \
+  --repo-owner example \
+  --repo-name service \
+  --revision-sha "$(git rev-parse HEAD)" \
+  --revision-branch main \
+  --scanned-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --policy-path signature-policy.json \
+  --extractor-output-path .lake/signature-current/sig0.json \
+  --tag weekly \
+  --out .lake/signature-current/snapshot.json
+```
+
+任意期間 diff は次で作る。`--before-sig0` / `--after-sig0` を渡すと、増えた
+component、edge、policy violation も report に入る。`--pr-metadata` を渡すと、
+PR の changed components と after revision SHA に基づく原因候補を confidence 付きで
+出す。複数 PR を候補にする場合は `--pr-metadata` を繰り返す。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- signature-diff \
+  --before-snapshot .lake/signature-previous/snapshot.json \
+  --after-snapshot .lake/signature-current/snapshot.json \
+  --before-sig0 .lake/signature-previous/sig0.json \
+  --after-sig0 .lake/signature-current/sig0.json \
+  --pr-metadata .lake/pr-metadata-123.json \
+  --out .lake/signature-current/diff-report.json
+```
+
+report は `worsenedAxes`, `improvedAxes`, `unchangedAxes`, `unmeasuredAxes`,
+`evidenceDiff`, `attribution` を持つ。`validationSummary.result = fail` または
+`not_run` の snapshot、extractor / rule set / policy が一致しない比較は
+`comparisonStatus.primaryDiffEligible = false` とし、主要 diff から除外する。
+未評価軸は `unmeasuredAxes` に理由を残し、placeholder 0 を risk 0 として扱わない。
+
+GitHub Actions では、週次 job で同じ 3 段階を実行して artifact として保存する。
+次は最小形であり、外部 storage に蓄積する場合は最後の upload 部分を置き換える。
+
+```yaml
+name: Signature diff
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  signature-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: leanprover/lean-action@v1
+      - name: Build current snapshot
+        run: |
+          cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- --root . --out .lake/signature-current/sig0.json
+          cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate --input .lake/signature-current/sig0.json --out .lake/signature-current/validation.json
+          cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- snapshot --input .lake/signature-current/sig0.json --validation-report .lake/signature-current/validation.json --repo-owner "$GITHUB_REPOSITORY_OWNER" --repo-name "${GITHUB_REPOSITORY#*/}" --revision-sha "$GITHUB_SHA" --revision-ref "$GITHUB_REF" --revision-branch "${GITHUB_REF_NAME:-main}" --scanned-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --tag weekly --out .lake/signature-current/snapshot.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: signature-current
+          path: .lake/signature-current
+```
+
 ## Test and CI
 
 ローカル検証は次で行う。
@@ -257,4 +340,5 @@ cargo test --manifest-path tools/sig0-extractor/Cargo.toml
 
 CI では GitHub Actions の `sig0-extractor cargo test` job が同じコマンドを実行する。
 Lean theorem ではなく tooling contract の再現性を確認するため、fixtures と CLI test で
-policy, runtime edge projection, relation complexity, dataset conversion を通す。
+policy, runtime edge projection, relation complexity, dataset conversion,
+snapshot diff を通す。

--- a/tools/sig0-extractor/src/lib.rs
+++ b/tools/sig0-extractor/src/lib.rs
@@ -12,6 +12,8 @@ pub const SCHEMA_VERSION: &str = "sig0-extractor-v0";
 pub const COMPONENT_KIND: &str = "lean-module";
 pub const VALIDATION_REPORT_SCHEMA_VERSION: &str = "component-universe-validation-report-v0";
 pub const EMPIRICAL_DATASET_SCHEMA_VERSION: &str = "empirical-signature-dataset-v0";
+pub const SIGNATURE_SNAPSHOT_STORE_SCHEMA_VERSION: &str = "signature-snapshot-store-v0";
+pub const SIGNATURE_DIFF_REPORT_SCHEMA_VERSION: &str = "signature-diff-report-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const RELATION_COMPLEXITY_CANDIDATE_SCHEMA_VERSION: &str = "relation-complexity-candidates/v0";
@@ -85,7 +87,7 @@ pub struct Component {
     pub path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Edge {
     pub source: String,
     pub target: String,
@@ -128,7 +130,7 @@ pub struct MetricStatus {
     pub source: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PolicyViolation {
     pub axis: String,
@@ -512,6 +514,223 @@ pub struct ArchitectureSignatureV1DatasetShape {
     pub empirical_change_cost: Option<usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureSnapshotStoreRecordV0 {
+    pub schema_version: String,
+    pub repository: SnapshotRepositoryRef,
+    pub revision: RepositoryRevisionRef,
+    pub scan: ScanMetadata,
+    pub extractor: SnapshotExtractorMetadata,
+    pub policy: SnapshotPolicyMetadata,
+    pub signature: ArchitectureSignatureV1DatasetShape,
+    pub metric_status: BTreeMap<String, MetricStatus>,
+    pub validation_summary: SnapshotValidationSummary,
+    pub artifacts: SnapshotArtifacts,
+    pub analysis_metadata: SnapshotAnalysisMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotRepositoryRef {
+    pub owner: String,
+    pub name: String,
+    pub default_branch: String,
+    pub remote_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepositoryRevisionRef {
+    pub sha: String,
+    #[serde(rename = "ref")]
+    pub ref_name: Option<String>,
+    pub branch: Option<String>,
+    pub committed_at: Option<String>,
+    pub parent_shas: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanMetadata {
+    pub scanned_at: String,
+    pub scanner_id: Option<String>,
+    pub trigger: String,
+    pub root: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotExtractorMetadata {
+    pub name: String,
+    pub version: String,
+    pub rule_set_version: String,
+    pub input_schema_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotPolicyMetadata {
+    pub policy_id: Option<String>,
+    pub schema_version: Option<String>,
+    pub version: Option<String>,
+    pub source_path: Option<String>,
+    pub content_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotValidationSummary {
+    pub schema_version: Option<String>,
+    pub result: String,
+    pub universe_mode: Option<String>,
+    pub failed_check_count: Option<usize>,
+    pub warning_check_count: Option<usize>,
+    pub not_measured_check_count: Option<usize>,
+    pub report_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotArtifacts {
+    pub extractor_output_path: Option<String>,
+    pub validation_report_path: Option<String>,
+    pub policy_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotAnalysisMetadata {
+    pub excluded_from_primary_diff: bool,
+    pub exclusion_reasons: Vec<String>,
+    pub tags: Vec<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotRecordInput {
+    pub repository: SnapshotRepositoryRef,
+    pub revision: RepositoryRevisionRef,
+    pub scan: ScanMetadata,
+    pub policy_version: Option<String>,
+    pub policy_source_path: Option<String>,
+    pub policy_content_hash: Option<String>,
+    pub extractor_output_path: Option<String>,
+    pub validation_report_path: Option<String>,
+    pub tags: Vec<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureDiffReportV0 {
+    pub schema_version: String,
+    pub before: SnapshotDiffEndpoint,
+    pub after: SnapshotDiffEndpoint,
+    pub comparison_status: SnapshotComparisonStatus,
+    pub delta_signature_signed: NullableSignatureIntVector,
+    pub metric_delta_status: BTreeMap<String, MetricDeltaStatus>,
+    pub worsened_axes: Vec<SignatureAxisChange>,
+    pub improved_axes: Vec<SignatureAxisChange>,
+    pub unchanged_axes: Vec<SignatureAxisChange>,
+    pub unmeasured_axes: Vec<UnmeasuredAxisDelta>,
+    pub evidence_diff: SnapshotEvidenceDiff,
+    pub attribution: SnapshotDiffAttribution,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotDiffEndpoint {
+    pub repository: SnapshotRepositoryRef,
+    pub revision: RepositoryRevisionRef,
+    pub validation_result: String,
+    pub extractor_version: String,
+    pub rule_set_version: String,
+    pub policy_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotComparisonStatus {
+    pub primary_diff_eligible: bool,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureAxisChange {
+    pub axis: String,
+    pub before: i64,
+    pub after: i64,
+    pub delta: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnmeasuredAxisDelta {
+    pub axis: String,
+    pub reason: String,
+    pub before_measured: bool,
+    pub after_measured: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotEvidenceDiff {
+    pub available: bool,
+    pub unavailable_reason: Option<String>,
+    pub component_delta: Option<ComponentSetDelta>,
+    pub edge_delta: Option<EdgeSetDelta>,
+    pub policy_violation_delta: Option<PolicyViolationSetDelta>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentSetDelta {
+    pub before_count: usize,
+    pub after_count: usize,
+    pub delta: i64,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeSetDelta {
+    pub before_count: usize,
+    pub after_count: usize,
+    pub delta: i64,
+    pub added: Vec<Edge>,
+    pub removed: Vec<Edge>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyViolationSetDelta {
+    pub before_count: usize,
+    pub after_count: usize,
+    pub delta: i64,
+    pub added: Vec<PolicyViolation>,
+    pub removed: Vec<PolicyViolation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotDiffAttribution {
+    pub method: String,
+    pub candidates: Vec<AttributionCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributionCandidate {
+    pub kind: String,
+    pub id: String,
+    pub confidence: f64,
+    pub reasons: Vec<String>,
+    pub changed_components: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NullableSignatureIntVector {
@@ -872,6 +1091,87 @@ pub fn build_empirical_dataset(
         issue_incident_links: input.issue_incident_links,
         analysis_metadata: input.analysis_metadata,
     })
+}
+
+pub fn build_signature_snapshot_record(
+    document: &Sig0Document,
+    validation_report: Option<&ComponentUniverseValidationReport>,
+    input: SnapshotRecordInput,
+) -> SignatureSnapshotStoreRecordV0 {
+    let validation_summary =
+        snapshot_validation_summary(validation_report, input.validation_report_path.clone());
+    let mut exclusion_reasons = Vec::new();
+    match validation_summary.result.as_str() {
+        "fail" => exclusion_reasons.push("validationSummary.result = fail".to_string()),
+        "not_run" => exclusion_reasons.push("validationSummary.result = not_run".to_string()),
+        _ => {}
+    }
+
+    SignatureSnapshotStoreRecordV0 {
+        schema_version: SIGNATURE_SNAPSHOT_STORE_SCHEMA_VERSION.to_string(),
+        repository: input.repository,
+        revision: input.revision,
+        scan: input.scan,
+        extractor: SnapshotExtractorMetadata {
+            name: EXTRACTOR_NAME.to_string(),
+            version: EXTRACTOR_VERSION.to_string(),
+            rule_set_version: RULE_SET_VERSION.to_string(),
+            input_schema_version: document.schema_version.clone(),
+        },
+        policy: SnapshotPolicyMetadata {
+            policy_id: document.policies.policy_id.clone(),
+            schema_version: document.policies.schema_version.clone(),
+            version: input.policy_version,
+            source_path: input.policy_source_path.clone(),
+            content_hash: input.policy_content_hash,
+        },
+        signature: dataset_signature_shape(document),
+        metric_status: dataset_metric_status(document),
+        validation_summary,
+        artifacts: SnapshotArtifacts {
+            extractor_output_path: input.extractor_output_path,
+            validation_report_path: input.validation_report_path,
+            policy_path: input.policy_source_path,
+        },
+        analysis_metadata: SnapshotAnalysisMetadata {
+            excluded_from_primary_diff: !exclusion_reasons.is_empty(),
+            exclusion_reasons,
+            tags: input.tags,
+            notes: input.notes,
+        },
+    }
+}
+
+pub fn build_signature_diff_report(
+    before: &SignatureSnapshotStoreRecordV0,
+    after: &SignatureSnapshotStoreRecordV0,
+    before_document: Option<&Sig0Document>,
+    after_document: Option<&Sig0Document>,
+    pr_metadata: &[EmpiricalDatasetInput],
+) -> SignatureDiffReportV0 {
+    let before_snapshot = store_record_signature_snapshot(before, "before");
+    let after_snapshot = store_record_signature_snapshot(after, "after");
+    let delta_signature_signed = delta_signature_signed(&before_snapshot, &after_snapshot);
+    let metric_delta_status = metric_delta_status(&before_snapshot, &after_snapshot);
+    let (worsened_axes, improved_axes, unchanged_axes, unmeasured_axes) =
+        classify_axis_deltas(before, after, &metric_delta_status);
+    let evidence_diff = snapshot_evidence_diff(before_document, after_document);
+    let attribution = snapshot_diff_attribution(after, &evidence_diff, &worsened_axes, pr_metadata);
+
+    SignatureDiffReportV0 {
+        schema_version: SIGNATURE_DIFF_REPORT_SCHEMA_VERSION.to_string(),
+        before: snapshot_diff_endpoint(before),
+        after: snapshot_diff_endpoint(after),
+        comparison_status: snapshot_comparison_status(before, after),
+        delta_signature_signed,
+        metric_delta_status,
+        worsened_axes,
+        improved_axes,
+        unchanged_axes,
+        unmeasured_axes,
+        evidence_diff,
+        attribution,
+    }
 }
 
 pub fn build_pr_metadata_from_github_files(
@@ -1618,6 +1918,348 @@ fn metric_status_reason(axis: &str, metric_status: &BTreeMap<String, MetricStatu
         .get(axis)
         .and_then(|status| status.reason.clone())
         .unwrap_or_else(|| "metricStatus entry is missing".to_string())
+}
+
+fn snapshot_validation_summary(
+    report: Option<&ComponentUniverseValidationReport>,
+    report_path: Option<String>,
+) -> SnapshotValidationSummary {
+    match report {
+        Some(report) => SnapshotValidationSummary {
+            schema_version: Some(report.schema_version.clone()),
+            result: report.summary.result.clone(),
+            universe_mode: Some(report.universe_mode.clone()),
+            failed_check_count: Some(report.summary.failed_check_count),
+            warning_check_count: Some(report.summary.warning_check_count),
+            not_measured_check_count: Some(report.summary.not_measured_check_count),
+            report_path,
+        },
+        None => SnapshotValidationSummary {
+            schema_version: None,
+            result: "not_run".to_string(),
+            universe_mode: None,
+            failed_check_count: None,
+            warning_check_count: None,
+            not_measured_check_count: None,
+            report_path: None,
+        },
+    }
+}
+
+fn store_record_signature_snapshot(
+    record: &SignatureSnapshotStoreRecordV0,
+    role: &str,
+) -> SignatureSnapshot {
+    SignatureSnapshot {
+        commit: GitCommitRef {
+            sha: record.revision.sha.clone(),
+            role: role.to_string(),
+        },
+        extractor: ExtractorRef {
+            name: record.extractor.name.clone(),
+            version: record.extractor.version.clone(),
+            rule_set_version: record.extractor.rule_set_version.clone(),
+            policy_version: record.policy.policy_id.clone(),
+        },
+        signature: record.signature.clone(),
+        metric_status: record.metric_status.clone(),
+    }
+}
+
+fn snapshot_diff_endpoint(record: &SignatureSnapshotStoreRecordV0) -> SnapshotDiffEndpoint {
+    SnapshotDiffEndpoint {
+        repository: record.repository.clone(),
+        revision: record.revision.clone(),
+        validation_result: record.validation_summary.result.clone(),
+        extractor_version: record.extractor.version.clone(),
+        rule_set_version: record.extractor.rule_set_version.clone(),
+        policy_id: record.policy.policy_id.clone(),
+    }
+}
+
+fn snapshot_comparison_status(
+    before: &SignatureSnapshotStoreRecordV0,
+    after: &SignatureSnapshotStoreRecordV0,
+) -> SnapshotComparisonStatus {
+    let mut reasons = Vec::new();
+    if !matches!(before.validation_summary.result.as_str(), "pass" | "warn") {
+        reasons.push(format!(
+            "before validationSummary.result = {}",
+            before.validation_summary.result
+        ));
+    }
+    if !matches!(after.validation_summary.result.as_str(), "pass" | "warn") {
+        reasons.push(format!(
+            "after validationSummary.result = {}",
+            after.validation_summary.result
+        ));
+    }
+    if before.extractor.name != after.extractor.name {
+        reasons.push("extractor.name differs".to_string());
+    }
+    if before.extractor.version != after.extractor.version {
+        reasons.push("extractor.version differs".to_string());
+    }
+    if before.extractor.rule_set_version != after.extractor.rule_set_version {
+        reasons.push("extractor.ruleSetVersion differs".to_string());
+    }
+    if before.policy.policy_id != after.policy.policy_id {
+        reasons.push("policy.policyId differs".to_string());
+    }
+    if before.policy.version != after.policy.version {
+        reasons.push("policy.version differs".to_string());
+    }
+
+    SnapshotComparisonStatus {
+        primary_diff_eligible: reasons.is_empty(),
+        reasons,
+    }
+}
+
+fn classify_axis_deltas(
+    before: &SignatureSnapshotStoreRecordV0,
+    after: &SignatureSnapshotStoreRecordV0,
+    status: &BTreeMap<String, MetricDeltaStatus>,
+) -> (
+    Vec<SignatureAxisChange>,
+    Vec<SignatureAxisChange>,
+    Vec<SignatureAxisChange>,
+    Vec<UnmeasuredAxisDelta>,
+) {
+    let mut worsened = Vec::new();
+    let mut improved = Vec::new();
+    let mut unchanged = Vec::new();
+    let mut unmeasured = Vec::new();
+
+    for axis in DATASET_DELTA_AXES {
+        let axis_status = status
+            .get(axis)
+            .expect("metric delta status exists for every dataset delta axis");
+        let before_value = signature_value(axis, &before.signature);
+        let after_value = signature_value(axis, &after.signature);
+        if !axis_status.comparable {
+            unmeasured.push(UnmeasuredAxisDelta {
+                axis: axis.to_string(),
+                reason: axis_status.reason.clone(),
+                before_measured: axis_status.before_measured,
+                after_measured: axis_status.after_measured,
+            });
+            continue;
+        }
+
+        let before_value = before_value.expect("comparable before value exists");
+        let after_value = after_value.expect("comparable after value exists");
+        let change = SignatureAxisChange {
+            axis: axis.to_string(),
+            before: before_value,
+            after: after_value,
+            delta: after_value - before_value,
+        };
+        match change.delta.cmp(&0) {
+            std::cmp::Ordering::Greater => worsened.push(change),
+            std::cmp::Ordering::Less => improved.push(change),
+            std::cmp::Ordering::Equal => unchanged.push(change),
+        }
+    }
+
+    (worsened, improved, unchanged, unmeasured)
+}
+
+fn snapshot_evidence_diff(
+    before: Option<&Sig0Document>,
+    after: Option<&Sig0Document>,
+) -> SnapshotEvidenceDiff {
+    let (before, after) = match (before, after) {
+        (Some(before), Some(after)) => (before, after),
+        _ => {
+            return SnapshotEvidenceDiff {
+                available: false,
+                unavailable_reason: Some(
+                    "before and after Sig0 extractor JSON are required for component / edge evidence diff"
+                        .to_string(),
+                ),
+                component_delta: None,
+                edge_delta: None,
+                policy_violation_delta: None,
+            };
+        }
+    };
+
+    let before_components = before
+        .components
+        .iter()
+        .map(|component| component.id.clone())
+        .collect::<BTreeSet<_>>();
+    let after_components = after
+        .components
+        .iter()
+        .map(|component| component.id.clone())
+        .collect::<BTreeSet<_>>();
+    let before_edges = before.edges.iter().cloned().collect::<BTreeSet<_>>();
+    let after_edges = after.edges.iter().cloned().collect::<BTreeSet<_>>();
+    let before_policy_violations = before
+        .policy_violations
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let after_policy_violations = after
+        .policy_violations
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    SnapshotEvidenceDiff {
+        available: true,
+        unavailable_reason: None,
+        component_delta: Some(ComponentSetDelta {
+            before_count: before_components.len(),
+            after_count: after_components.len(),
+            delta: after_components.len() as i64 - before_components.len() as i64,
+            added: set_added(&before_components, &after_components),
+            removed: set_removed(&before_components, &after_components),
+        }),
+        edge_delta: Some(EdgeSetDelta {
+            before_count: before_edges.len(),
+            after_count: after_edges.len(),
+            delta: after_edges.len() as i64 - before_edges.len() as i64,
+            added: set_added(&before_edges, &after_edges),
+            removed: set_removed(&before_edges, &after_edges),
+        }),
+        policy_violation_delta: Some(PolicyViolationSetDelta {
+            before_count: before_policy_violations.len(),
+            after_count: after_policy_violations.len(),
+            delta: after_policy_violations.len() as i64 - before_policy_violations.len() as i64,
+            added: set_added(&before_policy_violations, &after_policy_violations),
+            removed: set_removed(&before_policy_violations, &after_policy_violations),
+        }),
+    }
+}
+
+fn set_added<T: Ord + Clone>(before: &BTreeSet<T>, after: &BTreeSet<T>) -> Vec<T> {
+    after.difference(before).cloned().collect()
+}
+
+fn set_removed<T: Ord + Clone>(before: &BTreeSet<T>, after: &BTreeSet<T>) -> Vec<T> {
+    before.difference(after).cloned().collect()
+}
+
+fn snapshot_diff_attribution(
+    after: &SignatureSnapshotStoreRecordV0,
+    evidence_diff: &SnapshotEvidenceDiff,
+    worsened_axes: &[SignatureAxisChange],
+    pr_metadata: &[EmpiricalDatasetInput],
+) -> SnapshotDiffAttribution {
+    let touched_components = touched_components_from_evidence_diff(evidence_diff);
+    let mut candidates = pr_metadata
+        .iter()
+        .map(|metadata| {
+            attribution_candidate(
+                after,
+                &touched_components,
+                !worsened_axes.is_empty(),
+                metadata,
+            )
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        right
+            .confidence
+            .partial_cmp(&left.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(left.id.cmp(&right.id))
+    });
+
+    let method = if pr_metadata.is_empty() {
+        "none: PR metadata not provided".to_string()
+    } else if touched_components.is_empty() {
+        "pr-metadata: commit match and changed components; raw evidence diff unavailable or empty"
+            .to_string()
+    } else {
+        "pr-metadata: commit match and changed-component overlap with added/removed evidence"
+            .to_string()
+    };
+
+    SnapshotDiffAttribution { method, candidates }
+}
+
+fn touched_components_from_evidence_diff(evidence_diff: &SnapshotEvidenceDiff) -> BTreeSet<String> {
+    let mut components = BTreeSet::new();
+    if let Some(component_delta) = &evidence_diff.component_delta {
+        components.extend(component_delta.added.iter().cloned());
+        components.extend(component_delta.removed.iter().cloned());
+    }
+    if let Some(edge_delta) = &evidence_diff.edge_delta {
+        for edge in edge_delta.added.iter().chain(edge_delta.removed.iter()) {
+            components.insert(edge.source.clone());
+            components.insert(edge.target.clone());
+        }
+    }
+    if let Some(policy_delta) = &evidence_diff.policy_violation_delta {
+        for violation in policy_delta.added.iter().chain(policy_delta.removed.iter()) {
+            components.insert(violation.source.clone());
+            components.insert(violation.target.clone());
+        }
+    }
+    components
+}
+
+fn attribution_candidate(
+    after: &SignatureSnapshotStoreRecordV0,
+    touched_components: &BTreeSet<String>,
+    has_worsened_axes: bool,
+    metadata: &EmpiricalDatasetInput,
+) -> AttributionCandidate {
+    let changed_components = metadata.pr_metrics.changed_components.clone();
+    let changed_set = changed_components.iter().cloned().collect::<BTreeSet<_>>();
+    let overlap = changed_set
+        .intersection(touched_components)
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut confidence = 0.15;
+    let mut reasons = Vec::new();
+
+    if after.revision.sha == metadata.pull_request.head_commit {
+        confidence += 0.35;
+        reasons.push("after revision matches pullRequest.headCommit".to_string());
+    }
+    if metadata
+        .pull_request
+        .merge_commit
+        .as_ref()
+        .is_some_and(|merge_commit| after.revision.sha == *merge_commit)
+    {
+        confidence += 0.35;
+        reasons.push("after revision matches pullRequest.mergeCommit".to_string());
+    }
+    if !overlap.is_empty() {
+        let denominator = touched_components.len().max(1) as f64;
+        confidence += 0.35 * (overlap.len() as f64 / denominator).min(1.0);
+        reasons.push(format!(
+            "changed components overlap with evidence diff: {}",
+            overlap.join(", ")
+        ));
+    }
+    if has_worsened_axes {
+        confidence += 0.10;
+        reasons.push("signature has worsened axes".to_string());
+    }
+    if reasons.is_empty() {
+        reasons.push(
+            "weak candidate: PR metadata provided but no commit or evidence overlap".to_string(),
+        );
+    }
+
+    AttributionCandidate {
+        kind: "pullRequest".to_string(),
+        id: format!("#{}", metadata.pull_request.number),
+        confidence: round_confidence(confidence.min(0.95)),
+        reasons,
+        changed_components,
+    }
+}
+
+fn round_confidence(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
 }
 
 fn count_checks(checks: &[ValidationCheck], result: &str) -> usize {

--- a/tools/sig0-extractor/src/main.rs
+++ b/tools/sig0-extractor/src/main.rs
@@ -6,8 +6,11 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 use sig0_extractor::{
-    DEFAULT_UNIVERSE_MODE, EmpiricalDatasetInput, Sig0Document, build_empirical_dataset,
-    build_pr_metadata_from_github_files, extract_relation_complexity_observation_from_file,
+    ComponentUniverseValidationReport, DEFAULT_UNIVERSE_MODE, EmpiricalDatasetInput,
+    RepositoryRevisionRef, ScanMetadata, Sig0Document, SignatureSnapshotStoreRecordV0,
+    SnapshotRecordInput, SnapshotRepositoryRef, build_empirical_dataset,
+    build_pr_metadata_from_github_files, build_signature_diff_report,
+    build_signature_snapshot_record, extract_relation_complexity_observation_from_file,
     extract_sig0_with_runtime, validate_component_universe_report,
 };
 
@@ -107,6 +110,124 @@ enum Command {
         #[arg(long)]
         out: Option<PathBuf>,
     },
+
+    /// Build a repository-revision Signature snapshot store record.
+    Snapshot {
+        /// Input Sig0 extractor JSON path.
+        #[arg(long)]
+        input: PathBuf,
+
+        /// Optional ComponentUniverse validation report JSON path.
+        #[arg(long = "validation-report")]
+        validation_report: Option<PathBuf>,
+
+        /// Repository owner.
+        #[arg(long = "repo-owner")]
+        repo_owner: String,
+
+        /// Repository name.
+        #[arg(long = "repo-name")]
+        repo_name: String,
+
+        /// Repository default branch.
+        #[arg(long = "default-branch", default_value = "main")]
+        default_branch: String,
+
+        /// Optional repository remote URL.
+        #[arg(long = "remote-url")]
+        remote_url: Option<String>,
+
+        /// Measured revision SHA.
+        #[arg(long = "revision-sha")]
+        revision_sha: String,
+
+        /// Optional measured revision ref.
+        #[arg(long = "revision-ref")]
+        revision_ref: Option<String>,
+
+        /// Optional measured branch.
+        #[arg(long = "revision-branch")]
+        revision_branch: Option<String>,
+
+        /// Optional measured commit timestamp.
+        #[arg(long = "committed-at")]
+        committed_at: Option<String>,
+
+        /// Optional parent SHA. Repeat for merge commits.
+        #[arg(long = "parent-sha")]
+        parent_sha: Vec<String>,
+
+        /// Scan timestamp.
+        #[arg(long = "scanned-at")]
+        scanned_at: String,
+
+        /// Optional scanner id.
+        #[arg(long = "scanner-id")]
+        scanner_id: Option<String>,
+
+        /// Scan trigger.
+        #[arg(long, default_value = "manual")]
+        trigger: String,
+
+        /// Optional scan root recorded in the snapshot.
+        #[arg(long = "scan-root")]
+        scan_root: Option<String>,
+
+        /// Optional policy version.
+        #[arg(long = "policy-version")]
+        policy_version: Option<String>,
+
+        /// Optional policy source path.
+        #[arg(long = "policy-path")]
+        policy_path: Option<String>,
+
+        /// Optional policy content hash.
+        #[arg(long = "policy-content-hash")]
+        policy_content_hash: Option<String>,
+
+        /// Optional extractor output artifact path.
+        #[arg(long = "extractor-output-path")]
+        extractor_output_path: Option<String>,
+
+        /// Optional snapshot tag. Repeat for multiple tags.
+        #[arg(long)]
+        tag: Vec<String>,
+
+        /// Optional analysis note.
+        #[arg(long)]
+        notes: Option<String>,
+
+        /// Output snapshot JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Diff two Signature snapshot store records.
+    SignatureDiff {
+        /// Before snapshot store record JSON path.
+        #[arg(long = "before-snapshot")]
+        before_snapshot: PathBuf,
+
+        /// After snapshot store record JSON path.
+        #[arg(long = "after-snapshot")]
+        after_snapshot: PathBuf,
+
+        /// Optional before Sig0 extractor JSON for component / edge evidence diff.
+        #[arg(long = "before-sig0")]
+        before_sig0: Option<PathBuf>,
+
+        /// Optional after Sig0 extractor JSON for component / edge evidence diff.
+        #[arg(long = "after-sig0")]
+        after_sig0: Option<PathBuf>,
+
+        /// Optional PR metadata JSON for attribution. Repeat for multiple PRs.
+        #[arg(long = "pr-metadata")]
+        pr_metadata: Vec<PathBuf>,
+
+        /// Output diff report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -180,6 +301,103 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             write_json(out, &observation)?;
             Ok(ExitCode::SUCCESS)
         }
+        Some(Command::Snapshot {
+            input,
+            validation_report,
+            repo_owner,
+            repo_name,
+            default_branch,
+            remote_url,
+            revision_sha,
+            revision_ref,
+            revision_branch,
+            committed_at,
+            parent_sha,
+            scanned_at,
+            scanner_id,
+            trigger,
+            scan_root,
+            policy_version,
+            policy_path,
+            policy_content_hash,
+            extractor_output_path,
+            tag,
+            notes,
+            out,
+        }) => {
+            let document: Sig0Document = read_json(&input)?;
+            let validation: Option<ComponentUniverseValidationReport> = validation_report
+                .as_ref()
+                .map(|path| read_json(path))
+                .transpose()?;
+            let validation_report_path = validation_report.map(|path| path.display().to_string());
+            let snapshot = build_signature_snapshot_record(
+                &document,
+                validation.as_ref(),
+                SnapshotRecordInput {
+                    repository: SnapshotRepositoryRef {
+                        owner: repo_owner,
+                        name: repo_name,
+                        default_branch,
+                        remote_url,
+                    },
+                    revision: RepositoryRevisionRef {
+                        sha: revision_sha,
+                        ref_name: revision_ref,
+                        branch: revision_branch,
+                        committed_at,
+                        parent_shas: parent_sha,
+                    },
+                    scan: ScanMetadata {
+                        scanned_at,
+                        scanner_id,
+                        trigger,
+                        root: scan_root,
+                    },
+                    policy_version,
+                    policy_source_path: policy_path,
+                    policy_content_hash,
+                    extractor_output_path,
+                    validation_report_path,
+                    tags: tag,
+                    notes,
+                },
+            );
+            write_json(out, &snapshot)?;
+            Ok(ExitCode::SUCCESS)
+        }
+        Some(Command::SignatureDiff {
+            before_snapshot,
+            after_snapshot,
+            before_sig0,
+            after_sig0,
+            pr_metadata,
+            out,
+        }) => {
+            let before: SignatureSnapshotStoreRecordV0 = read_json(&before_snapshot)?;
+            let after: SignatureSnapshotStoreRecordV0 = read_json(&after_snapshot)?;
+            let before_document: Option<Sig0Document> = before_sig0
+                .as_ref()
+                .map(|path| read_json(path))
+                .transpose()?;
+            let after_document: Option<Sig0Document> = after_sig0
+                .as_ref()
+                .map(|path| read_json(path))
+                .transpose()?;
+            let pr_metadata = pr_metadata
+                .iter()
+                .map(read_json)
+                .collect::<Result<Vec<EmpiricalDatasetInput>, Box<dyn Error>>>()?;
+            let report = build_signature_diff_report(
+                &before,
+                &after,
+                before_document.as_ref(),
+                after_document.as_ref(),
+                &pr_metadata,
+            );
+            write_json(out, &report)?;
+            Ok(ExitCode::SUCCESS)
+        }
         None => {
             let document = extract_sig0_with_runtime(
                 &args.root,
@@ -212,4 +430,8 @@ fn write_json<T: serde::Serialize>(out: Option<PathBuf>, value: &T) -> Result<()
         }
     }
     Ok(())
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T, Box<dyn Error>> {
+    Ok(serde_json::from_reader(File::open(path)?)?)
 }

--- a/tools/sig0-extractor/tests/cli.rs
+++ b/tools/sig0-extractor/tests/cli.rs
@@ -227,6 +227,224 @@ fn cli_relation_complexity_fixture_outputs_observation() {
 }
 
 #[test]
+fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
+    let fixture = fixture_root();
+    let repo = temp_dir("snapshot-repo");
+    fs::create_dir_all(repo.join("Formal/Arch")).expect("fixture directories are created");
+    fs::write(
+        repo.join("Formal.lean"),
+        "import Formal.Arch.A\nimport Formal.Arch.B\n",
+    )
+    .expect("before root file is written");
+    fs::write(
+        repo.join("Formal/Arch/A.lean"),
+        "namespace Formal.Arch\n\ndef fixtureA : Nat := 0\n\nend Formal.Arch\n",
+    )
+    .expect("A file is written");
+    fs::write(
+        repo.join("Formal/Arch/B.lean"),
+        "import Formal.Arch.A\n\nnamespace Formal.Arch\n\ndef fixtureB : Nat := fixtureA + 1\n\nend Formal.Arch\n",
+    )
+    .expect("B file is written");
+
+    let out_dir = temp_dir("snapshot-diff");
+    let before_sig0 = out_dir.join("before-sig0.json");
+    let before_validation = out_dir.join("before-validation.json");
+    let before_snapshot = out_dir.join("before-snapshot.json");
+    let after_sig0 = out_dir.join("after-sig0.json");
+    let after_validation = out_dir.join("after-validation.json");
+    let after_snapshot = out_dir.join("after-snapshot.json");
+    let pr_metadata = out_dir.join("pr-metadata.json");
+    let report = out_dir.join("signature-diff.json");
+
+    run_sig0(&[
+        "--root",
+        repo.to_str().expect("repo path is utf-8"),
+        "--policy",
+        fixture
+            .join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--out",
+        before_sig0.to_str().expect("before sig0 path is utf-8"),
+    ]);
+    run_sig0(&[
+        "validate",
+        "--input",
+        before_sig0
+            .to_str()
+            .expect("before validation input path is utf-8"),
+        "--out",
+        before_validation
+            .to_str()
+            .expect("before validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "snapshot",
+        "--input",
+        before_sig0.to_str().expect("before sig0 path is utf-8"),
+        "--validation-report",
+        before_validation
+            .to_str()
+            .expect("before validation path is utf-8"),
+        "--repo-owner",
+        "example",
+        "--repo-name",
+        "service",
+        "--revision-sha",
+        "before-sha",
+        "--scanned-at",
+        "2026-04-26T00:00:00Z",
+        "--policy-path",
+        fixture
+            .join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--out",
+        before_snapshot
+            .to_str()
+            .expect("before snapshot path is utf-8"),
+    ]);
+
+    fs::write(
+        repo.join("Formal.lean"),
+        "import Formal.Arch.A\nimport Formal.Arch.B\nimport Formal.Arch.C\n",
+    )
+    .expect("after root file is written");
+    fs::write(
+        repo.join("Formal/Arch/C.lean"),
+        "import Formal.Arch.B\n\nnamespace Formal.Arch\n\ndef fixtureC : Nat := fixtureB + 1\n\nend Formal.Arch\n",
+    )
+    .expect("C file is written");
+    run_sig0(&[
+        "--root",
+        repo.to_str().expect("repo path is utf-8"),
+        "--policy",
+        fixture
+            .join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--out",
+        after_sig0.to_str().expect("after sig0 path is utf-8"),
+    ]);
+    run_sig0(&[
+        "validate",
+        "--input",
+        after_sig0
+            .to_str()
+            .expect("after validation input path is utf-8"),
+        "--out",
+        after_validation
+            .to_str()
+            .expect("after validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "snapshot",
+        "--input",
+        after_sig0.to_str().expect("after sig0 path is utf-8"),
+        "--validation-report",
+        after_validation
+            .to_str()
+            .expect("after validation path is utf-8"),
+        "--repo-owner",
+        "example",
+        "--repo-name",
+        "service",
+        "--revision-sha",
+        "after-sha",
+        "--scanned-at",
+        "2026-04-26T01:00:00Z",
+        "--policy-path",
+        fixture
+            .join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--out",
+        after_snapshot
+            .to_str()
+            .expect("after snapshot path is utf-8"),
+    ]);
+
+    fs::write(
+        &pr_metadata,
+        serde_json::json!({
+            "repository": {
+                "owner": "example",
+                "name": "service",
+                "defaultBranch": "main"
+            },
+            "pullRequest": {
+                "number": 77,
+                "author": "alice",
+                "createdAt": "2026-04-25T00:00:00Z",
+                "mergedAt": "2026-04-26T01:30:00Z",
+                "baseCommit": "before-sha",
+                "headCommit": "after-sha",
+                "mergeCommit": null,
+                "labels": [],
+                "isBotGenerated": false
+            },
+            "prMetrics": {
+                "changedFiles": 2,
+                "changedLinesAdded": 4,
+                "changedLinesDeleted": 0,
+                "changedComponents": ["Formal", "Formal.Arch.C"],
+                "reviewCommentCount": 0,
+                "reviewThreadCount": 0,
+                "reviewRoundCount": 0,
+                "firstReviewLatencyHours": null,
+                "approvalLatencyHours": null,
+                "mergeLatencyHours": null
+            }
+        })
+        .to_string(),
+    )
+    .expect("PR metadata is written");
+
+    run_sig0(&[
+        "signature-diff",
+        "--before-snapshot",
+        before_snapshot
+            .to_str()
+            .expect("before snapshot path is utf-8"),
+        "--after-snapshot",
+        after_snapshot
+            .to_str()
+            .expect("after snapshot path is utf-8"),
+        "--before-sig0",
+        before_sig0.to_str().expect("before sig0 path is utf-8"),
+        "--after-sig0",
+        after_sig0.to_str().expect("after sig0 path is utf-8"),
+        "--pr-metadata",
+        pr_metadata.to_str().expect("PR metadata path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "signature-diff-report-v0");
+    assert_eq!(json["comparisonStatus"]["primaryDiffEligible"], true);
+    assert!(
+        json["worsenedAxes"]
+            .as_array()
+            .expect("worsenedAxes is array")
+            .iter()
+            .any(|axis| axis["delta"].as_i64().expect("delta is integer") > 0)
+    );
+    assert_eq!(
+        json["evidenceDiff"]["componentDelta"]["added"],
+        serde_json::json!(["Formal.Arch.C"])
+    );
+    assert_eq!(json["attribution"]["candidates"][0]["id"], "#77");
+    assert!(
+        json["attribution"]["candidates"][0]["confidence"]
+            .as_f64()
+            .expect("confidence is number")
+            > 0.5
+    );
+}
+
+#[test]
 fn cli_validation_warns_for_module_root_import_target() {
     let root = module_root_fixture_root();
     let out_dir = temp_dir("module-root");


### PR DESCRIPTION
## 概要

Closes #156

- `sig0-extractor snapshot` を追加し、Sig0 output と validation report から `signature-snapshot-store-v0` record を生成できるようにした。
- `sig0-extractor signature-diff` を追加し、snapshot 同士の signed delta、悪化・改善・未評価軸、raw Sig0 JSON に基づく component / edge / policy violation diff、PR metadata に基づく attribution candidate を report できるようにした。
- snapshot diff MVP の CLI / GitHub Actions 再現手順と Lean status を docs に追記した。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/sig0-extractor/README.md`
- `docs/design/signature_snapshot_store_schema.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている