### PR TITLE
Theorem Precondition Checker v0を実装する

### DIFF
--- a/docs/proof_obligations.md
+++ b/docs/proof_obligations.md
@@ -52,6 +52,17 @@ claim level は、証明状態とは別に次の境界として扱う。
 「測定された範囲では violation がない」と「全 universe で obstruction がない」を区別し、
 未測定軸を zero と読まないための non-conclusion を持つ。
 
+`tools/archsig` の theorem precondition checker は、この境界を report 側で保持する
+tooling bridge である。Issue
+[#500](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/500) では
+static theorem package v0 に限定した registry / check report を追加し、
+`SelectedStaticSplitExtension`, `CoreEdgesPreserved`,
+`DeclaredInterfaceFactorization`, `NoNewForbiddenStaticEdge`,
+`EmbeddingPolicyPreserved` だけを初期 theorem refs として扱う。Lean status は
+`defined only` / tooling theorem metadata bridge であり、`MEASURED` witness は
+`PROVED` formal claim ではない。`missingPreconditions` が残る formal/proved claim は
+`BLOCKED_FORMAL_CLAIM` として表示し、Lean theorem package の結論として読まない。
+
 ## Lean status の読み方
 
 `docs/aat_v2_mathematical_design.md` は純粋な数学設計書であり、Lean 実装の

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -19,6 +19,7 @@ Lean の証明器ではなく、CI や AI agent が読むための architecture 
 - GitHub PR JSON から PR metadata を作り、dataset や diff attribution に使う。
 - relation complexity candidate JSON から workflow-level observation を作る。
 - Sig0 / validation / diff / PR metadata を AIR v0 に正規化する。
+- AIR claim に対して static theorem package v0 の前提充足状況を検査する。
 
 ## 標準フロー
 
@@ -48,6 +49,7 @@ AI / CI が最初に読むべき成果物は次である。
 | Diff report | `signature-diff-report-v0` | before / after の悪化軸、改善軸、未評価軸、evidence diff、PR attribution candidate。 |
 | AIR | `aat-air-v0` | Signature artifact layer を claim / evidence / coverage / extension boundary へ正規化した中間表現。 |
 | AIR validation report | `aat-air-validation-report-v0` | AIR の dangling refs、claim boundary、measured evidence traceability の検査結果。 |
+| Theorem precondition check report | `theorem-precondition-check-report-v0` | static theorem package v0 の registry と、AIR claim が `FORMAL_PROVED` へ昇格できるかの検査結果。 |
 | Dataset record | `empirical-signature-dataset-v0` | PR metadata と before / after signature を結合した実証研究用 record。 |
 
 通常の PR / CI 診断では、最終的に `signature-diff-report-v0` を読む。
@@ -309,6 +311,28 @@ canonical AIR fixture は `tools/archsig/tests/fixtures/air` に置く。
 - `policy_violation.json`
 - `unmeasured_runtime_semantic.json`
 
+## Theorem Precondition Check を作る
+
+AIR v0 の claim を static theorem package v0 registry に照合する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- theorem-check \
+  --air .lake/signature-current/air.json \
+  --out .lake/signature-current/theorem-check.json
+```
+
+初期 registry は static theorem package に限定し、Lean 側 entrypoint として
+`SelectedStaticSplitExtension` を持つ。参照できる theorem refs は
+`SelectedStaticSplitExtension`, `CoreEdgesPreserved`,
+`DeclaredInterfaceFactorization`, `NoNewForbiddenStaticEdge`,
+`EmbeddingPolicyPreserved` である。
+
+`claimLevel = formal`, `claimClassification = proved`, registry 登録済み theorem refs、
+かつ `missingPreconditions = []` の claim だけを `FORMAL_PROVED` として表示する。
+tooling の `measured` claim は `MEASURED_WITNESS` のまま残し、formal proof claim へ
+昇格しない。missing preconditions が残る formal/proved claim は
+`BLOCKED_FORMAL_CLAIM` として表示する。
+
 ## Feature Extension Report を作る
 
 AIR v0 から PR review 用の static Feature Extension Report v0 を生成する。
@@ -323,6 +347,9 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- feature-report \
 `splitStatus` を `split`, `non_split`, `unknown`, `unmeasured` へ分類する。
 runtime / semantic 層が未測定の場合は `coverageGaps` と `nonConclusions` に
 `UNMEASURED` として残し、static split の根拠にはしない。
+Feature Extension Report には `theoremPreconditionSummary` と
+`theoremPreconditionChecks` も含まれるため、`MEASURED` witness と `FORMAL_PROVED`
+claim の境界を report 内で確認できる。
 
 ## PR Metadata / Dataset を作る
 

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -17,6 +17,8 @@ pub const SIGNATURE_DIFF_REPORT_SCHEMA_VERSION: &str = "signature-diff-report-v0
 pub const AIR_SCHEMA_VERSION: &str = "aat-air-v0";
 pub const AIR_VALIDATION_REPORT_SCHEMA_VERSION: &str = "aat-air-validation-report-v0";
 pub const FEATURE_EXTENSION_REPORT_SCHEMA_VERSION: &str = "feature-extension-report-v0";
+pub const THEOREM_PRECONDITION_CHECK_REPORT_SCHEMA_VERSION: &str =
+    "theorem-precondition-check-report-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const RELATION_COMPLEXITY_CANDIDATE_SCHEMA_VERSION: &str = "relation-complexity-candidates/v0";
@@ -936,6 +938,8 @@ pub struct FeatureExtensionReportV0 {
     pub complexity_transfer_candidates: Vec<String>,
     pub semantic_path_summary: FeatureReportSemanticPathSummary,
     pub theorem_package_refs: Vec<String>,
+    pub theorem_precondition_summary: TheoremPreconditionCheckSummary,
+    pub theorem_precondition_checks: Vec<TheoremPreconditionCheck>,
     pub discharged_assumptions: Vec<String>,
     pub undischarged_assumptions: Vec<String>,
     pub coverage_gaps: Vec<FeatureReportCoverageGap>,
@@ -1057,6 +1061,84 @@ pub struct FeatureReportCoverageGap {
     pub unmeasured_axes: Vec<String>,
     pub unsupported_constructs: Vec<String>,
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TheoremPreconditionCheckReportV0 {
+    pub schema_version: String,
+    pub input: TheoremPreconditionCheckInput,
+    pub registry: TheoremPackageRegistryV0,
+    pub summary: TheoremPreconditionCheckSummary,
+    pub checks: Vec<TheoremPreconditionCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TheoremPreconditionCheckInput {
+    pub schema_version: String,
+    pub path: String,
+    pub architecture_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TheoremPackageRegistryV0 {
+    pub schema_version: String,
+    pub scope: String,
+    pub packages: Vec<TheoremPackageMetadataV0>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TheoremPackageMetadataV0 {
+    pub package_id: String,
+    pub lean_entrypoint: String,
+    pub theorem_refs: Vec<String>,
+    pub supported_subject_refs: Vec<String>,
+    pub supported_axes: Vec<String>,
+    pub claim_level: String,
+    pub claim_classification: String,
+    pub measurement_boundary: String,
+    pub required_assumptions: Vec<String>,
+    pub coverage_assumptions: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub missing_preconditions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TheoremPreconditionCheckSummary {
+    pub result: String,
+    pub checked_claim_count: usize,
+    pub applicable_claim_count: usize,
+    pub formal_proved_claim_count: usize,
+    pub measured_witness_count: usize,
+    pub blocked_claim_count: usize,
+    pub unmeasured_claim_count: usize,
+    pub unknown_theorem_ref_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TheoremPreconditionCheck {
+    pub claim_id: String,
+    pub subject_ref: String,
+    pub applicable_package_refs: Vec<String>,
+    pub theorem_refs: Vec<String>,
+    pub unknown_theorem_refs: Vec<String>,
+    pub claim_level: String,
+    pub input_claim_classification: String,
+    pub resolved_claim_classification: String,
+    pub measurement_boundary: String,
+    pub required_assumptions: Vec<String>,
+    pub coverage_assumptions: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub missing_preconditions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+    pub result: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1523,6 +1605,85 @@ pub fn validate_air_document_report(
     }
 }
 
+pub fn static_theorem_package_registry() -> TheoremPackageRegistryV0 {
+    TheoremPackageRegistryV0 {
+        schema_version: THEOREM_PRECONDITION_CHECK_REPORT_SCHEMA_VERSION.to_string(),
+        scope: "static theorem package v0".to_string(),
+        packages: vec![TheoremPackageMetadataV0 {
+            package_id: "static-theorem-package-v0".to_string(),
+            lean_entrypoint: "SelectedStaticSplitExtension".to_string(),
+            theorem_refs: vec![
+                "SelectedStaticSplitExtension".to_string(),
+                "CoreEdgesPreserved".to_string(),
+                "DeclaredInterfaceFactorization".to_string(),
+                "NoNewForbiddenStaticEdge".to_string(),
+                "EmbeddingPolicyPreserved".to_string(),
+            ],
+            supported_subject_refs: vec![
+                "extension.embedding".to_string(),
+                "extension.feature".to_string(),
+                "extension.split".to_string(),
+                "signature.hasCycle".to_string(),
+                "signature.projectionSoundnessViolation".to_string(),
+                "signature.lspViolationCount".to_string(),
+                "signature.boundaryViolationCount".to_string(),
+                "signature.abstractionViolationCount".to_string(),
+            ],
+            supported_axes: vec![
+                "hasCycle".to_string(),
+                "projectionSoundnessViolation".to_string(),
+                "lspViolationCount".to_string(),
+                "boundaryViolationCount".to_string(),
+                "abstractionViolationCount".to_string(),
+            ],
+            claim_level: "formal".to_string(),
+            claim_classification: "proved".to_string(),
+            measurement_boundary: "measuredZero".to_string(),
+            required_assumptions: vec![
+                "core edges are preserved".to_string(),
+                "feature/core interactions factor through a declared interface".to_string(),
+                "no new forbidden static edge is introduced".to_string(),
+                "embedding policy is preserved".to_string(),
+            ],
+            coverage_assumptions: vec![
+                "static dependency graph is inside the measured universe".to_string(),
+                "policy selector covers the checked static edges".to_string(),
+            ],
+            exactness_assumptions: vec![
+                "AIR component and relation identifiers match the Lean package parameters"
+                    .to_string(),
+            ],
+            missing_preconditions: Vec::new(),
+            non_conclusions: vec![
+                "static theorem package does not conclude runtime flatness".to_string(),
+                "static theorem package does not conclude semantic flatness".to_string(),
+                "static theorem package does not prove extractor completeness".to_string(),
+            ],
+        }],
+    }
+}
+
+pub fn build_theorem_precondition_check_report(
+    document: &AirDocumentV0,
+    input_path: &str,
+) -> TheoremPreconditionCheckReportV0 {
+    let registry = static_theorem_package_registry();
+    let checks = theorem_precondition_checks(document, &registry);
+    let summary = theorem_precondition_check_summary(&checks, document.claims.len());
+
+    TheoremPreconditionCheckReportV0 {
+        schema_version: THEOREM_PRECONDITION_CHECK_REPORT_SCHEMA_VERSION.to_string(),
+        input: TheoremPreconditionCheckInput {
+            schema_version: document.schema_version.clone(),
+            path: input_path.to_string(),
+            architecture_id: document.architecture_id.clone(),
+        },
+        registry,
+        summary,
+        checks,
+    }
+}
+
 pub fn build_feature_extension_report(
     document: &AirDocumentV0,
     input_path: &str,
@@ -1550,6 +1711,7 @@ pub fn build_feature_extension_report(
         &introduced_obstruction_witnesses,
     );
     let theorem_package_refs = feature_report_theorem_package_refs(document);
+    let theorem_precondition_report = build_theorem_precondition_check_report(document, input_path);
     let discharged_assumptions = feature_report_discharged_assumptions(document);
     let undischarged_assumptions = feature_report_undischarged_assumptions(document);
     let unsupported_constructs = feature_report_unsupported_constructs(&coverage_gaps);
@@ -1641,6 +1803,8 @@ pub fn build_feature_extension_report(
             nonfillability_witness_count: document.nonfillability_witnesses.len(),
         },
         theorem_package_refs,
+        theorem_precondition_summary: theorem_precondition_report.summary,
+        theorem_precondition_checks: theorem_precondition_report.checks,
         discharged_assumptions,
         undischarged_assumptions,
         coverage_gaps,
@@ -3194,6 +3358,175 @@ fn feature_report_claim_classification(split_status: &str) -> String {
         "unmeasured" => "UNMEASURED".to_string(),
         _ => "UNKNOWN".to_string(),
     }
+}
+
+fn theorem_precondition_checks(
+    document: &AirDocumentV0,
+    registry: &TheoremPackageRegistryV0,
+) -> Vec<TheoremPreconditionCheck> {
+    document
+        .claims
+        .iter()
+        .map(|claim| theorem_precondition_check(claim, registry))
+        .collect()
+}
+
+fn theorem_precondition_check(
+    claim: &AirClaim,
+    registry: &TheoremPackageRegistryV0,
+) -> TheoremPreconditionCheck {
+    let applicable_packages: Vec<&TheoremPackageMetadataV0> = registry
+        .packages
+        .iter()
+        .filter(|package| theorem_package_applies_to_claim(package, claim))
+        .collect();
+    let known_refs: BTreeSet<String> = registry
+        .packages
+        .iter()
+        .flat_map(|package| package.theorem_refs.iter().cloned())
+        .collect();
+    let unknown_theorem_refs: Vec<String> = claim
+        .theorem_refs
+        .iter()
+        .filter(|theorem_ref| !known_refs.contains(theorem_ref.as_str()))
+        .cloned()
+        .collect();
+    let applicable_package_refs = applicable_packages
+        .iter()
+        .map(|package| package.package_id.clone())
+        .collect();
+
+    let (resolved_claim_classification, result, reason) = if !unknown_theorem_refs.is_empty() {
+        (
+            "UNKNOWN_THEOREM_REF".to_string(),
+            "warn".to_string(),
+            "claim cites theorem refs outside the static theorem package registry".to_string(),
+        )
+    } else if claim.claim_classification == "measured" {
+        (
+            "MEASURED_WITNESS".to_string(),
+            "pass".to_string(),
+            "tooling measurement remains a measured witness, not a formal proved claim".to_string(),
+        )
+    } else if claim.claim_level == "formal"
+        && claim.claim_classification == "proved"
+        && !claim.missing_preconditions.is_empty()
+    {
+        (
+            "BLOCKED_FORMAL_CLAIM".to_string(),
+            "warn".to_string(),
+            "missing preconditions block formal proved classification".to_string(),
+        )
+    } else if claim.claim_level == "formal"
+        && claim.claim_classification == "proved"
+        && !claim.theorem_refs.is_empty()
+        && !applicable_packages.is_empty()
+    {
+        (
+            "FORMAL_PROVED".to_string(),
+            "pass".to_string(),
+            "theorem refs are registered and missing preconditions are empty".to_string(),
+        )
+    } else if claim.claim_level == "formal" && claim.claim_classification == "proved" {
+        (
+            "BLOCKED_FORMAL_CLAIM".to_string(),
+            "warn".to_string(),
+            "formal proved claim needs registered theorem refs".to_string(),
+        )
+    } else if claim.claim_classification == "unmeasured" || !claim.missing_preconditions.is_empty()
+    {
+        (
+            "UNMEASURED".to_string(),
+            "warn".to_string(),
+            "claim remains outside the measured theorem boundary".to_string(),
+        )
+    } else if applicable_packages.is_empty() && !claim.theorem_refs.is_empty() {
+        (
+            "UNKNOWN_THEOREM_REF".to_string(),
+            "warn".to_string(),
+            "claim has theorem refs but no applicable static theorem package".to_string(),
+        )
+    } else {
+        (
+            "TOOLING_CLAIM".to_string(),
+            "pass".to_string(),
+            "claim is reported at tooling level".to_string(),
+        )
+    };
+
+    TheoremPreconditionCheck {
+        claim_id: claim.claim_id.clone(),
+        subject_ref: claim.subject_ref.clone(),
+        applicable_package_refs,
+        theorem_refs: claim.theorem_refs.clone(),
+        unknown_theorem_refs,
+        claim_level: claim.claim_level.clone(),
+        input_claim_classification: claim.claim_classification.clone(),
+        resolved_claim_classification,
+        measurement_boundary: claim.measurement_boundary.clone(),
+        required_assumptions: claim.required_assumptions.clone(),
+        coverage_assumptions: claim.coverage_assumptions.clone(),
+        exactness_assumptions: claim.exactness_assumptions.clone(),
+        missing_preconditions: claim.missing_preconditions.clone(),
+        non_conclusions: claim.non_conclusions.clone(),
+        result,
+        reason,
+    }
+}
+
+fn theorem_precondition_check_summary(
+    checks: &[TheoremPreconditionCheck],
+    checked_claim_count: usize,
+) -> TheoremPreconditionCheckSummary {
+    let blocked_claim_count = checks
+        .iter()
+        .filter(|check| check.resolved_claim_classification == "BLOCKED_FORMAL_CLAIM")
+        .count();
+    let unknown_theorem_ref_count = checks
+        .iter()
+        .map(|check| check.unknown_theorem_refs.len())
+        .sum();
+    let result = if checks.iter().any(|check| check.result == "warn") {
+        "warn"
+    } else {
+        "pass"
+    };
+
+    TheoremPreconditionCheckSummary {
+        result: result.to_string(),
+        checked_claim_count,
+        applicable_claim_count: checks
+            .iter()
+            .filter(|check| !check.applicable_package_refs.is_empty())
+            .count(),
+        formal_proved_claim_count: checks
+            .iter()
+            .filter(|check| check.resolved_claim_classification == "FORMAL_PROVED")
+            .count(),
+        measured_witness_count: checks
+            .iter()
+            .filter(|check| check.resolved_claim_classification == "MEASURED_WITNESS")
+            .count(),
+        blocked_claim_count,
+        unmeasured_claim_count: checks
+            .iter()
+            .filter(|check| check.resolved_claim_classification == "UNMEASURED")
+            .count(),
+        unknown_theorem_ref_count,
+    }
+}
+
+fn theorem_package_applies_to_claim(package: &TheoremPackageMetadataV0, claim: &AirClaim) -> bool {
+    let theorem_ref_matches = claim
+        .theorem_refs
+        .iter()
+        .any(|theorem_ref| package.theorem_refs.contains(theorem_ref));
+    let subject_matches = package
+        .supported_subject_refs
+        .iter()
+        .any(|subject_ref| subject_ref == &claim.subject_ref);
+
+    theorem_ref_matches || subject_matches
 }
 
 fn feature_report_obstructing_relation(document: &AirDocumentV0, relation: &AirRelation) -> bool {
@@ -5839,6 +6172,111 @@ import Should.Not.Appear
     }
 
     #[test]
+    fn theorem_check_keeps_measured_witness_out_of_formal_proved_claims() {
+        let document = air_fixture_document("good_extension.json");
+        let report = build_theorem_precondition_check_report(&document, "good_extension.json");
+
+        assert_eq!(
+            report.schema_version,
+            THEOREM_PRECONDITION_CHECK_REPORT_SCHEMA_VERSION
+        );
+        assert_eq!(report.registry.scope, "static theorem package v0");
+        assert!(report.registry.packages.iter().any(|package| {
+            package.theorem_refs
+                == vec![
+                    "SelectedStaticSplitExtension".to_string(),
+                    "CoreEdgesPreserved".to_string(),
+                    "DeclaredInterfaceFactorization".to_string(),
+                    "NoNewForbiddenStaticEdge".to_string(),
+                    "EmbeddingPolicyPreserved".to_string(),
+                ]
+        }));
+
+        let boundary_check = report
+            .checks
+            .iter()
+            .find(|check| check.claim_id == "claim-boundary-zero")
+            .expect("boundary claim is checked");
+        assert_eq!(
+            boundary_check.resolved_claim_classification,
+            "MEASURED_WITNESS"
+        );
+        assert_eq!(report.summary.formal_proved_claim_count, 0);
+        assert!(report.summary.measured_witness_count > 0);
+    }
+
+    #[test]
+    fn theorem_check_blocks_formal_claims_with_missing_preconditions() {
+        let mut document = air_fixture_document("good_extension.json");
+        document.claims.push(AirClaim {
+            claim_id: "claim-static-split-blocked".to_string(),
+            subject_ref: "extension.split".to_string(),
+            predicate: "selected static split theorem package applies".to_string(),
+            claim_level: "formal".to_string(),
+            claim_classification: "proved".to_string(),
+            measurement_boundary: "measuredZero".to_string(),
+            theorem_refs: vec!["SelectedStaticSplitExtension".to_string()],
+            evidence_refs: Vec::new(),
+            required_assumptions: vec!["core edges are preserved".to_string()],
+            coverage_assumptions: vec!["static graph coverage".to_string()],
+            exactness_assumptions: vec!["AIR ids match Lean parameters".to_string()],
+            missing_preconditions: vec![
+                "declared interface factorization not discharged".to_string(),
+            ],
+            non_conclusions: vec!["runtime flatness is not concluded".to_string()],
+        });
+
+        let report = build_theorem_precondition_check_report(&document, "good_extension.json");
+        let check = report
+            .checks
+            .iter()
+            .find(|check| check.claim_id == "claim-static-split-blocked")
+            .expect("formal split claim is checked");
+
+        assert_eq!(check.resolved_claim_classification, "BLOCKED_FORMAL_CLAIM");
+        assert_eq!(check.result, "warn");
+        assert_eq!(report.summary.blocked_claim_count, 1);
+        assert_eq!(report.summary.formal_proved_claim_count, 0);
+    }
+
+    #[test]
+    fn theorem_check_accepts_registered_formal_claim_without_missing_preconditions() {
+        let mut document = air_fixture_document("good_extension.json");
+        document.claims.push(AirClaim {
+            claim_id: "claim-static-split-proved".to_string(),
+            subject_ref: "extension.split".to_string(),
+            predicate: "selected static split theorem package applies".to_string(),
+            claim_level: "formal".to_string(),
+            claim_classification: "proved".to_string(),
+            measurement_boundary: "measuredZero".to_string(),
+            theorem_refs: vec![
+                "SelectedStaticSplitExtension".to_string(),
+                "CoreEdgesPreserved".to_string(),
+                "DeclaredInterfaceFactorization".to_string(),
+                "NoNewForbiddenStaticEdge".to_string(),
+                "EmbeddingPolicyPreserved".to_string(),
+            ],
+            evidence_refs: Vec::new(),
+            required_assumptions: vec!["core edges are preserved".to_string()],
+            coverage_assumptions: vec!["static graph coverage".to_string()],
+            exactness_assumptions: vec!["AIR ids match Lean parameters".to_string()],
+            missing_preconditions: Vec::new(),
+            non_conclusions: vec!["runtime flatness is not concluded".to_string()],
+        });
+
+        let report = build_theorem_precondition_check_report(&document, "good_extension.json");
+        let check = report
+            .checks
+            .iter()
+            .find(|check| check.claim_id == "claim-static-split-proved")
+            .expect("formal split claim is checked");
+
+        assert_eq!(check.resolved_claim_classification, "FORMAL_PROVED");
+        assert_eq!(check.result, "pass");
+        assert_eq!(report.summary.formal_proved_claim_count, 1);
+    }
+
+    #[test]
     fn extracts_minimal_fixture() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal");
         let document = extract_sig0(&root).expect("fixture extracts");
@@ -6386,6 +6824,14 @@ import Should.Not.Appear
             runtime_edge_evidence: Vec::new(),
             runtime_dependency_graph: None,
         }
+    }
+
+    fn air_fixture_document(fixture: &str) -> AirDocumentV0 {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/air")
+            .join(fixture);
+        let contents = std::fs::read_to_string(&path).expect("AIR fixture is readable");
+        serde_json::from_str(&contents).expect("AIR fixture parses")
     }
 
     fn dataset_input() -> EmpiricalDatasetInput {

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -8,9 +8,10 @@ use archsig::{
     AirDocumentInput, AirDocumentV0, AirValidationReport, ComponentUniverseValidationReport,
     DEFAULT_UNIVERSE_MODE, EmpiricalDatasetInput, FeatureExtensionReportV0, RepositoryRevisionRef,
     ScanMetadata, Sig0Document, SignatureDiffReportV0, SignatureSnapshotStoreRecordV0,
-    SnapshotRecordInput, SnapshotRepositoryRef, build_air_document, build_empirical_dataset,
-    build_feature_extension_report, build_pr_metadata_from_github_files,
-    build_signature_diff_report, build_signature_snapshot_record,
+    SnapshotRecordInput, SnapshotRepositoryRef, TheoremPreconditionCheckReportV0,
+    build_air_document, build_empirical_dataset, build_feature_extension_report,
+    build_pr_metadata_from_github_files, build_signature_diff_report,
+    build_signature_snapshot_record, build_theorem_precondition_check_report,
     extract_relation_complexity_observation_from_file, extract_sig0_with_runtime,
     validate_air_document_report, validate_component_universe_report,
 };
@@ -284,6 +285,17 @@ enum Command {
         #[arg(long)]
         out: Option<PathBuf>,
     },
+
+    /// Check theorem package preconditions for AIR v0 claims.
+    TheoremCheck {
+        /// Input AIR JSON path.
+        #[arg(long)]
+        air: PathBuf,
+
+        /// Output theorem precondition check report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -508,6 +520,13 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             let document: AirDocumentV0 = read_json(&air)?;
             let report: FeatureExtensionReportV0 =
                 build_feature_extension_report(&document, &air.display().to_string());
+            write_json(out, &report)?;
+            Ok(ExitCode::SUCCESS)
+        }
+        Some(Command::TheoremCheck { air, out }) => {
+            let document: AirDocumentV0 = read_json(&air)?;
+            let report: TheoremPreconditionCheckReportV0 =
+                build_theorem_precondition_check_report(&document, &air.display().to_string());
             write_json(out, &report)?;
             Ok(ExitCode::SUCCESS)
         }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -157,6 +157,104 @@ fn cli_feature_report_keeps_unmeasured_extension_unmeasured() {
 }
 
 #[test]
+fn cli_theorem_check_reports_static_registry_and_blocks_missing_preconditions() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("theorem-check");
+    let input = out_dir.join("static-theorem-claim.json");
+    let report = out_dir.join("theorem-check.json");
+    let mut json = read_json(&root.join("good_extension.json"));
+
+    let claims = json["claims"].as_array_mut().expect("claims is an array");
+    claims.push(serde_json::json!({
+        "claimId": "claim-static-split-blocked",
+        "subjectRef": "extension.split",
+        "predicate": "selected static split theorem package applies",
+        "claimLevel": "formal",
+        "claimClassification": "proved",
+        "measurementBoundary": "measuredZero",
+        "theoremRefs": ["SelectedStaticSplitExtension"],
+        "evidenceRefs": [],
+        "requiredAssumptions": ["core edges are preserved"],
+        "coverageAssumptions": ["static graph coverage"],
+        "exactnessAssumptions": ["AIR ids match Lean parameters"],
+        "missingPreconditions": ["declared interface factorization not discharged"],
+        "nonConclusions": ["runtime flatness is not concluded"]
+    }));
+    fs::write(
+        &input,
+        serde_json::to_string_pretty(&json).expect("json serializes"),
+    )
+    .expect("theorem-check input is written");
+
+    run_sig0(&[
+        "theorem-check",
+        "--air",
+        input.to_str().expect("input path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let report = read_json(&report);
+    assert_eq!(
+        report["schemaVersion"],
+        "theorem-precondition-check-report-v0"
+    );
+    assert_eq!(report["registry"]["scope"], "static theorem package v0");
+    assert!(
+        report["registry"]["packages"][0]["theoremRefs"]
+            .as_array()
+            .expect("theorem refs is an array")
+            .iter()
+            .any(|theorem_ref| theorem_ref == "SelectedStaticSplitExtension")
+    );
+    assert!(
+        report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| check["claimId"] == "claim-static-split-blocked"
+                && check["resolvedClaimClassification"] == "BLOCKED_FORMAL_CLAIM")
+    );
+    assert!(
+        report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| check["claimId"] == "claim-boundary-zero"
+                && check["resolvedClaimClassification"] == "MEASURED_WITNESS")
+    );
+    assert_eq!(report["summary"]["formalProvedClaimCount"], 0);
+}
+
+#[test]
+fn cli_feature_report_includes_theorem_precondition_checks() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("feature-report-theorem-check");
+    let report = out_dir.join("feature-report.json");
+
+    run_sig0(&[
+        "feature-report",
+        "--air",
+        root.join("good_extension.json")
+            .to_str()
+            .expect("fixture path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(json["theoremPreconditionSummary"]["checkedClaimCount"], 4);
+    assert!(
+        json["theoremPreconditionChecks"]
+            .as_array()
+            .expect("theorem checks is array")
+            .iter()
+            .any(|check| check["claimId"] == "claim-boundary-zero"
+                && check["resolvedClaimClassification"] == "MEASURED_WITNESS")
+    );
+}
+
+#[test]
 fn cli_validate_air_accepts_canonical_fixtures() {
     let root = air_fixture_root();
     let out_dir = temp_dir("validate-air-fixtures");


### PR DESCRIPTION
## 概要

Closes #500
Refs #496

- AIR claim 用の static theorem package v0 registry と `theorem-check` CLI を追加
- Feature Extension Report に theorem precondition summary / checks を埋め込み、`MEASURED_WITNESS` と `FORMAL_PROVED` の境界を保持
- missing preconditions が残る formal/proved claim を `BLOCKED_FORMAL_CLAIM` として扱う

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`
- `docs/proof_obligations.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `lake build`（既存 linter warning は再表示、build は成功）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている