### PR TITLE
零曲率定理の阻害証人カーネルを追加

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -8,6 +8,7 @@ import Formal.Arch.Projection
 import Formal.Arch.Observation
 import Formal.Arch.LSP
 import Formal.Arch.LocalReplacement
+import Formal.Arch.Obstruction
 import Formal.Arch.SolidCounterexample
 import Formal.Arch.Signature
 import Formal.Arch.Finite

--- a/Formal/Arch/Obstruction.lean
+++ b/Formal/Arch/Obstruction.lean
@@ -1,0 +1,182 @@
+namespace Formal.Arch
+
+universe u v
+
+/--
+Finite witnesses that violate a supplied obstruction predicate.
+
+The input list is the measured witness universe. Duplicates are intentionally
+preserved, matching the executable metrics used elsewhere in the project.
+-/
+def violatingWitnesses {W : Type u} (bad : W -> Prop) [DecidablePred bad]
+    (xs : List W) : List W :=
+  xs.filter bad
+
+/-- Count measured witnesses that violate a supplied obstruction predicate. -/
+def violationCount {W : Type u} (bad : W -> Prop) [DecidablePred bad]
+    (xs : List W) : Nat :=
+  (violatingWitnesses bad xs).length
+
+/--
+Membership in the violating witness list is exactly membership in the measured
+universe plus the obstruction predicate.
+-/
+theorem mem_violatingWitnesses_iff {W : Type u} {bad : W -> Prop}
+    [DecidablePred bad] {xs : List W} {w : W} :
+    w ∈ violatingWitnesses bad xs ↔ w ∈ xs ∧ bad w := by
+  simp [violatingWitnesses]
+
+/--
+Zero measured violations is equivalent to every measured witness being good.
+-/
+theorem violationCount_eq_zero_iff_forall_not_bad {W : Type u}
+    {bad : W -> Prop} [DecidablePred bad] {xs : List W} :
+    violationCount bad xs = 0 ↔ ∀ w, w ∈ xs -> ¬ bad w := by
+  constructor
+  · intro hZero w hMem hBad
+    have hViolation : w ∈ violatingWitnesses bad xs := by
+      rw [mem_violatingWitnesses_iff]
+      exact ⟨hMem, hBad⟩
+    have hPositive : 0 < violationCount bad xs := by
+      unfold violationCount
+      exact List.length_pos_of_mem hViolation
+    exact (Nat.ne_of_gt hPositive) hZero
+  · intro hNoBad
+    unfold violationCount violatingWitnesses
+    induction xs with
+    | nil =>
+        simp
+    | cons x xs ih =>
+        have hx : ¬ bad x := hNoBad x (by simp)
+        have hxs : ∀ w, w ∈ xs -> ¬ bad w := by
+          intro w hw
+          exact hNoBad w (by simp [hw])
+        simp [hx, ih hxs]
+
+/-- A required equality diagram over an abstract expression type. -/
+structure RequiredDiagram (Expr : Type u) where
+  lhs : Expr
+  rhs : Expr
+
+/-- Semantics for interpreting diagram expressions as observable values. -/
+structure Semantics (Expr : Type u) (Obs : Type v) where
+  eval : Expr -> Obs
+
+/-- A required diagram commutes when its two sides have equal semantics. -/
+def DiagramCommutes {Expr : Type u} {Obs : Type v}
+    (sem : Semantics Expr Obs) (d : RequiredDiagram Expr) : Prop :=
+  sem.eval d.lhs = sem.eval d.rhs
+
+/-- A diagram obstruction witness is a required diagram that does not commute. -/
+def DiagramBad {Expr : Type u} {Obs : Type v}
+    (sem : Semantics Expr Obs) (d : RequiredDiagram Expr) : Prop :=
+  ¬ DiagramCommutes sem d
+
+/-- Diagram obstruction witnesses are decidable when observations have decidable equality. -/
+instance instDecidablePredDiagramBad {Expr : Type u} {Obs : Type v}
+    [DecidableEq Obs] (sem : Semantics Expr Obs) :
+    DecidablePred (DiagramBad sem) := by
+  intro d
+  unfold DiagramBad DiagramCommutes
+  infer_instance
+
+/-- Measured required diagrams whose two sides do not commute. -/
+def diagramViolatingWitnesses {Expr : Type u} {Obs : Type v}
+    (sem : Semantics Expr Obs) [DecidableEq Obs]
+    (diagrams : List (RequiredDiagram Expr)) : List (RequiredDiagram Expr) :=
+  violatingWitnesses (DiagramBad sem) diagrams
+
+/-- Count measured diagram obstruction witnesses. -/
+def diagramViolationCount {Expr : Type u} {Obs : Type v}
+    (sem : Semantics Expr Obs) [DecidableEq Obs]
+    (diagrams : List (RequiredDiagram Expr)) : Nat :=
+  violationCount (DiagramBad sem) diagrams
+
+/--
+The measured diagram list covers every required diagram.
+
+This is one-way on purpose: the measured list may contain additional diagrams,
+but every required diagram must be present.
+-/
+def CoversRequired {Expr : Type u}
+    (required : RequiredDiagram Expr -> Prop)
+    (measured : List (RequiredDiagram Expr)) : Prop :=
+  ∀ d, required d -> d ∈ measured
+
+/--
+Zero measured diagram violations constructively gives the absence of measured
+diagram obstruction witnesses.
+-/
+theorem no_measured_DiagramBad_of_diagramViolationCount_eq_zero
+    {Expr : Type u} {Obs : Type v} {sem : Semantics Expr Obs} [DecidableEq Obs]
+    {measured : List (RequiredDiagram Expr)}
+    (hZero : diagramViolationCount sem measured = 0) :
+    ∀ d, d ∈ measured -> ¬ DiagramBad sem d := by
+  rw [diagramViolationCount] at hZero
+  exact (violationCount_eq_zero_iff_forall_not_bad.mp hZero)
+
+/--
+If every measured diagram commutes, the measured diagram violation count is
+zero.
+-/
+theorem diagramViolationCount_eq_zero_of_forall_measured_DiagramCommutes
+    {Expr : Type u} {Obs : Type v} {sem : Semantics Expr Obs} [DecidableEq Obs]
+    {measured : List (RequiredDiagram Expr)}
+    (hCommutes : ∀ d, d ∈ measured -> DiagramCommutes sem d) :
+    diagramViolationCount sem measured = 0 := by
+  rw [diagramViolationCount]
+  exact violationCount_eq_zero_iff_forall_not_bad.mpr (by
+    intro d hMem hBad
+    exact hBad (hCommutes d hMem))
+
+/--
+With decidable semantic equality, zero measured diagram violations is equivalent
+to every measured diagram commuting.
+-/
+theorem diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes
+    {Expr : Type u} {Obs : Type v} {sem : Semantics Expr Obs} [DecidableEq Obs]
+    {measured : List (RequiredDiagram Expr)} :
+    diagramViolationCount sem measured = 0 ↔
+      ∀ d, d ∈ measured -> DiagramCommutes sem d := by
+  constructor
+  · intro hZero d hMem
+    by_cases hCommutes : DiagramCommutes sem d
+    · exact hCommutes
+    · exact False.elim
+        (no_measured_DiagramBad_of_diagramViolationCount_eq_zero hZero
+          d hMem hCommutes)
+  · intro hCommutes
+    exact diagramViolationCount_eq_zero_of_forall_measured_DiagramCommutes
+      hCommutes
+
+/--
+Under complete coverage, zero measured diagram violations constructively gives
+the absence of required diagram obstruction witnesses.
+-/
+theorem no_required_DiagramBad_of_coversRequired_and_diagramViolationCount_eq_zero
+    {Expr : Type u} {Obs : Type v} {sem : Semantics Expr Obs} [DecidableEq Obs]
+    {required : RequiredDiagram Expr -> Prop}
+    {measured : List (RequiredDiagram Expr)}
+    (hCovers : CoversRequired required measured)
+    (hZero : diagramViolationCount sem measured = 0) :
+    ∀ d, required d -> ¬ DiagramBad sem d := by
+  intro d hRequired
+  exact no_measured_DiagramBad_of_diagramViolationCount_eq_zero hZero
+    d (hCovers d hRequired)
+
+/--
+Under complete coverage and decidable semantic equality, zero measured diagram
+violations implies every required diagram commutes.
+-/
+theorem requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero
+    {Expr : Type u} {Obs : Type v} {sem : Semantics Expr Obs} [DecidableEq Obs]
+    {required : RequiredDiagram Expr -> Prop}
+    {measured : List (RequiredDiagram Expr)}
+    (hCovers : CoversRequired required measured)
+    (hZero : diagramViolationCount sem measured = 0) :
+    ∀ d, required d -> DiagramCommutes sem d := by
+  intro d hRequired
+  exact (diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes.mp
+    hZero) d (hCovers d hRequired)
+
+end Formal.Arch

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -287,9 +287,12 @@ required diagram を列挙するなど、一部の law family では `CoversRequ
 
 最初に Lean で証明する対象は、構造的・有限・全称的な命題に限定する。
 
-- `future proof obligation`: finite witness list 上の generic zero-count bridge。
-- `future proof obligation`: required diagram の可換性と diagram obstruction witness 不在の同値。
-- `future proof obligation`: finite measured law universe での diagram zero-count bridge。
+- `proved`: finite witness list 上の generic zero-count bridge,
+  `violationCount_eq_zero_iff_forall_not_bad`, [Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189)
+- `proved`: required diagram の可換性と diagram obstruction witness 不在の同値,
+  `diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes`, [Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189)
+- `proved`: finite measured law universe での diagram zero-count bridge,
+  `requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero`, [Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189)
 - `future proof obligation`: independent lawfulness predicate と witness 不在の exactness bridge。
 - `future proof obligation`: required Signature axis の `AvailableAndZero` と witness 不在の exactness bridge。
 - `future proof obligation`: complete coverage 下での measured zero から global lawfulness への bridge。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -165,6 +165,29 @@ Files: `Formal/Arch/Observation.lean`, `Formal/Arch/LSP.lean`, `Formal/Arch/Loca
 | `observationFactorsThrough_of_localReplacementContract` | `theorem` | 局所置換契約から observation factorization を得る。 | `proved` |
 | `violationCounts_eq_zero_of_localReplacementContract` | `theorem` | 局所置換契約から projection soundness violation count と LSP violation count が同時に 0 になることを得る。 | `proved` |
 
+## Obstruction Kernel
+
+File: `Formal/Arch/Obstruction.lean`
+
+| Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- |
+| `violatingWitnesses` | `def` | 有限な測定 witness list から、`bad` predicate を満たす阻害証人を取り出す。 | `defined only` |
+| `violationCount` | `def` | `violatingWitnesses` の長さとして measured obstruction count を数える。 | `defined only` |
+| `mem_violatingWitnesses_iff` | `theorem` | `violatingWitnesses` の membership が、測定対象であり `bad` を満たすことと一致する。 | `proved` |
+| `violationCount_eq_zero_iff_forall_not_bad` | `theorem` | `violationCount bad xs = 0` と、すべての測定 witness が `bad` でないことの同値。 | `proved` |
+| `RequiredDiagram` | `structure` | 左辺・右辺を持つ required equality diagram。 | `defined only` |
+| `Semantics` | `structure` | diagram expression を観測値へ解釈する意味論。 | `defined only` |
+| `DiagramCommutes` | `def` | required diagram の両辺の意味論が等しいこと。 | `defined only` |
+| `DiagramBad` | `def` | required diagram が可換でないことを表す diagram obstruction witness。 | `defined only` |
+| `diagramViolatingWitnesses` | `def` | 測定 diagram list から非可換な diagram obstruction witness を取り出す。 | `defined only` |
+| `diagramViolationCount` | `def` | 測定 diagram obstruction witness 数。 | `defined only` |
+| `CoversRequired` | `def` | required diagram がすべて measured list に含まれる complete coverage 条件。 | `defined only` |
+| `no_measured_DiagramBad_of_diagramViolationCount_eq_zero` | `theorem` | diagram violation count 0 から、測定 diagram obstruction witness が存在しないことを得る。 | `proved` |
+| `diagramViolationCount_eq_zero_of_forall_measured_DiagramCommutes` | `theorem` | 測定 diagram がすべて可換なら diagram violation count は 0。 | `proved` |
+| `diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes` | `theorem` | `[DecidableEq Obs]` の下で、diagram violation count 0 と測定 diagram の可換性が同値。 | `proved` |
+| `no_required_DiagramBad_of_coversRequired_and_diagramViolationCount_eq_zero` | `theorem` | complete coverage と diagram violation count 0 から、required diagram obstruction witness が存在しないことを得る。 | `proved` |
+| `requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero` | `theorem` | `[DecidableEq Obs]` の下で、complete coverage と diagram violation count 0 から required diagram の可換性を得る。 | `proved` |
+
 ## Signature v0
 
 File: `Formal/Arch/Signature.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -54,8 +54,12 @@ lawfulness への bridge である。
 | obstruction witness | 阻害証人 |
 | zero-count bridge | 零カウント橋渡し |
 
-Lean status は `future proof obligation` であり、現時点でこの定理全体が
-Lean で証明済みであるとは扱わない。
+Lean status は、generic witness-count kernel と required diagram の
+zero-count bridge については `proved` である
+([Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189))。
+ただし、アーキテクチャ零曲率定理全体、独立に定義された lawfulness predicate との
+exactness、required `ArchitectureSignature` axis との exactness は
+`future proof obligation` のまま扱う。
 
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、


### PR DESCRIPTION
## 概要

Closes #189

- generic obstruction witness kernel として `violatingWitnesses` / `violationCount` を追加しました。
- `RequiredDiagram`, `Semantics`, `DiagramCommutes`, `DiagramBad`, `CoversRequired` を追加し、complete coverage 下の diagram zero-count bridge を証明しました。
- zero-count bridge までを `proved`、中心定理全体と axis exactness は `future proof obligation` として docs を同期しました。

## 証明した定理

- `mem_violatingWitnesses_iff`
- `violationCount_eq_zero_iff_forall_not_bad`
- `no_measured_DiagramBad_of_diagramViolationCount_eq_zero`
- `diagramViolationCount_eq_zero_of_forall_measured_DiagramCommutes`
- `diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes`
- `no_required_DiagramBad_of_coversRequired_and_diagramViolationCount_eq_zero`
- `requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている