### PR TITLE
boundary / abstraction policy 軸の exactness を証明

### DIFF
--- a/Formal/Arch/SignatureLawfulness.lean
+++ b/Formal/Arch/SignatureLawfulness.lean
@@ -24,6 +24,50 @@ def PolicySound {C : Type u} (G : ArchGraph C)
     (allowed : C -> C -> Prop) : Prop :=
   ∀ {c d : C}, G.edge c d -> allowed c d
 
+/-- Boundary-policy soundness, kept separate from obstruction counting. -/
+def BoundaryPolicySound {C : Type u} (G : ArchGraph C)
+    (boundaryAllowed : C -> C -> Prop) : Prop :=
+  PolicySound G boundaryAllowed
+
+/-- Abstraction-policy soundness, kept separate from obstruction counting. -/
+def AbstractionPolicySound {C : Type u} (G : ArchGraph C)
+    (abstractionAllowed : C -> C -> Prop) : Prop :=
+  PolicySound G abstractionAllowed
+
+/-- Boundary-policy obstruction witness on one dependency pair. -/
+def BoundaryPolicyObstruction {C : Type u} (G : ArchGraph C)
+    (boundaryAllowed : C -> C -> Prop) (pair : C × C) : Prop :=
+  PolicyViolation G boundaryAllowed pair
+
+/-- Abstraction-policy obstruction witness on one dependency pair. -/
+def AbstractionPolicyObstruction {C : Type u} (G : ArchGraph C)
+    (abstractionAllowed : C -> C -> Prop) (pair : C × C) : Prop :=
+  PolicyViolation G abstractionAllowed pair
+
+theorem boundaryPolicySound_iff_no_boundaryPolicyObstruction
+    {C : Type u} {G : ArchGraph C} (boundaryAllowed : C -> C -> Prop) :
+    BoundaryPolicySound G boundaryAllowed ↔
+      ¬ ∃ pair : C × C, BoundaryPolicyObstruction G boundaryAllowed pair := by
+  constructor
+  · intro hSound hExists
+    rcases hExists with ⟨pair, hBad⟩
+    exact hBad.2 (hSound hBad.1)
+  · intro hNoObstruction c d hEdge
+    by_contra hNotAllowed
+    exact hNoObstruction ⟨(c, d), hEdge, hNotAllowed⟩
+
+theorem abstractionPolicySound_iff_no_abstractionPolicyObstruction
+    {C : Type u} {G : ArchGraph C} (abstractionAllowed : C -> C -> Prop) :
+    AbstractionPolicySound G abstractionAllowed ↔
+      ¬ ∃ pair : C × C, AbstractionPolicyObstruction G abstractionAllowed pair := by
+  constructor
+  · intro hSound hExists
+    rcases hExists with ⟨pair, hBad⟩
+    exact hBad.2 (hSound hBad.1)
+  · intro hNoObstruction c d hEdge
+    by_contra hNotAllowed
+    exact hNoObstruction ⟨(c, d), hEdge, hNotAllowed⟩
+
 /-- The five concrete required-law witnesses represented by Signature v1 axes. -/
 inductive ArchitectureRequiredLawWitness where
   | hasCycle
@@ -502,6 +546,100 @@ private theorem policyViolationCount_eq_zero_iff_no_obstruction
       (violationCount_eq_zero_iff_forall_not_bad).mpr hNoBad
     simpa [violationCount, violatingWitnesses, countWhere, PolicyViolation]
       using hZero
+
+theorem boundaryViolationCountOfFinite_eq_zero_iff_no_boundaryPolicyObstruction
+    {C : Type u} {G : ArchGraph C} [DecidableRel G.edge]
+    (U : ComponentUniverse G) (boundaryAllowed : C -> C -> Prop)
+    [DecidableRel boundaryAllowed] :
+    boundaryViolationCountOfFinite G U.components boundaryAllowed = 0 ↔
+      ¬ ∃ pair : C × C,
+        BoundaryPolicyObstruction G boundaryAllowed pair := by
+  simpa [boundaryViolationCountOfFinite, BoundaryPolicyObstruction]
+    using policyViolationCount_eq_zero_iff_no_obstruction U boundaryAllowed
+
+theorem abstractionViolationCountOfFinite_eq_zero_iff_no_abstractionPolicyObstruction
+    {C : Type u} {G : ArchGraph C} [DecidableRel G.edge]
+    (U : ComponentUniverse G) (abstractionAllowed : C -> C -> Prop)
+    [DecidableRel abstractionAllowed] :
+    abstractionViolationCountOfFinite G U.components abstractionAllowed = 0 ↔
+      ¬ ∃ pair : C × C,
+        AbstractionPolicyObstruction G abstractionAllowed pair := by
+  simpa [abstractionViolationCountOfFinite, AbstractionPolicyObstruction]
+    using policyViolationCount_eq_zero_iff_no_obstruction U abstractionAllowed
+
+theorem boundaryViolation_axisExact
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (U : ComponentUniverse G)
+    (boundaryAllowed abstractionAllowed : C -> C -> Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisAvailableAndZero
+        (v1OfFiniteWithRequiredLawAxes G π GA O U.components
+          boundaryAllowed abstractionAllowed)
+        .boundaryViolationCount ↔
+      BoundaryPolicySound G boundaryAllowed := by
+  constructor
+  · intro hAxis
+    have hZero :
+        boundaryViolationCountOfFinite G U.components boundaryAllowed = 0 := by
+      unfold ArchitectureSignatureV1.axisAvailableAndZero at hAxis
+      simpa [ArchitectureSignatureV1.axisValue, v1OfFiniteWithRequiredLawAxes,
+        v1CoreOfFinite, v0OfFinite, AvailableAndZero] using hAxis
+    change PolicySound G boundaryAllowed
+    exact (boundaryPolicySound_iff_no_boundaryPolicyObstruction
+      (G := G) boundaryAllowed).mpr
+        ((boundaryViolationCountOfFinite_eq_zero_iff_no_boundaryPolicyObstruction
+          U boundaryAllowed).mp hZero)
+  · intro hSound
+    have hZero :
+        boundaryViolationCountOfFinite G U.components boundaryAllowed = 0 :=
+      (boundaryViolationCountOfFinite_eq_zero_iff_no_boundaryPolicyObstruction
+        U boundaryAllowed).mpr
+        ((boundaryPolicySound_iff_no_boundaryPolicyObstruction
+          (G := G) boundaryAllowed).mp hSound)
+    unfold ArchitectureSignatureV1.axisAvailableAndZero
+    simp [ArchitectureSignatureV1.axisValue, v1OfFiniteWithRequiredLawAxes,
+      v1CoreOfFinite, v0OfFinite, AvailableAndZero, hZero]
+
+theorem abstractionViolation_axisExact
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (G : ArchGraph C) (π : InterfaceProjection C A) (GA : AbstractGraph A)
+    (O : Observation C Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel G.edge] [DecidableRel GA.edge]
+    (U : ComponentUniverse G)
+    (boundaryAllowed abstractionAllowed : C -> C -> Prop)
+    [DecidableRel boundaryAllowed] [DecidableRel abstractionAllowed] :
+    ArchitectureSignatureV1.axisAvailableAndZero
+        (v1OfFiniteWithRequiredLawAxes G π GA O U.components
+          boundaryAllowed abstractionAllowed)
+        .abstractionViolationCount ↔
+      AbstractionPolicySound G abstractionAllowed := by
+  constructor
+  · intro hAxis
+    have hZero :
+        abstractionViolationCountOfFinite G U.components abstractionAllowed = 0 := by
+      unfold ArchitectureSignatureV1.axisAvailableAndZero at hAxis
+      simpa [ArchitectureSignatureV1.axisValue, v1OfFiniteWithRequiredLawAxes,
+        v1CoreOfFinite, v0OfFinite, AvailableAndZero] using hAxis
+    change PolicySound G abstractionAllowed
+    exact (abstractionPolicySound_iff_no_abstractionPolicyObstruction
+      (G := G) abstractionAllowed).mpr
+        ((abstractionViolationCountOfFinite_eq_zero_iff_no_abstractionPolicyObstruction
+          U abstractionAllowed).mp hZero)
+  · intro hSound
+    have hZero :
+        abstractionViolationCountOfFinite G U.components abstractionAllowed = 0 :=
+      (abstractionViolationCountOfFinite_eq_zero_iff_no_abstractionPolicyObstruction
+        U abstractionAllowed).mpr
+        ((abstractionPolicySound_iff_no_abstractionPolicyObstruction
+          (G := G) abstractionAllowed).mp hSound)
+    unfold ArchitectureSignatureV1.axisAvailableAndZero
+    simp [ArchitectureSignatureV1.axisValue, v1OfFiniteWithRequiredLawAxes,
+      v1CoreOfFinite, v0OfFinite, AvailableAndZero, hZero]
 
 private theorem availableAndZero_boundary_iff_no_obstruction
     {C : Type u} {A : Type v} {Obs : Type w}

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -401,8 +401,21 @@ theorem を置き換えず、追加の axis または派生評価として接続
   `projectionSoundnessViolation_axisExact`,
   `lspViolationCount_axisExact`,
   [Issue #209](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/209)
+- `proved`: concrete required-law Signature entry point 上で、`.hasCycle` の
+  available-and-zero を `WalkAcyclic` および closed-walk obstruction witness 不在へ
+  接続する direct axis exactness theorem,
+  `hasCycle_axisExact`,
+  `hasCycle_axisExact_no_closedWalkObstruction`,
+  [Issue #210](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/210)
+- `proved`: concrete required-law Signature entry point 上で、
+  `.boundaryViolationCount` と `.abstractionViolationCount` の available-and-zero を
+  それぞれ `BoundaryPolicySound` / `AbstractionPolicySound` へ接続する direct axis
+  exactness theorem,
+  `boundaryViolation_axisExact`,
+  `abstractionViolation_axisExact`,
+  [Issue #211](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/211)
 - `future proof obligation`: required Signature axis の abstract bridge を具体的な
-  walk / policy / nilpotence witness family に接続する残りの theorem。
+  nilpotence witness family や追加 law family に接続する残りの theorem。
   特に `nilpotencyIndex` は `some k` として最初の zero adjacency power を返す
   executable index であり、`RequiredAxesAvailableAndZero` の zero-axis として読むには
   別途 axis interpretation / exactness theorem が必要である。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -260,6 +260,12 @@ File: `Formal/Arch/SignatureLawfulness.lean`
 | --- | --- | --- | --- |
 | `ArchitectureSignature.PolicyViolation` | `def` | boundary / abstraction policy に反する依存 pair。 | `defined only` |
 | `ArchitectureSignature.PolicySound` | `def` | graph edge が指定 policy をすべて満たすこと。 | `defined only` |
+| `ArchitectureSignature.BoundaryPolicySound` | `def` | boundary policy が graph edge をすべて許可すること。 | `defined only` |
+| `ArchitectureSignature.AbstractionPolicySound` | `def` | abstraction policy が graph edge をすべて許可すること。 | `defined only` |
+| `ArchitectureSignature.BoundaryPolicyObstruction` | `def` | boundary policy に反する dependency pair witness。 | `defined only` |
+| `ArchitectureSignature.AbstractionPolicyObstruction` | `def` | abstraction policy に反する dependency pair witness。 | `defined only` |
+| `ArchitectureSignature.boundaryPolicySound_iff_no_boundaryPolicyObstruction` | `theorem` | boundary policy soundness と boundary obstruction witness 不在を接続する。 | `proved` |
+| `ArchitectureSignature.abstractionPolicySound_iff_no_abstractionPolicyObstruction` | `theorem` | abstraction policy soundness と abstraction obstruction witness 不在を接続する。 | `proved` |
 | `ArchitectureSignature.ArchitectureRequiredLawWitness` | `inductive` | selected required Signature axes に対応する concrete witness family。 | `defined only` |
 | `ArchitectureSignature.ArchitectureLawModel` | `structure` | graph, projection, observation, finite universe, policy, LSP pair coverage を束ねる Signature-integrated law model。 | `defined only` |
 | `ArchitectureSignature.ArchitectureLawModel.signatureOf` | `def` | selected required law axes を concrete count で埋めた `ArchitectureSignatureV1`。 | `defined only` |
@@ -269,6 +275,10 @@ File: `Formal/Arch/SignatureLawfulness.lean`
 | `ArchitectureSignature.hasCycle_axisExact_no_closedWalkObstruction` | `theorem` | hasCycle axis available-and-zero と closed-walk obstruction witness 不在を接続する。 | `proved` |
 | `ArchitectureSignature.projectionSoundnessViolation_axisExact` | `theorem` | `v1OfFiniteWithRequiredLawAxes` の projection axis available-and-zero と `NoProjectionObstruction` を、finite edge coverage の下で接続する。 | `proved` |
 | `ArchitectureSignature.lspViolationCount_axisExact` | `theorem` | `v1OfFiniteWithRequiredLawAxes` の LSP axis available-and-zero と `NoLSPObstruction` を、same-abstraction pair coverage の下で接続する。 | `proved` |
+| `ArchitectureSignature.boundaryViolationCountOfFinite_eq_zero_iff_no_boundaryPolicyObstruction` | `theorem` | boundary violation count が 0 であることと boundary obstruction witness 不在を接続する。 | `proved` |
+| `ArchitectureSignature.abstractionViolationCountOfFinite_eq_zero_iff_no_abstractionPolicyObstruction` | `theorem` | abstraction violation count が 0 であることと abstraction obstruction witness 不在を接続する。 | `proved` |
+| `ArchitectureSignature.boundaryViolation_axisExact` | `theorem` | `v1OfFiniteWithRequiredLawAxes` の boundary axis available-and-zero と `BoundaryPolicySound` を、finite edge coverage の下で接続する。 | `proved` |
+| `ArchitectureSignature.abstractionViolation_axisExact` | `theorem` | `v1OfFiniteWithRequiredLawAxes` の abstraction axis available-and-zero と `AbstractionPolicySound` を、finite edge coverage の下で接続する。 | `proved` |
 | `ArchitectureSignature.architectureLawFamily` | `def` | selected required Signature axes 用の concrete `LawFamily`。 | `defined only` |
 | `ArchitectureSignature.architectureLawFamily_completeCoverage` | `theorem` | concrete law family の measured witness list が required witness universe と一致する。 | `proved` |
 | `ArchitectureSignature.architecture_requiredAxisFamilyExact` | `theorem` | selected required axes ごとに concrete `axisValue` と obstruction witness 不在が同値であること。 | `proved` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -886,6 +886,21 @@ Issue [#210](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2
 obstruction witness absence に接続する。`nilpotencyIndex` は引き続き required
 zero axis ではなく、matrix bridge 由来の diagnostic / extension axis として扱う。
 
+Issue [#211](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/211)
+では、boundary / abstraction policy の concrete Signature axis exactness を公開
+theorem として追加した。Lean では `BoundaryPolicySound` /
+`AbstractionPolicySound` を policy soundness predicate として定義し、
+`BoundaryPolicyObstruction` / `AbstractionPolicyObstruction` を有限
+component-pair witness 上の obstruction predicate として定義した。
+`boundaryViolationCountOfFinite_eq_zero_iff_no_boundaryPolicyObstruction` と
+`abstractionViolationCountOfFinite_eq_zero_iff_no_abstractionPolicyObstruction`
+は、それぞれ executable count が 0 であることと obstruction witness 不在を同値に
+する。`boundaryViolation_axisExact` と `abstractionViolation_axisExact` は
+`v1OfFiniteWithRequiredLawAxes` の required policy axis が available-and-zero で
+あることを、それぞれ `BoundaryPolicySound` / `AbstractionPolicySound` と同値に
+する。zero count から graph-level policy soundness へ戻す向きでは
+`ComponentUniverse.edgeClosed` による有限測定 universe coverage を使う。
+
 Issue [#83](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/83)
 では、v1 後半戦の子 Issue #87, #84, #85, #86 の決定を統合し、
 v0 互換軸、Lean core、matrix bridge、runtime / empirical extension の責務境界を


### PR DESCRIPTION
## 概要

Closes #211

boundary / abstraction policy axis について、executable count、obstruction witness 不在、policy soundness を接続する公開 theorem を追加しました。

## 証明した定理

- `ArchitectureSignature.boundaryPolicySound_iff_no_boundaryPolicyObstruction`
- `ArchitectureSignature.abstractionPolicySound_iff_no_abstractionPolicyObstruction`
- `ArchitectureSignature.boundaryViolationCountOfFinite_eq_zero_iff_no_boundaryPolicyObstruction`
- `ArchitectureSignature.abstractionViolationCountOfFinite_eq_zero_iff_no_abstractionPolicyObstruction`
- `ArchitectureSignature.boundaryViolation_axisExact`
- `ArchitectureSignature.abstractionViolation_axisExact`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/SignatureLawfulness.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
