### PR TITLE
Projection / LSP obstruction bridge を追加する

### DIFF
--- a/Formal/Arch/LSP.lean
+++ b/Formal/Arch/LSP.lean
@@ -1,5 +1,6 @@
 import Formal.Arch.Projection
 import Formal.Arch.Observation
+import Formal.Arch.Obstruction
 
 namespace Formal.Arch
 
@@ -28,6 +29,34 @@ def ObservationFactorsThrough {Impl : Type u} {Abs : Type v} {Obs : Type w}
 def ObservationallyDivergent {Impl : Type u} {Obs : Type v}
     (O : Observation Impl Obs) (x y : Impl) : Prop :=
   ¬ ObservationallyEquivalent O x y
+
+/-- Candidate ordered implementation pairs in a finite measurement universe. -/
+def lspCandidatePairs {Impl : Type u} (implementations : List Impl) :
+    List (Impl × Impl) :=
+  implementations.flatMap (fun x => implementations.map (fun y => (x, y)))
+
+/--
+An LSP obstruction witness: two implementations in the same abstract fiber
+whose observations differ.
+-/
+def LSPObstruction {Impl : Type u} {Abs : Type v} {Obs : Type w}
+    (π : InterfaceProjection Impl Abs) (O : Observation Impl Obs)
+    (pair : Impl × Impl) : Prop :=
+  π.expose pair.1 = π.expose pair.2 ∧ ObservationallyDivergent O pair.1 pair.2
+
+/-- LSP obstruction witnesses are decidable when abstraction and observation are decidable. -/
+instance instDecidablePredLSPObstruction {Impl : Type u} {Abs : Type v} {Obs : Type w}
+    (π : InterfaceProjection Impl Abs) (O : Observation Impl Obs)
+    [DecidableEq Abs] [DecidableEq Obs] :
+    DecidablePred (LSPObstruction π O) := by
+  intro pair
+  unfold LSPObstruction ObservationallyDivergent ObservationallyEquivalent
+  infer_instance
+
+/-- No LSP obstruction witness exists at implementation-pair level. -/
+def NoLSPObstruction {Impl : Type u} {Abs : Type v} {Obs : Type w}
+    (π : InterfaceProjection Impl Abs) (O : Observation Impl Obs) : Prop :=
+  ∀ pair : Impl × Impl, ¬ LSPObstruction π O pair
 
 /--
 Executable pair-level behavioral divergence.
@@ -67,6 +96,38 @@ theorem mem_lspViolationPairs_iff {Impl : Type u} {Abs : Type v} {Obs : Type w}
         π.expose pair.1 = π.expose pair.2 ∧ ObservationallyDivergent O pair.1 pair.2 := by
   rcases pair with ⟨x, y⟩
   simp [lspViolationPairs, ObservationallyDivergent, ObservationallyEquivalent]
+
+/--
+Membership in candidate LSP witnesses is membership of both implementations in
+the finite measurement universe.
+-/
+theorem mem_lspCandidatePairs_iff {Impl : Type u}
+    {implementations : List Impl} {pair : Impl × Impl} :
+    pair ∈ lspCandidatePairs implementations ↔
+      pair.1 ∈ implementations ∧ pair.2 ∈ implementations := by
+  rcases pair with ⟨x, y⟩
+  simp [lspCandidatePairs]
+
+/--
+The existing finite LSP violation membership is the generic obstruction kernel
+specialized to LSP obstruction witnesses.
+-/
+theorem mem_lspViolationPairs_iff_mem_violatingWitnesses
+    {Impl : Type u} {Abs : Type v} {Obs : Type w}
+    [DecidableEq Abs] [DecidableEq Obs]
+    {π : InterfaceProjection Impl Abs} {O : Observation Impl Obs}
+    {implementations : List Impl} {pair : Impl × Impl} :
+    pair ∈ lspViolationPairs π O implementations ↔
+      pair ∈ violatingWitnesses (LSPObstruction π O)
+        (lspCandidatePairs implementations) := by
+  rw [mem_lspViolationPairs_iff, mem_violatingWitnesses_iff,
+    mem_lspCandidatePairs_iff]
+  unfold LSPObstruction
+  constructor
+  · rintro ⟨hLeft, hRight, hAbs, hDivergent⟩
+    exact ⟨⟨hLeft, hRight⟩, hAbs, hDivergent⟩
+  · rintro ⟨⟨hLeft, hRight⟩, hAbs, hDivergent⟩
+    exact ⟨hLeft, hRight, hAbs, hDivergent⟩
 
 /-- Executable behavioral extension metric: measured LSP violation count. -/
 def lspViolationCount {Impl : Type u} {Abs : Type v} {Obs : Type w}
@@ -128,6 +189,21 @@ theorem lspCompatible_of_observationFactorsThrough
     O.observe x = OAbs (π.expose x) := hObs x
     _ = OAbs (π.expose y) := by rw [hAbs]
     _ = O.observe y := (hObs y).symm
+
+/--
+LSP compatibility is exactly the absence of LSP obstruction witnesses.
+-/
+theorem lspCompatible_iff_noLSPObstruction
+    {Impl : Type u} {Abs : Type v} {Obs : Type w}
+    {π : InterfaceProjection Impl Abs} {O : Observation Impl Obs} :
+    LSPCompatible π O ↔ NoLSPObstruction π O := by
+  constructor
+  · intro h pair hBad
+    exact hBad.2 (h hBad.1)
+  · intro h x y hAbs
+    by_cases hObs : ObservationallyEquivalent O x y
+    · exact hObs
+    · exact False.elim (h (x, y) ⟨hAbs, hObs⟩)
 
 /--
 If LSP compatibility holds, the finite executable violation count is zero.

--- a/Formal/Arch/LocalReplacement.lean
+++ b/Formal/Arch/LocalReplacement.lean
@@ -32,6 +32,41 @@ theorem observationFactorsThrough_of_localReplacementContract
   h.2
 
 /--
+Unfolding a local replacement contract through projection-obstruction
+exactness keeps the representative-stability and observation-factorization
+axes explicit.
+-/
+theorem localReplacementContract_iff_noProjectionObstruction_and_representativeStable_and_observationFactorsThrough
+    {C : Type u} {A : Type v} {Obs : Type w}
+    {G : ArchGraph C} {π : InterfaceProjection C A} {GA : AbstractGraph A}
+    {O : Observation C Obs} :
+    LocalReplacementContract G π GA O ↔
+      NoProjectionObstruction G π GA ∧ RepresentativeStable G π ∧
+        ObservationFactorsThrough π O := by
+  constructor
+  · intro h
+    exact ⟨projectionSound_iff_noProjectionObstruction.mp h.1.1, h.1.2, h.2⟩
+  · rintro ⟨hNoProjection, hStable, hObservation⟩
+    exact ⟨⟨projectionSound_iff_noProjectionObstruction.mpr hNoProjection,
+      hStable⟩, hObservation⟩
+
+/--
+A local replacement contract eliminates projection obstruction witnesses and
+LSP obstruction witnesses simultaneously.
+-/
+theorem noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract
+    {C : Type u} {A : Type v} {Obs : Type w}
+    {G : ArchGraph C} {π : InterfaceProjection C A} {GA : AbstractGraph A}
+    {O : Observation C Obs}
+    (h : LocalReplacementContract G π GA O) :
+    NoProjectionObstruction G π GA ∧ NoLSPObstruction π O :=
+  ⟨projectionSound_iff_noProjectionObstruction.mp
+      (projectionSound_of_localReplacementContract h),
+    lspCompatible_iff_noLSPObstruction.mp
+      (lspCompatible_of_observationFactorsThrough
+        (observationFactorsThrough_of_localReplacementContract h))⟩
+
+/--
 A local replacement contract simultaneously zeroes the measured projection and
 LSP violation counts.
 -/

--- a/Formal/Arch/Projection.lean
+++ b/Formal/Arch/Projection.lean
@@ -1,4 +1,5 @@
 import Formal.Arch.ThinCategory
+import Formal.Arch.Obstruction
 
 namespace Formal.Arch
 
@@ -25,6 +26,30 @@ def RespectsProjection {C : Type u} {A : Type v}
 abbrev ProjectionSound {C : Type u} {A : Type v}
     (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A) : Prop :=
   RespectsProjection G π GA
+
+/-- Candidate concrete dependency edges in a finite measurement universe. -/
+def projectionSoundnessCandidateEdges {C : Type u} (components : List C) : List (C × C) :=
+  components.flatMap (fun c => components.map (fun d => (c, d)))
+
+/-- A projection obstruction witness: a concrete edge with no projected abstract edge. -/
+def ProjectionObstruction {C : Type u} {A : Type v}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (edge : C × C) : Prop :=
+  G.edge edge.1 edge.2 ∧ ¬ GA.edge (π.expose edge.1) (π.expose edge.2)
+
+/-- Projection obstruction witnesses are decidable when both graphs have decidable edges. -/
+instance instDecidablePredProjectionObstruction {C : Type u} {A : Type v}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    [DecidableRel G.edge] [DecidableRel GA.edge] :
+    DecidablePred (ProjectionObstruction G π GA) := by
+  intro edge
+  unfold ProjectionObstruction
+  infer_instance
+
+/-- No projection obstruction witness exists at graph level. -/
+def NoProjectionObstruction {C : Type u} {A : Type v}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A) : Prop :=
+  ∀ edge : C × C, ¬ ProjectionObstruction G π GA edge
 
 /--
 Concrete dependency edges whose projected abstract edge is missing.
@@ -57,6 +82,38 @@ theorem mem_projectionSoundnessViolationEdges_iff {C : Type u} {A : Type v}
   simp [projectionSoundnessViolationEdges]
 
 /--
+Membership in candidate projection witnesses is membership of both endpoints in
+the finite measurement universe.
+-/
+theorem mem_projectionSoundnessCandidateEdges_iff {C : Type u}
+    {components : List C} {edge : C × C} :
+    edge ∈ projectionSoundnessCandidateEdges components ↔
+      edge.1 ∈ components ∧ edge.2 ∈ components := by
+  rcases edge with ⟨c, d⟩
+  simp [projectionSoundnessCandidateEdges]
+
+/--
+The existing finite projection violation membership is the generic obstruction
+kernel specialized to projection obstruction witnesses.
+-/
+theorem mem_projectionSoundnessViolationEdges_iff_mem_violatingWitnesses
+    {C : Type u} {A : Type v}
+    {G : ArchGraph C} {π : InterfaceProjection C A} {GA : AbstractGraph A}
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    {components : List C} {edge : C × C} :
+    edge ∈ projectionSoundnessViolationEdges G π GA components ↔
+      edge ∈ violatingWitnesses (ProjectionObstruction G π GA)
+        (projectionSoundnessCandidateEdges components) := by
+  rw [mem_projectionSoundnessViolationEdges_iff, mem_violatingWitnesses_iff,
+    mem_projectionSoundnessCandidateEdges_iff]
+  unfold ProjectionObstruction
+  constructor
+  · rintro ⟨hLeft, hRight, hEdge, hMissing⟩
+    exact ⟨⟨hLeft, hRight⟩, hEdge, hMissing⟩
+  · rintro ⟨⟨hLeft, hRight⟩, hEdge, hMissing⟩
+    exact ⟨hLeft, hRight, hEdge, hMissing⟩
+
+/--
 Executable projection bridge metric: the number of measured concrete
 dependencies that are not represented by an abstract edge.
 -/
@@ -65,6 +122,21 @@ def projectionSoundnessViolation {C : Type u} {A : Type v}
     [DecidableRel G.edge] [DecidableRel GA.edge]
     (components : List C) : Nat :=
   (projectionSoundnessViolationEdges G π GA components).length
+
+/--
+Projection soundness is exactly the absence of projection obstruction witnesses.
+-/
+theorem projectionSound_iff_noProjectionObstruction
+    {C : Type u} {A : Type v}
+    {G : ArchGraph C} {π : InterfaceProjection C A} {GA : AbstractGraph A} :
+    ProjectionSound G π GA ↔ NoProjectionObstruction G π GA := by
+  constructor
+  · intro h edge hBad
+    exact hBad.2 (h hBad.1)
+  · intro h c d hEdge
+    by_cases hAbstract : GA.edge (π.expose c) (π.expose d)
+    · exact hAbstract
+    · exact False.elim (h (c, d) ⟨hEdge, hAbstract⟩)
 
 /--
 If projection soundness holds, the finite executable violation count is zero.

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -308,8 +308,13 @@ required diagram を列挙するなど、一部の law family では `CoversRequ
   から `RequiredAxesAvailableAndZero <-> NoRequiredObstruction` を得る抽象 bridge,
   `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily`,
   [Issue #195](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/195)
-- `future proof obligation`: `ProjectionSound`, `LSPCompatible`, `WalkAcyclic` など具体的な
-  lawfulness predicate と witness 不在の exactness bridge。
+- `proved`: `ProjectionSound` / `LSPCompatible` と obstruction witness 不在の
+  exactness bridge、および既存 finite violation list membership が generic
+  `violatingWitnesses` の特殊例であること,
+  `projectionSound_iff_noProjectionObstruction`,
+  `lspCompatible_iff_noLSPObstruction`, [Issue #188](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/188)
+- `future proof obligation`: `WalkAcyclic` など残る具体的な lawfulness predicate と
+  witness 不在の exactness bridge。
 - `future proof obligation`: required Signature axis の abstract bridge を具体的な
   projection / LSP / walk / nilpotence witness family に接続する定理。
 - `proved`: 抽象 `LawFamily` では、complete coverage 下での measured zero から

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -108,9 +108,15 @@ File: `Formal/Arch/Projection.lean`
 | `ProjectedDeps` | `def` | 具象依存を抽象依存へ写した関係。 | `defined only` |
 | `RespectsProjection` | `def` | すべての具象依存 edge が抽象 edge として表現されること。 | `defined only` |
 | `ProjectionSound` | `abbrev` | 具象依存が抽象依存へ sound に写ること。 | `defined only` |
+| `projectionSoundnessCandidateEdges` | `def` | finite measurement universe から projection obstruction candidate edge を列挙する。 | `defined only` |
+| `ProjectionObstruction` | `def` | 抽象 edge に写らない具象 edge を projection obstruction witness として表す。 | `defined only` |
+| `NoProjectionObstruction` | `def` | graph-level に projection obstruction witness が存在しないこと。 | `defined only` |
 | `projectionSoundnessViolationEdges` | `def` | 有限な測定 universe 上で、abstract edge に写らない concrete edge のリスト。 | `defined only` |
 | `mem_projectionSoundnessViolationEdges_iff` | `theorem` | projection soundness violation edge の membership が、測定対象 concrete edge かつ projected abstract edge 不在であることと一致する。 | `proved` |
+| `mem_projectionSoundnessCandidateEdges_iff` | `theorem` | projection candidate edge の membership が、両端点が finite measurement universe に含まれることと一致する。 | `proved` |
+| `mem_projectionSoundnessViolationEdges_iff_mem_violatingWitnesses` | `theorem` | 既存 projection violation list の membership が generic `violatingWitnesses` の特殊例であることを示す。 | `proved` |
 | `projectionSoundnessViolation` | `def` | projection soundness に反する測定 concrete edge 数。 | `defined only` |
+| `projectionSound_iff_noProjectionObstruction` | `theorem` | `ProjectionSound` と projection obstruction witness 不在が同値。 | `proved` |
 | `projectionSoundnessViolation_eq_zero_of_projectionSound` | `theorem` | `ProjectionSound` なら finite violation count は 0。 | `proved` |
 | `projectionSound_of_projectionSoundnessViolation_eq_zero` | `theorem` | 測定 universe が concrete edge を閉じていれば、violation 0 から `ProjectionSound` を得る。 | `proved` |
 | `ProjectionComplete` | `def` | 抽象依存が具象依存で代表されること。 | `defined only` |
@@ -147,9 +153,14 @@ Files: `Formal/Arch/Observation.lean`, `Formal/Arch/LSP.lean`, `Formal/Arch/Loca
 | `LSPCompatible` | `def` | 全体の LSP 互換性。 | `defined only` |
 | `ObservationFactorsThrough` | `def` | 観測が抽象射影を通って factor すること。 | `defined only` |
 | `ObservationallyDivergent` | `def` | 観測値が一致しない measured pair。 | `defined only` |
+| `lspCandidatePairs` | `def` | finite measurement universe から LSP obstruction candidate pair を列挙する。 | `defined only` |
+| `LSPObstruction` | `def` | 同じ抽象 fiber 内で観測が異なる ordered pair を LSP obstruction witness として表す。 | `defined only` |
+| `NoLSPObstruction` | `def` | implementation-pair level に LSP obstruction witness が存在しないこと。 | `defined only` |
 | `observationalDivergence` | `def` | measured pair ごとの観測差分を 0/1 で数える behavioral metric。 | `defined only` |
 | `lspViolationPairs` | `def` | 有限な測定 universe 上で、同じ抽象に写るが観測が異なる ordered pair のリスト。 | `defined only` |
 | `mem_lspViolationPairs_iff` | `theorem` | LSP violation pair の membership が、測定対象 pair・同一抽象・観測差分と一致する。 | `proved` |
+| `mem_lspCandidatePairs_iff` | `theorem` | LSP candidate pair の membership が、両要素が finite measurement universe に含まれることと一致する。 | `proved` |
+| `mem_lspViolationPairs_iff_mem_violatingWitnesses` | `theorem` | 既存 LSP violation list の membership が generic `violatingWitnesses` の特殊例であることを示す。 | `proved` |
 | `lspViolationCount` | `def` | 有限な測定 universe 上の measured LSP violation 数。 | `defined only` |
 | `observationalDivergence_eq_zero_of_equivalent` | `theorem` | 観測同値なら pair-level divergence は 0。 | `proved` |
 | `observationallyEquivalent_of_observationalDivergence_eq_zero` | `theorem` | pair-level divergence 0 から観測同値を得る。 | `proved` |
@@ -157,12 +168,15 @@ Files: `Formal/Arch/Observation.lean`, `Formal/Arch/LSP.lean`, `Formal/Arch/Loca
 | `lspCompatibleAt_refl` | `theorem` | 同じ実装の LSP 互換性。 | `proved` |
 | `lspObservation_symm` | `theorem` | 一点ごとの LSP 互換性から得た観測同値を反転する。 | `proved` |
 | `lspCompatible_of_observationFactorsThrough` | `theorem` | 観測が射影を通って factor すれば LSP compatible。 | `proved` |
+| `lspCompatible_iff_noLSPObstruction` | `theorem` | `LSPCompatible` と LSP obstruction witness 不在が同値。 | `proved` |
 | `lspViolationCount_eq_zero_of_lspCompatible` | `theorem` | `LSPCompatible` なら finite LSP violation count は 0。 | `proved` |
 | `lspViolationCount_eq_zero_of_observationFactorsThrough` | `theorem` | `ObservationFactorsThrough` なら finite LSP violation count は 0。 | `proved` |
 | `lspCompatible_of_lspViolationCount_eq_zero` | `theorem` | 測定 universe が同一抽象 pair を閉じていれば、violation 0 から `LSPCompatible` を得る。 | `proved` |
 | `LocalReplacementContract` | `def` | `DIPCompatible` と `ObservationFactorsThrough` を同じ `InterfaceProjection` 上で束ねる局所置換契約。 | `defined only` |
 | `projectionSound_of_localReplacementContract` | `theorem` | 局所置換契約から projection soundness を得る。 | `proved` |
 | `observationFactorsThrough_of_localReplacementContract` | `theorem` | 局所置換契約から observation factorization を得る。 | `proved` |
+| `localReplacementContract_iff_noProjectionObstruction_and_representativeStable_and_observationFactorsThrough` | `theorem` | 局所置換契約を projection obstruction 不在、representative stability、observation factorization に分解する。 | `proved` |
+| `noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract` | `theorem` | 局所置換契約から projection obstruction と LSP obstruction の同時消滅を得る。 | `proved` |
 | `violationCounts_eq_zero_of_localReplacementContract` | `theorem` | 局所置換契約から projection soundness violation count と LSP violation count が同時に 0 になることを得る。 | `proved` |
 
 ## Obstruction Kernel

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -430,13 +430,18 @@ Lean status:
 
 - `defined only`: `ProjectionSound`, `ProjectionComplete`, `ProjectionExact`,
   `RepresentativeStable`, `DIPCompatible`, `StrongDIPCompatible`,
-  `projectionSoundnessViolationEdges`, `projectionSoundnessViolation`
+  `projectionSoundnessCandidateEdges`, `ProjectionObstruction`,
+  `NoProjectionObstruction`, `projectionSoundnessViolationEdges`,
+  `projectionSoundnessViolation`
 - `proved`: `projectionSound_of_projectionExact`,
   `projectionComplete_of_projectionExact`,
   `projectedConcreteEdge_of_projectionComplete`,
   `abstractEdge_iff_projectedConcreteEdge_of_projectionExact`,
   `dipCompatible_of_strongDIPCompatible`,
   `mem_projectionSoundnessViolationEdges_iff`,
+  `mem_projectionSoundnessCandidateEdges_iff`,
+  `mem_projectionSoundnessViolationEdges_iff_mem_violatingWitnesses`,
+  `projectionSound_iff_noProjectionObstruction`,
   `projectionSoundnessViolation_eq_zero_of_projectionSound`,
   `projectionSound_of_projectionSoundnessViolation_eq_zero`,
   `StrongAbstractCycleComponent.abstractGraph_not_decomposable`,
@@ -489,11 +494,15 @@ Lean status:
 
 - `defined only`: `Observation`, `ObservationallyEquivalent`,
   `LSPCompatibleAt`, `LSPCompatible`, `ObservationFactorsThrough`,
-  `ObservationallyDivergent`, `observationalDivergence`,
+  `ObservationallyDivergent`, `lspCandidatePairs`, `LSPObstruction`,
+  `NoLSPObstruction`, `observationalDivergence`,
   `lspViolationPairs`, `lspViolationCount`
 - `proved`: `lspAt_of_lsp`, `lspCompatibleAt_refl`,
   `lspObservation_symm`, `lspCompatible_of_observationFactorsThrough`,
-  `mem_lspViolationPairs_iff`, `observationalDivergence_eq_zero_of_equivalent`,
+  `lspCompatible_iff_noLSPObstruction`,
+  `mem_lspViolationPairs_iff`, `mem_lspCandidatePairs_iff`,
+  `mem_lspViolationPairs_iff_mem_violatingWitnesses`,
+  `observationalDivergence_eq_zero_of_equivalent`,
   `observationallyEquivalent_of_observationalDivergence_eq_zero`,
   `lspViolationCount_eq_zero_of_lspCompatible`,
   `lspViolationCount_eq_zero_of_observationFactorsThrough`,
@@ -534,12 +543,20 @@ Lean status:
 - `defined only`: `LocalReplacementContract`
 - `proved`: `projectionSound_of_localReplacementContract`,
   `observationFactorsThrough_of_localReplacementContract`,
+  `localReplacementContract_iff_noProjectionObstruction_and_representativeStable_and_observationFactorsThrough`,
+  `noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract`,
   `violationCounts_eq_zero_of_localReplacementContract`
 
 今後の proof obligation:
 
 - `observationalDivergence` や `lspViolationCount` の repository-level 集約、
   重みづけ、閾値設計は empirical / extractor tooling 側で扱う。
+- Issue [#188](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/188)
+  では、projection / LSP の既存 finite violation list membership を generic
+  `violatingWitnesses` の特殊例として接続し、`ProjectionSound` /
+  `LSPCompatible` と obstruction witness 不在の exactness bridge を証明した。
+  `LocalReplacementContract` については、projection obstruction 不在と
+  LSP obstruction 不在が同時に従う packaging theorem を追加した。
 
 ### 7. Architecture Signature は半順序を持つ
 


### PR DESCRIPTION
## 概要

Closes #188

projection / LSP の既存 finite violation list を generic obstruction kernel の witness membership と接続し、graph-level predicate と obstruction witness 不在の exactness bridge を追加しました。
LocalReplacementContract については、projection obstruction 不在と LSP obstruction 不在が同時に従う packaging theorem を追加しました。

## 証明した定理

- `mem_projectionSoundnessCandidateEdges_iff`
- `mem_projectionSoundnessViolationEdges_iff_mem_violatingWitnesses`
- `projectionSound_iff_noProjectionObstruction`
- `mem_lspCandidatePairs_iff`
- `mem_lspViolationPairs_iff_mem_violatingWitnesses`
- `lspCompatible_iff_noLSPObstruction`
- `localReplacementContract_iff_noProjectionObstruction_and_representativeStable_and_observationFactorsThrough`
- `noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている