### PR TITLE
Signature diff の短縮 CLI を追加する

### DIFF
--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -889,6 +889,9 @@ Lean status の区分:
 - Architecture Signature の時系列 diff / PR attribution MVP は
   [#156](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/156)
   で `sig0-extractor snapshot` と `sig0-extractor signature-diff` として実装済みである。
+  Snapshot 同士の最小 diff CLI contract は
+  [#158](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/158)
+  で `sig0-extractor diff --before ... --after ...` alias としても提供する。
   `signature-diff-report-v0` は悪化・改善・変化なし・未評価の軸を分け、raw Sig0 JSON
   がある場合は増えた component / edge / policy violation を report する。PR metadata
   を渡した場合の attribution は changed components と after revision SHA に基づく

--- a/tools/sig0-extractor/README.md
+++ b/tools/sig0-extractor/README.md
@@ -304,6 +304,16 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- signature-diff \
   --out .lake/signature-current/diff-report.json
 ```
 
+`signature-diff` は `diff` alias でも呼び出せる。snapshot path は短縮形の
+`--before` / `--after` も使える。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- diff \
+  --before .lake/signature-previous/snapshot.json \
+  --after .lake/signature-current/snapshot.json \
+  --out .lake/signature-current/diff-report.json
+```
+
 report は `worsenedAxes`, `improvedAxes`, `unchangedAxes`, `unmeasuredAxes`,
 `evidenceDiff`, `attribution` を持つ。`validationSummary.result = fail` または
 `not_run` の snapshot、extractor / rule set / policy が一致しない比較は

--- a/tools/sig0-extractor/src/main.rs
+++ b/tools/sig0-extractor/src/main.rs
@@ -203,13 +203,14 @@ enum Command {
     },
 
     /// Diff two Signature snapshot store records.
+    #[command(alias = "diff")]
     SignatureDiff {
         /// Before snapshot store record JSON path.
-        #[arg(long = "before-snapshot")]
+        #[arg(long = "before-snapshot", alias = "before")]
         before_snapshot: PathBuf,
 
         /// After snapshot store record JSON path.
-        #[arg(long = "after-snapshot")]
+        #[arg(long = "after-snapshot", alias = "after")]
         after_snapshot: PathBuf,
 
         /// Optional before Sig0 extractor JSON for component / edge evidence diff.

--- a/tools/sig0-extractor/tests/cli.rs
+++ b/tools/sig0-extractor/tests/cli.rs
@@ -402,12 +402,12 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
     .expect("PR metadata is written");
 
     run_sig0(&[
-        "signature-diff",
-        "--before-snapshot",
+        "diff",
+        "--before",
         before_snapshot
             .to_str()
             .expect("before snapshot path is utf-8"),
-        "--after-snapshot",
+        "--after",
         after_snapshot
             .to_str()
             .expect("after snapshot path is utf-8"),


### PR DESCRIPTION
## 概要

Closes #158

- `sig0-extractor signature-diff` に `diff` alias を追加し、Issue 記載の `--before` / `--after` 形式でも snapshot diff report を生成できるようにしました。
- 既存の snapshot diff integration test を短縮 CLI 形式で実行するよう更新しました。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/sig0-extractor/README.md`: `diff --before ... --after ...` の利用例を追加
- `docs/proof_obligations.md`: #158 の Lean status を `empirical hypothesis` / tooling implementation として追記

## 実施したテスト

- [x] `cargo fmt --manifest-path tools/sig0-extractor/Cargo.toml --check`
- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている