### PR TITLE
閉 walk obstruction bridge を追加する

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -14,3 +14,4 @@ import Formal.Arch.SolidCounterexample
 import Formal.Arch.Signature
 import Formal.Arch.Finite
 import Formal.Arch.Matrix
+import Formal.Arch.DependencyObstruction

--- a/Formal/Arch/DependencyObstruction.lean
+++ b/Formal/Arch/DependencyObstruction.lean
@@ -1,0 +1,128 @@
+import Formal.Arch.Matrix
+
+namespace Formal.Arch
+
+universe u
+
+/--
+A dependency obstruction witness is a nonempty closed walk.
+
+This packages `HasClosedWalk` as a first-class witness type so dependency
+cycles can use the generic obstruction-count kernel without forcing them into
+an equality-diagram shape.
+-/
+structure ClosedWalkWitness {C : Type u} (G : ArchGraph C) where
+  vertex : C
+  walk : Walk G vertex vertex
+  nonempty : 0 < walk.length
+
+/-- A closed-walk witness is itself the forbidden obstruction. -/
+def ClosedWalkBad {C : Type u} {G : ArchGraph C}
+    (_w : ClosedWalkWitness G) : Prop :=
+  True
+
+instance instDecidablePredClosedWalkBad {C : Type u} {G : ArchGraph C} :
+    DecidablePred (@ClosedWalkBad C G) := by
+  intro _w
+  exact isTrue trivial
+
+/-- Measured closed-walk obstruction witnesses. -/
+def closedWalkViolatingWitnesses {C : Type u} {G : ArchGraph C}
+    (witnesses : List (ClosedWalkWitness G)) :
+    List (ClosedWalkWitness G) :=
+  violatingWitnesses ClosedWalkBad witnesses
+
+/-- Count measured closed-walk obstruction witnesses. -/
+def closedWalkViolationCount {C : Type u} {G : ArchGraph C}
+    (witnesses : List (ClosedWalkWitness G)) : Nat :=
+  violationCount ClosedWalkBad witnesses
+
+/--
+Membership in measured closed-walk violations is exactly membership in the
+measured witness universe.
+-/
+theorem mem_closedWalkViolatingWitnesses_iff {C : Type u} {G : ArchGraph C}
+    {witnesses : List (ClosedWalkWitness G)} {w : ClosedWalkWitness G} :
+    w ∈ closedWalkViolatingWitnesses witnesses ↔ w ∈ witnesses := by
+  simp [closedWalkViolatingWitnesses, ClosedWalkBad,
+    mem_violatingWitnesses_iff]
+
+/-- Zero measured closed-walk violations means the measured witness list is empty. -/
+theorem closedWalkViolationCount_eq_zero_iff_forall_not_bad {C : Type u}
+    {G : ArchGraph C} {witnesses : List (ClosedWalkWitness G)} :
+    closedWalkViolationCount witnesses = 0 ↔
+      ∀ w, w ∈ witnesses -> ¬ ClosedWalkBad w := by
+  exact violationCount_eq_zero_iff_forall_not_bad
+
+/-- A closed-walk witness exposes the existing `HasClosedWalk` predicate. -/
+theorem hasClosedWalk_of_closedWalkWitness {C : Type u} {G : ArchGraph C}
+    (w : ClosedWalkWitness G) : HasClosedWalk G :=
+  ⟨w.vertex, w.walk, w.nonempty⟩
+
+/-- Existing `HasClosedWalk` evidence can be packaged as an obstruction witness. -/
+theorem exists_closedWalkWitness_of_hasClosedWalk {C : Type u} {G : ArchGraph C}
+    (h : HasClosedWalk G) : ∃ w : ClosedWalkWitness G, ClosedWalkBad w := by
+  rcases h with ⟨c, walk, hNonempty⟩
+  exact ⟨⟨c, walk, hNonempty⟩, trivial⟩
+
+/-- Closed-walk witnesses are exactly the existing `HasClosedWalk` predicate. -/
+theorem hasClosedWalk_iff_exists_closedWalkWitness {C : Type u}
+    {G : ArchGraph C} :
+    HasClosedWalk G ↔ ∃ w : ClosedWalkWitness G, ClosedWalkBad w := by
+  constructor
+  · exact exists_closedWalkWitness_of_hasClosedWalk
+  · rintro ⟨w, _⟩
+    exact hasClosedWalk_of_closedWalkWitness w
+
+/--
+Walk acyclicity is exact absence of closed-walk obstruction witnesses.
+-/
+theorem walkAcyclic_iff_no_closedWalkObstruction {C : Type u}
+    {G : ArchGraph C} :
+    WalkAcyclic G ↔ ∀ w : ClosedWalkWitness G, ¬ ClosedWalkBad w := by
+  constructor
+  · intro hWalkAcyclic w _hBad
+    exact hWalkAcyclic (hasClosedWalk_of_closedWalkWitness w)
+  · intro hNoWitness hClosed
+    rcases exists_closedWalkWitness_of_hasClosedWalk hClosed with ⟨w, hBad⟩
+    exact hNoWitness w hBad
+
+/--
+Graph acyclicity is exact absence of closed-walk obstruction witnesses.
+-/
+theorem acyclic_iff_no_closedWalkObstruction {C : Type u} {G : ArchGraph C} :
+    Acyclic G ↔ ∀ w : ClosedWalkWitness G, ¬ ClosedWalkBad w := by
+  exact Iff.trans acyclic_iff_walkAcyclic walkAcyclic_iff_no_closedWalkObstruction
+
+/--
+On a finite component universe, adjacency nilpotence is exact absence of
+closed-walk obstruction witnesses.
+-/
+theorem adjacencyNilpotent_iff_no_closedWalkObstruction {C : Type u}
+    {G : ArchGraph C} [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G) :
+    AdjacencyNilpotent U ↔ ∀ w : ClosedWalkWitness G, ¬ ClosedWalkBad w := by
+  exact Iff.trans (adjacencyNilpotent_iff_walkAcyclic U)
+    walkAcyclic_iff_no_closedWalkObstruction
+
+/--
+Adjacency nilpotence rules out closed-walk obstruction witnesses.
+-/
+theorem no_closedWalkObstruction_of_adjacencyNilpotent {C : Type u}
+    {G : ArchGraph C} [DecidableEq C] [DecidableRel G.edge]
+    {U : ComponentUniverse G} (hNil : AdjacencyNilpotent U) :
+    ∀ w : ClosedWalkWitness G, ¬ ClosedWalkBad w :=
+  (adjacencyNilpotent_iff_no_closedWalkObstruction U).mp hNil
+
+/--
+Absence of closed-walk obstruction witnesses gives adjacency nilpotence on a
+finite component universe.
+-/
+theorem adjacencyNilpotent_of_no_closedWalkObstruction {C : Type u}
+    {G : ArchGraph C} [DecidableEq C] [DecidableRel G.edge]
+    (U : ComponentUniverse G)
+    (hNoWitness : ∀ w : ClosedWalkWitness G, ¬ ClosedWalkBad w) :
+    AdjacencyNilpotent U :=
+  (adjacencyNilpotent_iff_no_closedWalkObstruction U).mpr hNoWitness
+
+end Formal.Arch

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -174,8 +174,8 @@ RequiredAxesAvailableAndZero L sig
 
 | 草案の成分 | 既存 Lean API | Lean 化の入口 |
 | --- | --- | --- |
-| dependency obstruction | `Walk`, `HasClosedWalk`, `WalkAcyclic`, `Acyclic` | 閉 walk を dependency witness として扱う。 |
-| nilpotence obstruction | `adjacencyNilpotent_iff_acyclic`, `spectralRadiusOfAdjacency` | 有限 `ComponentUniverse` 上の matrix bridge を obstruction family として参照する。 |
+| dependency obstruction | `ClosedWalkWitness`, `Walk`, `HasClosedWalk`, `WalkAcyclic`, `Acyclic` | 閉 walk を forbidden dependency witness として扱う。 |
+| nilpotence obstruction | `adjacencyNilpotent_iff_no_closedWalkObstruction`, `spectralRadiusOfAdjacency` | 有限 `ComponentUniverse` 上の matrix bridge を obstruction family として参照する。 |
 | projection obstruction | `ProjectionSound`, `projectionSoundnessViolationEdges` | 抽象辺に写らない具象辺を projection witness とする。 |
 | observation / LSP obstruction | `ObservationFactorsThrough`, `lspViolationPairs` | 同じ抽象 fiber 内の観測不一致を observation witness とする。 |
 | local replacement | `LocalReplacementContract` | projection witness と observation witness の同時消滅として扱う。 |
@@ -313,8 +313,14 @@ required diagram を列挙するなど、一部の law family では `CoversRequ
   `violatingWitnesses` の特殊例であること,
   `projectionSound_iff_noProjectionObstruction`,
   `lspCompatible_iff_noLSPObstruction`, [Issue #188](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/188)
-- `future proof obligation`: `WalkAcyclic` など残る具体的な lawfulness predicate と
-  witness 不在の exactness bridge。
+- `proved`: `ClosedWalkWitness` を forbidden dependency witness として追加し、
+  `WalkAcyclic`, `Acyclic`, finite `AdjacencyNilpotent` と witness 不在を接続する
+  exactness bridge,
+  `walkAcyclic_iff_no_closedWalkObstruction`,
+  `adjacencyNilpotent_iff_no_closedWalkObstruction`,
+  [Issue #190](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/190)
+- `future proof obligation`: 残る具体的な lawfulness predicate と witness 不在の
+  exactness bridge。
 - `future proof obligation`: required Signature axis の abstract bridge を具体的な
   projection / LSP / walk / nilpotence witness family に接続する定理。
 - `proved`: 抽象 `LawFamily` では、complete coverage 下での measured zero から

--- a/docs/formal/lean_module_organization.md
+++ b/docs/formal/lean_module_organization.md
@@ -15,7 +15,7 @@ follow-up Issue / PR に分割し、`lake build` を通して進める。
 | Structural invariants | `Layering`, `Decomposable`, `Finite` | `StrictLayered`, `Acyclic`, `FinitePropagation`, finite `ComponentUniverse`, finite graph bridge theorem を扱う。 |
 | Category / projection | `Category`, `ThinCategory`, `Projection` | thin category と抽象射影、DIP / projection soundness / exactness を扱う。 |
 | Behavior | `Observation`, `LSP`, `LocalReplacement` | 観測同値、LSP、projection bridge と observation bridge を束ねる局所置換契約を扱う。 |
-| Metrics / matrix | `Signature`, `Matrix` | Architecture Signature v0/v1、finite executable metrics、adjacency matrix / nilpotence / spectral bridge を扱う。 |
+| Metrics / matrix / obstruction bridge | `Signature`, `Matrix`, `DependencyObstruction` | Architecture Signature v0/v1、finite executable metrics、adjacency matrix / nilpotence / spectral bridge、closed-walk obstruction exactness を扱う。 |
 | Examples / counterexamples | `SolidCounterexample` | SOLID-style local contract だけでは `Decomposable` が従わない反例を保持する。 |
 
 この分類は reader-facing な責務整理であり、現時点の Lean import path は

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -416,6 +416,27 @@ File: `Formal/Arch/Matrix.lean`
 | `FiniteArchGraph.adjacencyNilpotent_of_acyclic` | `theorem` | `FiniteArchGraph` 入口で acyclicity から adjacency nilpotence を得る。 | `proved` |
 | `FiniteArchGraph.acyclic_of_adjacencyNilpotent` | `theorem` | `FiniteArchGraph` 入口で adjacency nilpotence から acyclicity を得る。 | `proved` |
 
+## Dependency Obstruction
+
+File: `Formal/Arch/DependencyObstruction.lean`
+
+| Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- |
+| `ClosedWalkWitness` | `structure` | 非空閉 walk を dependency obstruction witness として束ねる。 | `defined only` |
+| `ClosedWalkBad` | `def` | `ClosedWalkWitness` 自体を forbidden obstruction として扱う predicate。 | `defined only` |
+| `closedWalkViolatingWitnesses` | `def` | measured closed-walk witness list を generic `violatingWitnesses` へ載せる。 | `defined only` |
+| `closedWalkViolationCount` | `def` | measured closed-walk obstruction witness の個数。 | `defined only` |
+| `mem_closedWalkViolatingWitnesses_iff` | `theorem` | closed-walk violation list の membership が measured witness membership と一致する。 | `proved` |
+| `closedWalkViolationCount_eq_zero_iff_forall_not_bad` | `theorem` | measured closed-walk violation count が 0 であることと measured witness に bad がないことが一致する。 | `proved` |
+| `hasClosedWalk_of_closedWalkWitness` | `theorem` | `ClosedWalkWitness` から既存 `HasClosedWalk` を得る。 | `proved` |
+| `exists_closedWalkWitness_of_hasClosedWalk` | `theorem` | 既存 `HasClosedWalk` を `ClosedWalkWitness` として包装する。 | `proved` |
+| `hasClosedWalk_iff_exists_closedWalkWitness` | `theorem` | `HasClosedWalk` と closed-walk obstruction witness の存在が一致する。 | `proved` |
+| `walkAcyclic_iff_no_closedWalkObstruction` | `theorem` | `WalkAcyclic` と closed-walk obstruction witness 不在が一致する。 | `proved` |
+| `acyclic_iff_no_closedWalkObstruction` | `theorem` | graph-level `Acyclic` と closed-walk obstruction witness 不在が一致する。 | `proved` |
+| `adjacencyNilpotent_iff_no_closedWalkObstruction` | `theorem` | finite universe 上で adjacency nilpotence と closed-walk obstruction witness 不在が一致する。 | `proved` |
+| `no_closedWalkObstruction_of_adjacencyNilpotent` | `theorem` | adjacency nilpotence から closed-walk obstruction witness 不在を得る。 | `proved` |
+| `adjacencyNilpotent_of_no_closedWalkObstruction` | `theorem` | closed-walk obstruction witness 不在から finite universe 上の adjacency nilpotence を得る。 | `proved` |
+
 ## SOLID Counterexamples
 
 File: `Formal/Arch/SolidCounterexample.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -155,6 +155,9 @@ Lean status:
 
 - `proved`: `Acyclic -> WalkAcyclic`
 - `proved`: `WalkAcyclic -> Acyclic`
+- `proved`: `ClosedWalkWitness` packages `HasClosedWalk` as a forbidden
+  obstruction witness, and `WalkAcyclic` is exact absence of that witness,
+  [Issue #190](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/190)
 
 ### 2. 分解可能性の基礎定理
 
@@ -216,6 +219,14 @@ Issue [#55](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/55
 また `adjacencyNilpotent_iff_walkAcyclic` と
 `adjacencyNilpotent_iff_acyclic` により、有限 `ComponentUniverse` 上では
 adjacency nilpotence / `WalkAcyclic` / `Acyclic` が一致する。
+Issue [#190](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/190)
+では `ClosedWalkWitness` を追加し、閉 walk を equality diagram ではなく
+forbidden witness family として generic obstruction kernel に接続した。
+`walkAcyclic_iff_no_closedWalkObstruction`,
+`acyclic_iff_no_closedWalkObstruction`,
+`adjacencyNilpotent_iff_no_closedWalkObstruction` により、closed-walk witness
+不在、walk-level acyclicity、graph-level acyclicity、finite adjacency
+nilpotence の接続は Lean で証明済みである。
 
 Issue [#85](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/85)
 では、`nilpotencyIndex` を matrix bridge 由来の executable extension axis


### PR DESCRIPTION
## 概要

Closes #190

closed walk を equality diagram ではなく forbidden witness family として扱う `ClosedWalkWitness` を追加し、generic obstruction-count kernel と既存の `HasClosedWalk` / `WalkAcyclic` / `Acyclic` / finite `AdjacencyNilpotent` bridge を接続しました。

## 証明した定理

- `mem_closedWalkViolatingWitnesses_iff`
- `closedWalkViolationCount_eq_zero_iff_forall_not_bad`
- `hasClosedWalk_of_closedWalkWitness`
- `exists_closedWalkWitness_of_hasClosedWalk`
- `hasClosedWalk_iff_exists_closedWalkWitness`
- `walkAcyclic_iff_no_closedWalkObstruction`
- `acyclic_iff_no_closedWalkObstruction`
- `adjacencyNilpotent_iff_no_closedWalkObstruction`
- `no_closedWalkObstruction_of_adjacencyNilpotent`
- `adjacencyNilpotent_of_no_closedWalkObstruction`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/formal/lean_module_organization.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/DependencyObstruction.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている