### PR TITLE
零曲率定理の法則健全性ブリッジを追加

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -9,6 +9,7 @@ import Formal.Arch.Observation
 import Formal.Arch.LSP
 import Formal.Arch.LocalReplacement
 import Formal.Arch.Obstruction
+import Formal.Arch.Lawfulness
 import Formal.Arch.SolidCounterexample
 import Formal.Arch.Signature
 import Formal.Arch.Finite

--- a/Formal/Arch/Lawfulness.lean
+++ b/Formal/Arch/Lawfulness.lean
@@ -1,0 +1,170 @@
+import Formal.Arch.Obstruction
+
+namespace Formal.Arch
+
+universe u v w
+
+/--
+An abstract family of required laws together with its finite measured witness
+universe.
+
+`lawful` is deliberately a separate predicate. The obstruction framework can
+prove bridge theorems to it, but the definition itself is not reduced to
+`NoRequiredObstruction`.
+-/
+structure LawFamily (A : Type u) where
+  Witness : Type v
+  Axis : Type w
+  measured : List Witness
+  required : Witness -> Prop
+  bad : A -> Witness -> Prop
+  lawful : A -> Prop
+  lawful_iff_no_measured_bad :
+    ∀ a, lawful a ↔ ∀ w, w ∈ measured -> ¬ bad a w
+  requiredAxis : Axis -> Prop
+
+/-- A signature axis valuation used by abstract law-family bridge theorems. -/
+abbrev AxisSignature (Axis : Type u) := Axis -> Option Nat
+
+/-- A law family is lawful for an architecture according to its independent predicate. -/
+def Lawful {A : Type u} (a : A) (L : LawFamily A) : Prop :=
+  L.lawful a
+
+/-- No required obstruction witness exists for the law family. -/
+def NoRequiredObstruction {A : Type u} (a : A) (L : LawFamily A) : Prop :=
+  ∀ w, L.required w -> ¬ L.bad a w
+
+/-- No measured obstruction witness exists for the law family. -/
+def NoMeasuredObstruction {A : Type u} (a : A) (L : LawFamily A) : Prop :=
+  ∀ w, w ∈ L.measured -> ¬ L.bad a w
+
+/-- The finite measured witness list is exactly the required witness universe. -/
+def CompleteWitnessCoverage {A : Type u} (L : LawFamily A) : Prop :=
+  ∀ w, w ∈ L.measured ↔ L.required w
+
+/-- Count measured law-family obstruction witnesses. -/
+def lawViolationCount {A : Type u} (a : A) (L : LawFamily A)
+    [DecidablePred (L.bad a)] : Nat :=
+  violationCount (L.bad a) L.measured
+
+/--
+The independent lawfulness predicate is equivalent to absence of measured
+obstruction witnesses by the bridge carried by the law family.
+-/
+theorem lawful_iff_noMeasuredObstruction {A : Type u} {a : A}
+    {L : LawFamily A} :
+    Lawful a L ↔ NoMeasuredObstruction a L := by
+  exact L.lawful_iff_no_measured_bad a
+
+/--
+The finite measured violation count is zero exactly when the independent
+lawfulness predicate holds.
+-/
+theorem lawViolationCount_eq_zero_iff_lawful {A : Type u} {a : A}
+    {L : LawFamily A} [DecidablePred (L.bad a)] :
+    lawViolationCount a L = 0 ↔ Lawful a L := by
+  exact Iff.trans violationCount_eq_zero_iff_forall_not_bad
+    (Iff.symm lawful_iff_noMeasuredObstruction)
+
+/--
+Complete witness coverage turns measured obstruction absence into required
+obstruction absence.
+-/
+theorem noRequiredObstruction_of_completeCoverage_and_noMeasuredObstruction
+    {A : Type u} {a : A} {L : LawFamily A}
+    (hCoverage : CompleteWitnessCoverage L)
+    (hNoMeasured : NoMeasuredObstruction a L) :
+    NoRequiredObstruction a L := by
+  intro w hRequired
+  exact hNoMeasured w ((hCoverage w).mpr hRequired)
+
+/--
+Complete witness coverage turns required obstruction absence into measured
+obstruction absence.
+-/
+theorem noMeasuredObstruction_of_completeCoverage_and_noRequiredObstruction
+    {A : Type u} {a : A} {L : LawFamily A}
+    (hCoverage : CompleteWitnessCoverage L)
+    (hNoRequired : NoRequiredObstruction a L) :
+    NoMeasuredObstruction a L := by
+  intro w hMeasured
+  exact hNoRequired w ((hCoverage w).mp hMeasured)
+
+/--
+Under complete witness coverage, the independent lawfulness predicate is
+equivalent to the absence of required obstruction witnesses.
+-/
+theorem lawful_iff_noRequiredObstruction_of_completeCoverage
+    {A : Type u} {a : A} {L : LawFamily A}
+    (hCoverage : CompleteWitnessCoverage L) :
+    Lawful a L ↔ NoRequiredObstruction a L := by
+  constructor
+  · intro hLawful
+    exact noRequiredObstruction_of_completeCoverage_and_noMeasuredObstruction
+      hCoverage (lawful_iff_noMeasuredObstruction.mp hLawful)
+  · intro hNoRequired
+    exact lawful_iff_noMeasuredObstruction.mpr
+      (noMeasuredObstruction_of_completeCoverage_and_noRequiredObstruction
+        hCoverage hNoRequired)
+
+/--
+Under complete witness coverage, zero measured violations are equivalent to the
+absence of required obstruction witnesses.
+-/
+theorem lawViolationCount_eq_zero_iff_noRequiredObstruction_of_completeCoverage
+    {A : Type u} {a : A} {L : LawFamily A}
+    [DecidablePred (L.bad a)]
+    (hCoverage : CompleteWitnessCoverage L) :
+    lawViolationCount a L = 0 ↔ NoRequiredObstruction a L := by
+  exact Iff.trans lawViolationCount_eq_zero_iff_lawful
+    (lawful_iff_noRequiredObstruction_of_completeCoverage hCoverage)
+
+/--
+The axis has been measured and is exactly zero. This intentionally rejects
+`none`.
+-/
+def AvailableAndZero {Axis : Type u} (sig : AxisSignature Axis)
+    (axis : Axis) : Prop :=
+  sig axis = some 0
+
+/--
+Every required axis of the law family is present in the signature and measured
+as zero.
+-/
+def RequiredAxesAvailableAndZero {A : Type u} (L : LawFamily A)
+    (sig : AxisSignature L.Axis) : Prop :=
+  ∀ axis, L.requiredAxis axis -> AvailableAndZero sig axis
+
+/--
+A proof-carrying statement that required zero axes exactly represent absence of
+required obstruction witnesses.
+-/
+def RequiredAxisExact {A : Type u} (a : A) (L : LawFamily A)
+    (sig : AxisSignature L.Axis) : Prop :=
+  RequiredAxesAvailableAndZero L sig ↔ NoRequiredObstruction a L
+
+/--
+Required axis exactness exposes the bridge from signature zeros to required
+obstruction absence.
+-/
+theorem requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisExact
+    {A : Type u} {a : A} {L : LawFamily A} {sig : AxisSignature L.Axis}
+    (hExact : RequiredAxisExact a L sig) :
+    RequiredAxesAvailableAndZero L sig ↔ NoRequiredObstruction a L := by
+  exact hExact
+
+/--
+Central zero-curvature theorem shape: with complete witness coverage and an
+exact required-axis bridge, independent lawfulness is equivalent to all required
+signature axes being available and zero.
+-/
+theorem lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact
+    {A : Type u} {a : A} {L : LawFamily A} {sig : AxisSignature L.Axis}
+    (hCoverage : CompleteWitnessCoverage L)
+    (hExact : RequiredAxisExact a L sig) :
+    Lawful a L ↔ RequiredAxesAvailableAndZero L sig := by
+  exact Iff.trans
+    (lawful_iff_noRequiredObstruction_of_completeCoverage hCoverage)
+    (Iff.symm hExact)
+
+end Formal.Arch

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -293,9 +293,18 @@ required diagram を列挙するなど、一部の law family では `CoversRequ
   `diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes`, [Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189)
 - `proved`: finite measured law universe での diagram zero-count bridge,
   `requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero`, [Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189)
-- `future proof obligation`: independent lawfulness predicate と witness 不在の exactness bridge。
+- `proved`: 抽象 `LawFamily` で、独立 `Lawful` predicate、`NoRequiredObstruction`,
+  `RequiredAxesAvailableAndZero` を分離し、complete witness coverage と
+  required axis exactness を前提にした中心 bridge,
+  `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact`,
+  [Issue #191](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/191)
+- `future proof obligation`: `ProjectionSound`, `LSPCompatible`, `WalkAcyclic` など具体的な
+  lawfulness predicate と witness 不在の exactness bridge。
 - `future proof obligation`: required Signature axis の `AvailableAndZero` と witness 不在の exactness bridge。
-- `future proof obligation`: complete coverage 下での measured zero から global lawfulness への bridge。
+- `proved`: 抽象 `LawFamily` では、complete coverage 下での measured zero から
+  global lawfulness への bridge,
+  `lawViolationCount_eq_zero_iff_lawful`, `lawful_iff_noRequiredObstruction_of_completeCoverage`,
+  [Issue #191](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/191)
 - `defined only`: witness family をまとめる signature schema。
 - `empirical hypothesis`: obstruction count と変更コスト・障害率・レビュー負荷の相関。
 

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -188,6 +188,31 @@ File: `Formal/Arch/Obstruction.lean`
 | `no_required_DiagramBad_of_coversRequired_and_diagramViolationCount_eq_zero` | `theorem` | complete coverage と diagram violation count 0 から、required diagram obstruction witness が存在しないことを得る。 | `proved` |
 | `requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero` | `theorem` | `[DecidableEq Obs]` の下で、complete coverage と diagram violation count 0 から required diagram の可換性を得る。 | `proved` |
 
+## Lawfulness Bridge
+
+File: `Formal/Arch/Lawfulness.lean`
+
+| Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- |
+| `LawFamily` | `structure` | 独立した `lawful` predicate、測定 witness list、required witness predicate、bad witness predicate、required axis predicate を束ねる抽象法則族。 | `defined only` |
+| `AxisSignature` | `abbrev` | 抽象 axis から `Option Nat` metric への signature valuation。 | `defined only` |
+| `Lawful` | `def` | 法則族側で与えられた独立 predicate としての lawfulness。 | `defined only` |
+| `NoRequiredObstruction` | `def` | required witness 全体に bad witness が存在しないこと。 | `defined only` |
+| `NoMeasuredObstruction` | `def` | measured witness list に bad witness が存在しないこと。 | `defined only` |
+| `CompleteWitnessCoverage` | `def` | measured witness list が required witness universe と一致する完全被覆条件。 | `defined only` |
+| `lawViolationCount` | `def` | generic `violationCount` を使う law-family obstruction count。 | `defined only` |
+| `lawful_iff_noMeasuredObstruction` | `theorem` | 法則族が持つ bridge により、独立 lawfulness と measured obstruction 不在を接続する。 | `proved` |
+| `lawViolationCount_eq_zero_iff_lawful` | `theorem` | measured violation count 0 と独立 lawfulness の同値。 | `proved` |
+| `noRequiredObstruction_of_completeCoverage_and_noMeasuredObstruction` | `theorem` | 完全被覆下で measured obstruction 不在から required obstruction 不在を得る。 | `proved` |
+| `noMeasuredObstruction_of_completeCoverage_and_noRequiredObstruction` | `theorem` | 完全被覆下で required obstruction 不在から measured obstruction 不在を得る。 | `proved` |
+| `lawful_iff_noRequiredObstruction_of_completeCoverage` | `theorem` | 完全被覆下で独立 lawfulness と required obstruction 不在を接続する中心 bridge。 | `proved` |
+| `lawViolationCount_eq_zero_iff_noRequiredObstruction_of_completeCoverage` | `theorem` | 完全被覆下で measured violation count 0 と required obstruction 不在を接続する。 | `proved` |
+| `AvailableAndZero` | `def` | required axis が `some 0` として測定済みであること。`none` は許さない。 | `defined only` |
+| `RequiredAxesAvailableAndZero` | `def` | 法則族の required axis がすべて available and zero であること。 | `defined only` |
+| `RequiredAxisExact` | `def` | required axis の available-and-zero と required obstruction 不在が同値であること。 | `defined only` |
+| `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisExact` | `theorem` | required axis exactness から signature axis と obstruction 不在の bridge を取り出す。 | `proved` |
+| `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact` | `theorem` | 完全被覆と required axis exactness の下で、lawfulness と required axis zero を接続する零曲率定理候補。 | `proved` |
+
 ## Signature v0
 
 File: `Formal/Arch/Signature.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -57,8 +57,14 @@ lawfulness への bridge である。
 Lean status は、generic witness-count kernel と required diagram の
 zero-count bridge については `proved` である
 ([Issue #189](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/189))。
-ただし、アーキテクチャ零曲率定理全体、独立に定義された lawfulness predicate との
-exactness、required `ArchitectureSignature` axis との exactness は
+さらに抽象 `LawFamily` では、独立に与えられた `Lawful` predicate、required witness
+上の `NoRequiredObstruction`、required axis 上の
+`RequiredAxesAvailableAndZero` を分離し、complete witness coverage と
+required axis exactness を前提にした中心 bridge を Lean で証明済みである
+([Issue #191](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/191))。
+ただし、アーキテクチャ零曲率定理全体、具体的な `ProjectionSound` /
+`LSPCompatible` / `WalkAcyclic` などの lawfulness predicate との exactness、
+required `ArchitectureSignature` axis との exactness は
 `future proof obligation` のまま扱う。
 
 証明強度は段階的に扱う。`violationCount bad xs = 0` と


### PR DESCRIPTION
## 概要

Closes #191

- 抽象 `LawFamily` を追加し、独立した `Lawful` predicate と `NoRequiredObstruction` を分離しました。
- complete witness coverage 下で lawfulness、measured zero、required obstruction 不在を接続する bridge theorem を追加しました。
- required axis が available and zero であることを表す抽象 predicate と、中心定理候補の theorem statement を追加しました。

## 証明した定理

- `lawful_iff_noMeasuredObstruction`
- `lawViolationCount_eq_zero_iff_lawful`
- `noRequiredObstruction_of_completeCoverage_and_noMeasuredObstruction`
- `noMeasuredObstruction_of_completeCoverage_and_noRequiredObstruction`
- `lawful_iff_noRequiredObstruction_of_completeCoverage`
- `lawViolationCount_eq_zero_iff_noRequiredObstruction_of_completeCoverage`
- `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisExact`
- `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている