### PR TITLE
relationComplexity の pilot baseline を追加する

### DIFF
--- a/docs/design/relation_complexity_design.md
+++ b/docs/design/relation_complexity_design.md
@@ -233,5 +233,10 @@ raw count とは別の派生指標に分ける。
   で `sig0-extractor relation-complexity --input ...` として実装した。候補 evidence
   から workflow-level `RelationComplexityObservation` JSON を出力し、counts と
   `relationComplexity` は counted evidence tags から再計算可能にしている。
-- Event Sourcing / Saga / CRUD の pilot repository を選び、手動ラベルつき baseline dataset を作る。
+- Event Sourcing / Saga / CRUD を含む pilot baseline は
+  [#154](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/154)
+  で
+  [relation_complexity_pilot](../empirical/relation_complexity_pilot/README.md)
+  に追加した。手動ラベル、extractor output、差分 0 の確認、除外 evidence、
+  unsupported framework probe を記録している。
 - 状態遷移構造を Lean に入れるかどうかを、pilot の後に改めて判断する。

--- a/docs/empirical/relation_complexity_pilot/README.md
+++ b/docs/empirical/relation_complexity_pilot/README.md
@@ -1,0 +1,107 @@
+# relationComplexity pilot baseline
+
+Lean status: `empirical hypothesis` / pilot validation.
+
+Issue [#154](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/154)
+の pilot として、Event Sourcing / Saga / CRUD を含む小さな commerce 状態遷移
+sample を選び、`relationComplexity` の手動 baseline と
+`sig0-extractor relation-complexity` の出力差分を記録した。
+
+この pilot の目的は統計的結論ではない。`RelationComplexityObservation` の
+counting rule v0 が、手動レビュー済み candidate から構成要素ベクトルを再現できるか、
+また excluded evidence / unsupported framework / ambiguous candidate を primary count
+から分離できるかを確認する。
+
+## 対象
+
+- repository: `aatv2/reference-commerce-state-transitions`
+- revision: `pilot-2026-04-26`
+- measurement root: `samples/commerce-state-transitions`
+- language: TypeScript sample
+- frameworks: `event-sourcing`, `saga`, `crud`
+- workflow: `checkout-payment-fulfillment`
+- component: `CommerceCheckout`
+
+対象 workflow は、注文状態制約、在庫予約制約、Saga 補償、event log からの
+read model projection、支払い retry と idempotency key を持つ小さな手動 sample
+として扱う。これは実 repository からの完全抽出ではなく、rule set v0 の pilot
+baseline である。
+
+## 手動 baseline
+
+[`baseline/commerce_state_transitions_manual_baseline.json`](baseline/commerce_state_transitions_manual_baseline.json)
+に手動ラベルと count を保存した。
+
+| component | manual count |
+| --- | ---: |
+| `constraints` | 2 |
+| `compensations` | 2 |
+| `projections` | 1 |
+| `failureTransitions` | 3 |
+| `idempotencyRequirements` | 2 |
+| `relationComplexity` | 10 |
+
+`relationComplexity` は構成要素の合計値として保存するが、解釈では各 component
+を残す。Event Sourcing / Saga / CRUD の優劣を単一スコアで決めるものではない。
+
+## extractor output との差分
+
+入力 candidate は
+[`candidates/commerce_state_transitions_candidates.json`](candidates/commerce_state_transitions_candidates.json)、
+生成された observation は
+[`observations/commerce_state_transitions_observation.json`](observations/commerce_state_transitions_observation.json)
+に保存する。
+
+| component | manual | extractor | delta |
+| --- | ---: | ---: | ---: |
+| `constraints` | 2 | 2 | 0 |
+| `compensations` | 2 | 2 | 0 |
+| `projections` | 1 | 1 | 0 |
+| `failureTransitions` | 3 | 3 | 0 |
+| `idempotencyRequirements` | 2 | 2 | 0 |
+| `relationComplexity` | 10 | 10 | 0 |
+
+この pilot では accepted evidence の count は手動 baseline と一致した。差分 0 は
+「実 repository で完全抽出できる」という主張ではなく、review 済み candidate JSON に対して
+rule set v0 の正規化と counting が意図どおり動くことを示す tooling-side observation
+である。
+
+## 除外 evidence と曖昧な候補
+
+primary count から外した evidence は次の通り。
+
+| id / path | handling | reason |
+| --- | --- | --- |
+| `generated-orm-unique-index` | excluded | `framework-generated` なので application-owned transition logic として数えない。 |
+| `crud-field-format-validation` | excluded | CRUD field validation だが状態遷移分岐を増やさないため `false-positive` とした。 |
+| `ambiguous-shipping-provider-hook` | review later | ownership が `unknown` のため primary count から外す。 |
+| `src/checkout/CheckoutWorkflow.spec.ts` | excluded | test fixture。 |
+
+unsupported framework の扱いは
+[`candidates/unsupported_framework_probe.json`](candidates/unsupported_framework_probe.json)
+と
+[`observations/unsupported_framework_probe_observation.json`](observations/unsupported_framework_probe_observation.json)
+で確認した。`vendor-workflow-x` は `relation-complexity-rules/v0` の supported
+framework ではないため、candidate は `unsupported-framework:vendor-workflow-x`
+として `excludedEvidence` に残り、count は 0 になる。
+
+## Lean core への扱い
+
+この pilot は `empirical hypothesis` / pilot validation であり、状態遷移構造を
+Lean core に入れる判断はしない。現時点では `relationComplexity` を workflow-level
+observation として保持し、repository-level value は観測の集約として扱う方針を維持する。
+
+## 再生成手順
+
+```bash
+cargo run --quiet --manifest-path tools/sig0-extractor/Cargo.toml -- relation-complexity \
+  --input docs/empirical/relation_complexity_pilot/candidates/commerce_state_transitions_candidates.json \
+  --out docs/empirical/relation_complexity_pilot/observations/commerce_state_transitions_observation.json
+
+cargo run --quiet --manifest-path tools/sig0-extractor/Cargo.toml -- relation-complexity \
+  --input docs/empirical/relation_complexity_pilot/candidates/unsupported_framework_probe.json \
+  --out docs/empirical/relation_complexity_pilot/observations/unsupported_framework_probe_observation.json
+```
+
+検証では、上記 2 つの observation 生成に加えて `cargo test` の
+`relation_complexity` 関連 test を実行する。

--- a/docs/empirical/relation_complexity_pilot/baseline/commerce_state_transitions_manual_baseline.json
+++ b/docs/empirical/relation_complexity_pilot/baseline/commerce_state_transitions_manual_baseline.json
@@ -1,0 +1,99 @@
+{
+  "schemaVersion": "relation-complexity-manual-baseline/v0",
+  "repository": "aatv2/reference-commerce-state-transitions",
+  "revision": "pilot-2026-04-26",
+  "measurementUniverse": {
+    "root": "samples/commerce-state-transitions",
+    "languages": ["typescript"],
+    "frameworks": ["event-sourcing", "saga", "crud"],
+    "ruleSetVersion": "relation-complexity-rules/v0"
+  },
+  "workflow": {
+    "id": "checkout-payment-fulfillment",
+    "name": "Checkout payment and fulfillment",
+    "component": "CommerceCheckout",
+    "entrypoints": [
+      "src/checkout/CheckoutWorkflow.ts",
+      "src/orders/OrderProjection.ts"
+    ]
+  },
+  "manualCounts": {
+    "constraints": 2,
+    "compensations": 2,
+    "projections": 1,
+    "failureTransitions": 3,
+    "idempotencyRequirements": 2
+  },
+  "manualRelationComplexity": 10,
+  "manualLabels": [
+    {
+      "id": "order-state-invariant",
+      "tags": ["constraints"],
+      "decision": "count",
+      "reason": "Application-owned state invariant."
+    },
+    {
+      "id": "inventory-reservation-invariant",
+      "tags": ["constraints"],
+      "decision": "count",
+      "reason": "Application-owned inventory invariant."
+    },
+    {
+      "id": "release-inventory-on-payment-failure",
+      "tags": ["compensations", "failureTransitions"],
+      "decision": "count",
+      "reason": "Saga compensation and explicit failure branch."
+    },
+    {
+      "id": "refund-payment-on-shipping-failure",
+      "tags": ["compensations", "failureTransitions"],
+      "decision": "count",
+      "reason": "Saga compensation and explicit failure branch."
+    },
+    {
+      "id": "order-summary-projection",
+      "tags": ["projections"],
+      "decision": "count",
+      "reason": "Event-sourced read model projection."
+    },
+    {
+      "id": "payment-timeout-retry",
+      "tags": ["failureTransitions", "idempotencyRequirements"],
+      "decision": "count",
+      "reason": "Configured retry requires a stable idempotency key."
+    },
+    {
+      "id": "checkout-command-idempotency",
+      "tags": ["idempotencyRequirements"],
+      "decision": "count",
+      "reason": "Application command deduplication rule."
+    },
+    {
+      "id": "generated-orm-unique-index",
+      "tags": ["constraints"],
+      "decision": "exclude",
+      "reason": "Framework-generated schema metadata."
+    },
+    {
+      "id": "crud-field-format-validation",
+      "tags": ["constraints"],
+      "decision": "exclude",
+      "reason": "CRUD field validation without a state-transition branch."
+    },
+    {
+      "id": "ambiguous-shipping-provider-hook",
+      "tags": ["failureTransitions"],
+      "decision": "review-later",
+      "reason": "Ownership is unknown; keep out of the primary baseline."
+    }
+  ],
+  "extractorDiff": {
+    "constraints": 0,
+    "compensations": 0,
+    "projections": 0,
+    "failureTransitions": 0,
+    "idempotencyRequirements": 0,
+    "relationComplexity": 0
+  },
+  "notes": "This pilot baseline is a small hand-labeled sample for validating relation-complexity-rules/v0. It is not a statistical claim about real-world incident risk."
+}

--- a/docs/empirical/relation_complexity_pilot/candidates/commerce_state_transitions_candidates.json
+++ b/docs/empirical/relation_complexity_pilot/candidates/commerce_state_transitions_candidates.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": "relation-complexity-candidates/v0",
+  "repository": "aatv2/reference-commerce-state-transitions",
+  "revision": "pilot-2026-04-26",
+  "measurementUniverse": {
+    "root": "samples/commerce-state-transitions",
+    "languages": ["typescript"],
+    "frameworks": ["event-sourcing", "saga", "crud"]
+  },
+  "workflow": {
+    "id": "checkout-payment-fulfillment",
+    "name": "Checkout payment and fulfillment",
+    "component": "CommerceCheckout",
+    "entrypoints": [
+      "src/checkout/CheckoutWorkflow.ts",
+      "src/orders/OrderProjection.ts"
+    ]
+  },
+  "evidenceCandidates": [
+    {
+      "id": "order-state-invariant",
+      "path": "src/checkout/CheckoutWorkflow.ts",
+      "symbol": "CheckoutWorkflow.assertOrderCanBePaid",
+      "line": 42,
+      "tags": ["constraints"],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Order must be PENDING_PAYMENT before payment capture."
+    },
+    {
+      "id": "inventory-reservation-invariant",
+      "path": "src/checkout/InventoryReservation.ts",
+      "symbol": "InventoryReservation.reserve",
+      "line": 58,
+      "tags": ["constraints"],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Reservation cannot exceed available stock for the SKU."
+    },
+    {
+      "id": "release-inventory-on-payment-failure",
+      "path": "src/checkout/CheckoutSaga.ts",
+      "symbol": "CheckoutSaga.releaseInventory",
+      "line": 96,
+      "tags": ["compensations", "failureTransitions"],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Payment failure moves the workflow to inventory-release compensation."
+    },
+    {
+      "id": "refund-payment-on-shipping-failure",
+      "path": "src/checkout/CheckoutSaga.ts",
+      "symbol": "CheckoutSaga.refundPayment",
+      "line": 123,
+      "tags": ["compensations", "failureTransitions"],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Shipping failure triggers payment refund compensation."
+    },
+    {
+      "id": "order-summary-projection",
+      "path": "src/orders/OrderProjection.ts",
+      "symbol": "OrderProjection.applyOrderEvents",
+      "line": 35,
+      "tags": ["projections"],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Event log is projected into the order summary read model."
+    },
+    {
+      "id": "payment-timeout-retry",
+      "path": "src/payments/PaymentClient.ts",
+      "symbol": "PaymentClient.captureWithRetry",
+      "line": 77,
+      "tags": ["failureTransitions", "idempotencyRequirements"],
+      "ownership": "application-configured",
+      "reviewStatus": "accepted",
+      "notes": "Timeout retry uses a capture idempotency key."
+    },
+    {
+      "id": "checkout-command-idempotency",
+      "path": "src/checkout/CheckoutCommandHandler.ts",
+      "symbol": "CheckoutCommandHandler.handle",
+      "line": 21,
+      "tags": ["idempotencyRequirements"],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Command handler rejects duplicate checkout command ids."
+    },
+    {
+      "id": "generated-orm-unique-index",
+      "path": "src/generated/OrderRecord.ts",
+      "symbol": "OrderRecord.uniqueIndex",
+      "line": 14,
+      "tags": ["constraints"],
+      "ownership": "framework-generated",
+      "reviewStatus": "candidate",
+      "notes": "Generated ORM metadata, not application-owned transition logic."
+    },
+    {
+      "id": "crud-field-format-validation",
+      "path": "src/admin/OrderAdminController.ts",
+      "symbol": "OrderAdminController.updateEmail",
+      "line": 67,
+      "tags": ["constraints"],
+      "ownership": "application-owned",
+      "reviewStatus": "false-positive",
+      "notes": "Email format validation does not add a state-transition branch."
+    },
+    {
+      "id": "ambiguous-shipping-provider-hook",
+      "path": "src/shipping/ProviderAdapter.ts",
+      "symbol": "ProviderAdapter.onRetry",
+      "line": 51,
+      "tags": ["failureTransitions"],
+      "ownership": "unknown",
+      "reviewStatus": "candidate",
+      "notes": "Static candidate lacks enough evidence to decide whether retry is app policy or provider default."
+    }
+  ],
+  "excludedEvidence": [
+    {
+      "path": "src/checkout/CheckoutWorkflow.spec.ts",
+      "symbol": "CheckoutWorkflow test fixture",
+      "line": 18,
+      "reason": "test-fixture"
+    }
+  ]
+}

--- a/docs/empirical/relation_complexity_pilot/candidates/unsupported_framework_probe.json
+++ b/docs/empirical/relation_complexity_pilot/candidates/unsupported_framework_probe.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "relation-complexity-candidates/v0",
+  "repository": "aatv2/reference-commerce-state-transitions",
+  "revision": "pilot-2026-04-26",
+  "measurementUniverse": {
+    "root": "samples/commerce-state-transitions",
+    "languages": ["typescript"],
+    "frameworks": ["vendor-workflow-x"]
+  },
+  "workflow": {
+    "id": "scheduled-payout-reconciliation",
+    "name": "Scheduled payout reconciliation",
+    "component": "CommercePayout",
+    "entrypoints": ["src/payout/PayoutReconciliation.ts"]
+  },
+  "evidenceCandidates": [
+    {
+      "id": "vendor-retry-policy",
+      "path": "src/payout/PayoutReconciliation.ts",
+      "symbol": "PayoutReconciliation.retryPolicy",
+      "line": 88,
+      "tags": ["failureTransitions", "idempotencyRequirements"],
+      "ownership": "application-configured",
+      "reviewStatus": "candidate",
+      "notes": "The framework is not in relation-complexity-rules/v0, so the candidate is kept only as excluded evidence."
+    }
+  ],
+  "excludedEvidence": []
+}

--- a/docs/empirical/relation_complexity_pilot/observations/commerce_state_transitions_observation.json
+++ b/docs/empirical/relation_complexity_pilot/observations/commerce_state_transitions_observation.json
@@ -1,0 +1,149 @@
+{
+  "schemaVersion": "relation-complexity-observation/v0",
+  "repository": "aatv2/reference-commerce-state-transitions",
+  "revision": "pilot-2026-04-26",
+  "measurementUniverse": {
+    "root": "samples/commerce-state-transitions",
+    "languages": [
+      "typescript"
+    ],
+    "frameworks": [
+      "event-sourcing",
+      "saga",
+      "crud"
+    ],
+    "ruleSetVersion": "relation-complexity-rules/v0"
+  },
+  "workflow": {
+    "id": "checkout-payment-fulfillment",
+    "name": "Checkout payment and fulfillment",
+    "component": "CommerceCheckout",
+    "entrypoints": [
+      "src/checkout/CheckoutWorkflow.ts",
+      "src/orders/OrderProjection.ts"
+    ]
+  },
+  "counts": {
+    "constraints": 2,
+    "compensations": 2,
+    "projections": 1,
+    "failureTransitions": 3,
+    "idempotencyRequirements": 2
+  },
+  "relationComplexity": 10,
+  "evidence": [
+    {
+      "id": "checkout-command-idempotency",
+      "path": "src/checkout/CheckoutCommandHandler.ts",
+      "symbol": "CheckoutCommandHandler.handle",
+      "line": 21,
+      "tags": [
+        "idempotencyRequirements"
+      ],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Command handler rejects duplicate checkout command ids."
+    },
+    {
+      "id": "inventory-reservation-invariant",
+      "path": "src/checkout/InventoryReservation.ts",
+      "symbol": "InventoryReservation.reserve",
+      "line": 58,
+      "tags": [
+        "constraints"
+      ],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Reservation cannot exceed available stock for the SKU."
+    },
+    {
+      "id": "order-state-invariant",
+      "path": "src/checkout/CheckoutWorkflow.ts",
+      "symbol": "CheckoutWorkflow.assertOrderCanBePaid",
+      "line": 42,
+      "tags": [
+        "constraints"
+      ],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Order must be PENDING_PAYMENT before payment capture."
+    },
+    {
+      "id": "order-summary-projection",
+      "path": "src/orders/OrderProjection.ts",
+      "symbol": "OrderProjection.applyOrderEvents",
+      "line": 35,
+      "tags": [
+        "projections"
+      ],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Event log is projected into the order summary read model."
+    },
+    {
+      "id": "payment-timeout-retry",
+      "path": "src/payments/PaymentClient.ts",
+      "symbol": "PaymentClient.captureWithRetry",
+      "line": 77,
+      "tags": [
+        "failureTransitions",
+        "idempotencyRequirements"
+      ],
+      "ownership": "application-configured",
+      "reviewStatus": "accepted",
+      "notes": "Timeout retry uses a capture idempotency key."
+    },
+    {
+      "id": "refund-payment-on-shipping-failure",
+      "path": "src/checkout/CheckoutSaga.ts",
+      "symbol": "CheckoutSaga.refundPayment",
+      "line": 123,
+      "tags": [
+        "compensations",
+        "failureTransitions"
+      ],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Shipping failure triggers payment refund compensation."
+    },
+    {
+      "id": "release-inventory-on-payment-failure",
+      "path": "src/checkout/CheckoutSaga.ts",
+      "symbol": "CheckoutSaga.releaseInventory",
+      "line": 96,
+      "tags": [
+        "compensations",
+        "failureTransitions"
+      ],
+      "ownership": "application-owned",
+      "reviewStatus": "accepted",
+      "notes": "Payment failure moves the workflow to inventory-release compensation."
+    }
+  ],
+  "excludedEvidence": [
+    {
+      "path": "src/checkout/CheckoutWorkflow.spec.ts",
+      "reason": "test-fixture",
+      "symbol": "CheckoutWorkflow test fixture",
+      "line": 18
+    },
+    {
+      "path": "src/generated/OrderRecord.ts",
+      "reason": "ownership-not-counted:framework-generated",
+      "symbol": "OrderRecord.uniqueIndex",
+      "line": 14
+    },
+    {
+      "path": "src/admin/OrderAdminController.ts",
+      "reason": "review-status-not-counted:false-positive",
+      "symbol": "OrderAdminController.updateEmail",
+      "line": 67
+    },
+    {
+      "path": "src/shipping/ProviderAdapter.ts",
+      "reason": "ownership-not-counted:unknown",
+      "symbol": "ProviderAdapter.onRetry",
+      "line": 51
+    }
+  ]
+}

--- a/docs/empirical/relation_complexity_pilot/observations/unsupported_framework_probe_observation.json
+++ b/docs/empirical/relation_complexity_pilot/observations/unsupported_framework_probe_observation.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "relation-complexity-observation/v0",
+  "repository": "aatv2/reference-commerce-state-transitions",
+  "revision": "pilot-2026-04-26",
+  "measurementUniverse": {
+    "root": "samples/commerce-state-transitions",
+    "languages": [
+      "typescript"
+    ],
+    "frameworks": [
+      "vendor-workflow-x"
+    ],
+    "ruleSetVersion": "relation-complexity-rules/v0"
+  },
+  "workflow": {
+    "id": "scheduled-payout-reconciliation",
+    "name": "Scheduled payout reconciliation",
+    "component": "CommercePayout",
+    "entrypoints": [
+      "src/payout/PayoutReconciliation.ts"
+    ]
+  },
+  "counts": {
+    "constraints": 0,
+    "compensations": 0,
+    "projections": 0,
+    "failureTransitions": 0,
+    "idempotencyRequirements": 0
+  },
+  "relationComplexity": 0,
+  "evidence": [],
+  "excludedEvidence": [
+    {
+      "path": "src/payout/PayoutReconciliation.ts",
+      "reason": "unsupported-framework:vendor-workflow-x",
+      "symbol": "PayoutReconciliation.retryPolicy",
+      "line": 88
+    }
+  ]
+}

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -653,6 +653,17 @@ per component, per KLOC などの正規化は raw count を置き換えない将
 この規約の Lean status は `empirical hypothesis` / tooling design であり、
 Lean theorem ではない。
 
+Issue [#154](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/154)
+では、Event Sourcing / Saga / CRUD を含む commerce 状態遷移 sample に対し、
+`relationComplexity` の手動 baseline と extractor output を
+[relation_complexity_pilot](empirical/relation_complexity_pilot/README.md)
+に追加した。baseline は `constraints = 2`, `compensations = 2`,
+`projections = 1`, `failureTransitions = 3`, `idempotencyRequirements = 2`,
+`relationComplexity = 10` で、`relation-complexity-rules/v0` の output と一致する。
+除外 evidence、unsupported framework probe、曖昧な ownership の候補も primary count
+から分離して記録した。これは `empirical hypothesis` / pilot validation であり、
+Lean theorem ではない。
+
 v1 core / extension に追加・正規化した軸:
 
 - `sccExcessSize = sccMaxSize - 1`: 非循環 singleton SCC を 0 risk として扱うための循環リスク軸。
@@ -1102,6 +1113,10 @@ Issue [#36](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/36
 Issue [#124](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/124)
 では、この候補 evidence から workflow-level observation JSON を作る tooling 実装を追加した。
 これは Lean theorem ではなく、`empirical hypothesis` / tooling implementation である。
+Issue [#154](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/154)
+では、Event Sourcing / Saga / CRUD を含む小さな commerce 状態遷移 sample で手動
+baseline と extractor output の差分を記録し、rule set v0 の pilot validation とした。
+状態遷移構造を Lean core に入れる判断はこの Issue では行わない。
 
 Analysis tier: exploratory.
 


### PR DESCRIPTION
## 概要

Closes #154

- Event Sourcing / Saga / CRUD を含む commerce 状態遷移 sample を `relationComplexity` の pilot baseline として追加しました。
- 手動 baseline、extractor candidate、生成済み observation、手動 baseline との差分 0、除外 evidence、unsupported framework probe を記録しました。
- `docs/design/relation_complexity_design.md` と `docs/proof_obligations.md` に Lean status と pilot validation の位置づけを追記しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/empirical/relation_complexity_pilot/README.md`
- `docs/empirical/relation_complexity_pilot/baseline/commerce_state_transitions_manual_baseline.json`
- `docs/empirical/relation_complexity_pilot/candidates/*.json`
- `docs/empirical/relation_complexity_pilot/observations/*.json`
- `docs/design/relation_complexity_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `cargo run --quiet --manifest-path tools/sig0-extractor/Cargo.toml -- relation-complexity --input docs/empirical/relation_complexity_pilot/candidates/commerce_state_transitions_candidates.json --out docs/empirical/relation_complexity_pilot/observations/commerce_state_transitions_observation.json`
- [x] `cargo run --quiet --manifest-path tools/sig0-extractor/Cargo.toml -- relation-complexity --input docs/empirical/relation_complexity_pilot/candidates/unsupported_framework_probe.json --out docs/empirical/relation_complexity_pilot/observations/unsupported_framework_probe_observation.json`
- [x] `jq empty docs/empirical/relation_complexity_pilot/**/*.json`
- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml relation_complexity`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #154` 形式で本文に記載した
- [x] Lean status を `empirical hypothesis` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている