### PR TITLE
重み付き数値曲率 bridge を追加する

### DIFF
--- a/Formal/Arch/Curvature.lean
+++ b/Formal/Arch/Curvature.lean
@@ -65,6 +65,33 @@ def NoMeasuredNumericalCurvatureObstruction {Expr : Type u} {Obs : Type v}
   ∀ d, d ∈ measured -> ¬ NumericalCurvatureObstruction metric sem d
 
 /--
+Positive weights on the finite measured diagram universe.
+
+This is the bounded exactness assumption needed to read a weighted aggregate
+zero as zero curvature for every measured diagram. Diagrams outside the measured
+list remain unclaimed.
+-/
+def PositiveCurvatureWeightOn {Expr : Type u}
+    (measured : List (RequiredDiagram Expr))
+    (weight : RequiredDiagram Expr -> Nat) : Prop :=
+  ∀ d, d ∈ measured -> 0 < weight d
+
+/--
+Weighted numerical curvature over a finite measured diagram universe.
+
+The weight function is supplied by the caller so that calibration and empirical
+cost models stay outside the formal bridge.
+-/
+def totalWeightedCurvature {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    (sem : Semantics Expr Obs)
+    (weight : RequiredDiagram Expr -> Nat) : List (RequiredDiagram Expr) -> Nat
+  | [] => 0
+  | d :: ds =>
+      weight d * numericalCurvature metric sem d +
+        totalWeightedCurvature metric sem weight ds
+
+/--
 Zero numerical curvature is exactly diagram commutativity.
 -/
 theorem numericalCurvature_eq_zero_iff_DiagramCommutes
@@ -219,6 +246,111 @@ theorem totalCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction
     totalCurvature metric sem measured = 0 ↔
       NoMeasuredNumericalCurvatureObstruction metric sem measured := by
   rw [totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero]
+  constructor
+  · intro hZero d hMem hObstruction
+    exact hObstruction (hZero d hMem)
+  · intro hNoObstruction d hMem
+    by_cases hZero : numericalCurvature metric sem d = 0
+    · exact hZero
+    · exact False.elim (hNoObstruction d hMem hZero)
+
+/--
+Weighted total numerical curvature is zero exactly when every measured diagram
+has zero curvature, provided every measured diagram has a positive weight.
+-/
+theorem totalWeightedCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {weight : RequiredDiagram Expr -> Nat}
+    {measured : List (RequiredDiagram Expr)}
+    (hPositive : PositiveCurvatureWeightOn measured weight) :
+    totalWeightedCurvature metric sem weight measured = 0 ↔
+      ∀ d, d ∈ measured -> numericalCurvature metric sem d = 0 := by
+  induction measured with
+  | nil =>
+      simp [totalWeightedCurvature]
+  | cons d ds ih =>
+      constructor
+      · intro hZero d' hMem
+        rw [totalWeightedCurvature] at hZero
+        have hHeadWeighted :
+            weight d * numericalCurvature metric sem d = 0 :=
+          Nat.eq_zero_of_add_eq_zero_right hZero
+        have hTail :
+            totalWeightedCurvature metric sem weight ds = 0 :=
+          Nat.eq_zero_of_add_eq_zero_left hZero
+        have hHead : numericalCurvature metric sem d = 0 := by
+          have hWeightNe : weight d ≠ 0 :=
+            Nat.ne_of_gt (hPositive d (by simp))
+          rcases (Nat.mul_eq_zero.mp hHeadWeighted) with hWeightZero | hCurvatureZero
+          · exact False.elim (hWeightNe hWeightZero)
+          · exact hCurvatureZero
+        have hPositiveTail : PositiveCurvatureWeightOn ds weight := by
+          intro d'' hMemTail
+          exact hPositive d'' (by simp [hMemTail])
+        simp only [List.mem_cons] at hMem
+        rcases hMem with hEq | hMem
+        · cases hEq
+          exact hHead
+        · exact (ih hPositiveTail).mp hTail d' hMem
+      · intro hAll
+        rw [totalWeightedCurvature]
+        have hHead : numericalCurvature metric sem d = 0 :=
+          hAll d (by simp)
+        have hTail :
+            totalWeightedCurvature metric sem weight ds = 0 := by
+          have hPositiveTail : PositiveCurvatureWeightOn ds weight := by
+            intro d' hMem
+            exact hPositive d' (by simp [hMem])
+          exact (ih hPositiveTail).mpr (by
+            intro d' hMem
+            exact hAll d' (by simp [hMem]))
+        simp [hHead, hTail]
+
+/--
+Weighted total numerical curvature is zero exactly when every measured diagram
+commutes, under the same positive-weight boundedness assumption.
+-/
+theorem totalWeightedCurvature_eq_zero_iff_forall_measured_DiagramCommutes
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {weight : RequiredDiagram Expr -> Nat}
+    {measured : List (RequiredDiagram Expr)}
+    (hPositive : PositiveCurvatureWeightOn measured weight) :
+    totalWeightedCurvature metric sem weight measured = 0 ↔
+      ∀ d, d ∈ measured -> DiagramCommutes sem d := by
+  constructor
+  · intro hZero d hMem
+    exact (numericalCurvature_eq_zero_iff_DiagramCommutes metric).mp
+      ((totalWeightedCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+        metric hPositive).mp hZero d hMem)
+  · intro hCommutes
+    exact
+      (totalWeightedCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+        metric hPositive).mpr (by
+          intro d hMem
+          exact numericalCurvature_eq_zero_of_DiagramCommutes metric
+            (hCommutes d hMem))
+
+/--
+Weighted total numerical curvature is zero exactly when the measured diagram
+universe has no numerical curvature obstruction, provided measured weights are
+positive. This theorem remains list-scoped and does not assert unmeasured
+diagram coverage or empirical cost correlation.
+-/
+theorem totalWeightedCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction
+    {Expr : Type u} {Obs : Type v}
+    (metric : ZeroSeparatingDistance Obs)
+    {sem : Semantics Expr Obs}
+    {weight : RequiredDiagram Expr -> Nat}
+    {measured : List (RequiredDiagram Expr)}
+    (hPositive : PositiveCurvatureWeightOn measured weight) :
+    totalWeightedCurvature metric sem weight measured = 0 ↔
+      NoMeasuredNumericalCurvatureObstruction metric sem measured := by
+  rw [totalWeightedCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero
+    metric hPositive]
   constructor
   · intro hZero d hMem hObstruction
     exact hObstruction (hZero d hMem)

--- a/docs/aat_v2_mathematical_design.md
+++ b/docs/aat_v2_mathematical_design.md
@@ -1311,6 +1311,10 @@ ZeroReflectingSum V :=
 ```
 
 この仮定なしに、`totalCurvature = 0` から全 diagram の `curvature = 0` を主張しない。
+`Nat` 値の重み付き aggregate では、測定 universe 内の各 diagram が正の重みを持つ
+場合に限り、weighted total の zero から各 diagram の zero を読み戻す。
+重みの calibration や開発コストとの相関は、この zero-reflection theorem とは別の
+tooling / empirical claim として扱う。
 
 ## 13. 形式化の分解
 

--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -582,8 +582,10 @@ extractor completeness と empirical hypotheses は含めない。
   `totalCurvature = 0 <-> no measured numerical curvature obstruction` を証明した,
   [Issue #239](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/239),
   [Issue #240](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/240)。
-- `future proof obligation`: weighted curvature、Signature axis への載せ方、
-  およびより一般の集約構造での zero-reflection bridge。
+- `defined only` / `proved`: positive-weighted curvature について、
+  `totalWeightedCurvature = 0 <-> no measured numerical curvature obstruction`
+  を証明した。Signature axis への載せ方、およびより一般の集約構造での
+  zero-reflection bridge は future proof obligation として残す。
 - `proved`: 0/1 `RuntimeDependencyGraph` が与えられたとき、
   runtime exposure zero metric と measured / bounded runtime obstruction absence を
   接続する bridge、および `ComponentUniverse` 下で semantic `Reachable` 版へ接続する

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -729,6 +729,8 @@ File: `Formal/Arch/Curvature.lean`
 | `NoNumericalCurvatureObstruction` | `def` | required diagram family に数値 curvature obstruction が存在しないこと。 | `defined only` |
 | `totalCurvature` | `def` | 有限な測定済み diagram list 上で、各 diagram の数値 curvature を `Nat` 和として集約する。 | `defined only` |
 | `NoMeasuredNumericalCurvatureObstruction` | `def` | 測定済み diagram list 内に数値 curvature obstruction が存在しないこと。未測定 diagram には主張しない。 | `defined only` |
+| `PositiveCurvatureWeightOn` | `def` | 測定済み diagram list 上で各 diagram の重みが正であること。重み付き aggregate から各局所 curvature zero へ戻す bounded exactness 前提。 | `defined only` |
+| `totalWeightedCurvature` | `def` | 有限な測定済み diagram list 上で、`weight d * numericalCurvature d` を合計する。calibration や empirical cost model は外部に残す。 | `defined only` |
 | `numericalCurvature_eq_zero_iff_DiagramCommutes` | `theorem` | zero-separating distance の下で、数値 curvature 0 と diagram commutativity が一致する。 | `proved` |
 | `numericalCurvature_eq_zero_of_DiagramCommutes` | `theorem` | 可換な diagram は数値 curvature が 0 である。 | `proved` |
 | `DiagramCommutes_of_numericalCurvature_eq_zero` | `theorem` | 数値 curvature 0 から diagram commutativity を得る。 | `proved` |
@@ -738,6 +740,9 @@ File: `Formal/Arch/Curvature.lean`
 | `totalCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero` | `theorem` | 有限測定 universe 上で、合計 curvature 0 と各 measured diagram の curvature 0 が一致する。 | `proved` |
 | `totalCurvature_eq_zero_iff_forall_measured_DiagramCommutes` | `theorem` | 有限測定 universe 上で、合計 curvature 0 と各 measured diagram の可換性が一致する。 | `proved` |
 | `totalCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction` | `theorem` | 有限測定 universe 上で、合計 curvature 0 と measured numerical curvature obstruction 不在が一致する。 | `proved` |
+| `totalWeightedCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero` | `theorem` | 測定済み diagram が正の重みを持つ場合、重み付き合計 curvature 0 と各 measured diagram の curvature 0 が一致する。 | `proved` |
+| `totalWeightedCurvature_eq_zero_iff_forall_measured_DiagramCommutes` | `theorem` | 正の重み付き有限測定 universe 上で、重み付き合計 curvature 0 と各 measured diagram の可換性が一致する。 | `proved` |
+| `totalWeightedCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction` | `theorem` | 正の重み付き有限測定 universe 上で、重み付き合計 curvature 0 と measured numerical curvature obstruction 不在が一致する。未測定 diagram や empirical cost correlation は主張しない。 | `proved` |
 
 ## Lawfulness Bridge
 

--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -183,7 +183,7 @@ analysis とし、その他は必要データが揃う場合の exploratory anal
 | SOLID の形式化は一意ではない | AAT では操作的形式化として扱う。自然言語としての SOLID 全体の唯一の形式化は主張しない。 |
 | 静的依存と実行時依存の分離 | Lean core では `StaticDependencyGraph` と `RuntimeDependencyGraph` を graph role として分ける。edge metadata は tooling / empirical 側に置く。 |
 | runtime policy-aware metrics | raw runtime graph の theorem と、Circuit Breaker coverage / timeout / retry policy を反映した extension axis を分ける。 |
-| numerical curvature | finite diagram / zero-separating distance の proved bridge と、weighted / calibrated Signature axis や現実コストとの相関を分ける。 |
+| numerical curvature | finite diagram / zero-separating distance の proved bridge と、positive-weight bounded bridge を、calibrated Signature axis や現実コストとの相関から分ける。 |
 | unconditional operation calculus laws | `compose`, `replace`, `protect`, `repair` の bounded law package はあるが、無条件の結合法則、全 operation の冪等性、global flatness preservation は主張しない。 |
 | extractor completeness | extractor output は tooling evidence であり、完全な proof-carrying universe とは同一視しない。 |
 | relation complexity | 状態遷移代数層の empirical metric として扱い、構成要素ベクトルを残す。単一スコアだけで設計を評価しない。 |
@@ -204,7 +204,7 @@ corollary として扱う。
 | --- | --- | --- |
 | global flatness completion | `GlobalFlatCertificate`, `ArchitectureFlat`, `globalFlat_of_within_exhaustive` を certificate theorem として定義する。`ArchitectureFlatWithin` を primary theorem とし、global theorem は exhaustive coverage / exact observation / recorded non-conclusions がそろう場合の completion corollary に限る。Issue [#308](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/308) | `defined only` / `proved` for completion accessors |
 | claim / evidence boundary | `ClaimLevel`, `MeasurementBoundary`, `ArchitectureClaim` で `formal`, `tooling`, `empirical`, `hypothesis` の claim level と non-conclusions を明示する。tooling output と Lean theorem の境界、および unmeasured と measured-zero の区別を保つ。Issue [#309](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/309) | `defined only` / `proved` for boundary accessors |
-| weighted numerical curvature | 現在の zero-separating / finite measured curvature bridge を、positive weight や zero-reflecting weighted sum 前提つきの bounded theorem へ拡張する。cost correlation は empirical hypothesis に残す。Issue [#310](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/310) | `future proof obligation` |
+| weighted numerical curvature | `PositiveCurvatureWeightOn` と `totalWeightedCurvature` により、positive weight 前提つきで weighted aggregate zero と measured numerical curvature obstruction 不在を接続する。cost correlation は empirical hypothesis に残す。Issue [#310](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/310) | `defined only` / `proved` |
 | complexity transfer beyond bounded package | 既存の bounded complexity transfer package を土台に、`transfer_or_gap` や `no_free_elimination_bounded` 型の theorem を検討する。global conservation / lower bound は将来拡張とする。Issue [#311](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/311) | `future proof obligation` |
 | cohomological obstruction candidate | AAT v2 core には混ぜず、`DiagramFiller` / `NonFillabilityWitness` / `PathHomotopy` と接続できる小さい experimental extension として隔離する。Issue [#312](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/312) | future extension |
 


### PR DESCRIPTION
## 概要

Closes #310

positive weight 前提つきの bounded theorem として、重み付き数値 curvature aggregate から測定済み diagram ごとの curvature zero / commutativity / obstruction absence を読み戻す bridge を追加しました。重みの calibration、Signature axis 化、empirical cost correlation は Lean theorem から分離したまま docs に明記しています。

## 証明した定理

- `totalWeightedCurvature_eq_zero_iff_forall_measured_numericalCurvature_eq_zero`
- `totalWeightedCurvature_eq_zero_iff_forall_measured_DiagramCommutes`
- `totalWeightedCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction`

## 編集したドキュメント

- `docs/lean_theorem_index.md`
- `docs/proof_obligations.md`
- `docs/formal/flatness_obstruction_lean_design.md`
- `docs/aat_v2_mathematical_design.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
