### PR TITLE
ClaimLevel / Evidence boundary を整理する

### DIFF
--- a/Formal/Arch/CertifiedArchitecture.lean
+++ b/Formal/Arch/CertifiedArchitecture.lean
@@ -137,6 +137,145 @@ structure ArchitectureTheoremPackage (State : Type s) (Witness : Type t) where
   recordsNonConclusions : obligation.RecordsNonConclusions
 
 /--
+Claim levels used by proof-carrying architecture reports.
+
+Only `formal` is intended to be backed by Lean theorem-package discharge.
+Tooling output, empirical evidence, and research hypotheses remain separate
+claim levels.
+-/
+inductive ClaimLevel where
+  | formal
+  | tooling
+  | empirical
+  | hypothesis
+  deriving DecidableEq, Repr
+
+namespace ClaimLevel
+
+/-- The claim is a formal Lean theorem-package claim. -/
+def IsFormal (level : ClaimLevel) : Prop :=
+  level = ClaimLevel.formal
+
+/-- The claim is supported by tooling-side evidence. -/
+def IsTooling (level : ClaimLevel) : Prop :=
+  level = ClaimLevel.tooling
+
+/-- The claim is supported by empirical validation. -/
+def IsEmpirical (level : ClaimLevel) : Prop :=
+  level = ClaimLevel.empirical
+
+/-- The claim is a research hypothesis rather than a theorem. -/
+def IsHypothesis (level : ClaimLevel) : Prop :=
+  level = ClaimLevel.hypothesis
+
+end ClaimLevel
+
+/--
+Measurement boundary for report claims.
+
+`unmeasured` is intentionally distinct from `measuredZero`; the latter is the
+only zero-like measurement status.
+-/
+inductive MeasurementBoundary where
+  | measuredZero
+  | measuredNonzero
+  | unmeasured
+  | outOfScope
+  deriving DecidableEq, Repr
+
+namespace MeasurementBoundary
+
+/-- The measured value is explicitly zero. -/
+def IsMeasuredZero (boundary : MeasurementBoundary) : Prop :=
+  boundary = MeasurementBoundary.measuredZero
+
+/-- The axis or claim has not been measured. -/
+def IsUnmeasured (boundary : MeasurementBoundary) : Prop :=
+  boundary = MeasurementBoundary.unmeasured
+
+/-- Unmeasured evidence is not the same as measured zero. -/
+theorem unmeasured_not_measuredZero :
+    ¬ IsMeasuredZero MeasurementBoundary.unmeasured := by
+  intro h
+  cases h
+
+end MeasurementBoundary
+
+/--
+Architecture claim schema used to keep Lean theorem claims, tooling output,
+empirical evidence, and hypotheses separated.
+
+A formal claim may reference a theorem package; tooling and empirical fields
+are evidence boundaries, not automatic Lean proofs.  The `nonConclusions`
+field records what the claim explicitly does not establish.
+-/
+structure ArchitectureClaim (State : Type s) (Witness : Type t) where
+  level : ClaimLevel
+  statement : Prop
+  theoremPackage : Option (ArchitectureTheoremPackage State Witness)
+  toolingEvidence : Prop
+  empiricalEvidence : Prop
+  hypothesisContext : Prop
+  measurementBoundary : MeasurementBoundary
+  nonConclusions : Prop
+
+namespace ArchitectureClaim
+
+variable {State : Type s} {Witness : Type t}
+
+/-- The claim explicitly records what it does not establish. -/
+def RecordsNonConclusions (claim : ArchitectureClaim State Witness) : Prop :=
+  claim.nonConclusions
+
+/-- The claim is classified as formal. -/
+def IsFormal (claim : ArchitectureClaim State Witness) : Prop :=
+  claim.level = ClaimLevel.formal
+
+/-- The claim carries a referenced theorem package. -/
+def HasFormalPackage (claim : ArchitectureClaim State Witness) : Prop :=
+  ∃ package, claim.theoremPackage = some package
+
+/-- The claim is tooling-only and carries no formal theorem package. -/
+def ToolingOnly (claim : ArchitectureClaim State Witness) : Prop :=
+  claim.level = ClaimLevel.tooling ∧ claim.theoremPackage = none
+
+/-- The claim's measurement boundary is explicitly measured zero. -/
+def IsMeasuredZero (claim : ArchitectureClaim State Witness) : Prop :=
+  MeasurementBoundary.IsMeasuredZero claim.measurementBoundary
+
+/-- The claim's measurement boundary is unmeasured. -/
+def IsUnmeasured (claim : ArchitectureClaim State Witness) : Prop :=
+  MeasurementBoundary.IsUnmeasured claim.measurementBoundary
+
+/-- The recorded non-conclusion predicate is exactly the schema field. -/
+theorem records_nonConclusions_iff (claim : ArchitectureClaim State Witness) :
+    claim.RecordsNonConclusions ↔ claim.nonConclusions := by
+  rfl
+
+/-- Tooling-only claims do not carry a formal theorem package. -/
+theorem toolingOnly_no_formalPackage
+    (claim : ArchitectureClaim State Witness)
+    (hTooling : claim.ToolingOnly) :
+    ¬ claim.HasFormalPackage := by
+  intro hPackage
+  rcases hPackage with ⟨package, hPackage⟩
+  rw [hTooling.2] at hPackage
+  cases hPackage
+
+/-- An unmeasured claim boundary cannot be used as measured-zero evidence. -/
+theorem unmeasured_not_measuredZero
+    (claim : ArchitectureClaim State Witness)
+    (hUnmeasured : claim.IsUnmeasured) :
+    ¬ claim.IsMeasuredZero := by
+  intro hZero
+  unfold IsUnmeasured MeasurementBoundary.IsUnmeasured at hUnmeasured
+  unfold IsMeasuredZero MeasurementBoundary.IsMeasuredZero at hZero
+  rw [hUnmeasured] at hZero
+  exact MeasurementBoundary.unmeasured_not_measuredZero hZero
+
+end ArchitectureClaim
+
+/--
 Certified architecture object carrying law, invariant, witness, theorem-package,
 and proof-obligation discharge data for one `ArchitectureCore`.
 

--- a/docs/aat_v2_mathematical_design.md
+++ b/docs/aat_v2_mathematical_design.md
@@ -1268,6 +1268,28 @@ ProofObligation :=
 結論しない。測定されていない軸、仮定した前提、対象外の universe を theorem package から
 隠してはならない。
 
+proof obligation の外側で report や theorem package を読む場合、claim には
+次の evidence boundary を持たせる。
+
+```text
+ArchitectureClaim :=
+  level : ClaimLevel
+  + statement
+  + theoremPackage?
+  + toolingEvidence
+  + empiricalEvidence
+  + hypothesisContext
+  + measurementBoundary : measuredZero | measuredNonzero | unmeasured | outOfScope
+  + nonConclusions
+```
+
+`formal` claim だけが Lean theorem package の discharge によって支えられる。
+`tooling` claim は extractor / checker / CI report の evidence であり、それだけでは
+Lean theorem にならない。`empirical` claim は dataset や case study の主張であり、
+`hypothesis` claim は将来検証する研究仮説である。
+`measurementBoundary = unmeasured` は `measuredZero` ではない。未測定軸を zero と読む
+主張は、theorem package の結論にも non-conclusion の外側にも置かない。
+
 ### 12.4 Abstract Obstruction Valuation
 
 数学設計書では、抽象的な obstruction valuation を扱う。

--- a/docs/aat_v2_tooling_design.md
+++ b/docs/aat_v2_tooling_design.md
@@ -89,20 +89,24 @@ split しないならどの obstruction が原因かを、
 
 ## 2. Claim Taxonomy
 
-Report 内の claim は次のいずれかに分類する。
+Report 内の claim は、Lean 側の `ClaimLevel` と対応する evidence boundary として
+次のいずれかに分類する。
 
 ```text
-PROVED:
+FORMAL / PROVED:
   数学設計書の theorem package により、明示された前提の下で証明された claim。
 
-MEASURED:
+TOOLING / MEASURED:
   extractor / telemetry / policy / test / annotation により測定された claim。
 
-ASSUMED:
+TOOLING / ASSUMED:
   theorem または report の前提として置いた claim。
 
 EMPIRICAL:
   dataset / case study / statistical analysis による経験的 claim。
+
+HYPOTHESIS:
+  将来検証する研究仮説または設計仮説。
 
 UNMEASURED:
   測定されていない。安全とは解釈しない。
@@ -110,6 +114,12 @@ UNMEASURED:
 OUT_OF_SCOPE:
   指定された theorem package / extractor / report の対象外。
 ```
+
+既存 report 表示の `PROVED`, `MEASURED`, `ASSUMED`, `EMPIRICAL`,
+`UNMEASURED`, `OUT_OF_SCOPE` は UI 表示名として残してよい。ただし内部的には
+`formal`, `tooling`, `empirical`, `hypothesis` の claim level と、
+`measuredZero`, `measuredNonzero`, `unmeasured`, `outOfScope` の measurement boundary
+を分けて保持する。
 
 禁止規則:
 
@@ -120,6 +130,8 @@ OUT_OF_SCOPE:
 - AI generated を architecture lawful とみなさない。
 - MEASURED nonzero を repair 必須と断定しない。
 - PROVED claim の前提条件を report から隠さない。
+- tooling output を Lean theorem とみなさない。
+- nonConclusions を report から落とさない。
 ```
 
 ## 3. AIR: Architecture Intermediate Representation
@@ -435,7 +447,10 @@ diagrams: list
 operation: optional string
 evidence: list
 theorem_reference: optional string
+claim_level: formal | tooling | empirical | hypothesis
 claim_classification: PROVED | MEASURED | ASSUMED | EMPIRICAL | UNMEASURED | OUT_OF_SCOPE
+measurement_boundary: measuredZero | measuredNonzero | unmeasured | outOfScope
+non_conclusions: list
 repair_candidates: list
 ```
 
@@ -475,7 +490,13 @@ evidence:
     path: src/coupon/CouponService.ts
     symbol: CouponService.calculate
 theorem_reference: StaticSplitFeatureExtension
+claim_level: tooling
 claim_classification: MEASURED
+measurement_boundary: measuredNonzero
+non_conclusions:
+  - runtime flatness is not concluded
+  - semantic flatness is not concluded
+  - absence of other unmeasured witnesses is not concluded
 repair_candidates:
   - introduce CouponPort and route dependency through declared interface
   - move cache access behind PaymentPort contract
@@ -802,7 +823,12 @@ report:
   split_status: unknown
   semantic_witness:
     kind: non_commuting_diagram
+    claim_level: tooling
     claim_classification: MEASURED
+    measurement_boundary: measuredNonzero
+    non_conclusions:
+      - global semantic flatness is not concluded
+      - unmeasured semantic diagrams are not treated as commuting
 ```
 
 この例は、static split が成立しても semantic layer に obstruction が残りうることを示す。

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -650,6 +650,25 @@ completeness は主張しない。
 | `ArchitectureLawUniverse.Derived` | `def` | law が finite universe に含まれ、derived role を持つこと。 | `defined only` |
 | `ObstructionWitnessUniverse` | `structure` | bounded theorem package input としての finite obstruction witness universe。global obstruction enumeration は主張しない。 | `defined only` |
 | `ArchitectureTheoremPackage` | `structure` | 名前付き theorem package、対応する `ProofObligation`、明示的な non-conclusion record を束ねる。 | `defined only` |
+| `ClaimLevel` | `inductive` | architecture report claim を `formal` / `tooling` / `empirical` / `hypothesis` に分類する claim level。 | `defined only` |
+| `ClaimLevel.IsFormal` | `def` | claim level が Lean theorem-package claim であること。 | `defined only` |
+| `ClaimLevel.IsTooling` | `def` | claim level が tooling-side evidence claim であること。 | `defined only` |
+| `ClaimLevel.IsEmpirical` | `def` | claim level が empirical validation claim であること。 | `defined only` |
+| `ClaimLevel.IsHypothesis` | `def` | claim level が research hypothesis であること。 | `defined only` |
+| `MeasurementBoundary` | `inductive` | report claim の測定境界を measured zero / measured nonzero / unmeasured / out of scope に分ける。 | `defined only` |
+| `MeasurementBoundary.IsMeasuredZero` | `def` | boundary が明示的な measured zero であること。 | `defined only` |
+| `MeasurementBoundary.IsUnmeasured` | `def` | boundary が unmeasured であること。 | `defined only` |
+| `MeasurementBoundary.unmeasured_not_measuredZero` | `theorem` | unmeasured boundary は measured zero ではないこと。 | `proved` |
+| `ArchitectureClaim` | `structure` | theorem package reference、tooling / empirical / hypothesis evidence、measurement boundary、non-conclusions を持つ claim schema。 | `defined only` |
+| `ArchitectureClaim.RecordsNonConclusions` | `def` | architecture claim の non-conclusion clause を predicate として取り出す。 | `defined only` |
+| `ArchitectureClaim.IsFormal` | `def` | architecture claim が formal level であること。 | `defined only` |
+| `ArchitectureClaim.HasFormalPackage` | `def` | architecture claim が theorem package reference を持つこと。 | `defined only` |
+| `ArchitectureClaim.ToolingOnly` | `def` | architecture claim が tooling-only で theorem package を持たないこと。 | `defined only` |
+| `ArchitectureClaim.IsMeasuredZero` | `def` | architecture claim の measurement boundary が measured zero であること。 | `defined only` |
+| `ArchitectureClaim.IsUnmeasured` | `def` | architecture claim の measurement boundary が unmeasured であること。 | `defined only` |
+| `ArchitectureClaim.records_nonConclusions_iff` | `theorem` | recorded non-conclusion predicate と claim field が一致すること。 | `proved` |
+| `ArchitectureClaim.toolingOnly_no_formalPackage` | `theorem` | tooling-only claim は formal theorem package reference を持たないこと。 | `proved` |
+| `ArchitectureClaim.unmeasured_not_measuredZero` | `theorem` | unmeasured claim boundary は measured-zero evidence ではないこと。 | `proved` |
 | `CertifiedArchitecture` | `structure` | core、law universe、invariant family、witness universe、theorem package list、listed package の discharge proof を束ねる certified architecture object。 | `defined only` |
 | `CertifiedArchitecture.theoremPackageObligations` | `def` | certified architecture が持つ theorem package から proof obligation list を取り出す。 | `defined only` |
 | `CertifiedArchitecture.ProofObligationDischargeSet` | `def` | listed theorem package がすべて discharged であること。 | `defined only` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -39,6 +39,19 @@ Lean 実装 status や Issue 管理状態はこの文書と
 Tooling output、extractor output、AI generated code、未測定軸は、それだけで
 `proved` にはならない。`unmeasured` と測定済み 0 も区別する。
 
+claim level は、証明状態とは別に次の境界として扱う。
+
+| Claim level | 扱い |
+| --- | --- |
+| `formal` | Lean theorem package と明示された前提の discharge によって支えられる claim。 |
+| `tooling` | extractor、policy checker、CI report、validation report などの tooling-side evidence による claim。Lean theorem ではない。 |
+| `empirical` | dataset、pilot、統計解析、case study による claim。Lean proof のブロッカーではない。 |
+| `hypothesis` | 研究仮説または将来検証する設計仮説。証明済み claim として扱わない。 |
+
+`nonConclusions` は claim level に関係なく必須である。特に `tooling` claim は、
+「測定された範囲では violation がない」と「全 universe で obstruction がない」を区別し、
+未測定軸を zero と読まないための non-conclusion を持つ。
+
 ## 現在の QED 境界
 
 現時点で Lean proved と呼ぶ中核は、AAT v2 の **static structural core** である。
@@ -189,7 +202,7 @@ exactness / no-unmeasured-axis が閉じた場合の completion corollary とし
 | 領域 | 次の扱い | Lean status |
 | --- | --- | --- |
 | global flatness completion | `GlobalFlatCertificate` や `global_of_within_exhaustive` のような certificate theorem として検討する。global theorem を primary theorem にはしない。Issue [#308](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/308) | `future proof obligation` |
-| claim / evidence boundary | `formal`, `tooling`, `empirical`, `hypothesis` の claim level と non-conclusions を明示し、tooling output と Lean theorem の境界を保つ。Issue [#309](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/309) | `defined only` / `future proof obligation` |
+| claim / evidence boundary | `ClaimLevel`, `MeasurementBoundary`, `ArchitectureClaim` で `formal`, `tooling`, `empirical`, `hypothesis` の claim level と non-conclusions を明示する。tooling output と Lean theorem の境界、および unmeasured と measured-zero の区別を保つ。Issue [#309](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/309) | `defined only` / `proved` for boundary accessors |
 | weighted numerical curvature | 現在の zero-separating / finite measured curvature bridge を、positive weight や zero-reflecting weighted sum 前提つきの bounded theorem へ拡張する。cost correlation は empirical hypothesis に残す。Issue [#310](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/310) | `future proof obligation` |
 | complexity transfer beyond bounded package | 既存の bounded complexity transfer package を土台に、`transfer_or_gap` や `no_free_elimination_bounded` 型の theorem を検討する。global conservation / lower bound は将来拡張とする。Issue [#311](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/311) | `future proof obligation` |
 | cohomological obstruction candidate | AAT v2 core には混ぜず、`DiagramFiller` / `NonFillabilityWitness` / `PathHomotopy` と接続できる小さい experimental extension として隔離する。Issue [#312](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/312) | future extension |


### PR DESCRIPTION
## 概要

Closes #309

- `ClaimLevel`, `MeasurementBoundary`, `ArchitectureClaim` を追加し、formal / tooling / empirical / hypothesis の claim level と measurement boundary を Lean schema として分離しました。
- tooling-only claim が theorem package reference を持たないこと、unmeasured boundary が measured-zero evidence ではないことを accessor theorem として固定しました。
- proof obligations、数学設計書、ツール設計書、Lean theorem index の claim boundary 記述を更新しました。

## 証明した定理

- `MeasurementBoundary.unmeasured_not_measuredZero`
- `ArchitectureClaim.records_nonConclusions_iff`
- `ArchitectureClaim.toolingOnly_no_formalPackage`
- `ArchitectureClaim.unmeasured_not_measuredZero`

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/aat_v2_mathematical_design.md`
- `docs/aat_v2_tooling_design.md`
- `docs/lean_theorem_index.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている