### PR TITLE
Coupon例のsemantic witnessとvaluation theoremを追加する

### DIFF
--- a/Formal/Arch/DiagramFiller.lean
+++ b/Formal/Arch/DiagramFiller.lean
@@ -1,4 +1,5 @@
 import Formal.Arch.ArchitecturePath
+import Formal.Arch.AnalyticRepresentation
 
 namespace Formal.Arch
 
@@ -165,9 +166,9 @@ theorem obstructionAsNonFillability_complete_bounded {State : Type u}
 A small path skeleton for the canonical coupon/discount ordering example from
 the design note.
 
-No non-fillability theorem is asserted here. The example only exposes the two
-operation orders as a diagram so later semantic contracts can attach a concrete
-rounding-order witness.
+The selected semantic contract below tracks only rounding-order observations.
+It is a bounded example: it does not claim global semantic completeness or
+extractor completeness outside this selected diagram and witness.
 -/
 namespace CouponDiscountExample
 
@@ -206,6 +207,181 @@ def couponDiscountDiagram :
 
 inductive CouponDiscountWitness where
   | roundingOrder
+  deriving DecidableEq, Repr
+
+namespace CouponDiscountStep
+
+/-- Selected observation code for the coupon/discount ordering example. -/
+def roundingCode : {X Y : CouponState} -> CouponDiscountStep X Y -> Nat
+  | _, _, applyCouponFirst => 1
+  | _, _, applyDiscountAfterCoupon => 2
+  | _, _, applyDiscountFirst => 3
+  | _, _, applyCouponAfterDiscount => 4
+
+end CouponDiscountStep
+
+/-- Selected semantic observation of an operation path. -/
+def roundingTrace :
+    {X Y : CouponState} -> ArchitecturePath CouponDiscountStep X Y -> Nat
+  | _, _, ArchitecturePath.nil _ => 0
+  | _, _, ArchitecturePath.cons step rest =>
+      CouponDiscountStep.roundingCode step + 10 * roundingTrace rest
+
+/--
+Selected independent-square contract for the coupon example: only swaps that
+preserve the rounding observation for every suffix are allowed.
+-/
+def RoundingIndependentSquare
+    (W X Y Z : CouponState)
+    (a : CouponDiscountStep W X) (b : CouponDiscountStep X Z)
+    (c : CouponDiscountStep W Y) (d : CouponDiscountStep Y Z) : Prop :=
+  ∀ {T : CouponState} (rest : ArchitecturePath CouponDiscountStep Z T),
+    roundingTrace (ArchitecturePath.cons a (ArchitecturePath.cons b rest)) =
+      roundingTrace (ArchitecturePath.cons c (ArchitecturePath.cons d rest))
+
+/-- Selected same-contract replacement: replacement must preserve observation. -/
+def RoundingSameExternalContract
+    (X Y : CouponState) (s t : CouponDiscountStep X Y) : Prop :=
+  ∀ {Z : CouponState} (rest : ArchitecturePath CouponDiscountStep Y Z),
+    roundingTrace (ArchitecturePath.cons s rest) =
+      roundingTrace (ArchitecturePath.cons t rest)
+
+/-- Selected repair fills are exactly those that preserve rounding observation. -/
+def RoundingRepairFill
+    (X Y : CouponState)
+    (p q : ArchitecturePath CouponDiscountStep X Y) : Prop :=
+  roundingTrace p = roundingTrace q
+
+/-- The selected filler generators preserve the rounding observation. -/
+theorem pathHomotopy_preserves_roundingTrace
+    {X Y : CouponState} {p q : ArchitecturePath CouponDiscountStep X Y}
+    (h :
+      ArchitecturePath.PathHomotopy
+        RoundingIndependentSquare RoundingSameExternalContract
+        RoundingRepairFill p q) :
+    roundingTrace p = roundingTrace q := by
+  induction h with
+  | refl p => rfl
+  | symm _ ih => exact Eq.symm ih
+  | trans _ _ ihLeft ihRight => exact Eq.trans ihLeft ihRight
+  | swapIndependent a b c d rest hIndependent =>
+      exact hIndependent rest
+  | replaceBySameContract s t rest hSame =>
+      exact hSame rest
+  | repairFill hRepair =>
+      exact hRepair
+
+theorem couponThenDiscount_roundingTrace :
+    roundingTrace couponThenDiscount = 21 :=
+  rfl
+
+theorem discountThenCoupon_roundingTrace :
+    roundingTrace discountThenCoupon = 43 :=
+  rfl
+
+/--
+The rounding-order witness refutes the selected filler: every selected filler
+would preserve `roundingTrace`, but the two operation orders have different
+selected observations.
+-/
+theorem roundingOrder_refutes_selectedDiagramFiller :
+    ¬ DiagramFiller
+      RoundingIndependentSquare RoundingSameExternalContract RoundingRepairFill
+      couponDiscountDiagram := by
+  intro hFiller
+  have hTrace := pathHomotopy_preserves_roundingTrace hFiller
+  change roundingTrace couponThenDiscount = roundingTrace discountThenCoupon at hTrace
+  rw [couponThenDiscount_roundingTrace, discountThenCoupon_roundingTrace] at hTrace
+  exact (by decide : (21 : Nat) ≠ 43) hTrace
+
+/-- Concrete non-fillability witness for the selected coupon/discount diagram. -/
+def roundingOrderNonFillabilityWitness :
+    NonFillabilityWitness
+      RoundingIndependentSquare RoundingSameExternalContract RoundingRepairFill
+      couponDiscountDiagram CouponDiscountWitness where
+  witness := CouponDiscountWitness.roundingOrder
+  refutesFiller := by
+    intro hFiller
+    exact roundingOrder_refutes_selectedDiagramFiller hFiller
+
+/-- The concrete witness is the selected `roundingOrder` witness. -/
+theorem roundingOrder_nonFillabilityWitnessFor :
+    NonFillabilityWitnessFor
+      RoundingIndependentSquare RoundingSameExternalContract RoundingRepairFill
+      couponDiscountDiagram CouponDiscountWitness.roundingOrder := by
+  exact ⟨roundingOrderNonFillabilityWitness, rfl⟩
+
+/-- Selected semantic residual for the coupon/discount diagram. -/
+def roundingOrderResidual
+    (D : ArchitectureDiagram CouponDiscountStep .start .finished) : Nat :=
+  if roundingTrace D.lhs = roundingTrace D.rhs then 0 else 1
+
+/-- Selected semantic obstruction tracked by the coupon/discount valuation. -/
+def RoundingSemanticObstruction
+    (D : ArchitectureDiagram CouponDiscountStep .start .finished)
+    (w : CouponDiscountWitness) : Prop :=
+  w = CouponDiscountWitness.roundingOrder ∧
+    roundingTrace D.lhs ≠ roundingTrace D.rhs
+
+/--
+Selected valuation for the canonical coupon/discount example.
+
+This valuation is witness-relative and records only the selected rounding-order
+residual. It does not make claims about unmeasured semantic axes.
+-/
+def roundingOrderValuation :
+    ObstructionValuation
+      (ArchitectureDiagram CouponDiscountStep .start .finished)
+      CouponDiscountWitness where
+  obstruction := RoundingSemanticObstruction
+  value := fun D _w => roundingOrderResidual D
+  zeroReflectsAbsence := by
+    intro D w hZero hObs
+    rcases hObs with ⟨_hWitness, hNe⟩
+    unfold roundingOrderResidual at hZero
+    by_cases hEq : roundingTrace D.lhs = roundingTrace D.rhs
+    · exact hNe hEq
+    · rw [if_neg hEq] at hZero
+      exact (by decide : (1 : Nat) ≠ 0) hZero
+  obstructionGivesPositive := by
+    intro D w hObs
+    rcases hObs with ⟨_hWitness, hNe⟩
+    unfold roundingOrderResidual
+    by_cases hEq : roundingTrace D.lhs = roundingTrace D.rhs
+    · exact False.elim (hNe hEq)
+    · rw [if_neg hEq]
+      decide
+  coverageAssumptions := True
+  nonConclusions := True
+
+theorem couponDiscount_roundingOrderResidual_positive :
+    0 < roundingOrderResidual couponDiscountDiagram := by
+  unfold roundingOrderResidual
+  change 0 < if roundingTrace couponThenDiscount =
+    roundingTrace discountThenCoupon then 0 else 1
+  rw [couponThenDiscount_roundingTrace, discountThenCoupon_roundingTrace]
+  rw [if_neg (by decide : (21 : Nat) ≠ 43)]
+  decide
+
+theorem roundingOrderValuation_obstruction :
+    roundingOrderValuation.obstruction
+      couponDiscountDiagram CouponDiscountWitness.roundingOrder := by
+  constructor
+  · rfl
+  · change roundingTrace couponThenDiscount ≠ roundingTrace discountThenCoupon
+    rw [couponThenDiscount_roundingTrace, discountThenCoupon_roundingTrace]
+    decide
+
+theorem roundingOrderValuation_positive :
+    0 < roundingOrderValuation.value
+      couponDiscountDiagram CouponDiscountWitness.roundingOrder :=
+  roundingOrderValuation.obstructionGivesPositive
+    couponDiscountDiagram CouponDiscountWitness.roundingOrder
+    roundingOrderValuation_obstruction
+
+theorem roundingOrderValuation_recordsNonConclusions :
+    ObstructionValuation.RecordsNonConclusions roundingOrderValuation := by
+  trivial
 
 end CouponDiscountExample
 

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -462,10 +462,21 @@ File: `Formal/Arch/DiagramFiller.lean`
 | `WitnessUniverseComplete` | `def` | bounded completeness theorem 用の有限 witness universe 完全性前提。 | `defined only` |
 | `obstructionAsNonFillability_complete_bounded` | `theorem` | `WitnessUniverseComplete` と `¬ DiagramFiller D` から、有限 universe 内の `NonFillabilityWitnessFor D w` を得る bounded completeness theorem。 | `proved` |
 | `CouponDiscountExample.couponDiscountDiagram` | `def` | coupon と discount の順序依存例を、二つの operation order を持つ diagram skeleton として表す。 | `defined only` |
+| `CouponDiscountExample.roundingTrace` | `def` | coupon / discount path の selected rounding-order observation を `Nat` trace として与える。 | `defined only` |
+| `CouponDiscountExample.RoundingIndependentSquare` | `def` | selected filler generator のうち rounding observation を保存する independent-square contract。 | `defined only` |
+| `CouponDiscountExample.RoundingSameExternalContract` | `def` | rounding observation を保存する same-contract replacement contract。 | `defined only` |
+| `CouponDiscountExample.RoundingRepairFill` | `def` | rounding observation を保存する selected repair fill contract。 | `defined only` |
+| `CouponDiscountExample.pathHomotopy_preserves_roundingTrace` | `theorem` | selected filler generator から生成される path homotopy が `roundingTrace` を保存することを示す。 | `proved` |
+| `CouponDiscountExample.roundingOrder_refutes_selectedDiagramFiller` | `theorem` | `roundingOrder` witness が selected coupon / discount diagram filler を反駁する。 | `proved` |
+| `CouponDiscountExample.roundingOrder_nonFillabilityWitnessFor` | `theorem` | `CouponDiscountWitness.roundingOrder` が selected diagram の `NonFillabilityWitnessFor` であることを示す。 | `proved` |
+| `CouponDiscountExample.roundingOrderResidual` | `def` | selected coupon / discount diagram の semantic residual を `0/1` valuation として定義する。 | `defined only` |
+| `CouponDiscountExample.roundingOrderValuation` | `def` | selected rounding-order residual に相対化された `ObstructionValuation` package。 | `defined only` |
+| `CouponDiscountExample.roundingOrderValuation_positive` | `theorem` | canonical coupon / discount diagram で selected rounding-order valuation が positive になることを示す。 | `proved` |
 
 Non-conclusions: bounded completeness は `WitnessUniverseComplete` に相対化される。
-global semantic completeness、finite universe 外の witness coverage、実コード extractor
-completeness は主張しない。
+coupon / discount valuation は selected rounding-order residual に相対化される。
+global semantic completeness、finite universe 外の witness coverage、未測定 semantic axis の
+zero 性、実コード extractor completeness は主張しない。
 
 ## Flatness
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -82,7 +82,7 @@ ArchitectureLawful X
 | Repair termination / synthesis / no-solution certificate | `defined only` / `proved` for bounded schema accessor theorems | [AAT v2 数学設計書](aat_v2_mathematical_design.md#75-no-solution-certificate), [Lean theorem index](lean_theorem_index.md#repair-synthesis), Issue [#277](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/277) |
 | Structural Architecture Extension Formula / obstruction classification | `defined only` / `proved` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#84-structural-architecture-extension-formula), [Lean theorem index](lean_theorem_index.md#architecture-extension-formula), Issue [#262](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/262) |
 | ArchitecturePath / homotopy skeleton | `defined only` / `proved` | [Lean theorem index](lean_theorem_index.md#architecture-path) |
-| DiagramFiller / obstruction as non-fillability | `defined only` / `proved` | [Lean theorem index](lean_theorem_index.md#diagram-filler), Issue [#285](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/285) |
+| DiagramFiller / obstruction as non-fillability | `defined only` / `proved` | [Lean theorem index](lean_theorem_index.md#diagram-filler), Issues [#285](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/285), [#286](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/286) |
 | Projection / DIP bridge | `proved` for soundness bridges; exact projection refinements tracked separately | [Projection soundness と exact projection の使い分け](design/projection_exact_soundness.md), [Lean theorem index](lean_theorem_index.md#projection--dip) |
 | Observation / LSP bridge | `proved` for finite violation-count bridges | [Observation bridge と projection bridge の関係](design/observation_projection_bridge.md), [Lean theorem index](lean_theorem_index.md#observation--lsp) |
 | Matrix / nilpotence / spectral bridge | `proved` for finite structural bridges; cost interpretation is empirical | [spectral radius bridge 設計](design/spectral_radius_bridge.md), [Lean theorem index](lean_theorem_index.md#matrix-bridge) |
@@ -122,6 +122,19 @@ Issue [#275](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2
 | [#277](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/277) | repair termination / synthesis / no-solution certificate soundness | `defined only` / `proved` | `BoundedRepairPlan`, `FiniteRepairPackage`, `SynthesisConstraintSystem`, `SynthesisSoundnessPackage`, `NoSolutionCertificate`, `ValidNoSolutionCertificate`, `NoSolutionCertificate.sound_of_valid` は実装済み。solver が `none` を返すだけでは非存在を主張しない。 |
 | [#278](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/278) | ArchitectureEvolution transition theorem package | `defined only` / `proved` | `ArchitectureTransition`, `ArchitectureEvolution`, `TransitionPreservesFlatness`, `DriftObstructionSchema`, `MigrationSequence`, `EveryStepLawful`, `EventuallyFlat` は実装済み。実装済み API は [Lean theorem index](lean_theorem_index.md#architecture-evolution) を参照する。transition schema は bounded flatness predicate と selected witness reporting に相対化され、global extractor completeness や全 obstruction coverage は non-conclusions として扱う。 |
 | [#280](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/280) | AnalyticRepresentation bridge と representation strength | `defined only` / `proved` | `AnalyticRepresentation`, `ZeroPreserving`, `ZeroReflecting`, `ObstructionPreserving`, `ObstructionReflecting`, `ObstructionValuation`, `ZeroReflectingSum` は実装済み。zero-reflecting / obstruction-reflecting は coverage、witness completeness、semantic contract coverage に相対化し、witness absence だけから flatness を主張しない。 |
+
+### Mathematical design follow-up task package
+
+Issue [#284](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/284)
+は、数学設計書に残る小さな Lean theorem package の親索引である。
+子 Issue の現在の扱いは次の通り。
+
+| Issue | 対象 | Lean status | 次の扱い |
+| --- | --- | --- | --- |
+| [#285](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/285) | `NonFillabilityWitness` の bounded completeness theorem | `defined only` / `proved` | `WitnessUniverseComplete` と `obstructionAsNonFillability_complete_bounded` は実装済み。bounded completeness は有限 witness universe 完全性前提に相対化され、global semantic completeness は主張しない。 |
+| [#286](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/286) | Coupon feature extension example の semantic witness / valuation theorem | `defined only` / `proved` | `roundingTrace`, selected filler contracts、`roundingOrder_refutes_selectedDiagramFiller`, `roundingOrder_nonFillabilityWitnessFor`, `roundingOrderValuation_positive` は実装済み。valuation は selected rounding-order residual に限られ、未測定 semantic axis の zero 性や実コード extractor completeness は主張しない。 |
+| [#288](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/288) | Complexity Transfer の bounded theorem package | `future proof obligation` | bounded assumptions と selected transfer theorem package を後続で定義・証明する。 |
+| [#287](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/287) | ArchitectureCore / CertifiedArchitecture の proof-carrying schema | `future proof obligation` | 実コード extractor の完全性ではなく、proof-carrying measurement universe としての schema を後続で定義する。 |
 
 ## Empirical Hypothesis Index
 


### PR DESCRIPTION
## 概要

Closes #286

Coupon feature extension example に、selected rounding-order observation を導入し、coupon / discount の二つの operation order が selected filler では埋められないことを証明しました。

semantic residual に相対化した `ObstructionValuation` package も追加し、canonical coupon / discount diagram で selected valuation が positive になる theorem を追加しました。global semantic completeness、未測定 semantic axis の zero 性、実コード extractor completeness は non-conclusions として維持しています。

## 証明した定理

- `CouponDiscountExample.pathHomotopy_preserves_roundingTrace`
- `CouponDiscountExample.couponThenDiscount_roundingTrace`
- `CouponDiscountExample.discountThenCoupon_roundingTrace`
- `CouponDiscountExample.roundingOrder_refutes_selectedDiagramFiller`
- `CouponDiscountExample.roundingOrder_nonFillabilityWitnessFor`
- `CouponDiscountExample.couponDiscount_roundingOrderResidual_positive`
- `CouponDiscountExample.roundingOrderValuation_obstruction`
- `CouponDiscountExample.roundingOrderValuation_positive`
- `CouponDiscountExample.roundingOrderValuation_recordsNonConclusions`

## 編集したドキュメント

- `docs/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
