### PR TITLE
零曲率定理のLean statusを文書同期する

### DIFF
--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -1,6 +1,7 @@
 # アーキテクチャ零曲率定理 Lean 化設計
 
-Lean status: `future proof obligation` / formalization design.
+Lean status: `proved` core / `defined only` schema /
+`future proof obligation` / `empirical hypothesis`.
 
 この文書は [Flatness–Obstruction Conjecture](../math/Flatness–Obstruction%20Conjecture.md)
 を、数学面の草案として残したまま Lean 化するための設計メモである。
@@ -19,7 +20,8 @@ Lean 側では、この主張を最初から数値的な `Curv_A = Sem_A(p) - Se
 として定義しない。まず、要求された law family に対して有限
 `obstruction witness` が存在するかどうかを扱う。可換であるべき図式の非可換性は、
 その最重要な特殊例として定義する。数値的な curvature, distance, norm, rank は、
-観測値に追加構造を入れた後の executable metric として扱う。
+観測値に追加構造を入れた後の派生 executable metric として扱う。
+したがって、数値 curvature の未導入は Lean proved core の未完了を意味しない。
 
 ## 形式化の基本方針
 
@@ -260,8 +262,11 @@ RequiredAxesAvailableAndZero L sig
 Lean では、抽象 `LawFamily` に対して axis ごとの `AxisExact`、required witness
 cover、required axis 全体の
 `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily`
-を証明済みである。具体的な `ProjectionSound` / `LSPCompatible` などの
-law family への exactness 接続は、個別の proof obligation として残す。
+を証明済みである。具体的な `ProjectionSound` / `LSPCompatible` /
+`WalkAcyclic` / `LocalReplacementContract` / finite diagram law family については、
+それぞれの witness 不在との exactness bridge を証明済みである。
+ただし、required Signature axis の抽象 bridge を、すべての具体 law family の
+axis valuation へ接続する theorem は今後の proof obligation として残す。
 
 complete coverage は単なる強い仮定として放置しない。
 有限 component universe から component pair を列挙する、有限 diagram universe から
@@ -298,7 +303,27 @@ universe を cover する。
    各 finite diagram family の `DiagramLawful <-> NoDiagramObstruction` bridge は
    `proved`。
 11. 観測値に距離・重み・半環などを入れる必要が出た時点で、数値的 curvature metric を
-   派生定義として追加する。
+   派生定義として追加する。現時点では Issue
+   [#194](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/194)
+   の設計整理として、Lean proved core から分離しておく。
+
+## 数値 curvature metric の派生層
+
+数値 curvature metric は、zero-count bridge や required obstruction witness 不在の
+代替ではなく、それらの上に載る派生的な測定層である。`Formal/Arch/Curvature.lean`
+のような module は、少なくとも次の追加構造を固定してから導入する。
+
+- 観測値 `Obs` 上の差分・距離・同値など、diagram 非可換性を数値化する構造。
+- finite measured universe から数値を集約する方法。
+- `none`、測定済み 0、測定済み非零を区別する Signature axis への載せ方。
+- 数値と変更コスト・障害率・レビュー負荷の関係を検証する empirical protocol。
+
+このため、`Curv_A = Sem_A(p) - Sem_A(q)` 型の一般 metric は現時点では
+`future proof obligation` ではなく `future design` / `empirical hypothesis` として
+扱う。Lean core の `proved` 対象は、有限 witness list、required diagram、
+lawfulness predicate、obstruction witness 不在、required axis zero の構造的 bridge
+である。数値 metric が必要になった場合も、既存の obstruction witness zero-count
+theorem を置き換えず、追加の axis または派生評価として接続する。
 
 ## 証明対象と非対象
 
@@ -331,6 +356,11 @@ universe を cover する。
   `walkAcyclic_iff_no_closedWalkObstruction`,
   `adjacencyNilpotent_iff_no_closedWalkObstruction`,
   [Issue #190](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/190)
+- `proved`: `LocalReplacementContract` から projection obstruction と LSP
+  obstruction の同時消滅、および対応する finite violation count が 0 であること,
+  `noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract`,
+  `violationCounts_eq_zero_of_localReplacementContract`,
+  [Issue #188](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/188)
 - `proved`: 抽象 `LawFamily` では、complete coverage 下での measured zero から
   global lawfulness への bridge,
   `lawViolationCount_eq_zero_iff_lawful`, `lawful_iff_noRequiredObstruction_of_completeCoverage`,
@@ -351,12 +381,13 @@ universe を cover する。
   `effectRoundtripLawful_iff_noEffectRoundtripObstruction`,
   `effectCompensationLawful_iff_noEffectCompensationObstruction`,
   [Issue #193](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/193)
-- `future proof obligation`: 残る具体的な lawfulness predicate と witness 不在の
-  exactness bridge。
 - `future proof obligation`: required Signature axis の abstract bridge を具体的な
   projection / LSP / walk / nilpotence witness family に接続する定理。
 - `defined only`: witness family をまとめる signature schema と
   `ArchitectureSignatureV1` axis classification。
+- `future design` / `empirical hypothesis`: 一般の数値 curvature metric を定義する
+  観測値上の追加構造、集約規則、validation protocol,
+  [Issue #194](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/194)。
 - `empirical hypothesis`: obstruction count と変更コスト・障害率・レビュー負荷の相関。
 
 次は初期 Lean proof の対象にしない。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -513,6 +513,9 @@ File: `Formal/Arch/SolidCounterexample.lean`
 次は意図的に Lean core へ混ぜていない。
 
 - `Decomposable` の定義への acyclicity, finite propagation, nilpotence, spectral conditions の混入。
+- 一般の `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
+  `Formal/Arch/Curvature.lean` は、観測値上の差分・距離・重み・集約規則が固まるまで
+  意図的に追加しない。
 - `relationComplexity`, `runtimePropagation`, `empiricalChangeCost` の実証相関。
 - extractor output が `ComponentUniverse` の完全な witness であるという主張。
 - `rho(A)` と変更波及・障害伝播コストの相関。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -67,17 +67,20 @@ required axis exactness については、`MeasuredZero` と `AvailableAndZero` 
 `RequiredAxesAvailableAndZero <-> NoRequiredObstruction` を得る抽象 bridge も
 Lean で証明済みである
 ([Issue #195](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/195))。
-ただし、アーキテクチャ零曲率定理全体、具体的な `ProjectionSound` /
-`LSPCompatible` / `WalkAcyclic` などの lawfulness predicate との exactness、
-required `ArchitectureSignature` axis との具体 law family 接続は
-`future proof obligation` のまま扱う。
+具体的な `ProjectionSound` / `LSPCompatible` / `WalkAcyclic` /
+`LocalReplacementContract` / finite diagram law family についても、それぞれの
+lawfulness predicate と obstruction witness 不在を接続する exactness bridge は
+Lean で証明済みである。残る中心的な `future proof obligation` は、required
+`ArchitectureSignature` axis の抽象 bridge を具体 law family の axis valuation へ
+接続する theorem である。
 
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、
-それだけでは中心定理の証明とは呼ばない。強い proof obligation は、
+それだけでは中心定理の証明とは呼ばない。強い Lean proof は、
 `ProjectionSound`, `LSPCompatible`, `WalkAcyclic`, `LocalReplacementContract`
 など、obstruction framework とは独立に定義された lawfulness predicate と、
-各 witness family の阻害証人不在を bridge theorem で接続することである。
+各 witness family の阻害証人不在を bridge theorem で接続することで進める。
+これらの代表的な exactness bridge は #188, #190, #193 で証明済みである。
 さらに、required `ArchitectureSignature` axis の抽象 exactness bridge を
 具体 law family に接続し、complete coverage を有限 universe から構成できる law family
 を増やすことを目標にする。
@@ -103,6 +106,14 @@ diagram constructors は `defined only`、各 replay / roundtrip / compensation 
 `DiagramLawful <-> NoDiagramObstruction` bridge は `proved` である。これは required
 diagram family の受け皿であり、実コードベース抽出器の完全性、観測値上の距離、
 重み、半環、数値 curvature metric は主張しない。
+
+Issue [#194](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/194)
+では、数値的 curvature metric と empirical hypothesis を Lean proved core から
+派生層へ分離する。`Curv_A = Sem_A(p) - Sem_A(q)` 型の一般 metric は、
+観測値上の距離・差分・重み・集約規則と validation protocol が固まるまで
+`future design` / `empirical hypothesis` として扱う。これは obstruction witness
+zero-count theorem の代替ではなく、必要になった場合に追加 axis または派生評価として
+接続する。
 
 ## 基本 convention
 
@@ -912,6 +923,7 @@ Lean status の区分:
 | `observationalDivergence`, `lspViolationCount` | 観測差分と measured LSP violation pair を数える behavioral extension | `defined only` / `proved` |
 | `nilpotencyIndex` | finite `ComponentUniverse` 上で最初の zero adjacency power を探す executable metric。acyclic graph では `some` になる bridge を証明済み | `defined only` / `proved` |
 | `rho(A)` | 行列解析上の伝播増幅指標として扱う。finite DAG では 0、finite closed walk では正になる bridge を証明済み | `proved` for `DAG -> rho(A)=0` / `proved` for cycle positivity / `empirical hypothesis` |
+| `numericCurvature` | 一般の観測値差分 `Sem_A(p) - Sem_A(q)` 型 metric は、観測値上の距離・重み・集約規則が固まるまで Lean core へ入れない派生候補 | `future design` / `empirical hypothesis` |
 | `runtimePropagation` | 0/1 `RuntimeDependencyGraph` 上では `reachableConeSizeOfFinite` による runtime exposure radius として計算する。既存名は `runtimeExposureRadius` の互換名であり、blast radius は reverse reachability 由来の tooling / analysis metric として分ける | `defined only` / `empirical hypothesis` |
 | `relationComplexity` | 状態遷移代数層の設計に依存する | `empirical hypothesis` |
 | `empiricalChangeCost` | 実データで検証する目的変数 | `empirical hypothesis` |


### PR DESCRIPTION
## 概要

Closes #187
Closes #194

- アーキテクチャ零曲率定理の Lean status を、proved core / defined only schema / future proof obligation / empirical hypothesis に整理しました。
- Projection / LSP / WalkAcyclic / LocalReplacement / finite diagram law family の exactness bridge が証明済みであることを docs に反映しました。
- 数値 curvature metric は Lean proved core ではなく、観測値上の追加構造と empirical protocol が固まった後の派生層として明記しました。

## 証明した定理

- なし

## 編集したドキュメント

- docs/formal/flatness_obstruction_lean_design.md
- docs/proof_obligations.md
- docs/formal/lean_theorem_index.md

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている