### PR TITLE
AlgSig PRD を docs/prd に追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,13 @@ Lean で証明済みの構造的事実、定義のみの概念、将来の証明
 
 `docs/design/` には、全体方針から切り出した個別 design、tooling protocol、empirical protocol を置く。
 
+## PRD
+
+- [PRD 一覧](prd/README.md)
+
+`docs/prd/` には、実装前または検討中の product requirement document を置く。
+PRD の内容は、そのまま証明済み主張とは扱わず、実装・設計メモ・proof obligation へ分解してから追跡する。
+
 ## Empirical pilot
 
 - [lean4-samples empirical pilot](empirical/lean4_samples_pilot/README.md):

--- a/docs/prd/Algebraic Law Signature MVP for sig0-extractor.md
+++ b/docs/prd/Algebraic Law Signature MVP for sig0-extractor.md
@@ -1,0 +1,976 @@
+# PRD: Algebraic Law Signature MVP for `sig0-extractor`
+
+Status: Draft v0.1
+
+Lean status: `empirical hypothesis` / tooling output. This PRD is not a Lean proof claim.
+
+## 1. 概要
+
+この文書は、[Algebraic Signature Extension for `sig0-extractor`](<Algebraic Signature Extension for sig0-extractor.md>) の Phase 0 実装仕様である。
+
+MVPでは、自動解析器ではなく、明示された law registry と evidence JSON を集計する **law registry + evidence aggregator** に絞る。
+
+```text
+architecture-laws/v0
++ law-evidence/v0
+-> algebraic-signature-v0
+-> algebraic-validate
+```
+
+現行 `sig0-extractor` は Lean 証明器ではなく、CI や AI agent が読む JSON artifact を生成する architecture telemetry generator である。現行フローも `scan -> validate -> snapshot -> signature-diff` を中心とし、`metricStatus` によって「測定済み 0」と「未評価」を区別する。このMVPも同じ思想を継承する。([1])
+
+## 2. MVPスコープ
+
+### やること
+
+- `architecture-laws/v0` schema
+- `law-evidence/v0` schema
+- `algebraic-signature-v0` output
+- `algebraic-laws` command
+- `algebraic-validate` command
+- law result status の解決
+- law単位 count と witness単位 count の分離
+- kind別 violation metric の `metricStatus` ルール
+- fixtures と README 更新
+
+### MVPではやらないこと
+
+- snapshot 統合
+- signature-diff 統合
+- dataset 統合
+- effect-signature
+- relation-complexity からの law candidate 自動生成
+- language-specific static analyzer
+- 実アプリ全体の正しさを Lean で証明すること
+
+現行 Rust 実装では `SignatureSnapshot` と `SignatureSnapshotStoreRecordV0` が単一の `signature` と単一の `metric_status` を持つ。`signatureArtifacts[]` 方向の拡張は妥当だが、最初のPRに含めると後方互換とレビュー範囲が大きくなるため、MVP後の follow-up に分ける。([2])
+
+## 3. Status語彙
+
+### 3.1 Law result status
+
+`lawResults[].status` は次の3状態に固定する。
+
+```text
+satisfied
+violated
+unmeasured
+```
+
+| status | 意味 |
+| --- | --- |
+| `satisfied` | 宣言済み law に対して、少なくとも1つの conclusive satisfied evidence がある。 |
+| `violated` | 宣言済み law に対して、少なくとも1つの conclusive violated evidence / witness / counterexample がある。 |
+| `unmeasured` | law は宣言されているが、conclusive evidence がない。 |
+
+`undeclared` は `lawResults[].status` に入れない。
+
+law registry に存在しない `lawId` への evidence は、`lawResults` ではなく、validation report の `danglingEvidence`、`excludedEvidence`、または candidate law state として扱う。
+
+### 3.2 Evidence status
+
+`law-evidence/v0` の `evidence[].status` は次の3状態に固定する。
+
+```text
+satisfied
+violated
+inconclusive
+```
+
+`failed`, `passed`, `error` は evidence status には使わない。これらは test runner の実行結果として `runnerResult` などの payload に入れる。
+
+悪い例:
+
+```json
+{
+  "evidenceKind": "property-test",
+  "status": "failed"
+}
+```
+
+良い例:
+
+```json
+{
+  "evidenceKind": "property-test",
+  "status": "violated",
+  "runnerResult": {
+    "outcome": "failed",
+    "framework": "proptest",
+    "exitCode": 1
+  }
+}
+```
+
+CLI は evidence status を次のように集計する。
+
+| evidence status | 集計上の意味 |
+| --- | --- |
+| `satisfied` | law を satisfied 候補にする。 |
+| `violated` | law を violated 候補にする。 |
+| `inconclusive` | law を discharge しない。 |
+
+### 3.3 Resolution rule
+
+同一 law に複数 evidence がある場合は、次の順で解決する。
+
+1. `violated` evidence が1つ以上ある場合、`lawResult.status = violated`
+2. `violated` evidence がなく、`satisfied` evidence が1つ以上ある場合、`lawResult.status = satisfied`
+3. `satisfied` / `violated` がなく、`inconclusive` evidence のみ、または evidence がない場合、`lawResult.status = unmeasured`
+
+`satisfied` と `violated` が同一 law に混在する場合、集計上は保守的に `violated` とし、validation report に `conflictingEvidence` warning を出す。
+
+```json
+{
+  "lawId": "order.cancel.idempotent",
+  "status": "violated",
+  "resolution": "violated-precedence",
+  "validationNotes": [
+    "both satisfied and violated evidence exist"
+  ]
+}
+```
+
+## 4. Count単位
+
+MVPでは **law単位の count** と **evidence / witness単位の count** を分離する。
+
+### 4.1 Law単位の指標
+
+| 指標 | 単位 | 定義 |
+| --- | ---: | --- |
+| `declaredLawCount` | law ID数 | registry 内の distinct law ID 数。 |
+| `requiredLawCount` | law ID数 | `required = true` の distinct law ID 数。 |
+| `satisfiedLawCount` | law ID数 | required law のうち `status = satisfied` の数。 |
+| `violatedLawCount` | law ID数 | required law のうち `status = violated` の数。 |
+| `unmeasuredLawCount` | law ID数 | required law のうち `status = unmeasured` の数。 |
+| `idempotencyViolationCount` | law ID数 | required かつ `kind = idempotency` かつ `status = violated` の数。 |
+| `compensationDefectCount` | law ID数 | required かつ `kind = compensation` かつ `status = violated` の数。 |
+| `replayHomomorphismDefect` | law ID数 | required かつ `kind = event-log-homomorphism` かつ `status = violated` の数。 |
+| `roundtripLossCount` | law ID数 | required かつ `kind = roundtrip` かつ `status = violated` の数。 |
+
+MVPの signature count は required law のみを対象にする。optional law は `lawResults` には出してよいが、P0 signature count には入れない。
+
+### 4.2 Evidence / witness単位の指標
+
+| 指標 | 単位 | 定義 |
+| --- | ---: | --- |
+| `counterexampleCount` | witness数 | valid かつ declared law に紐づく counterexample / witness 数。 |
+| `manualEvidenceRatio` | evidence比率 | conclusive evidence のうち `evidenceKind = manual` の割合。 |
+
+`violatedLawCount` と `counterexampleCount` は一致しなくてよい。
+
+例:
+
+```json
+{
+  "violatedLawCount": 1,
+  "counterexampleCount": 3
+}
+```
+
+## 5. `lawDebt`
+
+MVP v0では `lawDebt` は `unmeasuredLawCount` の派生値である。
+
+```text
+lawDebt :=
+  required law のうち、
+  satisfied でも violated でもない law 数
+```
+
+MVPでは `lawResults.status` が3状態なので、validation は次を保証する。
+
+```text
+lawDebt = unmeasuredLawCount
+```
+
+`algebraic-signature-v0` では、次の注意を README と output の `metricStatus` に残す。
+
+```text
+In algebraic-signature-v0, lawDebt is currently a derived alias of unmeasuredLawCount.
+Do not treat it as an independent metric.
+```
+
+将来版では、`unsupported`, `invalid`, `inconclusive`, `waived = false` などを含めて、次のように拡張する余地を残す。
+
+```text
+lawDebt :=
+  required law のうち、
+  satisfied によって discharge されておらず、
+  waived でもない law 数
+```
+
+## 6. `metricStatus` ルール
+
+### 6.1 Core count metrics
+
+次の指標は、`--laws` が正常に読め、validation が fatal でなければ `measured = true` にする。
+
+```text
+declaredLawCount
+requiredLawCount
+satisfiedLawCount
+violatedLawCount
+unmeasuredLawCount
+lawDebt
+counterexampleCount
+```
+
+理由は、registry と evidence を読んだ結果として law 単位の分類が確定しているためである。
+
+### 6.2 `lawCoverageRatio`
+
+定義:
+
+```text
+lawCoverageRatio =
+  (satisfiedLawCount + violatedLawCount) / requiredLawCount
+```
+
+`requiredLawCount = 0` の場合は `null` にする。`1.0` にはしない。
+
+```json
+{
+  "lawCoverageRatio": null,
+  "metricStatus": {
+    "lawCoverageRatio": {
+      "measured": false,
+      "reason": "undefined because requiredLawCount is 0"
+    }
+  }
+}
+```
+
+これは、AI reviewer が「全部カバー済み」と誤読するのを防ぐためである。
+
+### 6.3 Kind別 violation metrics
+
+対象:
+
+```text
+idempotencyViolationCount
+compensationDefectCount
+replayHomomorphismDefect
+roundtripLossCount
+```
+
+これらは値だけで読まず、対象 kind の required law 群が評価可能だったかを `metricStatus` とセットで読む。
+
+#### ケースA: required law of kind が存在しない
+
+```json
+{
+  "idempotencyViolationCount": 0,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": true,
+      "source": "law-registry:no-required-laws-for-kind",
+      "reason": "no required idempotency laws declared; value is vacuous zero"
+    }
+  }
+}
+```
+
+これは「冪等性違反がない」という意味ではなく、required idempotency law が宣言されていないため集計対象が空、という意味である。
+
+#### ケースB: required law of kind があり、全て conclusive
+
+```json
+{
+  "idempotencyViolationCount": 1,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": true,
+      "source": "law-evidence:v0"
+    }
+  }
+}
+```
+
+#### ケースC: required law of kind があるが、一部 unmeasured
+
+```json
+{
+  "idempotencyViolationCount": 0,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": false,
+      "source": "law-evidence:v0",
+      "reason": "2 required idempotency laws are unmeasured"
+    }
+  }
+}
+```
+
+このケースでは、値が 0 でも risk 0 とは読まない。
+
+## 7. Schema
+
+### 7.1 `architecture-laws/v0`
+
+```json
+{
+  "schemaVersion": "architecture-laws/v0",
+  "lawUniverse": {
+    "id": "order-service-laws-v0",
+    "version": "2026-04-26",
+    "equivalencePolicy": "observational-v0"
+  },
+  "laws": [
+    {
+      "id": "order.cancel.idempotent",
+      "kind": "idempotency",
+      "required": true,
+      "subject": {
+        "operation": "CancelOrder",
+        "component": "Order.Application.CancelOrder"
+      },
+      "equivalence": "observational",
+      "severity": "high",
+      "tags": ["retryable-command"]
+    },
+    {
+      "id": "payment.reserve.compensated",
+      "kind": "compensation",
+      "required": true,
+      "subject": {
+        "forward": "ReservePayment",
+        "compensate": "ReleasePayment"
+      },
+      "equivalence": "observational",
+      "severity": "medium",
+      "tags": ["saga"]
+    },
+    {
+      "id": "order.projection.homomorphism",
+      "kind": "event-log-homomorphism",
+      "required": true,
+      "subject": {
+        "projection": "OrderReadModelProjection",
+        "eventStream": "OrderEvents"
+      },
+      "equivalence": "strict",
+      "severity": "high",
+      "tags": ["event-sourcing"]
+    },
+    {
+      "id": "user.dto.roundtrip",
+      "kind": "roundtrip",
+      "required": true,
+      "subject": {
+        "forward": "User.toDto",
+        "backward": "UserDto.toDomain"
+      },
+      "equivalence": "observational",
+      "severity": "medium",
+      "tags": ["representation"]
+    }
+  ]
+}
+```
+
+### 7.2 `law-evidence/v0`
+
+```json
+{
+  "schemaVersion": "law-evidence/v0",
+  "repository": {
+    "owner": "example",
+    "name": "order-service"
+  },
+  "revision": {
+    "sha": "abc123"
+  },
+  "evidence": [
+    {
+      "id": "ev-order-cancel-001",
+      "lawId": "order.cancel.idempotent",
+      "evidenceKind": "property-test",
+      "status": "violated",
+      "artifactPath": "target/law-checks/order_cancel_idempotent.json",
+      "runnerResult": {
+        "outcome": "failed",
+        "framework": "proptest",
+        "exitCode": 1
+      },
+      "counterexamples": [
+        {
+          "input": {
+            "orderId": "123",
+            "initialState": "Cancellable"
+          },
+          "expectedObservation": "single OrderCancelled event",
+          "actualObservation": "two OrderCancelled events"
+        }
+      ]
+    },
+    {
+      "id": "ev-order-projection-001",
+      "lawId": "order.projection.homomorphism",
+      "evidenceKind": "replay-check",
+      "status": "satisfied",
+      "sampleCount": 1200
+    },
+    {
+      "id": "ev-user-dto-001",
+      "lawId": "user.dto.roundtrip",
+      "evidenceKind": "property-test",
+      "status": "inconclusive",
+      "runnerResult": {
+        "outcome": "timeout",
+        "framework": "proptest",
+        "exitCode": 124
+      }
+    }
+  ]
+}
+```
+
+### 7.3 `algebraic-signature-v0`
+
+```json
+{
+  "schemaVersion": "algebraic-signature-v0",
+  "signatureKind": "algebraic-laws",
+  "lawUniverse": {
+    "id": "order-service-laws-v0",
+    "version": "2026-04-26",
+    "equivalencePolicy": "observational-v0"
+  },
+  "signature": {
+    "declaredLawCount": 4,
+    "requiredLawCount": 4,
+    "satisfiedLawCount": 1,
+    "violatedLawCount": 1,
+    "unmeasuredLawCount": 2,
+    "lawDebt": 2,
+    "lawCoverageRatio": 0.5,
+    "manualEvidenceRatio": 0.0,
+    "counterexampleCount": 1,
+    "idempotencyViolationCount": 1,
+    "compensationDefectCount": 0,
+    "replayHomomorphismDefect": 0,
+    "roundtripLossCount": 0
+  },
+  "metricStatus": {
+    "lawDebt": {
+      "measured": true,
+      "source": "derived:unmeasuredLawCount",
+      "reason": "in algebraic-signature-v0, lawDebt is a derived alias of unmeasuredLawCount"
+    },
+    "compensationDefectCount": {
+      "measured": false,
+      "source": "law-evidence:v0",
+      "reason": "1 required compensation law is unmeasured"
+    },
+    "roundtripLossCount": {
+      "measured": false,
+      "source": "law-evidence:v0",
+      "reason": "1 required roundtrip law is unmeasured"
+    }
+  },
+  "lawResults": [
+    {
+      "lawId": "order.cancel.idempotent",
+      "kind": "idempotency",
+      "required": true,
+      "status": "violated",
+      "evidenceIds": ["ev-order-cancel-001"],
+      "counterexampleCount": 1
+    },
+    {
+      "lawId": "payment.reserve.compensated",
+      "kind": "compensation",
+      "required": true,
+      "status": "unmeasured",
+      "evidenceIds": []
+    },
+    {
+      "lawId": "order.projection.homomorphism",
+      "kind": "event-log-homomorphism",
+      "required": true,
+      "status": "satisfied",
+      "evidenceIds": ["ev-order-projection-001"]
+    },
+    {
+      "lawId": "user.dto.roundtrip",
+      "kind": "roundtrip",
+      "required": true,
+      "status": "unmeasured",
+      "evidenceIds": ["ev-user-dto-001"],
+      "notes": [
+        "inconclusive evidence does not discharge the law"
+      ]
+    }
+  ],
+  "excludedEvidence": [],
+  "validationSummary": {
+    "result": "pass",
+    "failedCheckCount": 0,
+    "warningCheckCount": 0
+  }
+}
+```
+
+## 8. Validation仕様
+
+### 8.1 `algebraic-validate`
+
+law registry と evidence を直接検査する。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-validate \
+  --laws architecture-laws.json \
+  --evidence law-evidence.json \
+  --out algebraic-validation.json
+```
+
+生成済み signature を検査する形も許す。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-validate \
+  --input algebraic-signature.json \
+  --out algebraic-validation.json
+```
+
+### 8.2 Validation checks
+
+| check | result | 内容 |
+| --- | --- | --- |
+| `duplicateLawId` | fail | law registry 内に同じ law ID が複数ある。 |
+| `unsupportedLawKind` | fail | MVP非対応の law kind が required law として存在する。 |
+| `danglingEvidence` | warn/fail option | evidence の `lawId` が registry に存在しない。 |
+| `duplicateEvidenceId` | fail | evidence ID が重複している。 |
+| `invalidEvidenceStatus` | fail | status が `satisfied` / `violated` / `inconclusive` 以外。 |
+| `conflictingEvidence` | warn | 同一 law に `satisfied` と `violated` が混在する。 |
+| `missingEvidenceForRequiredLaw` | warn | required law に conclusive evidence がない。 |
+| `counterexampleMissingForViolation` | warn | violated evidence なのに counterexample / witness がない。 |
+| `lawDebtDerivedInvariant` | fail | `lawDebt != unmeasuredLawCount`。 |
+| `countConsistency` | fail | `requiredLawCount != satisfiedLawCount + violatedLawCount + unmeasuredLawCount`。 |
+
+`danglingEvidence` はデフォルトでは aggregate から除外する。strict mode では fail にできる。
+
+## 9. CLI要件
+
+### 9.1 `algebraic-laws`
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-laws \
+  --laws architecture-laws.json \
+  --evidence law-evidence.json \
+  --out algebraic-signature.json
+```
+
+責務:
+
+1. law registry を読む。
+2. evidence を読む。
+3. evidence を declared law に join する。
+4. `lawResults` を resolution rule で解決する。
+5. signature counts を生成する。
+6. `metricStatus` を生成する。
+7. `excludedEvidence` を生成する。
+8. `validationSummary` を埋める。
+
+### 9.2 `algebraic-validate`
+
+責務:
+
+1. schema 語彙の検査。
+2. law ID / evidence ID の重複検査。
+3. dangling evidence 検査。
+4. count consistency 検査。
+5. `lawDebt` derived invariant 検査。
+6. required law の missing evidence warning。
+
+## 10. Rust側の型追加案
+
+MVPでは現行 snapshot 構造に触らず、新規型を追加する。
+
+```rust
+pub struct ArchitectureLawsV0 {
+    pub schema_version: String,
+    pub law_universe: LawUniverseRef,
+    pub laws: Vec<ArchitectureLaw>,
+}
+
+pub struct ArchitectureLaw {
+    pub id: String,
+    pub kind: LawKind,
+    pub required: bool,
+    pub subject: serde_json::Value,
+    pub equivalence: Option<String>,
+    pub severity: Option<String>,
+    pub tags: Vec<String>,
+}
+
+pub enum LawKind {
+    Idempotency,
+    Compensation,
+    EventLogHomomorphism,
+    Roundtrip,
+}
+
+pub struct LawEvidenceFileV0 {
+    pub schema_version: String,
+    pub repository: Option<RepositoryRef>,
+    pub revision: Option<RepositoryRevisionRef>,
+    pub evidence: Vec<LawEvidence>,
+}
+
+pub struct LawEvidence {
+    pub id: String,
+    pub law_id: String,
+    pub evidence_kind: EvidenceKind,
+    pub status: EvidenceStatus,
+    pub counterexamples: Vec<serde_json::Value>,
+    pub artifact_path: Option<String>,
+    pub runner_result: Option<serde_json::Value>,
+}
+
+pub enum EvidenceStatus {
+    Satisfied,
+    Violated,
+    Inconclusive,
+}
+
+pub enum LawResultStatus {
+    Satisfied,
+    Violated,
+    Unmeasured,
+}
+```
+
+## 11. Fixtures
+
+MVPで必ず作る fixture:
+
+```text
+fixtures/algebraic/minimal_satisfied
+fixtures/algebraic/idempotency_violated
+fixtures/algebraic/unmeasured_required_law
+fixtures/algebraic/inconclusive_evidence
+fixtures/algebraic/dangling_evidence
+fixtures/algebraic/duplicate_law_id
+fixtures/algebraic/no_required_laws
+fixtures/algebraic/no_required_laws_for_kind
+fixtures/algebraic/conflicting_evidence
+fixtures/algebraic/multiple_counterexamples_one_law
+```
+
+重要な期待値:
+
+```json
+{
+  "violatedLawCount": 1,
+  "idempotencyViolationCount": 1,
+  "counterexampleCount": 3
+}
+```
+
+```json
+{
+  "satisfiedLawCount": 0,
+  "violatedLawCount": 0,
+  "unmeasuredLawCount": 1,
+  "lawDebt": 1
+}
+```
+
+```json
+{
+  "idempotencyViolationCount": 0,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": true,
+      "source": "law-registry:no-required-laws-for-kind"
+    }
+  }
+}
+```
+
+```json
+{
+  "idempotencyViolationCount": 0,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": false,
+      "reason": "1 required idempotency law is unmeasured"
+    }
+  }
+}
+```
+
+## 12. Leanで証明すべきこと
+
+MVPのLean側は、各アーキテクチャ法則そのものの深い証明より、まず指標意味論の正しさを対象にする。
+
+### 12.1 Required law partition
+
+validation pass、distinct law IDs、resolution rule applied を前提に、required laws が `satisfied` / `violated` / `unmeasured` に分割されることを示す。
+
+```lean
+theorem required_law_partition :
+  requiredLawCount = satisfiedLawCount + violatedLawCount + unmeasuredLawCount
+```
+
+### 12.2 `lawDebt` derived invariant
+
+MVPでは以下を証明する。
+
+```lean
+theorem lawDebt_eq_unmeasured_v0 :
+  lawDebt = unmeasuredLawCount
+```
+
+### 12.3 Violation count witness theorem
+
+```lean
+theorem violatedLawCount_pos_exists :
+  violatedLawCount > 0 →
+  ∃ law, law.required ∧ result law = Violated
+```
+
+kind別にも同様の witness theorem を置く。
+
+```lean
+theorem idempotencyViolationCount_pos_exists :
+  idempotencyViolationCount > 0 →
+  ∃ law, law.required ∧ law.kind = Idempotency ∧ result law = Violated
+```
+
+### 12.4 Counterexample soundness
+
+CLIが valid evidence だけを集計しているという前提のもとで、次を示す。
+
+```text
+counterexampleCount > 0
+ならば、
+少なくとも1つの violated evidence に counterexample witness が存在する。
+```
+
+### 12.5 ゼロ違反の非含意
+
+次は成立しない。
+
+```text
+violatedLawCount = 0
+→
+全lawが正しい
+```
+
+Lean側では、反例モデルとして次を構成する。
+
+```text
+requiredLawCount = 1
+violatedLawCount = 0
+unmeasuredLawCount = 1
+```
+
+これにより、zero violation でも all satisfied ではないことを明示する。
+
+## 13. Phase 1以降の代数法則
+
+MVP後に、各 law kind の理論的意味を Lean 側で追加する。
+
+### Idempotency
+
+```lean
+def Idempotent (f : S → S) : Prop :=
+  ∀ s, f (f s) = f s
+```
+
+証明対象:
+
+```text
+Idempotent f なら、任意回 retry しても1回実行と同じ状態になる。
+```
+
+### Compensation
+
+```lean
+def ObservationalCompensation
+  (obs : S → O)
+  (f comp : S → S) : Prop :=
+  ∀ s, obs (comp (f s)) = obs s
+```
+
+証明対象:
+
+```text
+補償射が観測同値上の retraction であるなら、失敗 prefix の観測回復が成立する。
+```
+
+### Event log homomorphism
+
+```text
+project(xs ++ ys) = replayFrom(project(xs), ys)
+```
+
+証明対象:
+
+```text
+projection が fold として定義されるなら、append 分割に対する homomorphism law が成立する。
+```
+
+### Roundtrip
+
+```lean
+def RoundTripLeft (encode : A → B) (decode : B → A) : Prop :=
+  ∀ a, decode (encode a) = a
+```
+
+証明対象:
+
+```text
+RoundTripLeft encode decode なら、encode 後 decode で A 側情報は失われない。
+```
+
+## 14. Issue分割案
+
+### Issue 1: Algebraic Laws MVP schema and aggregator
+
+内容:
+
+- `architecture-laws/v0`
+- `law-evidence/v0`
+- `algebraic-signature-v0`
+- `algebraic-laws` command
+- basic fixtures
+- README update
+
+完了条件:
+
+```text
+law registry + evidence JSON から algebraic-signature-v0 が生成できる。
+```
+
+### Issue 2: Algebraic validate
+
+内容:
+
+- `algebraic-validate` command
+- `duplicateLawId`
+- `danglingEvidence`
+- `unsupportedLawKind`
+- `conflictingEvidence`
+- `countConsistency`
+- `lawDebtDerivedInvariant`
+
+完了条件:
+
+```text
+fixtures で pass / warn / fail が安定して出る。
+```
+
+### Issue 3: MetricStatus hardening
+
+内容:
+
+- kind別 `metricStatus` rules
+- `no-required-laws-for-kind`
+- `unmeasured-required-laws-for-kind`
+- `lawCoverageRatio` null handling
+
+完了条件:
+
+```text
+0がrisk 0なのか、対象law未宣言なのか、未評価なのかを区別できる。
+```
+
+### Issue 4: Lean metric semantics
+
+内容:
+
+- `LawResultStatus`
+- required law partition
+- `lawDebt = unmeasuredLawCount`
+- violation count witness theorem
+- zero violation does not imply all satisfied
+
+完了条件:
+
+```text
+MVP signature count の意味論が Lean で整理される。
+```
+
+### Issue 5: Snapshot / diff follow-up
+
+MVP後に、後方互換を守って `signatureArtifacts` の optional 追加を検討する。
+
+```json
+{
+  "schemaVersion": "signature-snapshot-store-v0",
+  "signature": { "... existing sig0 shape ...": "..." },
+  "metricStatus": { "... existing metric status ...": "..." },
+  "signatureArtifacts": [
+    {
+      "kind": "sig0",
+      "schemaVersion": "sig0-extractor-v0",
+      "path": ".lake/sig0.json"
+    },
+    {
+      "kind": "algebraic-laws",
+      "schemaVersion": "algebraic-signature-v0",
+      "path": ".lake/algebraic-signature.json"
+    }
+  ]
+}
+```
+
+既存フィールドは残す。`signatureArtifacts` は optional 追加にする。
+
+## 15. MVP指標一覧
+
+最初のP0指標は次の通り。
+
+```text
+declaredLawCount
+requiredLawCount
+satisfiedLawCount
+violatedLawCount
+unmeasuredLawCount
+lawDebt
+lawCoverageRatio
+manualEvidenceRatio
+counterexampleCount
+idempotencyViolationCount
+compensationDefectCount
+replayHomomorphismDefect
+roundtripLossCount
+```
+
+必須注記:
+
+- `satisfiedLawCount` / `violatedLawCount` / `unmeasuredLawCount` は law ID 単位。
+- `counterexampleCount` は witness 単位。
+- kind別 violation metric は required law ID 単位。
+- `lawDebt` は `algebraic-signature-v0` では `unmeasuredLawCount` の派生値。
+- evidence status は `satisfied | violated | inconclusive` のみ。
+- `lawResults` status は `satisfied | violated | unmeasured` のみ。
+- `undeclared` は law status ではなく validation / dangling evidence として扱う。
+
+## 16. AI reviewer向け読み方
+
+AI reviewer は signature 値だけで判断せず、必ず `metricStatus` を併読する。
+
+誤読:
+
+```text
+idempotencyViolationCount = 0
+だから冪等性問題なし。
+```
+
+正しい読み方:
+
+```text
+idempotencyViolationCount = 0
+だが、metricStatus.idempotencyViolationCount.measured = false。
+required idempotency law の一部が未評価なので、冪等性リスクは未判断。
+```
+
+## 17. 参照
+
+[1]: https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/sig0-extractor/README.md "AlgebraicArchitectureTheoryV2/tools/sig0-extractor/README.md at main"
+[2]: https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/sig0-extractor/src/lib.rs "AlgebraicArchitectureTheoryV2/tools/sig0-extractor/src/lib.rs at main"

--- a/docs/prd/Algebraic Signature Extension for sig0-extractor.md
+++ b/docs/prd/Algebraic Signature Extension for sig0-extractor.md
@@ -1,0 +1,1854 @@
+# PRD: Algebraic Signature Extension for `sig0-extractor`
+
+## 1. プロダクト概要
+
+### 仮称
+
+**AlgSig v0: Algebraic Architecture Signature Extension**
+
+### 一文要約
+
+既存の依存グラフ中心の `sig0-extractor` に、**設計原則が要求する代数法則・状態遷移法則・履歴再構成性・副作用境界・表現変換の健全性**を測る `algebraic-signature-v0` を追加する。
+
+### 背景
+
+研究全体のゴールでは、ソフトウェアアーキテクチャを「依存・抽象・観測・状態遷移・実行時依存の複数グラフまたは代数構造」として表現し、不変量の破れを `ArchitectureSignature` として定量評価することが掲げられています。さらに、目標は単一スコアではなく、分解可能性、置換可能性、履歴再構成性、障害局所性、変更容易性など、どの不変量が破れているかを多軸で診断することです。([GitHub][2])
+
+現行の `sig0-extractor` は、依存グラフ由来の `hasCycle`, `sccMaxSize`, `maxDepth`, `fanoutRisk`, boundary / abstraction violation などを扱えます。また、`Relation Complexity` では `constraints`, `compensations`, `projections`, `failureTransitions`, `idempotencyRequirements` をcandidate evidenceから数える足場があります。([GitHub][1])
+
+今回の拡張では、この `Relation Complexity` を単なる数え上げから一段進めて、
+
+> 補償が本当に準逆射として振る舞うか
+> retryable operation が本当に冪等か
+> event replay がモノイド準同型として振る舞うか
+> DTO / Entity / Event の変換が roundtrip law を守るか
+> domain が禁止された effect を発生させていないか
+
+を測る。
+
+---
+
+# 2. 解決したい課題
+
+## 現状の課題
+
+既存の依存グラフ方式では、次のような診断は難しい。
+
+### 依存は綺麗だが、操作法則が壊れている
+
+例:
+
+```text
+CancelOrder は retryable と宣言されているが、
+2回呼ぶと OrderCancelled event が2回出る。
+```
+
+依存グラフでは変化なしでも、アーキテクチャ上は重大な冪等性違反。
+
+### 依存は増えていないが、Event Sourcing の再構成性が壊れている
+
+例:
+
+```text
+project(xs ++ ys) と projectFrom(project(xs), ys) が一致しない。
+```
+
+これは依存関係ではなく、履歴再構成性の破れ。
+
+### 補償処理は存在するが、補償射としては弱い
+
+例:
+
+```text
+reservePayment の後に releasePayment を実行しても、
+外部観測上は元状態に戻らない。
+```
+
+現行の `relationComplexity` では「compensation がある」と数えられても、それが代数的に妥当かは評価できない。
+
+### import graph は綺麗だが、effect が漏れている
+
+例:
+
+```text
+Domain layer は DB module を import していないが、
+Repository.write effect を直接発生させている。
+```
+
+これは依存辺ではなく、effect signature の漏洩。
+
+---
+
+# 3. プロダクトゴール
+
+## Goal 1: 依存グラフとは別軸の `AlgebraicArchitectureSignature` を追加する
+
+既存の `sig0-extractor-v0` を壊さず、別artifactとして以下を出力する。
+
+```text
+algebraic-signature-v0
+```
+
+これは、既存の `signature-diff-report-v0` や `empirical-signature-dataset-v0` に接続できるようにする。
+
+---
+
+## Goal 2: 「法則違反」「法則未評価」「法則未宣言」を分ける
+
+既存CLIの強みである、
+
+```text
+測定済み 0 ≠ 未評価
+```
+
+を代数指標にも継承する。
+
+MVPでは `lawResults[].status` を次の3状態に固定する。
+
+| 状態           | 意味                                                      |
+| ------------ | ------------------------------------------------------- |
+| `satisfied`  | 宣言済みlawに対して、少なくとも1つの conclusive satisfied evidence がある |
+| `violated`   | 宣言済みlawに対して、少なくとも1つの conclusive violated evidence / witness / counterexample がある |
+| `unmeasured` | law は宣言されているが、conclusive evidence がない |
+
+`undeclared` は `lawResults[].status` に入れない。law registry に存在しない `lawId` への evidence は、`danglingEvidence`, `excludedEvidence`, validation check, candidate law state として扱う。
+
+`law-evidence/v0` の `evidence[].status` は次の3状態に固定する。
+
+```text
+satisfied
+violated
+inconclusive
+```
+
+`failed`, `passed`, `error` は evidence status には使わず、test runner の実行結果として `runnerResult` などの payload に入れる。
+
+同一 law に複数 evidence がある場合は、以下で解決する。
+
+```text
+1. violated evidence が1つ以上ある
+   -> lawResult.status = violated
+
+2. violated evidence がなく、satisfied evidence が1つ以上ある
+   -> lawResult.status = satisfied
+
+3. satisfied / violated がなく、inconclusive evidenceのみ、またはevidenceなし
+   -> lawResult.status = unmeasured
+```
+
+`satisfied` と `violated` が同一 law に混在する場合、集計上は保守的に `violated` とし、validation report に `conflictingEvidence` warning を出す。
+
+これにより、AI reviewer が、
+
+```text
+violatedLawCount = 0
+```
+
+だけを見て「安全」と誤読するのを防ぐ。
+
+---
+
+## Goal 3: Leanで「指標の意味」を保証し、実コード診断はCLIが行う
+
+Lean側では、任意の実コードが正しいことを証明しない。
+代わりに、以下を証明する。
+
+```text
+この法則が成り立つなら、どの不変量が保存されるか。
+この counterexample が存在するなら、その law は成り立たない。
+この metric は、宣言された law universe に対して何を数えているか。
+```
+
+CLI側では、JSON evidence、property test結果、replay check結果、手動candidate evidenceを読み、実コード上の観測値を集計する。
+
+---
+
+# 4. 非ゴール
+
+この拡張でやらないこと。
+
+1. **任意のアプリケーションコードから全ての代数法則を自動推論すること**
+   MVPでは law registry と evidence JSON を明示入力にする。
+
+2. **Leanで実アプリ全体の正しさを証明すること**
+   Leanは理論中核と指標意味論の証明に限定する。
+
+3. **単一スコアでアーキテクチャ品質を判定すること**
+   研究目標と同様、多軸Signatureとして扱う。研究目標でも単一スコアではなく、どの軸が悪化したか、どの不変量が破れているかを説明する方針が示されています。([GitHub][2])
+
+4. **依存グラフ指標を置き換えること**
+   既存の `hasCycle`, `fanoutRisk`, `boundaryViolationCount` などは維持し、AlgSigは別軸として追加する。
+
+---
+
+# 5. 対象ユーザー
+
+## Primary
+
+### 研究者
+
+代数的アーキテクチャ論の仮説を、実コードベース上のデータで検証したい。
+
+### アーキテクト / Tech Lead
+
+PR単位で、
+
+```text
+この変更はどの不変量を壊したか？
+依存関係は綺麗でも、設計法則は壊れていないか？
+```
+
+を確認したい。
+
+### AI code review agent
+
+diff report を読み、
+
+```text
+このPRは fanout は増やしていないが、retryable command の冪等性を破っている
+```
+
+のようなレビューコメントを出したい。
+
+---
+
+# 6. 追加する主要指標
+
+## 6.1 Core Law Metrics
+
+まず全ての代数指標に共通する基本軸。
+
+| 指標                    |          型 | 意味                                           |
+| --------------------- | ---------: | -------------------------------------------- |
+| `declaredLawCount`    |        int | law registry に宣言された distinct law ID 数                    |
+| `requiredLawCount`    |        int | `required=true` の distinct law ID 数                        |
+| `satisfiedLawCount`   |        int | required law のうち `status=satisfied` の law ID 数          |
+| `violatedLawCount`    |        int | required law のうち `status=violated` の law ID 数    |
+| `unmeasuredLawCount`  |        int | required law のうち `status=unmeasured` の law ID 数               |
+| `lawDebt`             |        int | MVPでは `unmeasuredLawCount` の派生値 |
+| `lawCoverageRatio`    | float/null | required law のうち評価済みの割合                      |
+| `manualEvidenceRatio` | float/null | conclusive evidence のうち manual attestation 由来の割合        |
+| `counterexampleCount` |        int | validかつdeclared lawに紐づく concrete counterexample / witness の件数                  |
+
+MVPでは `satisfiedLawCount`, `violatedLawCount`, `unmeasuredLawCount` は law ID 単位で数える。`counterexampleCount` は witness 単位であり、`violatedLawCount` と一致しなくてよい。
+
+また、MVP v0では `lawDebt = unmeasuredLawCount` である。将来版では `unsupported`, `invalid`, `waived=false` などを含める余地を残すが、`algebraic-signature-v0` では独立指標として読まない。
+
+`lawCoverageRatio` は次で定義する。
+
+```text
+lawCoverageRatio =
+  (satisfiedLawCount + violatedLawCount) / requiredLawCount
+```
+
+`requiredLawCount = 0` の場合、`lawCoverageRatio` は `null` とし、`metricStatus.lawCoverageRatio.measured = false` にする。`1.0` にはしない。
+
+### 診断例
+
+```text
+violatedLawCount = 0
+unmeasuredLawCount = 12
+```
+
+この場合、診断は「違反なし」ではなく、
+
+```text
+宣言された law の多くが未評価であり、lawfulness は判断不能
+```
+
+になる。
+
+### kind別 violation metric の `metricStatus`
+
+`idempotencyViolationCount`, `compensationDefectCount`, `replayHomomorphismDefect`, `roundtripLossCount` などの kind別 violation metric は、MVPでは required law ID 単位で数える。
+
+ただし、値だけで安全とは読まない。対象 kind の required law が存在し、その一部が `unmeasured` の場合、violation count が0でも `metricStatus.<axis>.measured = false` にする。
+
+例:
+
+```json
+{
+  "idempotencyViolationCount": 0,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": false,
+      "source": "law-evidence:v0",
+      "reason": "2 required idempotency laws are unmeasured"
+    }
+  }
+}
+```
+
+対象 kind の required law が1つも宣言されていない場合は、集計対象が空であることを明示した上で `measured = true` とする。
+
+```json
+{
+  "idempotencyViolationCount": 0,
+  "metricStatus": {
+    "idempotencyViolationCount": {
+      "measured": true,
+      "source": "law-registry:no-required-laws-for-kind",
+      "reason": "no required idempotency laws declared; value is vacuous zero"
+    }
+  }
+}
+```
+
+---
+
+## 6.2 Idempotency Metrics
+
+対象:
+
+```text
+retryable command
+message handler
+webhook handler
+cancel / close / deactivate 系 operation
+```
+
+### 追加指標
+
+| 指標                          | 意味                                               |
+| --------------------------- | ------------------------------------------------ |
+| `idempotencyLawCount`       | 冪等性 law の宣言数                                     |
+| `idempotencyViolationCount` | `f ∘ f = f` が破れた件数                               |
+| `idempotencyGap`            | retryable と宣言された operation のうち、冪等性 evidence がない数 |
+| `duplicateEffectRisk`       | 2回実行時に重複 event / 重複 side effect が観測された件数         |
+| `retrySafetyCoverage`       | retryable operation のうち冪等性が評価済みの割合               |
+
+### Law
+
+```text
+Idempotent(f) := ∀ s, f(f(s)) = f(s)
+```
+
+または観測同値版:
+
+```text
+Obs(f(f(s))) = Obs(f(s))
+```
+
+### 診断例
+
+```text
+CancelOrder is declared retryable,
+but second execution emits duplicate OrderCancelled event.
+```
+
+---
+
+## 6.3 Compensation / Saga Metrics
+
+対象:
+
+```text
+Saga
+workflow
+transaction boundary
+forward operation + compensation operation
+```
+
+### 追加指標
+
+| 指標                               | 意味                                                |
+| -------------------------------- | ------------------------------------------------- |
+| `compensationLawCount`           | compensation law の宣言数                             |
+| `compensationCoverageGap`        | forward operation はあるが compensation evidence がない数 |
+| `compensationDefectCount`        | `compensate ∘ action ≈ id` が破れた数                  |
+| `nonInvertibleCompensationCount` | compensation が明示されているが逆射/準逆射ではない数                 |
+| `failureRecoveryGap`             | failure transition に対する recovery law がない数         |
+
+### Law
+
+厳密な逆射:
+
+```text
+compensate(action(s)) = s
+```
+
+現実的には観測同値:
+
+```text
+Obs(compensate(action(s))) = Obs(s)
+```
+
+### 診断例
+
+```text
+ReserveInventory has compensation CancelReservation,
+but stock version and audit observation are not restored.
+```
+
+重要なのは、研究目標にある通り、Sagaは局所回復性を与えるが、補償射は一般に逆射ではないという前提を守ることです。([GitHub][2])
+
+---
+
+## 6.4 Event Log Homomorphism Metrics
+
+対象:
+
+```text
+Event Sourcing
+projection
+read model
+snapshot
+event replay
+event schema migration
+```
+
+### 追加指標
+
+| 指標                               | 意味                                         |
+| -------------------------------- | ------------------------------------------ |
+| `eventProjectionLawCount`        | event projection law の宣言数                  |
+| `replayHomomorphismDefect`       | 一括replayと分割replayが一致しない件数                  |
+| `snapshotRoundtripDefect`        | snapshot + replay と full replay が一致しない件数   |
+| `projectionOrderSensitivity`     | 独立eventの順序交換でread modelが変わる件数              |
+| `eventMigrationNaturalityDefect` | migration と projection の順序を変えると結果が変わる件数    |
+| `historyReconstructionGap`       | event log から現状態を再構成できない law / evidence 欠落数 |
+
+### Law
+
+event列を自由モノイド `E*` と見て、
+
+```text
+project(xs ++ ys) = replayFrom(project(xs), ys)
+```
+
+または fold 表現:
+
+```text
+project = fold applyEvent initialState
+```
+
+### 診断例
+
+```text
+OrderProjection violates replay homomorphism:
+project(xs ++ ys) != replayFrom(project(xs), ys)
+```
+
+これは依存グラフでは検出できない、Event Sourcing固有の履歴再構成性リスク。
+
+---
+
+## 6.5 Effect Algebra Leakage Metrics
+
+対象:
+
+```text
+Clean Architecture
+Hexagonal Architecture
+DIP
+domain purity
+application service
+infrastructure effect
+```
+
+### 追加指標
+
+| 指標                            | 意味                                                   |
+| ----------------------------- | ---------------------------------------------------- |
+| `effectOperationCount`        | 観測された effect operation 数                             |
+| `effectLeakageCount`          | 許可されていない zone で発生した effect 数                         |
+| `unhandledEffectCount`        | effect は発生しているが handler がない数                         |
+| `handlerCoverageRatio`        | effect operation のうち handler が定義されている割合              |
+| `ambientAuthorityUsageCount`  | global env / default credential / implicit IO 等への依存数 |
+| `nonCommutingEffectPairCount` | 可換と宣言された effect pair が順序依存した件数                       |
+
+### Law / Policy
+
+```text
+AllowedEffects(zone) ⊆ EffectSignature
+ActualEffects(component) ⊆ AllowedEffects(zone)
+```
+
+handler coverage:
+
+```text
+∀ e ∈ ActualEffects, ∃ handler, Handles(handler, e)
+```
+
+### 診断例
+
+```text
+Domain layer has no forbidden import edge,
+but emits SqlWrite effect.
+```
+
+これは依存グラフではなく、effect signature の違反。
+
+---
+
+## 6.6 Projection / Functor Soundness Metrics
+
+対象:
+
+```text
+abstract architecture
+concrete implementation
+port / adapter
+use case composition
+DIP projection
+```
+
+### 追加指標
+
+| 指標                                 | 意味                                                    |
+| ---------------------------------- | ----------------------------------------------------- |
+| `projectionCompletenessGap`        | concrete operation が abstract operation に写らない件数       |
+| `projectionAmbiguityCount`         | 1つの concrete operation が複数abstract operationに曖昧対応する件数 |
+| `compositionPreservationViolation` | `F(g ∘ f) = F(g) ∘ F(f)` が破れる件数                       |
+| `identityPreservationViolation`    | no-op / identity が抽象側で identity として保存されない件数           |
+| `projectionSoundnessViolation`     | 抽象射影全体のsoundness違反数                                   |
+
+### Law
+
+```text
+F(id) = id
+F(g ∘ f) = F(g) ∘ F(f)
+```
+
+### 診断例
+
+```text
+approveAndNotify should project to notify ∘ approve,
+but notification failure leaves approve state committed.
+```
+
+これは「依存しているか」ではなく、「抽象設計上の合成として正しく振る舞うか」を見る。
+
+---
+
+## 6.7 Domain Representation / Roundtrip Metrics
+
+対象:
+
+```text
+DTO
+DB Entity
+Domain Model
+API Response
+Event Payload
+Serializer / Deserializer
+Mapper
+Adapter
+```
+
+### 追加指標
+
+| 指標                             | 意味                                              |
+| ------------------------------ | ----------------------------------------------- |
+| `roundtripLawCount`            | roundtrip law の宣言数                              |
+| `roundtripLossCount`           | `decode(encode(x)) = x` が破れた件数                  |
+| `lossyProjectionWithoutPolicy` | 情報を落とす変換なのにpolicyがない件数                          |
+| `conceptRedundancyIndex`       | 同一domain conceptに対する表現数                         |
+| `semanticFieldDriftCount`      | 同名/同概念fieldの意味ズレ件数                              |
+| `adapterLawViolationCount`     | adapterがidentity/composition/roundtrip lawを破る件数 |
+
+### Law
+
+```text
+fromDto(toDto(domain)) = domain
+```
+
+または観測同値:
+
+```text
+Obs(fromDto(toDto(domain))) = Obs(domain)
+```
+
+### 診断例
+
+```text
+Money is represented as DomainMoney, PaymentAmount, PriceDto, InvoiceAmount,
+and conversion loses currency precision.
+```
+
+---
+
+## 6.8 Invariant Preservation Metrics
+
+対象:
+
+```text
+business invariant
+validation rule
+database constraint
+state machine guard
+workflow precondition
+```
+
+### 追加指標
+
+| 指標                               | 意味                                        |
+| -------------------------------- | ----------------------------------------- |
+| `invariantLawCount`              | invariant preservation law の宣言数           |
+| `invariantPreservationGap`       | operation が保存すべき invariant の evidence 欠落数 |
+| `invariantViolationWitnessCount` | invariant violation の counterexample 件数   |
+| `constraintInconsistencyCount`   | 複数constraintのmeetがunsatになる件数              |
+| `constraintDuplicationCount`     | 同じinvariantが複数箇所に重複実装されている件数              |
+| `monotonicityViolationCount`     | 単調であるべき状態更新がpartial orderを逆行する件数          |
+
+### Law
+
+```text
+Inv(s) -> Inv(f(s))
+```
+
+合成閉包:
+
+```text
+Preserves Inv f
+Preserves Inv g
+----------------
+Preserves Inv (g ∘ f)
+```
+
+---
+
+# 7. 新しいSignature構造
+
+## 7.1 出力artifact
+
+```json
+{
+  "schemaVersion": "algebraic-signature-v0",
+  "signatureKind": "algebraic-laws",
+  "repository": {
+    "owner": "example",
+    "name": "service"
+  },
+  "revision": {
+    "sha": "abc123",
+    "ref": "feature/order-cancel"
+  },
+  "lawUniverse": {
+    "id": "order-service-laws-v0",
+    "policyVersion": "2026-04-26",
+    "equivalencePolicy": "observational-v0"
+  },
+  "signature": {
+    "declaredLawCount": 24,
+    "requiredLawCount": 21,
+    "satisfiedLawCount": 13,
+    "violatedLawCount": 2,
+    "unmeasuredLawCount": 6,
+    "lawDebt": 6,
+    "lawCoverageRatio": 0.714,
+    "manualEvidenceRatio": 0.25,
+    "counterexampleCount": 1,
+
+    "idempotencyViolationCount": 1,
+    "idempotencyGap": 2,
+    "compensationDefectCount": 1,
+    "compensationCoverageGap": 1,
+    "replayHomomorphismDefect": 0,
+    "snapshotRoundtripDefect": 0,
+    "effectLeakageCount": 3,
+    "unhandledEffectCount": 1,
+    "projectionSoundnessViolation": 0,
+    "roundtripLossCount": 2,
+    "invariantViolationWitnessCount": 1
+  },
+  "metricStatus": {
+    "lawDebt": {
+      "measured": true,
+      "source": "derived:unmeasuredLawCount",
+      "reason": "in algebraic-signature-v0, lawDebt is a derived alias of unmeasuredLawCount"
+    },
+    "replayHomomorphismDefect": {
+      "measured": true,
+      "source": "event-replay-check:v0"
+    },
+    "projectionSoundnessViolation": {
+      "measured": false,
+      "reason": "no projection evidence provided"
+    }
+  },
+  "lawResults": [
+    {
+      "lawId": "order.cancel.idempotent",
+      "kind": "idempotency",
+      "status": "violated",
+      "severity": "high",
+      "evidenceIds": ["ev-order-cancel-001"],
+      "counterexampleCount": 1,
+      "evidence": [
+        {
+          "id": "ev-order-cancel-001",
+          "evidenceKind": "property-test",
+          "status": "violated",
+          "runnerResult": {
+            "outcome": "failed",
+            "framework": "proptest",
+            "exitCode": 1
+          },
+          "counterexamples": [
+            {
+              "operation": "CancelOrder(orderId=123)",
+              "observation": "second execution emits duplicate OrderCancelled"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "excludedEvidence": [
+    {
+      "id": "framework-generated-handler-001",
+      "reason": "framework-generated"
+    }
+  ]
+}
+```
+
+---
+
+# 8. 入力スキーマ
+
+## 8.1 `architecture-laws/v0`
+
+law registry。
+MVPでは自動推論せず、このregistryを中心にする。
+
+```json
+{
+  "schemaVersion": "architecture-laws/v0",
+  "lawUniverse": {
+    "id": "order-service-laws-v0",
+    "policyVersion": "2026-04-26",
+    "equivalencePolicy": "observational-v0"
+  },
+  "laws": [
+    {
+      "id": "order.cancel.idempotent",
+      "kind": "idempotency",
+      "required": true,
+      "subject": {
+        "operation": "CancelOrder",
+        "component": "Order.Application.CancelOrder"
+      },
+      "equivalence": "observational",
+      "observation": {
+        "events": true,
+        "publicState": true,
+        "auditLog": false
+      },
+      "severity": "high",
+      "tags": ["retryable-command", "order-workflow"]
+    },
+    {
+      "id": "order.projection.homomorphism",
+      "kind": "event-log-homomorphism",
+      "required": true,
+      "subject": {
+        "projection": "OrderReadModelProjection",
+        "eventStream": "OrderEvents"
+      },
+      "equivalence": "strict",
+      "severity": "high"
+    },
+    {
+      "id": "payment.reserve.compensated",
+      "kind": "compensation",
+      "required": true,
+      "subject": {
+        "forward": "ReservePayment",
+        "compensate": "ReleasePayment"
+      },
+      "equivalence": "observational",
+      "severity": "medium"
+    },
+    {
+      "id": "user.dto.roundtrip",
+      "kind": "roundtrip",
+      "required": true,
+      "subject": {
+        "forward": "User.toDto",
+        "backward": "UserDto.toDomain"
+      },
+      "equivalence": "observational",
+      "severity": "medium"
+    }
+  ]
+}
+```
+
+---
+
+## 8.2 `law-evidence/v0`
+
+property test、replay check、Lean proof、manual attestationなどを受け取る。
+
+```json
+{
+  "schemaVersion": "law-evidence/v0",
+  "repository": {
+    "owner": "example",
+    "name": "service"
+  },
+  "revision": {
+    "sha": "abc123"
+  },
+  "evidence": [
+    {
+      "id": "ev-order-cancel-001",
+      "lawId": "order.cancel.idempotent",
+      "evidenceKind": "property-test",
+      "status": "violated",
+      "artifactPath": "target/law-checks/order_cancel_idempotent.json",
+      "runnerResult": {
+        "outcome": "failed",
+        "framework": "proptest",
+        "exitCode": 1
+      },
+      "counterexamples": [
+        {
+          "input": {
+            "orderId": "123",
+            "initialState": "Cancellable"
+          },
+          "expectedObservation": "single OrderCancelled event",
+          "actualObservation": "two OrderCancelled events"
+        }
+      ]
+    },
+    {
+      "id": "ev-order-projection-001",
+      "lawId": "order.projection.homomorphism",
+      "evidenceKind": "replay-check",
+      "status": "satisfied",
+      "sampleCount": 1200
+    },
+    {
+      "id": "ev-user-dto-001",
+      "lawId": "user.dto.roundtrip",
+      "evidenceKind": "property-test",
+      "status": "inconclusive",
+      "runnerResult": {
+        "outcome": "timeout",
+        "framework": "proptest",
+        "exitCode": 124
+      }
+    }
+  ]
+}
+```
+
+---
+
+## 8.3 `effect-policy/v0`
+
+```json
+{
+  "schemaVersion": "effect-policy/v0",
+  "zones": [
+    {
+      "zone": "domain",
+      "allowedEffects": ["Pure", "Validate", "Decide"]
+    },
+    {
+      "zone": "application",
+      "allowedEffects": ["ReadRepo", "WriteRepo", "PublishEvent"]
+    },
+    {
+      "zone": "infrastructure",
+      "allowedEffects": ["SqlRead", "SqlWrite", "HttpCall", "QueueSend"]
+    }
+  ],
+  "handlers": [
+    {
+      "effect": "WriteRepo",
+      "handlerComponent": "Order.Infrastructure.OrderRepository"
+    }
+  ]
+}
+```
+
+---
+
+## 8.4 `effect-evidence/v0`
+
+```json
+{
+  "schemaVersion": "effect-evidence/v0",
+  "observations": [
+    {
+      "component": "Order.Domain.CancelOrder",
+      "zone": "domain",
+      "effects": ["Validate", "WriteRepo"],
+      "evidenceKind": "static-marker",
+      "source": "effect annotations"
+    }
+  ]
+}
+```
+
+---
+
+# 9. CLI要件
+
+## 9.1 新規サブコマンド
+
+### `algebraic-laws`
+
+law registry と evidence を読み、`algebraic-signature-v0` を出す。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-laws \
+  --laws architecture-laws.json \
+  --evidence law-evidence.json \
+  --out .lake/algebraic-signature.json
+```
+
+### `effect-signature`
+
+effect policy と evidence を読み、effect leakage metrics を出す。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- effect-signature \
+  --policy effect-policy.json \
+  --evidence effect-evidence.json \
+  --out .lake/effect-signature.json
+```
+
+### `algebraic-validate`
+
+`algebraic-signature-v0` の妥当性を検査する。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-validate \
+  --laws architecture-laws.json \
+  --evidence law-evidence.json \
+  --out .lake/algebraic-validation.json
+```
+
+生成済みsignatureを検査する形も許す。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-validate \
+  --input .lake/algebraic-signature.json \
+  --out .lake/algebraic-validation.json
+```
+
+検査内容:
+
+| Check | 内容 |
+| --- | --- |
+| `duplicateLawId` | law registry内に同じlaw IDが複数ある |
+| `unsupportedLawKind` | MVP非対応のlaw kindがrequired lawとして存在する |
+| `danglingEvidence` | evidenceのlawIdがregistryに存在しない。デフォルトではaggregateから除外し、strict modeではfailにできる |
+| `duplicateEvidenceId` | evidence IDが重複している |
+| `invalidEvidenceStatus` | statusが`satisfied` / `violated` / `inconclusive`以外 |
+| `conflictingEvidence` | 同一lawに`satisfied`と`violated`が混在する。集計上は`violated`を優先し、warningを出す |
+| `missingEvidenceForRequiredLaw` | required lawにconclusive evidenceがない |
+| `counterexampleMissingForViolation` | violated evidenceなのにcounterexample / witnessがない |
+| `lawDebtDerivedInvariant` | `lawDebt != unmeasuredLawCount` |
+| `countConsistency` | `requiredLawCount != satisfiedLawCount + violatedLawCount + unmeasuredLawCount` |
+| `invalidEquivalencePolicy` | equivalence policy が未定義 |
+| `manualEvidenceRatioWarning` | manual attestation が多すぎる場合にwarn |
+
+---
+
+## 9.2 既存 `snapshot` の拡張
+
+既存snapshotは `sig0.json` を保存する。
+拡張後は複数signature artifactを扱えるようにする。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- snapshot \
+  --input .lake/sig0.json \
+  --algebraic-signature .lake/algebraic-signature.json \
+  --validation-report .lake/sig0-validation.json \
+  --algebraic-validation-report .lake/algebraic-validation.json \
+  --repo-owner example \
+  --repo-name service \
+  --revision-sha "$(git rev-parse HEAD)" \
+  --out .lake/signature-current/snapshot.json
+```
+
+snapshot内では以下のように保持する。
+
+```json
+{
+  "signatureArtifacts": [
+    {
+      "schemaVersion": "sig0-extractor-v0",
+      "path": ".lake/sig0.json"
+    },
+    {
+      "schemaVersion": "algebraic-signature-v0",
+      "path": ".lake/algebraic-signature.json"
+    }
+  ]
+}
+```
+
+---
+
+## 9.3 `signature-diff` の拡張
+
+既存のdiffは、悪化軸、改善軸、未評価軸、evidence diff、PR attribution candidateを出します。([GitHub][1])
+AlgSigでも同じ考え方を使う。
+
+追加diff項目:
+
+```json
+{
+  "algebraicDiff": {
+    "worsenedAxes": [
+      {
+        "axis": "idempotencyViolationCount",
+        "before": 0,
+        "after": 1,
+        "delta": 1
+      }
+    ],
+    "improvedAxes": [],
+    "unmeasuredAxes": [
+      {
+        "axis": "projectionSoundnessViolation",
+        "reason": "no projection evidence provided"
+      }
+    ],
+    "lawStatusDiff": {
+      "newlyViolatedLaws": ["order.cancel.idempotent"],
+      "newlySatisfiedLaws": [],
+      "newlyUnmeasuredLaws": []
+    },
+    "evidenceDiff": {
+      "addedCounterexamples": [
+        {
+          "lawId": "order.cancel.idempotent",
+          "summary": "second CancelOrder emits duplicate OrderCancelled"
+        }
+      ]
+    }
+  }
+}
+```
+
+### primary diff eligibility
+
+`comparisonStatus.primaryDiffEligible = false` にする条件:
+
+| 条件                              | 理由                        |
+| ------------------------------- | ------------------------- |
+| `lawUniverse.id` が違う            | 比較対象のlaw集合が違う             |
+| `equivalencePolicy` が違う         | 観測同値の定義が違う                |
+| `ruleSetVersion` が違う            | 集計規則が違う                   |
+| before/afterの片方でvalidation fail | 入力artifactが比較不能           |
+| evidence sourceのcoverageが大きく異なる | observed violation数の比較が偏る |
+
+---
+
+## 9.4 `dataset` の拡張
+
+既存datasetは、before / after の両方で測定済みかつ値が `null` でない軸だけを `deltaSignatureSigned` に出す設計です。([GitHub][1])
+AlgSigでも同じルールを守る。
+
+追加dataset項目:
+
+```json
+{
+  "algebraicSignatureBefore": {
+    "violatedLawCount": 1,
+    "lawDebt": 8,
+    "idempotencyViolationCount": 0
+  },
+  "algebraicSignatureAfter": {
+    "violatedLawCount": 2,
+    "lawDebt": 6,
+    "idempotencyViolationCount": 1
+  },
+  "deltaAlgebraicSignatureSigned": {
+    "violatedLawCount": 1,
+    "lawDebt": -2,
+    "idempotencyViolationCount": 1
+  },
+  "algebraicAttribution": {
+    "changedLaws": ["order.cancel.idempotent"],
+    "changedComponents": ["Order.Application.CancelOrder"],
+    "newCounterexampleCount": 1
+  }
+}
+```
+
+---
+
+# 10. Leanで証明すべきこと
+
+## 10.1 基礎定義
+
+Lean側では、まず以下を定義する。
+
+```lean
+Law
+LawKind
+LawUniverse
+EvidenceStatus
+MetricStatus
+ObservedViolation
+ArchitectureOperation
+Observation
+```
+
+概念的には、
+
+```lean
+structure Law where
+  id : String
+  kind : LawKind
+  required : Bool
+```
+
+ただし、実装上はString中心ではなく、有限型や識別子型で扱える形が望ましい。
+
+---
+
+## 10.2 指標意味論の証明
+
+### 証明すべきこと
+
+```text
+MVP v0では
+lawDebt = required laws without conclusive satisfied/violated evidence
+        = unmeasuredLawCount
+```
+
+Leanで示すべき定理:
+
+```text
+lawDebt = 0
+↔
+全 required law が satisfied または violated の status を持つ
+```
+
+ただし、これは「全lawが真」という意味ではない。
+
+また、
+
+```text
+violatedLawCount > 0
+→
+少なくとも1つの law に counterexample evidence が存在する
+```
+
+も証明する。
+
+### 重要な非主張
+
+```text
+violatedLawCount = 0
+→
+全lawが真
+```
+
+これは証明してはいけない。
+`unmeasuredLawCount = 0` や evidence の完全性仮定がない限り、成立しない。
+
+---
+
+## 10.3 Idempotency
+
+### 定義
+
+```lean
+def Idempotent (f : S → S) : Prop :=
+  ∀ s, f (f s) = f s
+```
+
+観測同値版:
+
+```lean
+def ObservationallyIdempotent
+  (obs : S → O)
+  (f : S → S) : Prop :=
+  ∀ s, obs (f (f s)) = obs (f s)
+```
+
+### 証明すべき定理
+
+```text
+Idempotent f
+→
+任意回数 retry しても1回実行と同じ状態になる
+```
+
+観測同値版:
+
+```text
+ObservationallyIdempotent obs f
+→
+任意回数 retry しても外部観測は1回実行と同じ
+```
+
+CLI診断との接続:
+
+```text
+idempotencyViolationCount > 0
+→
+少なくとも1つの retryable operation について、
+f(f(s)) ≠ f(s) または Obs(f(f(s))) ≠ Obs(f(s)) の witness がある
+```
+
+---
+
+## 10.4 Compensation / Saga
+
+### 定義
+
+厳密補償:
+
+```lean
+def IsLeftInverse (comp f : S → S) : Prop :=
+  ∀ s, comp (f s) = s
+```
+
+観測補償:
+
+```lean
+def ObservationalCompensation
+  (obs : S → O)
+  (f comp : S → S) : Prop :=
+  ∀ s, obs (comp (f s)) = obs s
+```
+
+### 証明すべき定理
+
+```text
+ObservationalCompensation obs f comp
+→
+f実行後にcompを実行すると、外部観測上は元に戻る
+```
+
+さらに、Saga全体について:
+
+```text
+各stepに観測補償があり、
+補償順序が逆順で適用されるなら、
+失敗prefixに対して観測回復が成立する
+```
+
+### 注意
+
+Sagaの補償は一般に完全な逆射ではない。
+したがってLeanでは、`inverse` ではなく `observational retraction` や `compensation under observation` として扱う。
+
+---
+
+## 10.5 Event Log Homomorphism
+
+### 定義
+
+event列を自由モノイドとして扱う。
+
+```lean
+def Project (events : List E) : R
+```
+
+またはfoldとして:
+
+```lean
+def project : List E → R :=
+  List.foldl apply initial
+```
+
+### Law
+
+```lean
+project (xs ++ ys) = replayFrom (project xs) ys
+```
+
+### 証明すべき定理
+
+```text
+projection が fold として定義されているなら、
+append に対する homomorphism law が成り立つ
+```
+
+```text
+project(xs ++ ys) = replayFrom(project(xs), ys)
+```
+
+snapshotについて:
+
+```text
+snapshot = project xs
+→
+replayFrom snapshot ys = project (xs ++ ys)
+```
+
+migrationについては自然性として扱う。
+
+```text
+migrateReadModel(project_old events)
+=
+project_new(migrateEvents events)
+```
+
+CLI診断との接続:
+
+```text
+replayHomomorphismDefect > 0
+→
+append分解に対するprojection不一致のcounterexampleがある
+```
+
+---
+
+## 10.6 Roundtrip / Representation Isomorphism
+
+### 定義
+
+```lean
+def RoundTripLeft (encode : A → B) (decode : B → A) : Prop :=
+  ∀ a, decode (encode a) = a
+```
+
+観測同値版:
+
+```lean
+def ObservationalRoundTrip
+  (obs : A → O)
+  (encode : A → B)
+  (decode : B → A) : Prop :=
+  ∀ a, obs (decode (encode a)) = obs a
+```
+
+### 証明すべき定理
+
+```text
+RoundTripLeft encode decode
+→
+encode後decodeしてもA側の情報は失われない
+```
+
+合成について:
+
+```text
+A ↔ B が roundtrip
+B ↔ C が roundtrip
+なら、
+A ↔ C も roundtrip
+```
+
+ただし、観測同値版では observation の整合条件が必要。
+
+---
+
+## 10.7 Invariant Preservation
+
+### 定義
+
+```lean
+def Preserves (Inv : S → Prop) (f : S → S) : Prop :=
+  ∀ s, Inv s → Inv (f s)
+```
+
+### 証明すべき定理
+
+合成閉包:
+
+```text
+Preserves Inv f
+Preserves Inv g
+→
+Preserves Inv (g ∘ f)
+```
+
+workflowへの拡張:
+
+```text
+各commandがInvを保存するなら、
+command列全体もInvを保存する
+```
+
+CLI診断との接続:
+
+```text
+invariantViolationWitnessCount > 0
+→
+Inv s は真だが Inv(f(s)) が偽になる witness がある
+```
+
+---
+
+## 10.8 Effect Algebra Leakage
+
+### 定義
+
+```lean
+ActualEffects : Component → Set Effect
+AllowedEffects : Zone → Set Effect
+ComponentZone : Component → Zone
+```
+
+law:
+
+```lean
+∀ c, ActualEffects c ⊆ AllowedEffects (ComponentZone c)
+```
+
+handler coverage:
+
+```lean
+∀ e ∈ ActualEffects c, ∃ h, Handles h e
+```
+
+### 証明すべき定理
+
+```text
+全componentでActualEffects ⊆ AllowedEffectsが成立
+→
+effect leakage は0
+```
+
+```text
+effectLeakageCount > 0
+→
+あるcomponent c と effect e が存在し、
+e ∈ ActualEffects c かつ e ∉ AllowedEffects(zone c)
+```
+
+---
+
+## 10.9 Projection / Functor Soundness
+
+### 定義
+
+Concrete architecture と Abstract architecture を小さなcategoryまたはcomposition structureとして定義する。
+
+```lean
+F : Concrete → Abstract
+```
+
+law:
+
+```lean
+F id = id
+F (g ∘ f) = F g ∘ F f
+```
+
+### 証明すべき定理
+
+```text
+Fがidentityとcompositionを保存するなら、
+concrete workflowの抽象像は、abstract operationの合成として解釈できる
+```
+
+CLI診断との接続:
+
+```text
+compositionPreservationViolation > 0
+→
+F(g ∘ f) ≠ F(g) ∘ F(f) の witness がある
+```
+
+---
+
+# 11. 実装ロードマップ
+
+## Phase 0: Schema and Aggregation MVP
+
+目的:
+
+```text
+law registry + evidence JSON から algebraic-signature-v0 を生成する
+```
+
+実装するもの:
+
+* `architecture-laws/v0`
+* `law-evidence/v0`
+* `algebraic-signature-v0`
+* `algebraic-laws` subcommand
+* `algebraic-validate` subcommand
+* `declaredLawCount`
+* `requiredLawCount`
+* `satisfiedLawCount`
+* `lawDebt`
+* `violatedLawCount`
+* `unmeasuredLawCount`
+* `lawCoverageRatio`
+* `manualEvidenceRatio`
+* `counterexampleCount`
+* `idempotencyViolationCount`
+* `compensationDefectCount`
+* `replayHomomorphismDefect`
+* `roundtripLossCount`
+
+この段階では、ソースコード自動解析はしない。
+property testやreplay checkの結果JSONを読む。
+また、snapshot / signature-diff / dataset 統合は Phase 4 に回し、Phase 0 の最初のPRには含めない。
+
+---
+
+## Phase 1: Relation ComplexityからLawfulnessへ拡張
+
+目的:
+
+現行の `relation-complexity` を、単なるtag countからlaw候補生成へ拡張する。
+
+現在の relation complexity は `constraints`, `compensations`, `projections`, `failureTransitions`, `idempotencyRequirements` を数えます。([GitHub][1])
+これを以下に発展させる。
+
+```text
+idempotencyRequirements
+  -> idempotency law candidate
+
+compensations
+  -> compensation law candidate
+
+projections
+  -> event-log-homomorphism / projection law candidate
+
+constraints
+  -> invariant preservation law candidate
+
+failureTransitions
+  -> recovery / compensation law candidate
+```
+
+新規コマンド案:
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- law-candidates \
+  --relation-complexity relation-complexity-candidates.json \
+  --out architecture-laws.generated.json
+```
+
+ただし、generated law は `required=false` または `candidate=true` として扱い、人間が昇格させる。
+
+---
+
+## Phase 2: Event Replay Checker連携
+
+目的:
+
+Event Sourcing系のlawを実データで測る。
+
+実装するもの:
+
+* `event-log-evidence/v0`
+* `replayHomomorphismDefect`
+* `snapshotRoundtripDefect`
+* `eventMigrationNaturalityDefect`
+
+CLIは直接アプリコードを実行しない。
+外部replay checkerが出したJSONを読む。
+
+```bash
+cargo run --manifest-path tools/sig0-extractor/Cargo.toml -- algebraic-laws \
+  --laws architecture-laws.json \
+  --evidence law-evidence.json \
+  --event-replay-evidence event-replay-evidence.json \
+  --out .lake/algebraic-signature.json
+```
+
+---
+
+## Phase 3: Effect Signature
+
+目的:
+
+Clean Architecture / Hexagonal / DIP を import graph ではなく effect leakage として測る。
+
+実装するもの:
+
+* `effect-policy/v0`
+* `effect-evidence/v0`
+* `effectLeakageCount`
+* `unhandledEffectCount`
+* `handlerCoverageRatio`
+* `ambientAuthorityUsageCount`
+
+MVPでは、effect evidence は以下から受け取る。
+
+```text
+annotations
+static markers
+manually generated JSON
+language-specific analyzer output
+```
+
+---
+
+## Phase 4: Snapshot / Diff / Dataset統合
+
+目的:
+
+既存のPR診断フローにAlgSigを統合する。
+
+実装するもの:
+
+* snapshotで `algebraic-signature-v0` を保存
+* signature-diffで `algebraicDiff` を生成
+* datasetで `deltaAlgebraicSignatureSigned` を生成
+* `primaryDiffEligible` 判定に `lawUniverse`, `equivalencePolicy`, `ruleSetVersion` を追加
+
+---
+
+## Phase 5: Lean Formal Core
+
+目的:
+
+CLI指標の理論的意味をLeanで保証する。
+
+成果物:
+
+```text
+Formal/Arch/Algebraic/Law.lean
+Formal/Arch/Algebraic/Metric.lean
+Formal/Arch/Algebraic/Idempotency.lean
+Formal/Arch/Algebraic/Compensation.lean
+Formal/Arch/Algebraic/EventLog.lean
+Formal/Arch/Algebraic/Roundtrip.lean
+Formal/Arch/Algebraic/Invariant.lean
+Formal/Arch/Algebraic/Effect.lean
+Formal/Arch/Algebraic/Projection.lean
+```
+
+---
+
+# 12. 受け入れ基準
+
+## 12.1 MVP受け入れ基準
+
+### Case 1: idempotency violation
+
+入力:
+
+* `architecture-laws.json` に `order.cancel.idempotent`
+* `law-evidence.json` に violated evidence
+
+期待出力:
+
+```json
+{
+  "signature": {
+    "violatedLawCount": 1,
+    "idempotencyViolationCount": 1,
+    "lawDebt": 0
+  },
+  "lawResults": [
+    {
+      "lawId": "order.cancel.idempotent",
+      "status": "violated"
+    }
+  ]
+}
+```
+
+---
+
+### Case 2: law未評価
+
+入力:
+
+* law registryに required law が3つ
+* evidenceは1つだけ
+
+期待出力:
+
+```json
+{
+  "signature": {
+    "requiredLawCount": 3,
+    "satisfiedLawCount": 1,
+    "violatedLawCount": 0,
+    "unmeasuredLawCount": 2,
+    "lawDebt": 2
+  }
+}
+```
+
+診断文:
+
+```text
+violatedLawCount = 0 だが、lawDebt = 2 のため lawfulness は未評価。
+```
+
+---
+
+### Case 3: before/after diff
+
+before:
+
+```json
+"idempotencyViolationCount": 0
+```
+
+after:
+
+```json
+"idempotencyViolationCount": 1
+```
+
+期待diff:
+
+```json
+{
+  "algebraicDiff": {
+    "worsenedAxes": [
+      {
+        "axis": "idempotencyViolationCount",
+        "before": 0,
+        "after": 1,
+        "delta": 1
+      }
+    ],
+    "lawStatusDiff": {
+      "newlyViolatedLaws": ["order.cancel.idempotent"]
+    }
+  }
+}
+```
+
+---
+
+### Case 4: lawUniverse不一致
+
+before:
+
+```json
+"lawUniverse": { "id": "order-service-laws-v0" }
+```
+
+after:
+
+```json
+"lawUniverse": { "id": "order-service-laws-v1" }
+```
+
+期待出力:
+
+```json
+{
+  "comparisonStatus": {
+    "primaryDiffEligible": false,
+    "reasons": [
+      "law universe differs"
+    ]
+  }
+}
+```
+
+---
+
+# 13. AI reviewer向け診断テンプレート
+
+## 13.1 Red診断
+
+```text
+このPRは依存グラフ上のfanoutを増やしていませんが、
+algebraic signature上では idempotencyViolationCount が 0 -> 1 に悪化しています。
+
+新たに violated になった law:
+- order.cancel.idempotent
+
+counterexample:
+- CancelOrder(orderId=123) を2回実行すると OrderCancelled event が2回発行されます。
+
+このoperationが retryable-command として宣言されている場合、
+重複実行時の観測を1回実行と一致させる必要があります。
+```
+
+---
+
+## 13.2 Yellow診断
+
+```text
+このPRでは violatedLawCount は増えていません。
+ただし lawDebt が 4 -> 7 に増えています。
+
+つまり、違反がないのではなく、
+新しく追加されたworkflowに対する代数法則のevidenceが不足しています。
+
+未評価law:
+- payment.reserve.compensated
+- order.projection.homomorphism
+- user.dto.roundtrip
+```
+
+---
+
+## 13.3 Green診断
+
+```text
+このPRでは以下の代数指標が改善しています。
+
+- lawDebt: 5 -> 2
+- replayHomomorphismDefect: 1 -> 0
+
+Event projection の分割replay lawが満たされるようになり、
+履歴再構成性のriskが下がっています。
+```
+
+---
+
+# 14. 優先順位
+
+## P0: 必須
+
+* `architecture-laws/v0`
+* `law-evidence/v0`
+* `algebraic-signature-v0`
+* `algebraic-laws` command
+* `algebraic-validate` command
+* core law metrics
+* idempotency metrics
+* compensation metrics
+* event replay homomorphism metrics
+* roundtrip metrics
+
+## P1: 強く推奨
+
+* relation-complexityからlaw candidate生成
+* effect signature metrics
+* invariant preservation metrics
+* snapshot / diffの最小統合
+* dataset統合
+* AI reviewer用diagnostic summary
+
+## P2: 将来拡張
+
+* projection / functor soundness
+* observability kernel
+* LSP / behavioral trace inclusion
+* configuration algebra
+* capability algebra
+* language-specific static analyzers
+
+---
+
+# 15. 成功指標
+
+## Product success
+
+```text
+PR diff report上で、
+依存グラフに変化がないにもかかわらず、
+代数法則の悪化を検出できる。
+```
+
+具体的には:
+
+* 新規 idempotency violation を検出できる
+* 新規 replay homomorphism defect を検出できる
+* compensation law の未評価 / 破れを区別できる
+* roundtrip loss を evidence 付きで報告できる
+* `lawDebt` と `violatedLawCount` を分離できる
+
+## Research success
+
+```text
+algebraic signature の悪化と、
+review cost / bug fix cost / incident recurrence / change propagation の関係をdatasetで検証できる。
+```
+
+研究目標では、signatureの悪化と変更ファイル数、SCCと障害修正時間、fanoutとレビューコスト、境界違反と将来の変更波及、relation complexityと運用リスクの関係を実データで検証する方針が示されています。AlgSigはここに、lawDebt、idempotencyViolation、replayHomomorphismDefect、compensationDefectなどを追加する位置づけです。([GitHub][2])
+
+---

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,0 +1,12 @@
+# PRD
+
+このディレクトリには、実装前または検討中の product requirement document を置く。
+
+PRD は、研究主張そのものではなく、CLI、dataset、CI、AI reviewer などの tooling に落とすための要求仕様として扱う。Lean status は PRD 内で確定させず、実装・証明・実証仮説に反映する段階で `docs/proof_obligations.md` や個別 design document に移す。
+
+## 現在のPRD
+
+- [Algebraic Signature Extension for sig0-extractor](<Algebraic Signature Extension for sig0-extractor.md>):
+  依存グラフベースの計測に、設計法則・状態遷移・履歴再構成性・表現変換の別軸を追加する全体構想。
+- [Algebraic Law Signature MVP for sig0-extractor](<Algebraic Law Signature MVP for sig0-extractor.md>):
+  `architecture-laws/v0` と `law-evidence/v0` から `algebraic-signature-v0` を生成し、`algebraic-validate` で検査する Phase 0 の実装仕様。


### PR DESCRIPTION
## 概要

Closes #181

`sig0-extractor` に依存グラフとは別軸の algebraic signature を追加するためのPRDを `docs/prd` に整理しました。

- Algebraic Signature Extension の全体構想を追加
- Algebraic Law Signature MVP の Phase 0 実装仕様を追加
- `docs/README.md` から PRD 一覧への導線を追加

## 証明した定理

- なし

## 編集したドキュメント

- `docs/README.md`
- `docs/prd/README.md`
- `docs/prd/Algebraic Signature Extension for sig0-extractor.md`
- `docs/prd/Algebraic Law Signature MVP for sig0-extractor.md`

## 実施したテスト

- [ ] `lake build`（docs のみの変更で Lean import / theorem には影響しないため未実施）
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical hypothesis` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
