### PR TITLE
GlobalFlatCertificate による flatness completion を追加する

### DIFF
--- a/Formal/Arch/Flatness.lean
+++ b/Formal/Arch/Flatness.lean
@@ -258,6 +258,125 @@ theorem noUnmeasuredRequiredAxis_of_architectureFlatWithin
   exact hFlat.1
 
 /--
+Exhaustive coverage premise for completing bounded architecture flatness.
+
+This is named separately from `ArchitectureFlatWithin` so that global
+completion corollaries expose the coverage assumption instead of hiding it in a
+primary theorem.
+-/
+def ExhaustiveFlatnessCoverage
+    (X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs)
+    (U : ComponentUniverse X.static) : Prop :=
+  NoUnmeasuredRequiredAxis X U
+
+/--
+Exact observation premise for completing the selected static / runtime /
+semantic flatness evidence into bounded architecture flatness.
+
+The premise is still relative to `U` and the measured semantic list. It is a
+bridge assumption, not a claim of extractor or telemetry completeness.
+-/
+def ExactFlatnessObservation
+    (X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs)
+    (U : ComponentUniverse X.static) : Prop :=
+  StaticFlatWithin X U ->
+  RuntimeFlatWithin X U ->
+  SemanticFlatWithin X ->
+  ArchitectureFlatWithin X U
+
+/-- Coverage discharges the exact-observation bridge for the existing layers. -/
+theorem exactFlatnessObservation_of_exhaustiveCoverage
+    {X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs}
+    {U : ComponentUniverse X.static}
+    (hCoverage : ExhaustiveFlatnessCoverage X U) :
+    ExactFlatnessObservation X U := by
+  intro hStatic hRuntime hSemantic
+  exact ⟨hCoverage, hStatic, hRuntime, hSemantic⟩
+
+/--
+Certificate for reading bounded flatness as completed global flatness.
+
+The certificate keeps the bounded theorem package primary: `flatWithin` is the
+proved architecture flatness statement, while `exhaustiveCoverage`,
+`exactObservation`, and `recordsNonConclusions` record the extra assumptions
+that justify exposing a global predicate.
+-/
+structure GlobalFlatCertificate
+    (X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs) where
+  completionUniverse : ComponentUniverse X.static
+  flatWithin : ArchitectureFlatWithin X completionUniverse
+  exhaustiveCoverage : ExhaustiveFlatnessCoverage X completionUniverse
+  exactObservation : ExactFlatnessObservation X completionUniverse
+  nonConclusions : Prop
+  recordsNonConclusions : nonConclusions
+
+/--
+Global architecture flatness is a completion predicate backed by an explicit
+certificate. It is not the primary theorem package.
+-/
+def ArchitectureFlat
+    (X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs) :
+    Prop :=
+  Nonempty (GlobalFlatCertificate X)
+
+namespace GlobalFlatCertificate
+
+/-- A global-flat certificate carries the underlying bounded flatness theorem. -/
+theorem architectureFlatWithin
+    {X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs}
+    (certificate : GlobalFlatCertificate X) :
+    ArchitectureFlatWithin X certificate.completionUniverse :=
+  certificate.flatWithin
+
+/-- A global-flat certificate exposes exhaustive coverage explicitly. -/
+theorem exhaustiveFlatnessCoverage
+    {X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs}
+    (certificate : GlobalFlatCertificate X) :
+    ExhaustiveFlatnessCoverage X certificate.completionUniverse :=
+  certificate.exhaustiveCoverage
+
+/-- A global-flat certificate exposes exact observation explicitly. -/
+theorem exactFlatnessObservation
+    {X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs}
+    (certificate : GlobalFlatCertificate X) :
+    ExactFlatnessObservation X certificate.completionUniverse :=
+  certificate.exactObservation
+
+/-- A global-flat certificate records the non-conclusions it does not prove. -/
+theorem nonConclusions_recorded
+    {X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs}
+    (certificate : GlobalFlatCertificate X) :
+    certificate.nonConclusions :=
+  certificate.recordsNonConclusions
+
+end GlobalFlatCertificate
+
+/--
+Completion corollary from bounded flatness to global flatness.
+
+The theorem deliberately requires exhaustive coverage, exact observation, and
+recorded non-conclusions as visible inputs; without those, the bounded
+`ArchitectureFlatWithin` theorem is not promoted.
+-/
+theorem globalFlat_of_within_exhaustive
+    {X : ArchitectureFlatnessModel C A StaticObs SemanticExpr SemanticObs}
+    {U : ComponentUniverse X.static}
+    (hWithin : ArchitectureFlatWithin X U)
+    (hCoverage : ExhaustiveFlatnessCoverage X U)
+    (hExact : ExactFlatnessObservation X U)
+    {nonConclusions : Prop}
+    (hNonConclusions : nonConclusions) :
+    ArchitectureFlat X :=
+  ⟨{
+    completionUniverse := U
+    flatWithin := hWithin
+    exhaustiveCoverage := hCoverage
+    exactObservation := hExact
+    nonConclusions := nonConclusions
+    recordsNonConclusions := hNonConclusions
+  }⟩
+
+/--
 Coverage for a feature extension relative to the extended architecture universe.
 
 This packages the minimum assumptions needed by later preservation theorems:

--- a/docs/aat_v2_mathematical_design.md
+++ b/docs/aat_v2_mathematical_design.md
@@ -628,6 +628,10 @@ ArchitectureFlatWithin U X'
 
 AAT は、対応する coverage と zero-reflection assumptions が明示的に discharge されない限り、
 bounded theorem package から global architecture flatness を推論しない。
+Global architecture flatness を述語として使う場合も、主語は bounded
+`ArchitectureFlatWithin` に残し、exhaustive coverage、exact observation、
+no-unmeasured required axis、non-conclusions を含む certificate からの completion
+corollary としてのみ読む。
 
 層別には次に分ける。
 
@@ -1329,6 +1333,8 @@ ZeroReflectingSum V :=
   の下でのみ証明する。
 - Fundamental Theorem of Architectural Flatness は、
   bounded theorem package として定義する。
+- Global flatness は primary theorem ではなく、coverage / exactness /
+  no-unmeasured-axis が閉じた certificate による completion corollary として扱う。
 ```
 
 ### 13.3 Feature Extension Core

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -611,6 +611,16 @@ File: `Formal/Arch/Flatness.lean`
 | `runtimeFlatWithin_of_architectureFlatWithin` | `theorem` | bounded architecture flatness から runtime flatness を取り出す。 | `proved` |
 | `semanticFlatWithin_of_architectureFlatWithin` | `theorem` | bounded architecture flatness から semantic flatness を取り出す。 | `proved` |
 | `noUnmeasuredRequiredAxis_of_architectureFlatWithin` | `theorem` | bounded architecture flatness から coverage package を取り出す。 | `proved` |
+| `ExhaustiveFlatnessCoverage` | `def` | bounded flatness を global completion として読むための exhaustive coverage premise。`NoUnmeasuredRequiredAxis` を明示名で公開する。 | `defined only` |
+| `ExactFlatnessObservation` | `def` | selected static / runtime / semantic flatness evidence を bounded `ArchitectureFlatWithin` へまとめる exact observation bridge。extractor / telemetry completeness は主張しない。 | `defined only` |
+| `exactFlatnessObservation_of_exhaustiveCoverage` | `theorem` | exhaustive coverage から既存三層 flatness の exact-observation bridge を構成する。 | `proved` |
+| `GlobalFlatCertificate` | `structure` | `ArchitectureFlatWithin`、exhaustive coverage、exact observation、non-conclusions を束ね、global flatness を completion corollary として読むための certificate。 | `defined only` |
+| `ArchitectureFlat` | `def` | `GlobalFlatCertificate` の存在として定義される global completion predicate。primary theorem package ではない。 | `defined only` |
+| `GlobalFlatCertificate.architectureFlatWithin` | `theorem` | certificate から underlying bounded flatness を取り出す。 | `proved` |
+| `GlobalFlatCertificate.exhaustiveFlatnessCoverage` | `theorem` | certificate から exhaustive coverage premise を取り出す。 | `proved` |
+| `GlobalFlatCertificate.exactFlatnessObservation` | `theorem` | certificate から exact observation premise を取り出す。 | `proved` |
+| `GlobalFlatCertificate.nonConclusions_recorded` | `theorem` | certificate が記録する non-conclusions を取り出す。 | `proved` |
+| `globalFlat_of_within_exhaustive` | `theorem` | `ArchitectureFlatWithin` を、exhaustive coverage / exact observation / recorded non-conclusions 前提つきで `ArchitectureFlat` へ上げる completion corollary。 | `proved` |
 | `ExtensionCoverageComplete` | `def` | feature extension の core embedding、feature embedding、extended static edges、declared coverage assumptions が supplied extended universe で cover されること。 | `defined only` |
 | `StaticSplitExtensionCoverageComplete` | `def` | `StaticSplitExtension` 用の coverage package。 | `defined only` |
 | `coreEmbedding_mem_of_extensionCoverageComplete` | `theorem` | complete extension coverage から core embedding の universe membership を得る。 | `proved` |

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -193,7 +193,8 @@ analysis とし、その他は必要データが揃う場合の exploratory anal
 数学設計書の中心 theorem 候補は、現時点では無条件の global theorem ではなく、
 coverage-aware / bounded theorem package として扱う。今後も
 `ArchitectureFlatWithin` を主語にし、global `ArchitectureFlat` は coverage /
-exactness / no-unmeasured-axis が閉じた場合の completion corollary として検討する。
+exactness / no-unmeasured-axis が閉じた場合の certificate-backed completion
+corollary として扱う。
 
 この方針により、AAT v2 は「アーキテクチャが無条件に良い」と主張するのではなく、
 どの universe、coverage、observation model、witness family の下で、どの不変量が
@@ -201,7 +202,7 @@ exactness / no-unmeasured-axis が閉じた場合の completion corollary とし
 
 | 領域 | 次の扱い | Lean status |
 | --- | --- | --- |
-| global flatness completion | `GlobalFlatCertificate` や `global_of_within_exhaustive` のような certificate theorem として検討する。global theorem を primary theorem にはしない。Issue [#308](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/308) | `future proof obligation` |
+| global flatness completion | `GlobalFlatCertificate`, `ArchitectureFlat`, `globalFlat_of_within_exhaustive` を certificate theorem として定義する。`ArchitectureFlatWithin` を primary theorem とし、global theorem は exhaustive coverage / exact observation / recorded non-conclusions がそろう場合の completion corollary に限る。Issue [#308](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/308) | `defined only` / `proved` for completion accessors |
 | claim / evidence boundary | `ClaimLevel`, `MeasurementBoundary`, `ArchitectureClaim` で `formal`, `tooling`, `empirical`, `hypothesis` の claim level と non-conclusions を明示する。tooling output と Lean theorem の境界、および unmeasured と measured-zero の区別を保つ。Issue [#309](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/309) | `defined only` / `proved` for boundary accessors |
 | weighted numerical curvature | 現在の zero-separating / finite measured curvature bridge を、positive weight や zero-reflecting weighted sum 前提つきの bounded theorem へ拡張する。cost correlation は empirical hypothesis に残す。Issue [#310](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/310) | `future proof obligation` |
 | complexity transfer beyond bounded package | 既存の bounded complexity transfer package を土台に、`transfer_or_gap` や `no_free_elimination_bounded` 型の theorem を検討する。global conservation / lower bound は将来拡張とする。Issue [#311](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/311) | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #308

`ArchitectureFlatWithin` を primary theorem package として残したまま、global `ArchitectureFlat` を `GlobalFlatCertificate` の存在として読む completion schema を追加しました。

`globalFlat_of_within_exhaustive` は、bounded flatness、exhaustive coverage、exact observation、recorded non-conclusions を明示前提にして global completion predicate へ上げます。無条件の global theorem や extractor / telemetry completeness は主張しません。

## 証明した定理

- `exactFlatnessObservation_of_exhaustiveCoverage`
- `GlobalFlatCertificate.architectureFlatWithin`
- `GlobalFlatCertificate.exhaustiveFlatnessCoverage`
- `GlobalFlatCertificate.exactFlatnessObservation`
- `GlobalFlatCertificate.nonConclusions_recorded`
- `globalFlat_of_within_exhaustive`

## 編集したドキュメント

- `docs/proof_obligations.md`
- `docs/lean_theorem_index.md`
- `docs/aat_v2_mathematical_design.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
