### PR TITLE
零曲率 theorem package を完成する

### DIFF
--- a/Formal/Arch/SignatureLawfulness.lean
+++ b/Formal/Arch/SignatureLawfulness.lean
@@ -1008,6 +1008,65 @@ theorem matrixDiagnosticCorollaries_of_requiredSignatureAxesZero
     ((architectureLawful_iff_requiredSignatureAxesZero X).mpr hZero)
 
 /--
+The full proved zero-curvature theorem package for the current law-universe
+policy.
+
+The package contains the final selected required-axis theorem together with the
+matrix diagnostic corollaries that follow from it. Runtime, empirical, and
+general numerical-curvature axes remain outside this proved package.
+-/
+noncomputable def ArchitectureZeroCurvatureTheoremPackage
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed] :
+    Prop :=
+  RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X) ∧
+  MatrixDiagnosticCorollaries X
+
+/--
+Selected required architecture lawfulness gives the full proved theorem package.
+-/
+theorem architectureZeroCurvatureTheoremPackage_of_architectureLawful
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed]
+    (hLawful : ArchitectureLawful X) :
+    ArchitectureZeroCurvatureTheoremPackage X := by
+  exact ⟨(architectureLawful_iff_requiredSignatureAxesZero X).mp hLawful,
+    matrixDiagnosticCorollaries_of_architectureLawful X hLawful⟩
+
+/--
+The full proved theorem package entails the selected required architecture laws.
+-/
+theorem architectureLawful_of_architectureZeroCurvatureTheoremPackage
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed]
+    (hPackage : ArchitectureZeroCurvatureTheoremPackage X) :
+    ArchitectureLawful X := by
+  exact (architectureLawful_iff_requiredSignatureAxesZero X).mpr hPackage.1
+
+/--
+Full proved zero-curvature theorem package for the current law-universe policy.
+-/
+theorem architectureLawful_iff_architectureZeroCurvatureTheoremPackage
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed] :
+    ArchitectureLawful X ↔ ArchitectureZeroCurvatureTheoremPackage X := by
+  constructor
+  · exact architectureZeroCurvatureTheoremPackage_of_architectureLawful X
+  · exact architectureLawful_of_architectureZeroCurvatureTheoremPackage X
+
+/--
 A local replacement contract is a derived corollary for the selected
 projection and LSP Signature axes.
 -/
@@ -1069,6 +1128,25 @@ theorem requiredSignatureAxesZero_of_localReplacementContract
     (hAbstraction : AbstractionPolicySound X.G X.abstractionAllowed) :
     RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X) := by
   exact (architectureLawful_iff_requiredSignatureAxesZero X).mp
+    (architectureLawful_of_localReplacementContract hWalk hLocal hBoundary
+      hAbstraction)
+
+/--
+Local replacement plus the remaining static laws gives the full proved
+zero-curvature theorem package.
+-/
+theorem architectureZeroCurvatureTheoremPackage_of_localReplacementContract
+    {C : Type u} {A : Type v} {Obs : Type w}
+    (X : ArchitectureLawModel C A Obs)
+    [DecidableEq C] [DecidableEq A] [DecidableEq Obs]
+    [DecidableRel X.G.edge] [DecidableRel X.GA.edge]
+    [DecidableRel X.boundaryAllowed] [DecidableRel X.abstractionAllowed]
+    (hWalk : WalkAcyclic X.G)
+    (hLocal : LocalReplacementContract X.G X.π X.GA X.O)
+    (hBoundary : BoundaryPolicySound X.G X.boundaryAllowed)
+    (hAbstraction : AbstractionPolicySound X.G X.abstractionAllowed) :
+    ArchitectureZeroCurvatureTheoremPackage X := by
+  exact architectureZeroCurvatureTheoremPackage_of_architectureLawful X
     (architectureLawful_of_localReplacementContract hWalk hLocal hBoundary
       hAbstraction)
 

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -309,6 +309,16 @@ incident scope / repair time / hotfix size との関係は empirical hypothesis 
 `runtimePropagation = some 0` や coverage ratio 0/1 条件を追加しない。未抽出の
 `none`、測定済みの `some 0`、risk 0 の主張は常に区別する。
 
+Issue [#226](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/226)
+では、全体 theorem package を `ArchitectureZeroCurvatureTheoremPackage` として
+追加した。この package は
+`RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X)` と
+`MatrixDiagnosticCorollaries X` を束ねる。Lean theorem
+`architectureLawful_iff_architectureZeroCurvatureTheoremPackage` は、current
+law-universe policy のもとで `ArchitectureLawful X` とこの package が同値で
+あることを示す。runtime / empirical / 一般数値 curvature は package に含めず、
+diagnostic / empirical boundary として残す。
+
 complete coverage は単なる強い仮定として放置しない。
 有限 component universe から component pair を列挙する、有限 diagram universe から
 required diagram を列挙するなど、一部の law family では `CoversRequired` を実際に
@@ -484,6 +494,13 @@ theorem を置き換えず、追加の axis または派生評価として接続
   `runtimeBlastRadius`, Circuit Breaker coverage, policy-aware runtime metrics,
   incident / repair cost との関係は tooling / empirical protocol 側に残す,
   [Issue #225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225)。
+- `defined only` / `proved`: full theorem package を
+  `ArchitectureZeroCurvatureTheoremPackage` として追加し、current law-universe
+  policy のもとで `ArchitectureLawful X` と theorem package が同値であることを
+  `architectureLawful_iff_architectureZeroCurvatureTheoremPackage` で証明した。
+  LocalReplacement から package へ進む derived bridge も
+  `architectureZeroCurvatureTheoremPackage_of_localReplacementContract` で証明済みである,
+  [Issue #226](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/226)。
 - `defined only`: witness family をまとめる signature schema と
   `ArchitectureSignatureV1` axis measurement classification。
 - `future design` / `empirical hypothesis`: 一般の数値 curvature metric を定義する

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -302,9 +302,22 @@ File: `Formal/Arch/SignatureLawfulness.lean`
 | `ArchitectureSignature.MatrixDiagnosticCorollaries` | `def` | selected required laws から導かれる matrix diagnostics を束ねる derived corollary package。adjacency nilpotence、`nilpotencyIndexOfFinite = some k`、`spectralRadiusOfAdjacency = 0` を含む。 | `defined only` |
 | `ArchitectureSignature.matrixDiagnosticCorollaries_of_architectureLawful` | `theorem` | `ArchitectureLawful X` から matrix diagnostic corollaries を得る。`nilpotencyIndex` と `spectralRadius` を required zero-axis にはしない。 | `proved` |
 | `ArchitectureSignature.matrixDiagnosticCorollaries_of_requiredSignatureAxesZero` | `theorem` | `RequiredSignatureAxesZero (signatureOf X)` から matrix diagnostic corollaries を得る #224 bridge。 | `proved` |
+| `ArchitectureSignature.ArchitectureZeroCurvatureTheoremPackage` | `def` | current law-universe policy で Lean proved と読む theorem package。selected required axes zero と matrix diagnostic corollaries を束ね、runtime / empirical / numerical curvature は含めない。 | `defined only` |
+| `ArchitectureSignature.architectureZeroCurvatureTheoremPackage_of_architectureLawful` | `theorem` | `ArchitectureLawful X` から full proved zero-curvature theorem package を得る。 | `proved` |
+| `ArchitectureSignature.architectureLawful_of_architectureZeroCurvatureTheoremPackage` | `theorem` | theorem package から selected required `ArchitectureLawful X` を戻す。 | `proved` |
+| `ArchitectureSignature.architectureLawful_iff_architectureZeroCurvatureTheoremPackage` | `theorem` | current law-universe policy で、`ArchitectureLawful X` と full proved zero-curvature theorem package が同値であることを示す #226 packaging theorem。 | `proved` |
 | `ArchitectureSignature.localReplacementContract_requiredSignatureProjectionLSPAxes` | `theorem` | `LocalReplacementContract` から selected required Signature axes の projection / LSP が available-and-zero であることを得る derived corollary bridge。 | `proved` |
 | `ArchitectureSignature.architectureLawful_of_localReplacementContract` | `theorem` | closed-walk acyclicity、`LocalReplacementContract`、boundary / abstraction policy soundness から `ArchitectureLawful X` を得る。 | `proved` |
 | `ArchitectureSignature.requiredSignatureAxesZero_of_localReplacementContract` | `theorem` | closed-walk acyclicity、`LocalReplacementContract`、boundary / abstraction policy soundness から `RequiredSignatureAxesZero (signatureOf X)` を得る derived zero-curvature bridge。 | `proved` |
+| `ArchitectureSignature.architectureZeroCurvatureTheoremPackage_of_localReplacementContract` | `theorem` | LocalReplacement と残りの static laws から full proved zero-curvature theorem package を得る derived bridge。 | `proved` |
+
+### 零曲率 theorem package の読み順
+
+1. `architectureLawCandidateRole_requiredLaw_iff` で required law が 5 条件に限られることを確認する。
+2. `architectureLawful_iff_requiredSignatureAxesZero` を主 theorem として読む。
+3. LocalReplacement / state-effect laws は `localReplacementContract_requiredSignatureProjectionLSPAxes`, `requiredSignatureAxesZero_of_localReplacementContract`, `stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction`, `effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction` で derived corollary として読む。
+4. nilpotency / spectral diagnostics は `MatrixDiagnosticCorollaries` と `matrixDiagnosticCorollaries_of_requiredSignatureAxesZero` で読む。
+5. 全体 package は `architectureLawful_iff_architectureZeroCurvatureTheoremPackage` を入口にし、runtime / empirical / numerical curvature は「現在 Lean に入れていないもの」の境界として読む。
 
 ## State Transition / Effect Boundary Laws
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -108,7 +108,7 @@ required law, derived corollary, diagnostic axis, empirical axis を区別する
 混同しない。`nilpotencyIndex = none` も未評価または非 nilpotent を表し、risk 0
 とは読まない。
 
-後続 Issue の依存順は、#222 の policy を前提にする。まず
+零曲率 theorem 群は、#222 の policy を前提に次の順で整理した。まず
 [#223](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/223) で
 LocalReplacement / state-effect laws を derived corollary として Signature 統合 theorem
 へ接続する条件を整理し、次に
@@ -118,7 +118,7 @@ evidence の境界は
 [#225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225) で
 扱い、最後に
 [#226](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/226) で
-full theorem packaging と theorem index を完成する。
+full theorem packaging と theorem index を完成した。
 
 Issue [#223](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/223)
 では、#222 の policy に従い、LocalReplacement と state-effect laws を required
@@ -159,6 +159,19 @@ Circuit Breaker coverage と `unprotectedRuntimeExposureRadius` /
 incident scope / repair time / hotfix size との関係は H5 empirical hypothesis として
 扱う。未抽出 `none`、測定済み `some 0`、risk 0 の解釈は区別し、runtime / empirical
 axis の未評価は Lean theorem packaging のブロッカーにしない。
+
+Issue [#226](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/226)
+では、#222 から #225 までの方針と bridge を theorem package として束ねた。
+Lean では `ArchitectureZeroCurvatureTheoremPackage` を追加し、
+`RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X)` と
+`MatrixDiagnosticCorollaries X` を full proved package として読む。
+`architectureLawful_iff_architectureZeroCurvatureTheoremPackage` により、
+current law-universe policy ではこの package と `ArchitectureLawful X` が同値である。
+LocalReplacement から package へ進む入口は
+`architectureZeroCurvatureTheoremPackage_of_localReplacementContract` である。
+runtime / empirical / 一般数値 curvature はこの package に含めず、diagnostic /
+empirical boundary として残す。Lean status は theorem package の同値が `proved`、
+runtime / empirical boundary が `defined only` / `empirical hypothesis` である。
 
 証明強度は段階的に扱う。`violationCount bad xs = 0` と
 `forall w, w in xs -> not bad w` の同値は必要な共通補題だが、

--- a/docs/research_goal.md
+++ b/docs/research_goal.md
@@ -19,6 +19,9 @@
 Lean 側では、この主張を最初から数値的な曲率として定義しない。
 まず witness 型、bad predicate、測定候補 list、violation count からなる
 generic witness-count kernel と、有限測定 universe 上の零カウント橋渡しとして育てる。
+現在の Lean proved package では、selected required axes の零性と
+matrix diagnostics を `ArchitectureZeroCurvatureTheoremPackage` として束ねる。
+runtime / empirical / 一般数値 curvature は、この package の外側に残す。
 
 この中心定理候補の上で、より広い最終ゴールは次である。
 


### PR DESCRIPTION
## 概要

Closes #226
Closes #221

- `ArchitectureZeroCurvatureTheoremPackage` を追加し、selected required axes zero と matrix diagnostic corollaries を current proved package として束ねました。
- `ArchitectureLawful X` と theorem package の同値、および LocalReplacement から package へ進む derived bridge を証明しました。
- theorem index、proof obligations、Lean 化設計、研究ゴールを #226 の Lean status と読み順に同期しました。

## 証明した定理

- `ArchitectureSignature.architectureZeroCurvatureTheoremPackage_of_architectureLawful`
- `ArchitectureSignature.architectureLawful_of_architectureZeroCurvatureTheoremPackage`
- `ArchitectureSignature.architectureLawful_iff_architectureZeroCurvatureTheoremPackage`
- `ArchitectureSignature.architectureZeroCurvatureTheoremPackage_of_localReplacementContract`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/research_goal.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/SignatureLawfulness.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている