### PR TITLE
静的 split 失敗 witness の bounded theorem package を追加

### DIFF
--- a/Formal/Arch/FeatureExtension.lean
+++ b/Formal/Arch/FeatureExtension.lean
@@ -122,4 +122,191 @@ structure StaticSplitFeatureExtension (Core : Type u) (Feature : Type v)
 abbrev StaticSplitExtension :=
   StaticSplitFeatureExtension
 
+/--
+Selected static split condition for a fixed feature extension and fixed policy
+parameters.
+
+This predicate is the unbundled form of `StaticSplitFeatureExtension`: it is
+useful when diagnostic theorems need to talk about failure of one selected
+static split package without claiming runtime, semantic, or extractor
+completeness.
+-/
+structure SelectedStaticSplitExtension
+    (X : FeatureExtension Core Feature Extended FeatureView)
+    (declaredInterface : Extended -> Prop)
+    (coreAllowedStaticEdge : Core -> Core -> Prop)
+    (extendedAllowedStaticEdge : Extended -> Extended -> Prop) : Prop where
+  coreEdgesPreserved : CoreEdgesPreserved X
+  declaredInterfaceFactorization :
+    DeclaredInterfaceFactorization X declaredInterface
+  noNewForbiddenStaticEdge :
+    NoNewForbiddenStaticEdge X.extended extendedAllowedStaticEdge
+  policyPreserved :
+    EmbeddingPolicyPreserved X coreAllowedStaticEdge extendedAllowedStaticEdge
+
+/-- The bundled static split schema supplies the selected static split predicate. -/
+theorem selectedStaticSplitExtension_of_staticSplitFeatureExtension
+    (S : StaticSplitFeatureExtension Core Feature Extended FeatureView) :
+    SelectedStaticSplitExtension S.extension S.declaredInterface
+      S.coreAllowedStaticEdge S.extendedAllowedStaticEdge :=
+  ⟨S.coreEdgesPreserved, S.declaredInterfaceFactorization,
+    S.noNewForbiddenStaticEdge, S.policyPreserved⟩
+
+/-- A selected static split predicate can be bundled back into the existing schema. -/
+def staticSplitFeatureExtension_of_selectedStaticSplitExtension
+    (X : FeatureExtension Core Feature Extended FeatureView)
+    (declaredInterface : Extended -> Prop)
+    (coreAllowedStaticEdge : Core -> Core -> Prop)
+    (extendedAllowedStaticEdge : Extended -> Extended -> Prop)
+    (hSplit :
+      SelectedStaticSplitExtension X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge) :
+    StaticSplitFeatureExtension Core Feature Extended FeatureView where
+  extension := X
+  declaredInterface := declaredInterface
+  coreAllowedStaticEdge := coreAllowedStaticEdge
+  extendedAllowedStaticEdge := extendedAllowedStaticEdge
+  coreEdgesPreserved := hSplit.coreEdgesPreserved
+  declaredInterfaceFactorization := hSplit.declaredInterfaceFactorization
+  noNewForbiddenStaticEdge := hSplit.noNewForbiddenStaticEdge
+  policyPreserved := hSplit.policyPreserved
+
+/--
+Selected diagnostic witnesses for failure of the static split package.
+
+The constructors mirror the current Lean static split kernel: core edge
+preservation, declared interface factorization, no-new-forbidden-edge, and
+embedding policy preservation. They are intentionally static-only.
+-/
+inductive StaticExtensionWitness
+    (X : FeatureExtension Core Feature Extended FeatureView)
+    (declaredInterface : Extended -> Prop)
+    (coreAllowedStaticEdge : Core -> Core -> Prop)
+    (extendedAllowedStaticEdge : Extended -> Extended -> Prop) where
+  | missingCoreEdge (src dst : Core)
+      (coreEdge : X.core.edge src dst)
+      (missingExtendedEdge :
+        ¬ X.extended.edge (X.coreEmbedding src) (X.coreEmbedding dst))
+  | unfactoredBoundaryEdge (src dst : Extended)
+      (extendedEdge : X.extended.edge src dst)
+      (crossesBoundary : CrossesFeatureCoreBoundary X src dst)
+      (missingDeclaredFactor :
+        ¬ EdgeFactorsThroughDeclaredInterface X.extended declaredInterface src dst)
+  | forbiddenStaticEdge (src dst : Extended)
+      (extendedEdge : X.extended.edge src dst)
+      (forbidden : ¬ extendedAllowedStaticEdge src dst)
+  | embeddingPolicyBroken (src dst : Core)
+      (coreAllowed : coreAllowedStaticEdge src dst)
+      (extendedForbidden :
+        ¬ extendedAllowedStaticEdge (X.coreEmbedding src) (X.coreEmbedding dst))
+
+/-- Selected static witness existence, kept separate from any global universe. -/
+def StaticExtensionWitnessExists
+    (X : FeatureExtension Core Feature Extended FeatureView)
+    (declaredInterface : Extended -> Prop)
+    (coreAllowedStaticEdge : Core -> Core -> Prop)
+    (extendedAllowedStaticEdge : Extended -> Extended -> Prop) : Prop :=
+  Nonempty
+    (StaticExtensionWitness X declaredInterface coreAllowedStaticEdge
+      extendedAllowedStaticEdge)
+
+/--
+Coverage/exactness premise for the selected static diagnostic universe.
+
+This is a bounded assumption: it states that the selected static witness family
+covers failures of the selected static split predicate. It does not assert that
+all runtime, semantic, or extractor-level failures are represented.
+-/
+def StaticSplitFailureCoverage
+    (X : FeatureExtension Core Feature Extended FeatureView)
+    (declaredInterface : Extended -> Prop)
+    (coreAllowedStaticEdge : Core -> Core -> Prop)
+    (extendedAllowedStaticEdge : Extended -> Extended -> Prop) : Prop :=
+  ¬ SelectedStaticSplitExtension X declaredInterface coreAllowedStaticEdge
+      extendedAllowedStaticEdge ->
+    StaticExtensionWitnessExists X declaredInterface coreAllowedStaticEdge
+      extendedAllowedStaticEdge
+
+/--
+A selected static witness is sound: it refutes the corresponding selected
+static split predicate.
+-/
+theorem not_selectedStaticSplitExtension_of_staticExtensionWitness
+    {X : FeatureExtension Core Feature Extended FeatureView}
+    {declaredInterface : Extended -> Prop}
+    {coreAllowedStaticEdge : Core -> Core -> Prop}
+    {extendedAllowedStaticEdge : Extended -> Extended -> Prop}
+    (witness :
+      StaticExtensionWitness X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge) :
+    ¬ SelectedStaticSplitExtension X declaredInterface coreAllowedStaticEdge
+      extendedAllowedStaticEdge := by
+  intro hSplit
+  cases witness with
+  | missingCoreEdge src dst coreEdge missingExtendedEdge =>
+      exact missingExtendedEdge (hSplit.coreEdgesPreserved coreEdge)
+  | unfactoredBoundaryEdge src dst extendedEdge crossesBoundary missingDeclaredFactor =>
+      exact missingDeclaredFactor
+        (hSplit.declaredInterfaceFactorization extendedEdge crossesBoundary)
+  | forbiddenStaticEdge src dst extendedEdge forbidden =>
+      exact forbidden (hSplit.noNewForbiddenStaticEdge extendedEdge)
+  | embeddingPolicyBroken src dst coreAllowed extendedForbidden =>
+      exact extendedForbidden (hSplit.policyPreserved coreAllowed)
+
+/-- Soundness-only form for selected static witness existence. -/
+theorem not_selectedStaticSplitExtension_of_staticExtensionWitnessExists
+    {X : FeatureExtension Core Feature Extended FeatureView}
+    {declaredInterface : Extended -> Prop}
+    {coreAllowedStaticEdge : Core -> Core -> Prop}
+    {extendedAllowedStaticEdge : Extended -> Extended -> Prop}
+    (hWitness :
+      StaticExtensionWitnessExists X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge) :
+    ¬ SelectedStaticSplitExtension X declaredInterface coreAllowedStaticEdge
+      extendedAllowedStaticEdge := by
+  rcases hWitness with ⟨witness⟩
+  exact not_selectedStaticSplitExtension_of_staticExtensionWitness witness
+
+/--
+Bounded completeness: under the selected coverage/exactness premise, a failure
+of the selected static split predicate has a selected static witness.
+-/
+theorem staticExtensionWitnessExists_of_not_selectedStaticSplitExtension
+    {X : FeatureExtension Core Feature Extended FeatureView}
+    {declaredInterface : Extended -> Prop}
+    {coreAllowedStaticEdge : Core -> Core -> Prop}
+    {extendedAllowedStaticEdge : Extended -> Extended -> Prop}
+    (hCoverage :
+      StaticSplitFailureCoverage X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge)
+    (hNonSplit :
+      ¬ SelectedStaticSplitExtension X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge) :
+    StaticExtensionWitnessExists X declaredInterface coreAllowedStaticEdge
+      extendedAllowedStaticEdge :=
+  hCoverage hNonSplit
+
+/--
+Soundness plus bounded completeness for the selected static witness universe.
+
+The equivalence is relative to `StaticSplitFailureCoverage`; it is not a global
+claim about unmeasured runtime edges, semantic diagrams, or extractor
+completeness.
+-/
+theorem staticExtensionWitnessExists_iff_not_selectedStaticSplitExtension
+    {X : FeatureExtension Core Feature Extended FeatureView}
+    {declaredInterface : Extended -> Prop}
+    {coreAllowedStaticEdge : Core -> Core -> Prop}
+    {extendedAllowedStaticEdge : Extended -> Extended -> Prop}
+    (hCoverage :
+      StaticSplitFailureCoverage X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge) :
+    StaticExtensionWitnessExists X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge ↔
+      ¬ SelectedStaticSplitExtension X declaredInterface coreAllowedStaticEdge
+        extendedAllowedStaticEdge := by
+  constructor
+  · exact not_selectedStaticSplitExtension_of_staticExtensionWitnessExists
+  · exact staticExtensionWitnessExists_of_not_selectedStaticSplitExtension hCoverage
+
 end Formal.Arch

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -204,6 +204,16 @@ File: `Formal/Arch/FeatureExtension.lean`
 | `EmbeddingPolicyPreserved` | `def` | core 側 policy が embedding 後の extended policy として保存されること。 | `defined only` |
 | `StaticSplitFeatureExtension` | `structure` | core edge preservation、declared interface factorization、forbidden static edge absence、policy preservation を束ねる静的 split extension schema。 | `defined only` |
 | `StaticSplitExtension` | `abbrev` | `StaticSplitFeatureExtension` の短縮名。 | `defined only` |
+| `SelectedStaticSplitExtension` | `structure` | 固定された feature extension と policy parameters に対し、静的 split の4条件を unbundled predicate として束ねる。runtime / semantic / extractor completeness は含めない。 | `defined only` |
+| `selectedStaticSplitExtension_of_staticSplitFeatureExtension` | `theorem` | 既存の bundled `StaticSplitFeatureExtension` から selected static split predicate を得る。 | `proved` |
+| `staticSplitFeatureExtension_of_selectedStaticSplitExtension` | `def` | selected static split predicate を既存の bundled schema に戻す。 | `defined only` |
+| `StaticExtensionWitness` | `inductive` | core edge preservation、declared interface factorization、no-new-forbidden-edge、embedding policy preservation の失敗を表す selected static diagnostic witness family。 | `defined only` |
+| `StaticExtensionWitnessExists` | `def` | selected static diagnostic witness が存在すること。 | `defined only` |
+| `StaticSplitFailureCoverage` | `def` | selected static split 失敗が selected witness family で cover されるという bounded coverage / exactness 前提。global completeness は主張しない。 | `defined only` |
+| `not_selectedStaticSplitExtension_of_staticExtensionWitness` | `theorem` | selected static witness が対応する selected static split predicate を反証する soundness theorem。 | `proved` |
+| `not_selectedStaticSplitExtension_of_staticExtensionWitnessExists` | `theorem` | selected static witness の存在から selected static split predicate の不成立を得る。 | `proved` |
+| `staticExtensionWitnessExists_of_not_selectedStaticSplitExtension` | `theorem` | `StaticSplitFailureCoverage` 前提の下で、selected static split predicate の失敗から selected witness の存在を得る bounded completeness theorem。 | `proved` |
+| `staticExtensionWitnessExists_iff_not_selectedStaticSplitExtension` | `theorem` | selected coverage / exactness 前提に相対化された、selected witness 存在と selected static split 失敗の同値。 | `proved` |
 
 ## Split Extension Lifting
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -73,7 +73,7 @@ ArchitectureLawful X
 | --- | --- | --- |
 | Generic witness-count kernel / zero-count bridge | `proved` | [Lean 化設計](formal/flatness_obstruction_lean_design.md), [Lean theorem index](lean_theorem_index.md#flatness) |
 | Required law / axis exactness bridge | `proved` | [Lean theorem index](lean_theorem_index.md#signature-integrated-lawfulness) |
-| FeatureExtension / StaticSplitFeatureExtension | `defined only` / `proved` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#2-第一級対象-featureextension), [Lean theorem index](lean_theorem_index.md#feature-extension) |
+| FeatureExtension / StaticSplitFeatureExtension | `defined only` / `proved` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#2-第一級対象-featureextension), [Lean theorem index](lean_theorem_index.md#feature-extension), Issue [#299](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/299) |
 | SplitExtensionLifting / selected section law | `defined only` / `proved` | [AAT v2 数学設計書](aat_v2_mathematical_design.md#83-split-extension-as-lifting-and-section), [Lean theorem index](lean_theorem_index.md#split-extension-lifting), Issue [#264](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/264) |
 | ArchitectureOperation / ProofObligation schema | `defined only` / `proved` for schema accessor theorems | [AAT v2 数学設計書](aat_v2_mathematical_design.md#3-architecture-calculus), [Lean theorem index](lean_theorem_index.md#architecture-operation) |
 | Architecture Calculus laws | `defined only` / `proved` for bounded schema accessor theorems | [AAT v2 数学設計書](aat_v2_mathematical_design.md#32-calculus-laws), [Lean theorem index](lean_theorem_index.md#architecture-calculus-laws), Issue [#279](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/279) |
@@ -135,6 +135,19 @@ Issue [#284](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2
 | [#286](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/286) | Coupon feature extension example の semantic witness / valuation theorem | `defined only` / `proved` | coupon / discount path skeleton、`roundingTrace`、selected filler contracts、trace 計算 theorem、`roundingOrder_refutes_selectedDiagramFiller`, `roundingOrder_nonFillabilityWitnessFor`, `roundingOrderValuation_obstruction`, `roundingOrderValuation_positive`, `roundingOrderValuation_recordsNonConclusions` は実装済み。valuation は selected rounding-order residual に限られ、未測定 semantic axis の zero 性や実コード extractor completeness は主張しない。 |
 | [#288](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/288) | Complexity Transfer の bounded theorem package | `defined only` / `proved` | `ArchitectureTransform`, `SelectedComplexityMeasure`, `RequirementSchema`, `ComplexityTransferSchema`, `BoundedComplexityTransferPackage`, `complexityTransfer_alternative` は実装済み。empirical cost 改善、global complexity conservation、selected witness universe 外の completeness は non-conclusions として扱う。 |
 | [#287](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/287) | ArchitectureCore / CertifiedArchitecture の proof-carrying schema | `defined only` / `proved` for accessor theorems | `ArchitectureCore`, `ArchitectureLawUniverse`, `ArchitectureTheoremPackage`, `CertifiedArchitecture` を実装済み。実コード extractor の完全性、runtime telemetry completeness、global semantic universe completeness は主張しない。 |
+
+### Split / operation / runtime-semantic follow-up task package
+
+Issue [#296](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/296)
+は、数学設計書に残る split / operation / runtime-semantic Lean 実装の親索引である。
+子 Issue の現在の扱いは次の通り。
+
+| Issue | 対象 | Lean status | 次の扱い |
+| --- | --- | --- | --- |
+| [#299](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/299) | Static split failure witness の coverage-aware diagnostic theorem | `defined only` / `proved` | `SelectedStaticSplitExtension`, `StaticExtensionWitness`, `StaticSplitFailureCoverage`, soundness theorem、bounded completeness theorem、coverage 相対の同値 theorem は実装済み。runtime flatness、semantic flatness、global extractor completeness は non-conclusions として扱う。 |
+| [#297](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/297) | `NonSplitExtensionWitness` の soundness / bounded completeness package | `future proof obligation` | `ExtensionObstructionWitness` と split 失敗を直接接続する theorem package は後続 Issue で扱う。 |
+| [#300](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/300) | Runtime / Semantic split preservation の bounded theorem package | `future proof obligation` | runtime interaction protection と semantic diagram preservation から bounded flatness を discharge する package は後続 Issue で扱う。 |
+| [#298](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/298) | ArchitectureOperation の concrete graph transformation kernel | `defined only` / `future proof obligation` | concrete graph transformation kernel は設計整理後に扱う。無条件の operation laws や global flatness preservation は主張しない。 |
 
 ## Empirical Hypothesis Index
 


### PR DESCRIPTION
## 概要

Closes #299

- `StaticSplitFeatureExtension` と同じ4条件を固定パラメータ上の `SelectedStaticSplitExtension` として切り出した。
- selected static diagnostic witness family と、soundness / bounded completeness / coverage 相対の同値 theorem を追加した。
- #296 配下の follow-up 状態と Lean theorem index を更新した。

## 証明した定理

- `selectedStaticSplitExtension_of_staticSplitFeatureExtension`
- `not_selectedStaticSplitExtension_of_staticExtensionWitness`
- `not_selectedStaticSplitExtension_of_staticExtensionWitnessExists`
- `staticExtensionWitnessExists_of_not_selectedStaticSplitExtension`
- `staticExtensionWitnessExists_iff_not_selectedStaticSplitExtension`

## 編集したドキュメント

- `docs/lean_theorem_index.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている