### PR TITLE
DiagramFiller の非充填 soundness を追加する

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -10,6 +10,7 @@ import Formal.Arch.LSP
 import Formal.Arch.LocalReplacement
 import Formal.Arch.FeatureExtension
 import Formal.Arch.ArchitecturePath
+import Formal.Arch.DiagramFiller
 import Formal.Arch.Obstruction
 import Formal.Arch.Lawfulness
 import Formal.Arch.StateEffect

--- a/Formal/Arch/DiagramFiller.lean
+++ b/Formal/Arch/DiagramFiller.lean
@@ -1,0 +1,183 @@
+import Formal.Arch.ArchitecturePath
+
+namespace Formal.Arch
+
+universe u v w
+
+/--
+A semantic architecture diagram is a pair of finite architecture paths with the
+same endpoints.
+
+The intended examples are operation-order diagrams such as coupon-before-
+discount versus discount-before-coupon. The type records only the finite path
+skeleton; concrete semantic equality, repair, or obstruction predicates are
+supplied by the surrounding theorem package.
+-/
+structure ArchitectureDiagram {State : Type u}
+    (Step : State -> State -> Type v) (X Y : State) : Type (max u v) where
+  lhs : ArchitecturePath Step X Y
+  rhs : ArchitecturePath Step X Y
+
+/--
+A filler for an architecture diagram is a generated homotopy between its two
+paths.
+
+The three predicate parameters are the same generators used by
+`ArchitecturePath.PathHomotopy`: independent-step swaps, same-contract
+replacement, and repair fills. This keeps diagram filling tied to the finite
+path calculus without introducing higher-category machinery.
+-/
+def DiagramFiller {State : Type u} {Step : State -> State -> Type v}
+    (IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop)
+    (SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop)
+    (RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop)
+    {X Y : State} (D : ArchitectureDiagram Step X Y) : Prop :=
+  ArchitecturePath.PathHomotopy (Step := Step)
+    IndependentSquare SameExternalContract RepairFill D.lhs D.rhs
+
+/--
+A concrete non-fillability witness for a diagram.
+
+The `witness` field is intentionally domain-specific data supplied by the
+caller. The sound part of the witness is the constructive refutation of any
+diagram filler. A future bounded-completeness theorem may show that every
+non-fillable diagram has such a witness in a finite witness universe, but that
+claim is not built into this definition.
+-/
+structure NonFillabilityWitness {State : Type u}
+    {Step : State -> State -> Type v}
+    (IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop)
+    (SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop)
+    (RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop)
+    {X Y : State} (D : ArchitectureDiagram Step X Y)
+    (Witness : Type w) : Type (max u v w) where
+  witness : Witness
+  refutesFiller :
+    DiagramFiller IndependentSquare SameExternalContract RepairFill D -> False
+
+/-- The witness record above is about the particular witness value `w`. -/
+def NonFillabilityWitnessFor {State : Type u}
+    {Step : State -> State -> Type v}
+    (IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop)
+    (SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop)
+    (RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop)
+    {X Y : State} (D : ArchitectureDiagram Step X Y)
+    {Witness : Type w} (w : Witness) : Prop :=
+  ∃ h : NonFillabilityWitness
+      IndependentSquare SameExternalContract RepairFill D Witness,
+    h.witness = w
+
+/--
+Soundness of non-fillability witnesses.
+
+This is the safe direction: once a concrete witness refutes every filler, the
+diagram is not fillable. The converse requires finite witness coverage and
+exactness assumptions, so it is deliberately left as a future proof obligation.
+-/
+theorem obstructionAsNonFillability_sound {State : Type u}
+    {Step : State -> State -> Type v}
+    {IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop}
+    {SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop}
+    {RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop}
+    {X Y : State} {D : ArchitectureDiagram Step X Y}
+    {Witness : Type w} {w : Witness}
+    (hWitness :
+      NonFillabilityWitnessFor
+        IndependentSquare SameExternalContract RepairFill D w) :
+    ¬ DiagramFiller IndependentSquare SameExternalContract RepairFill D := by
+  intro hFiller
+  rcases hWitness with ⟨h, _hEq⟩
+  exact h.refutesFiller hFiller
+
+/--
+Bounded completeness premise for the future converse theorem.
+
+This definition is a named assumption, not a theorem: it says a finite witness
+universe is complete enough to explain non-fillability of this diagram.
+-/
+def WitnessUniverseComplete {State : Type u}
+    {Step : State -> State -> Type v}
+    (IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop)
+    (SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop)
+    (RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop)
+    {X Y : State} (D : ArchitectureDiagram Step X Y)
+    {Witness : Type w} (U : List Witness) : Prop :=
+  (¬ DiagramFiller IndependentSquare SameExternalContract RepairFill D) ->
+    ∃ witness : Witness, witness ∈ U ∧
+      NonFillabilityWitnessFor
+        IndependentSquare SameExternalContract RepairFill D witness
+
+/-
+A small path skeleton for the canonical coupon/discount ordering example from
+the design note.
+
+No non-fillability theorem is asserted here. The example only exposes the two
+operation orders as a diagram so later semantic contracts can attach a concrete
+rounding-order witness.
+-/
+namespace CouponDiscountExample
+
+inductive CouponState where
+  | start
+  | couponApplied
+  | discountApplied
+  | finished
+
+inductive CouponDiscountStep : CouponState -> CouponState -> Type where
+  | applyCouponFirst :
+      CouponDiscountStep .start .couponApplied
+  | applyDiscountAfterCoupon :
+      CouponDiscountStep .couponApplied .finished
+  | applyDiscountFirst :
+      CouponDiscountStep .start .discountApplied
+  | applyCouponAfterDiscount :
+      CouponDiscountStep .discountApplied .finished
+
+def couponThenDiscount :
+    ArchitecturePath CouponDiscountStep .start .finished :=
+  ArchitecturePath.cons CouponDiscountStep.applyCouponFirst
+    (ArchitecturePath.cons CouponDiscountStep.applyDiscountAfterCoupon
+      (ArchitecturePath.nil CouponState.finished))
+
+def discountThenCoupon :
+    ArchitecturePath CouponDiscountStep .start .finished :=
+  ArchitecturePath.cons CouponDiscountStep.applyDiscountFirst
+    (ArchitecturePath.cons CouponDiscountStep.applyCouponAfterDiscount
+      (ArchitecturePath.nil CouponState.finished))
+
+def couponDiscountDiagram :
+    ArchitectureDiagram CouponDiscountStep .start .finished where
+  lhs := couponThenDiscount
+  rhs := discountThenCoupon
+
+inductive CouponDiscountWitness where
+  | roundingOrder
+
+end CouponDiscountExample
+
+end Formal.Arch

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -217,6 +217,20 @@ File: `Formal/Arch/ArchitecturePath.lean`
 | `ArchitecturePath.HomotopyInvariant` | `def` | generated path homotopy の下で安定な invariant。endpoint と state universe は `ArchitecturePath` の index によって明示される。 | `defined only` |
 | `ArchitecturePath.architectureHomotopyInvariance` | `theorem` | `HomotopyInvariant` を homotopic path pair に適用する bridge theorem。 | `proved` |
 
+## Diagram Filler
+
+File: `Formal/Arch/DiagramFiller.lean`
+
+| Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- |
+| `ArchitectureDiagram` | `structure` | 同じ start / target state を持つ二つの有限 architecture path を semantic diagram skeleton として束ねる。 | `defined only` |
+| `DiagramFiller` | `def` | `ArchitecturePath.PathHomotopy` により、diagram の左右 path が finite path calculus 上で fillable であることを表す。 | `defined only` |
+| `NonFillabilityWitness` | `structure` | domain-specific witness value と、任意の `DiagramFiller` を反駁する soundness 証拠を束ねる。 | `defined only` |
+| `NonFillabilityWitnessFor` | `def` | `NonFillabilityWitness` が特定の witness value `w` についての証人であること。 | `defined only` |
+| `obstructionAsNonFillability_sound` | `theorem` | `NonFillabilityWitnessFor D w` から `¬ DiagramFiller D` を得る片方向 soundness theorem。 | `proved` |
+| `WitnessUniverseComplete` | `def` | bounded completeness theorem 用の有限 witness universe 完全性前提。逆向き theorem 自体は未主張。 | `defined only` |
+| `CouponDiscountExample.couponDiscountDiagram` | `def` | coupon と discount の順序依存例を、二つの operation order を持つ diagram skeleton として表す。 | `defined only` |
+
 ## Flatness
 
 File: `Formal/Arch/Flatness.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -195,10 +195,35 @@ Lean status:
 今後の proof obligation:
 
 - `PathHomotopy` の `IndependentSquare`, `SameExternalContract`, `RepairFill` を、
-  concrete な feature extension / refactoring / semantic diagram filling の theorem と
-  接続する。
+  concrete な feature extension / refactoring の theorem と接続する。
 - homotopy invariant の非自明な事例、特に selected flatness や obstruction absence の
   invariant package を別 Issue で構成する。
+
+Issue [#248](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/248)
+では、semantic curvature を数値ではなく diagram filling failure として扱う最小 core を
+`Formal.Arch.DiagramFiller` に追加した。Lean では `ArchitectureDiagram` が同じ
+start / target state を持つ左右の `ArchitecturePath` を束ね、`DiagramFiller` は
+既存の `PathHomotopy` によって左右 path が fillable であることを表す。
+`NonFillabilityWitness` は domain-specific witness value と filler の反駁を保持し、
+`obstructionAsNonFillability_sound` が
+`NonFillabilityWitnessFor D w -> ¬ DiagramFiller D` の片方向 soundness を証明する。
+coupon / discount の順序依存例は `CouponDiscountExample.couponDiscountDiagram` として
+path skeleton だけを置き、rounding-order witness の具体的意味論は後続 theorem に残す。
+
+Lean status:
+
+- `defined only`: `ArchitectureDiagram`, `DiagramFiller`,
+  `NonFillabilityWitness`, `NonFillabilityWitnessFor`,
+  `WitnessUniverseComplete`, `CouponDiscountExample.couponDiscountDiagram`
+- `proved`: `obstructionAsNonFillability_sound`
+
+今後の proof obligation:
+
+- `WitnessUniverseComplete` と coverage / exactness assumptions の下でのみ、
+  `¬ DiagramFiller D` から有限 witness universe 内の
+  `NonFillabilityWitnessFor D w` を得る bounded completeness theorem を扱う。
+- coupon / discount example に観測意味論と rounding-order witness を与え、
+  static lawfulness とは独立した semantic non-fillability witness として接続する。
 
 | 候補 | 分類 | final theorem での扱い |
 | --- | --- | --- |


### PR DESCRIPTION
## 概要

Closes #248
Refs #243

semantic curvature を数値ではなく diagram filling failure として扱う最小 Lean core を追加しました。`ArchitectureDiagram` は同じ endpoint を持つ左右の `ArchitecturePath` を束ね、`DiagramFiller` は既存の `PathHomotopy` で fillability を表します。

`NonFillabilityWitness` は domain-specific witness value と filler の反駁を保持し、逆向き completeness は `WitnessUniverseComplete` と future proof obligation として分離しました。

## 証明した定理

- `obstructionAsNonFillability_sound`: `NonFillabilityWitnessFor D w` から `¬ DiagramFiller D` を得る片方向 soundness theorem

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`: `DiagramFiller` module の Lean API と status を追加
- `docs/proof_obligations.md`: #248 の Lean status と残る bounded completeness / coupon semantic witness obligation を追加

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan: 該当なし
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan: 該当なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている