### PR TITLE
数値曲率と DiagramCommutes の零橋渡しを追加

### DIFF
--- a/Formal.lean
+++ b/Formal.lean
@@ -14,6 +14,7 @@ import Formal.Arch.DiagramFiller
 import Formal.Arch.Obstruction
 import Formal.Arch.Lawfulness
 import Formal.Arch.StateEffect
+import Formal.Arch.Curvature
 import Formal.Arch.SolidCounterexample
 import Formal.Arch.Signature
 import Formal.Arch.Finite

--- a/Formal/Arch/Curvature.lean
+++ b/Formal/Arch/Curvature.lean
@@ -1,0 +1,127 @@
+import Formal.Arch.StateEffect
+
+namespace Formal.Arch
+
+universe u v
+
+/--
+A natural-number-valued distance on observations whose zero values exactly
+separate equality.
+
+This is the minimal numerical structure needed for the first curvature bridge:
+zero numerical curvature should mean diagram commutativity, without committing
+to weights, calibration, or an empirical cost model.
+-/
+structure ZeroSeparatingDistance (Obs : Type u) where
+  distance : Obs -> Obs -> Nat
+  distance_eq_zero_iff : ∀ x y, distance x y = 0 ↔ x = y
+
+/--
+Numerical curvature of a required diagram: the distance between the observable
+semantics of its two sides.
+-/
+def numericalCurvature {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    (sem : Semantics Expr Obs) (d : RequiredDiagram Expr) : Nat :=
+  metric.distance (sem.eval d.lhs) (sem.eval d.rhs)
+
+/-- A diagram has numerical curvature obstruction when its curvature is nonzero. -/
+def NumericalCurvatureObstruction {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    (sem : Semantics Expr Obs) (d : RequiredDiagram Expr) : Prop :=
+  numericalCurvature metric sem d ≠ 0
+
+/--
+No required numerical curvature obstruction exists for the selected diagram
+family.
+-/
+def NoNumericalCurvatureObstruction {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    (sem : Semantics Expr Obs)
+    (required : RequiredDiagram Expr -> Prop) : Prop :=
+  ∀ d, required d -> ¬ NumericalCurvatureObstruction metric sem d
+
+/--
+Zero numerical curvature is exactly diagram commutativity.
+-/
+theorem numericalCurvature_eq_zero_iff_DiagramCommutes
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs} {d : RequiredDiagram Expr} :
+    numericalCurvature metric sem d = 0 ↔ DiagramCommutes sem d := by
+  exact metric.distance_eq_zero_iff (sem.eval d.lhs) (sem.eval d.rhs)
+
+/-- Commuting diagrams have zero numerical curvature. -/
+theorem numericalCurvature_eq_zero_of_DiagramCommutes
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs} {d : RequiredDiagram Expr}
+    (hCommutes : DiagramCommutes sem d) :
+    numericalCurvature metric sem d = 0 :=
+  (numericalCurvature_eq_zero_iff_DiagramCommutes metric).mpr hCommutes
+
+/-- Zero numerical curvature forces diagram commutativity. -/
+theorem DiagramCommutes_of_numericalCurvature_eq_zero
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs} {d : RequiredDiagram Expr}
+    (hZero : numericalCurvature metric sem d = 0) :
+    DiagramCommutes sem d :=
+  (numericalCurvature_eq_zero_iff_DiagramCommutes metric).mp hZero
+
+/--
+Numerical curvature obstruction is exactly the existing diagram obstruction
+predicate, for a single diagram.
+-/
+theorem numericalCurvatureObstruction_iff_DiagramBad
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs} {d : RequiredDiagram Expr} :
+    NumericalCurvatureObstruction metric sem d ↔ DiagramBad sem d := by
+  constructor
+  · intro hCurvature hCommutes
+    exact hCurvature
+      (numericalCurvature_eq_zero_of_DiagramCommutes metric hCommutes)
+  · intro hBad hZero
+    exact hBad
+      (DiagramCommutes_of_numericalCurvature_eq_zero metric hZero)
+
+/--
+Absence of numerical curvature obstruction for one diagram is equivalent to
+diagram commutativity.
+-/
+theorem not_numericalCurvatureObstruction_iff_DiagramCommutes
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs} {d : RequiredDiagram Expr} :
+    ¬ NumericalCurvatureObstruction metric sem d ↔ DiagramCommutes sem d := by
+  constructor
+  · intro hNoObstruction
+    by_cases hZero : numericalCurvature metric sem d = 0
+    · exact DiagramCommutes_of_numericalCurvature_eq_zero metric hZero
+    · exact False.elim (hNoObstruction hZero)
+  · intro hCommutes hObstruction
+    exact hObstruction
+      (numericalCurvature_eq_zero_of_DiagramCommutes metric hCommutes)
+
+/--
+For a required diagram family, diagram lawfulness is exactly absence of
+numerical curvature obstruction.
+-/
+theorem diagramLawful_iff_noNumericalCurvatureObstruction
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {required : RequiredDiagram Expr -> Prop} :
+    DiagramLawful sem required ↔
+      NoNumericalCurvatureObstruction metric sem required := by
+  constructor
+  · intro hLawful d hRequired hObstruction
+    exact hObstruction
+      (numericalCurvature_eq_zero_of_DiagramCommutes metric
+        (hLawful d hRequired))
+  · intro hNoObstruction d hRequired
+    exact (not_numericalCurvatureObstruction_iff_DiagramCommutes metric).mp
+      (hNoObstruction d hRequired)
+
+end Formal.Arch

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -296,6 +296,23 @@ File: `Formal/Arch/Obstruction.lean`
 | `no_required_DiagramBad_of_coversRequired_and_diagramViolationCount_eq_zero` | `theorem` | complete coverage と diagram violation count 0 から、required diagram obstruction witness が存在しないことを得る。 | `proved` |
 | `requiredDiagramCommutes_of_coversRequired_and_diagramViolationCount_eq_zero` | `theorem` | `[DecidableEq Obs]` の下で、complete coverage と diagram violation count 0 から required diagram の可換性を得る。 | `proved` |
 
+## Numerical Curvature
+
+File: `Formal/Arch/Curvature.lean`
+
+| Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- |
+| `ZeroSeparatingDistance` | `structure` | 観測値上の `Nat` 値距離と、`distance x y = 0 ↔ x = y` の zero-separation law を束ねる。 | `defined only` |
+| `numericalCurvature` | `def` | required diagram の両辺の観測意味論間の距離として数値 curvature を定義する。 | `defined only` |
+| `NumericalCurvatureObstruction` | `def` | diagram の数値 curvature が非零であることを obstruction witness として表す。 | `defined only` |
+| `NoNumericalCurvatureObstruction` | `def` | required diagram family に数値 curvature obstruction が存在しないこと。 | `defined only` |
+| `numericalCurvature_eq_zero_iff_DiagramCommutes` | `theorem` | zero-separating distance の下で、数値 curvature 0 と diagram commutativity が一致する。 | `proved` |
+| `numericalCurvature_eq_zero_of_DiagramCommutes` | `theorem` | 可換な diagram は数値 curvature が 0 である。 | `proved` |
+| `DiagramCommutes_of_numericalCurvature_eq_zero` | `theorem` | 数値 curvature 0 から diagram commutativity を得る。 | `proved` |
+| `numericalCurvatureObstruction_iff_DiagramBad` | `theorem` | 数値 curvature obstruction と既存の `DiagramBad` predicate が一致する。 | `proved` |
+| `not_numericalCurvatureObstruction_iff_DiagramCommutes` | `theorem` | 個別 diagram で、数値 curvature obstruction 不在と可換性が一致する。 | `proved` |
+| `diagramLawful_iff_noNumericalCurvatureObstruction` | `theorem` | required diagram family の lawfulness と数値 curvature obstruction 不在を接続する。 | `proved` |
+
 ## Lawfulness Bridge
 
 File: `Formal/Arch/Lawfulness.lean`
@@ -686,9 +703,9 @@ File: `Formal/Arch/SolidCounterexample.lean`
 次は意図的に Lean core へ混ぜていない。
 
 - `Decomposable` の定義への acyclicity, finite propagation, nilpotence, spectral conditions の混入。
-- 一般の `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
-  `Formal/Arch/Curvature.lean` は、観測値上の差分・距離・重み・集約規則が固まるまで
-  意図的に追加しない。
+- 重み付き・集約済みの一般 `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
+  `Formal/Arch/Curvature.lean` は、個別 diagram の zero-separating distance bridge だけを
+  含み、重み・集約規則・empirical cost model はまだ導入しない。
 - `relationComplexity`, `runtimePropagation`, `empiricalChangeCost` の実証相関。
 - extractor output が `ComponentUniverse` の完全な witness であるという主張。
 - `rho(A)` と変更波及・障害伝播コストの相関。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -386,14 +386,18 @@ Issue [#223](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2
 `stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction` と
 `effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction` で証明済みである。
 
-Issue [#194](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/194)
-では、数値的 curvature metric を数学的コアの拡張として扱う。ただし、Lean theorem
-として狙うのは `curvature = 0 <-> DiagramCommutes` と
+Issue [#239](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/239)
+では、数値的 curvature metric を数学的コアの拡張として扱う。Lean では
+`ZeroSeparatingDistance`, `numericalCurvature`,
+`NumericalCurvatureObstruction`, `NoNumericalCurvatureObstruction` を追加し、
+個別 diagram について `numericalCurvature = 0 <-> DiagramCommutes` と
+`DiagramLawful <-> NoNumericalCurvatureObstruction` の bridge を証明した。
+次の集約 target は
 `totalCurvature = 0 <-> no numerical curvature obstruction` の bridge であり、
 変更コスト・障害率・レビュー負荷との相関や重みの calibration は empirical
-hypothesis として分離する。`Curv_A = Sem_A(p) - Sem_A(q)` 型の一般 metric は、
-観測値上の zero-separating distance、非負集約、Signature axis への載せ方を固定してから
-`future proof obligation` として Lean 化する。これは obstruction witness zero-count
+hypothesis として分離する。重み付き・集約済みの一般 metric と
+Signature axis への載せ方は `future proof obligation` として残す。
+これは obstruction witness zero-count
 theorem の代替ではなく、追加 axis または派生評価として接続する。
 
 ## 基本 convention
@@ -1338,7 +1342,7 @@ Lean status の区分:
 | `observationalDivergence`, `lspViolationCount` | 観測差分と measured LSP violation pair を数える behavioral extension | `defined only` / `proved` |
 | `nilpotencyIndex` | finite `ComponentUniverse` 上で最初の zero adjacency power を探す executable metric。acyclic graph では `some` になる bridge を証明済み。`some k` は index 値であり、required zero-axis ではない | `defined only` / `proved` |
 | `rho(A)` | 行列解析上の伝播増幅指標として扱う。finite DAG では 0、finite closed walk では正になる bridge を証明済み | `proved` for `DAG -> rho(A)=0` / `proved` for cycle positivity / `empirical hypothesis` |
-| `numericCurvature` | 一般の観測値差分 `Sem_A(p) - Sem_A(q)` 型 metric は、zero-separating distance と非負集約を固定した上で `curvature = 0 <-> DiagramCommutes` bridge として Lean 化する。重み calibration や現実コストとの相関は empirical 側に残す | `future proof obligation` / `empirical hypothesis` |
+| `numericCurvature` | 個別 diagram では `ZeroSeparatingDistance` と `numericalCurvature` を追加し、`numericalCurvature = 0 <-> DiagramCommutes` および `DiagramLawful <-> NoNumericalCurvatureObstruction` を証明済み。非負集約、Signature axis への載せ方、重み calibration や現実コストとの相関は別層に残す | `proved` / `future proof obligation` / `empirical hypothesis` |
 | `runtimePropagation` | 0/1 `RuntimeDependencyGraph` 上では `reachableConeSizeOfFinite` による runtime exposure radius として計算する。既存名は `runtimeExposureRadius` の互換名であり、zero metric と runtime obstruction absence の bridge は `reachesWithin` ベースの measured obstruction として証明済み。semantic `Reachable` 版、blast radius、policy-aware runtime exposure は別 bridge または tooling / analysis metric として分ける | `defined only` / `proved` / `future proof obligation` / `empirical hypothesis` |
 | `relationComplexity` | 状態遷移代数層の設計に依存する | `empirical hypothesis` |
 | `empiricalChangeCost` | 実データで検証する目的変数 | `empirical hypothesis` |


### PR DESCRIPTION
## 概要

Closes #239

数値 curvature の最小コアとして、観測値上の `ZeroSeparatingDistance` と required diagram の `numericalCurvature` を追加しました。zero-separation law により、個別 diagram の `numericalCurvature = 0` と `DiagramCommutes` が同値であることを証明し、既存の diagram obstruction count を置き換えずに追加 bridge として接続しています。

## 証明した定理

- `numericalCurvature_eq_zero_iff_DiagramCommutes`
- `numericalCurvature_eq_zero_of_DiagramCommutes`
- `DiagramCommutes_of_numericalCurvature_eq_zero`
- `numericalCurvatureObstruction_iff_DiagramBad`
- `not_numericalCurvatureObstruction_iff_DiagramCommutes`
- `diagramLawful_iff_noNumericalCurvatureObstruction`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/Curvature.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
