### PR TITLE
Issue 195: Signature axis exactness を整理する

### DIFF
--- a/Formal/Arch/Lawfulness.lean
+++ b/Formal/Arch/Lawfulness.lean
@@ -26,6 +26,68 @@ structure LawFamily (A : Type u) where
 /-- A signature axis valuation used by abstract law-family bridge theorems. -/
 abbrev AxisSignature (Axis : Type u) := Axis -> Option Nat
 
+/--
+An optional metric has no measured nonzero value.
+
+This is intentionally weaker than `AvailableAndZero`: `none` satisfies
+`MeasuredZero`, because no measured nonzero value is present.
+-/
+def MeasuredZero (metric : Option Nat) : Prop :=
+  ∀ n, metric = some n -> n = 0
+
+/--
+An optional metric is present and exactly zero.
+
+This intentionally rejects `none`; required law axes use this stronger
+predicate when zero is meant to certify a covered law family.
+-/
+def AvailableAndZero (metric : Option Nat) : Prop :=
+  metric = some 0
+
+/-- A signature axis has no measured nonzero value. -/
+def AxisMeasuredZero {Axis : Type u} (sig : AxisSignature Axis)
+    (axis : Axis) : Prop :=
+  MeasuredZero (sig axis)
+
+/-- A signature axis is present and exactly zero. -/
+def AxisAvailableAndZero {Axis : Type u} (sig : AxisSignature Axis)
+    (axis : Axis) : Prop :=
+  AvailableAndZero (sig axis)
+
+/-- Missing measurements are measured-zero in the weak sense. -/
+theorem measuredZero_none : MeasuredZero none := by
+  intro n hSome
+  cases hSome
+
+/-- Missing measurements are not available-and-zero. -/
+theorem not_availableAndZero_none : ¬ AvailableAndZero none := by
+  intro hAvailable
+  cases hAvailable
+
+/-- A present zero metric is measured-zero. -/
+theorem measuredZero_of_availableAndZero {metric : Option Nat}
+    (hAvailable : AvailableAndZero metric) :
+    MeasuredZero metric := by
+  intro n hSome
+  rw [hAvailable] at hSome
+  cases hSome
+  rfl
+
+/-- For present metrics, measured-zero is exactly equality to zero. -/
+theorem measuredZero_some_iff {n : Nat} :
+    MeasuredZero (some n) ↔ n = 0 := by
+  constructor
+  · intro hMeasured
+    exact hMeasured n rfl
+  · intro hZero m hSome
+    cases hSome
+    exact hZero
+
+/-- For present metrics, available-and-zero is exactly equality to zero. -/
+theorem availableAndZero_some_iff {n : Nat} :
+    AvailableAndZero (some n) ↔ n = 0 := by
+  simp [AvailableAndZero]
+
 /-- A law family is lawful for an architecture according to its independent predicate. -/
 def Lawful {A : Type u} (a : A) (L : LawFamily A) : Prop :=
   L.lawful a
@@ -120,20 +182,38 @@ theorem lawViolationCount_eq_zero_iff_noRequiredObstruction_of_completeCoverage
     (lawful_iff_noRequiredObstruction_of_completeCoverage hCoverage)
 
 /--
-The axis has been measured and is exactly zero. This intentionally rejects
-`none`.
--/
-def AvailableAndZero {Axis : Type u} (sig : AxisSignature Axis)
-    (axis : Axis) : Prop :=
-  sig axis = some 0
-
-/--
 Every required axis of the law family is present in the signature and measured
 as zero.
 -/
 def RequiredAxesAvailableAndZero {A : Type u} (L : LawFamily A)
     (sig : AxisSignature L.Axis) : Prop :=
-  ∀ axis, L.requiredAxis axis -> AvailableAndZero sig axis
+  ∀ axis, L.requiredAxis axis -> AxisAvailableAndZero sig axis
+
+/--
+Axis-level exactness: one available-and-zero axis is equivalent to absence of
+bad witnesses in the witness subfamily represented by that axis.
+-/
+def AxisExact {A : Type u} (a : A) (L : LawFamily A)
+    (sig : AxisSignature L.Axis) (axis : L.Axis)
+    (witnessForAxis : L.Witness -> Prop) : Prop :=
+  AxisAvailableAndZero sig axis ↔ ∀ w, witnessForAxis w -> ¬ L.bad a w
+
+/-- An axis witness subfamily contains only required witnesses. -/
+def AxisCoversOnlyRequired {A : Type u} (L : LawFamily A)
+    (witnessForAxis : L.Axis -> L.Witness -> Prop) : Prop :=
+  ∀ axis, L.requiredAxis axis -> ∀ w, witnessForAxis axis w -> L.required w
+
+/-- Every required witness is represented by at least one required axis. -/
+def RequiredWitnessCoveredByAxis {A : Type u} (L : LawFamily A)
+    (witnessForAxis : L.Axis -> L.Witness -> Prop) : Prop :=
+  ∀ w, L.required w ->
+    ∃ axis, L.requiredAxis axis ∧ witnessForAxis axis w
+
+/-- Every required axis is exact for its represented witness subfamily. -/
+def RequiredAxisFamilyExact {A : Type u} (a : A) (L : LawFamily A)
+    (sig : AxisSignature L.Axis)
+    (witnessForAxis : L.Axis -> L.Witness -> Prop) : Prop :=
+  ∀ axis, L.requiredAxis axis -> AxisExact a L sig axis (witnessForAxis axis)
 
 /--
 A proof-carrying statement that required zero axes exactly represent absence of
@@ -152,6 +232,40 @@ theorem requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisEx
     (hExact : RequiredAxisExact a L sig) :
     RequiredAxesAvailableAndZero L sig ↔ NoRequiredObstruction a L := by
   exact hExact
+
+/--
+Axis-level exactness and a required-axis cover produce the global required-axis
+bridge used by the zero-curvature theorem shape.
+-/
+theorem requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily
+    {A : Type u} {a : A} {L : LawFamily A} {sig : AxisSignature L.Axis}
+    {witnessForAxis : L.Axis -> L.Witness -> Prop}
+    (hExact : RequiredAxisFamilyExact a L sig witnessForAxis)
+    (hOnlyRequired : AxisCoversOnlyRequired L witnessForAxis)
+    (hCovered : RequiredWitnessCoveredByAxis L witnessForAxis) :
+    RequiredAxesAvailableAndZero L sig ↔ NoRequiredObstruction a L := by
+  constructor
+  · intro hAxes w hRequired
+    rcases hCovered w hRequired with ⟨axis, hRequiredAxis, hWitness⟩
+    exact ((hExact axis hRequiredAxis).mp (hAxes axis hRequiredAxis)) w hWitness
+  · intro hNoRequired axis hRequiredAxis
+    exact (hExact axis hRequiredAxis).mpr (by
+      intro w hWitness
+      exact hNoRequired w (hOnlyRequired axis hRequiredAxis w hWitness))
+
+/--
+Axis-level exactness can be packaged as the whole-family exactness predicate
+used by existing bridge theorems.
+-/
+theorem requiredAxisExact_of_axisExactFamily
+    {A : Type u} {a : A} {L : LawFamily A} {sig : AxisSignature L.Axis}
+    {witnessForAxis : L.Axis -> L.Witness -> Prop}
+    (hExact : RequiredAxisFamilyExact a L sig witnessForAxis)
+    (hOnlyRequired : AxisCoversOnlyRequired L witnessForAxis)
+    (hCovered : RequiredWitnessCoveredByAxis L witnessForAxis) :
+    RequiredAxisExact a L sig := by
+  exact requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily
+    hExact hOnlyRequired hCovered
 
 /--
 Central zero-curvature theorem shape: with complete witness coverage and an

--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -1,4 +1,5 @@
 import Formal.Arch.Graph
+import Formal.Arch.Lawfulness
 
 namespace Formal.Arch
 
@@ -452,6 +453,134 @@ structure ArchitectureSignatureV1 where
   relationComplexity : Option Nat
   empiricalChangeCost : Option Nat
   deriving DecidableEq, Repr
+
+/--
+Classification of Signature v1 axes by their current Lean status.
+
+This is a schema-level classification: concrete bridge theorems can move an
+axis from `unmeasuredRequiredLaw` to `provedWitnessAxis` without changing the
+`ArchitectureSignatureV1` output record.
+-/
+inductive AxisMeasurementClass where
+  | provedWitnessAxis
+  | definedExecutableAxis
+  | empiricalAxis
+  | unmeasuredRequiredLaw
+  deriving DecidableEq, Repr
+
+/-- The named axes exposed by the Signature v1 schema. -/
+inductive ArchitectureSignatureV1Axis where
+  | hasCycle
+  | sccMaxSize
+  | maxDepth
+  | fanoutRisk
+  | boundaryViolationCount
+  | abstractionViolationCount
+  | sccExcessSize
+  | maxFanout
+  | reachableConeSize
+  | weightedSccRisk
+  | projectionSoundnessViolation
+  | lspViolationCount
+  | nilpotencyIndex
+  | runtimePropagation
+  | relationComplexity
+  | empiricalChangeCost
+  deriving DecidableEq, Repr
+
+namespace ArchitectureSignatureV1
+
+/-- Read any Signature v1 axis as an optional natural-number metric. -/
+def axisValue (sig : ArchitectureSignatureV1) :
+    ArchitectureSignatureV1Axis -> Option Nat
+  | .hasCycle => some sig.core.v0.hasCycle
+  | .sccMaxSize => some sig.core.v0.sccMaxSize
+  | .maxDepth => some sig.core.v0.maxDepth
+  | .fanoutRisk => some sig.core.v0.fanoutRisk
+  | .boundaryViolationCount => some sig.core.v0.boundaryViolationCount
+  | .abstractionViolationCount => some sig.core.v0.abstractionViolationCount
+  | .sccExcessSize => some sig.core.sccExcessSize
+  | .maxFanout => some sig.core.maxFanout
+  | .reachableConeSize => some sig.core.reachableConeSize
+  | .weightedSccRisk => sig.weightedSccRisk
+  | .projectionSoundnessViolation => sig.projectionSoundnessViolation
+  | .lspViolationCount => sig.lspViolationCount
+  | .nilpotencyIndex => sig.nilpotencyIndex
+  | .runtimePropagation => sig.runtimePropagation
+  | .relationComplexity => sig.relationComplexity
+  | .empiricalChangeCost => sig.empiricalChangeCost
+
+/-- Classify Signature v1 axes by their current proof and measurement status. -/
+def axisMeasurementClass : ArchitectureSignatureV1Axis -> AxisMeasurementClass
+  | .projectionSoundnessViolation => .unmeasuredRequiredLaw
+  | .lspViolationCount => .unmeasuredRequiredLaw
+  | .relationComplexity => .empiricalAxis
+  | .empiricalChangeCost => .empiricalAxis
+  | _ => .definedExecutableAxis
+
+/-- Weak zero predicate for a Signature v1 axis value. -/
+def axisMeasuredZero (sig : ArchitectureSignatureV1)
+    (axis : ArchitectureSignatureV1Axis) : Prop :=
+  MeasuredZero (axisValue sig axis)
+
+/-- Strong available-and-zero predicate for a Signature v1 axis value. -/
+def axisAvailableAndZero (sig : ArchitectureSignatureV1)
+    (axis : ArchitectureSignatureV1Axis) : Prop :=
+  AvailableAndZero (axisValue sig axis)
+
+/-- Missing Signature v1 axis values are weakly measured-zero. -/
+theorem axisMeasuredZero_of_axisValue_none {sig : ArchitectureSignatureV1}
+    {axis : ArchitectureSignatureV1Axis}
+    (hNone : axisValue sig axis = none) :
+    axisMeasuredZero sig axis := by
+  unfold axisMeasuredZero
+  rw [hNone]
+  exact measuredZero_none
+
+/-- Missing Signature v1 axis values are not available-and-zero. -/
+theorem not_axisAvailableAndZero_of_axisValue_none
+    {sig : ArchitectureSignatureV1} {axis : ArchitectureSignatureV1Axis}
+    (hNone : axisValue sig axis = none) :
+    ¬ axisAvailableAndZero sig axis := by
+  unfold axisAvailableAndZero
+  rw [hNone]
+  exact not_availableAndZero_none
+
+/-- Present Signature v1 axis values are available-and-zero exactly at value 0. -/
+theorem axisAvailableAndZero_some_iff {sig : ArchitectureSignatureV1}
+    {axis : ArchitectureSignatureV1Axis} {n : Nat}
+    (hSome : axisValue sig axis = some n) :
+    axisAvailableAndZero sig axis ↔ n = 0 := by
+  unfold axisAvailableAndZero
+  rw [hSome]
+  exact availableAndZero_some_iff
+
+theorem projectionSoundnessViolation_axisClass :
+    axisMeasurementClass .projectionSoundnessViolation =
+      AxisMeasurementClass.unmeasuredRequiredLaw := by
+  rfl
+
+theorem lspViolationCount_axisClass :
+    axisMeasurementClass .lspViolationCount =
+      AxisMeasurementClass.unmeasuredRequiredLaw := by
+  rfl
+
+theorem relationComplexity_axisClass :
+    axisMeasurementClass .relationComplexity =
+      AxisMeasurementClass.empiricalAxis := by
+  rfl
+
+theorem empiricalChangeCost_axisClass :
+    axisMeasurementClass .empiricalChangeCost =
+      AxisMeasurementClass.empiricalAxis := by
+  rfl
+
+theorem nilpotencyIndex_axisClass :
+    axisMeasurementClass .nilpotencyIndex =
+      AxisMeasurementClass.definedExecutableAxis := by
+  rfl
+
+end ArchitectureSignatureV1
 
 /--
 Build the Lean-measured Signature v1 core from a finite component universe.

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -148,7 +148,7 @@ violationCount bad xs = 0
 ```text
 Lawful A L
 NoRequiredObstruction A L
-RequiredAxesAvailableAndZero sig L
+RequiredAxesAvailableAndZero L sig
 ```
 
 `Lawful A L` は、既存の意味論的 predicate や law family の充足条件として定義する。
@@ -159,7 +159,7 @@ RequiredAxesAvailableAndZero sig L
 `NoRequiredObstruction A L` は、各 law family に付随する witness 型 `W` と
 `bad : W -> Prop` によって定義する。
 
-`RequiredAxesAvailableAndZero sig L` は、`ArchitectureSignature` の required axis が
+`RequiredAxesAvailableAndZero L sig` は、`ArchitectureSignature` の required axis が
 測定済みで、かつ 0 であることとして定義する。
 `none` や未測定 axis は、lawfulness の証明では zero として扱わない。
 
@@ -248,12 +248,17 @@ AxisExact axis witnessFamily :=
 required axis 全体では、次を目標にする。
 
 ```text
-RequiredAxesAvailableAndZero sig L
+RequiredAxesAvailableAndZero L sig
   <-> NoRequiredObstruction A L
 ```
 
 この bridge が入ることで、`ArchitectureSignature` は単なる表示 schema ではなく、
 要求法則族に対する阻害証人の零性を表す多軸座標として扱える。
+Lean では、抽象 `LawFamily` に対して axis ごとの `AxisExact`、required witness
+cover、required axis 全体の
+`requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily`
+を証明済みである。具体的な `ProjectionSound` / `LSPCompatible` などの
+law family への exactness 接続は、個別の proof obligation として残す。
 
 complete coverage は単なる強い仮定として放置しない。
 有限 component universe から component pair を列挙する、有限 diagram universe から
@@ -298,14 +303,21 @@ required diagram を列挙するなど、一部の law family では `CoversRequ
   required axis exactness を前提にした中心 bridge,
   `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact`,
   [Issue #191](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/191)
+- `proved`: required Signature axis について、`MeasuredZero` と
+  `AvailableAndZero` を分離し、axis ごとの `AxisExact` と required witness cover
+  から `RequiredAxesAvailableAndZero <-> NoRequiredObstruction` を得る抽象 bridge,
+  `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily`,
+  [Issue #195](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/195)
 - `future proof obligation`: `ProjectionSound`, `LSPCompatible`, `WalkAcyclic` など具体的な
   lawfulness predicate と witness 不在の exactness bridge。
-- `future proof obligation`: required Signature axis の `AvailableAndZero` と witness 不在の exactness bridge。
+- `future proof obligation`: required Signature axis の abstract bridge を具体的な
+  projection / LSP / walk / nilpotence witness family に接続する定理。
 - `proved`: 抽象 `LawFamily` では、complete coverage 下での measured zero から
   global lawfulness への bridge,
   `lawViolationCount_eq_zero_iff_lawful`, `lawful_iff_noRequiredObstruction_of_completeCoverage`,
   [Issue #191](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/191)
-- `defined only`: witness family をまとめる signature schema。
+- `defined only`: witness family をまとめる signature schema と
+  `ArchitectureSignatureV1` axis classification。
 - `empirical hypothesis`: obstruction count と変更コスト・障害率・レビュー負荷の相関。
 
 次は初期 Lean proof の対象にしない。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -196,6 +196,15 @@ File: `Formal/Arch/Lawfulness.lean`
 | --- | --- | --- | --- |
 | `LawFamily` | `structure` | 独立した `lawful` predicate、測定 witness list、required witness predicate、bad witness predicate、required axis predicate を束ねる抽象法則族。 | `defined only` |
 | `AxisSignature` | `abbrev` | 抽象 axis から `Option Nat` metric への signature valuation。 | `defined only` |
+| `MeasuredZero` | `def` | `Option Nat` metric に測定済み非零値がないこと。`none` を許す弱い零性。 | `defined only` |
+| `AvailableAndZero` | `def` | `Option Nat` metric が `some 0` として測定済みであること。`none` は許さない強い零性。 | `defined only` |
+| `AxisMeasuredZero` | `def` | signature valuation の指定 axis が weak measured-zero であること。 | `defined only` |
+| `AxisAvailableAndZero` | `def` | signature valuation の指定 axis が available-and-zero であること。 | `defined only` |
+| `measuredZero_none` | `theorem` | 未測定 `none` は weak measured-zero を満たす。 | `proved` |
+| `not_availableAndZero_none` | `theorem` | 未測定 `none` は available-and-zero を満たさない。 | `proved` |
+| `measuredZero_of_availableAndZero` | `theorem` | available-and-zero なら weak measured-zero。 | `proved` |
+| `measuredZero_some_iff` | `theorem` | `some n` の weak measured-zero は `n = 0` と同値。 | `proved` |
+| `availableAndZero_some_iff` | `theorem` | `some n` の available-and-zero は `n = 0` と同値。 | `proved` |
 | `Lawful` | `def` | 法則族側で与えられた独立 predicate としての lawfulness。 | `defined only` |
 | `NoRequiredObstruction` | `def` | required witness 全体に bad witness が存在しないこと。 | `defined only` |
 | `NoMeasuredObstruction` | `def` | measured witness list に bad witness が存在しないこと。 | `defined only` |
@@ -207,10 +216,15 @@ File: `Formal/Arch/Lawfulness.lean`
 | `noMeasuredObstruction_of_completeCoverage_and_noRequiredObstruction` | `theorem` | 完全被覆下で required obstruction 不在から measured obstruction 不在を得る。 | `proved` |
 | `lawful_iff_noRequiredObstruction_of_completeCoverage` | `theorem` | 完全被覆下で独立 lawfulness と required obstruction 不在を接続する中心 bridge。 | `proved` |
 | `lawViolationCount_eq_zero_iff_noRequiredObstruction_of_completeCoverage` | `theorem` | 完全被覆下で measured violation count 0 と required obstruction 不在を接続する。 | `proved` |
-| `AvailableAndZero` | `def` | required axis が `some 0` として測定済みであること。`none` は許さない。 | `defined only` |
 | `RequiredAxesAvailableAndZero` | `def` | 法則族の required axis がすべて available and zero であること。 | `defined only` |
+| `AxisExact` | `def` | 1 つの axis の available-and-zero と、その axis が表す witness subfamily の bad witness 不在が同値であること。 | `defined only` |
+| `AxisCoversOnlyRequired` | `def` | axis が表す witness subfamily が required witness だけを含むこと。 | `defined only` |
+| `RequiredWitnessCoveredByAxis` | `def` | required witness が少なくとも 1 つの required axis によって表されること。 | `defined only` |
+| `RequiredAxisFamilyExact` | `def` | required axis ごとの `AxisExact` がそろっていること。 | `defined only` |
 | `RequiredAxisExact` | `def` | required axis の available-and-zero と required obstruction 不在が同値であること。 | `defined only` |
 | `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisExact` | `theorem` | required axis exactness から signature axis と obstruction 不在の bridge を取り出す。 | `proved` |
+| `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily` | `theorem` | axis ごとの exactness と required witness cover から、required axis 全体の available-and-zero と required obstruction 不在を接続する。 | `proved` |
+| `requiredAxisExact_of_axisExactFamily` | `theorem` | axis ごとの exactness を既存の whole-family exactness predicate にパッケージする。 | `proved` |
 | `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact` | `theorem` | 完全被覆と required axis exactness の下で、lawfulness と required axis zero を接続する零曲率定理候補。 | `proved` |
 
 ## Signature v0
@@ -260,6 +274,15 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.v0OfFinite` | `def` | finite universe から v0 signature を計算する。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1Core` | `structure` | v0 signature と Lean-measured v1 core axis を束ねる schema。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1` | `structure` | v1 core と optional extension axis を束ねる output schema。 | `defined only` |
+| `ArchitectureSignature.AxisMeasurementClass` | `inductive` | Signature v1 axis を `proved witness axis` / `defined executable axis` / `empirical axis` / `unmeasured required law` に分類する。 | `defined only` |
+| `ArchitectureSignature.ArchitectureSignatureV1Axis` | `inductive` | Signature v1 schema が公開する named axis。 | `defined only` |
+| `ArchitectureSignature.ArchitectureSignatureV1.axisValue` | `def` | Signature v1 の任意 axis を `Option Nat` metric として読む。 | `defined only` |
+| `ArchitectureSignature.ArchitectureSignatureV1.axisMeasurementClass` | `def` | Signature v1 axis の現在の Lean/proof/empirical status 分類。 | `defined only` |
+| `ArchitectureSignature.ArchitectureSignatureV1.axisMeasuredZero` | `def` | Signature v1 axis value の weak measured-zero predicate。 | `defined only` |
+| `ArchitectureSignature.ArchitectureSignatureV1.axisAvailableAndZero` | `def` | Signature v1 axis value の strong available-and-zero predicate。 | `defined only` |
+| `ArchitectureSignature.ArchitectureSignatureV1.axisMeasuredZero_of_axisValue_none` | `theorem` | `axisValue = none` の axis は weak measured-zero。 | `proved` |
+| `ArchitectureSignature.ArchitectureSignatureV1.not_axisAvailableAndZero_of_axisValue_none` | `theorem` | `axisValue = none` の axis は available-and-zero ではない。 | `proved` |
+| `ArchitectureSignature.ArchitectureSignatureV1.axisAvailableAndZero_some_iff` | `theorem` | `axisValue = some n` の axis available-and-zero は `n = 0` と同値。 | `proved` |
 | `ArchitectureSignature.v1CoreOfFinite` | `def` | finite universe から v1 core signature を計算する。 | `defined only` |
 | `ArchitectureSignature.v1OfFinite` | `def` | finite universe から v1 schema を作り、未評価 extension axis を `none` にする。 | `defined only` |
 | `ArchitectureSignature.v1OfFiniteWithWeightedSccRisk` | `def` | 明示的な component weight から `weightedSccRisk` を埋めた v1 schema を作る。 | `defined only` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -62,9 +62,14 @@ zero-count bridge については `proved` である
 `RequiredAxesAvailableAndZero` を分離し、complete witness coverage と
 required axis exactness を前提にした中心 bridge を Lean で証明済みである
 ([Issue #191](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/191))。
+required axis exactness については、`MeasuredZero` と `AvailableAndZero` を
+分離し、axis ごとの `AxisExact` と required witness cover から
+`RequiredAxesAvailableAndZero <-> NoRequiredObstruction` を得る抽象 bridge も
+Lean で証明済みである
+([Issue #195](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/195))。
 ただし、アーキテクチャ零曲率定理全体、具体的な `ProjectionSound` /
 `LSPCompatible` / `WalkAcyclic` などの lawfulness predicate との exactness、
-required `ArchitectureSignature` axis との exactness は
+required `ArchitectureSignature` axis との具体 law family 接続は
 `future proof obligation` のまま扱う。
 
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
@@ -73,9 +78,9 @@ required `ArchitectureSignature` axis との exactness は
 `ProjectionSound`, `LSPCompatible`, `WalkAcyclic`, `LocalReplacementContract`
 など、obstruction framework とは独立に定義された lawfulness predicate と、
 各 witness family の阻害証人不在を bridge theorem で接続することである。
-さらに、required `ArchitectureSignature` axis の `AvailableAndZero` と
-阻害証人不在を exact に接続し、complete coverage を有限 universe から構成できる
-law family を増やすことを目標にする。
+さらに、required `ArchitectureSignature` axis の抽象 exactness bridge を
+具体 law family に接続し、complete coverage を有限 universe から構成できる law family
+を増やすことを目標にする。
 
 ## 基本 convention
 


### PR DESCRIPTION
## 概要

Closes #195

- `MeasuredZero` と `AvailableAndZero` を `Option Nat` metric の predicate として分離し、`none` を弱い measured-zero と強い available-and-zero で区別しました。
- axis ごとの `AxisExact`、required witness cover、required axis 全体の bridge を追加しました。
- `ArchitectureSignatureV1` の named axis、axis value、Lean status 分類を追加しました。

## 証明した定理

- `measuredZero_none`
- `not_availableAndZero_none`
- `measuredZero_of_availableAndZero`
- `measuredZero_some_iff`
- `availableAndZero_some_iff`
- `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily`
- `requiredAxisExact_of_axisExactFamily`
- `ArchitectureSignature.ArchitectureSignatureV1.axisMeasuredZero_of_axisValue_none`
- `ArchitectureSignature.ArchitectureSignatureV1.not_axisAvailableAndZero_of_axisValue_none`
- `ArchitectureSignature.ArchitectureSignatureV1.axisAvailableAndZero_some_iff`

## 編集したドキュメント

- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 該当なし
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 該当なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている