### PR TITLE
Signature diff attribution を拡張する

### DIFF
--- a/docs/design/signature_snapshot_store_schema.md
+++ b/docs/design/signature_snapshot_store_schema.md
@@ -334,8 +334,12 @@ Signature axis diff だけを report する。
 
 `attribution` は v0 では PR metadata に基づく原因候補である。after revision SHA が
 `pullRequest.headCommit` または `pullRequest.mergeCommit` と一致するか、PR の
-`changedComponents` が `evidenceDiff` の追加・削除 component と重なるかを使って
-confidence を出す。これは因果証明ではなく、調査開始点を提示する ranking である。
+`changedComponents` が `evidenceDiff` の追加・削除 component、edge endpoint、
+policy violation endpoint と重なるかを使って confidence を出す。候補には数値
+`confidence` と `confidenceLevel: high | medium | low | unknown`、および
+`matchedComponents`, `matchedEdges`, `matchedPolicyViolations`, `affectedAxes` を残す。
+複数 PR が同じ悪化軸に関与し得る場合は、`sharedWorsenedAxes` に軸名を残し、単一原因
+として確定しない。これは因果証明ではなく、調査開始点を提示する ranking である。
 
 CLI の再現手順は
 [`tools/sig0-extractor/README.md`](../../tools/sig0-extractor/README.md) の

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -894,9 +894,11 @@ Lean status の区分:
   で `sig0-extractor diff --before ... --after ...` alias としても提供する。
   `signature-diff-report-v0` は悪化・改善・変化なし・未評価の軸を分け、raw Sig0 JSON
   がある場合は増えた component / edge / policy violation を report する。PR metadata
-  を渡した場合の attribution は changed components と after revision SHA に基づく
-  confidence 付き原因候補であり、因果証明ではない。Lean status は
-  `empirical hypothesis` / tooling implementation である。
+  を渡した場合の attribution は [#159](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/159)
+  で changed components、after revision SHA、追加・削除 edge / policy violation endpoint
+  の対応から `high | medium | low | unknown` の confidence level 付き原因候補を出す。
+  複数 PR が同じ悪化軸に関与し得る場合は `sharedWorsenedAxes` に残す。これは因果証明
+  ではなく、Lean status は `empirical hypothesis` / tooling implementation である。
 - RelationComplexityObservation extractor rule set v0 は
   [#124](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/124)
   で `sig0-extractor relation-complexity --input ...` として実装済みである。

--- a/tools/sig0-extractor/README.md
+++ b/tools/sig0-extractor/README.md
@@ -291,8 +291,9 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- snapshot \
 
 任意期間 diff は次で作る。`--before-sig0` / `--after-sig0` を渡すと、増えた
 component、edge、policy violation も report に入る。`--pr-metadata` を渡すと、
-PR の changed components と after revision SHA に基づく原因候補を confidence 付きで
-出す。複数 PR を候補にする場合は `--pr-metadata` を繰り返す。
+PR の changed components と after revision SHA に基づく原因候補を `high`,
+`medium`, `low`, `unknown` の confidence level 付きで出す。複数 PR を候補にする
+場合は `--pr-metadata` を繰り返す。
 
 ```bash
 cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- signature-diff \
@@ -315,7 +316,12 @@ cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- diff \
 ```
 
 report は `worsenedAxes`, `improvedAxes`, `unchangedAxes`, `unmeasuredAxes`,
-`evidenceDiff`, `attribution` を持つ。`validationSummary.result = fail` または
+`evidenceDiff`, `attribution` を持つ。`attribution.candidates[]` は
+`changedComponents`, `matchedComponents`, `matchedEdges`, `matchedPolicyViolations`,
+`affectedAxes` を含む。複数 PR が同じ悪化軸に関与する候補として残る場合は
+`attribution.sharedWorsenedAxes` にその軸を残す。これは因果証明ではなく、
+同期間の PR metadata と evidence diff に基づく調査開始点である。
+`validationSummary.result = fail` または
 `not_run` の snapshot、extractor / rule set / policy が一致しない比較は
 `comparisonStatus.primaryDiffEligible = false` とし、主要 diff から除外する。
 未評価軸は `unmeasuredAxes` に理由を残し、placeholder 0 を risk 0 として扱わない。

--- a/tools/sig0-extractor/src/lib.rs
+++ b/tools/sig0-extractor/src/lib.rs
@@ -718,6 +718,7 @@ pub struct PolicyViolationSetDelta {
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotDiffAttribution {
     pub method: String,
+    pub shared_worsened_axes: Vec<String>,
     pub candidates: Vec<AttributionCandidate>,
 }
 
@@ -727,8 +728,13 @@ pub struct AttributionCandidate {
     pub kind: String,
     pub id: String,
     pub confidence: f64,
+    pub confidence_level: String,
     pub reasons: Vec<String>,
     pub changed_components: Vec<String>,
+    pub matched_components: Vec<String>,
+    pub matched_edges: Vec<Edge>,
+    pub matched_policy_violations: Vec<PolicyViolation>,
+    pub affected_axes: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2150,13 +2156,18 @@ fn snapshot_diff_attribution(
     pr_metadata: &[EmpiricalDatasetInput],
 ) -> SnapshotDiffAttribution {
     let touched_components = touched_components_from_evidence_diff(evidence_diff);
+    let worsened_axis_names = worsened_axes
+        .iter()
+        .map(|axis| axis.axis.clone())
+        .collect::<Vec<_>>();
     let mut candidates = pr_metadata
         .iter()
         .map(|metadata| {
             attribution_candidate(
                 after,
+                evidence_diff,
                 &touched_components,
-                !worsened_axes.is_empty(),
+                &worsened_axis_names,
                 metadata,
             )
         })
@@ -2179,7 +2190,22 @@ fn snapshot_diff_attribution(
             .to_string()
     };
 
-    SnapshotDiffAttribution { method, candidates }
+    let shared_worsened_axes = if candidates
+        .iter()
+        .filter(|candidate| candidate.confidence_level != "unknown")
+        .count()
+        > 1
+    {
+        worsened_axis_names
+    } else {
+        Vec::new()
+    };
+
+    SnapshotDiffAttribution {
+        method,
+        shared_worsened_axes,
+        candidates,
+    }
 }
 
 fn touched_components_from_evidence_diff(evidence_diff: &SnapshotEvidenceDiff) -> BTreeSet<String> {
@@ -2205,8 +2231,9 @@ fn touched_components_from_evidence_diff(evidence_diff: &SnapshotEvidenceDiff) -
 
 fn attribution_candidate(
     after: &SignatureSnapshotStoreRecordV0,
+    evidence_diff: &SnapshotEvidenceDiff,
     touched_components: &BTreeSet<String>,
-    has_worsened_axes: bool,
+    worsened_axes: &[String],
     metadata: &EmpiricalDatasetInput,
 ) -> AttributionCandidate {
     let changed_components = metadata.pr_metrics.changed_components.clone();
@@ -2215,7 +2242,13 @@ fn attribution_candidate(
         .intersection(touched_components)
         .cloned()
         .collect::<Vec<_>>();
-    let mut confidence = 0.15;
+    let matched_edges = matched_edges_from_evidence_diff(evidence_diff, &changed_set);
+    let matched_policy_violations =
+        matched_policy_violations_from_evidence_diff(evidence_diff, &changed_set);
+    let mut matched_components = overlap;
+    matched_components.sort();
+    matched_components.dedup();
+    let mut confidence = 0.0;
     let mut reasons = Vec::new();
 
     if after.revision.sha == metadata.pull_request.head_commit {
@@ -2231,30 +2264,125 @@ fn attribution_candidate(
         confidence += 0.35;
         reasons.push("after revision matches pullRequest.mergeCommit".to_string());
     }
-    if !overlap.is_empty() {
+    if !matched_components.is_empty() {
         let denominator = touched_components.len().max(1) as f64;
-        confidence += 0.35 * (overlap.len() as f64 / denominator).min(1.0);
+        confidence += 0.35 * (matched_components.len() as f64 / denominator).min(1.0);
         reasons.push(format!(
             "changed components overlap with evidence diff: {}",
-            overlap.join(", ")
+            matched_components.join(", ")
         ));
     }
-    if has_worsened_axes {
+    if !matched_edges.is_empty() {
+        confidence += 0.15;
+        reasons.push(format!(
+            "changed components touch added/removed edges: {}",
+            edge_labels(&matched_edges).join(", ")
+        ));
+    }
+    if !matched_policy_violations.is_empty() {
+        confidence += 0.15;
+        reasons.push(format!(
+            "changed components touch added/removed policy violations: {}",
+            policy_violation_labels(&matched_policy_violations).join(", ")
+        ));
+    }
+    if !worsened_axes.is_empty() && confidence > 0.0 {
         confidence += 0.10;
-        reasons.push("signature has worsened axes".to_string());
+        reasons.push(format!(
+            "signature worsened on axes: {}",
+            worsened_axes.join(", ")
+        ));
     }
     if reasons.is_empty() {
         reasons.push(
             "weak candidate: PR metadata provided but no commit or evidence overlap".to_string(),
         );
     }
+    let confidence = round_confidence(confidence.min(0.95));
 
     AttributionCandidate {
         kind: "pullRequest".to_string(),
         id: format!("#{}", metadata.pull_request.number),
-        confidence: round_confidence(confidence.min(0.95)),
+        confidence,
+        confidence_level: confidence_level(confidence).to_string(),
         reasons,
         changed_components,
+        matched_components,
+        matched_edges,
+        matched_policy_violations,
+        affected_axes: if confidence > 0.0 {
+            worsened_axes.to_vec()
+        } else {
+            Vec::new()
+        },
+    }
+}
+
+fn matched_edges_from_evidence_diff(
+    evidence_diff: &SnapshotEvidenceDiff,
+    changed_components: &BTreeSet<String>,
+) -> Vec<Edge> {
+    let Some(edge_delta) = &evidence_diff.edge_delta else {
+        return Vec::new();
+    };
+    edge_delta
+        .added
+        .iter()
+        .chain(edge_delta.removed.iter())
+        .filter(|edge| {
+            changed_components.contains(&edge.source) || changed_components.contains(&edge.target)
+        })
+        .cloned()
+        .collect()
+}
+
+fn matched_policy_violations_from_evidence_diff(
+    evidence_diff: &SnapshotEvidenceDiff,
+    changed_components: &BTreeSet<String>,
+) -> Vec<PolicyViolation> {
+    let Some(policy_delta) = &evidence_diff.policy_violation_delta else {
+        return Vec::new();
+    };
+    policy_delta
+        .added
+        .iter()
+        .chain(policy_delta.removed.iter())
+        .filter(|violation| {
+            changed_components.contains(&violation.source)
+                || changed_components.contains(&violation.target)
+        })
+        .cloned()
+        .collect()
+}
+
+fn edge_labels(edges: &[Edge]) -> Vec<String> {
+    edges
+        .iter()
+        .map(|edge| format!("{} -> {}", edge.source, edge.target))
+        .collect()
+}
+
+fn policy_violation_labels(violations: &[PolicyViolation]) -> Vec<String> {
+    violations
+        .iter()
+        .map(|violation| {
+            format!(
+                "{}:{} -> {}",
+                violation.axis, violation.source, violation.target
+            )
+        })
+        .collect()
+}
+
+fn confidence_level(confidence: f64) -> &'static str {
+    if confidence >= 0.80 {
+        "high"
+    } else if confidence >= 0.50 {
+        "medium"
+    } else if confidence > 0.0 {
+        "low"
+    } else {
+        "unknown"
     }
 }
 

--- a/tools/sig0-extractor/tests/cli.rs
+++ b/tools/sig0-extractor/tests/cli.rs
@@ -255,6 +255,7 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
     let after_validation = out_dir.join("after-validation.json");
     let after_snapshot = out_dir.join("after-snapshot.json");
     let pr_metadata = out_dir.join("pr-metadata.json");
+    let peer_pr_metadata = out_dir.join("peer-pr-metadata.json");
     let report = out_dir.join("signature-diff.json");
 
     run_sig0(&[
@@ -400,6 +401,41 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
         .to_string(),
     )
     .expect("PR metadata is written");
+    fs::write(
+        &peer_pr_metadata,
+        serde_json::json!({
+            "repository": {
+                "owner": "example",
+                "name": "service",
+                "defaultBranch": "main"
+            },
+            "pullRequest": {
+                "number": 78,
+                "author": "bob",
+                "createdAt": "2026-04-25T02:00:00Z",
+                "mergedAt": "2026-04-26T00:30:00Z",
+                "baseCommit": "before-sha",
+                "headCommit": "peer-sha",
+                "mergeCommit": null,
+                "labels": [],
+                "isBotGenerated": false
+            },
+            "prMetrics": {
+                "changedFiles": 1,
+                "changedLinesAdded": 2,
+                "changedLinesDeleted": 0,
+                "changedComponents": ["Formal.Arch.B"],
+                "reviewCommentCount": 0,
+                "reviewThreadCount": 0,
+                "reviewRoundCount": 0,
+                "firstReviewLatencyHours": null,
+                "approvalLatencyHours": null,
+                "mergeLatencyHours": null
+            }
+        })
+        .to_string(),
+    )
+    .expect("peer PR metadata is written");
 
     run_sig0(&[
         "diff",
@@ -417,6 +453,10 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
         after_sig0.to_str().expect("after sig0 path is utf-8"),
         "--pr-metadata",
         pr_metadata.to_str().expect("PR metadata path is utf-8"),
+        "--pr-metadata",
+        peer_pr_metadata
+            .to_str()
+            .expect("peer PR metadata path is utf-8"),
         "--out",
         report.to_str().expect("report path is utf-8"),
     ]);
@@ -441,6 +481,26 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
             .as_f64()
             .expect("confidence is number")
             > 0.5
+    );
+    assert_eq!(
+        json["attribution"]["candidates"][0]["confidenceLevel"],
+        "high"
+    );
+    assert_eq!(
+        json["attribution"]["candidates"][0]["matchedEdges"][0]["target"],
+        "Formal.Arch.C"
+    );
+    assert!(
+        !json["attribution"]["candidates"][0]["affectedAxes"]
+            .as_array()
+            .expect("affectedAxes is array")
+            .is_empty()
+    );
+    assert!(
+        !json["attribution"]["sharedWorsenedAxes"]
+            .as_array()
+            .expect("sharedWorsenedAxes is array")
+            .is_empty()
     );
 }
 


### PR DESCRIPTION
## 概要

Closes #159

Signature diff report の PR attribution を拡張し、PR metadata の changed components と evidence diff の component / edge / policy violation endpoint を対応づける原因候補を出すようにしました。原因候補は因果証明ではなく、empirical / tooling output として `confidenceLevel: high | medium | low | unknown`、matched evidence、affected axes を保持します。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/sig0-extractor/README.md`
- `docs/design/signature_snapshot_store_schema.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
