### PR TITLE
LocalReplacement と state-effect の零曲率 bridge を追加

### DIFF
--- a/Formal/Arch/SignatureLawfulness.lean
+++ b/Formal/Arch/SignatureLawfulness.lean
@@ -1,4 +1,5 @@
 import Formal.Arch.DependencyObstruction
+import Formal.Arch.LocalReplacement
 
 namespace Formal.Arch
 
@@ -956,6 +957,71 @@ theorem architectureLawful_iff_requiredSignatureAxesZero
     ArchitectureLawful X ↔
       RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X) := by
   exact architectureLawful_iff_requiredSignatureAxesAvailableAndZero X
+
+/--
+A local replacement contract is a derived corollary for the selected
+projection and LSP Signature axes.
+-/
+theorem localReplacementContract_requiredSignatureProjectionLSPAxes
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed]
+    (hLocal : LocalReplacementContract X.G X.π X.GA X.O) :
+    ArchitectureSignatureV1.axisAvailableAndZero
+        (ArchitectureLawModel.signatureOf X)
+        .projectionSoundnessViolation ∧
+      ArchitectureSignatureV1.axisAvailableAndZero
+        (ArchitectureLawModel.signatureOf X)
+        .lspViolationCount := by
+  have hNoObstruction :
+      NoProjectionObstruction X.G X.π X.GA ∧ NoLSPObstruction X.π X.O :=
+    noProjectionObstruction_and_noLSPObstruction_of_localReplacementContract
+      hLocal
+  constructor
+  · exact (projectionSoundnessViolation_axisExact X.G X.π X.GA X.O X.U
+      X.boundaryAllowed X.abstractionAllowed).mpr hNoObstruction.1
+  · exact (lspViolationCount_axisExact X.G X.π X.GA X.O X.U
+      X.boundaryAllowed X.abstractionAllowed X.lspPairClosed).mpr
+      hNoObstruction.2
+
+/--
+Local replacement supplies the projection and LSP parts of `ArchitectureLawful`;
+the remaining static laws are the closed-walk and policy conditions.
+-/
+theorem architectureLawful_of_localReplacementContract
+    {C : Type u} {A : Type v} {Obs : Type w}
+    {X : ArchitectureLawModel C A Obs}
+    (hWalk : WalkAcyclic X.G)
+    (hLocal : LocalReplacementContract X.G X.π X.GA X.O)
+    (hBoundary : BoundaryPolicySound X.G X.boundaryAllowed)
+    (hAbstraction : AbstractionPolicySound X.G X.abstractionAllowed) :
+    ArchitectureLawful X := by
+  exact ⟨hWalk, projectionSound_of_localReplacementContract hLocal,
+    lspCompatible_of_observationFactorsThrough
+      (observationFactorsThrough_of_localReplacementContract hLocal),
+    hBoundary, hAbstraction⟩
+
+/--
+Derived zero-curvature bridge: a local replacement contract, closed-walk
+acyclicity, and the two policy laws imply that all selected required Signature
+axes are zero.
+-/
+theorem requiredSignatureAxesZero_of_localReplacementContract
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed]
+    (hWalk : WalkAcyclic X.G)
+    (hLocal : LocalReplacementContract X.G X.π X.GA X.O)
+    (hBoundary : BoundaryPolicySound X.G X.boundaryAllowed)
+    (hAbstraction : AbstractionPolicySound X.G X.abstractionAllowed) :
+    RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X) := by
+  exact (architectureLawful_iff_requiredSignatureAxesZero X).mp
+    (architectureLawful_of_localReplacementContract hWalk hLocal hBoundary
+      hAbstraction)
 
 end ArchitectureSignature
 

--- a/Formal/Arch/StateEffect.lean
+++ b/Formal/Arch/StateEffect.lean
@@ -316,4 +316,99 @@ theorem effectCompensationLawful_iff_noEffectCompensationObstruction
     EffectCompensationLawful sem cases ↔ NoEffectCompensationObstruction sem cases := by
   exact diagramLawfulByList_iff_noDiagramObstructionByList
 
+/--
+Aggregate lawfulness for the finite state-transition replay, roundtrip, and
+compensation law family.
+-/
+def StateTransitionLawFamilyLawful {State : Type u} {Event : Type v} {Obs : Type w}
+    (sem : Semantics (StateTransitionExpr State Event) Obs)
+    (replayCases : List (StateReplayCase State Event))
+    (roundtripCases : List (StateRoundtripCase State Event))
+    (compensationCases : List (StateCompensationCase State Event)) : Prop :=
+  StateReplayLawful sem replayCases ∧
+  StateRoundtripLawful sem roundtripCases ∧
+  StateCompensationLawful sem compensationCases
+
+/-- No obstruction witness exists for the aggregate state-transition law family. -/
+def NoStateTransitionLawFamilyObstruction {State : Type u} {Event : Type v} {Obs : Type w}
+    (sem : Semantics (StateTransitionExpr State Event) Obs)
+    (replayCases : List (StateReplayCase State Event))
+    (roundtripCases : List (StateRoundtripCase State Event))
+    (compensationCases : List (StateCompensationCase State Event)) : Prop :=
+  NoStateReplayObstruction sem replayCases ∧
+  NoStateRoundtripObstruction sem roundtripCases ∧
+  NoStateCompensationObstruction sem compensationCases
+
+/--
+The aggregate state-transition law family is lawful exactly when the replay,
+roundtrip, and compensation obstruction families are all absent.
+-/
+theorem stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction
+    {State : Type u} {Event : Type v} {Obs : Type w}
+    {sem : Semantics (StateTransitionExpr State Event) Obs}
+    {replayCases : List (StateReplayCase State Event)}
+    {roundtripCases : List (StateRoundtripCase State Event)}
+    {compensationCases : List (StateCompensationCase State Event)} :
+    StateTransitionLawFamilyLawful sem replayCases roundtripCases compensationCases ↔
+      NoStateTransitionLawFamilyObstruction sem replayCases roundtripCases
+        compensationCases := by
+  constructor
+  · intro hLawful
+    exact ⟨stateReplayLawful_iff_noStateReplayObstruction.mp hLawful.1,
+      stateRoundtripLawful_iff_noStateRoundtripObstruction.mp hLawful.2.1,
+      stateCompensationLawful_iff_noStateCompensationObstruction.mp hLawful.2.2⟩
+  · intro hNoObstruction
+    exact ⟨stateReplayLawful_iff_noStateReplayObstruction.mpr hNoObstruction.1,
+      stateRoundtripLawful_iff_noStateRoundtripObstruction.mpr hNoObstruction.2.1,
+      stateCompensationLawful_iff_noStateCompensationObstruction.mpr
+        hNoObstruction.2.2⟩
+
+/--
+Aggregate lawfulness for the finite effect-boundary replay, roundtrip, and
+compensation law family.
+-/
+def EffectBoundaryLawFamilyLawful {Effect : Type u} {Boundary : Type v} {Obs : Type w}
+    (sem : Semantics (EffectBoundaryExpr Effect Boundary) Obs)
+    (replayCases : List (EffectReplayCase Effect Boundary))
+    (roundtripCases : List (EffectRoundtripCase Effect Boundary))
+    (compensationCases : List (EffectCompensationCase Effect Boundary)) : Prop :=
+  EffectReplayLawful sem replayCases ∧
+  EffectRoundtripLawful sem roundtripCases ∧
+  EffectCompensationLawful sem compensationCases
+
+/-- No obstruction witness exists for the aggregate effect-boundary law family. -/
+def NoEffectBoundaryLawFamilyObstruction {Effect : Type u} {Boundary : Type v}
+    {Obs : Type w}
+    (sem : Semantics (EffectBoundaryExpr Effect Boundary) Obs)
+    (replayCases : List (EffectReplayCase Effect Boundary))
+    (roundtripCases : List (EffectRoundtripCase Effect Boundary))
+    (compensationCases : List (EffectCompensationCase Effect Boundary)) : Prop :=
+  NoEffectReplayObstruction sem replayCases ∧
+  NoEffectRoundtripObstruction sem roundtripCases ∧
+  NoEffectCompensationObstruction sem compensationCases
+
+/--
+The aggregate effect-boundary law family is lawful exactly when the replay,
+roundtrip, and compensation obstruction families are all absent.
+-/
+theorem effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction
+    {Effect : Type u} {Boundary : Type v} {Obs : Type w}
+    {sem : Semantics (EffectBoundaryExpr Effect Boundary) Obs}
+    {replayCases : List (EffectReplayCase Effect Boundary)}
+    {roundtripCases : List (EffectRoundtripCase Effect Boundary)}
+    {compensationCases : List (EffectCompensationCase Effect Boundary)} :
+    EffectBoundaryLawFamilyLawful sem replayCases roundtripCases compensationCases ↔
+      NoEffectBoundaryLawFamilyObstruction sem replayCases roundtripCases
+        compensationCases := by
+  constructor
+  · intro hLawful
+    exact ⟨effectReplayLawful_iff_noEffectReplayObstruction.mp hLawful.1,
+      effectRoundtripLawful_iff_noEffectRoundtripObstruction.mp hLawful.2.1,
+      effectCompensationLawful_iff_noEffectCompensationObstruction.mp hLawful.2.2⟩
+  · intro hNoObstruction
+    exact ⟨effectReplayLawful_iff_noEffectReplayObstruction.mpr hNoObstruction.1,
+      effectRoundtripLawful_iff_noEffectRoundtripObstruction.mpr hNoObstruction.2.1,
+      effectCompensationLawful_iff_noEffectCompensationObstruction.mpr
+        hNoObstruction.2.2⟩
+
 end Formal.Arch

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -415,6 +415,15 @@ theorem を置き換えず、追加の axis または派生評価として接続
   `effectRoundtripLawful_iff_noEffectRoundtripObstruction`,
   `effectCompensationLawful_iff_noEffectCompensationObstruction`,
   [Issue #193](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/193)
+- `proved`: LocalReplacement を required law に追加せず derived corollary として
+  selected required Signature axes および final zero-curvature theorem に接続する
+  bridge, および state-effect diagram laws を aggregate package と obstruction absence
+  の同値として束ねる bridge,
+  `localReplacementContract_requiredSignatureProjectionLSPAxes`,
+  `requiredSignatureAxesZero_of_localReplacementContract`,
+  `stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction`,
+  `effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction`,
+  [Issue #223](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/223)
 - `proved`: concrete required-law Signature entry point 上で、
   `.projectionSoundnessViolation` と `.lspViolationCount` の available-and-zero を
   それぞれ `NoProjectionObstruction` / `NoLSPObstruction` へ接続する direct axis
@@ -441,7 +450,8 @@ theorem を置き換えず、追加の axis または派生評価として接続
   `architectureLawCandidateRole_requiredLaw_iff` で証明した,
   [Issue #222](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/222)。
 - `future proof obligation`: full law universe policy に従い、derived corollary /
-  diagnostic axis を theorem index へ接続する残りの theorem。特に
+  diagnostic axis を theorem index へ接続する残りの theorem。LocalReplacement /
+  state-effect laws の derived corollary bridge は #223 で証明済みであり、特に
   `nilpotencyIndex` は `some k` として最初の zero adjacency power を返す
   executable index であり、`RequiredAxesAvailableAndZero` の zero-axis ではない。
 - `defined only`: witness family をまとめる signature schema と

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -299,6 +299,9 @@ File: `Formal/Arch/SignatureLawfulness.lean`
 | `ArchitectureSignature.architecture_requiredAxisExact` | `theorem` | concrete law family で required axis 全体の available-and-zero と required obstruction 不在を接続する。 | `proved` |
 | `ArchitectureSignature.architectureLawful_iff_requiredSignatureAxesAvailableAndZero` | `theorem` | selected required Signature axes について、`ArchitectureLawful X` と `RequiredSignatureAxesAvailableAndZero (signatureOf X)` を接続する final Signature-integrated zero-curvature theorem。 | `proved` |
 | `ArchitectureSignature.architectureLawful_iff_requiredSignatureAxesZero` | `theorem` | selected required Signature axes について、`ArchitectureLawful X` と `RequiredSignatureAxesZero (signatureOf X)` を接続する final Signature-integrated zero-curvature theorem。 | `proved` |
+| `ArchitectureSignature.localReplacementContract_requiredSignatureProjectionLSPAxes` | `theorem` | `LocalReplacementContract` から selected required Signature axes の projection / LSP が available-and-zero であることを得る derived corollary bridge。 | `proved` |
+| `ArchitectureSignature.architectureLawful_of_localReplacementContract` | `theorem` | closed-walk acyclicity、`LocalReplacementContract`、boundary / abstraction policy soundness から `ArchitectureLawful X` を得る。 | `proved` |
+| `ArchitectureSignature.requiredSignatureAxesZero_of_localReplacementContract` | `theorem` | closed-walk acyclicity、`LocalReplacementContract`、boundary / abstraction policy soundness から `RequiredSignatureAxesZero (signatureOf X)` を得る derived zero-curvature bridge。 | `proved` |
 
 ## State Transition / Effect Boundary Laws
 
@@ -332,6 +335,12 @@ File: `Formal/Arch/StateEffect.lean`
 | `effectReplayLawful_iff_noEffectReplayObstruction` | `theorem` | effect-boundary replay lawfulness と obstruction witness 不在の同値。 | `proved` |
 | `effectRoundtripLawful_iff_noEffectRoundtripObstruction` | `theorem` | effect-boundary roundtrip lawfulness と obstruction witness 不在の同値。 | `proved` |
 | `effectCompensationLawful_iff_noEffectCompensationObstruction` | `theorem` | effect-boundary compensation lawfulness と obstruction witness 不在の同値。 | `proved` |
+| `StateTransitionLawFamilyLawful` | `def` | 状態遷移 replay / roundtrip / compensation law family の aggregate lawfulness。 | `defined only` |
+| `NoStateTransitionLawFamilyObstruction` | `def` | 状態遷移 replay / roundtrip / compensation law family の aggregate obstruction absence。 | `defined only` |
+| `stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction` | `theorem` | 状態遷移 law family package の lawfulness と obstruction absence を接続する。 | `proved` |
+| `EffectBoundaryLawFamilyLawful` | `def` | effect-boundary replay / roundtrip / compensation law family の aggregate lawfulness。 | `defined only` |
+| `NoEffectBoundaryLawFamilyObstruction` | `def` | effect-boundary replay / roundtrip / compensation law family の aggregate obstruction absence。 | `defined only` |
+| `effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction` | `theorem` | effect-boundary law family package の lawfulness と obstruction absence を接続する。 | `proved` |
 
 ## Signature v0
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -120,6 +120,21 @@ evidence の境界は
 [#226](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/226) で
 full theorem packaging と theorem index を完成する。
 
+Issue [#223](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/223)
+では、#222 の policy に従い、LocalReplacement と state-effect laws を required
+zero-axis へ追加せず derived corollary として theorem 群へ接続した。Lean では
+`localReplacementContract_requiredSignatureProjectionLSPAxes` により
+`LocalReplacementContract` から selected required Signature axes の projection /
+LSP が available-and-zero であることを得る。また
+`requiredSignatureAxesZero_of_localReplacementContract` により、closed-walk
+acyclicity と boundary / abstraction policy soundness を追加すれば
+`RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X)` が従う。
+state-effect 側は `StateTransitionLawFamilyLawful` と
+`EffectBoundaryLawFamilyLawful` を aggregate package とし、それぞれの obstruction
+absence との同値を
+`stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction` と
+`effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction` で証明した。
+
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、
 それだけでは中心定理の証明とは呼ばない。強い Lean proof は、
@@ -152,6 +167,16 @@ diagram constructors は `defined only`、各 replay / roundtrip / compensation 
 `DiagramLawful <-> NoDiagramObstruction` bridge は `proved` である。これは required
 diagram family の受け皿であり、実コードベース抽出器の完全性、観測値上の距離、
 重み、半環、数値 curvature metric は主張しない。
+
+Issue [#223](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/223)
+では、この state-effect API を aggregate law-family package として束ねる
+`StateTransitionLawFamilyLawful`,
+`NoStateTransitionLawFamilyObstruction`,
+`EffectBoundaryLawFamilyLawful`,
+`NoEffectBoundaryLawFamilyObstruction` を追加した。Lean status は `defined only` /
+`proved` で、aggregate package と obstruction absence の同値は
+`stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction` と
+`effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction` で証明済みである。
 
 Issue [#194](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/194)
 では、数値的 curvature metric と empirical hypothesis を Lean proved core から


### PR DESCRIPTION
## 概要

Closes #223

#222 の full law universe policy に従い、LocalReplacement / state-effect laws を required zero-axis へ追加せず、derived corollary として theorem 群へ接続しました。

## 証明した定理

- `ArchitectureSignature.localReplacementContract_requiredSignatureProjectionLSPAxes`
- `ArchitectureSignature.architectureLawful_of_localReplacementContract`
- `ArchitectureSignature.requiredSignatureAxesZero_of_localReplacementContract`
- `stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction`
- `effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`
- `docs/formal/flatness_obstruction_lean_design.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
