### PR TITLE
semantic canonical fixture と business-flow CLI tests を追加する

### DIFF
--- a/docs/aat_v2_tooling_design.md
+++ b/docs/aat_v2_tooling_design.md
@@ -1736,6 +1736,23 @@ Runtime integration の canonical AIR fixtures は、次の測定境界を固定
     coverage / projection / exactness / theorem preconditions が不足する場合に blocked とする。
 ```
 
+Semantic integration の canonical AIR fixtures は、次の測定境界を固定する。
+
+```text
+- semantic_measured_zero.json:
+    selected business-flow diagram の観測が一致する場合を measuredZero として扱い、
+    selected non-fillability witness 不在を report する。
+- semantic_nonfillability.json:
+    selected coupon / discount diagram の観測差分を measuredNonzero の
+    non-fillability witness として扱う。
+- semantic_unmeasured.json:
+    selected path / diagram があっても観測 evidence が未測定なら unmeasured とし、
+    semantic risk zero とは読まない。
+- semantic_formal_claim_blocked.json:
+    observation evidence があっても contract / test evidence が不足する formal
+    diagram filler claim は blocked とする。
+```
+
 ### 12.5 Standardization targets
 
 標準化対象は次である。

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -685,6 +685,136 @@ fn cli_feature_report_surfaces_semantic_nonfillability_witness() {
 }
 
 #[test]
+fn cli_feature_report_surfaces_semantic_measured_zero_boundary() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("feature-report-semantic-zero");
+    let report = out_dir.join("feature-report.json");
+
+    run_sig0(&[
+        "feature-report",
+        "--air",
+        root.join("semantic_measured_zero.json")
+            .to_str()
+            .expect("fixture path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(
+        json["semanticPathSummary"]["measurementBoundary"],
+        "measuredZero"
+    );
+    assert_eq!(json["semanticPathSummary"]["pathCount"], 2);
+    assert_eq!(json["semanticPathSummary"]["diagramCount"], 1);
+    assert_eq!(json["semanticPathSummary"]["nonfillabilityWitnessCount"], 0);
+    assert!(
+        json["semanticPathSummary"]["diagrams"]
+            .as_array()
+            .expect("semantic diagrams are an array")
+            .iter()
+            .any(
+                |diagram| diagram["diagramId"] == "diagram-coupon-discount-commuting-order"
+                    && diagram["fillerClaimRef"] == "claim-coupon-discount-commutes"
+                    && diagram["nonfillabilityWitnessRefs"]
+                        .as_array()
+                        .expect("semantic witness refs are an array")
+                        .is_empty()
+            )
+    );
+    assert!(
+        json["introducedObstructionWitnesses"]
+            .as_array()
+            .expect("obstruction witnesses are an array")
+            .iter()
+            .all(|witness| witness["layer"] != "semantic")
+    );
+}
+
+#[test]
+fn cli_feature_report_keeps_semantic_unmeasured_boundary_distinct_from_zero() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("feature-report-semantic-unmeasured");
+    let report = out_dir.join("feature-report.json");
+
+    run_sig0(&[
+        "feature-report",
+        "--air",
+        root.join("semantic_unmeasured.json")
+            .to_str()
+            .expect("fixture path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(
+        json["semanticPathSummary"]["measurementBoundary"],
+        "unmeasured"
+    );
+    assert!(
+        json["semanticPathSummary"]["unmeasuredAxes"]
+            .as_array()
+            .expect("semantic unmeasured axes are an array")
+            .iter()
+            .any(|axis| axis == "projectionSoundnessViolation")
+    );
+    assert!(
+        json["semanticPathSummary"]["nonConclusions"]
+            .as_array()
+            .expect("semantic non-conclusions are an array")
+            .iter()
+            .any(|conclusion| conclusion == "semantic risk zero is not concluded")
+    );
+    assert!(
+        json["coverageGaps"]
+            .as_array()
+            .expect("coverage gaps are an array")
+            .iter()
+            .any(|gap| gap["layer"] == "semantic" && gap["measurementBoundary"] == "UNMEASURED")
+    );
+}
+
+#[test]
+fn cli_theorem_check_blocks_semantic_formal_claim_without_contract_and_test_evidence() {
+    let root = air_fixture_root();
+    let out_dir = temp_dir("theorem-check-semantic-blocked");
+    let report = out_dir.join("semantic-blocked-theorem-check.json");
+
+    run_sig0(&[
+        "theorem-check",
+        "--air",
+        root.join("semantic_formal_claim_blocked.json")
+            .to_str()
+            .expect("fixture path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let report = read_json(&report);
+    assert!(
+        report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(
+                |check| check["claimId"] == "claim-coupon-discount-filler-formal-blocked"
+                    && check["resolvedClaimClassification"] == "BLOCKED_FORMAL_CLAIM"
+                    && check["missingPreconditions"]
+                        .as_array()
+                        .expect("missing preconditions is array")
+                        .iter()
+                        .any(|precondition| precondition == "contract evidence is absent")
+                    && check["missingPreconditions"]
+                        .as_array()
+                        .expect("missing preconditions is array")
+                        .iter()
+                        .any(|precondition| precondition == "test evidence is absent")
+            )
+    );
+}
+
+#[test]
 fn cli_theorem_check_reports_static_registry_and_blocks_missing_preconditions() {
     let root = air_fixture_root();
     let out_dir = temp_dir("theorem-check");
@@ -1023,7 +1153,10 @@ fn cli_validate_air_accepts_canonical_fixtures() {
         "runtime_measured_nonzero.json",
         "runtime_unmeasured.json",
         "runtime_zero_bridge_blocked.json",
+        "semantic_measured_zero.json",
         "semantic_nonfillability.json",
+        "semantic_unmeasured.json",
+        "semantic_formal_claim_blocked.json",
         "unmeasured_runtime_semantic.json",
     ] {
         let report = out_dir.join(format!("{fixture}.report.json"));

--- a/tools/archsig/tests/fixtures/air/semantic_formal_claim_blocked.json
+++ b/tools/archsig/tests/fixtures/air/semantic_formal_claim_blocked.json
@@ -1,0 +1,208 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-semantic-formal-claim-blocked",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-semantic-blocked",
+    "after": "after-semantic-blocked"
+  },
+  "feature": {
+    "featureId": "#canonical-semantic-blocked",
+    "title": "Add coupon and discount workflow",
+    "description": "A selected semantic diagram has observation evidence but lacks contract and test evidence for a formal filler claim",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-semantic-observation",
+      "kind": "semantic",
+      "schemaVersion": "business-flow-observation-v0",
+      "path": "tests/coupon_discount_observation.json",
+      "contentHash": null,
+      "producedBy": "archsig"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-blocked-observation",
+      "kind": "observation_result",
+      "artifactRef": "artifact-semantic-observation",
+      "path": "tests/coupon_discount_observation.json",
+      "symbol": "couponDiscountObservation",
+      "line": 7,
+      "ruleId": "business-flow-observation-v0",
+      "confidence": "medium"
+    },
+    {
+      "evidenceId": "evidence-blocked-diagram",
+      "kind": "semantic_diagram",
+      "artifactRef": "artifact-semantic-observation",
+      "path": "docs/diagrams/coupon_discount_blocked.yaml",
+      "symbol": "diagram-coupon-discount-blocked-order",
+      "line": 1,
+      "ruleId": "selected-semantic-diagram",
+      "confidence": "medium"
+    }
+  ],
+  "components": [
+    {
+      "id": "CouponService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "DiscountService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [],
+  "policies": {
+    "laws": [],
+    "boundaries": [],
+    "allowedEdges": [],
+    "forbiddenEdges": [],
+    "abstractionRules": [],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [
+    {
+      "id": "diagram-coupon-discount-blocked-order",
+      "lhsPathRef": "path-discount-then-coupon",
+      "rhsPathRef": "path-coupon-then-discount",
+      "equivalence": "observational",
+      "fillerClaimRef": "claim-coupon-discount-filler-formal-blocked",
+      "nonfillabilityWitnessRefs": [],
+      "observationRefs": ["evidence-blocked-observation"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-blocked-observation", "evidence-blocked-diagram"]
+    }
+  ],
+  "architecturePaths": [
+    {
+      "pathId": "path-discount-then-coupon",
+      "sourceState": "cart-before-pricing",
+      "targetState": "cart-priced",
+      "steps": ["apply-discount", "apply-coupon"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-blocked-observation"]
+    },
+    {
+      "pathId": "path-coupon-then-discount",
+      "sourceState": "cart-before-pricing",
+      "targetState": "cart-priced",
+      "steps": ["apply-coupon", "apply-discount"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-blocked-observation"]
+    }
+  ],
+  "homotopyGenerators": [
+    {
+      "generatorId": "generator-blocked-order",
+      "kind": "independent_square",
+      "diagramRefs": ["diagram-coupon-discount-blocked-order"],
+      "preservesObservationClaimRefs": ["claim-coupon-discount-filler-formal-blocked"],
+      "evidenceRefs": ["evidence-blocked-observation"]
+    }
+  ],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "projectionSoundnessViolation",
+        "value": 0,
+        "measured": true,
+        "measurementBoundary": "measuredZero",
+        "source": "business-flow-observation-v0",
+        "reason": null
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "semantic",
+        "measurementBoundary": "measuredZero",
+        "universeRefs": ["artifact-semantic-observation"],
+        "measuredAxes": ["projectionSoundnessViolation"],
+        "unmeasuredAxes": [],
+        "extractionScope": ["selected coupon / discount observation"],
+        "exactnessAssumptions": ["fixture records selected workflow observation"],
+        "unsupportedConstructs": []
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-coupon-discount-filler-formal-blocked",
+      "subjectRef": "semantic.diagram.diagram-coupon-discount-blocked-order",
+      "predicate": "selected semantic diagram filler is blocked until contract and test evidence are present",
+      "claimLevel": "formal",
+      "claimClassification": "assumed",
+      "measurementBoundary": "measuredZero",
+      "theoremRefs": ["DiagramFiller", "totalCurvature_eq_zero_iff_noMeasuredNumericalCurvatureObstruction"],
+      "evidenceRefs": ["evidence-blocked-observation", "evidence-blocked-diagram"],
+      "requiredAssumptions": ["selected paths have an explicit filler contract"],
+      "coverageAssumptions": ["selected business-flow observations are covered"],
+      "exactnessAssumptions": ["contract observations match AIR path endpoints"],
+      "missingPreconditions": [
+        "contract evidence is absent",
+        "test evidence is absent"
+      ],
+      "nonConclusions": [
+        "formal diagram filler claim is not concluded",
+        "semantic measured zero witness is not a global semantic completeness result"
+      ]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding requires theorem preconditions",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["before/after component correspondence"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["theorem precondition checker has not run"],
+      "nonConclusions": ["split extension is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature view requires diff attribution",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["feature ownership"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["feature extension report has not run"],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-coupon-discount-filler-formal-blocked"],
+    "splitClaimRef": null,
+    "splitStatus": "unknown"
+  }
+}

--- a/tools/archsig/tests/fixtures/air/semantic_measured_zero.json
+++ b/tools/archsig/tests/fixtures/air/semantic_measured_zero.json
@@ -1,0 +1,235 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-semantic-measured-zero",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-semantic-zero",
+    "after": "after-semantic-zero"
+  },
+  "feature": {
+    "featureId": "#canonical-semantic-zero",
+    "title": "Add coupon and discount workflow",
+    "description": "Coupon and discount ordering is measured through a commuting selected semantic diagram",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-semantic-business-flow",
+      "kind": "semantic",
+      "schemaVersion": "business-flow-test-v0",
+      "path": "tests/coupon_discount_commuting_order.json",
+      "contentHash": null,
+      "producedBy": "archsig"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-commuting-order",
+      "kind": "observation_result",
+      "artifactRef": "artifact-semantic-business-flow",
+      "path": "tests/coupon_discount_commuting_order.json",
+      "symbol": "couponDiscountCommutingObservation",
+      "line": 8,
+      "ruleId": "business-flow-test-v0",
+      "confidence": "high"
+    },
+    {
+      "evidenceId": "evidence-commuting-flow-test",
+      "kind": "test",
+      "artifactRef": "artifact-semantic-business-flow",
+      "path": "tests/coupon_discount_commuting_order.json",
+      "symbol": "couponDiscountCommutingTest",
+      "line": 3,
+      "ruleId": "business-flow-test-v0",
+      "confidence": "high"
+    },
+    {
+      "evidenceId": "evidence-commuting-contract",
+      "kind": "manual_annotation",
+      "artifactRef": null,
+      "path": "docs/contracts/coupon_discount_commuting.md",
+      "symbol": "selected coupon discount commuting contract",
+      "line": 1,
+      "ruleId": "selected-contract",
+      "confidence": "medium"
+    },
+    {
+      "evidenceId": "evidence-commuting-diagram",
+      "kind": "semantic_diagram",
+      "artifactRef": "artifact-semantic-business-flow",
+      "path": "docs/diagrams/coupon_discount_commuting.yaml",
+      "symbol": "diagram-coupon-discount-commuting-order",
+      "line": 1,
+      "ruleId": "selected-semantic-diagram",
+      "confidence": "medium"
+    }
+  ],
+  "components": [
+    {
+      "id": "CouponService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "DiscountService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [],
+  "policies": {
+    "laws": [],
+    "boundaries": [],
+    "allowedEdges": [],
+    "forbiddenEdges": [],
+    "abstractionRules": [],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [
+    {
+      "id": "diagram-coupon-discount-commuting-order",
+      "lhsPathRef": "path-discount-then-coupon",
+      "rhsPathRef": "path-coupon-then-discount",
+      "equivalence": "observational",
+      "fillerClaimRef": "claim-coupon-discount-commutes",
+      "nonfillabilityWitnessRefs": [],
+      "observationRefs": ["evidence-commuting-order", "evidence-commuting-flow-test"],
+      "lifecycle": "added",
+      "evidenceRefs": [
+        "evidence-commuting-order",
+        "evidence-commuting-flow-test",
+        "evidence-commuting-contract",
+        "evidence-commuting-diagram"
+      ]
+    }
+  ],
+  "architecturePaths": [
+    {
+      "pathId": "path-discount-then-coupon",
+      "sourceState": "cart-before-pricing",
+      "targetState": "cart-priced",
+      "steps": ["apply-discount", "apply-coupon"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-commuting-order", "evidence-commuting-flow-test"]
+    },
+    {
+      "pathId": "path-coupon-then-discount",
+      "sourceState": "cart-before-pricing",
+      "targetState": "cart-priced",
+      "steps": ["apply-coupon", "apply-discount"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-commuting-order", "evidence-commuting-flow-test"]
+    }
+  ],
+  "homotopyGenerators": [
+    {
+      "generatorId": "generator-commuting-order",
+      "kind": "independent_square",
+      "diagramRefs": ["diagram-coupon-discount-commuting-order"],
+      "preservesObservationClaimRefs": ["claim-coupon-discount-commutes"],
+      "evidenceRefs": ["evidence-commuting-order", "evidence-commuting-contract"]
+    }
+  ],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "projectionSoundnessViolation",
+        "value": 0,
+        "measured": true,
+        "measurementBoundary": "measuredZero",
+        "source": "business-flow-test-v0",
+        "reason": null
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "semantic",
+        "measurementBoundary": "measuredZero",
+        "universeRefs": ["artifact-semantic-business-flow"],
+        "measuredAxes": ["projectionSoundnessViolation"],
+        "unmeasuredAxes": [],
+        "extractionScope": ["selected coupon / discount commuting business-flow test"],
+        "exactnessAssumptions": ["fixture records matching selected workflow observations"],
+        "unsupportedConstructs": []
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-coupon-discount-commutes",
+      "subjectRef": "semantic.diagram.diagram-coupon-discount-commuting-order",
+      "predicate": "selected coupon / discount order diagram has measured equal observations",
+      "claimLevel": "tooling",
+      "claimClassification": "measured",
+      "measurementBoundary": "measuredZero",
+      "theoremRefs": ["diagramViolationCount_eq_zero_iff_forall_measured_DiagramCommutes"],
+      "evidenceRefs": [
+        "evidence-commuting-order",
+        "evidence-commuting-flow-test",
+        "evidence-commuting-contract",
+        "evidence-commuting-diagram"
+      ],
+      "requiredAssumptions": ["selected observations are comparable"],
+      "coverageAssumptions": ["selected business-flow test covers coupon / discount ordering"],
+      "exactnessAssumptions": ["fixture records matching selected workflow observations"],
+      "missingPreconditions": [],
+      "nonConclusions": [
+        "global semantic flatness is not concluded",
+        "unmeasured diagrams are not treated as commuting"
+      ]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding requires theorem preconditions",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["before/after component correspondence"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["theorem precondition checker has not run"],
+      "nonConclusions": ["split extension is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature view requires diff attribution",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["feature ownership"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["feature extension report has not run"],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-coupon-discount-commutes"],
+    "splitClaimRef": null,
+    "splitStatus": "split"
+  }
+}

--- a/tools/archsig/tests/fixtures/air/semantic_unmeasured.json
+++ b/tools/archsig/tests/fixtures/air/semantic_unmeasured.json
@@ -1,0 +1,195 @@
+{
+  "schemaVersion": "aat-air-v0",
+  "architectureId": "canonical-semantic-unmeasured",
+  "ids": {
+    "componentIdPolicy": "canonical component id",
+    "relationIdPolicy": "canonical relation id",
+    "evidenceIdPolicy": "canonical evidence id",
+    "claimIdPolicy": "canonical claim id"
+  },
+  "revision": {
+    "before": "before-semantic-unmeasured",
+    "after": "after-semantic-unmeasured"
+  },
+  "feature": {
+    "featureId": "#canonical-semantic-unmeasured",
+    "title": "Add coupon and discount workflow",
+    "description": "Coupon and discount ordering has selected paths but no semantic measurement",
+    "source": "manual",
+    "aiSession": null
+  },
+  "artifacts": [
+    {
+      "artifactId": "artifact-semantic-plan",
+      "kind": "semantic",
+      "schemaVersion": "business-flow-plan-v0",
+      "path": "docs/diagrams/coupon_discount_unmeasured.yaml",
+      "contentHash": null,
+      "producedBy": "manual"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "evidence-unmeasured-diagram",
+      "kind": "semantic_diagram",
+      "artifactRef": "artifact-semantic-plan",
+      "path": "docs/diagrams/coupon_discount_unmeasured.yaml",
+      "symbol": "diagram-coupon-discount-unmeasured-order",
+      "line": 1,
+      "ruleId": "selected-semantic-diagram",
+      "confidence": "medium"
+    }
+  ],
+  "components": [
+    {
+      "id": "CouponService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    },
+    {
+      "id": "DiscountService",
+      "kind": "service",
+      "lifecycle": "added",
+      "owner": null,
+      "evidenceRefs": []
+    }
+  ],
+  "relations": [],
+  "policies": {
+    "laws": [],
+    "boundaries": [],
+    "allowedEdges": [],
+    "forbiddenEdges": [],
+    "abstractionRules": [],
+    "protectionRules": []
+  },
+  "semanticDiagrams": [
+    {
+      "id": "diagram-coupon-discount-unmeasured-order",
+      "lhsPathRef": "path-discount-then-coupon",
+      "rhsPathRef": "path-coupon-then-discount",
+      "equivalence": "observational",
+      "fillerClaimRef": null,
+      "nonfillabilityWitnessRefs": [],
+      "observationRefs": [],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-unmeasured-diagram"]
+    }
+  ],
+  "architecturePaths": [
+    {
+      "pathId": "path-discount-then-coupon",
+      "sourceState": "cart-before-pricing",
+      "targetState": "cart-priced",
+      "steps": ["apply-discount", "apply-coupon"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-unmeasured-diagram"]
+    },
+    {
+      "pathId": "path-coupon-then-discount",
+      "sourceState": "cart-before-pricing",
+      "targetState": "cart-priced",
+      "steps": ["apply-coupon", "apply-discount"],
+      "lifecycle": "added",
+      "evidenceRefs": ["evidence-unmeasured-diagram"]
+    }
+  ],
+  "homotopyGenerators": [
+    {
+      "generatorId": "generator-unmeasured-order",
+      "kind": "independent_square",
+      "diagramRefs": ["diagram-coupon-discount-unmeasured-order"],
+      "preservesObservationClaimRefs": ["claim-semantic-unmeasured"],
+      "evidenceRefs": ["evidence-unmeasured-diagram"]
+    }
+  ],
+  "nonfillabilityWitnesses": [],
+  "signature": {
+    "axes": [
+      {
+        "axis": "projectionSoundnessViolation",
+        "value": null,
+        "measured": false,
+        "measurementBoundary": "unmeasured",
+        "source": null,
+        "reason": "semantic observations were not collected"
+      }
+    ]
+  },
+  "coverage": {
+    "layers": [
+      {
+        "layer": "semantic",
+        "measurementBoundary": "unmeasured",
+        "universeRefs": [],
+        "measuredAxes": [],
+        "unmeasuredAxes": ["projectionSoundnessViolation"],
+        "extractionScope": [],
+        "exactnessAssumptions": [],
+        "unsupportedConstructs": ["semantic observation result evidence not provided"]
+      }
+    ]
+  },
+  "claims": [
+    {
+      "claimId": "claim-semantic-unmeasured",
+      "subjectRef": "signature.projectionSoundnessViolation",
+      "predicate": "selected semantic diagram is outside the current measurement boundary",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["selected observations are comparable"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["observation-result evidence is absent", "test evidence is absent"],
+      "nonConclusions": [
+        "semantic risk zero is not concluded",
+        "unmeasured diagrams are not treated as commuting"
+      ]
+    },
+    {
+      "claimId": "claim-extension-embedding",
+      "subjectRef": "extension.embedding",
+      "predicate": "embedding requires theorem preconditions",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["before/after component correspondence"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["theorem precondition checker has not run"],
+      "nonConclusions": ["split extension is not concluded"]
+    },
+    {
+      "claimId": "claim-extension-feature-view",
+      "subjectRef": "extension.feature",
+      "predicate": "feature view requires diff attribution",
+      "claimLevel": "tooling",
+      "claimClassification": "unmeasured",
+      "measurementBoundary": "unmeasured",
+      "theoremRefs": [],
+      "evidenceRefs": [],
+      "requiredAssumptions": ["feature ownership"],
+      "coverageAssumptions": [],
+      "exactnessAssumptions": [],
+      "missingPreconditions": ["feature extension report has not run"],
+      "nonConclusions": ["feature quotient is not constructed"]
+    }
+  ],
+  "operationTrace": {
+    "operations": []
+  },
+  "extension": {
+    "embeddingClaimRef": "claim-extension-embedding",
+    "featureViewClaimRef": "claim-extension-feature-view",
+    "interactionClaimRefs": ["claim-semantic-unmeasured"],
+    "splitClaimRef": null,
+    "splitStatus": "unmeasured"
+  }
+}


### PR DESCRIPTION
## 概要

Closes #535

semantic canonical fixture を business-flow example として分離し、selected path / diagram / evidence / claim refs を Feature Extension Report と theorem precondition check で辿れるようにしました。

- `semantic_measured_zero.json` で selected diagram の観測一致を `measuredZero` として固定
- `semantic_unmeasured.json` で selected diagram があっても観測 evidence 未測定なら semantic risk zero と読まない境界を固定
- `semantic_formal_claim_blocked.json` で contract / test evidence 不足の formal diagram filler claim を blocked として固定
- 既存 `semantic_nonfillability.json` と合わせて measured nonzero / non-fillability witness 境界を CLI tests で確認

Lean status: empirical hypothesis / tooling validation。business-flow fixture は bounded example であり、全 business semantics や extractor completeness は主張しません。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat_v2_tooling_design.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #535` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
