### PR TITLE
AIR v0 schema と archsig air を追加

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -6,7 +6,7 @@ Lean status: `empirical hypothesis` / tooling output.
 Lean の証明器ではなく、CI や AI agent が読むための architecture telemetry generator として扱う。
 
 現状の自動 scan は Lean module import graph に対応する。出力 schema は JSON で固定し、
-後段の `validate`, `snapshot`, `signature-diff`, `dataset` は JSON artifact を入力にして動く。
+後段の `validate`, `snapshot`, `signature-diff`, `air`, `dataset` は JSON artifact を入力にして動く。
 
 ## 何ができるか
 
@@ -18,6 +18,7 @@ Lean の証明器ではなく、CI や AI agent が読むための architecture 
 - revision ごとの snapshot を作り、before / after の signature diff を出す。
 - GitHub PR JSON から PR metadata を作り、dataset や diff attribution に使う。
 - relation complexity candidate JSON から workflow-level observation を作る。
+- Sig0 / validation / diff / PR metadata を AIR v0 に正規化する。
 
 ## 標準フロー
 
@@ -28,6 +29,7 @@ scan
   -> validate
   -> snapshot
   -> signature-diff
+  -> air
   -> AI agent / CI job が diff report を読む
 ```
 
@@ -44,6 +46,7 @@ AI / CI が最初に読むべき成果物は次である。
 | Validation report | `component-universe-validation-report-v0` | Sig0 output の duplicate、edge closure、policy status などの検査結果。 |
 | Snapshot | `signature-snapshot-store-v0` | repository revision ごとの保存用 signature record。 |
 | Diff report | `signature-diff-report-v0` | before / after の悪化軸、改善軸、未評価軸、evidence diff、PR attribution candidate。 |
+| AIR | `aat-air-v0` | Signature artifact layer を claim / evidence / coverage / extension boundary へ正規化した中間表現。 |
 | Dataset record | `empirical-signature-dataset-v0` | PR metadata と before / after signature を結合した実証研究用 record。 |
 
 通常の PR / CI 診断では、最終的に `signature-diff-report-v0` を読む。
@@ -266,6 +269,24 @@ diff report は次を持つ。
 
 `validationSummary.result = fail` または `not_run` の snapshot、extractor / rule set / policy が一致しない比較は
 `comparisonStatus.primaryDiffEligible = false` になる。
+
+## AIR を作る
+
+Sig0 output、validation report、diff report、PR metadata を AIR v0 に正規化する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- air \
+  --sig0 .lake/signature-current/sig0.json \
+  --validation .lake/signature-current/validation.json \
+  --diff .lake/signature-current/diff-report.json \
+  --pr-metadata .lake/pr-metadata-123.json \
+  --law-policy signature-policy.json \
+  --out .lake/signature-current/air.json
+```
+
+AIR では `static_edges` / `runtime_edges` を出さず、`relations` を canonical representation として使う。
+各 signature axis は `measurementBoundary` に `measuredZero`, `measuredNonzero`, `unmeasured` を持つため、
+測定済み 0 と未測定の placeholder 0 を分けて読める。
 
 ## PR Metadata / Dataset を作る
 

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -14,6 +14,7 @@ pub const VALIDATION_REPORT_SCHEMA_VERSION: &str = "component-universe-validatio
 pub const EMPIRICAL_DATASET_SCHEMA_VERSION: &str = "empirical-signature-dataset-v0";
 pub const SIGNATURE_SNAPSHOT_STORE_SCHEMA_VERSION: &str = "signature-snapshot-store-v0";
 pub const SIGNATURE_DIFF_REPORT_SCHEMA_VERSION: &str = "signature-diff-report-v0";
+pub const AIR_SCHEMA_VERSION: &str = "aat-air-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const RELATION_COMPLEXITY_CANDIDATE_SCHEMA_VERSION: &str = "relation-complexity-candidates/v0";
@@ -638,6 +639,251 @@ pub struct SignatureDiffReportV0 {
     pub attribution: SnapshotDiffAttribution,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirDocumentV0 {
+    pub schema_version: String,
+    pub architecture_id: String,
+    pub ids: AirIdPolicies,
+    pub revision: AirRevision,
+    pub feature: AirFeature,
+    pub artifacts: Vec<AirArtifact>,
+    pub evidence: Vec<AirEvidence>,
+    pub components: Vec<AirComponent>,
+    pub relations: Vec<AirRelation>,
+    pub policies: AirPolicies,
+    pub semantic_diagrams: Vec<AirSemanticDiagram>,
+    pub architecture_paths: Vec<AirArchitecturePath>,
+    pub homotopy_generators: Vec<AirHomotopyGenerator>,
+    pub nonfillability_witnesses: Vec<AirNonfillabilityWitness>,
+    pub signature: AirSignature,
+    pub coverage: AirCoverage,
+    pub claims: Vec<AirClaim>,
+    pub operation_trace: AirOperationTrace,
+    pub extension: AirExtension,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirIdPolicies {
+    pub component_id_policy: String,
+    pub relation_id_policy: String,
+    pub evidence_id_policy: String,
+    pub claim_id_policy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirRevision {
+    pub before: Option<String>,
+    pub after: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirFeature {
+    pub feature_id: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub source: String,
+    pub ai_session: Option<AirAiSession>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirAiSession {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub prompt_ref: Option<String>,
+    pub generated_patch: Option<bool>,
+    pub human_reviewed: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirArtifact {
+    pub artifact_id: String,
+    pub kind: String,
+    pub schema_version: Option<String>,
+    pub path: Option<String>,
+    pub content_hash: Option<String>,
+    pub produced_by: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirEvidence {
+    pub evidence_id: String,
+    pub kind: String,
+    pub artifact_ref: Option<String>,
+    pub path: Option<String>,
+    pub symbol: Option<String>,
+    pub line: Option<usize>,
+    pub rule_id: Option<String>,
+    pub confidence: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirComponent {
+    pub id: String,
+    pub kind: String,
+    pub lifecycle: String,
+    pub owner: Option<String>,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirRelation {
+    pub id: String,
+    pub layer: String,
+    #[serde(rename = "from")]
+    pub from_component: Option<String>,
+    #[serde(rename = "to")]
+    pub to_component: Option<String>,
+    pub kind: String,
+    pub lifecycle: String,
+    pub protected_by: Option<String>,
+    pub extraction_rule: Option<String>,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirPolicies {
+    pub laws: Vec<String>,
+    pub boundaries: Vec<String>,
+    pub allowed_edges: Vec<String>,
+    pub forbidden_edges: Vec<String>,
+    pub abstraction_rules: Vec<String>,
+    pub protection_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirSemanticDiagram {
+    pub id: String,
+    pub lhs_path_ref: String,
+    pub rhs_path_ref: String,
+    pub equivalence: String,
+    pub filler_claim_ref: Option<String>,
+    pub nonfillability_witness_refs: Vec<String>,
+    pub observation_refs: Vec<String>,
+    pub lifecycle: String,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirArchitecturePath {
+    pub path_id: String,
+    pub source_state: String,
+    pub target_state: String,
+    pub steps: Vec<String>,
+    pub lifecycle: String,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirHomotopyGenerator {
+    pub generator_id: String,
+    pub kind: String,
+    pub diagram_refs: Vec<String>,
+    pub preserves_observation_claim_refs: Vec<String>,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirNonfillabilityWitness {
+    pub witness_id: String,
+    pub diagram_ref: String,
+    pub witness_kind: String,
+    pub claim_ref: String,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirSignature {
+    pub axes: Vec<AirSignatureAxis>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirSignatureAxis {
+    pub axis: String,
+    pub value: Option<i64>,
+    pub measured: bool,
+    pub measurement_boundary: String,
+    pub source: Option<String>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirCoverage {
+    pub layers: Vec<AirCoverageLayer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirCoverageLayer {
+    pub layer: String,
+    pub measurement_boundary: String,
+    pub universe_refs: Vec<String>,
+    pub measured_axes: Vec<String>,
+    pub unmeasured_axes: Vec<String>,
+    pub extraction_scope: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub unsupported_constructs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirClaim {
+    pub claim_id: String,
+    pub subject_ref: String,
+    pub predicate: String,
+    pub claim_level: String,
+    pub claim_classification: String,
+    pub measurement_boundary: String,
+    pub theorem_refs: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub required_assumptions: Vec<String>,
+    pub coverage_assumptions: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub missing_preconditions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirOperationTrace {
+    pub operations: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirExtension {
+    pub embedding_claim_ref: Option<String>,
+    pub feature_view_claim_ref: Option<String>,
+    pub interaction_claim_refs: Vec<String>,
+    pub split_claim_ref: Option<String>,
+    pub split_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AirDocumentInput {
+    pub sig0_path: String,
+    pub validation_path: Option<String>,
+    pub diff_path: Option<String>,
+    pub pr_metadata_path: Option<String>,
+    pub law_policy_path: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotDiffEndpoint {
@@ -1174,6 +1420,243 @@ pub fn build_signature_diff_report(
         unmeasured_axes,
         evidence_diff,
         attribution,
+    }
+}
+
+pub fn build_air_document(
+    sig0: &Sig0Document,
+    validation: Option<&ComponentUniverseValidationReport>,
+    diff: Option<&SignatureDiffReportV0>,
+    pr_metadata: Option<&EmpiricalDatasetInput>,
+    input: AirDocumentInput,
+) -> AirDocumentV0 {
+    let signature = dataset_signature_shape(sig0);
+    let metric_status = dataset_metric_status(sig0);
+    let signature_axes = air_signature_axes(&signature, &metric_status);
+    let component_lifecycle = air_component_lifecycle(diff);
+
+    let mut artifacts = vec![AirArtifact {
+        artifact_id: "artifact-sig0".to_string(),
+        kind: "sig0".to_string(),
+        schema_version: Some(sig0.schema_version.clone()),
+        path: Some(input.sig0_path),
+        content_hash: None,
+        produced_by: Some(EXTRACTOR_NAME.to_string()),
+    }];
+    if let (Some(report), Some(path)) = (validation, input.validation_path) {
+        artifacts.push(AirArtifact {
+            artifact_id: "artifact-validation".to_string(),
+            kind: "validation".to_string(),
+            schema_version: Some(report.schema_version.clone()),
+            path: Some(path),
+            content_hash: None,
+            produced_by: Some(EXTRACTOR_NAME.to_string()),
+        });
+    }
+    if let (Some(report), Some(path)) = (diff, input.diff_path) {
+        artifacts.push(AirArtifact {
+            artifact_id: "artifact-diff".to_string(),
+            kind: "diff".to_string(),
+            schema_version: Some(report.schema_version.clone()),
+            path: Some(path),
+            content_hash: None,
+            produced_by: Some(EXTRACTOR_NAME.to_string()),
+        });
+    }
+    if input.pr_metadata_path.is_some() {
+        artifacts.push(AirArtifact {
+            artifact_id: "artifact-pr-metadata".to_string(),
+            kind: "pr_metadata".to_string(),
+            schema_version: Some(EMPIRICAL_DATASET_SCHEMA_VERSION.to_string()),
+            path: input.pr_metadata_path,
+            content_hash: None,
+            produced_by: Some(EXTRACTOR_NAME.to_string()),
+        });
+    }
+    if input.law_policy_path.is_some() {
+        artifacts.push(AirArtifact {
+            artifact_id: "artifact-law-policy".to_string(),
+            kind: "policy".to_string(),
+            schema_version: sig0.policies.schema_version.clone(),
+            path: input.law_policy_path,
+            content_hash: None,
+            produced_by: None,
+        });
+    }
+
+    let mut evidence: Vec<AirEvidence> = artifacts
+        .iter()
+        .map(|artifact| AirEvidence {
+            evidence_id: format!("evidence-{}-artifact", artifact.kind.replace('_', "-")),
+            kind: artifact_evidence_kind(&artifact.kind),
+            artifact_ref: Some(artifact.artifact_id.clone()),
+            path: artifact.path.clone(),
+            symbol: None,
+            line: None,
+            rule_id: artifact.schema_version.clone(),
+            confidence: Some("high".to_string()),
+        })
+        .collect();
+    let mut relations = Vec::new();
+    let component_paths: BTreeMap<String, String> = sig0
+        .components
+        .iter()
+        .map(|component| (component.id.clone(), component.path.clone()))
+        .collect();
+    for (index, edge) in sig0.edges.iter().enumerate() {
+        let evidence_id = numbered_id("evidence-static", index);
+        evidence.push(AirEvidence {
+            evidence_id: evidence_id.clone(),
+            kind: "source_location".to_string(),
+            artifact_ref: Some("artifact-sig0".to_string()),
+            path: component_paths.get(&edge.source).cloned(),
+            symbol: Some(edge.source.clone()),
+            line: None,
+            rule_id: Some(edge.evidence.clone()),
+            confidence: Some("high".to_string()),
+        });
+        relations.push(AirRelation {
+            id: numbered_id("relation-static", index),
+            layer: "static".to_string(),
+            from_component: Some(edge.source.clone()),
+            to_component: Some(edge.target.clone()),
+            kind: edge.kind.clone(),
+            lifecycle: relation_lifecycle(edge, diff),
+            protected_by: None,
+            extraction_rule: Some("lean-import".to_string()),
+            evidence_refs: vec![evidence_id],
+        });
+    }
+    for (index, runtime) in sig0.runtime_edge_evidence.iter().enumerate() {
+        let evidence_id = numbered_id("evidence-runtime", index);
+        evidence.push(AirEvidence {
+            evidence_id: evidence_id.clone(),
+            kind: "runtime_trace".to_string(),
+            artifact_ref: Some("artifact-sig0".to_string()),
+            path: Some(runtime.evidence_location.path.clone()),
+            symbol: runtime.evidence_location.symbol.clone(),
+            line: runtime.evidence_location.line,
+            rule_id: Some(runtime.label.clone()),
+            confidence: runtime.confidence.clone(),
+        });
+        relations.push(AirRelation {
+            id: numbered_id("relation-runtime", index),
+            layer: "runtime".to_string(),
+            from_component: Some(runtime.source.clone()),
+            to_component: Some(runtime.target.clone()),
+            kind: runtime_relation_kind(&runtime.label),
+            lifecycle: "after".to_string(),
+            protected_by: runtime.circuit_breaker_coverage.clone(),
+            extraction_rule: Some(RUNTIME_PROJECTION_RULE_VERSION.to_string()),
+            evidence_refs: vec![evidence_id],
+        });
+    }
+    for (index, violation) in sig0.policy_violations.iter().enumerate() {
+        let evidence_id = numbered_id("evidence-policy", index);
+        evidence.push(AirEvidence {
+            evidence_id: evidence_id.clone(),
+            kind: "policy_rule".to_string(),
+            artifact_ref: Some("artifact-sig0".to_string()),
+            path: None,
+            symbol: None,
+            line: None,
+            rule_id: violation.relation_ids.as_ref().map(|ids| ids.join(",")),
+            confidence: Some("high".to_string()),
+        });
+        relations.push(AirRelation {
+            id: numbered_id("relation-policy", index),
+            layer: "policy".to_string(),
+            from_component: Some(violation.source.clone()),
+            to_component: Some(violation.target.clone()),
+            kind: "policy_rule".to_string(),
+            lifecycle: "after".to_string(),
+            protected_by: None,
+            extraction_rule: Some(violation.axis.clone()),
+            evidence_refs: vec![evidence_id],
+        });
+    }
+
+    let components = sig0
+        .components
+        .iter()
+        .map(|component| AirComponent {
+            id: component.id.clone(),
+            kind: "module".to_string(),
+            lifecycle: component_lifecycle
+                .get(&component.id)
+                .cloned()
+                .unwrap_or_else(|| "after".to_string()),
+            owner: None,
+            evidence_refs: Vec::new(),
+        })
+        .collect();
+    let claims = air_claims(&signature_axes);
+    let interaction_claim_refs = air_interaction_claim_refs(&claims);
+    let revision = air_revision(diff, pr_metadata);
+    let feature = air_feature(pr_metadata);
+
+    AirDocumentV0 {
+        schema_version: AIR_SCHEMA_VERSION.to_string(),
+        architecture_id: sig0.root.clone(),
+        ids: AirIdPolicies {
+            component_id_policy: "sig0 component id".to_string(),
+            relation_id_policy: "layer-prefixed stable ordinal".to_string(),
+            evidence_id_policy: "layer-prefixed stable ordinal".to_string(),
+            claim_id_policy: "axis-prefixed stable id".to_string(),
+        },
+        revision,
+        feature,
+        artifacts,
+        evidence,
+        components,
+        relations,
+        policies: AirPolicies {
+            laws: sig0
+                .policies
+                .policy_id
+                .iter()
+                .map(|policy_id| format!("policy:{policy_id}"))
+                .collect(),
+            boundaries: sig0
+                .policies
+                .boundary_group_count
+                .map(|count| vec![format!("boundary groups: {count}")])
+                .unwrap_or_default(),
+            allowed_edges: sig0.policies.boundary_allowed.clone(),
+            forbidden_edges: sig0
+                .policy_violations
+                .iter()
+                .map(|violation| {
+                    format!(
+                        "{}:{}->{}",
+                        violation.axis, violation.source, violation.target
+                    )
+                })
+                .collect(),
+            abstraction_rules: sig0.policies.abstraction_allowed.clone(),
+            protection_rules: Vec::new(),
+        },
+        semantic_diagrams: Vec::new(),
+        architecture_paths: Vec::new(),
+        homotopy_generators: Vec::new(),
+        nonfillability_witnesses: Vec::new(),
+        signature: AirSignature {
+            axes: signature_axes.clone(),
+        },
+        coverage: AirCoverage {
+            layers: air_coverage_layers(&signature_axes),
+        },
+        claims,
+        operation_trace: AirOperationTrace {
+            operations: Vec::new(),
+        },
+        extension: AirExtension {
+            embedding_claim_ref: Some("claim-extension-embedding".to_string()),
+            feature_view_claim_ref: Some("claim-extension-feature-view".to_string()),
+            interaction_claim_refs,
+            split_claim_ref: None,
+            split_status: "unmeasured".to_string(),
+        },
     }
 }
 
@@ -1779,6 +2262,376 @@ fn dataset_metric_status(document: &Sig0Document) -> BTreeMap<String, MetricStat
         status.insert(axis.to_string(), axis_status);
     }
     status
+}
+
+fn air_signature_axes(
+    signature: &ArchitectureSignatureV1DatasetShape,
+    metric_status: &BTreeMap<String, MetricStatus>,
+) -> Vec<AirSignatureAxis> {
+    DATASET_SIGNATURE_AXES
+        .iter()
+        .map(|axis| {
+            let value = signature_axis_value(signature, axis).map(|value| value as i64);
+            let status = metric_status.get(*axis).cloned().unwrap_or_else(|| {
+                unmeasured_status(format!("missing metricStatus entry for {axis}"))
+            });
+            AirSignatureAxis {
+                axis: (*axis).to_string(),
+                value,
+                measured: status.measured,
+                measurement_boundary: measurement_boundary(&status, value),
+                source: status.source,
+                reason: status.reason,
+            }
+        })
+        .collect()
+}
+
+fn signature_axis_value(
+    signature: &ArchitectureSignatureV1DatasetShape,
+    axis: &str,
+) -> Option<usize> {
+    match axis {
+        "hasCycle" => Some(signature.has_cycle),
+        "sccMaxSize" => Some(signature.scc_max_size),
+        "maxDepth" => Some(signature.max_depth),
+        "fanoutRisk" => Some(signature.fanout_risk),
+        "boundaryViolationCount" => Some(signature.boundary_violation_count),
+        "abstractionViolationCount" => Some(signature.abstraction_violation_count),
+        "sccExcessSize" => Some(signature.scc_excess_size),
+        "maxFanout" => Some(signature.max_fanout),
+        "reachableConeSize" => Some(signature.reachable_cone_size),
+        "weightedSccRisk" => signature.weighted_scc_risk,
+        "projectionSoundnessViolation" => signature.projection_soundness_violation,
+        "lspViolationCount" => signature.lsp_violation_count,
+        "nilpotencyIndex" => signature.nilpotency_index,
+        "runtimePropagation" => signature.runtime_propagation,
+        "relationComplexity" => signature.relation_complexity,
+        "empiricalChangeCost" => signature.empirical_change_cost,
+        _ => None,
+    }
+}
+
+fn measurement_boundary(status: &MetricStatus, value: Option<i64>) -> String {
+    if !status.measured {
+        return "unmeasured".to_string();
+    }
+    match value {
+        Some(0) => "measuredZero".to_string(),
+        Some(_) => "measuredNonzero".to_string(),
+        None => "unmeasured".to_string(),
+    }
+}
+
+fn numbered_id(prefix: &str, index: usize) -> String {
+    format!("{prefix}-{:04}", index + 1)
+}
+
+fn runtime_relation_kind(label: &str) -> String {
+    match label {
+        "http" | "grpc" | "queue" | "db" | "event" | "batch" => label.to_string(),
+        label if label.contains("queue") => "queue".to_string(),
+        label if label.contains("event") => "event".to_string(),
+        label if label.contains("rpc") => "grpc".to_string(),
+        label if label.contains("db") => "db".to_string(),
+        _ => "call".to_string(),
+    }
+}
+
+fn artifact_evidence_kind(kind: &str) -> String {
+    match kind {
+        "policy" => "policy_rule",
+        "pr_metadata" => "pr_file",
+        "diff" | "validation" | "sig0" => "observation_result",
+        _ => "manual_annotation",
+    }
+    .to_string()
+}
+
+fn relation_lifecycle(edge: &Edge, diff: Option<&SignatureDiffReportV0>) -> String {
+    let Some(diff) = diff else {
+        return "after".to_string();
+    };
+    let Some(edge_delta) = &diff.evidence_diff.edge_delta else {
+        return "after".to_string();
+    };
+    if edge_delta.added.iter().any(|added| added == edge) {
+        "added".to_string()
+    } else if edge_delta.removed.iter().any(|removed| removed == edge) {
+        "removed".to_string()
+    } else {
+        "unchanged".to_string()
+    }
+}
+
+fn air_component_lifecycle(diff: Option<&SignatureDiffReportV0>) -> BTreeMap<String, String> {
+    let mut lifecycle = BTreeMap::new();
+    if let Some(component_delta) =
+        diff.and_then(|report| report.evidence_diff.component_delta.as_ref())
+    {
+        for component in &component_delta.added {
+            lifecycle.insert(component.clone(), "added".to_string());
+        }
+        for component in &component_delta.removed {
+            lifecycle.insert(component.clone(), "removed".to_string());
+        }
+    }
+    lifecycle
+}
+
+fn air_revision(
+    diff: Option<&SignatureDiffReportV0>,
+    pr_metadata: Option<&EmpiricalDatasetInput>,
+) -> AirRevision {
+    if let Some(diff) = diff {
+        return AirRevision {
+            before: Some(diff.before.revision.sha.clone()),
+            after: diff.after.revision.sha.clone(),
+        };
+    }
+    if let Some(pr_metadata) = pr_metadata {
+        return AirRevision {
+            before: Some(pr_metadata.pull_request.base_commit.clone()),
+            after: pr_metadata.pull_request.head_commit.clone(),
+        };
+    }
+    AirRevision {
+        before: None,
+        after: "unknown".to_string(),
+    }
+}
+
+fn air_feature(pr_metadata: Option<&EmpiricalDatasetInput>) -> AirFeature {
+    if let Some(pr_metadata) = pr_metadata {
+        AirFeature {
+            feature_id: Some(format!("#{}", pr_metadata.pull_request.number)),
+            title: None,
+            description: Some(format!(
+                "pull request by {} with {} changed files",
+                pr_metadata.pull_request.author, pr_metadata.pr_metrics.changed_files
+            )),
+            source: "pr".to_string(),
+            ai_session: None,
+        }
+    } else {
+        AirFeature {
+            feature_id: None,
+            title: None,
+            description: None,
+            source: "unknown".to_string(),
+            ai_session: None,
+        }
+    }
+}
+
+fn air_claims(signature_axes: &[AirSignatureAxis]) -> Vec<AirClaim> {
+    let mut claims: Vec<AirClaim> = signature_axes
+        .iter()
+        .map(|axis| {
+            let measured = axis.measured && axis.value.is_some();
+            let mut missing_preconditions = Vec::new();
+            let mut non_conclusions = vec![
+                "tooling measurement is not a Lean proof".to_string(),
+                "extractor output is not a complete ComponentUniverse proof".to_string(),
+            ];
+            if !measured {
+                missing_preconditions.push(format!("{} is unmeasured", axis.axis));
+                non_conclusions.push("placeholder zero is not measured zero".to_string());
+            }
+            AirClaim {
+                claim_id: format!("claim-axis-{}", stable_id_fragment(&axis.axis)),
+                subject_ref: format!("signature.{}", axis.axis),
+                predicate: if measured {
+                    "axis value measured by tooling".to_string()
+                } else {
+                    "axis is outside the current measurement boundary".to_string()
+                },
+                claim_level: "tooling".to_string(),
+                claim_classification: if measured {
+                    "measured".to_string()
+                } else {
+                    "unmeasured".to_string()
+                },
+                measurement_boundary: axis.measurement_boundary.clone(),
+                theorem_refs: Vec::new(),
+                evidence_refs: vec!["evidence-sig0-artifact".to_string()],
+                required_assumptions: Vec::new(),
+                coverage_assumptions: Vec::new(),
+                exactness_assumptions: Vec::new(),
+                missing_preconditions,
+                non_conclusions,
+            }
+        })
+        .collect();
+    claims.push(AirClaim {
+        claim_id: "claim-extension-embedding".to_string(),
+        subject_ref: "extension.embedding".to_string(),
+        predicate: "before architecture is embedded into after architecture only if diff evidence and theorem preconditions are discharged".to_string(),
+        claim_level: "tooling".to_string(),
+        claim_classification: "unmeasured".to_string(),
+        measurement_boundary: "unmeasured".to_string(),
+        theorem_refs: Vec::new(),
+        evidence_refs: Vec::new(),
+        required_assumptions: vec!["before/after component correspondence".to_string()],
+        coverage_assumptions: vec!["static diff coverage".to_string()],
+        exactness_assumptions: Vec::new(),
+        missing_preconditions: vec!["theorem precondition checker has not run".to_string()],
+        non_conclusions: vec!["split extension is not concluded".to_string()],
+    });
+    claims.push(AirClaim {
+        claim_id: "claim-extension-feature-view".to_string(),
+        subject_ref: "extension.feature".to_string(),
+        predicate: "feature-owned delta can be interpreted from PR metadata and diff evidence"
+            .to_string(),
+        claim_level: "tooling".to_string(),
+        claim_classification: "unmeasured".to_string(),
+        measurement_boundary: "unmeasured".to_string(),
+        theorem_refs: Vec::new(),
+        evidence_refs: Vec::new(),
+        required_assumptions: vec!["PR-to-component attribution".to_string()],
+        coverage_assumptions: vec!["diff evidence coverage".to_string()],
+        exactness_assumptions: Vec::new(),
+        missing_preconditions: vec!["feature extension report has not run".to_string()],
+        non_conclusions: vec!["feature quotient is not constructed".to_string()],
+    });
+    claims
+}
+
+fn air_interaction_claim_refs(claims: &[AirClaim]) -> Vec<String> {
+    claims
+        .iter()
+        .filter(|claim| {
+            claim.subject_ref == "signature.boundaryViolationCount"
+                || claim.subject_ref == "signature.abstractionViolationCount"
+                || claim.subject_ref == "signature.runtimePropagation"
+        })
+        .map(|claim| claim.claim_id.clone())
+        .collect()
+}
+
+fn stable_id_fragment(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn air_coverage_layers(signature_axes: &[AirSignatureAxis]) -> Vec<AirCoverageLayer> {
+    vec![
+        air_coverage_layer(
+            "static",
+            signature_axes,
+            &[
+                "hasCycle",
+                "sccMaxSize",
+                "maxDepth",
+                "fanoutRisk",
+                "sccExcessSize",
+                "maxFanout",
+                "reachableConeSize",
+            ],
+            vec!["Lean import graph".to_string()],
+            Vec::new(),
+        ),
+        air_coverage_layer(
+            "policy",
+            signature_axes,
+            &["boundaryViolationCount", "abstractionViolationCount"],
+            vec!["policy file".to_string()],
+            vec!["policy coverage depends on selector completeness".to_string()],
+        ),
+        air_coverage_layer(
+            "runtime",
+            signature_axes,
+            &["runtimePropagation"],
+            vec!["runtime edge evidence JSON".to_string()],
+            vec![
+                "runtime projection is a tooling observation, not telemetry completeness"
+                    .to_string(),
+            ],
+        ),
+        air_unmeasured_coverage_layer(
+            "semantic",
+            vec![
+                "lspViolationCount".to_string(),
+                "projectionSoundnessViolation".to_string(),
+            ],
+        ),
+        air_unmeasured_coverage_layer(
+            "operation",
+            vec![
+                "relationComplexity".to_string(),
+                "empiricalChangeCost".to_string(),
+            ],
+        ),
+    ]
+}
+
+fn air_coverage_layer(
+    layer: &str,
+    signature_axes: &[AirSignatureAxis],
+    axes: &[&str],
+    extraction_scope: Vec<String>,
+    exactness_assumptions: Vec<String>,
+) -> AirCoverageLayer {
+    let mut measured_axes = Vec::new();
+    let mut unmeasured_axes = Vec::new();
+    let mut boundaries = Vec::new();
+    for axis in axes {
+        if let Some(signature_axis) = signature_axes
+            .iter()
+            .find(|signature_axis| signature_axis.axis == *axis)
+        {
+            boundaries.push(signature_axis.measurement_boundary.clone());
+            if signature_axis.measured {
+                measured_axes.push((*axis).to_string());
+            } else {
+                unmeasured_axes.push((*axis).to_string());
+            }
+        }
+    }
+    AirCoverageLayer {
+        layer: layer.to_string(),
+        measurement_boundary: combined_measurement_boundary(&boundaries),
+        universe_refs: vec!["artifact-sig0".to_string()],
+        measured_axes,
+        unmeasured_axes,
+        extraction_scope,
+        exactness_assumptions,
+        unsupported_constructs: Vec::new(),
+    }
+}
+
+fn air_unmeasured_coverage_layer(layer: &str, unmeasured_axes: Vec<String>) -> AirCoverageLayer {
+    AirCoverageLayer {
+        layer: layer.to_string(),
+        measurement_boundary: "unmeasured".to_string(),
+        universe_refs: Vec::new(),
+        measured_axes: Vec::new(),
+        unmeasured_axes,
+        extraction_scope: Vec::new(),
+        exactness_assumptions: Vec::new(),
+        unsupported_constructs: vec!["extractor not implemented for this layer".to_string()],
+    }
+}
+
+fn combined_measurement_boundary(boundaries: &[String]) -> String {
+    if boundaries.is_empty() || boundaries.iter().any(|boundary| boundary == "unmeasured") {
+        "unmeasured".to_string()
+    } else if boundaries
+        .iter()
+        .any(|boundary| boundary == "measuredNonzero")
+    {
+        "measuredNonzero".to_string()
+    } else {
+        "measuredZero".to_string()
+    }
 }
 
 fn delta_signature_signed(

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -5,9 +5,10 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use archsig::{
-    ComponentUniverseValidationReport, DEFAULT_UNIVERSE_MODE, EmpiricalDatasetInput,
-    RepositoryRevisionRef, ScanMetadata, Sig0Document, SignatureSnapshotStoreRecordV0,
-    SnapshotRecordInput, SnapshotRepositoryRef, build_empirical_dataset,
+    AirDocumentInput, ComponentUniverseValidationReport, DEFAULT_UNIVERSE_MODE,
+    EmpiricalDatasetInput, RepositoryRevisionRef, ScanMetadata, Sig0Document,
+    SignatureDiffReportV0, SignatureSnapshotStoreRecordV0, SnapshotRecordInput,
+    SnapshotRepositoryRef, build_air_document, build_empirical_dataset,
     build_pr_metadata_from_github_files, build_signature_diff_report,
     build_signature_snapshot_record, extract_relation_complexity_observation_from_file,
     extract_sig0_with_runtime, validate_component_universe_report,
@@ -229,6 +230,33 @@ enum Command {
         #[arg(long)]
         out: Option<PathBuf>,
     },
+
+    /// Build an AIR v0 document from Signature artifacts.
+    Air {
+        /// Input ArchSig Sig0 JSON path.
+        #[arg(long)]
+        sig0: PathBuf,
+
+        /// Optional ComponentUniverse validation report JSON path.
+        #[arg(long)]
+        validation: Option<PathBuf>,
+
+        /// Optional Signature diff report JSON path.
+        #[arg(long)]
+        diff: Option<PathBuf>,
+
+        /// Optional PR metadata JSON path.
+        #[arg(long = "pr-metadata")]
+        pr_metadata: Option<PathBuf>,
+
+        /// Optional law / policy JSON path recorded as AIR policy artifact.
+        #[arg(long = "law-policy")]
+        law_policy: Option<PathBuf>,
+
+        /// Output AIR JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -397,6 +425,37 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 &pr_metadata,
             );
             write_json(out, &report)?;
+            Ok(ExitCode::SUCCESS)
+        }
+        Some(Command::Air {
+            sig0,
+            validation,
+            diff,
+            pr_metadata,
+            law_policy,
+            out,
+        }) => {
+            let document: Sig0Document = read_json(&sig0)?;
+            let validation_report: Option<ComponentUniverseValidationReport> =
+                validation.as_ref().map(read_json).transpose()?;
+            let diff_report: Option<SignatureDiffReportV0> =
+                diff.as_ref().map(read_json).transpose()?;
+            let pr_metadata_document: Option<EmpiricalDatasetInput> =
+                pr_metadata.as_ref().map(read_json).transpose()?;
+            let air = build_air_document(
+                &document,
+                validation_report.as_ref(),
+                diff_report.as_ref(),
+                pr_metadata_document.as_ref(),
+                AirDocumentInput {
+                    sig0_path: sig0.display().to_string(),
+                    validation_path: validation.map(|path| path.display().to_string()),
+                    diff_path: diff.map(|path| path.display().to_string()),
+                    pr_metadata_path: pr_metadata.map(|path| path.display().to_string()),
+                    law_policy_path: law_policy.map(|path| path.display().to_string()),
+                },
+            );
+            write_json(out, &air)?;
             Ok(ExitCode::SUCCESS)
         }
         None => {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -227,6 +227,105 @@ fn cli_relation_complexity_fixture_outputs_observation() {
 }
 
 #[test]
+fn cli_air_normalizes_sig0_validation_and_pr_metadata() {
+    let root = fixture_root();
+    let out_dir = temp_dir("air");
+    let sig0 = out_dir.join("sig0.json");
+    let validation = out_dir.join("validation.json");
+    let air = out_dir.join("air.json");
+
+    run_sig0(&[
+        "--root",
+        root.to_str().expect("fixture path is utf-8"),
+        "--policy",
+        root.join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--runtime-edges",
+        root.join("runtime_edges.json")
+            .to_str()
+            .expect("runtime path is utf-8"),
+        "--out",
+        sig0.to_str().expect("sig0 path is utf-8"),
+    ]);
+    run_sig0(&[
+        "validate",
+        "--input",
+        sig0.to_str().expect("sig0 path is utf-8"),
+        "--out",
+        validation.to_str().expect("validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "air",
+        "--sig0",
+        sig0.to_str().expect("sig0 path is utf-8"),
+        "--validation",
+        validation.to_str().expect("validation path is utf-8"),
+        "--pr-metadata",
+        root.join("pr_metadata.json")
+            .to_str()
+            .expect("metadata path is utf-8"),
+        "--law-policy",
+        root.join("policy_measured_zero.json")
+            .to_str()
+            .expect("policy path is utf-8"),
+        "--out",
+        air.to_str().expect("air path is utf-8"),
+    ]);
+
+    let json = read_json(&air);
+    assert_eq!(json["schemaVersion"], "aat-air-v0");
+    assert_eq!(json["feature"]["featureId"], "#42");
+    assert_eq!(json["revision"]["before"], "base-sha");
+    assert_eq!(json["revision"]["after"], "head-sha");
+    assert!(
+        json["relations"]
+            .as_array()
+            .expect("relations is array")
+            .iter()
+            .any(|relation| relation["layer"] == "static" && relation["kind"] == "import")
+    );
+    assert!(
+        json["relations"]
+            .as_array()
+            .expect("relations is array")
+            .iter()
+            .any(|relation| relation["layer"] == "runtime" && relation["kind"] == "grpc")
+    );
+    assert!(
+        json["signature"]["axes"]
+            .as_array()
+            .expect("axes is array")
+            .iter()
+            .any(|axis| {
+                axis["axis"] == "boundaryViolationCount"
+                    && axis["measurementBoundary"] == "measuredZero"
+            })
+    );
+    assert!(
+        json["signature"]["axes"]
+            .as_array()
+            .expect("axes is array")
+            .iter()
+            .any(|axis| {
+                axis["axis"] == "runtimePropagation"
+                    && axis["measurementBoundary"] == "measuredNonzero"
+            })
+    );
+    assert_eq!(json["extension"]["splitStatus"], "unmeasured");
+    assert!(
+        json["claims"]
+            .as_array()
+            .expect("claims is array")
+            .iter()
+            .any(|claim| {
+                claim["claimId"] == "claim-axis-boundaryviolationcount"
+                    && claim["claimClassification"] == "measured"
+            })
+    );
+}
+
+#[test]
 fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
     let fixture = fixture_root();
     let repo = temp_dir("snapshot-repo");
@@ -257,6 +356,7 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
     let pr_metadata = out_dir.join("pr-metadata.json");
     let peer_pr_metadata = out_dir.join("peer-pr-metadata.json");
     let report = out_dir.join("signature-diff.json");
+    let air = out_dir.join("air.json");
 
     run_sig0(&[
         "--root",
@@ -501,6 +601,35 @@ fn cli_snapshot_diff_reports_axes_evidence_and_pr_attribution() {
             .as_array()
             .expect("sharedWorsenedAxes is array")
             .is_empty()
+    );
+
+    run_sig0(&[
+        "air",
+        "--sig0",
+        after_sig0.to_str().expect("after sig0 path is utf-8"),
+        "--validation",
+        after_validation
+            .to_str()
+            .expect("after validation path is utf-8"),
+        "--diff",
+        report.to_str().expect("diff report path is utf-8"),
+        "--pr-metadata",
+        pr_metadata.to_str().expect("PR metadata path is utf-8"),
+        "--out",
+        air.to_str().expect("air path is utf-8"),
+    ]);
+
+    let json = read_json(&air);
+    assert_eq!(json["revision"]["before"], "before-sha");
+    assert_eq!(json["revision"]["after"], "after-sha");
+    assert!(
+        json["components"]
+            .as_array()
+            .expect("components is array")
+            .iter()
+            .any(|component| {
+                component["id"] == "Formal.Arch.C" && component["lifecycle"] == "added"
+            })
     );
 }
 


### PR DESCRIPTION
## 概要

Closes #497

- `aat-air-v0` 用の Rust serde schema と `build_air_document` を追加しました。
- `archsig air` CLI を追加し、`--sig0`, `--validation`, `--diff`, `--pr-metadata`, `--law-policy` から AIR JSON を生成できるようにしました。
- AIR では `relations` を canonical representation とし、signature axis ごとに `measuredZero` / `measuredNonzero` / `unmeasured` の `measurementBoundary` を出力します。

Lean status: empirical hypothesis / tooling implementation

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `lake build`（成功。既存の `FeatureExtensionExamples.lean` linter warning 2件のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている