### PR TITLE
零曲率定理レビュー指摘を文書へ反映する

### DIFF
--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -180,7 +180,7 @@ RequiredAxesAvailableAndZero L sig
 | nilpotence obstruction | `adjacencyNilpotent_iff_no_closedWalkObstruction`, `spectralRadiusOfAdjacency` | 有限 `ComponentUniverse` 上の matrix bridge を obstruction family として参照する。 |
 | projection obstruction | `ProjectionSound`, `projectionSoundnessViolationEdges` | 抽象辺に写らない具象辺を projection witness とする。 |
 | observation / LSP obstruction | `ObservationFactorsThrough`, `lspViolationPairs` | 同じ抽象 fiber 内の観測不一致を observation witness とする。 |
-| local replacement | `LocalReplacementContract` | projection witness と observation witness の同時消滅として扱う。 |
+| local replacement | `LocalReplacementContract` | projection obstruction 不在、representative stability、observation factorization へ分解し、そこから projection / LSP obstruction の同時消滅を得る。 |
 | state transition / effect boundary laws | `StateTransitionExpr`, `EffectBoundaryExpr` | replay / roundtrip / compensation を required diagram family として扱う。 |
 | signature axis | `ArchitectureSignatureV1` | witness family ごとの count / optional metric として接続する。 |
 
@@ -267,6 +267,14 @@ cover、required axis 全体の
 それぞれの witness 不在との exactness bridge を証明済みである。
 ただし、required Signature axis の抽象 bridge を、すべての具体 law family の
 axis valuation へ接続する theorem は今後の proof obligation として残す。
+
+したがって、現時点で Lean proved と呼べるのは、アーキテクチャ零曲率定理の
+structural core である。すなわち、抽象 `LawFamily`、complete witness coverage、
+required axis exactness を前提に、`Lawful` と
+`RequiredAxesAvailableAndZero` を接続する bridge は証明済みである。一方、
+`ArchitectureSignatureV1.axisValue` を projection / LSP / walk / nilpotence などの
+具体 law family valuation へ接続する theorem は、まだ `future proof obligation`
+として残る。
 
 complete coverage は単なる強い仮定として放置しない。
 有限 component universe から component pair を列挙する、有限 diagram universe から
@@ -356,8 +364,11 @@ theorem を置き換えず、追加の axis または派生評価として接続
   `walkAcyclic_iff_no_closedWalkObstruction`,
   `adjacencyNilpotent_iff_no_closedWalkObstruction`,
   [Issue #190](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/190)
-- `proved`: `LocalReplacementContract` から projection obstruction と LSP
-  obstruction の同時消滅、および対応する finite violation count が 0 であること,
+- `proved`: `LocalReplacementContract` は projection obstruction 不在、
+  representative stability、observation factorization に分解され、そこから
+  projection obstruction と LSP obstruction の同時消滅、および対応する finite
+  violation count が 0 であること,
+  `localReplacementContract_iff_noProjectionObstruction_and_representativeStable_and_observationFactorsThrough`,
   `noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract`,
   `violationCounts_eq_zero_of_localReplacementContract`,
   [Issue #188](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/188)
@@ -383,6 +394,9 @@ theorem を置き換えず、追加の axis または派生評価として接続
   [Issue #193](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/193)
 - `future proof obligation`: required Signature axis の abstract bridge を具体的な
   projection / LSP / walk / nilpotence witness family に接続する定理。
+  特に `nilpotencyIndex` は `some k` として最初の zero adjacency power を返す
+  executable index であり、`RequiredAxesAvailableAndZero` の zero-axis として読むには
+  別途 axis interpretation / exactness theorem が必要である。
 - `defined only`: witness family をまとめる signature schema と
   `ArchitectureSignatureV1` axis classification。
 - `future design` / `empirical hypothesis`: 一般の数値 curvature metric を定義する

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -250,7 +250,7 @@ File: `Formal/Arch/Lawfulness.lean`
 | `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisExact` | `theorem` | required axis exactness から signature axis と obstruction 不在の bridge を取り出す。 | `proved` |
 | `requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_axisExactFamily` | `theorem` | axis ごとの exactness と required witness cover から、required axis 全体の available-and-zero と required obstruction 不在を接続する。 | `proved` |
 | `requiredAxisExact_of_axisExactFamily` | `theorem` | axis ごとの exactness を既存の whole-family exactness predicate にパッケージする。 | `proved` |
-| `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact` | `theorem` | 完全被覆と required axis exactness の下で、lawfulness と required axis zero を接続する零曲率定理候補。 | `proved` |
+| `lawful_iff_requiredAxesAvailableAndZero_of_completeCoverage_and_requiredAxisExact` | `theorem` | 完全被覆と required axis exactness の下で、lawfulness と required axis zero を接続する零曲率定理の structural core。具体 `ArchitectureSignatureV1.axisValue` への接続は別 theorem として残る。 | `proved` |
 
 ## State Transition / Effect Boundary Laws
 
@@ -433,8 +433,8 @@ File: `Formal/Arch/Matrix.lean`
 | `adjacencyPowerZeroOnComponentsBool_iff_zero` | `theorem` | `ComponentUniverse.covers` の下で executable zero test が graph-level 全 0 条件と一致する。 | `proved` |
 | `firstZeroPowerIndex` | `def` | 候補 power list から最初の zero adjacency power を返す。 | `defined only` |
 | `nilpotencyIndexSearchBound` | `def` | executable `nilpotencyIndex` が探索する finite DAG-complete bound。 | `defined only` |
-| `nilpotencyIndexOfFinite` | `def` | finite `ComponentUniverse` 上の executable nilpotency index candidate。 | `defined only` |
-| `ArchitectureSignature.v1OfComponentUniverseWithNilpotencyIndex` | `def` | `ArchitectureSignatureV1.nilpotencyIndex` を matrix bridge から埋める entry point。 | `defined only` |
+| `nilpotencyIndexOfFinite` | `def` | finite `ComponentUniverse` 上の executable nilpotency index candidate。`some k` は最初の zero adjacency power であり、required zero-axis ではない。 | `defined only` |
+| `ArchitectureSignature.v1OfComponentUniverseWithNilpotencyIndex` | `def` | `ArchitectureSignatureV1.nilpotencyIndex` を matrix bridge から埋める entry point。`RequiredAxesAvailableAndZero` へ接続するには別途 axis interpretation が必要。 | `defined only` |
 | `Walk.append` | `def` | walk の連結。 | `defined only` |
 | `Walk.length_append` | `theorem` | walk 連結で長さが加法的になる。 | `proved` |
 | `Walk.repeatClosed` | `def` | 閉 walk の繰り返し。 | `defined only` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -74,6 +74,14 @@ Lean で証明済みである。残る中心的な `future proof obligation` は
 `ArchitectureSignature` axis の抽象 bridge を具体 law family の axis valuation へ
 接続する theorem である。
 
+したがって、現時点で Lean proved と呼べるのは、アーキテクチャ零曲率定理の
+structural core である。抽象 `LawFamily`、complete witness coverage、
+required axis exactness を前提に、`Lawful` と
+`RequiredAxesAvailableAndZero` を接続する bridge は証明済みである。一方、
+`ArchitectureSignatureV1.axisValue` を projection / LSP / walk / nilpotence などの
+具体 law family valuation へ接続する theorem は、まだ `future proof obligation`
+として残る。
+
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、
 それだけでは中心定理の証明とは呼ばない。強い Lean proof は、
@@ -277,6 +285,10 @@ Issue [#85](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/85
 `nilpotencyIndexOfFinite` が必ず `some` になることを示す。
 `ArchitectureSignature.v1OfComponentUniverseWithNilpotencyIndex` は、この値を
 `ArchitectureSignatureV1.nilpotencyIndex` に埋める entry point である。
+この axis は `some k` として最初の zero adjacency power を返す executable index
+であり、`some 0` を要求する `AvailableAndZero` 型の zero-axis ではない。
+したがって nilpotence obstruction を required axis zero として読むには、
+別途 axis interpretation / exactness theorem が必要である。
 
 Issue [#79](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/79)
 では、`rho(A)` bridge を mathlib-backed な解析的拡張として分離する方針にした。
@@ -577,10 +589,18 @@ behavioral extension を扱う。
 Issue [#118](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/118)
 では、局所契約 bundle を `LocalReplacementContract G π GA O` として Lean に追加した。
 これは `DIPCompatible G π GA ∧ ObservationFactorsThrough π O` を束ねる薄い定義であり、
+`localReplacementContract_iff_noProjectionObstruction_and_representativeStable_and_observationFactorsThrough`
+により、projection obstruction 不在、representative stability、
+observation factorization へ分解される。
 `violationCounts_eq_zero_of_localReplacementContract` により
 `projectionSoundnessViolation = 0` と `lspViolationCount = 0` を同時に得る。
 この theorem は `components` と `implementations` の測定 universe を受け取る
 packaging theorem であり、repository-level の重みづけや総合スコアは含めない。
+なお、Lean で証明済みの同値は `LocalReplacementContract ↔
+NoProjectionObstruction ∧ RepresentativeStable ∧ ObservationFactorsThrough`
+であり、`LocalReplacementContract ↔ NoProjectionObstruction ∧ NoLSPObstruction`
+ではない。`ObservationFactorsThrough` から `LSPCompatible` /
+`NoLSPObstruction` が従う、という向きで扱う。
 
 Lean status:
 
@@ -599,8 +619,10 @@ Lean status:
   では、projection / LSP の既存 finite violation list membership を generic
   `violatingWitnesses` の特殊例として接続し、`ProjectionSound` /
   `LSPCompatible` と obstruction witness 不在の exactness bridge を証明した。
-  `LocalReplacementContract` については、projection obstruction 不在と
-  LSP obstruction 不在が同時に従う packaging theorem を追加した。
+  `LocalReplacementContract` については、projection obstruction 不在、
+  representative stability、observation factorization への分解 theorem と、
+  projection obstruction 不在と LSP obstruction 不在が同時に従う packaging
+  theorem を追加した。
 
 ### 7. Architecture Signature は半順序を持つ
 
@@ -921,7 +943,7 @@ Lean status の区分:
 | `weightedSccRisk` | `weight : C -> Nat` を入力し、各 component の重み付き SCC excess を合計する executable metric。重みの由来は empirical / extractor tooling 側に残す | `defined only` / `proved` |
 | `projectionSoundnessViolation` | 具象依存が抽象依存へ sound に写らない measured edge を数える | `defined only` / `proved` |
 | `observationalDivergence`, `lspViolationCount` | 観測差分と measured LSP violation pair を数える behavioral extension | `defined only` / `proved` |
-| `nilpotencyIndex` | finite `ComponentUniverse` 上で最初の zero adjacency power を探す executable metric。acyclic graph では `some` になる bridge を証明済み | `defined only` / `proved` |
+| `nilpotencyIndex` | finite `ComponentUniverse` 上で最初の zero adjacency power を探す executable metric。acyclic graph では `some` になる bridge を証明済み。`some k` は index 値であり、required zero-axis ではない | `defined only` / `proved` |
 | `rho(A)` | 行列解析上の伝播増幅指標として扱う。finite DAG では 0、finite closed walk では正になる bridge を証明済み | `proved` for `DAG -> rho(A)=0` / `proved` for cycle positivity / `empirical hypothesis` |
 | `numericCurvature` | 一般の観測値差分 `Sem_A(p) - Sem_A(q)` 型 metric は、観測値上の距離・重み・集約規則が固まるまで Lean core へ入れない派生候補 | `future design` / `empirical hypothesis` |
 | `runtimePropagation` | 0/1 `RuntimeDependencyGraph` 上では `reachableConeSizeOfFinite` による runtime exposure radius として計算する。既存名は `runtimeExposureRadius` の互換名であり、blast radius は reverse reachability 由来の tooling / analysis metric として分ける | `defined only` / `empirical hypothesis` |


### PR DESCRIPTION
## 概要

関連: #187
関連: #194

- レビュー結論に合わせて、零曲率定理は無限定な完全証明ではなく structural core が Lean proved であると明記しました。
- `ArchitectureSignatureV1.axisValue` と具体 law family valuation の接続が future proof obligation として残ることを強調しました。
- `LocalReplacementContract` の同値は `NoProjectionObstruction ∧ NoLSPObstruction` だけではなく、`RepresentativeStable` と `ObservationFactorsThrough` を含む形であることを明記しました。
- `nilpotencyIndex` は `some k` を返す executable index であり、required zero-axis ではないことを追記しました。

## 証明した定理

- なし

## 編集したドキュメント

- docs/formal/flatness_obstruction_lean_design.md
- docs/formal/lean_theorem_index.md
- docs/proof_obligations.md

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue なし。#187 / #194 のレビュー反映であり、既に closed のため `Closes #N` は使わない
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている