### PR TITLE
零曲率定理の required law axes constructor を追加する

### DIFF
--- a/Formal/Arch/Signature.lean
+++ b/Formal/Arch/Signature.lean
@@ -1,9 +1,10 @@
 import Formal.Arch.Graph
 import Formal.Arch.Lawfulness
+import Formal.Arch.LSP
 
 namespace Formal.Arch
 
-universe u
+universe u v w
 
 /--
 Initial architecture signature.
@@ -496,6 +497,35 @@ inductive ArchitectureSignatureV1Axis where
   | empiricalChangeCost
   deriving DecidableEq, Repr
 
+/--
+Selected v1 axes treated as required zero law axes by the current
+Signature-integrated lawfulness bridge.
+
+The selection is intentionally narrow. Structural propagation magnitudes,
+matrix indices, runtime exposure, and empirical cost axes remain diagnostics or
+future bridge work rather than required zero-law obligations.
+-/
+def selectedRequiredLawAxes : List ArchitectureSignatureV1Axis :=
+  [ .hasCycle
+  , .projectionSoundnessViolation
+  , .lspViolationCount
+  , .boundaryViolationCount
+  , .abstractionViolationCount
+  ]
+
+/-- Predicate form of `selectedRequiredLawAxes`. -/
+def IsSelectedRequiredLawAxis (axis : ArchitectureSignatureV1Axis) : Prop :=
+  axis ∈ selectedRequiredLawAxes
+
+theorem mem_selectedRequiredLawAxes_iff {axis : ArchitectureSignatureV1Axis} :
+    axis ∈ selectedRequiredLawAxes ↔
+      axis = .hasCycle ∨
+      axis = .projectionSoundnessViolation ∨
+      axis = .lspViolationCount ∨
+      axis = .boundaryViolationCount ∨
+      axis = .abstractionViolationCount := by
+  simp [selectedRequiredLawAxes]
+
 namespace ArchitectureSignatureV1
 
 /-- Read any Signature v1 axis as an optional natural-number metric. -/
@@ -627,6 +657,147 @@ def v1OfFinite {C : Type u} (G : ArchGraph C)
   runtimePropagation := none
   relationComplexity := none
   empiricalChangeCost := none
+
+/--
+Build a Signature v1 value with the selected required law axes populated.
+
+The selected required law axes are `hasCycle`, `projectionSoundnessViolation`,
+`lspViolationCount`, `boundaryViolationCount`, and `abstractionViolationCount`.
+Other axes such as `nilpotencyIndex`, propagation magnitudes, runtime exposure,
+and empirical costs are not required zero-law axes: they are structural,
+matrix, runtime, or empirical diagnostics whose zero value does not by itself
+state lawfulness for the selected law family.
+-/
+def v1OfFiniteWithRequiredLawAxes {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1 where
+  core := v1CoreOfFinite G components boundaryAllowed abstractionAllowed
+  weightedSccRisk := none
+  projectionSoundnessViolation :=
+    some (projectionSoundnessViolation G π GA components)
+  lspViolationCount := some (lspViolationCount π O components)
+  nilpotencyIndex := none
+  runtimePropagation := none
+  relationComplexity := none
+  empiricalChangeCost := none
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_hasCycle
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .hasCycle =
+      some (boolRisk (hasCycleBool G components)) := by
+  rfl
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_projectionSoundnessViolation
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .projectionSoundnessViolation =
+      some (projectionSoundnessViolation G π GA components) := by
+  rfl
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_lspViolationCount
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .lspViolationCount =
+      some (lspViolationCount π O components) := by
+  rfl
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_boundaryViolationCount
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .boundaryViolationCount =
+      some (boundaryViolationCountOfFinite G components boundaryAllowed) := by
+  rfl
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_abstractionViolationCount
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .abstractionViolationCount =
+      some (abstractionViolationCountOfFinite G components abstractionAllowed) := by
+  rfl
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_nilpotencyIndex
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .nilpotencyIndex =
+      none := by
+  rfl
+
+theorem axisValue_v1OfFiniteWithRequiredLawAxes_runtimePropagation
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (components : List C)
+    (boundaryAllowed abstractionAllowed : C → C → Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisValue
+        (v1OfFiniteWithRequiredLawAxes G π GA O components
+          boundaryAllowed abstractionAllowed)
+        .runtimePropagation =
+      none := by
+  rfl
 
 /--
 Build a Signature v1 value with the Lean executable weighted SCC axis populated.

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -302,10 +302,13 @@ universe を cover する。
    として接続する。
 7. `ArchitectureSignatureV1` の axis を witness family status に分類し、
    `MeasuredZero` と `AvailableAndZero` を分ける。
-8. axis ごとの `AxisExact` と、required axis 全体の
+8. selected required law axes を `hasCycle`, projection, LSP, boundary,
+   abstraction に固定し、required axis 用 constructor で concrete count を
+   `some count` として埋める。
+9. axis ごとの `AxisExact` と、required axis 全体の
    `RequiredAxesAvailableAndZero <-> NoRequiredObstruction` bridge を追加する。
-9. 有限 universe から `CoversRequired` を構成できる law family を増やす。
-10. 状態遷移履歴、effect boundary, replay / roundtrip / compensation law を
+10. 有限 universe から `CoversRequired` を構成できる law family を増やす。
+11. 状態遷移履歴、effect boundary, replay / roundtrip / compensation law を
    個別の `Expr` と `Semantics` として追加する。Lean status: `proved` /
    `defined only`。`StateTransitionExpr`, `EffectBoundaryExpr` は `defined only`、
    各 finite diagram family の `DiagramLawful <-> NoDiagramObstruction` bridge は

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -335,6 +335,9 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.ArchitectureSignatureV1` | `structure` | v1 core と optional extension axis を束ねる output schema。 | `defined only` |
 | `ArchitectureSignature.AxisMeasurementClass` | `inductive` | Signature v1 axis を `proved witness axis` / `defined executable axis` / `empirical axis` / `unmeasured required law` に分類する。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1Axis` | `inductive` | Signature v1 schema が公開する named axis。 | `defined only` |
+| `ArchitectureSignature.selectedRequiredLawAxes` | `def` | Signature-integrated lawfulness bridge の初期 required zero law axes を列挙する。 | `defined only` |
+| `ArchitectureSignature.IsSelectedRequiredLawAxis` | `def` | `selectedRequiredLawAxes` の predicate 版。 | `defined only` |
+| `ArchitectureSignature.mem_selectedRequiredLawAxes_iff` | `theorem` | selected required axis が `hasCycle`, projection, LSP, boundary, abstraction のいずれかであることを展開する。 | `proved` |
 | `ArchitectureSignature.ArchitectureSignatureV1.axisValue` | `def` | Signature v1 の任意 axis を `Option Nat` metric として読む。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1.axisMeasurementClass` | `def` | Signature v1 axis の現在の Lean/proof/empirical status 分類。 | `defined only` |
 | `ArchitectureSignature.ArchitectureSignatureV1.axisMeasuredZero` | `def` | Signature v1 axis value の weak measured-zero predicate。 | `defined only` |
@@ -344,6 +347,12 @@ File: `Formal/Arch/Signature.lean`
 | `ArchitectureSignature.ArchitectureSignatureV1.axisAvailableAndZero_some_iff` | `theorem` | `axisValue = some n` の axis available-and-zero は `n = 0` と同値。 | `proved` |
 | `ArchitectureSignature.v1CoreOfFinite` | `def` | finite universe から v1 core signature を計算する。 | `defined only` |
 | `ArchitectureSignature.v1OfFinite` | `def` | finite universe から v1 schema を作り、未評価 extension axis を `none` にする。 | `defined only` |
+| `ArchitectureSignature.v1OfFiniteWithRequiredLawAxes` | `def` | selected required law axes のうち projection / LSP / policy count を `some count` として埋める v1 entry point。 | `defined only` |
+| `ArchitectureSignature.axisValue_v1OfFiniteWithRequiredLawAxes_hasCycle` | `theorem` | required-axis entry point の `hasCycle` axis 計算補題。 | `proved` |
+| `ArchitectureSignature.axisValue_v1OfFiniteWithRequiredLawAxes_projectionSoundnessViolation` | `theorem` | required-axis entry point の projection soundness axis 計算補題。 | `proved` |
+| `ArchitectureSignature.axisValue_v1OfFiniteWithRequiredLawAxes_lspViolationCount` | `theorem` | required-axis entry point の LSP violation axis 計算補題。 | `proved` |
+| `ArchitectureSignature.axisValue_v1OfFiniteWithRequiredLawAxes_boundaryViolationCount` | `theorem` | required-axis entry point の boundary policy axis 計算補題。 | `proved` |
+| `ArchitectureSignature.axisValue_v1OfFiniteWithRequiredLawAxes_abstractionViolationCount` | `theorem` | required-axis entry point の abstraction policy axis 計算補題。 | `proved` |
 | `ArchitectureSignature.v1OfFiniteWithWeightedSccRisk` | `def` | 明示的な component weight から `weightedSccRisk` を埋めた v1 schema を作る。 | `defined only` |
 | `ArchitectureSignature.runtimePropagationOfFinite` | `def` | 0/1 runtime graph 上の reachable cone size を exposure 側の `runtimePropagation` 最小 metric として計算する。 | `defined only` |
 | `ArchitectureSignature.v1OfFiniteWithRuntimePropagation` | `def` | 静的 graph から v1 core を計算し、runtime graph から exposure 側の `runtimePropagation` axis を埋める。 | `defined only` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -78,7 +78,7 @@ Lean で証明済みである。残る中心的な `future proof obligation` は
 structural core である。抽象 `LawFamily`、complete witness coverage、
 required axis exactness を前提に、`Lawful` と
 `RequiredAxesAvailableAndZero` を接続する bridge は証明済みである。一方、
-`ArchitectureSignatureV1.axisValue` を projection / LSP / walk / nilpotence などの
+`ArchitectureSignatureV1.axisValue` を projection / LSP / walk / policy などの
 具体 law family valuation へ接続する theorem は、まだ `future proof obligation`
 として残る。
 
@@ -831,6 +831,21 @@ v0 signature を内側に持ち、`sccExcessSize`, `maxFanout`,
 `Option Nat` として保持する。`none` は未評価を意味し、risk 0 とは解釈しない。
 `v1CoreOfFinite` と `v1OfFinite` は finite component list からこの schema を
 構成する executable entry point である。
+
+Issue [#208](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/208)
+では、Signature-integrated lawfulness bridge で required zero law axis として
+扱う初期 scope を `hasCycle`, `projectionSoundnessViolation`,
+`lspViolationCount`, `boundaryViolationCount`, `abstractionViolationCount` に固定した。
+Lean では `selectedRequiredLawAxes` / `IsSelectedRequiredLawAxis` と、
+`v1OfFiniteWithRequiredLawAxes` を追加し、projection / LSP / boundary /
+abstraction の measured count を `some count` として埋める entry point を用意した。
+後続の axis exactness theorem が使うため、各 selected axis の
+`ArchitectureSignatureV1.axisValue` 計算補題も追加済みである。`nilpotencyIndex`,
+`fanoutRisk`, `maxDepth`, `reachableConeSize`, `weightedSccRisk`,
+`runtimePropagation`, `relationComplexity`, `empiricalChangeCost` は required zero
+law axis ではない。前半は構造量・伝播量または matrix bridge の診断軸であり、
+後半は runtime / empirical evidence に依存するため、`some 0` を要求する
+法則健全性の required axis と混同しない。
 
 Issue [#83](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/83)
 では、v1 後半戦の子 Issue #87, #84, #85, #86 の決定を統合し、


### PR DESCRIPTION
## 概要

Closes #208

- Signature-integrated lawfulness bridge の初期 required zero law axes を `hasCycle`, `projectionSoundnessViolation`, `lspViolationCount`, `boundaryViolationCount`, `abstractionViolationCount` に固定しました。
- `v1OfFiniteWithRequiredLawAxes` を追加し、projection / LSP / policy count を `some count` として埋める entry point を追加しました。
- `nilpotencyIndex`, propagation magnitude, runtime / empirical axes を required zero law axis と混同しない理由を docs に反映しました。

## 証明した定理

- `mem_selectedRequiredLawAxes_iff`
- `axisValue_v1OfFiniteWithRequiredLawAxes_hasCycle`
- `axisValue_v1OfFiniteWithRequiredLawAxes_projectionSoundnessViolation`
- `axisValue_v1OfFiniteWithRequiredLawAxes_lspViolationCount`
- `axisValue_v1OfFiniteWithRequiredLawAxes_boundaryViolationCount`
- `axisValue_v1OfFiniteWithRequiredLawAxes_abstractionViolationCount`
- `axisValue_v1OfFiniteWithRequiredLawAxes_nilpotencyIndex`
- `axisValue_v1OfFiniteWithRequiredLawAxes_runtimePropagation`

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/formal/lean_theorem_index.md`
- `docs/formal/flatness_obstruction_lean_design.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/Signature.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている