### PR TITLE
GitHub Actions で Signature diff report を生成する

### DIFF
--- a/.github/workflows/signature-diff.yml
+++ b/.github/workflows/signature-diff.yml
@@ -1,0 +1,225 @@
+name: Signature diff report
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      before_ref:
+        description: "Baseline revision or ref. Defaults to HEAD^ for manual runs."
+        required: false
+      after_ref:
+        description: "Target revision or ref. Defaults to the checked-out revision."
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  signature-diff:
+    name: signature diff report
+    runs-on: ubuntu-latest
+    env:
+      OUT_DIR: .lake/signature-diff-ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve comparison refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          event="${{ github.event_name }}"
+          before_ref=""
+          after_ref=""
+          trigger="$event"
+
+          if [ "$event" = "pull_request" ]; then
+            before_ref="${{ github.event.pull_request.base.sha }}"
+            after_ref="$GITHUB_SHA"
+          elif [ "$event" = "push" ]; then
+            before_ref="${{ github.event.before }}"
+            after_ref="${{ github.sha }}"
+            if [ "$before_ref" = "0000000000000000000000000000000000000000" ]; then
+              before_ref="${after_ref}^"
+            fi
+          elif [ "$event" = "workflow_dispatch" ]; then
+            before_ref="${{ inputs.before_ref }}"
+            after_ref="${{ inputs.after_ref }}"
+            if [ -z "$after_ref" ]; then
+              after_ref="$GITHUB_SHA"
+            fi
+            if [ -z "$before_ref" ]; then
+              before_ref="${after_ref}^"
+            fi
+          else
+            after_ref="$GITHUB_SHA"
+            before_ref="${after_ref}^"
+          fi
+
+          git rev-parse --verify "${before_ref}^{commit}" >/dev/null
+          git rev-parse --verify "${after_ref}^{commit}" >/dev/null
+
+          {
+            echo "BEFORE_REF=$before_ref"
+            echo "AFTER_REF=$after_ref"
+            echo "SIGNATURE_TRIGGER=$trigger"
+          } >> "$GITHUB_ENV"
+
+      - name: Build PR metadata
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUT_DIR/pr"
+
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            > "$OUT_DIR/pr/github-pr.json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+            > "$OUT_DIR/pr/github-pr-files.json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" \
+            > "$OUT_DIR/pr/github-pr-reviews.json"
+
+          cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- pr-metadata \
+            --pull-request "$OUT_DIR/pr/github-pr.json" \
+            --files "$OUT_DIR/pr/github-pr-files.json" \
+            --reviews "$OUT_DIR/pr/github-pr-reviews.json" \
+            --out "$OUT_DIR/pr/pr-metadata.json"
+
+      - name: Build snapshots and diff report
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          scan_revision() {
+            local role="$1"
+            local ref="$2"
+            local out="$3"
+            local worktree="$RUNNER_TEMP/signature-${role}"
+            local sha
+            local committed_at
+            local validation_code
+
+            rm -rf "$worktree" "$out"
+            mkdir -p "$out"
+            git worktree add --detach "$worktree" "$ref"
+
+            sha="$(git -C "$worktree" rev-parse HEAD)"
+            committed_at="$(git -C "$worktree" show -s --format=%cI HEAD)"
+
+            cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- \
+              --root "$worktree" \
+              --out "$out/sig0.json"
+
+            set +e
+            cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- validate \
+              --input "$out/sig0.json" \
+              --out "$out/validation.json" \
+              --universe-mode local-only
+            validation_code=$?
+            set -e
+            if [ "$validation_code" -gt 1 ]; then
+              exit "$validation_code"
+            fi
+
+            cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- snapshot \
+              --input "$out/sig0.json" \
+              --validation-report "$out/validation.json" \
+              --repo-owner "$GITHUB_REPOSITORY_OWNER" \
+              --repo-name "${GITHUB_REPOSITORY#*/}" \
+              --revision-sha "$sha" \
+              --revision-ref "$ref" \
+              --revision-branch "${GITHUB_REF_NAME:-main}" \
+              --committed-at "$committed_at" \
+              --scanned-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --trigger "$SIGNATURE_TRIGGER" \
+              --scan-root "." \
+              --extractor-output-path "$out/sig0.json" \
+              --tag "ci" \
+              --out "$out/snapshot.json"
+
+            git worktree remove --force "$worktree"
+          }
+
+          scan_revision "before" "$BEFORE_REF" "$OUT_DIR/before"
+          scan_revision "after" "$AFTER_REF" "$OUT_DIR/after"
+
+          pr_args=()
+          if [ -f "$OUT_DIR/pr/pr-metadata.json" ]; then
+            pr_args=(--pr-metadata "$OUT_DIR/pr/pr-metadata.json")
+          fi
+
+          cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- diff \
+            --before "$OUT_DIR/before/snapshot.json" \
+            --after "$OUT_DIR/after/snapshot.json" \
+            --before-sig0 "$OUT_DIR/before/sig0.json" \
+            --after-sig0 "$OUT_DIR/after/sig0.json" \
+            "${pr_args[@]}" \
+            --out "$OUT_DIR/diff-report.json"
+
+      - name: Write job summary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          report="$OUT_DIR/diff-report.json"
+          before_sha="$(jq -r '.before.revision.sha' "$report")"
+          after_sha="$(jq -r '.after.revision.sha' "$report")"
+          eligible="$(jq -r '.comparisonStatus.primaryDiffEligible' "$report")"
+          reasons="$(jq -r '.comparisonStatus.reasons | if length == 0 then "なし" else join("; ") end' "$report")"
+          worsened="$(jq -r '.worsenedAxes | if length == 0 then "なし" else map(.axis + " (" + (.delta|tostring) + ")") | join(", ") end' "$report")"
+          improved="$(jq -r '.improvedAxes | if length == 0 then "なし" else map(.axis + " (" + (.delta|tostring) + ")") | join(", ") end' "$report")"
+          unmeasured="$(jq -r '.unmeasuredAxes | if length == 0 then "なし" else map(.axis + ": " + .reason) | join("; ") end' "$report")"
+          evidence_available="$(jq -r '.evidenceDiff.available' "$report")"
+          added_edges="$(jq -r '.evidenceDiff.edgeDelta.added | if . == null then 0 else length end' "$report")"
+          removed_edges="$(jq -r '.evidenceDiff.edgeDelta.removed | if . == null then 0 else length end' "$report")"
+          added_components="$(jq -r '.evidenceDiff.componentDelta.added | if . == null then 0 else length end' "$report")"
+          removed_components="$(jq -r '.evidenceDiff.componentDelta.removed | if . == null then 0 else length end' "$report")"
+
+          {
+            echo "## Architecture Signature diff report"
+            echo
+            echo "- before: \`$before_sha\`"
+            echo "- after: \`$after_sha\`"
+            echo "- primary diff eligible: \`$eligible\`"
+            echo "- eligibility reasons: $reasons"
+            echo
+            echo "### Axis changes"
+            echo
+            echo "- worsened: $worsened"
+            echo "- improved: $improved"
+            echo "- unmeasured / incomparable: $unmeasured"
+            echo
+            echo "### Evidence diff"
+            echo
+            echo "- raw evidence available: \`$evidence_available\`"
+            echo "- components: +$added_components / -$removed_components"
+            echo "- edges: +$added_edges / -$removed_edges"
+            echo
+            echo "### Attribution candidates"
+            echo
+            jq -r '.attribution.candidates
+              | if length == 0 then "- なし"
+                else map("- " + .id + " [" + .confidenceLevel + ", " + (.confidence|tostring) + "]: " + (.affectedAxes | if length == 0 then "affected axes なし" else join(", ") end))
+                | join("\n")
+                end' "$report"
+            echo
+            echo "Full JSON artifacts are attached to this workflow run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Signature report artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: signature-diff-report-${{ github.run_id }}
+          path: .lake/signature-diff-ci

--- a/docs/design/signature_snapshot_store_schema.md
+++ b/docs/design/signature_snapshot_store_schema.md
@@ -344,3 +344,15 @@ policy violation endpoint と重なるかを使って confidence を出す。候
 CLI の再現手順は
 [`tools/sig0-extractor/README.md`](../../tools/sig0-extractor/README.md) の
 `Snapshot diff MVP` を参照する。
+
+CI integration は
+[`Signature diff report workflow`](../../.github/workflows/signature-diff.yml) で扱う。
+この workflow は PR / push / schedule / manual run で before / after snapshot を生成し、
+`signature-diff-report-v0` と raw Sig0 output を artifact として保存する。PR では
+GitHub API 由来の PR metadata を `pr-metadata` subcommand で正規化し、diff report の
+`attribution.candidates` に原因候補を残す。job summary には悪化軸、改善軸、
+比較不能軸、raw evidence diff、attribution candidate を表示する。
+
+policy / runtime evidence がない軸は `unmeasuredAxes` に理由を残す。CI report は
+調査開始点を与える empirical / tooling output であり、Lean theorem や単一スコア評価
+ではない。

--- a/tools/sig0-extractor/README.md
+++ b/tools/sig0-extractor/README.md
@@ -326,8 +326,22 @@ report は `worsenedAxes`, `improvedAxes`, `unchangedAxes`, `unmeasuredAxes`,
 `comparisonStatus.primaryDiffEligible = false` とし、主要 diff から除外する。
 未評価軸は `unmeasuredAxes` に理由を残し、placeholder 0 を risk 0 として扱わない。
 
-GitHub Actions では、週次 job で同じ 3 段階を実行して artifact として保存する。
-次は最小形であり、外部 storage に蓄積する場合は最後の upload 部分を置き換える。
+GitHub Actions では、[Signature diff report workflow](../../.github/workflows/signature-diff.yml)
+が同じ 3 段階を実行し、before / after の Sig0 output、validation report、
+snapshot、`signature-diff-report-v0` を artifact として保存する。PR では base
+revision と checkout revision を比較し、GitHub API から PR metadata を生成して
+attribution candidate も report に含める。push / schedule では checkout revision と
+直前 revision を比較する。manual run では `before_ref` と `after_ref` で任意の
+baseline / target ref を指定できる。
+
+workflow の job summary には、悪化軸、改善軸、比較不能軸、raw evidence diff、
+PR attribution candidate が表示される。policy / runtime evidence を渡していない軸は
+未評価理由として `unmeasuredAxes` に残り、placeholder 0 を risk 0 として扱わない。
+これは Lean theorem ではなく empirical / tooling report である。
+
+外部 storage に snapshot を蓄積する場合は、artifact upload step を置き換えるか、
+後続 job で `.lake/signature-diff-ci/*/snapshot.json` を保存先へ同期する。
+workflow の中核は次の形である。
 
 ```yaml
 name: Signature diff


### PR DESCRIPTION
## 概要

Closes #160

- PR / push / schedule / manual run で before / after の Signature snapshot と diff report を生成する GitHub Actions workflow を追加した。
- PR では GitHub API から PR metadata を生成し、diff report の attribution candidate と job summary に反映する。
- workflow の利用手順と Lean status を `tools/sig0-extractor/README.md` と `docs/design/signature_snapshot_store_schema.md` に追記した。

Lean status: empirical hypothesis / tooling integration.

## 証明した定理

- なし

## 編集したドキュメント

- `tools/sig0-extractor/README.md`
- `docs/design/signature_snapshot_store_schema.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/sig0-extractor/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている