### PR TITLE
READMEをAAT/SFT構成に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,151 @@
-# 代数的アーキテクチャ論 V2
+# 代数的アーキテクチャ論 & ソフトウェアの場の理論
 
-このリポジトリは、**Algebraic Architecture Theory V2** の Lean 形式化と研究ノートを管理するための独立リポジトリです。
+このリポジトリは、**Algebraic Architecture Theory**（AAT / 代数的アーキテクチャ論）と
+**Software Field Theory**（SFT / ソフトウェアの場の理論）の Lean 形式化、研究ノート、
+tooling 設計を管理するための独立リポジトリです。
 
-## 大目標
-
-AAT v2 の目標は、機能追加によってソフトウェアアーキテクチャがどのように拡大し、
-どの不変量を保存し、どの obstruction を導入するかを、証明・測定・仮定・実証を
-分離して診断できる理論とツールチェーンを作ることです。
-
-中心的な問いは次です。
+大きな目的は、ソフトウェアアーキテクチャを静的な形だけでなく、
+変更・レビュー・CI・運用・AI agent の proposal によって変化し続ける対象として扱い、
+何が保存され、何が破れ、どの未来へ進みやすくなったのかを診断できる理論と
+ツールチェーンを作ることです。
 
 ```text
-この feature addition は、既存 architecture を lawful に拡大しているか。
-split しない場合、どの obstruction witness がそれを妨げているか。
+AAT makes architecture locally algebraic.
+ArchSig makes architecture observable.
+SFT makes software evolution computable.
 ```
 
-より短く言えば、目標はアーキテクチャレビューを「感想」から「診断」に近づけることです。
+日本語では次のように読みます。
 
-この目標を支える基本的な見方は次です。
+```text
+AAT はアーキテクチャを局所代数にする。
+ArchSig はアーキテクチャを観測可能にする。
+SFT はソフトウェア進化を計算可能にする。
+```
 
-- 設計原則は、アーキテクチャ不変量を保存・改善する操作として読む。
-- アーキテクチャ品質は、不変量の破れを単一スコアではなく多軸シグネチャとして評価する。
-- Lean で証明する主張、tooling が測定する主張、実証研究で検証する仮説を混同しない。
+全体像は [研究の全体目標](docs/research_goal.md) を入口とします。
 
-全体像は [研究の全体目標](docs/research_goal.md) を source of truth とします。
+## 研究の問い
 
-## 研究方針
+この研究は、アーキテクチャレビューを「感想」から「診断」へ近づけることを目指します。
+中心にある問いは次です。
 
-AAT v2 は、数学的中核、Lean 形式化、tooling、実証研究を分けて扱います。
+```text
+この変更は、選択された architecture invariant を保存しているか。
+保存していないなら、どの obstruction witness がそれを示しているか。
+その破れはどの ArchitectureSignature axis に現れるか。
+この PRD / Issue / PR は、どの future architecture を開きやすくするか。
+どの review / CI / policy / governance が危険な trajectory を狭めるか。
+```
 
-| 層 | 扱うもの | Source of truth |
+この問いに答えるため、次を明確に分けます。
+
+- Lean で証明する構造的主張。
+- tooling が artifact から観測・推定する主張。
+- 実証研究で検証する仮説。
+- 明示された theorem boundary / forecast boundary の外に残す non-conclusions。
+
+## 層の分担
+
+| 層 | 役割 | Source of truth |
 | --- | --- | --- |
-| 数学的中核 | architecture object、operation、invariant、obstruction witness、signature、theorem boundary | [AAT 数学理論](docs/aat/mathematical_theory.md) |
-| AAT / SFT 境界 | AAT の局所主張を SFT の forecast / governance 側でどう読むか | [AAT / SFT Interface](docs/sft/aat_interface.md) |
-| SFT | field model、ArtifactMediatedChange、ForecastCone、ConsequenceEnvelope、governance intervention | [ソフトウェアの場の理論](docs/sft/software_field_theory.md) |
-| Lean 形式化 | 前提を明示できる構造的命題、finite universe、lawfulness bridge、bounded theorem package | [証明義務と実証仮説](docs/aat/proof_obligations.md), [Lean 定義・定理索引](docs/aat/lean_theorem_index.md) |
-| Tooling | AIR、extractor、measured Signature、coverage / exactness metadata、Feature Extension Report、CI policy | [AAT Tooling Documentation](docs/tool/README.md) |
-| 実証仮説 | Signature と変更波及、レビューコスト、incident scope、障害修正コストとの関係 | [証明義務と実証仮説](docs/aat/proof_obligations.md), GitHub Issues |
+| AAT | architecture object、operation、invariant、obstruction witness、signature、theorem boundary を扱う局所代数。 | [AAT 数学理論](docs/aat/mathematical_theory.md) |
+| AAT / SFT Interface | AAT の局所主張を SFT の projection、observable coordinate、governance 側でどう読むかを定める境界。 | [AAT / SFT Interface](docs/sft/aat_interface.md) |
+| ArchSig / Tooling | 実 artifact から signature、witness、claim boundary、forecast evidence を抽出する観測層。 | [AAT Tooling Documentation](docs/tool/README.md) |
+| SFT | PRD、Spec、Issue、PR、review、CI、organization、AI、feedback が reachable future をどう変えるかを扱う計算理論。 | [ソフトウェアの場の理論](docs/sft/software_field_theory.md) |
+| Lean 形式化 | 前提を明示できる構造的命題、finite universe、lawfulness bridge、bounded theorem package。 | [Lean 定義・定理索引](docs/aat/lean_theorem_index.md) |
+| Proof / empirical ledger | theorem boundary、未解決 proof obligation、empirical hypothesis、Issue との対応。 | [証明義務と実証仮説](docs/aat/proof_obligations.md) |
 
 README は詳細な theorem 一覧や進捗台帳を重複して持ちません。
 現在の Lean status、non-conclusion boundary、未解決 proof obligation は
 [証明義務と実証仮説](docs/aat/proof_obligations.md) と
 [Lean 定義・定理索引](docs/aat/lean_theorem_index.md) で管理します。
 
-## 進捗の読み方
+## 読む順序
 
-- Lean status、proof obligation、empirical hypothesis:
-  [証明義務と実証仮説](docs/aat/proof_obligations.md)
-- 実装済み Lean API:
-  [Lean 定義・定理索引](docs/aat/lean_theorem_index.md)
-- module 配置と import 方針:
-  [Lean 定義・定理索引](docs/aat/lean_theorem_index.md)
-- GitHub Issue の状態、優先度、milestone:
-  GitHub Issues
+1. [研究の全体目標](docs/research_goal.md)
+2. [AAT 数学理論](docs/aat/mathematical_theory.md)
+3. [AAT / SFT Interface](docs/sft/aat_interface.md)
+4. [ソフトウェアの場の理論](docs/sft/software_field_theory.md)
+5. [証明義務と実証仮説](docs/aat/proof_obligations.md)
+6. [Lean 定義・定理索引](docs/aat/lean_theorem_index.md)
+7. [AAT Tooling Documentation](docs/tool/README.md)
+8. 必要に応じて [docs 読み方](docs/README.md),
+   [AAT directory guide](docs/aat/README.md),
+   [SFT directory guide](docs/sft/README.md)
 
-## Lean 形式化の読み方
+## AAT
+
+AAT は、ソフトウェアアーキテクチャを bounded な `ArchitectureObject` として切り出し、
+その上の操作がどの不変量を保存し、どの obstruction witness を生み、
+どの signature axis に現れるかを扱う理論です。
+
+```text
+software architecture
+  = ArchitectureObject
+  + ArchitectureOperation
+  + InvariantFamily
+  + ObstructionWitness
+  + ArchitectureSignature
+  + theorem boundary / non-conclusions
+```
+
+AAT は設計原則をスローガンではなく operation として読みます。
+SOLID、Layered / Clean Architecture、Event Sourcing、Saga、Circuit Breaker、
+Replicated Log などを万能な格言として並べるのではなく、
+それぞれがどの invariant、operation、observation、theorem boundary に関係するかを問います。
+
+## SFT
+
+SFT は、ソフトウェア進化を計算可能な対象として扱う理論です。
+コードベースは、変更を受け取って終わる静的な構造ではありません。
+PRD、Spec、Issue、PR、review、CI、organization、AI、lifecycle decision は、
+次に起こりやすい変更、見落とされやすい破れ、蓄積する制約、減衰される shortcut を作ります。
+
+SFT は AAT の局所代数を、field model の architecture projection、observable coordinate、
+local transition law、governance input として使います。
+ただし、AAT theorem はそのまま empirical forecast にはなりません。
+`ForecastCone`、`ConsequenceEnvelope`、`FieldUpdate`、AI proposal governance は、
+明示された computable core と claim boundary の下で扱います。
+
+## Tooling
+
+tooling の目標は、AAT と SFT の語彙を実際の開発 artifact に接続することです。
+ArchSig は、コードベース、PR、report、policy から観測できるものを取り出し、
+signature axis、obstruction witness、theorem boundary status、forecast boundary を
+レビューや CI が扱える evidence に変換します。
+
+ただし、tooling は理論そのものではありません。
+measured zero と unmeasured を混同せず、tool pass を Lean theorem として読みません。
+
+## Lean 形式化
 
 現在 Lean 側に存在する主要な定義・定理は
 [Lean 定義・定理索引](docs/aat/lean_theorem_index.md) を参照してください。
-
 定理名、bounded reading、non-conclusion boundary は
 [証明義務と実証仮説](docs/aat/proof_obligations.md) と
-[Lean 定義・定理索引](docs/aat/lean_theorem_index.md) で確認できます。
+[Lean 定義・定理索引](docs/aat/lean_theorem_index.md) で管理します。
 
 アーキテクチャ零曲率定理の static structural core は Lean で証明済みですが、
 runtime metrics、empirical hypotheses、一般数値 curvature、実コード extractor の完全性は
-この QED には含めません。詳細な theorem 名と境界は
-[証明義務と実証仮説](docs/aat/proof_obligations.md) と
-[Lean 定義・定理索引](docs/aat/lean_theorem_index.md) を参照してください。
-
-## 詳細ドキュメント
-
-- [docs 読み方](docs/README.md)
-- [研究の全体目標](docs/research_goal.md)
-- [AAT 数学理論](docs/aat/mathematical_theory.md)
-- [AAT / SFT Interface](docs/sft/aat_interface.md)
-- [ソフトウェアの場の理論](docs/sft/software_field_theory.md)
-- [証明義務と実証仮説](docs/aat/proof_obligations.md)
-- [Lean 定義・定理索引](docs/aat/lean_theorem_index.md)
-- [AAT Tooling Documentation](docs/tool/README.md)
+この QED には含めません。
 
 ## リポジトリ構成
 
 - `Formal.lean`
   - Lean ライブラリの public entry point。
 - `Formal/Arch`
-  - `Core`, `Law`, `Signature`, `Extension`, `Operation`, `Patterns`, `Repair`, `Evolution`, `Examples` に分けた Lean 形式化。
+  - `Core`, `Law`, `Signature`, `Extension`, `Operation`, `Patterns`, `Repair`, `Evolution`, `Examples`
+    に分けた Lean 形式化。
   - 主要な定義・定理と module path は [Lean 定義・定理索引](docs/aat/lean_theorem_index.md) を参照。
 - `docs`
   - 第一級理論文書、Lean status、proof obligations、tool docs、empirical protocol。
+- `docs/aat`
+  - AAT の数学理論、proof obligations、Lean theorem index。
+- `docs/sft`
+  - AAT / SFT interface と SFT 本文。
+- `docs/tool`
+  - AIR、extractor、report、claim boundary、workflow、schema compatibility。
 - `Main.lean`
   - 実行ターゲット `aatv2` の最小 entry point。
 - `lakefile.toml`
@@ -115,10 +172,12 @@ Algebraic Architecture Theory V2
 - Lean ソースに `axiom`, `admit`, `sorry`, `unsafe` を導入しない。
 - 未証明の主張は `docs/aat/proof_obligations.md` または GitHub Issues に明示する。
 - Lean で証明済みの主張、定義のみの概念、将来の証明義務、実証仮説を混同しない。
-- `proof_obligations.md` は GitHub Issues への索引としても使う。
+- AAT theorem、tooling output、SFT forecast、empirical hypothesis を同一視しない。
+- `docs/aat/proof_obligations.md` は GitHub Issues への索引としても使う。
 
 ## タスク管理
 
-未解決課題は GitHub Issues で管理します。Issue は研究の依存構造に沿って milestone と
+未解決課題は GitHub Issues で管理します。
+Issue は研究の依存構造に沿って milestone と
 `type:*`, `area:*`, `priority:*`, `status:*` label で整理します。
 README には Issue 一覧を重複して持たせません。


### PR DESCRIPTION
## 概要

README を AAT 単独の入口から、AAT / ArchSig / SFT 全体の入口として読める内容に更新しました。
対応 Issue はありません。README の現状反映を目的とした小規模なドキュメント更新です。

## 証明した定理

- なし

## 編集したドキュメント

- `README.md`

## 実施したテスト

- [ ] `lake build`（README のみの更新で Lean source / import に影響しないため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（README 内の運用ポリシー文のみ該当）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対応 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
