### PR TITLE
Feature Extension Report に runtime summary を追加する

### DIFF
--- a/docs/aat_v2_tooling_design.md
+++ b/docs/aat_v2_tooling_design.md
@@ -1034,6 +1034,7 @@ runtime / semantic / empirical axis は evidence schema と unmeasured boundary 
 - architecture id / revision
 - feature id / PR / issue / AI session reference
 - before / after architecture summary
+- runtime summary
 - interpreted extension summary
 - split status
 - preserved invariants
@@ -1058,7 +1059,7 @@ Level 1: Review Summary
   split_status, claim classification, top witnesses, required action.
 
 Level 2: Evidence Detail
-  changed components, changed edges, witness evidence, coverage gaps.
+  changed components, changed edges, witness evidence, runtime summary, coverage gaps.
 
 Level 3: Formal Detail
   theorem package references, discharged assumptions, exactness assumptions,
@@ -1067,6 +1068,13 @@ Level 3: Formal Detail
 
 CI や PR comment に出す既定表示は Level 1 とし、Level 2 / Level 3 は折りたたみ可能な
 詳細として扱う。Report の完全性と、レビューで読める密度は別の設計制約である。
+
+runtime summary は、`runtimePropagation` を exposure radius として表示する。
+`runtimePropagation = null` は未測定であり runtime risk 0 ではない。
+`runtimePropagation = 0` は測定 universe と projection rule の範囲での measured witness であり、
+coverage、projection rule、exactness assumptions、theorem preconditions が揃うまで
+formal runtime zero bridge claim として扱わない。blast radius や policy-aware runtime
+propagation は別 metric / 別 claim として扱う。
 
 Report は、次のような判断を明示する。
 

--- a/tools/archsig/src/feature_report.rs
+++ b/tools/archsig/src/feature_report.rs
@@ -6,7 +6,7 @@ use crate::{
     FeatureExtensionReportV0, FeatureReportArchitectureSummary, FeatureReportCoverageGap,
     FeatureReportEdgeRef, FeatureReportEvidenceRef, FeatureReportInput,
     FeatureReportInterpretedExtension, FeatureReportInvariant, FeatureReportObstructionWitness,
-    FeatureReportReviewSummary, FeatureReportSemanticPathSummary,
+    FeatureReportReviewSummary, FeatureReportRuntimeSummary, FeatureReportSemanticPathSummary,
 };
 
 pub fn build_feature_extension_report(
@@ -57,6 +57,7 @@ pub fn build_feature_extension_report(
         .filter(|axis| !axis.measured)
         .map(|axis| axis.axis.clone())
         .collect();
+    let runtime_summary = feature_report_runtime_summary(document, &coverage_gaps);
 
     FeatureExtensionReportV0 {
         schema_version: FEATURE_EXTENSION_REPORT_SCHEMA_VERSION.to_string(),
@@ -80,6 +81,7 @@ pub fn build_feature_extension_report(
                 &split_status,
                 &introduced_obstruction_witnesses,
                 &coverage_gaps,
+                &runtime_summary,
             ),
         },
         architecture_summary: FeatureReportArchitectureSummary {
@@ -92,6 +94,7 @@ pub fn build_feature_extension_report(
             measured_axes,
             unmeasured_axes,
         },
+        runtime_summary,
         interpreted_extension: FeatureReportInterpretedExtension {
             embedding_claim_ref: document.extension.embedding_claim_ref.clone(),
             feature_view_claim_ref: document.extension.feature_view_claim_ref.clone(),
@@ -136,10 +139,111 @@ pub fn build_feature_extension_report(
         unsupported_constructs,
         repair_suggestions,
         empirical_annotations: vec![
-            "Feature Extension Report v0 is a static tooling report".to_string(),
-            "Runtime and semantic conclusions require separate evidence".to_string(),
+            "Feature Extension Report v0 combines static split evidence with measured runtime exposure when available".to_string(),
+            "runtimePropagation is reported as runtime exposure radius, not blast radius".to_string(),
+            "Runtime formal claims require coverage, projection, exactness, and theorem preconditions".to_string(),
         ],
         non_conclusions,
+    }
+}
+
+fn feature_report_runtime_summary(
+    document: &AirDocumentV0,
+    coverage_gaps: &[FeatureReportCoverageGap],
+) -> FeatureReportRuntimeSummary {
+    let runtime_axis = document
+        .signature
+        .axes
+        .iter()
+        .find(|axis| axis.axis == "runtimePropagation");
+    let runtime_layer = document
+        .coverage
+        .layers
+        .iter()
+        .find(|layer| layer.layer == "runtime");
+    let runtime_claims: Vec<&AirClaim> = document
+        .claims
+        .iter()
+        .filter(|claim| claim.subject_ref == "signature.runtimePropagation")
+        .collect();
+    let measured = runtime_axis
+        .map(|axis| axis.measured && axis.value.is_some())
+        .unwrap_or(false);
+    let runtime_propagation = runtime_axis.and_then(|axis| axis.value);
+
+    let mut non_conclusions = BTreeSet::new();
+    non_conclusions
+        .insert("runtimePropagation is an exposure radius, not runtime blast radius".to_string());
+    non_conclusions
+        .insert("runtimePropagation is not policy-aware runtime propagation".to_string());
+    non_conclusions
+        .insert("measured runtime witness is not a formal runtime zero bridge claim".to_string());
+    if !measured {
+        non_conclusions
+            .insert("runtimePropagation null is UNMEASURED, not runtime risk zero".to_string());
+    } else if runtime_propagation == Some(0) {
+        non_conclusions.insert(
+            "runtimePropagation = 0 needs coverage, projection, exactness, and theorem preconditions before a formal claim".to_string(),
+        );
+    }
+    for claim in runtime_claims.iter().copied() {
+        for conclusion in &claim.non_conclusions {
+            non_conclusions.insert(conclusion.clone());
+        }
+        for missing in &claim.missing_preconditions {
+            non_conclusions.insert(format!("missing runtime precondition: {missing}"));
+        }
+    }
+
+    FeatureReportRuntimeSummary {
+        relation_count: count_air_relations(document, "runtime"),
+        measurement_boundary: runtime_axis
+            .map(|axis| axis.measurement_boundary.clone())
+            .or_else(|| runtime_layer.map(|layer| layer.measurement_boundary.clone()))
+            .unwrap_or_else(|| "unmeasured".to_string()),
+        runtime_propagation,
+        interpretation: if measured {
+            "runtimePropagation is measured runtime exposure radius over the projected 0/1 runtime graph"
+                .to_string()
+        } else {
+            "runtimePropagation is UNMEASURED; runtime risk zero is not concluded".to_string()
+        },
+        measured_axes: runtime_layer
+            .map(|layer| layer.measured_axes.clone())
+            .unwrap_or_default(),
+        unmeasured_axes: runtime_layer
+            .map(|layer| layer.unmeasured_axes.clone())
+            .unwrap_or_else(|| vec!["runtimePropagation".to_string()]),
+        projection_rule: runtime_layer.and_then(|layer| layer.projection_rule.clone()),
+        extraction_scope: runtime_layer
+            .map(|layer| layer.extraction_scope.clone())
+            .unwrap_or_default(),
+        exactness_assumptions: runtime_layer
+            .map(|layer| layer.exactness_assumptions.clone())
+            .unwrap_or_default(),
+        coverage_gaps: coverage_gaps
+            .iter()
+            .filter(|gap| gap.layer == "runtime")
+            .flat_map(|gap| {
+                gap.unmeasured_axes
+                    .iter()
+                    .map(|axis| format!("runtime axis unmeasured: {axis}"))
+                    .chain(
+                        gap.unsupported_constructs
+                            .iter()
+                            .map(|construct| format!("runtime unsupported construct: {construct}")),
+                    )
+            })
+            .collect(),
+        claim_refs: runtime_claims
+            .iter()
+            .map(|claim| claim.claim_id.clone())
+            .collect(),
+        claim_classifications: runtime_claims
+            .iter()
+            .map(|claim| claim.claim_classification.clone())
+            .collect(),
+        non_conclusions: non_conclusions.into_iter().collect(),
     }
 }
 
@@ -439,12 +543,20 @@ fn feature_report_required_action(
     split_status: &str,
     witnesses: &[FeatureReportObstructionWitness],
     coverage_gaps: &[FeatureReportCoverageGap],
+    runtime_summary: &FeatureReportRuntimeSummary,
 ) -> String {
+    if split_status == "non_split" && !witnesses.is_empty() {
+        return "review introduced obstruction witnesses before treating the feature as split"
+            .to_string();
+    }
+    if runtime_summary.runtime_propagation.unwrap_or_default() > 0 {
+        return "review measured runtime exposure radius separately from static split evidence"
+            .to_string();
+    }
+    if !runtime_summary.coverage_gaps.is_empty() {
+        return "add runtime edge evidence before treating runtime risk as zero".to_string();
+    }
     match split_status {
-        "non_split" if !witnesses.is_empty() => {
-            "review introduced obstruction witnesses before treating the feature as split"
-                .to_string()
-        }
         "split" if !coverage_gaps.is_empty() => {
             "review static split together with UNMEASURED coverage gaps".to_string()
         }

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -888,6 +888,8 @@ pub struct FeatureExtensionReportV0 {
     pub feature: AirFeature,
     pub review_summary: FeatureReportReviewSummary,
     pub architecture_summary: FeatureReportArchitectureSummary,
+    #[serde(default)]
+    pub runtime_summary: FeatureReportRuntimeSummary,
     pub interpreted_extension: FeatureReportInterpretedExtension,
     pub split_status: String,
     pub preserved_invariants: Vec<FeatureReportInvariant>,
@@ -936,6 +938,45 @@ pub struct FeatureReportArchitectureSummary {
     pub semantic_diagram_count: usize,
     pub measured_axes: Vec<String>,
     pub unmeasured_axes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureReportRuntimeSummary {
+    pub relation_count: usize,
+    pub measurement_boundary: String,
+    pub runtime_propagation: Option<i64>,
+    pub interpretation: String,
+    pub measured_axes: Vec<String>,
+    pub unmeasured_axes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projection_rule: Option<String>,
+    pub extraction_scope: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub coverage_gaps: Vec<String>,
+    pub claim_refs: Vec<String>,
+    pub claim_classifications: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+impl Default for FeatureReportRuntimeSummary {
+    fn default() -> Self {
+        Self {
+            relation_count: 0,
+            measurement_boundary: "unmeasured".to_string(),
+            runtime_propagation: None,
+            interpretation: "runtimePropagation is unmeasured".to_string(),
+            measured_axes: Vec::new(),
+            unmeasured_axes: Vec::new(),
+            projection_rule: None,
+            extraction_scope: Vec::new(),
+            exactness_assumptions: Vec::new(),
+            coverage_gaps: Vec::new(),
+            claim_refs: Vec::new(),
+            claim_classifications: Vec::new(),
+            non_conclusions: vec!["runtime risk zero is not concluded".to_string()],
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -49,6 +49,110 @@ fn read_json(path: &Path) -> Value {
     serde_json::from_str(&contents).expect("json output parses")
 }
 
+fn runtime_axis_mut(json: &mut Value) -> &mut Value {
+    json["signature"]["axes"]
+        .as_array_mut()
+        .expect("signature axes are an array")
+        .iter_mut()
+        .find(|axis| axis["axis"] == "runtimePropagation")
+        .expect("runtimePropagation axis exists")
+}
+
+fn runtime_layer_mut(json: &mut Value) -> &mut Value {
+    json["coverage"]["layers"]
+        .as_array_mut()
+        .expect("coverage layers are an array")
+        .iter_mut()
+        .find(|layer| layer["layer"] == "runtime")
+        .expect("runtime coverage layer exists")
+}
+
+fn runtime_claim_mut(json: &mut Value) -> &mut Value {
+    json["claims"]
+        .as_array_mut()
+        .expect("claims are an array")
+        .iter_mut()
+        .find(|claim| claim["subjectRef"] == "signature.runtimePropagation")
+        .expect("runtime claim exists")
+}
+
+fn set_measured_runtime_axis(json: &mut Value, runtime_propagation: i64) {
+    let measurement_boundary = if runtime_propagation == 0 {
+        "measuredZero"
+    } else {
+        "measuredNonzero"
+    };
+    let axis = runtime_axis_mut(json);
+    axis["value"] = serde_json::json!(runtime_propagation);
+    axis["measured"] = serde_json::json!(true);
+    axis["measurementBoundary"] = serde_json::json!(measurement_boundary);
+    axis["source"] = serde_json::json!("runtime-edge-projection-v0");
+    axis["reason"] = Value::Null;
+
+    let layer = runtime_layer_mut(json);
+    layer["measurementBoundary"] = serde_json::json!(measurement_boundary);
+    layer["universeRefs"] = serde_json::json!(["artifact-sig0"]);
+    layer["measuredAxes"] = serde_json::json!(["runtimePropagation"]);
+    layer["unmeasuredAxes"] = serde_json::json!([]);
+    layer["projectionRule"] = serde_json::json!("runtime-edge-projection-v0");
+    layer["extractionScope"] = serde_json::json!([
+        "runtime edge evidence JSON",
+        "0/1 runtime dependency graph over measured component pairs"
+    ]);
+    layer["exactnessAssumptions"] = serde_json::json!([
+        "runtime-edge-projection-v0 maps each observed component pair to one runtime edge",
+        "runtime evidence component ids resolve inside the AIR component universe"
+    ]);
+    layer["unsupportedConstructs"] = serde_json::json!([]);
+
+    let claim = runtime_claim_mut(json);
+    claim["claimId"] = serde_json::json!("claim-runtime-exposure-radius");
+    claim["predicate"] =
+        serde_json::json!("runtimePropagation is measured runtime exposure radius");
+    claim["claimClassification"] = serde_json::json!("measured");
+    claim["measurementBoundary"] = serde_json::json!(measurement_boundary);
+    claim["evidenceRefs"] = serde_json::json!(["evidence-sig0"]);
+    claim["coverageAssumptions"] = serde_json::json!(["runtime edge evidence coverage"]);
+    claim["exactnessAssumptions"] = serde_json::json!(["runtime-edge-projection-v0 exactness"]);
+    claim["missingPreconditions"] = serde_json::json!([]);
+    claim["nonConclusions"] = serde_json::json!([
+        "runtime blast radius is not concluded",
+        "formal runtime zero bridge is not concluded"
+    ]);
+}
+
+fn add_runtime_relation(json: &mut Value) {
+    json["evidence"]
+        .as_array_mut()
+        .expect("evidence is an array")
+        .push(serde_json::json!({
+            "evidenceId": "evidence-runtime-coupon",
+            "kind": "runtime_trace",
+            "artifactRef": "artifact-sig0",
+            "path": "runtime/routes.json",
+            "symbol": "userCallsCoupon",
+            "line": 17,
+            "ruleId": "grpc",
+            "confidence": "fixture"
+        }));
+    json["relations"]
+        .as_array_mut()
+        .expect("relations are an array")
+        .push(serde_json::json!({
+            "id": "relation-runtime-coupon",
+            "layer": "runtime",
+            "from": "UserService",
+            "to": "CouponService",
+            "kind": "grpc",
+            "lifecycle": "added",
+            "protectedBy": "unknown",
+            "extractionRule": "runtime-edge-projection-v0",
+            "evidenceRefs": ["evidence-runtime-coupon"]
+        }));
+    runtime_claim_mut(json)["evidenceRefs"] =
+        serde_json::json!(["evidence-sig0", "evidence-runtime-coupon"]);
+}
+
 #[test]
 fn cli_feature_report_classifies_good_static_fixture_as_split() {
     let root = air_fixture_root();
@@ -95,6 +199,128 @@ fn cli_feature_report_classifies_good_static_fixture_as_split() {
             .expect("non-conclusions are an array")
             .iter()
             .any(|conclusion| conclusion == "static split does not conclude runtime flatness")
+    );
+}
+
+#[test]
+fn cli_feature_report_surfaces_runtime_exposure_boundaries() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("feature-report-runtime");
+
+    let mut measured_zero_input = read_json(&root.join("good_extension.json"));
+    set_measured_runtime_axis(&mut measured_zero_input, 0);
+    let measured_zero_air = out_dir.join("runtime-measured-zero.air.json");
+    let measured_zero_report = out_dir.join("runtime-measured-zero.report.json");
+    fs::write(
+        &measured_zero_air,
+        serde_json::to_string_pretty(&measured_zero_input).expect("json serializes"),
+    )
+    .expect("measured zero AIR is written");
+    run_sig0(&[
+        "feature-report",
+        "--air",
+        measured_zero_air.to_str().expect("AIR path is utf-8"),
+        "--out",
+        measured_zero_report.to_str().expect("report path is utf-8"),
+    ]);
+    let measured_zero = read_json(&measured_zero_report);
+    assert_eq!(measured_zero["runtimeSummary"]["runtimePropagation"], 0);
+    assert_eq!(
+        measured_zero["runtimeSummary"]["measurementBoundary"],
+        "measuredZero"
+    );
+    assert_eq!(
+        measured_zero["runtimeSummary"]["projectionRule"],
+        "runtime-edge-projection-v0"
+    );
+    assert!(
+        measured_zero["runtimeSummary"]["measuredAxes"]
+            .as_array()
+            .expect("runtime measured axes are an array")
+            .iter()
+            .any(|axis| axis == "runtimePropagation")
+    );
+    assert!(
+        measured_zero["runtimeSummary"]["nonConclusions"]
+            .as_array()
+            .expect("runtime non-conclusions are an array")
+            .iter()
+            .any(|conclusion| conclusion
+                == "runtimePropagation = 0 needs coverage, projection, exactness, and theorem preconditions before a formal claim")
+    );
+
+    let mut measured_nonzero_input = read_json(&root.join("good_extension.json"));
+    set_measured_runtime_axis(&mut measured_nonzero_input, 2);
+    add_runtime_relation(&mut measured_nonzero_input);
+    let measured_nonzero_air = out_dir.join("runtime-measured-nonzero.air.json");
+    let measured_nonzero_report = out_dir.join("runtime-measured-nonzero.report.json");
+    fs::write(
+        &measured_nonzero_air,
+        serde_json::to_string_pretty(&measured_nonzero_input).expect("json serializes"),
+    )
+    .expect("measured nonzero AIR is written");
+    run_sig0(&[
+        "feature-report",
+        "--air",
+        measured_nonzero_air.to_str().expect("AIR path is utf-8"),
+        "--out",
+        measured_nonzero_report
+            .to_str()
+            .expect("report path is utf-8"),
+    ]);
+    let measured_nonzero = read_json(&measured_nonzero_report);
+    assert_eq!(measured_nonzero["runtimeSummary"]["runtimePropagation"], 2);
+    assert_eq!(measured_nonzero["runtimeSummary"]["relationCount"], 1);
+    assert_eq!(
+        measured_nonzero["reviewSummary"]["requiredAction"],
+        "review measured runtime exposure radius separately from static split evidence"
+    );
+    assert!(
+        measured_nonzero["runtimeSummary"]["nonConclusions"]
+            .as_array()
+            .expect("runtime non-conclusions are an array")
+            .iter()
+            .any(|conclusion| conclusion
+                == "runtimePropagation is an exposure radius, not runtime blast radius")
+    );
+
+    let unmeasured_report = out_dir.join("runtime-unmeasured.report.json");
+    run_sig0(&[
+        "feature-report",
+        "--air",
+        root.join("good_extension.json")
+            .to_str()
+            .expect("fixture path is utf-8"),
+        "--out",
+        unmeasured_report.to_str().expect("report path is utf-8"),
+    ]);
+    let unmeasured = read_json(&unmeasured_report);
+    assert_eq!(
+        unmeasured["runtimeSummary"]["runtimePropagation"],
+        Value::Null
+    );
+    assert_eq!(
+        unmeasured["runtimeSummary"]["measurementBoundary"],
+        "unmeasured"
+    );
+    assert_eq!(
+        unmeasured["reviewSummary"]["requiredAction"],
+        "add runtime edge evidence before treating runtime risk as zero"
+    );
+    assert!(
+        unmeasured["runtimeSummary"]["coverageGaps"]
+            .as_array()
+            .expect("runtime coverage gaps are an array")
+            .iter()
+            .any(|gap| gap == "runtime axis unmeasured: runtimePropagation")
+    );
+    assert!(
+        unmeasured["runtimeSummary"]["nonConclusions"]
+            .as_array()
+            .expect("runtime non-conclusions are an array")
+            .iter()
+            .any(|conclusion| conclusion
+                == "runtimePropagation null is UNMEASURED, not runtime risk zero")
     );
 }
 


### PR DESCRIPTION
## 概要

Closes #519

Feature Extension Report v0 に `runtimeSummary` を追加し、runtime relation count、`runtimePropagation` の測定境界、projection rule、exactness assumptions、runtime coverage gaps、runtime non-conclusions を report 上で明示するようにしました。

`runtimePropagation` は exposure radius として扱い、`null` を runtime risk 0 と読ませず、`0` も coverage / projection / exactness / theorem preconditions が揃うまで formal runtime zero bridge claim へ昇格しない境界を report に保持します。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat_v2_tooling_design.md`

## 実施したテスト

- [ ] `lake build`（Lean ソース変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #519` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
