### PR TITLE
ArchSig tool docs の導線を更新

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@
 - [アーキテクチャ零曲率定理 Lean 化設計](formal/flatness_obstruction_lean_design.md): 数学草案を Lean の generic witness-count kernel / law diagram / finite zero-count bridge へ落とす設計。
 - [runtimePropagation 設計](design/runtime_propagation_design.md): runtime metric を static structural core から分け、0/1 runtime graph 上の zero bridge は bounded Lean theorem package、policy-aware coverage、extractor completeness、incident 相関は実用・実証層として扱う設計。
 - [B6 empirical hypothesis evaluation plan](design/b6_empirical_hypothesis_evaluation.md): Feature Extension Report / Architecture Signature / obstruction profile と outcome linkage を H1-H5 の evaluation query へ接続する Phase B6 の研究検証計画。
+- [B9/B10 schema version catalog](design/schema_version_catalog.md): schema version、compatibility policy、B10 operational feedback artifact の catalog と non-conclusion boundary。
+- [ArchSig tooling index](design/archsig_tooling_index.md): ArchSig tooling の schema、CLI、fixture、non-conclusion boundary の索引。
 
 Lean で証明済みの構造的事実、定義のみの概念、将来の証明義務、実証仮説は混同しない。
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,6 +8,7 @@
 | --- | --- | --- |
 | [ArchSig v0 設計](archsig_design.md) | tooling design / empirical hypothesis | Lean module import graph から Signature v0 JSON を作る最小 extractor と、Lean `ComponentUniverse` との責務境界を整理する。 |
 | [ArchSig tooling index](archsig_tooling_index.md) | tooling validation index | ArchSig tooling の schema、CLI、fixture、non-conclusion boundary を追跡する。 |
+| [B9/B10 schema version catalog](schema_version_catalog.md) | tooling schema / empirical hypothesis | B9 schema compatibility policy と B10 operational feedback artifact の version catalog、canonical fixture、non-conclusion boundary を固定する。 |
 | [Adapter registry v0 schema](adapter_registry_schema.md) | tooling schema / empirical hypothesis | non-Lean extractor、framework adapter、runtime / semantic evidence adapter の evidence boundary と projection rule を固定する。 |
 | [Law policy template registry v0 schema](law_policy_template_registry_schema.md) | tooling schema / empirical hypothesis | law policy template の selector assumptions、required evidence、non-conclusion boundary を固定する。 |
 | [Custom rule plugin registry v0 schema](custom_rule_plugin_registry_schema.md) | tooling schema / empirical hypothesis | custom rule plugin の trust boundary、input / output contract、formal claim promotion boundary を固定する。 |

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -28,6 +28,9 @@ Lean status: `empirical hypothesis` / tooling output.
 | Law policy template registry validation report | `law-policy-template-registry-validation-report-v0` | policy template registry の boundary refs と non-conclusions を検査する。 |
 | Custom rule plugin registry validation report | `custom-rule-plugin-registry-validation-report-v0` | custom rule plugin registry の theorem refs と claim boundary を検査する。 |
 | Measurement unit registry validation report | `measurement-unit-registry-validation-report-v0` | measurement unit selection と evidence adapter boundary を検査する。 |
+| Repair rule registry validation report | `repair-rule-registry-validation-report-v0` | repair rule registry の selected obstruction boundary と advisory non-conclusions を検査する。 |
+| Synthesis constraint validation report | `synthesis-constraint-validation-report-v0` | synthesis candidate / no-solution boundary と solver completeness non-conclusion を検査する。 |
+| No-solution certificate validation report | `no-solution-certificate-validation-report-v0` | valid certificate claim refs と finite candidate universe boundary を検査する。 |
 | Schema compatibility report | `schema-compatibility-check-report-v0` | schema migration / compatibility の field mapping、non-conclusions、coverage / exactness boundary を検査する。 |
 | Detectable values / reported axes catalog | `detectable-values-reported-axes-catalog-v0` | reported axes と detectable values の catalog。 |
 
@@ -39,6 +42,18 @@ Lean status: `empirical hypothesis` / tooling output.
 | PR history dataset | `pr-history-dataset-v0` | GitHub PR metadata と artifact refs を履歴 record として保存する。 |
 | Feature extension dataset | `feature-extension-dataset-v0` | PR history と Feature Extension Report / theorem check を join する。 |
 | Outcome linkage dataset | `outcome-linkage-dataset-v0` | feature extension dataset と rollback / incident / MTTR などの outcome observation を join する。 |
+
+## Operational Feedback Artifacts
+
+| 出力 | schemaVersion | 用途 |
+| --- | --- | --- |
+| Report outcome daily ledger | `report-outcome-daily-ledger-v0` | outcome linkage dataset と architecture drift ledger を daily aggregation window で join する。 |
+| Calibration review record | `calibration-review-record-v0` | false positive / false negative review と metric calibration input を保存する。 |
+| Team threshold policy | `team-threshold-policy-v0` | team-specific threshold tuning と CI mode policy を保存する。 |
+| Ownership boundary monitor | `ownership-boundary-monitor-v0` | ownership scope と boundary erosion signal を operational observation として保存する。 |
+| Repair adoption record | `repair-adoption-record-v0` | repair suggestion の adopted / rejected / deferred decision と follow-up outcome refs を保存する。 |
+| Incident correlation monitor | `incident-correlation-monitor-v0` | incident / rollback / MTTR correlation、confounder、missing / private data boundary を保存する。 |
+| Hypothesis refresh cycle | `hypothesis-refresh-cycle-v0` | empirical hypothesis の retained / rejected / proposed update を versioned research tracking として保存する。 |
 
 ## Measurement Boundary
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -92,6 +92,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- air \
   --diff .lake/signature-current/diff-report.json \
   --pr-metadata .lake/pr-metadata-123.json \
   --law-policy signature-policy.json \
+  --framework-adapter framework-adapter.json \
   --out .lake/signature-current/air.json
 ```
 
@@ -102,6 +103,9 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- validate-air \
   --input .lake/signature-current/air.json \
   --out .lake/signature-current/air-validation.json
 ```
+
+`--strict-measured-evidence` を付けると、evidence refs を持たない measured claim を
+warning ではなく failure として扱う。
 
 Theorem precondition check を作る。
 
@@ -138,7 +142,16 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- organization-policy \
 
 cargo run --manifest-path tools/archsig/Cargo.toml -- policy-decision \
   --feature-report .lake/signature-current/feature-report.json \
+  --policy organization-policy.json \
   --out .lake/signature-current/policy-decision.json
+```
+
+B7 report artifact retention manifest を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- report-artifacts \
+  --input report-artifacts.json \
+  --out .lake/signature-current/report-artifacts-validation.json
 ```
 
 B8 extension registry を検査する。
@@ -152,6 +165,22 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- custom-rule-plugins \
 
 cargo run --manifest-path tools/archsig/Cargo.toml -- measurement-units \
   --out .lake/signature-current/measurement-units-validation.json
+```
+
+B5 repair / synthesis artifact を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- repair-registry \
+  --input repair-rule-registry.json \
+  --out .lake/signature-current/repair-registry-validation.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- synthesis-constraints \
+  --input tools/archsig/tests/fixtures/minimal/synthesis_constraints_candidate.json \
+  --out .lake/signature-current/synthesis-constraints.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- no-solution-certificate \
+  --input tools/archsig/tests/fixtures/minimal/no_solution_certificate_valid.json \
+  --out .lake/signature-current/no-solution-certificate-validation.json
 ```
 
 B9 schema compatibility を検査する。
@@ -190,6 +219,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- pr-metadata \
   --pull-request github-pr.json \
   --files github-pr-files.json \
   --reviews github-pr-reviews.json \
