### PR TITLE
ArchitecturePathのappend基本法則を証明する

### DIFF
--- a/Formal/Arch/Evolution/ArchitecturePath.lean
+++ b/Formal/Arch/Evolution/ArchitecturePath.lean
@@ -36,6 +36,39 @@ def append : {X Y Z : State} ->
   | _, _, _, nil _, q => q
   | _, _, _, cons step rest, q => cons step (append rest q)
 
+/-- Appending an empty path on the right leaves a path unchanged. -/
+@[simp] theorem append_nil {X Y : State} (p : ArchitecturePath Step X Y) :
+    append p (nil Y) = p := by
+  induction p with
+  | nil X => rfl
+  | cons step rest ih =>
+      simp [append, ih]
+
+/-- Appending a path to an empty path on the left leaves it unchanged. -/
+@[simp] theorem nil_append {X Y : State} (p : ArchitecturePath Step X Y) :
+    append (nil X) p = p :=
+  rfl
+
+/-- Architecture path append is associative. -/
+@[simp] theorem append_assoc {W X Y Z : State}
+    (p : ArchitecturePath Step W X) (q : ArchitecturePath Step X Y)
+    (r : ArchitecturePath Step Y Z) :
+    append (append p q) r = append p (append q r) := by
+  induction p with
+  | nil W => rfl
+  | cons step rest ih =>
+      simp [append, ih]
+
+/-- Path length is additive under append. -/
+@[simp] theorem length_append {X Y Z : State}
+    (p : ArchitecturePath Step X Y) (q : ArchitecturePath Step Y Z) :
+    length (append p q) = length p + length q := by
+  induction p with
+  | nil X =>
+      simp [append, length]
+  | cons step rest ih =>
+      simp [append, length, ih, Nat.add_assoc, Nat.add_comm]
+
 /-- `InvariantHolds I X` says architecture invariant `I` holds at state `X`. -/
 def InvariantHolds (I : State -> Prop) (X : State) : Prop :=
   I X
@@ -51,6 +84,17 @@ def EveryStepPreserves : {X Y : State} ->
   | _, _, nil _, _I => True
   | _, _, cons step rest, I =>
       StepPreservesInvariant I step ∧ EveryStepPreserves rest I
+
+/-- Stepwise invariant preservation over an appended path splits by segment. -/
+@[simp] theorem everyStepPreserves_append {I : State -> Prop} {X Y Z : State}
+    (p : ArchitecturePath Step X Y) (q : ArchitecturePath Step Y Z) :
+    EveryStepPreserves (append p q) I ↔
+      EveryStepPreserves p I ∧ EveryStepPreserves q I := by
+  induction p with
+  | nil X =>
+      simp [append, EveryStepPreserves]
+  | cons step rest ih =>
+      simp [append, EveryStepPreserves, ih, and_assoc]
 
 /-- If every step preserves an invariant, the whole path preserves it. -/
 theorem pathPreservesInvariant {I : State -> Prop} :

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -1195,9 +1195,14 @@ File: `Formal/Arch/Evolution/ArchitecturePath.lean`
 | `ArchitecturePath.ApplyPath` | `def` | path を start state に適用した target state を返す endpoint projection。 | `defined only` |
 | `ArchitecturePath.length` | `def` | path に含まれる primitive architecture step 数。 | `defined only` |
 | `ArchitecturePath.append` | `def` | endpoint が一致する二つの architecture path を連結する。 | `defined only` |
+| `ArchitecturePath.append_nil` | `theorem` | 右側に empty path を append しても path は変わらない。 | `proved` |
+| `ArchitecturePath.nil_append` | `theorem` | 左側の empty path に path を append すると元の path になる。 | `proved` |
+| `ArchitecturePath.append_assoc` | `theorem` | endpoint-indexed architecture path の append が結合的である。 | `proved` |
+| `ArchitecturePath.length_append` | `theorem` | append した path の長さは左右 path の長さの和になる。 | `proved` |
 | `ArchitecturePath.InvariantHolds` | `def` | state predicate としての architecture invariant が特定 state で成り立つこと。 | `defined only` |
 | `ArchitecturePath.StepPreservesInvariant` | `def` | primitive step が invariant を source から target へ保存すること。 | `defined only` |
 | `ArchitecturePath.EveryStepPreserves` | `def` | path 上のすべての primitive step が invariant を保存すること。 | `defined only` |
+| `ArchitecturePath.everyStepPreserves_append` | `theorem` | append した path 上の stepwise preservation は、左右 segment の preservation に分解できる。 | `proved` |
 | `ArchitecturePath.pathPreservesInvariant` | `theorem` | すべての step が invariant を保存するなら、path 全体も start から target へ invariant を保存する。 | `proved` |
 | `ArchitecturePath.PathHomotopy` | `inductive` | refl / symm / trans と、independent square swap、same external contract replacement、repair fill で生成される有限 path homotopy relation。 | `defined only` |
 | `ArchitecturePath.HomotopyInvariant` | `def` | generated path homotopy の下で安定な invariant。endpoint と state universe は `ArchitecturePath` の index によって明示される。 | `defined only` |


### PR DESCRIPTION
## 概要

Closes #450

`ArchitecturePath.append` の有限 path calculus 基本法則を theorem として追加しました。後続の `PathHomotopy` 文脈閉包や invariant preservation で使いやすいよう、append の単位律・結合律・length 加法性に加えて、`EveryStepPreserves` と append の分解補題も `@[simp]` theorem として整備しています。

## 証明した定理

- `ArchitecturePath.append_nil`
- `ArchitecturePath.nil_append`
- `ArchitecturePath.append_assoc`
- `ArchitecturePath.length_append`
- `ArchitecturePath.everyStepPreserves_append`

## 編集したドキュメント

- `docs/lean_theorem_index.md`

## 実施したテスト

- [x] `lake env lean Formal/Arch/Evolution/ArchitecturePath.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
