### PR TITLE
Bounded theorem package 強化ロードマップを docs に反映する

### DIFF
--- a/docs/design/runtime_propagation_design.md
+++ b/docs/design/runtime_propagation_design.md
@@ -114,8 +114,8 @@ runtime obstruction / runtime metric zero bridge を育てる。
 static structural core の QED では、runtime / empirical 系の軸を selected required law
 axis へ追加しない。Lean 側の full law universe policy では `runtimePropagation` は
 `diagnosticAxis`、`relationComplexity` と `empiricalChangeCost` は `empiricalAxis`
-である。runtime metrics の zero bridge は、将来の数学的コア拡張として
-static package とは別に扱う。したがって、`ArchitectureLawful` や
+である。runtime metrics の zero bridge は、0/1 runtime graph 上の bounded bridge
+として証明済みだが、static required zero-law package とは別に扱う。したがって、`ArchitectureLawful` や
 `RequiredSignatureAxesZero` の成立条件として `runtimePropagation = some 0` を
 要求しない。
 
@@ -123,7 +123,7 @@ static package とは別に扱う。したがって、`ArchitectureLawful` や
 
 | 対象 | zero-curvature theorem での分類 | Lean status |
 | --- | --- | --- |
-| `runtimePropagation` / `runtimeExposureRadius` | 0/1 `RuntimeDependencyGraph` 上で測定できる diagnostic axis。static required zero-law axis ではない。zero metric と runtime obstruction absence の bridge は future proof obligation | `defined only` / `future proof obligation` |
+| `runtimePropagation` / `runtimeExposureRadius` | 0/1 `RuntimeDependencyGraph` 上で測定できる diagnostic axis。static required zero-law axis ではない。zero metric と runtime obstruction absence の bridge は bounded theorem として証明済み | `defined only` / `proved` |
 | `runtimeBlastRadius` | reverse reachability 由来の tooling / analysis metric。Lean core field には入れない | `empirical hypothesis` |
 | `runtimeFanout` | runtime graph 上の局所集中を測る analysis-derived metric。v1 field には追加しない | `empirical hypothesis` |
 | `circuitBreakerCoverageRatio` | measured runtime pair に対する policy-aware coverage 指標 | `empirical hypothesis` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -175,6 +175,31 @@ analysis とし、その他は必要データが揃う場合の exploratory anal
 | extractor completeness | extractor output は tooling evidence であり、完全な proof-carrying universe とは同一視しない。 |
 | relation complexity | 状態遷移代数層の empirical metric として扱い、構成要素ベクトルを残す。単一スコアだけで設計を評価しない。 |
 
+## Bounded theorem package 強化ロードマップ
+
+数学設計書の中心 theorem 候補は、現時点では無条件の global theorem ではなく、
+coverage-aware / bounded theorem package として扱う。今後も
+`ArchitectureFlatWithin` を主語にし、global `ArchitectureFlat` は coverage /
+exactness / no-unmeasured-axis が閉じた場合の completion corollary として検討する。
+
+この方針により、AAT v2 は「アーキテクチャが無条件に良い」と主張するのではなく、
+どの universe、coverage、observation model、witness family の下で、どの不変量が
+保存・改善・移転されたかを明示する。
+
+| 領域 | 次の扱い | Lean status |
+| --- | --- | --- |
+| global flatness completion | `GlobalFlatCertificate` や `global_of_within_exhaustive` のような certificate theorem として検討する。global theorem を primary theorem にはしない。Issue [#308](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/308) | `future proof obligation` |
+| claim / evidence boundary | `formal`, `tooling`, `empirical`, `hypothesis` の claim level と non-conclusions を明示し、tooling output と Lean theorem の境界を保つ。Issue [#309](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/309) | `defined only` / `future proof obligation` |
+| weighted numerical curvature | 現在の zero-separating / finite measured curvature bridge を、positive weight や zero-reflecting weighted sum 前提つきの bounded theorem へ拡張する。cost correlation は empirical hypothesis に残す。Issue [#310](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/310) | `future proof obligation` |
+| complexity transfer beyond bounded package | 既存の bounded complexity transfer package を土台に、`transfer_or_gap` や `no_free_elimination_bounded` 型の theorem を検討する。global conservation / lower bound は将来拡張とする。Issue [#311](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/311) | `future proof obligation` |
+| cohomological obstruction candidate | AAT v2 core には混ぜず、`DiagramFiller` / `NonFillabilityWitness` / `PathHomotopy` と接続できる小さい experimental extension として隔離する。Issue [#312](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/312) | future extension |
+
+これらのタスクでは、実コード extractor の完全性、telemetry の完全性、empirical cost
+correlation、incident zero は Lean theorem として直接主張しない。必要な場合は
+bridge assumption、validation protocol、または empirical hypothesis として分離する。
+追跡親 Issue は [#307](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/307)
+である。
+
 ## 更新ルール
 
 - Lean theorem、定義、module path を追加・削除・rename した場合は、必要に応じて


### PR DESCRIPTION
## 概要

Closes #313
Refs #307

bounded theorem package 強化ロードマップを `docs/proof_obligations.md` に追加し、#308〜#312 の後続タスクと対応づけました。あわせて、`runtimePropagation` の zero bridge が現在は bounded theorem として証明済みであるため、`docs/design/runtime_propagation_design.md` の古い `future proof obligation` 表現を `defined only` / `proved` に更新しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/design/runtime_propagation_design.md`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 実施。Lean source には該当なし。docs の方針説明のみ既存一致。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている