### PR TITLE
有限測定図式の合計曲率ブリッジを証明する

### DIFF
--- a/Formal/Arch/Curvature.lean
+++ b/Formal/Arch/Curvature.lean
@@ -42,6 +42,29 @@ def NoNumericalCurvatureObstruction {Expr : Type u} {Obs : Type v}
   ∀ d, required d -> ¬ NumericalCurvatureObstruction metric sem d
 
 /--
+Total numerical curvature over a finite measured diagram universe.
+
+Duplicates are counted as repeated measurements, matching the finite executable
+metrics elsewhere in the signature layer.
+-/
+def totalCurvature {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    (sem : Semantics Expr Obs) : List (RequiredDiagram Expr) -> Nat
+  | [] => 0
+  | d :: ds => numericalCurvature metric sem d + totalCurvature metric sem ds
+
+/--
+No numerical curvature obstruction exists in the finite measured diagram
+universe. This is intentionally list-scoped: it does not claim that every
+semantic diagram has been measured.
+-/
+def NoMeasuredNumericalCurvatureObstruction {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    (sem : Semantics Expr Obs)
+    (measured : List (RequiredDiagram Expr)) : Prop :=
+  ∀ d, d ∈ measured -> ¬ NumericalCurvatureObstruction metric sem d
+
+/--
 Zero numerical curvature is exactly diagram commutativity.
 -/
 theorem numericalCurvature_eq_zero_iff_DiagramCommutes
@@ -123,5 +146,85 @@ theorem diagramLawful_iff_noNumericalCurvatureObstruction
   · intro hNoObstruction d hRequired
     exact (not_numericalCurvatureObstruction_iff_DiagramCommutes metric).mp
       (hNoObstruction d hRequired)
+
+/--
+Total numerical curvature is zero exactly when every measured diagram has zero
+curvature.
+-/
+theorem totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {measured : List (RequiredDiagram Expr)} :
+    totalCurvature metric sem measured = 0 ↔
+      ∀ d, d ∈ measured -> numericalCurvature metric sem d = 0 := by
+  induction measured with
+  | nil =>
+      simp [totalCurvature]
+  | cons d ds ih =>
+      constructor
+      · intro hZero d' hMem
+        rw [totalCurvature] at hZero
+        have hHead : numericalCurvature metric sem d = 0 :=
+          Nat.eq_zero_of_add_eq_zero_right hZero
+        have hTail : totalCurvature metric sem ds = 0 :=
+          Nat.eq_zero_of_add_eq_zero_left hZero
+        simp only [List.mem_cons] at hMem
+        rcases hMem with hEq | hMem
+        · cases hEq
+          exact hHead
+        · exact ih.mp hTail d' hMem
+      · intro hAll
+        rw [totalCurvature]
+        have hHead : numericalCurvature metric sem d = 0 :=
+          hAll d (by simp)
+        have hTail : totalCurvature metric sem ds = 0 :=
+          ih.mpr (by
+            intro d' hMem
+            exact hAll d' (by simp [hMem]))
+        simp [hHead, hTail]
+
+/--
+Total numerical curvature is zero exactly when every measured diagram commutes.
+-/
+theorem totalCurvature_eq_zero_iff_forall_measured_DiagramCommutes
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {measured : List (RequiredDiagram Expr)} :
+    totalCurvature metric sem measured = 0 ↔
+      ∀ d, d ∈ measured -> DiagramCommutes sem d := by
+  constructor
+  · intro hZero d hMem
+    exact (numericalCurvature_eq_zero_iff_DiagramCommutes metric).mp
+      ((totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+        metric).mp hZero d hMem)
+  · intro hCommutes
+    exact
+      (totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+        metric).mpr (by
+          intro d hMem
+          exact numericalCurvature_eq_zero_of_DiagramCommutes metric
+            (hCommutes d hMem))
+
+/--
+Total numerical curvature is zero exactly when the measured diagram universe has
+no numerical curvature obstruction.
+-/
+theorem totalCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {measured : List (RequiredDiagram Expr)} :
+    totalCurvature metric sem measured = 0 ↔
+      NoMeasuredNumericalCurvatureObstruction metric sem measured := by
+  rw [totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero]
+  constructor
+  · intro hZero d hMem hObstruction
+    exact hObstruction (hZero d hMem)
+  · intro hNoObstruction d hMem
+    by_cases hZero : numericalCurvature metric sem d = 0
+    · exact hZero
+    · exact False.elim (hNoObstruction d hMem hZero)
 
 end Formal.Arch

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -575,11 +575,14 @@ extractor completeness と empirical hypotheses は含めない。
   [Issue #226](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/226)。
 - `defined only`: witness family をまとめる signature schema と
   `ArchitectureSignatureV1` axis measurement classification。
-- `future proof obligation`: 一般の数値 curvature metric について、観測値上の
-  zero-separating distance と非負集約を前提に
-  `curvature = 0 <-> DiagramCommutes` および
-  `totalCurvature = 0 <-> no numerical curvature obstruction` を証明する bridge,
-  [Issue #194](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/194)。
+- `proved`: zero-separating distance 上の数値 curvature について、
+  `curvature = 0 <-> DiagramCommutes` を証明し、さらに有限な測定済み
+  diagram list 上の `Nat` 和として
+  `totalCurvature = 0 <-> no measured numerical curvature obstruction` を証明した,
+  [Issue #239](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/239),
+  [Issue #240](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/240)。
+- `future proof obligation`: weighted curvature、Signature axis への載せ方、
+  およびより一般の集約構造での zero-reflection bridge。
 - `proved`: 0/1 `RuntimeDependencyGraph` が与えられたとき、
   runtime exposure zero metric と measured / bounded runtime obstruction absence を
   接続する bridge。

--- a/docs/formal/lean_theorem_index.md
+++ b/docs/formal/lean_theorem_index.md
@@ -306,12 +306,17 @@ File: `Formal/Arch/Curvature.lean`
 | `numericalCurvature` | `def` | required diagram の両辺の観測意味論間の距離として数値 curvature を定義する。 | `defined only` |
 | `NumericalCurvatureObstruction` | `def` | diagram の数値 curvature が非零であることを obstruction witness として表す。 | `defined only` |
 | `NoNumericalCurvatureObstruction` | `def` | required diagram family に数値 curvature obstruction が存在しないこと。 | `defined only` |
+| `totalCurvature` | `def` | 有限な測定済み diagram list 上で、各 diagram の数値 curvature を `Nat` 和として集約する。 | `defined only` |
+| `NoMeasuredNumericalCurvatureObstruction` | `def` | 測定済み diagram list 内に数値 curvature obstruction が存在しないこと。未測定 diagram には主張しない。 | `defined only` |
 | `numericalCurvature_eq_zero_iff_DiagramCommutes` | `theorem` | zero-separating distance の下で、数値 curvature 0 と diagram commutativity が一致する。 | `proved` |
 | `numericalCurvature_eq_zero_of_DiagramCommutes` | `theorem` | 可換な diagram は数値 curvature が 0 である。 | `proved` |
 | `DiagramCommutes_of_numericalCurvature_eq_zero` | `theorem` | 数値 curvature 0 から diagram commutativity を得る。 | `proved` |
 | `numericalCurvatureObstruction_iff_DiagramBad` | `theorem` | 数値 curvature obstruction と既存の `DiagramBad` predicate が一致する。 | `proved` |
 | `not_numericalCurvatureObstruction_iff_DiagramCommutes` | `theorem` | 個別 diagram で、数値 curvature obstruction 不在と可換性が一致する。 | `proved` |
 | `diagramLawful_iff_noNumericalCurvatureObstruction` | `theorem` | required diagram family の lawfulness と数値 curvature obstruction 不在を接続する。 | `proved` |
+| `totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero` | `theorem` | 有限測定 universe 上で、合計 curvature 0 と各 measured diagram の curvature 0 が一致する。 | `proved` |
+| `totalCurvature_eq_zero_iff_forall_measured_DiagramCommutes` | `theorem` | 有限測定 universe 上で、合計 curvature 0 と各 measured diagram の可換性が一致する。 | `proved` |
+| `totalCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction` | `theorem` | 有限測定 universe 上で、合計 curvature 0 と measured numerical curvature obstruction 不在が一致する。 | `proved` |
 
 ## Lawfulness Bridge
 
@@ -703,9 +708,10 @@ File: `Formal/Arch/SolidCounterexample.lean`
 次は意図的に Lean core へ混ぜていない。
 
 - `Decomposable` の定義への acyclicity, finite propagation, nilpotence, spectral conditions の混入。
-- 重み付き・集約済みの一般 `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
-  `Formal/Arch/Curvature.lean` は、個別 diagram の zero-separating distance bridge だけを
-  含み、重み・集約規則・empirical cost model はまだ導入しない。
+- 重み付き・より一般の `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
+  `Formal/Arch/Curvature.lean` は、zero-separating distance の個別 diagram bridge と
+  有限測定 list 上の `Nat` total bridge までを含み、重み・Signature axis 化・
+  empirical cost model はまだ導入しない。
 - `relationComplexity`, `runtimePropagation`, `empiricalChangeCost` の実証相関。
 - extractor output が `ComponentUniverse` の完全な witness であるという主張。
 - `rho(A)` と変更波及・障害伝播コストの相関。

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -392,12 +392,15 @@ Issue [#239](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2
 `NumericalCurvatureObstruction`, `NoNumericalCurvatureObstruction` を追加し、
 個別 diagram について `numericalCurvature = 0 <-> DiagramCommutes` と
 `DiagramLawful <-> NoNumericalCurvatureObstruction` の bridge を証明した。
-次の集約 target は
-`totalCurvature = 0 <-> no numerical curvature obstruction` の bridge であり、
+Issue [#240](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/240)
+では、有限な測定済み diagram list 上の `totalCurvature` と
+`NoMeasuredNumericalCurvatureObstruction` を追加し、
+`totalCurvature = 0 <-> every measured diagram has curvature 0` および
+`totalCurvature = 0 <-> NoMeasuredNumericalCurvatureObstruction` を証明した。
+この theorem は list-scoped であり、未測定 diagram を zero obstruction とは扱わない。
 変更コスト・障害率・レビュー負荷との相関や重みの calibration は empirical
-hypothesis として分離する。重み付き・集約済みの一般 metric と
-Signature axis への載せ方は `future proof obligation` として残す。
-これは obstruction witness zero-count
+hypothesis として分離する。重み付き・Signature axis への載せ方は
+`future proof obligation` として残す。これは obstruction witness zero-count
 theorem の代替ではなく、追加 axis または派生評価として接続する。
 
 ## 基本 convention
@@ -1342,7 +1345,7 @@ Lean status の区分:
 | `observationalDivergence`, `lspViolationCount` | 観測差分と measured LSP violation pair を数える behavioral extension | `defined only` / `proved` |
 | `nilpotencyIndex` | finite `ComponentUniverse` 上で最初の zero adjacency power を探す executable metric。acyclic graph では `some` になる bridge を証明済み。`some k` は index 値であり、required zero-axis ではない | `defined only` / `proved` |
 | `rho(A)` | 行列解析上の伝播増幅指標として扱う。finite DAG では 0、finite closed walk では正になる bridge を証明済み | `proved` for `DAG -> rho(A)=0` / `proved` for cycle positivity / `empirical hypothesis` |
-| `numericCurvature` | 個別 diagram では `ZeroSeparatingDistance` と `numericalCurvature` を追加し、`numericalCurvature = 0 <-> DiagramCommutes` および `DiagramLawful <-> NoNumericalCurvatureObstruction` を証明済み。非負集約、Signature axis への載せ方、重み calibration や現実コストとの相関は別層に残す | `proved` / `future proof obligation` / `empirical hypothesis` |
+| `numericCurvature` | 個別 diagram では `ZeroSeparatingDistance` と `numericalCurvature` を追加し、`numericalCurvature = 0 <-> DiagramCommutes` および `DiagramLawful <-> NoNumericalCurvatureObstruction` を証明済み。有限な測定済み diagram list 上では `totalCurvature = 0 <-> NoMeasuredNumericalCurvatureObstruction` を証明済み。Signature axis への載せ方、重み calibration や現実コストとの相関は別層に残す | `proved` / `future proof obligation` / `empirical hypothesis` |
 | `runtimePropagation` | 0/1 `RuntimeDependencyGraph` 上では `reachableConeSizeOfFinite` による runtime exposure radius として計算する。既存名は `runtimeExposureRadius` の互換名であり、zero metric と runtime obstruction absence の bridge は `reachesWithin` ベースの measured obstruction として証明済み。semantic `Reachable` 版、blast radius、policy-aware runtime exposure は別 bridge または tooling / analysis metric として分ける | `defined only` / `proved` / `future proof obligation` / `empirical hypothesis` |
 | `relationComplexity` | 状態遷移代数層の設計に依存する | `empirical hypothesis` |
 | `empiricalChangeCost` | 実データで検証する目的変数 | `empirical hypothesis` |


### PR DESCRIPTION
## 概要

Closes #240

有限な測定済み diagram list 上の `totalCurvature` と `NoMeasuredNumericalCurvatureObstruction` を追加し、合計数値 curvature の 0 と測定済み obstruction 不在を接続しました。

この bridge は list-scoped な数学的コア拡張として扱い、未測定 diagram、重み付き curvature、Signature axis 化、empirical cost model には踏み込みません。

## 証明した定理

- `totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero`
- `totalCurvature_eq_zero_iff_forall_measured_DiagramCommutes`
- `totalCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction`

## 編集したドキュメント

- `docs/formal/lean_theorem_index.md`
- `docs/proof_obligations.md`
- `docs/formal/flatness_obstruction_lean_design.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