+  --review-threads github-review-threads.json \
   --out pr-metadata.json
 ```
 
@@ -211,6 +241,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- pr-history-dataset \
   --pull-request github-pr.json \
   --files github-pr-files.json \
   --reviews github-pr-reviews.json \
+  --review-threads github-review-threads.json \
   --signature-artifact base=.lake/sig0-base.json \
   --signature-artifact head=.lake/sig0-head.json \
   --feature-report-artifact head=.lake/signature-current/feature-report.json \
@@ -228,15 +259,48 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- outcome-linkage-dataset \
   --out .lake/outcome-linkage-dataset.json
 ```
 
-## Other Artifacts
+## Operational Feedback
 
-Synthesis constraint artifact を検査する。
+B10 daily ledger を作る。
 
 ```bash
-cargo run --manifest-path tools/archsig/Cargo.toml -- synthesis-constraints \
-  --input tools/archsig/tests/fixtures/minimal/synthesis_constraints_candidate.json \
-  --out .lake/signature-current/synthesis-constraints.json
+cargo run --manifest-path tools/archsig/Cargo.toml -- report-outcome-daily-ledger \
+  --outcome-linkage .lake/outcome-linkage-dataset.json \
+  --drift-ledger .lake/architecture-drift-ledger.json \
+  --generated-at 2026-05-05T00:00:00Z \
+  --window-start 2026-05-04T00:00:00Z \
+  --window-end 2026-05-05T00:00:00Z \
+  --out .lake/report-outcome-daily-ledger.json
 ```
+
+Canonical B10 artifact を出力する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- calibration-review-record \
+  --out .lake/calibration-review-record.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- team-threshold-policy \
+  --out .lake/team-threshold-policy.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- ownership-boundary-monitor \
+  --out .lake/ownership-boundary-monitor.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- repair-adoption-record \
+  --out .lake/repair-adoption-record.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- incident-correlation-monitor \
+  --out .lake/incident-correlation-monitor.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- hypothesis-refresh-cycle \
+  --out .lake/hypothesis-refresh-cycle.json
+```
+
+これらは empirical / operational feedback artifact であり、因果証明、formal claim
+promotion、theorem precondition discharge、extractor completeness、architecture
+lawfulness を結論しない。詳しい読み方は
+[Operational Feedback](operational-feedback.md) を参照する。
+
+## Other Artifacts
 
 Workflow 単位の relation complexity observation を作る。
 


### PR DESCRIPTION
## 概要

Closes #632

ArchSig tooling が B10 operational feedback まで進んだ現状に合わせて、tool 側 docs の導線を更新した。

- `tools/archsig/docs/commands.md` に、現行 CLI から漏れていた `repair-registry`, `no-solution-certificate`, `report-artifacts`, `--review-threads`, `--strict-measured-evidence`, `--framework-adapter` を追加
- `tools/archsig/docs/artifacts-and-boundaries.md` に repair / synthesis / no-solution validation artifact と B10 operational feedback artifact を追加
- 上位 docs から B9/B10 schema catalog と ArchSig tooling index へ辿れるようにした

Rust 実装、Lean theorem、schema は変更していない。Lean status は tooling docs / empirical hypothesis boundary の整理であり、tooling output を Lean theorem claim として強めていない。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/README.md`
- `docs/design/README.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [x] `lake build`
  - 成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning は継続。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
  - `rg -n "[\\u200B-\\u200F\\u202A-\\u202E\\u2066-\\u2069]" docs/README.md docs/design/README.md tools/archsig/docs/artifacts-and-boundaries.md tools/archsig/docs/commands.md`
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
  - `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal docs`
  - docs の方針説明のみ。Lean source への混入なし。
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- --help`
- [x] `CARGO_INCREMENTAL=0 cargo test --manifest-path tools/archsig/Cargo.toml`
  - 113 tests passed。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
