### PR TITLE
ArchSig READMEのFeature Reportフローを更新する

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -31,7 +31,9 @@ scan
   -> snapshot
   -> signature-diff
   -> air
-  -> AI agent / CI job が diff report を読む
+  -> theorem-check
+  -> feature-report
+  -> AI agent / CI job が feature report と diff report を読む
 ```
 
 単一 revision の状態だけを見たい場合は `scan` と `validate` まででよい。
@@ -50,9 +52,11 @@ AI / CI が最初に読むべき成果物は次である。
 | AIR | `aat-air-v0` | Signature artifact layer を claim / evidence / coverage / extension boundary へ正規化した中間表現。 |
 | AIR validation report | `aat-air-validation-report-v0` | AIR の dangling refs、claim boundary、measured evidence traceability の検査結果。 |
 | Theorem precondition check report | `theorem-precondition-check-report-v0` | static theorem package v0 の registry と、AIR claim が `FORMAL_PROVED` へ昇格できるかの検査結果。 |
+| Feature Extension Report | `feature-extension-report-v0` | AIR から生成する PR review 用 static report。split status、witness、coverage gap、theorem precondition checks を併読する。 |
 | Dataset record | `empirical-signature-dataset-v0` | PR metadata と before / after signature を結合した実証研究用 record。 |
 
-通常の PR / CI 診断では、最終的に `signature-diff-report-v0` を読む。
+通常の PR / CI 診断では、最終的に `feature-extension-report-v0` と
+`signature-diff-report-v0` を読む。
 
 この CLI では、測定済み 0 と未評価を分ける。
 


### PR DESCRIPTION
## 概要

Closes #524

`tools/archsig/README.md` の標準フローを、実装済みの `theorem-check` / `feature-report` まで含む形に更新しました。通常の PR / CI 診断で `feature-extension-report-v0` と `signature-diff-report-v0` を併読することも明記しています。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`

## 実施したテスト

- [x] `lake build`
  - 成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean:201`, `:207` の linter warning は継続。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
