### PR TITLE
PathHomotopy の文脈閉包 theorem を追加する

### DIFF
--- a/Formal/Arch/Evolution/ArchitecturePath.lean
+++ b/Formal/Arch/Evolution/ArchitecturePath.lean
@@ -148,6 +148,86 @@ inductive PathHomotopy
   | repairFill {X Y : State} {p q : ArchitecturePath Step X Y} :
       RepairFill X Y p q ->
         PathHomotopy IndependentSquare SameExternalContract RepairFill p q
+  | consCongr {X Y Z : State}
+      (step : Step X Y) {p q : ArchitecturePath Step Y Z} :
+      PathHomotopy IndependentSquare SameExternalContract RepairFill p q ->
+        PathHomotopy IndependentSquare SameExternalContract RepairFill
+          (cons step p) (cons step q)
+  | appendRightCongr {X Y Z : State}
+      {p q : ArchitecturePath Step X Y}
+      (suffix : ArchitecturePath Step Y Z) :
+      PathHomotopy IndependentSquare SameExternalContract RepairFill p q ->
+        PathHomotopy IndependentSquare SameExternalContract RepairFill
+          (append p suffix) (append q suffix)
+
+namespace PathHomotopy
+
+/-- Path homotopy is closed under adding a shared head step. -/
+theorem cons_congr
+    {IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop}
+    {SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop}
+    {RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop}
+    {X Y Z : State} (step : Step X Y)
+    {p q : ArchitecturePath Step Y Z}
+    (hHomotopy :
+      PathHomotopy (Step := Step)
+        IndependentSquare SameExternalContract RepairFill p q) :
+    PathHomotopy (Step := Step)
+      IndependentSquare SameExternalContract RepairFill
+        (cons step p) (cons step q) :=
+  PathHomotopy.consCongr step hHomotopy
+
+/-- Path homotopy is closed under appending a shared left context. -/
+theorem append_left
+    {IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop}
+    {SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop}
+    {RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop}
+    {W X Y : State} (ctx : ArchitecturePath Step W X)
+    {p q : ArchitecturePath Step X Y}
+    (hHomotopy :
+      PathHomotopy (Step := Step)
+        IndependentSquare SameExternalContract RepairFill p q) :
+    PathHomotopy (Step := Step)
+      IndependentSquare SameExternalContract RepairFill
+        (append ctx p) (append ctx q) := by
+  induction ctx with
+  | nil W =>
+      simpa [append] using hHomotopy
+  | cons step rest ih =>
+      simpa [append] using
+        (PathHomotopy.cons_congr (Step := Step) step (ih hHomotopy))
+
+/-- Path homotopy is closed under appending a shared right context. -/
+theorem append_right
+    {IndependentSquare :
+      (W X Y Z : State) ->
+        Step W X -> Step X Z -> Step W Y -> Step Y Z -> Prop}
+    {SameExternalContract :
+      (X Y : State) -> Step X Y -> Step X Y -> Prop}
+    {RepairFill :
+      (X Y : State) -> ArchitecturePath Step X Y ->
+        ArchitecturePath Step X Y -> Prop}
+    {X Y Z : State} {p q : ArchitecturePath Step X Y}
+    (hHomotopy :
+      PathHomotopy (Step := Step)
+        IndependentSquare SameExternalContract RepairFill p q)
+    (suffix : ArchitecturePath Step Y Z) :
+    PathHomotopy (Step := Step)
+      IndependentSquare SameExternalContract RepairFill
+        (append p suffix) (append q suffix) :=
+  PathHomotopy.appendRightCongr suffix hHomotopy
+
+end PathHomotopy
 
 /-- An invariant that is stable under the generated path homotopy relation. -/
 def HomotopyInvariant

--- a/Formal/Arch/Evolution/DiagramFiller.lean
+++ b/Formal/Arch/Evolution/DiagramFiller.lean
@@ -246,11 +246,55 @@ def RoundingSameExternalContract
     roundingTrace (ArchitecturePath.cons s rest) =
       roundingTrace (ArchitecturePath.cons t rest)
 
-/-- Selected repair fills are exactly those that preserve rounding observation. -/
+/--
+Selected repair fills are exactly those that preserve rounding observation in
+every suffix context.
+-/
 def RoundingRepairFill
     (X Y : CouponState)
     (p q : ArchitecturePath CouponDiscountStep X Y) : Prop :=
-  roundingTrace p = roundingTrace q
+  ∀ {Z : CouponState} (suffix : ArchitecturePath CouponDiscountStep Y Z),
+    roundingTrace (ArchitecturePath.append p suffix) =
+      roundingTrace (ArchitecturePath.append q suffix)
+
+/-- The selected filler generators preserve the rounding observation in every suffix context. -/
+theorem pathHomotopy_preserves_roundingTrace_append
+    {X Y : CouponState} {p q : ArchitecturePath CouponDiscountStep X Y}
+    (h :
+      ArchitecturePath.PathHomotopy
+        RoundingIndependentSquare RoundingSameExternalContract
+        RoundingRepairFill p q) :
+    ∀ {Z : CouponState} (suffix : ArchitecturePath CouponDiscountStep Y Z),
+      roundingTrace (ArchitecturePath.append p suffix) =
+        roundingTrace (ArchitecturePath.append q suffix) := by
+  induction h with
+  | refl p =>
+      intro _ suffix
+      rfl
+  | symm _ ih =>
+      intro _ suffix
+      exact Eq.symm (ih suffix)
+  | trans _ _ ihLeft ihRight =>
+      intro _ suffix
+      exact Eq.trans (ihLeft suffix) (ihRight suffix)
+  | swapIndependent a b c d rest hIndependent =>
+      intro _ suffix
+      simpa [ArchitecturePath.append] using
+        hIndependent (ArchitecturePath.append rest suffix)
+  | replaceBySameContract s t rest hSame =>
+      intro _ suffix
+      simpa [ArchitecturePath.append] using
+        hSame (ArchitecturePath.append rest suffix)
+  | repairFill hRepair =>
+      intro _ suffix
+      exact hRepair suffix
+  | consCongr step _ ih =>
+      intro _ suffix
+      simp [ArchitecturePath.append, roundingTrace, ih suffix]
+  | appendRightCongr suffix _ ih =>
+      intro _ suffix'
+      simpa [ArchitecturePath.append_assoc] using
+        ih (ArchitecturePath.append suffix suffix')
 
 /-- The selected filler generators preserve the rounding observation. -/
 theorem pathHomotopy_preserves_roundingTrace
@@ -260,16 +304,8 @@ theorem pathHomotopy_preserves_roundingTrace
         RoundingIndependentSquare RoundingSameExternalContract
         RoundingRepairFill p q) :
     roundingTrace p = roundingTrace q := by
-  induction h with
-  | refl p => rfl
-  | symm _ ih => exact Eq.symm ih
-  | trans _ _ ihLeft ihRight => exact Eq.trans ihLeft ihRight
-  | swapIndependent a b c d rest hIndependent =>
-      exact hIndependent rest
-  | replaceBySameContract s t rest hSame =>
-      exact hSame rest
-  | repairFill hRepair =>
-      exact hRepair
+  simpa using
+    pathHomotopy_preserves_roundingTrace_append h (ArchitecturePath.nil Y)
 
 theorem couponThenDiscount_roundingTrace :
     roundingTrace couponThenDiscount = 21 :=

--- a/docs/lean_theorem_index.md
+++ b/docs/lean_theorem_index.md
@@ -1204,7 +1204,10 @@ File: `Formal/Arch/Evolution/ArchitecturePath.lean`
 | `ArchitecturePath.EveryStepPreserves` | `def` | path 上のすべての primitive step が invariant を保存すること。 | `defined only` |
 | `ArchitecturePath.everyStepPreserves_append` | `theorem` | append した path 上の stepwise preservation は、左右 segment の preservation に分解できる。 | `proved` |
 | `ArchitecturePath.pathPreservesInvariant` | `theorem` | すべての step が invariant を保存するなら、path 全体も start から target へ invariant を保存する。 | `proved` |
-| `ArchitecturePath.PathHomotopy` | `inductive` | refl / symm / trans と、independent square swap、same external contract replacement、repair fill で生成される有限 path homotopy relation。 | `defined only` |
+| `ArchitecturePath.PathHomotopy` | `inductive` | refl / symm / trans、independent square swap、same external contract replacement、repair fill、cons / right-append context closure で生成される有限 path homotopy relation。 | `defined only` |
+| `ArchitecturePath.PathHomotopy.cons_congr` | `theorem` | homotopic な tail path の前に同じ primitive step を付けても homotopy が保たれる。 | `proved` |
+| `ArchitecturePath.PathHomotopy.append_left` | `theorem` | homotopic な path pair の左側に同じ prefix path を append しても homotopy が保たれる。 | `proved` |
+| `ArchitecturePath.PathHomotopy.append_right` | `theorem` | homotopic な path pair の右側に同じ suffix path を append しても homotopy が保たれる。 | `proved` |
 | `ArchitecturePath.HomotopyInvariant` | `def` | generated path homotopy の下で安定な invariant。endpoint と state universe は `ArchitecturePath` の index によって明示される。 | `defined only` |
 | `ArchitecturePath.architectureHomotopyInvariance` | `theorem` | `HomotopyInvariant` を homotopic path pair に適用する bridge theorem。 | `proved` |
 
@@ -1270,7 +1273,8 @@ File: `Formal/Arch/Evolution/DiagramFiller.lean`
 | `CouponDiscountExample.roundingTrace` | `def` | coupon / discount path の selected rounding-order observation を `Nat` trace として与える。 | `defined only` |
 | `CouponDiscountExample.RoundingIndependentSquare` | `def` | selected filler generator のうち rounding observation を保存する independent-square contract。 | `defined only` |
 | `CouponDiscountExample.RoundingSameExternalContract` | `def` | rounding observation を保存する same-contract replacement contract。 | `defined only` |
-| `CouponDiscountExample.RoundingRepairFill` | `def` | rounding observation を保存する selected repair fill contract。 | `defined only` |
+| `CouponDiscountExample.RoundingRepairFill` | `def` | rounding observation を任意の suffix context で保存する selected repair fill contract。 | `defined only` |
+| `CouponDiscountExample.pathHomotopy_preserves_roundingTrace_append` | `theorem` | selected filler generator から生成される path homotopy が、任意の suffix context で `roundingTrace` を保存することを示す。 | `proved` |
 | `CouponDiscountExample.pathHomotopy_preserves_roundingTrace` | `theorem` | selected filler generator から生成される path homotopy が `roundingTrace` を保存することを示す。 | `proved` |
 | `CouponDiscountExample.couponThenDiscount_roundingTrace` | `theorem` | coupon-first path の selected rounding trace が `21` であることを計算する。 | `proved` |
 | `CouponDiscountExample.discountThenCoupon_roundingTrace` | `theorem` | discount-first path の selected rounding trace が `43` であることを計算する。 | `proved` |


### PR DESCRIPTION
## 概要

Closes #448

- `PathHomotopy` に cons / right-append の構造的文脈閉包 constructor を追加し、公開 theorem として `PathHomotopy.cons_congr`, `PathHomotopy.append_left`, `PathHomotopy.append_right` を整備しました。
- right-append 文脈閉包に合わせて coupon / discount 例の selected repair fill を suffix-stable な observation preservation として補強しました。
- `docs/lean_theorem_index.md` に追加 API と coupon 例 theorem を反映しました。

## 証明した定理

- `ArchitecturePath.PathHomotopy.cons_congr`
- `ArchitecturePath.PathHomotopy.append_left`
- `ArchitecturePath.PathHomotopy.append_right`
- `CouponDiscountExample.pathHomotopy_preserves_roundingTrace_append`
- `CouponDiscountExample.pathHomotopy_preserves_roundingTrace` を suffix-stable theorem の特殊化として更新

## 編集したドキュメント

- `docs/lean_theorem_index.md`

## 実施したテスト

- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている