### PR TITLE
projection と LSP の Signature 軸 exactness を証明

### DIFF
--- a/Formal/Arch/SignatureLawfulness.lean
+++ b/Formal/Arch/SignatureLawfulness.lean
@@ -100,6 +100,85 @@ def RequiredSignatureAxesAvailableAndZero (sig : ArchitectureSignatureV1) : Prop
   ∀ axis, IsSelectedRequiredLawAxis axis ->
     ArchitectureSignatureV1.axisAvailableAndZero sig axis
 
+/--
+The projection-soundness Signature axis is exact for the concrete required-law
+entry point. The reverse direction from zero count to graph-level obstruction
+absence uses the `ComponentUniverse.edgeClosed` coverage assumption.
+-/
+theorem projectionSoundnessViolation_axisExact
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (U : ComponentUniverse G)
+    (boundaryAllowed abstractionAllowed : C -> C -> Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisAvailableAndZero
+        (v1OfFiniteWithRequiredLawAxes G π GA O U.components
+          boundaryAllowed abstractionAllowed)
+        .projectionSoundnessViolation ↔
+      NoProjectionObstruction G π GA := by
+  constructor
+  · intro hAxis
+    have hZero :
+        projectionSoundnessViolation G π GA U.components = 0 := by
+      unfold ArchitectureSignatureV1.axisAvailableAndZero at hAxis
+      simpa [ArchitectureSignatureV1.axisValue,
+        v1OfFiniteWithRequiredLawAxes, AvailableAndZero] using hAxis
+    exact projectionSound_iff_noProjectionObstruction.mp
+      (projectionSound_of_projectionSoundnessViolation_eq_zero
+        U.edgeClosed hZero)
+  · intro hNoObstruction
+    have hSound : ProjectionSound G π GA :=
+      projectionSound_iff_noProjectionObstruction.mpr hNoObstruction
+    have hZero :
+        projectionSoundnessViolation G π GA U.components = 0 :=
+      projectionSoundnessViolation_eq_zero_of_projectionSound
+        U.components hSound
+    unfold ArchitectureSignatureV1.axisAvailableAndZero
+    simp [ArchitectureSignatureV1.axisValue, v1OfFiniteWithRequiredLawAxes,
+      AvailableAndZero, hZero]
+
+/--
+The LSP Signature axis is exact for the concrete required-law entry point. The
+reverse direction from zero count to implementation-pair obstruction absence
+uses explicit same-abstraction pair coverage.
+-/
+theorem lspViolationCount_axisExact
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (U : ComponentUniverse G)
+    (boundaryAllowed abstractionAllowed : C -> C -> Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed]
+    (hPairClosed :
+      ∀ {x y : C}, π.expose x = π.expose y ->
+        x ∈ U.components ∧ y ∈ U.components) :
+    ArchitectureSignatureV1.axisAvailableAndZero
+        (v1OfFiniteWithRequiredLawAxes G π GA O U.components
+          boundaryAllowed abstractionAllowed)
+        .lspViolationCount ↔
+      NoLSPObstruction π O := by
+  constructor
+  · intro hAxis
+    have hZero : lspViolationCount π O U.components = 0 := by
+      unfold ArchitectureSignatureV1.axisAvailableAndZero at hAxis
+      simpa [ArchitectureSignatureV1.axisValue,
+        v1OfFiniteWithRequiredLawAxes, AvailableAndZero] using hAxis
+    exact lspCompatible_iff_noLSPObstruction.mp
+      (lspCompatible_of_lspViolationCount_eq_zero hPairClosed hZero)
+  · intro hNoObstruction
+    have hLSP : LSPCompatible π O :=
+      lspCompatible_iff_noLSPObstruction.mpr hNoObstruction
+    have hZero : lspViolationCount π O U.components = 0 :=
+      lspViolationCount_eq_zero_of_lspCompatible U.components hLSP
+    unfold ArchitectureSignatureV1.axisAvailableAndZero
+    simp [ArchitectureSignatureV1.axisValue, v1OfFiniteWithRequiredLawAxes,
+      AvailableAndZero, hZero]
+
 /-- The witness subfamily represented by each Signature v1 axis. -/
 def architectureWitnessForAxis :
     ArchitectureSignatureV1Axis -> ArchitectureRequiredLawWitness -> Prop

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -394,8 +394,15 @@ theorem を置き換えず、追加の axis または派生評価として接続
   `effectRoundtripLawful_iff_noEffectRoundtripObstruction`,
   `effectCompensationLawful_iff_noEffectCompensationObstruction`,
   [Issue #193](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/193)
+- `proved`: concrete required-law Signature entry point 上で、
+  `.projectionSoundnessViolation` と `.lspViolationCount` の available-and-zero を
+  それぞれ `NoProjectionObstruction` / `NoLSPObstruction` へ接続する direct axis
+  exactness theorem,
+  `projectionSoundnessViolation_axisExact`,
+  `lspViolationCount_axisExact`,
+  [Issue #209](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/209)
 - `future proof obligation`: required Signature axis の abstract bridge を具体的な
-  projection / LSP / walk / nilpotence witness family に接続する定理。
+  walk / policy / nilpotence witness family に接続する残りの theorem。
   特に `nilpotencyIndex` は `some k` として最初の zero adjacency power を返す
   executable index であり、`RequiredAxesAvailableAndZero` の zero-axis として読むには
   別途 axis interpretation / exactness theorem が必要である。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -265,6 +265,8 @@ File: `Formal/Arch/SignatureLawfulness.lean`
 | `ArchitectureSignature.ArchitectureLawModel.signatureOf` | `def` | selected required law axes を concrete count で埋めた `ArchitectureSignatureV1`。 | `defined only` |
 | `ArchitectureSignature.ArchitectureLawful` | `def` | `WalkAcyclic`, `ProjectionSound`, `LSPCompatible`, boundary policy soundness, abstraction policy soundness の統合 lawfulness。 | `defined only` |
 | `ArchitectureSignature.RequiredSignatureAxesAvailableAndZero` | `def` | selected required Signature axes がすべて `some 0` であること。 | `defined only` |
+| `ArchitectureSignature.projectionSoundnessViolation_axisExact` | `theorem` | `v1OfFiniteWithRequiredLawAxes` の projection axis available-and-zero と `NoProjectionObstruction` を、finite edge coverage の下で接続する。 | `proved` |
+| `ArchitectureSignature.lspViolationCount_axisExact` | `theorem` | `v1OfFiniteWithRequiredLawAxes` の LSP axis available-and-zero と `NoLSPObstruction` を、same-abstraction pair coverage の下で接続する。 | `proved` |
 | `ArchitectureSignature.architectureLawFamily` | `def` | selected required Signature axes 用の concrete `LawFamily`。 | `defined only` |
 | `ArchitectureSignature.architectureLawFamily_completeCoverage` | `theorem` | concrete law family の measured witness list が required witness universe と一致する。 | `proved` |
 | `ArchitectureSignature.architecture_requiredAxisFamilyExact` | `theorem` | selected required axes ごとに concrete `axisValue` と obstruction witness 不在が同値であること。 | `proved` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -70,17 +70,19 @@ Lean で証明済みである
 具体的な `ProjectionSound` / `LSPCompatible` / `WalkAcyclic` /
 `LocalReplacementContract` / finite diagram law family についても、それぞれの
 lawfulness predicate と obstruction witness 不在を接続する exactness bridge は
-Lean で証明済みである。残る中心的な `future proof obligation` は、required
-`ArchitectureSignature` axis の抽象 bridge を具体 law family の axis valuation へ
-接続する theorem である。
+Lean で証明済みである。Signature 側では、selected required axes を concrete
+count で埋める `v1OfFiniteWithRequiredLawAxes` と concrete law family の統合 bridge
+に加え、projection / LSP の direct axis exactness も Lean で証明済みである
+([Issue #209](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/209))。
 
 したがって、現時点で Lean proved と呼べるのは、アーキテクチャ零曲率定理の
 structural core である。抽象 `LawFamily`、complete witness coverage、
 required axis exactness を前提に、`Lawful` と
-`RequiredAxesAvailableAndZero` を接続する bridge は証明済みである。一方、
-`ArchitectureSignatureV1.axisValue` を projection / LSP / walk / policy などの
-具体 law family valuation へ接続する theorem は、まだ `future proof obligation`
-として残る。
+`RequiredAxesAvailableAndZero` を接続する bridge は証明済みである。さらに
+`ArchitectureSignatureV1.axisValue` のうち projection / LSP の concrete axis は、
+`NoProjectionObstruction` / `NoLSPObstruction` へ直接接続済みである。一方、
+hasCycle や boundary / abstraction policy の direct axis theorem、および
+final theorem の scope 整理は個別 Issue の `future proof obligation` として残る。
 
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、
@@ -858,6 +860,18 @@ complete witness coverage と required axis exactness を構成した。最終 t
 `RequiredSignatureAxesAvailableAndZero (ArchitectureLawModel.signatureOf X)` の同値を
 証明する。`nilpotencyIndex`, runtime / empirical metrics, numerical curvature は
 required zero axis に含めず、診断軸または future bridge work として分離した。
+
+Issue [#209](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/209)
+では、projection / LSP の concrete Signature axis exactness を公開 theorem として
+追加した。`projectionSoundnessViolation_axisExact` は
+`v1OfFiniteWithRequiredLawAxes` の `.projectionSoundnessViolation` が
+available-and-zero であることと `NoProjectionObstruction` を同値にする。zero count
+から graph-level obstruction absence へ戻す向きでは `ComponentUniverse.edgeClosed`
+を使う。`lspViolationCount_axisExact` は `.lspViolationCount` と
+`NoLSPObstruction` を同値にし、zero count から pair-level obstruction absence へ
+戻す向きでは same-abstraction pair coverage を明示的に仮定する。schema-level の
+`ArchitectureSignatureV1.axisMeasurementClass` は既定分類のまま残し、concrete
+entry point 上の proved witness axis theorem と区別する。
 
 Issue [#83](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/83)
 では、v1 後半戦の子 Issue #87, #84, #85, #86 の決定を統合し、


### PR DESCRIPTION
## 概要

Closes #209

v1OfFiniteWithRequiredLawAxes が埋める projection / LSP の required axis について、available-and-zero と obstruction absence の direct exactness theorem を追加しました。schema-level の axisMeasurementClass は既定分類のまま残し、concrete entry point 上の proved theorem と区別しています。

## 証明した定理

- ArchitectureSignature.projectionSoundnessViolation_axisExact
- ArchitectureSignature.lspViolationCount_axisExact

## 編集したドキュメント

- docs/proof_obligations.md
- docs/formal/lean_theorem_index.md
- docs/formal/flatness_obstruction_lean_design.md

## 実施したテスト

- [x] lake build
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [x] axiom / admit / sorry / unsafe scan

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている