### PR TITLE
runtime zero bridge の進捗記述を更新

### DIFF
--- a/docs/formal/flatness_obstruction_lean_design.md
+++ b/docs/formal/flatness_obstruction_lean_design.md
@@ -559,13 +559,13 @@ extractor completeness と empirical hypotheses は含めない。
   [Issue #224](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/224)。
   `nilpotencyIndex` は `some k` として最初の zero adjacency power を返す
   executable index であり、`RequiredAxesAvailableAndZero` の zero-axis ではない。
-- `defined only` / `future proof obligation` / `empirical hypothesis`: runtime / empirical 系の required-law
+- `defined only` / `proved` / `empirical hypothesis`: runtime / empirical 系の required-law
   境界を固定する。`runtimePropagation` は 0/1 `RuntimeDependencyGraph` 上の
   exposure radius として定義済みの diagnostic axis であり、
   `ArchitectureLawful` や `RequiredSignatureAxesZero` の required zero-axis ではない。
-  0/1 graph 上の runtime zero bridge は future proof obligation とし、
-  extractor completeness と incident / repair cost との関係は tooling / empirical
-  protocol 側に残す,
+  0/1 graph 上の runtime zero bridge は proved bridge として扱い、
+  policy-aware runtime exposure、blast radius、extractor completeness と
+  incident / repair cost との関係は tooling / empirical protocol 側に残す,
   [Issue #225](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/225)。
 - `defined only` / `proved`: static structural core の QED を読むための theorem package を
   `ArchitectureZeroCurvatureTheoremPackage` として追加し、current law-universe


### PR DESCRIPTION
## 概要

Closes #387

`docs/formal/flatness_obstruction_lean_design.md` に残っていた古い Lean status 記述を更新します。0/1 `RuntimeDependencyGraph` 上の runtime zero bridge は proved bridge として扱い、policy-aware runtime exposure、blast radius、extractor completeness、incident / repair cost との関係は tooling / empirical 側に残す境界を明確にします。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/formal/flatness_obstruction_lean_design.md`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 実施。Lean source には検出なし。docs の方針説明中の既存記述のみ検出。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている