### PR TITLE
AIR validation と canonical fixture を追加する

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -47,6 +47,7 @@ AI / CI が最初に読むべき成果物は次である。
 | Snapshot | `signature-snapshot-store-v0` | repository revision ごとの保存用 signature record。 |
 | Diff report | `signature-diff-report-v0` | before / after の悪化軸、改善軸、未評価軸、evidence diff、PR attribution candidate。 |
 | AIR | `aat-air-v0` | Signature artifact layer を claim / evidence / coverage / extension boundary へ正規化した中間表現。 |
+| AIR validation report | `aat-air-validation-report-v0` | AIR の dangling refs、claim boundary、measured evidence traceability の検査結果。 |
 | Dataset record | `empirical-signature-dataset-v0` | PR metadata と before / after signature を結合した実証研究用 record。 |
 
 通常の PR / CI 診断では、最終的に `signature-diff-report-v0` を読む。
@@ -287,6 +288,26 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- air \
 AIR では `static_edges` / `runtime_edges` を出さず、`relations` を canonical representation として使う。
 各 signature axis は `measurementBoundary` に `measuredZero`, `measuredNonzero`, `unmeasured` を持つため、
 測定済み 0 と未測定の placeholder 0 を分けて読める。
+
+AIR の参照整合性を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- validate-air \
+  --input .lake/signature-current/air.json \
+  --out .lake/signature-current/air-validation.json
+```
+
+`validate-air` は dangling component / artifact / evidence / claim refs、coverage universe refs、
+claim classification と `measurementBoundary` の不整合を検出する。
+`claimClassification = measured` の claim に `evidenceRefs` がない場合は通常 warning とし、
+CI で fail にしたい場合は `--strict-measured-evidence` を付ける。
+
+canonical AIR fixture は `tools/archsig/tests/fixtures/air` に置く。
+
+- `good_extension.json`
+- `hidden_interaction.json`
+- `policy_violation.json`
+- `unmeasured_runtime_semantic.json`
 
 ## PR Metadata / Dataset を作る
 

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -15,6 +15,7 @@ pub const EMPIRICAL_DATASET_SCHEMA_VERSION: &str = "empirical-signature-dataset-
 pub const SIGNATURE_SNAPSHOT_STORE_SCHEMA_VERSION: &str = "signature-snapshot-store-v0";
 pub const SIGNATURE_DIFF_REPORT_SCHEMA_VERSION: &str = "signature-diff-report-v0";
 pub const AIR_SCHEMA_VERSION: &str = "aat-air-v0";
+pub const AIR_VALIDATION_REPORT_SCHEMA_VERSION: &str = "aat-air-validation-report-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const RELATION_COMPLEXITY_CANDIDATE_SCHEMA_VERSION: &str = "relation-complexity-candidates/v0";
@@ -886,6 +887,37 @@ pub struct AirDocumentInput {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AirValidationReport {
+    pub schema_version: String,
+    pub input: AirValidationInput,
+    pub summary: AirValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub architecture_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirValidationSummary {
+    pub result: String,
+    pub component_count: usize,
+    pub relation_count: usize,
+    pub evidence_count: usize,
+    pub claim_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SnapshotDiffEndpoint {
     pub repository: SnapshotRepositoryRef,
     pub revision: RepositoryRevisionRef,
@@ -1288,6 +1320,64 @@ pub fn validate_component_universe_report(
         checks,
         warnings,
     })
+}
+
+pub fn validate_air_document_report(
+    document: &AirDocumentV0,
+    input_path: &str,
+    strict_measured_evidence: bool,
+) -> AirValidationReport {
+    let mut checks = Vec::new();
+
+    checks.push(check_air_schema_version(&document.schema_version));
+    checks.push(check_air_unique_ids(document));
+    checks.push(check_air_artifact_refs(document));
+    checks.push(check_air_component_refs(document));
+    checks.push(check_air_evidence_refs(document));
+    checks.push(check_air_claim_refs(document));
+    checks.push(check_air_path_and_witness_refs(document));
+    checks.push(check_air_coverage_universe_refs(document));
+    checks.push(check_air_signature_measurement_boundary(document));
+    checks.push(check_air_claim_measurement_boundary(document));
+    checks.push(check_air_measured_claim_evidence(
+        document,
+        strict_measured_evidence,
+    ));
+
+    let failed_check_count = count_checks(&checks, "fail");
+    let warning_check_count = count_checks(&checks, "warn");
+    let result = if failed_check_count > 0 {
+        "fail"
+    } else if warning_check_count > 0 {
+        "warn"
+    } else {
+        "pass"
+    };
+    let warnings = checks
+        .iter()
+        .filter(|check| check.result == "warn")
+        .filter_map(|check| check.reason.clone())
+        .collect();
+
+    AirValidationReport {
+        schema_version: AIR_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: AirValidationInput {
+            schema_version: document.schema_version.clone(),
+            path: input_path.to_string(),
+            architecture_id: document.architecture_id.clone(),
+        },
+        summary: AirValidationSummary {
+            result: result.to_string(),
+            component_count: document.components.len(),
+            relation_count: document.relations.len(),
+            evidence_count: document.evidence.len(),
+            claim_count: document.claims.len(),
+            failed_check_count,
+            warning_check_count,
+        },
+        checks,
+        warnings,
+    }
 }
 
 pub fn build_empirical_dataset(
@@ -3459,6 +3549,634 @@ fn check_metric_measured(
         );
     }
     check
+}
+
+fn check_air_schema_version(schema_version: &str) -> ValidationCheck {
+    let mut check = validation_check(
+        "air-schema-version-supported",
+        "AIR schema version is supported",
+        if schema_version == AIR_SCHEMA_VERSION {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!("unsupported schemaVersion: {schema_version}"));
+    }
+    check
+}
+
+fn check_air_unique_ids(document: &AirDocumentV0) -> ValidationCheck {
+    let duplicate_examples: Vec<ValidationExample> = [
+        (
+            "artifact",
+            duplicates(
+                document
+                    .artifacts
+                    .iter()
+                    .map(|artifact| artifact.artifact_id.as_str()),
+            ),
+        ),
+        (
+            "evidence",
+            duplicates(
+                document
+                    .evidence
+                    .iter()
+                    .map(|evidence| evidence.evidence_id.as_str()),
+            ),
+        ),
+        (
+            "component",
+            duplicates(
+                document
+                    .components
+                    .iter()
+                    .map(|component| component.id.as_str()),
+            ),
+        ),
+        (
+            "relation",
+            duplicates(
+                document
+                    .relations
+                    .iter()
+                    .map(|relation| relation.id.as_str()),
+            ),
+        ),
+        (
+            "claim",
+            duplicates(document.claims.iter().map(|claim| claim.claim_id.as_str())),
+        ),
+    ]
+    .into_iter()
+    .flat_map(|(kind, ids)| {
+        ids.into_iter()
+            .map(move |id| generic_validation_example(kind, &id, "duplicate id"))
+    })
+    .collect();
+
+    let mut check = validation_check(
+        "air-id-nodup",
+        "AIR ids are duplicate-free within each reference namespace",
+        if duplicate_examples.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !duplicate_examples.is_empty() {
+        check.reason = Some("duplicate AIR ids found".to_string());
+        check.count = Some(duplicate_examples.len());
+        check.examples = duplicate_examples.into_iter().take(5).collect();
+    }
+    check
+}
+
+fn check_air_artifact_refs(document: &AirDocumentV0) -> ValidationCheck {
+    let artifact_ids = air_artifact_ids(document);
+    let unresolved: Vec<ValidationExample> = document
+        .evidence
+        .iter()
+        .filter_map(|evidence| {
+            let artifact_ref = evidence.artifact_ref.as_ref()?;
+            (!artifact_ids.contains(artifact_ref)).then(|| {
+                generic_validation_example(
+                    &evidence.evidence_id,
+                    artifact_ref,
+                    "dangling artifact_ref",
+                )
+            })
+        })
+        .collect();
+
+    air_ref_check(
+        "air-artifact-refs-resolved",
+        "evidence artifact refs resolve to AIR artifacts",
+        unresolved,
+    )
+}
+
+fn check_air_component_refs(document: &AirDocumentV0) -> ValidationCheck {
+    let component_ids = air_component_ids(document);
+    let mut unresolved = Vec::new();
+    for relation in &document.relations {
+        if let Some(component_ref) = &relation.from_component {
+            if !component_ids.contains(component_ref) {
+                unresolved.push(generic_validation_example(
+                    &relation.id,
+                    component_ref,
+                    "dangling relation.from",
+                ));
+            }
+        }
+        if let Some(component_ref) = &relation.to_component {
+            if !component_ids.contains(component_ref) {
+                unresolved.push(generic_validation_example(
+                    &relation.id,
+                    component_ref,
+                    "dangling relation.to",
+                ));
+            }
+        }
+    }
+
+    air_ref_check(
+        "air-component-refs-resolved",
+        "relation component refs resolve to AIR components",
+        unresolved,
+    )
+}
+
+fn check_air_evidence_refs(document: &AirDocumentV0) -> ValidationCheck {
+    let evidence_ids = air_evidence_ids(document);
+    let mut unresolved = Vec::new();
+
+    for component in &document.components {
+        unresolved.extend(unresolved_refs(
+            &component.id,
+            "dangling component.evidence_refs",
+            &component.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+    for relation in &document.relations {
+        unresolved.extend(unresolved_refs(
+            &relation.id,
+            "dangling relation.evidence_refs",
+            &relation.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+    for diagram in &document.semantic_diagrams {
+        unresolved.extend(unresolved_refs(
+            &diagram.id,
+            "dangling semantic_diagram.evidence_refs",
+            &diagram.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+    for path in &document.architecture_paths {
+        unresolved.extend(unresolved_refs(
+            &path.path_id,
+            "dangling architecture_path.evidence_refs",
+            &path.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+    for generator in &document.homotopy_generators {
+        unresolved.extend(unresolved_refs(
+            &generator.generator_id,
+            "dangling homotopy_generator.evidence_refs",
+            &generator.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+    for witness in &document.nonfillability_witnesses {
+        unresolved.extend(unresolved_refs(
+            &witness.witness_id,
+            "dangling nonfillability_witness.evidence_refs",
+            &witness.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+    for claim in &document.claims {
+        unresolved.extend(unresolved_refs(
+            &claim.claim_id,
+            "dangling claim.evidence_refs",
+            &claim.evidence_refs,
+            &evidence_ids,
+        ));
+    }
+
+    air_ref_check(
+        "air-evidence-refs-resolved",
+        "AIR evidence refs resolve to evidence objects",
+        unresolved,
+    )
+}
+
+fn check_air_claim_refs(document: &AirDocumentV0) -> ValidationCheck {
+    let claim_ids = air_claim_ids(document);
+    let mut unresolved = Vec::new();
+
+    for diagram in &document.semantic_diagrams {
+        if let Some(claim_ref) = &diagram.filler_claim_ref {
+            if !claim_ids.contains(claim_ref) {
+                unresolved.push(generic_validation_example(
+                    &diagram.id,
+                    claim_ref,
+                    "dangling semantic_diagram.filler_claim_ref",
+                ));
+            }
+        }
+    }
+    for generator in &document.homotopy_generators {
+        unresolved.extend(unresolved_refs(
+            &generator.generator_id,
+            "dangling homotopy_generator.preserves_observation_claim_refs",
+            &generator.preserves_observation_claim_refs,
+            &claim_ids,
+        ));
+    }
+    for witness in &document.nonfillability_witnesses {
+        if !claim_ids.contains(&witness.claim_ref) {
+            unresolved.push(generic_validation_example(
+                &witness.witness_id,
+                &witness.claim_ref,
+                "dangling nonfillability_witness.claim_ref",
+            ));
+        }
+    }
+    unresolved.extend(optional_unresolved_ref(
+        "extension.embedding_claim_ref",
+        document.extension.embedding_claim_ref.as_ref(),
+        &claim_ids,
+    ));
+    unresolved.extend(optional_unresolved_ref(
+        "extension.feature_view_claim_ref",
+        document.extension.feature_view_claim_ref.as_ref(),
+        &claim_ids,
+    ));
+    unresolved.extend(optional_unresolved_ref(
+        "extension.split_claim_ref",
+        document.extension.split_claim_ref.as_ref(),
+        &claim_ids,
+    ));
+    unresolved.extend(unresolved_refs(
+        "extension.interaction_claim_refs",
+        "dangling extension.interaction_claim_refs",
+        &document.extension.interaction_claim_refs,
+        &claim_ids,
+    ));
+
+    air_ref_check(
+        "air-claim-refs-resolved",
+        "AIR claim refs resolve to claim objects",
+        unresolved,
+    )
+}
+
+fn check_air_path_and_witness_refs(document: &AirDocumentV0) -> ValidationCheck {
+    let path_ids: BTreeSet<String> = document
+        .architecture_paths
+        .iter()
+        .map(|path| path.path_id.clone())
+        .collect();
+    let diagram_ids: BTreeSet<String> = document
+        .semantic_diagrams
+        .iter()
+        .map(|diagram| diagram.id.clone())
+        .collect();
+    let witness_ids: BTreeSet<String> = document
+        .nonfillability_witnesses
+        .iter()
+        .map(|witness| witness.witness_id.clone())
+        .collect();
+    let mut unresolved = Vec::new();
+
+    for diagram in &document.semantic_diagrams {
+        if !path_ids.contains(&diagram.lhs_path_ref) {
+            unresolved.push(generic_validation_example(
+                &diagram.id,
+                &diagram.lhs_path_ref,
+                "dangling semantic_diagram.lhs_path_ref",
+            ));
+        }
+        if !path_ids.contains(&diagram.rhs_path_ref) {
+            unresolved.push(generic_validation_example(
+                &diagram.id,
+                &diagram.rhs_path_ref,
+                "dangling semantic_diagram.rhs_path_ref",
+            ));
+        }
+        unresolved.extend(unresolved_refs(
+            &diagram.id,
+            "dangling semantic_diagram.nonfillability_witness_refs",
+            &diagram.nonfillability_witness_refs,
+            &witness_ids,
+        ));
+    }
+    for generator in &document.homotopy_generators {
+        unresolved.extend(unresolved_refs(
+            &generator.generator_id,
+            "dangling homotopy_generator.diagram_refs",
+            &generator.diagram_refs,
+            &diagram_ids,
+        ));
+    }
+    for witness in &document.nonfillability_witnesses {
+        if !diagram_ids.contains(&witness.diagram_ref) {
+            unresolved.push(generic_validation_example(
+                &witness.witness_id,
+                &witness.diagram_ref,
+                "dangling nonfillability_witness.diagram_ref",
+            ));
+        }
+    }
+
+    air_ref_check(
+        "air-path-witness-refs-resolved",
+        "AIR path, diagram, and witness refs resolve",
+        unresolved,
+    )
+}
+
+fn check_air_coverage_universe_refs(document: &AirDocumentV0) -> ValidationCheck {
+    let artifact_ids = air_artifact_ids(document);
+    let unresolved: Vec<ValidationExample> = document
+        .coverage
+        .layers
+        .iter()
+        .flat_map(|layer| {
+            unresolved_refs(
+                &layer.layer,
+                "dangling coverage.layers.universe_refs",
+                &layer.universe_refs,
+                &artifact_ids,
+            )
+        })
+        .collect();
+    air_ref_check(
+        "air-coverage-universe-refs-resolved",
+        "coverage universe refs resolve to artifacts",
+        unresolved,
+    )
+}
+
+fn check_air_signature_measurement_boundary(document: &AirDocumentV0) -> ValidationCheck {
+    let valid_boundaries = [
+        "measuredZero",
+        "measuredNonzero",
+        "unmeasured",
+        "outOfScope",
+    ];
+    let mut invalid = Vec::new();
+
+    for axis in &document.signature.axes {
+        if !valid_boundaries.contains(&axis.measurement_boundary.as_str()) {
+            invalid.push(generic_validation_example(
+                &axis.axis,
+                &axis.measurement_boundary,
+                "unsupported signature measurement_boundary",
+            ));
+            continue;
+        }
+        if !axis.measured {
+            if !matches!(
+                axis.measurement_boundary.as_str(),
+                "unmeasured" | "outOfScope"
+            ) {
+                invalid.push(generic_validation_example(
+                    &axis.axis,
+                    &axis.measurement_boundary,
+                    "unmeasured axis must use unmeasured or outOfScope boundary",
+                ));
+            }
+            continue;
+        }
+        match axis.value {
+            Some(0) => {
+                if axis.measurement_boundary != "measuredZero" {
+                    invalid.push(generic_validation_example(
+                        &axis.axis,
+                        &axis.measurement_boundary,
+                        "zero measured axis must use measuredZero boundary",
+                    ));
+                }
+            }
+            Some(_) => {
+                if axis.measurement_boundary != "measuredNonzero" {
+                    invalid.push(generic_validation_example(
+                        &axis.axis,
+                        &axis.measurement_boundary,
+                        "nonzero measured axis must use measuredNonzero boundary",
+                    ));
+                }
+            }
+            None => {
+                invalid.push(generic_validation_example(
+                    &axis.axis,
+                    &axis.measurement_boundary,
+                    "measured axis must carry a value",
+                ));
+            }
+        }
+    }
+
+    for layer in &document.coverage.layers {
+        if !valid_boundaries.contains(&layer.measurement_boundary.as_str()) {
+            invalid.push(generic_validation_example(
+                &layer.layer,
+                &layer.measurement_boundary,
+                "unsupported coverage measurement_boundary",
+            ));
+        }
+    }
+
+    air_ref_check(
+        "air-signature-boundary-compatible",
+        "signature and coverage measurement boundaries are internally consistent",
+        invalid,
+    )
+}
+
+fn check_air_claim_measurement_boundary(document: &AirDocumentV0) -> ValidationCheck {
+    let valid_boundaries = [
+        "measuredZero",
+        "measuredNonzero",
+        "unmeasured",
+        "outOfScope",
+    ];
+    let valid_classifications = [
+        "proved",
+        "measured",
+        "assumed",
+        "empirical",
+        "unmeasured",
+        "out_of_scope",
+    ];
+    let mut invalid = Vec::new();
+
+    for claim in &document.claims {
+        if !valid_boundaries.contains(&claim.measurement_boundary.as_str()) {
+            invalid.push(generic_validation_example(
+                &claim.claim_id,
+                &claim.measurement_boundary,
+                "unsupported measurement_boundary",
+            ));
+        }
+        if !valid_classifications.contains(&claim.claim_classification.as_str()) {
+            invalid.push(generic_validation_example(
+                &claim.claim_id,
+                &claim.claim_classification,
+                "unsupported claim_classification",
+            ));
+        }
+        if claim.claim_classification == "measured"
+            && !matches!(
+                claim.measurement_boundary.as_str(),
+                "measuredZero" | "measuredNonzero"
+            )
+        {
+            invalid.push(generic_validation_example(
+                &claim.claim_id,
+                &claim.measurement_boundary,
+                "measured claim must use a measured boundary",
+            ));
+        }
+        if matches!(
+            claim.measurement_boundary.as_str(),
+            "measuredZero" | "measuredNonzero"
+        ) && claim.claim_classification == "unmeasured"
+        {
+            invalid.push(generic_validation_example(
+                &claim.claim_id,
+                &claim.claim_classification,
+                "measured boundary cannot be classified as unmeasured",
+            ));
+        }
+        if claim.claim_classification == "proved" && claim.claim_level != "formal" {
+            invalid.push(generic_validation_example(
+                &claim.claim_id,
+                &claim.claim_level,
+                "proved claim must be claim_level formal",
+            ));
+        }
+        if claim.claim_classification == "proved" && !claim.missing_preconditions.is_empty() {
+            invalid.push(generic_validation_example(
+                &claim.claim_id,
+                &claim.missing_preconditions.join(", "),
+                "proved claim has missing preconditions",
+            ));
+        }
+    }
+
+    air_ref_check(
+        "air-claim-boundary-compatible",
+        "claim classification is compatible with measurement boundary",
+        invalid,
+    )
+}
+
+fn check_air_measured_claim_evidence(
+    document: &AirDocumentV0,
+    strict_measured_evidence: bool,
+) -> ValidationCheck {
+    let missing_evidence: Vec<ValidationExample> = document
+        .claims
+        .iter()
+        .filter(|claim| claim.claim_classification == "measured" && claim.evidence_refs.is_empty())
+        .map(|claim| {
+            generic_validation_example(
+                &claim.claim_id,
+                &claim.subject_ref,
+                "measured claim has no evidence_refs",
+            )
+        })
+        .collect();
+    let mut check = validation_check(
+        "air-measured-claims-have-evidence",
+        "measured tooling claims are traceable to evidence",
+        if missing_evidence.is_empty() {
+            "pass"
+        } else if strict_measured_evidence {
+            "fail"
+        } else {
+            "warn"
+        },
+    );
+    if !missing_evidence.is_empty() {
+        check.reason = Some("measured claims without evidence refs found".to_string());
+        check.count = Some(missing_evidence.len());
+        check.examples = missing_evidence.into_iter().take(5).collect();
+    }
+    check
+}
+
+fn air_ref_check(id: &str, title: &str, unresolved: Vec<ValidationExample>) -> ValidationCheck {
+    let mut check = validation_check(
+        id,
+        title,
+        if unresolved.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !unresolved.is_empty() {
+        check.reason = Some("dangling or invalid AIR references found".to_string());
+        check.count = Some(unresolved.len());
+        check.examples = unresolved.into_iter().take(5).collect();
+    }
+    check
+}
+
+fn unresolved_refs(
+    owner: &str,
+    reason: &str,
+    refs: &[String],
+    valid_refs: &BTreeSet<String>,
+) -> Vec<ValidationExample> {
+    refs.iter()
+        .filter(|value| !valid_refs.contains(*value))
+        .map(|value| generic_validation_example(owner, value, reason))
+        .collect()
+}
+
+fn optional_unresolved_ref(
+    owner: &str,
+    value: Option<&String>,
+    valid_refs: &BTreeSet<String>,
+) -> Vec<ValidationExample> {
+    value
+        .filter(|value| !valid_refs.contains(*value))
+        .map(|value| generic_validation_example(owner, value, "dangling optional claim ref"))
+        .into_iter()
+        .collect()
+}
+
+fn air_artifact_ids(document: &AirDocumentV0) -> BTreeSet<String> {
+    document
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.artifact_id.clone())
+        .collect()
+}
+
+fn air_evidence_ids(document: &AirDocumentV0) -> BTreeSet<String> {
+    document
+        .evidence
+        .iter()
+        .map(|evidence| evidence.evidence_id.clone())
+        .collect()
+}
+
+fn air_component_ids(document: &AirDocumentV0) -> BTreeSet<String> {
+    document
+        .components
+        .iter()
+        .map(|component| component.id.clone())
+        .collect()
+}
+
+fn air_claim_ids(document: &AirDocumentV0) -> BTreeSet<String> {
+    document
+        .claims
+        .iter()
+        .map(|claim| claim.claim_id.clone())
+        .collect()
+}
+
+fn generic_validation_example(source: &str, target: &str, evidence: &str) -> ValidationExample {
+    ValidationExample {
+        component_id: None,
+        path: None,
+        source: Some(source.to_string()),
+        target: Some(target.to_string()),
+        evidence: Some(evidence.to_string()),
+    }
 }
 
 fn duplicates<'a>(values: impl Iterator<Item = &'a str>) -> Vec<String> {

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -5,13 +5,13 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use archsig::{
-    AirDocumentInput, ComponentUniverseValidationReport, DEFAULT_UNIVERSE_MODE,
-    EmpiricalDatasetInput, RepositoryRevisionRef, ScanMetadata, Sig0Document,
-    SignatureDiffReportV0, SignatureSnapshotStoreRecordV0, SnapshotRecordInput,
+    AirDocumentInput, AirDocumentV0, AirValidationReport, ComponentUniverseValidationReport,
+    DEFAULT_UNIVERSE_MODE, EmpiricalDatasetInput, RepositoryRevisionRef, ScanMetadata,
+    Sig0Document, SignatureDiffReportV0, SignatureSnapshotStoreRecordV0, SnapshotRecordInput,
     SnapshotRepositoryRef, build_air_document, build_empirical_dataset,
     build_pr_metadata_from_github_files, build_signature_diff_report,
     build_signature_snapshot_record, extract_relation_complexity_observation_from_file,
-    extract_sig0_with_runtime, validate_component_universe_report,
+    extract_sig0_with_runtime, validate_air_document_report, validate_component_universe_report,
 };
 use clap::{Parser, Subcommand};
 
@@ -257,6 +257,21 @@ enum Command {
         #[arg(long)]
         out: Option<PathBuf>,
     },
+
+    /// Validate an AIR v0 document.
+    ValidateAir {
+        /// Input AIR JSON path.
+        #[arg(long)]
+        input: PathBuf,
+
+        /// Output AIR validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+
+        /// Treat measured claims without evidence refs as failures instead of warnings.
+        #[arg(long)]
+        strict_measured_evidence: bool,
+    },
 }
 
 fn main() -> ExitCode {
@@ -457,6 +472,25 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             );
             write_json(out, &air)?;
             Ok(ExitCode::SUCCESS)
+        }
+        Some(Command::ValidateAir {
+            input,
+            out,
+            strict_measured_evidence,
+        }) => {
+            let document: AirDocumentV0 = read_json(&input)?;
+            let report: AirValidationReport = validate_air_document_report(
+                &document,
+                &input.display().to_string(),
+                strict_measured_evidence,
+            );
+            let failed = report.summary.result == "fail";
+            write_json(out, &report)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
         }
         None => {
             let document = extract_sig0_with_runtime(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -13,6 +13,10 @@ fn module_root_fixture_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/module_root")
 }
 
+fn air_fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/air")
+}
+
 fn temp_dir(test_name: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -24,10 +28,7 @@ fn temp_dir(test_name: &str) -> PathBuf {
 }
 
 fn run_sig0(args: &[&str]) {
-    let output = Command::new(env!("CARGO_BIN_EXE_archsig"))
-        .args(args)
-        .output()
-        .expect("archsig command runs");
+    let output = run_sig0_output(args);
     assert!(
         output.status.success(),
         "command failed\nstdout:\n{}\nstderr:\n{}",
@@ -36,9 +37,155 @@ fn run_sig0(args: &[&str]) {
     );
 }
 
+fn run_sig0_output(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_archsig"))
+        .args(args)
+        .output()
+        .expect("archsig command runs")
+}
+
 fn read_json(path: &Path) -> Value {
     let contents = fs::read_to_string(path).expect("json output is readable");
     serde_json::from_str(&contents).expect("json output parses")
+}
+
+#[test]
+fn cli_validate_air_accepts_canonical_fixtures() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("validate-air-fixtures");
+    for fixture in [
+        "good_extension.json",
+        "hidden_interaction.json",
+        "policy_violation.json",
+        "unmeasured_runtime_semantic.json",
+    ] {
+        let report = out_dir.join(format!("{fixture}.report.json"));
+        run_sig0(&[
+            "validate-air",
+            "--input",
+            root.join(fixture).to_str().expect("fixture path is utf-8"),
+            "--out",
+            report.to_str().expect("report path is utf-8"),
+        ]);
+
+        let json = read_json(&report);
+        assert_eq!(json["schemaVersion"], "aat-air-validation-report-v0");
+        assert_eq!(json["summary"]["result"], "pass");
+        assert_eq!(json["summary"]["failedCheckCount"], 0);
+    }
+}
+
+#[test]
+fn cli_validate_air_detects_dangling_refs_and_boundary_mismatch() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("validate-air-invalid");
+    let input = out_dir.join("invalid-air.json");
+    let report = out_dir.join("invalid-air-report.json");
+    let mut json = read_json(&root.join("good_extension.json"));
+
+    json["relations"][0]["to"] = serde_json::json!("MissingComponent");
+    json["claims"][0]["measurementBoundary"] = serde_json::json!("unmeasured");
+    json["extension"]["interactionClaimRefs"] = serde_json::json!(["claim-missing"]);
+    fs::write(
+        &input,
+        serde_json::to_string_pretty(&json).expect("json serializes"),
+    )
+    .expect("invalid AIR is written");
+
+    let output = run_sig0_output(&[
+        "validate-air",
+        "--input",
+        input.to_str().expect("input path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "invalid AIR should fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = read_json(&report);
+    assert_eq!(report["summary"]["result"], "fail");
+    assert!(
+        report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| check["id"] == "air-component-refs-resolved" && check["result"] == "fail")
+    );
+    assert!(
+        report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(
+                |check| check["id"] == "air-claim-boundary-compatible" && check["result"] == "fail"
+            )
+    );
+    assert!(
+        report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| check["id"] == "air-claim-refs-resolved" && check["result"] == "fail")
+    );
+}
+
+#[test]
+fn cli_validate_air_can_escalate_missing_measured_evidence_to_failure() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("validate-air-strict");
+    let input = out_dir.join("missing-evidence-air.json");
+    let warn_report = out_dir.join("warn-report.json");
+    let strict_report = out_dir.join("strict-report.json");
+    let mut json = read_json(&root.join("good_extension.json"));
+
+    json["claims"][0]["evidenceRefs"] = serde_json::json!([]);
+    fs::write(
+        &input,
+        serde_json::to_string_pretty(&json).expect("json serializes"),
+    )
+    .expect("AIR with missing measured evidence is written");
+
+    run_sig0(&[
+        "validate-air",
+        "--input",
+        input.to_str().expect("input path is utf-8"),
+        "--out",
+        warn_report.to_str().expect("warn report path is utf-8"),
+    ]);
+    let warn = read_json(&warn_report);
+    assert_eq!(warn["summary"]["result"], "warn");
+    assert!(
+        warn["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| check["id"] == "air-measured-claims-have-evidence"
+                && check["result"] == "warn")
+    );
+
+    let output = run_sig0_output(&[
+        "validate-air",
+        "--input",
+        input.to_str().expect("input path is utf-8"),
+        "--strict-measured-evidence",
+        "--out",
+        strict_report.to_str().expect("strict report path is utf-8"),
+    ]);
+    assert!(!output.status.success(), "strict validation should fail");
+    let strict = read_json(&strict_report);
+    assert_eq!(strict["summary"]["result"], "fail");
+    assert!(
+        strict["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| check["id"] == "air-measured-claims-have-evidence"
+                && check["result"] == "fail")
+    );
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/air/good_extension.json
+++ b/tools/archsig/tests/fixtures/air/good_extension.json
@@ -1,0 +1,217 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-good-extension",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-good",
+    "after": "after-good"
+  },
+  "feature": {
+    "featureId": "#canonical-good",
+    "title": "Add coupon calculation",
+    "description": "CouponService is added through CouponPort",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-sig0",
+      "kind": "sig0",
+      "schemaVersion": "archsig-sig0-v0",
+      "path": "canonical/good/sig0.json",
+      "contentHash": null,
+      "producedBy": "archsig"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-sig0",
+      "kind": "observation_result",
+      "artifactRef": "artifact-sig0",
+      "path": "canonical/good/sig0.json",
+      "symbol": null,
+      "line": null,
+      "ruleId": "archsig-sig0-v0",
+      "confidence": "high"
+    },
+    {
+      "evidenceId": "evidence-static-coupon-port",
+      "kind": "source_location",
+      "artifactRef": "artifact-sig0",
+      "path": "src/user_service.rs",
+      "symbol": "UserService",
+      "line": 12,
+      "ruleId": "declared-interface",
+      "confidence": "high"
+    }
+  ],
+  "components": [
+    {
+      "id": "UserService",
+      "kind": "service",
+      "lifecycle": "unchanged",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "CouponPort",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "CouponService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [
+    {
+      "id": "relation-static-coupon-port",
+      "layer": "static",
+      "from": "UserService",
+      "to": "CouponPort",
+      "kind": "import",
+      "lifecycle": "added",
+      "protectedBy": null,
+      "extractionRule": "lean-import",
+      "evidenceRefs": ["evidence-static-coupon-port"]
+    }
+  ],
+  "policies": {
+    "laws": ["policy:canonical-layering"],
+    "boundaries": ["feature depends on declared interface"],
+    "allowedEdges": ["UserService->CouponPort"],
+    "forbiddenEdges": [],
+    "abstractionRules": ["declared-interface-only"],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [],
+  "architecturePaths": [],
+  "homotopyGenerators": [],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "boundaryViolationCount",
+        "value": 0,
+        "measured": true,
+        "measurementBoundary": "measuredZero",
+        "source": "policy:canonical-layering",
+        "reason": null
+      },
+      {
+        "axis": "runtimePropagation",
+        "value": null,
+        "measured": false,
+        "measurementBoundary": "unmeasured",
+        "source": null,
+        "reason": "runtime evidence not provided"
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "static",
+        "measurementBoundary": "measuredZero",
+        "universeRefs": ["artifact-sig0"],
+        "measuredAxes": ["boundaryViolationCount"],
+        "unmeasuredAxes": [],
+        "extractionScope": ["static dependency graph"],
+        "exactnessAssumptions": ["policy selector is complete for this fixture"],
+        "unsupportedConstructs": []
+      },
+      {
+        "layer": "runtime",
+        "measurementBoundary": "unmeasured",
+        "universeRefs": [],
+        "measuredAxes": [],
+        "unmeasuredAxes": ["runtimePropagation"],
+        "extractionScope": [],
+        "exactnessAssumptions": [],
+        "unsupportedConstructs": ["runtime extractor not provided"]
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-boundary-zero",
+      "subjectRef": "signature.boundaryViolationCount",
+      "predicate": "boundary policy has measured zero violations",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredZero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-sig0"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": ["policy selector is complete for this fixture"],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["tooling measurement is not a Lean proof"]
+    },
+    {
+      "claimId": "claim-runtime-unmeasured",
+      "subjectRef": "signature.runtimePropagation",
+      "predicate": "runtime axis is outside current measurement boundary",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": [],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["runtime evidence is absent"],
+      "nonConclusions": ["runtime split is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding requires theorem preconditions",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["before/after component correspondence"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["theorem precondition checker has not run"],
+      "nonConclusions": ["split extension is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature view requires diff attribution",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["feature ownership"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["feature extension report has not run"],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-boundary-zero", "claim-runtime-unmeasured"],
+    "splitClaimRef": null,
+    "splitStatus": "unmeasured"
+  }
+}

--- a/tools/archsig/tests/fixtures/air/hidden_interaction.json
+++ b/tools/archsig/tests/fixtures/air/hidden_interaction.json
@@ -1,0 +1,177 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-hidden-interaction",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-hidden",
+    "after": "after-hidden"
+  },
+  "feature": {
+    "featureId": "#canonical-hidden",
+    "title": "Add coupon calculation",
+    "description": "CouponService reaches PaymentAdapter internals",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-sig0",
+      "kind": "sig0",
+      "schemaVersion": "archsig-sig0-v0",
+      "path": "canonical/hidden/sig0.json",
+      "contentHash": null,
+      "producedBy": "archsig"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-sig0",
+      "kind": "observation_result",
+      "artifactRef": "artifact-sig0",
+      "path": "canonical/hidden/sig0.json",
+      "symbol": null,
+      "line": null,
+      "ruleId": "archsig-sig0-v0",
+      "confidence": "high"
+    },
+    {
+      "evidenceId": "evidence-hidden-edge",
+      "kind": "source_location",
+      "artifactRef": "artifact-sig0",
+      "path": "src/coupon_service.rs",
+      "symbol": "CouponService::cache_probe",
+      "line": 34,
+      "ruleId": "hidden-interaction-candidate",
+      "confidence": "high"
+    }
+  ],
+  "components": [
+    {
+      "id": "CouponService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "PaymentAdapter",
+      "kind": "service",
+      "lifecycle": "unchanged",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [
+    {
+      "id": "relation-hidden-cache",
+      "layer": "static",
+      "from": "CouponService",
+      "to": "PaymentAdapter",
+      "kind": "data_dependency",
+      "lifecycle": "added",
+      "protectedBy": null,
+      "extractionRule": "hidden-interaction-candidate",
+      "evidenceRefs": ["evidence-hidden-edge"]
+    }
+  ],
+  "policies": {
+    "laws": ["policy:canonical-layering"],
+    "boundaries": ["feature depends on declared interface"],
+    "allowedEdges": [],
+    "forbiddenEdges": ["hiddenInteraction:CouponService->PaymentAdapter"],
+    "abstractionRules": ["declared-interface-only"],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [],
+  "architecturePaths": [],
+  "homotopyGenerators": [],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "boundaryViolationCount",
+        "value": 1,
+        "measured": true,
+        "measurementBoundary": "measuredNonzero",
+        "source": "policy:canonical-layering",
+        "reason": null
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "static",
+        "measurementBoundary": "measuredNonzero",
+        "universeRefs": ["artifact-sig0"],
+        "measuredAxes": ["boundaryViolationCount"],
+        "unmeasuredAxes": [],
+        "extractionScope": ["static dependency graph"],
+        "exactnessAssumptions": [],
+        "unsupportedConstructs": []
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-hidden-interaction",
+      "subjectRef": "relation-hidden-cache",
+      "predicate": "feature introduces a hidden interaction candidate",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredNonzero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-hidden-edge"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": ["static dependency graph coverage"],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["runtime and semantic impact are not concluded"]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding is obstructed by hidden interaction evidence",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredNonzero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-hidden-edge"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": ["static dependency graph coverage"],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["tooling measurement is not a Lean proof"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature-owned delta is visible in static evidence",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredNonzero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-hidden-edge"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-hidden-interaction"],
+    "splitClaimRef": null,
+    "splitStatus": "unknown"
+  }
+}

--- a/tools/archsig/tests/fixtures/air/policy_violation.json
+++ b/tools/archsig/tests/fixtures/air/policy_violation.json
@@ -1,0 +1,167 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-policy-violation",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-policy",
+    "after": "after-policy"
+  },
+  "feature": {
+    "featureId": "#canonical-policy",
+    "title": "Add coupon calculation",
+    "description": "Feature crosses a declared boundary",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-policy",
+      "kind": "policy",
+      "schemaVersion": "signature-policy-v0",
+      "path": "canonical/policy/policy.json",
+      "contentHash": null,
+      "producedBy": null
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-policy-rule",
+      "kind": "policy_rule",
+      "artifactRef": "artifact-policy",
+      "path": "canonical/policy/policy.json",
+      "symbol": null,
+      "line": 7,
+      "ruleId": "boundary:ui-to-infra-forbidden",
+      "confidence": "high"
+    }
+  ],
+  "components": [
+    {
+      "id": "CouponController",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "PaymentRepository",
+      "kind": "database",
+      "lifecycle": "unchanged",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [
+    {
+      "id": "relation-policy-boundary",
+      "layer": "policy",
+      "from": "CouponController",
+      "to": "PaymentRepository",
+      "kind": "policy_rule",
+      "lifecycle": "added",
+      "protectedBy": null,
+      "extractionRule": "boundaryViolationCount",
+      "evidenceRefs": ["evidence-policy-rule"]
+    }
+  ],
+  "policies": {
+    "laws": ["policy:canonical-boundary"],
+    "boundaries": ["ui cannot depend on infra persistence"],
+    "allowedEdges": [],
+    "forbiddenEdges": ["boundaryViolationCount:CouponController->PaymentRepository"],
+    "abstractionRules": [],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [],
+  "architecturePaths": [],
+  "homotopyGenerators": [],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "boundaryViolationCount",
+        "value": 1,
+        "measured": true,
+        "measurementBoundary": "measuredNonzero",
+        "source": "policy:canonical-boundary",
+        "reason": null
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "policy",
+        "measurementBoundary": "measuredNonzero",
+        "universeRefs": ["artifact-policy"],
+        "measuredAxes": ["boundaryViolationCount"],
+        "unmeasuredAxes": [],
+        "extractionScope": ["policy rule evaluation"],
+        "exactnessAssumptions": ["policy file covers the fixture components"],
+        "unsupportedConstructs": []
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-policy-violation",
+      "subjectRef": "relation-policy-boundary",
+      "predicate": "boundary policy is violated",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredNonzero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-policy-rule"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": ["policy file covers the fixture components"],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["policy witness is not a formal theorem"]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding is obstructed by policy violation evidence",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredNonzero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-policy-rule"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": ["policy rule evaluation"],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["tooling measurement is not a Lean proof"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature-owned delta is visible in policy evidence",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredNonzero",
+      "theoremRefs": [],
+      "evidenceRefs": ["evidence-policy-rule"],
+      "requiredAssumptions": [],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": [],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-policy-violation"],
+    "splitClaimRef": null,
+    "splitStatus": "unknown"
+  }
+}

--- a/tools/archsig/tests/fixtures/air/unmeasured_runtime_semantic.json
+++ b/tools/archsig/tests/fixtures/air/unmeasured_runtime_semantic.json
@@ -1,0 +1,181 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-unmeasured-runtime-semantic",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-unmeasured",
+    "after": "after-unmeasured"
+  },
+  "feature": {
+    "featureId": "#canonical-unmeasured",
+    "title": "Add coupon calculation",
+    "description": "Static evidence exists, runtime and semantic axes are not measured",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-sig0",
+      "kind": "sig0",
+      "schemaVersion": "archsig-sig0-v0",
+      "path": "canonical/unmeasured/sig0.json",
+      "contentHash": null,
+      "producedBy": "archsig"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-sig0",
+      "kind": "observation_result",
+      "artifactRef": "artifact-sig0",
+      "path": "canonical/unmeasured/sig0.json",
+      "symbol": null,
+      "line": null,
+      "ruleId": "archsig-sig0-v0",
+      "confidence": "high"
+    }
+  ],
+  "components": [
+    {
+      "id": "CouponService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [],
+  "policies": {
+    "laws": [],
+    "boundaries": [],
+    "allowedEdges": [],
+    "forbiddenEdges": [],
+    "abstractionRules": [],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [],
+  "architecturePaths": [],
+  "homotopyGenerators": [],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "runtimePropagation",
+        "value": null,
+        "measured": false,
+        "measurementBoundary": "unmeasured",
+        "source": null,
+        "reason": "runtime edge evidence not provided"
+      },
+      {
+        "axis": "projectionSoundnessViolation",
+        "value": null,
+        "measured": false,
+        "measurementBoundary": "unmeasured",
+        "source": null,
+        "reason": "semantic extractor not implemented"
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "runtime",
+        "measurementBoundary": "unmeasured",
+        "universeRefs": [],
+        "measuredAxes": [],
+        "unmeasuredAxes": ["runtimePropagation"],
+        "extractionScope": [],
+        "exactnessAssumptions": [],
+        "unsupportedConstructs": ["runtime extractor not provided"]
+      },
+      {
+        "layer": "semantic",
+        "measurementBoundary": "unmeasured",
+        "universeRefs": [],
+        "measuredAxes": [],
+        "unmeasuredAxes": ["projectionSoundnessViolation"],
+        "extractionScope": [],
+        "exactnessAssumptions": [],
+        "unsupportedConstructs": ["semantic extractor not implemented"]
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-runtime-unmeasured",
+      "subjectRef": "signature.runtimePropagation",
+      "predicate": "runtime axis is outside current measurement boundary",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": [],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["runtime edge evidence is absent"],
+      "nonConclusions": ["runtime split is not concluded"]
+    },
+    {
+      "claimId": "claim-semantic-unmeasured",
+      "subjectRef": "signature.projectionSoundnessViolation",
+      "predicate": "semantic axis is outside current measurement boundary",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": [],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["semantic diagrams are absent"],
+      "nonConclusions": ["semantic flatness is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding requires theorem preconditions",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["before/after component correspondence"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["theorem precondition checker has not run"],
+      "nonConclusions": ["split extension is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature view requires diff attribution",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["feature ownership"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["feature extension report has not run"],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-runtime-unmeasured", "claim-semantic-unmeasured"],
+    "splitClaimRef": null,
+    "splitStatus": "unmeasured"
+  }
+}


### PR DESCRIPTION
## 概要

Closes #498

AIR v0 向けの `validate-air` CLI と validation report schema を追加しました。dangling component / artifact / evidence / claim refs、coverage universe refs、measurement boundary と claim classification の不整合、measured claim の evidence traceability を検査します。

canonical fixture として good extension、hidden interaction、policy violation、unmeasured runtime / semantic axis を追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`: `validate-air` の使い方、AIR validation report schema、canonical fixture 一覧を追記

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `lake build`（成功。既存の `FeatureExtensionExamples.lean` linter warning 2 件あり）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている

Lean status: empirical hypothesis / tooling validation.