### PR TITLE
Lean theorem index と proof obligations の完了監査

### DIFF
--- a/docs/aat_v2_mathematical_design.md
+++ b/docs/aat_v2_mathematical_design.md
@@ -1023,23 +1023,26 @@ ArchitectureExtensionFormula_structural:
     ∨ ClassifiedAsResidualCoverageGap U X F X' w
 ```
 
-この theorem の corollary として、lawful split extension は flatness を保存する。
+この classification theorem と split extension の lawfulness package から、bounded な
+flatness preservation を読む。
 
 ```lean
 LawfulExtensionPreservesFlatness:
-  ArchitectureFlat X →
-  FeatureFlat F →
-  SplitExtension X F X' →
+  StaticSplitExtension X F X' →
   ExtensionCoverageComplete U X F X' →
-  NoInteractionWitness U X F X' →
-  NoLiftFailure U X F X' →
-  NoFillFailure U X F X' →
-  NoUnaccountedTransfer U X F X' →
+  StaticFlatnessSideConditions U X' →
+  RuntimeCoverageComplete U X' →
+  RuntimeFlatWithin U X' →
+  SemanticCoverageComplete X' →
+  SemanticFlatWithin X' →
   ArchitectureFlatWithin U X'
 ```
 
 `ArchitectureFlatWithin U X'` は、universe `U` で観測・証明できる範囲の flatness である。
-実コード extractor、telemetry、semantic diagram universe の完全性を暗黙に仮定しない。
+static split extension は新しい forbidden static edge を作らないことを保証するが、
+acyclicity、projection soundness、LSP compatibility、runtime flatness、semantic flatness は
+明示前提として扱う。実コード extractor、telemetry、semantic diagram universe の完全性を
+暗黙に仮定しない。
 
 ## 11. Analytic Representation and Canonical Example
 

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -857,7 +857,7 @@ File: `Formal/Arch/SignatureLawfulness.lean`
 2. `architectureLawful_iff_requiredSignatureAxesZero` を static structural core の QED の主 theorem として読む。
 3. LocalReplacement / state-effect laws は `localReplacementContract_requiredSignatureProjectionLSPAxes`, `requiredSignatureAxesZero_of_localReplacementContract`, `stateTransitionLawFamilyLawful_iff_noStateTransitionLawFamilyObstruction`, `effectBoundaryLawFamilyLawful_iff_noEffectBoundaryLawFamilyObstruction` で derived corollary として読む。
 4. nilpotency / spectral diagnostics は `MatrixDiagnosticCorollaries` と `matrixDiagnosticCorollaries_of_requiredSignatureAxesZero` で読む。
-5. package は `architectureLawful_iff_architectureZeroCurvatureTheoremPackage` を入口にし、static structural core の QED として読む。runtime / empirical / numerical curvature は「現在 Lean に入れていないもの」の境界として読む。
+5. package は `architectureLawful_iff_architectureZeroCurvatureTheoremPackage` を入口にし、static structural core の QED として読む。runtime / empirical axis はこの package に含めず、numerical curvature は別の bounded diagram bridge として読む。
 
 ## State Transition / Effect Boundary Laws
 
@@ -1172,10 +1172,10 @@ File: `Formal/Arch/SolidCounterexample.lean`
 次は意図的に Lean core へ混ぜていない。
 
 - `Decomposable` の定義への acyclicity, finite propagation, nilpotence, spectral conditions の混入。
-- 重み付き・より一般の `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
-  `Formal/Arch/Curvature.lean` は、zero-separating distance の個別 diagram bridge と
-  有限測定 list 上の `Nat` total bridge までを含み、重み・Signature axis 化・
-  empirical cost model はまだ導入しない。
+- より一般の `Sem_A(p) - Sem_A(q)` 型の数値 curvature metric。
+  `Formal/Arch/Curvature.lean` は、zero-separating distance の個別 diagram bridge、
+  有限測定 list 上の `Nat` total bridge、正の重みに相対化された weighted total bridge
+  までを含む。Signature axis 化、重み calibration、empirical cost model はまだ導入しない。
 - `relationComplexity`, `runtimePropagation`, `empiricalChangeCost` の実証相関。
 - extractor output が `ComponentUniverse` の完全な witness であるという主張。
 - `rho(A)` と変更波及・障害伝播コストの相関。


### PR DESCRIPTION
## 概要

Closes #329

- `LawfulExtensionPreservesFlatness` の数学設計書上の読み方を、bounded / coverage-aware theorem package として整理しました。
- `docs/lean_theorem_index.md` の零曲率 package 説明を、numerical curvature の別 bridge と矛盾しない表現へ更新しました。
- weighted numerical curvature が Lean 側に入っている現状に合わせ、「現在 Lean に入れていないもの」の境界を Signature axis 化、重み calibration、empirical cost model へ絞りました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat_v2_mathematical_design.md`
- `docs/lean_theorem_index.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている