### PR TITLE
runtime / empirical 軸の零曲率境界を文書化する

### DIFF
--- a/docs/design/runtime_propagation_design.md
+++ b/docs/design/runtime_propagation_design.md
@@ -63,6 +63,31 @@ Lean 側では
 `none` は未評価を意味し、runtime risk 0 ではない。`some 0` は、測定済みの runtime
 graph において runtime edge の到達範囲が空であることを表す。
 
+## required-law 境界
+
+全体零曲率理論では、runtime / empirical 系の軸を selected required law axis へ
+追加しない。Lean 側の full law universe policy では `runtimePropagation` は
+`diagnosticAxis`、`relationComplexity` と `empiricalChangeCost` は `empiricalAxis`
+である。したがって、`ArchitectureLawful` や
+`RequiredSignatureAxesZero` の成立条件として `runtimePropagation = some 0` を
+要求しない。
+
+境界は次のように読む。
+
+| 対象 | zero-curvature theorem での分類 | Lean status |
+| --- | --- | --- |
+| `runtimePropagation` / `runtimeExposureRadius` | 0/1 `RuntimeDependencyGraph` 上で測定できる diagnostic axis。required zero-law axis ではない | `defined only` |
+| `runtimeBlastRadius` | reverse reachability 由来の tooling / analysis metric。Lean core field には入れない | `empirical hypothesis` |
+| `runtimeFanout` | runtime graph 上の局所集中を測る analysis-derived metric。v1 field には追加しない | `empirical hypothesis` |
+| `circuitBreakerCoverageRatio` | measured runtime pair に対する policy-aware coverage 指標 | `empirical hypothesis` |
+| `unprotectedRuntimeExposureRadius`, `unprotectedRuntimeBlastRadius` | coverage policy を反映した派生 runtime metric | `empirical hypothesis` |
+| incident scope / repair time / hotfix size との関係 | H5 empirical protocol で検証する反証可能な仮説 | `empirical hypothesis` |
+
+この分類により、runtime graph が未抽出で `runtimePropagation = none` の場合でも、
+selected required law theorem の証明義務は増えない。runtime evidence がある場合は
+diagnostic として `some n` を記録できるが、`some 0` は「測定済み 0」であって
+全体 lawfulness の追加条件ではない。
+
 ## Extractor 境界
 
 extractor / empirical tooling 側は、次の情報を保持する。

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -298,6 +298,17 @@ adjacency nilpotence、`nilpotencyIndexOfFinite X.U = some k`、および
 `spectralRadiusOfAdjacency X.U = 0` が従う。これは `nilpotencyIndex` や
 `spectralRadius` を required zero-axis に昇格するものではない。
 
+Issue [#225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225)
+では、runtime / empirical 系の境界を固定する。`runtimePropagation` は
+0/1 `RuntimeDependencyGraph` 上の outgoing exposure radius として定義済みの
+diagnostic axis であり、selected required law theorem の zero-axis ではない。
+`runtimeBlastRadius` は reverse reachability 由来の tooling / analysis metric、
+Circuit Breaker coverage とその policy-aware 派生 metric は empirical extension、
+incident scope / repair time / hotfix size との関係は empirical hypothesis として
+扱う。したがって、`ArchitectureLawful` と `RequiredSignatureAxesZero` の同値に
+`runtimePropagation = some 0` や coverage ratio 0/1 条件を追加しない。未抽出の
+`none`、測定済みの `some 0`、risk 0 の主張は常に区別する。
+
 complete coverage は単なる強い仮定として放置しない。
 有限 component universe から component pair を列挙する、有限 diagram universe から
 required diagram を列挙するなど、一部の law family では `CoversRequired` を実際に
@@ -466,6 +477,13 @@ theorem を置き換えず、追加の axis または派生評価として接続
   [Issue #224](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/224)。
   `nilpotencyIndex` は `some k` として最初の zero adjacency power を返す
   executable index であり、`RequiredAxesAvailableAndZero` の zero-axis ではない。
+- `defined only` / `empirical hypothesis`: runtime / empirical 系の required-law
+  境界を固定する。`runtimePropagation` は 0/1 `RuntimeDependencyGraph` 上の
+  exposure radius として定義済みの diagnostic axis であり、
+  `ArchitectureLawful` や `RequiredSignatureAxesZero` の required zero-axis ではない。
+  `runtimeBlastRadius`, Circuit Breaker coverage, policy-aware runtime metrics,
+  incident / repair cost との関係は tooling / empirical protocol 側に残す,
+  [Issue #225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225)。
 - `defined only`: witness family をまとめる signature schema と
   `ArchitectureSignatureV1` axis measurement classification。
 - `future design` / `empirical hypothesis`: 一般の数値 curvature metric を定義する
@@ -477,6 +495,8 @@ theorem を置き換えず、追加の axis または派生評価として接続
 
 - 任意のリスク評価が `ArchitectureSignature` を通して因子化するという完全な普遍性予想。
 - 変更波及や障害伝播が spectral mass によって支配されるという実証的主張。
+- runtime exposure / blast radius や Circuit Breaker coverage が incident scope,
+  repair time, hotfix size を支配するという実証的主張。
 - 一般の観測値に対する `Sem_A(p) - Sem_A(q)` 型の数値 curvature。
 
 これらは、必要な追加構造と empirical protocol が固まった後に、別 Issue として扱う。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -148,6 +148,18 @@ diagnostic corollaries を得る。これは `nilpotencyIndex = some k` を
 available-and-zero axis と読む主張ではなく、selected required lawfulness から
 有限 adjacency matrix diagnostics が従うという bridge である。
 
+Issue [#225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225)
+では、#222 の policy に従い、runtime / empirical 系の required-law 境界を
+明文化した。`runtimePropagation` は 0/1 `RuntimeDependencyGraph` 上の
+outgoing exposure radius として計算できる diagnostic axis であり、
+`ArchitectureLawful` や `RequiredSignatureAxesZero` の required zero-axis ではない。
+`runtimeBlastRadius` は reverse reachability 由来の tooling / analysis metric、
+Circuit Breaker coverage と `unprotectedRuntimeExposureRadius` /
+`unprotectedRuntimeBlastRadius` は policy-aware empirical extension、
+incident scope / repair time / hotfix size との関係は H5 empirical hypothesis として
+扱う。未抽出 `none`、測定済み `some 0`、risk 0 の解釈は区別し、runtime / empirical
+axis の未評価は Lean theorem packaging のブロッカーにしない。
+
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、
 それだけでは中心定理の証明とは呼ばない。強い Lean proof は、
@@ -1054,6 +1066,14 @@ Issue [#126](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1
 H5 empirical protocol として固定した。`runtimeFanout` は v1 extension axis へ追加せず、
 analysis-derived metric として dataset / analysis metadata 側に保持する。
 詳細は [runtimePropagation 設計](design/runtime_propagation_design.md) に分離する。
+
+Issue [#225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225)
+では、これらの runtime / empirical 軸が selected required law theorem の追加前提では
+ないことを再確認した。Lean theorem として扱う最小範囲は
+`runtimePropagationOfFinite` と `v1OfFiniteWithRuntimePropagation` の定義、および
+full law universe policy 上で `runtimePropagation` が `diagnosticAxis` に分類される
+ことまでである。blast radius、coverage policy、incident cost との関係は
+empirical hypothesis であり、#226 の theorem packaging をブロックしない。
 
 Issue [#62](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/62)
 では、projection bridge の最小 Lean 定義を追加した。`projectionSoundnessViolation`


### PR DESCRIPTION
## 概要

Closes #225

runtime / empirical 系の軸を selected required law theorem の追加前提にしない境界を文書化しました。`runtimePropagation` は 0/1 `RuntimeDependencyGraph` 上の diagnostic axis、`runtimeBlastRadius` / Circuit Breaker coverage / incident cost との関係は tooling / empirical hypothesis として整理しています。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/design/runtime_propagation_design.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 成功

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている