### PR TITLE
StaticSplitExtension の StaticFlatWithin 保存定理を追加

### DIFF
--- a/Formal/Arch/Flatness.lean
+++ b/Formal/Arch/Flatness.lean
@@ -206,4 +206,55 @@ theorem extended_edge_mem_of_extensionCoverageComplete
     src ∈ U.components ∧ dst ∈ U.components :=
   hCoverage.2.2.1 hEdge
 
+/--
+Static split-extension policy soundness for a compatible static graph.
+
+The split extension supplies only the static edge-policy part. Other static
+laws, such as acyclicity, projection soundness, and LSP compatibility, remain
+separate assumptions of the flatness theorem below.
+-/
+theorem policySound_of_staticSplitExtension
+    (S : StaticSplitExtension Core Feature Extended FeatureView)
+    {G : ArchGraph Extended} {allowed : Extended -> Extended -> Prop}
+    (hEdges :
+      ∀ {src dst : Extended}, G.edge src dst ->
+        S.extension.extended.edge src dst)
+    (hAllowed :
+      ∀ {src dst : Extended}, S.extendedAllowedStaticEdge src dst ->
+        allowed src dst) :
+    ArchitectureSignature.PolicySound G allowed := by
+  intro src dst hEdge
+  exact hAllowed (S.noNewForbiddenStaticEdge (hEdges hEdge))
+
+/--
+Static split extensions preserve coverage-aware static flatness.
+
+This theorem is deliberately static-only: it concludes `StaticFlatWithin`, not
+runtime, semantic, or full `ArchitectureFlatWithin`. The non-policy static laws
+are explicit premises because the static split-extension schema only controls
+new forbidden static edges.
+-/
+theorem staticFlatWithin_of_staticSplitExtension
+    (S : StaticSplitExtension Core Feature Extended FeatureView)
+    {X : ArchitectureFlatnessModel Extended A StaticObs SemanticExpr SemanticObs}
+    {U : ComponentUniverse X.static}
+    (hCoverage : StaticCoverageComplete X U)
+    (hEdges :
+      ∀ {src dst : Extended}, X.static.edge src dst ->
+        S.extension.extended.edge src dst)
+    (hBoundaryAllowed :
+      ∀ {src dst : Extended}, S.extendedAllowedStaticEdge src dst ->
+        X.boundaryAllowed src dst)
+    (hAbstractionAllowed :
+      ∀ {src dst : Extended}, S.extendedAllowedStaticEdge src dst ->
+        X.abstractionAllowed src dst)
+    (hWalkAcyclic : WalkAcyclic X.static)
+    (hProjectionSound : ProjectionSound X.static X.projection X.abstractStatic)
+    (hLSP : LSPCompatible X.projection X.staticObservation) :
+    StaticFlatWithin X U := by
+  have _hStaticCoverage : StaticCoverageComplete X U := hCoverage
+  refine ⟨hWalkAcyclic, hProjectionSound, hLSP, ?_, ?_⟩
+  · exact policySound_of_staticSplitExtension S hEdges hBoundaryAllowed
+  · exact policySound_of_staticSplitExtension S hEdges hAbstractionAllowed
+
 end Formal.Arch

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -225,6 +225,8 @@ File: `Formal/Arch/Flatness.lean`
 | `coreEmbedding_mem_of_extensionCoverageComplete` | `theorem` | complete extension coverage から core embedding の universe membership を得る。 | `proved` |
 | `featureEmbedding_mem_of_extensionCoverageComplete` | `theorem` | complete extension coverage から feature embedding の universe membership を得る。 | `proved` |
 | `extended_edge_mem_of_extensionCoverageComplete` | `theorem` | complete extension coverage から extended static edge endpoints の universe membership を得る。 | `proved` |
+| `policySound_of_staticSplitExtension` | `theorem` | compatible な static graph に対して、`StaticSplitExtension` の no-new-forbidden-edge 条件から policy soundness を得る。 | `proved` |
+| `staticFlatWithin_of_staticSplitExtension` | `theorem` | coverage-aware な静的範囲で、static split extension と残りの静的 law 前提から `StaticFlatWithin` を得る。runtime / semantic flatness は結論しない。 | `proved` |
 
 ## Obstruction Kernel
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -150,11 +150,26 @@ Lean status:
   `featureEmbedding_mem_of_extensionCoverageComplete`,
   `extended_edge_mem_of_extensionCoverageComplete`
 
+Issue [#246](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/246)
+では、静的 split extension が coverage-aware な静的 flatness に接続する最小 theorem を
+`Formal.Arch.Flatness` に追加した。Lean では
+`policySound_of_staticSplitExtension` が compatible な static graph に対して
+`StaticSplitExtension` の no-new-forbidden-edge 条件から policy soundness を導き、
+`staticFlatWithin_of_staticSplitExtension` が `StaticFlatWithin` を構成する。
+この theorem は静的層だけを結論し、runtime flatness、semantic flatness、full
+`ArchitectureFlatWithin` は結論しない。walk acyclicity、projection soundness、
+LSP compatibility は、`StaticSplitExtension` の責務ではないため明示前提として残す。
+
+Lean status:
+
+- `proved`: `policySound_of_staticSplitExtension`,
+  `staticFlatWithin_of_staticSplitExtension`
+
 今後の proof obligation:
 
-- `StaticSplitFeatureExtension` が `StaticFlatWithin` / `ArchitectureFlatWithin` を
-  保存する theorem は Issue [#246](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/246)
-  で扱う。
+- `StaticSplitFeatureExtension` から runtime / semantic flatness や full
+  `ArchitectureFlatWithin` を導く theorem は、この静的 theorem からは導かない。
+  必要な coverage、runtime protection、semantic diagram law は別 Issue で扱う。
 - semantic diagram list の完全性や telemetry completeness は Lean theorem ではなく、
   tooling / empirical evidence の別前提として扱う。
 


### PR DESCRIPTION
## 概要

Closes #246

`StaticSplitExtension` が coverage-aware な静的 flatness に接続する最小 theorem を追加しました。
split extension schema が直接担保する範囲を static edge policy に限定し、walk acyclicity / projection soundness / LSP compatibility は明示前提として残しています。
runtime flatness、semantic flatness、full `ArchitectureFlatWithin` は結論しないことを docs に反映しました。

## 証明した定理

- `policySound_of_staticSplitExtension`
- `staticFlatWithin_of_staticSplitExtension`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/Flatness.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
