### PR TITLE
Architecture Calculus証明タスク索引を整理

### DIFF
--- a/docs/aat_v2_mathematical_design.md
+++ b/docs/aat_v2_mathematical_design.md
@@ -1061,6 +1061,18 @@ LawfulExtensionPreservesFlatness:
 `ArchitectureFlatWithin U X'` は、universe `U` で観測・証明できる範囲の flatness である。
 実コード extractor、telemetry、semantic diagram universe の完全性を暗黙に仮定しない。
 
+Issue [#262](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/262)
+の最初の Lean 対象範囲は、`ExtensionCoverage`, `ExtensionObstructionWitness`,
+classification predicate 群、および `ArchitectureExtensionFormula_structural`
+の bounded classification theorem である。
+
+Lean status: `ArchitectureExtensionFormula_structural` と
+`LawfulExtensionPreservesFlatness` は `future proof obligation`。
+前提となる `ArchitectureOperation` / `ProofObligation` schema、repair step decreases、
+selected split-extension lifting はそれぞれ Issue #265, #266, #264 で Lean 化済みである。
+`LawfulExtensionPreservesFlatness` は #262 内で直接 corollary として切れる場合のみ証明し、
+coverage assumptions が大きくなる場合は後続 Issue に分割する。
+
 ### 8.5 Analytic representation layer
 
 解析的表現は、理論コアではなく Architecture Extension Formula の representation として扱う。
@@ -1390,6 +1402,13 @@ soundness は future proof obligation。
 - split extension を selected lifting / section / factorization として定義する。
 - Architecture Extension Formula の structural classification theorem を証明する。
 ```
+
+Lean status: finite architecture path core、generated path homotopy、
+diagram filling / non-fillability witness soundness、selected split-extension lifting は
+`defined only` / `proved` の theorem package として存在する。
+Architecture Extension Formula の structural classification theorem は Issue
+[#262](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/262)
+の `future proof obligation` であり、coverage / classification theorem として扱う。
 
 ### Phase A6: Representation Bridges
 

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -278,6 +278,21 @@ File: `Formal/Arch/Repair.lean`
 Non-conclusions: repair theorem package は runtime flatness、semantic flatness、all obstruction removal、
 repair termination、finite repair、synthesis soundness、no-solution certificate soundness を主張しない。
 
+## Architecture Extension Formula
+
+Issue [#262](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/262)
+の `ArchitectureExtensionFormula_structural` は、現時点では `future proof obligation`
+であり、対応する Lean module / theorem はまだ存在しない。
+
+予定されている Lean 対象範囲は、`ExtensionCoverage`, `ExtensionObstructionWitness`,
+inherited core / feature local / interaction / lifting failure / filling failure /
+complexity transfer / residual coverage gap の classification predicate 群、および
+bounded classification theorem である。実装時にはこの節を File と API table へ更新する。
+
+Non-conclusions: 最初の theorem package は disjoint decomposition、global extractor
+completeness、runtime / semantic universe completeness、または universe 外の obstruction
+分類を主張しない。
+
 ## Architecture Path
 
 File: `Formal/Arch/ArchitecturePath.lean`

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -74,6 +74,7 @@ ArchitectureLawful X
 | SplitExtensionLifting / selected section law | `defined only` / `proved` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#83-split-extension-as-lifting-and-section), [Lean theorem index](lean_theorem_index.md#split-extension-lifting), Issue [#264](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/264) |
 | ArchitectureOperation / ProofObligation schema | `defined only` / `proved` for schema accessor theorems | [AAT v2 数学設計書](aat_v2_mathematical_design.md#3-architecture-calculus), [Lean theorem index](lean_theorem_index.md#architecture-operation) |
 | Repair step decreases / selected obstruction measure | `defined only` / `proved` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#73-repair-as-re-splitting), [Lean theorem index](lean_theorem_index.md#repair), Issue [#266](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/266) |
+| Structural Architecture Extension Formula / obstruction classification | `future proof obligation` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#84-structural-architecture-extension-formula), [Lean theorem index](lean_theorem_index.md#architecture-extension-formula), Issue [#262](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/262) |
 | ArchitecturePath / homotopy skeleton | `defined only` / `proved` | [Lean theorem index](lean_theorem_index.md#architecture-path) |
 | DiagramFiller / obstruction as non-fillability | `defined only` / `proved` / `future proof obligation` | [Lean theorem index](lean_theorem_index.md#diagram-filler) |
 | Projection / DIP bridge | `proved` for soundness bridges; exact projection refinements tracked separately | [Projection soundness と exact projection の使い分け](design/projection_exact_soundness.md), [Lean theorem index](lean_theorem_index.md#projection--dip) |
@@ -81,6 +82,23 @@ ArchitectureLawful X
 | Matrix / nilpotence / spectral bridge | `proved` for finite structural bridges; cost interpretation is empirical | [spectral radius bridge 設計](design/spectral_radius_bridge.md), [Lean theorem index](lean_theorem_index.md#matrix-bridge) |
 | Runtime propagation | `defined only` / `proved` for 0/1 runtime graph zero bridge; policy-aware coverage is separate | [runtimePropagation 設計](design/runtime_propagation_design.md), [Lean theorem index](lean_theorem_index.md#finite-universe--bridge-theorems) |
 | SOLID-style counterexamples | `proved` for current Lean examples | [Lean theorem index](lean_theorem_index.md#solid-counterexamples) |
+
+### Architecture Calculus / Extension Formula task package
+
+Issue [#261](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/261)
+は、Architecture Calculus から Structural Architecture Extension Formula へ進む
+Lean 証明タスクの親索引である。子 Issue の現在の扱いは次の通り。
+
+| Issue | 対象 | Lean status | 次の扱い |
+| --- | --- | --- | --- |
+| [#265](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/265) | `ArchitectureOperation` / `ProofObligation` schema と witness mapping theorem | `defined only` / `proved` | 完了済み。実装済み API は [Lean theorem index](lean_theorem_index.md#architecture-operation) を参照する。 |
+| [#266](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/266) | repair step decreases theorem / selected obstruction measure | `defined only` / `proved` | 完了済み。実装済み API は [Lean theorem index](lean_theorem_index.md#repair) を参照する。 |
+| [#264](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/264) | SplitExtensionLifting / selected section law | `defined only` / `proved` | 完了済み。実装済み API は [Lean theorem index](lean_theorem_index.md#split-extension-lifting) を参照する。 |
+| [#262](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/262) | `ArchitectureExtensionFormula_structural` classification theorem | `future proof obligation` | 次に着手する Lean proof task。`ExtensionCoverage`, `ExtensionObstructionWitness`, classification predicate 群、bounded classification theorem を追加する。 |
+
+#262 は disjoint decomposition ではなく coverage / classification theorem として扱う。
+`LawfulExtensionPreservesFlatness` は #262 内で corollary として切れる場合のみ証明し、
+前提が大きい場合は後続 Issue に分割する。
 
 ## Empirical Hypothesis Index
 


### PR DESCRIPTION
## 概要

Closes #261

Architecture Calculus から Structural Architecture Extension Formula へ進む Lean 証明タスクの親索引を docs に追加しました。#265/#266/#264 の完了済み theorem package と、残タスク #262 の `future proof obligation` 境界を明確にしています。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/proof_obligations.md`: #261 の子 Issue 状態と #262 の残 proof obligation を追加
- `docs/lean_theorem_index.md`: `ArchitectureExtensionFormula_structural` が未実装の future proof obligation であることを明記
- `docs/aat_v2_mathematical_design.md`: 8.4 と Phase A5 の Lean status を現在の実装状態に合わせて更新

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている