### PR TITLE
B12.1 ArtifactDescriptor schema を追加する

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -17,7 +17,8 @@ PR comment、dataset generation などの後段 command に渡せる。
 - Sig0 output を validation し、revision snapshot と before / after diff を作る。
 - PR metadata、AIR、theorem precondition check、Feature Extension Report、policy decision、
   PR comment summary を生成する。
-- 実証研究用 dataset と B10 operational feedback artifact を JSON として出力する。
+- 実証研究用 dataset、B10 operational feedback artifact、B12 SFT forecasting input
+  descriptor を JSON として出力する。
 
 詳細な command と artifact は次に分けている。
 
@@ -91,6 +92,7 @@ scan
 | `feature-extension-report-v0` | split status、witness、coverage gap、theorem precondition checks。 |
 | `policy-decision-report-v0` | organization policy に基づく pass / warn / fail / advisory decision。 |
 | `pr-comment-summary-v0` | GitHub Checks / PR comment 向け Markdown summary。 |
+| `artifact-descriptor-v0` | PRD / Spec / Issue / AI proposal を SFT forecasting MVP の入力境界へ正規化する。 |
 
 [Signature diff report workflow](../../.github/workflows/signature-diff.yml) は、PR / push /
 schedule / manual run で Sig0、validation、snapshot、`signature-diff-report-v0` を作り、

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -55,6 +55,18 @@ Lean status: `empirical hypothesis` / tooling output.
 | Incident correlation monitor | `incident-correlation-monitor-v0` | incident / rollback / MTTR correlation、confounder、missing / private data boundary を保存する。 |
 | Hypothesis refresh cycle | `hypothesis-refresh-cycle-v0` | empirical hypothesis の retained / rejected / proposed update を versioned research tracking として保存する。 |
 
+## SFT Forecasting Input Artifacts
+
+| 出力 | schemaVersion | 用途 |
+| --- | --- | --- |
+| ArtifactDescriptor | `artifact-descriptor-v0` | PRD / Spec / Issue / AI proposal の source refs、action class candidates、scope、missing evidence、measurement boundary、forecast non-conclusions を保持する。 |
+| ArtifactDescriptor validation report | `artifact-descriptor-validation-report-v0` | descriptor が theorem claim、ground truth architecture object、causal forecast に昇格していないことを検査する。 |
+
+`artifact-descriptor-v0` は B12 SFT forecasting MVP の最初の入力正規化 artifact である。
+この段階では operation support estimate、ForecastCone、ConsequenceEnvelope、
+probability、causal prediction は生成しない。missing evidence、unsupported constructs、
+forecast non-conclusions は後段 artifact に引き継ぐ境界として読む。
+
 ## Measurement Boundary
 
 `archsig` は測定済み 0 と未評価を分ける。

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -211,6 +211,23 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- architecture-dynamics-metr
   --out .lake/signature-current/architecture-dynamics-metrics-validation.json
 ```
 
+B12 ArtifactDescriptor の canonical fixture を出力し、既存 descriptor を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- artifact-descriptor \
+  --fixture \
+  --out .lake/signature-current/artifact-descriptor.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- artifact-descriptor \
+  --input tools/archsig/tests/fixtures/minimal/artifact_descriptor.json \
+  --out .lake/signature-current/artifact-descriptor-validation.json
+```
+
+`artifact-descriptor-v0` は PRD / Spec / Issue / AI proposal を source refs、
+action class candidates、scope、missing evidence、measurement boundary、
+forecast non-conclusions に正規化する。operation support、ForecastCone、probability、
+causal forecast はこの command では生成しない。
+
 B5 repair / synthesis artifact を検査する。
 
 ```bash

--- a/tools/archsig/src/artifact_descriptor.rs
+++ b/tools/archsig/src/artifact_descriptor.rs
@@ -1,0 +1,573 @@
+use std::collections::BTreeSet;
+
+use crate::validation::{count_checks, generic_validation_example, validation_check};
+use crate::{
+    ARTIFACT_DESCRIPTOR_SCHEMA_VERSION, ARTIFACT_DESCRIPTOR_VALIDATION_REPORT_SCHEMA_VERSION,
+    ArtifactActionClassCandidateV0, ArtifactDescriptorMeasurementBoundaryV0,
+    ArtifactDescriptorMissingEvidenceV0, ArtifactDescriptorScopeV0, ArtifactDescriptorSourceRefV0,
+    ArtifactDescriptorV0, ArtifactDescriptorValidationInput, ArtifactDescriptorValidationReportV0,
+    ArtifactDescriptorValidationSummary, ValidationCheck,
+};
+
+const REQUIRED_NON_CONCLUSIONS: [&str; 5] = [
+    "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+    "artifact descriptor is not a ground truth architecture object",
+    "artifact descriptor does not provide a causal forecast",
+    "missing evidence and unsupported constructs are not measured zero",
+    "forecast non-conclusions must be preserved by downstream SFT artifacts",
+];
+
+const REQUIRED_FORECAST_NON_CONCLUSIONS: [&str; 4] = [
+    "descriptor action classes are candidates, not forecasted effects",
+    "descriptor scope does not prove operation support completeness",
+    "descriptor boundary does not assign probability to future outcomes",
+    "descriptor evidence does not establish causal prediction",
+];
+
+const ALLOWED_ARTIFACT_KINDS: [&str; 4] = ["prd", "spec", "issue", "ai-proposal"];
+const ALLOWED_MISSING_EVIDENCE_STATUSES: [&str; 4] =
+    ["missing", "private", "unmeasured", "outOfScope"];
+
+pub fn static_artifact_descriptor() -> ArtifactDescriptorV0 {
+    let issue_ref = source_ref(
+        "source:issue-733",
+        "issue",
+        "https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/733",
+        Some("GitHub Issue #733"),
+        "primary artifact request",
+        &[
+            "title",
+            "body",
+            "completion criteria",
+            "Lean status",
+            "related docs",
+        ],
+    );
+    let roadmap_ref = source_ref(
+        "source:roadmap-b12",
+        "doc",
+        "docs/tool/roadmap.md#phase-b12-sft-forecasting-mvp",
+        Some("Phase B12 / B12.1"),
+        "forecasting MVP boundary",
+        &["pipeline", "minimal output", "B12.1 milestone"],
+    );
+    let sft_ref = source_ref(
+        "source:sft-computational-problems",
+        "doc",
+        "docs/sft/software_field_theory.md#20-sft-computational-problems",
+        Some("SFT Computational Problems"),
+        "theory boundary",
+        &[
+            "ArtifactDescriptor role",
+            "ConsequenceEnvelope simulator boundary",
+            "non-conclusions",
+        ],
+    );
+    let source_refs = vec![issue_ref.clone(), roadmap_ref.clone(), sft_ref.clone()];
+    let missing_evidence = vec![
+        missing_evidence(
+            "missing:prd-body",
+            "prd",
+            "fixture has no full PRD body",
+            "operation support cannot be treated as complete",
+            "missing",
+        ),
+        missing_evidence(
+            "missing:runtime-impact",
+            "runtime-evidence",
+            "runtime traces are outside B12.1 descriptor normalization",
+            "runtime propagation remains a downstream boundary item",
+            "unmeasured",
+        ),
+    ];
+    let source_ref_ids = source_refs
+        .iter()
+        .map(|source| source.source_ref_id.clone())
+        .collect::<Vec<_>>();
+    let selected_region_refs = vec![
+        "tools/archsig".to_string(),
+        "docs/tool/roadmap.md#phase-b12-sft-forecasting-mvp".to_string(),
+        "docs/sft/software_field_theory.md#21-prd-to-consequenceenvelope-simulator".to_string(),
+    ];
+
+    ArtifactDescriptorV0 {
+        schema_version: ARTIFACT_DESCRIPTOR_SCHEMA_VERSION.to_string(),
+        descriptor_id: "fixture-artifact-descriptor-v0".to_string(),
+        artifact_kind: "issue".to_string(),
+        artifact_title: "B12.1 ArtifactDescriptor schema".to_string(),
+        source_refs,
+        action_class_candidates: vec![
+            action_candidate(
+                "candidate:add-schema",
+                "schema-definition",
+                "high",
+                &["source:issue-733", "source:roadmap-b12"],
+                "Issue requests a Rust schema for artifact-descriptor-v0.",
+            ),
+            action_candidate(
+                "candidate:add-validator",
+                "tooling-validation",
+                "high",
+                &["source:issue-733"],
+                "Issue requires a canonical fixture and validator.",
+            ),
+            action_candidate(
+                "candidate:add-cli-entrypoint",
+                "cli-entrypoint",
+                "medium",
+                &["source:issue-733"],
+                "Issue names an archsig artifact-descriptor entrypoint.",
+            ),
+        ],
+        scope: ArtifactDescriptorScopeV0 {
+            scope_id: "scope:b12.1-artifact-descriptor".to_string(),
+            selected_region_refs: selected_region_refs.clone(),
+            excluded_region_refs: vec![
+                "operation-support-estimate".to_string(),
+                "forecast-cone-probability".to_string(),
+                "causal-outcome-prediction".to_string(),
+            ],
+            target_audience: vec![
+                "archsig-cli".to_string(),
+                "sft-forecaster-pipeline".to_string(),
+                "review-ci".to_string(),
+            ],
+            artifact_boundary:
+                "normalizes PRD / Spec / Issue / AI proposal input before operation support"
+                    .to_string(),
+            assumptions: vec![
+                "source refs are retained as bounded tooling evidence".to_string(),
+                "action class candidates are used only as downstream estimation input".to_string(),
+            ],
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        },
+        missing_evidence,
+        measurement_boundary: ArtifactDescriptorMeasurementBoundaryV0 {
+            boundary_id: "boundary:b12.1-artifact-descriptor".to_string(),
+            measured_layers: vec!["artifact-normalization".to_string()],
+            measured_axes: vec![
+                "sourceRefs".to_string(),
+                "actionClassCandidates".to_string(),
+                "scope".to_string(),
+                "missingEvidence".to_string(),
+                "forecastNonConclusions".to_string(),
+            ],
+            source_ref_ids,
+            selected_region_refs,
+            assumptions: vec![
+                "descriptor validation checks structure and boundary preservation only".to_string(),
+                "descriptor validation does not run a repository extractor".to_string(),
+            ],
+            unsupported_constructs: vec![
+                "operation support probability".to_string(),
+                "ground truth architecture reconstruction".to_string(),
+                "future outcome causality".to_string(),
+            ],
+            missing_evidence_ids: vec![
+                "missing:prd-body".to_string(),
+                "missing:runtime-impact".to_string(),
+            ],
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        },
+        forecast_non_conclusions: strings(&REQUIRED_FORECAST_NON_CONCLUSIONS),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+pub fn validate_artifact_descriptor_report(
+    descriptor: &ArtifactDescriptorV0,
+    input_path: &str,
+) -> ArtifactDescriptorValidationReportV0 {
+    let checks = vec![
+        check_schema_version(descriptor),
+        check_identity(descriptor),
+        check_source_refs(descriptor),
+        check_action_candidates(descriptor),
+        check_scope_and_boundary(descriptor),
+        check_missing_evidence(descriptor),
+        check_non_conclusions(descriptor),
+    ];
+    let summary = ArtifactDescriptorValidationSummary {
+        result: validation_result(&checks),
+        source_ref_count: descriptor.source_refs.len(),
+        action_class_candidate_count: descriptor.action_class_candidates.len(),
+        missing_evidence_count: descriptor.missing_evidence.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    ArtifactDescriptorValidationReportV0 {
+        schema_version: ARTIFACT_DESCRIPTOR_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: ArtifactDescriptorValidationInput {
+            schema_version: descriptor.schema_version.clone(),
+            path: input_path.to_string(),
+            descriptor_id: descriptor.descriptor_id.clone(),
+            artifact_kind: descriptor.artifact_kind.clone(),
+        },
+        descriptor: descriptor.clone(),
+        summary,
+        checks,
+    }
+}
+
+fn source_ref(
+    source_ref_id: &str,
+    source_kind: &str,
+    path_or_url: &str,
+    stable_ref: Option<&str>,
+    evidence_role: &str,
+    retained_fields: &[&str],
+) -> ArtifactDescriptorSourceRefV0 {
+    ArtifactDescriptorSourceRefV0 {
+        source_ref_id: source_ref_id.to_string(),
+        source_kind: source_kind.to_string(),
+        path_or_url: path_or_url.to_string(),
+        stable_ref: stable_ref.map(str::to_string),
+        evidence_role: evidence_role.to_string(),
+        retained_fields: strings(retained_fields),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn action_candidate(
+    candidate_id: &str,
+    action_class: &str,
+    confidence: &str,
+    source_ref_ids: &[&str],
+    rationale: &str,
+) -> ArtifactActionClassCandidateV0 {
+    ArtifactActionClassCandidateV0 {
+        candidate_id: candidate_id.to_string(),
+        action_class: action_class.to_string(),
+        confidence: confidence.to_string(),
+        source_ref_ids: strings(source_ref_ids),
+        rationale: rationale.to_string(),
+        assumptions: vec![
+            "candidate was inferred from selected source refs only".to_string(),
+            "candidate does not imply an operation support estimate".to_string(),
+        ],
+        non_conclusions: strings(&REQUIRED_FORECAST_NON_CONCLUSIONS),
+    }
+}
+
+fn missing_evidence(
+    evidence_id: &str,
+    evidence_kind: &str,
+    reason: &str,
+    effect: &str,
+    status: &str,
+) -> ArtifactDescriptorMissingEvidenceV0 {
+    ArtifactDescriptorMissingEvidenceV0 {
+        evidence_id: evidence_id.to_string(),
+        evidence_kind: evidence_kind.to_string(),
+        reason: reason.to_string(),
+        effect: effect.to_string(),
+        status: status.to_string(),
+        non_conclusions: vec![
+            REQUIRED_NON_CONCLUSIONS[3].to_string(),
+            "missing descriptor evidence remains a downstream forecast boundary item".to_string(),
+        ],
+    }
+}
+
+fn check_schema_version(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let mut check = validation_check(
+        "artifact-descriptor-schema-version-supported",
+        "artifact descriptor schema version is supported",
+        if descriptor.schema_version == ARTIFACT_DESCRIPTOR_SCHEMA_VERSION {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!(
+            "unsupported artifact descriptor schemaVersion: {}",
+            descriptor.schema_version
+        ));
+    }
+    check
+}
+
+fn check_identity(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let invalid = [
+        ("descriptorId", descriptor.descriptor_id.trim().is_empty()),
+        ("artifactKind", descriptor.artifact_kind.trim().is_empty()),
+        ("artifactTitle", descriptor.artifact_title.trim().is_empty()),
+    ]
+    .into_iter()
+    .filter_map(|(field, missing)| missing.then_some(field))
+    .collect::<Vec<_>>();
+    let unsupported_kind = !ALLOWED_ARTIFACT_KINDS.contains(&descriptor.artifact_kind.as_str());
+    let mut check = validation_check(
+        "artifact-descriptor-identity-present",
+        "descriptor identity fields and artifact kind are valid",
+        if invalid.is_empty() && !unsupported_kind {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "missing required identity fields: {}",
+            invalid.join(", ")
+        ));
+    } else if unsupported_kind {
+        check.reason = Some(format!(
+            "unsupported artifactKind `{}`; expected one of {}",
+            descriptor.artifact_kind,
+            ALLOWED_ARTIFACT_KINDS.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_source_refs(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let mut missing = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut duplicates = Vec::new();
+    for source in &descriptor.source_refs {
+        if source.source_ref_id.trim().is_empty()
+            || source.source_kind.trim().is_empty()
+            || source.path_or_url.trim().is_empty()
+            || source.evidence_role.trim().is_empty()
+            || source.retained_fields.is_empty()
+        {
+            missing.push(source.source_ref_id.clone());
+        }
+        if !seen.insert(source.source_ref_id.as_str()) {
+            duplicates.push(source.source_ref_id.clone());
+        }
+    }
+    let mut check = validation_check(
+        "artifact-descriptor-source-refs-retained",
+        "source refs preserve source kind, location, role, and retained fields",
+        if !descriptor.source_refs.is_empty() && missing.is_empty() && duplicates.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if descriptor.source_refs.is_empty() {
+        check.reason = Some("at least one source ref is required".to_string());
+    } else if !missing.is_empty() {
+        check.reason = Some(format!(
+            "source refs with missing metadata: {}",
+            missing.join(", ")
+        ));
+    } else if !duplicates.is_empty() {
+        check.reason = Some(format!(
+            "duplicate sourceRefId values: {}",
+            duplicates.join(", ")
+        ));
+    }
+    check.count = Some(descriptor.source_refs.len());
+    check
+}
+
+fn check_action_candidates(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let source_ids = descriptor
+        .source_refs
+        .iter()
+        .map(|source| source.source_ref_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let invalid = descriptor
+        .action_class_candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.candidate_id.trim().is_empty()
+                || candidate.action_class.trim().is_empty()
+                || candidate.confidence.trim().is_empty()
+                || candidate.source_ref_ids.is_empty()
+                || candidate
+                    .source_ref_ids
+                    .iter()
+                    .any(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+        })
+        .map(|candidate| candidate.candidate_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "artifact-descriptor-action-candidates-bounded",
+        "action class candidates are non-empty and point to retained source refs",
+        if !descriptor.action_class_candidates.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if descriptor.action_class_candidates.is_empty() {
+        check.reason = Some("at least one action class candidate is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "action candidates with missing fields or dangling source refs: {}",
+            invalid.join(", ")
+        ));
+    }
+    check.count = Some(descriptor.action_class_candidates.len());
+    check
+}
+
+fn check_scope_and_boundary(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let source_ids = descriptor
+        .source_refs
+        .iter()
+        .map(|source| source.source_ref_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let missing_ids = descriptor
+        .missing_evidence
+        .iter()
+        .map(|evidence| evidence.evidence_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let boundary = &descriptor.measurement_boundary;
+    let dangling_source_refs = boundary
+        .source_ref_ids
+        .iter()
+        .filter(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let dangling_missing_evidence = boundary
+        .missing_evidence_ids
+        .iter()
+        .filter(|evidence_id| !missing_ids.contains(evidence_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let scope_invalid = descriptor.scope.scope_id.trim().is_empty()
+        || descriptor.scope.selected_region_refs.is_empty()
+        || descriptor.scope.artifact_boundary.trim().is_empty();
+    let boundary_invalid = boundary.boundary_id.trim().is_empty()
+        || boundary.measured_layers.is_empty()
+        || boundary.measured_axes.is_empty()
+        || boundary.source_ref_ids.is_empty()
+        || boundary.assumptions.is_empty();
+    let mut check = validation_check(
+        "artifact-descriptor-scope-and-measurement-boundary",
+        "scope and measurement boundary retain selected regions, source refs, and missing evidence refs",
+        if !scope_invalid
+            && !boundary_invalid
+            && dangling_source_refs.is_empty()
+            && dangling_missing_evidence.is_empty()
+        {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if scope_invalid {
+        check.reason = Some(
+            "scope must include scopeId, selectedRegionRefs, and artifactBoundary".to_string(),
+        );
+    } else if boundary_invalid {
+        check.reason = Some(
+            "measurement boundary must include id, layers, axes, source refs, and assumptions"
+                .to_string(),
+        );
+    } else if !dangling_source_refs.is_empty() {
+        check.reason = Some(format!(
+            "measurement boundary references unknown source refs: {}",
+            dangling_source_refs.join(", ")
+        ));
+    } else if !dangling_missing_evidence.is_empty() {
+        check.reason = Some(format!(
+            "measurement boundary references unknown missing evidence ids: {}",
+            dangling_missing_evidence.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_missing_evidence(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let invalid = descriptor
+        .missing_evidence
+        .iter()
+        .filter(|evidence| {
+            evidence.evidence_id.trim().is_empty()
+                || evidence.evidence_kind.trim().is_empty()
+                || evidence.reason.trim().is_empty()
+                || evidence.effect.trim().is_empty()
+                || !ALLOWED_MISSING_EVIDENCE_STATUSES.contains(&evidence.status.as_str())
+        })
+        .map(|evidence| evidence.evidence_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "artifact-descriptor-missing-evidence-status",
+        "missing evidence keeps explicit non-zero statuses",
+        if invalid.is_empty() { "pass" } else { "fail" },
+    );
+    if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "missing evidence entries with invalid metadata or status: {}",
+            invalid.join(", ")
+        ));
+        check.examples = invalid
+            .iter()
+            .map(|evidence_id| {
+                generic_validation_example(
+                    evidence_id,
+                    "missingEvidence.status",
+                    "expected missing/private/unmeasured/outOfScope",
+                )
+            })
+            .collect();
+    }
+    check.count = Some(descriptor.missing_evidence.len());
+    check
+}
+
+fn check_non_conclusions(descriptor: &ArtifactDescriptorV0) -> ValidationCheck {
+    let missing_descriptor = REQUIRED_NON_CONCLUSIONS
+        .iter()
+        .filter(|required| {
+            !descriptor
+                .non_conclusions
+                .iter()
+                .any(|actual| actual == *required)
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    let missing_forecast = REQUIRED_FORECAST_NON_CONCLUSIONS
+        .iter()
+        .filter(|required| {
+            !descriptor
+                .forecast_non_conclusions
+                .iter()
+                .any(|actual| actual == *required)
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "artifact-descriptor-non-conclusions-preserved",
+        "descriptor and forecast non-conclusions preserve theorem, ground-truth, and causal boundaries",
+        if missing_descriptor.is_empty() && missing_forecast.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !missing_descriptor.is_empty() {
+        check.reason = Some(format!(
+            "missing descriptor non-conclusions: {}",
+            missing_descriptor.join("; ")
+        ));
+    } else if !missing_forecast.is_empty() {
+        check.reason = Some(format!(
+            "missing forecast non-conclusions: {}",
+            missing_forecast.join("; ")
+        ));
+    }
+    check
+}
+
+fn validation_result(checks: &[ValidationCheck]) -> String {
+    if checks.iter().any(|check| check.result == "fail") {
+        "fail".to_string()
+    } else if checks.iter().any(|check| check.result == "warn") {
+        "warn".to_string()
+    } else {
+        "pass".to_string()
+    }
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -2,6 +2,7 @@ mod air;
 mod air_validation;
 mod architecture_dynamics_metrics;
 mod architecture_field;
+mod artifact_descriptor;
 mod artifact_retention;
 mod baseline_suppression;
 mod component_validation;
@@ -52,6 +53,7 @@ pub use architecture_field::{
     static_architecture_field_snapshot, static_operation_proposal_log,
     validate_architecture_field_snapshot, validate_operation_proposal_log,
 };
+pub use artifact_descriptor::{static_artifact_descriptor, validate_artifact_descriptor_report};
 pub use artifact_retention::{
     static_report_artifact_retention_manifest, validate_report_artifact_retention_report,
 };

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -7,7 +7,8 @@ use std::process::ExitCode;
 use archsig::{
     AirDocumentInput, AirDocumentV0, AirValidationReport, ArchitectureDynamicsMetricsReportV0,
     ArchitectureDynamicsMetricsReportValidationReportV0, ArchitectureFieldSnapshotV0,
-    ArchitectureFieldSnapshotValidationReportV0, CalibrationReviewRecordV0,
+    ArchitectureFieldSnapshotValidationReportV0, ArtifactDescriptorV0,
+    ArtifactDescriptorValidationReportV0, CalibrationReviewRecordV0,
     ComponentUniverseValidationReport, CustomRulePluginRegistryV0,
     CustomRulePluginRegistryValidationReportV0, DEFAULT_UNIVERSE_MODE,
     DetectableValuesReportedAxesCatalogV0, DriftLedgerAggregationWindowV0,
@@ -36,17 +37,18 @@ use archsig::{
     build_theorem_precondition_check_report, extract_python_sig0,
     extract_relation_complexity_observation_from_file, extract_sig0_with_runtime,
     render_pr_comment_markdown, static_architecture_dynamics_metrics_report,
-    static_architecture_field_snapshot, static_calibration_review_record,
-    static_custom_rule_plugin_registry, static_detectable_values_reported_axes_catalog,
-    static_dynamics_measurement_contract, static_hypothesis_refresh_cycle,
-    static_incident_correlation_monitor, static_law_policy_template_registry,
-    static_measurement_unit_registry, static_no_solution_certificate,
-    static_operation_proposal_log, static_organization_policy, static_ownership_boundary_monitor,
-    static_pr_force_report, static_repair_adoption_record, static_repair_rule_registry,
-    static_report_artifact_retention_manifest, static_schema_version_catalog,
-    static_signature_trajectory_report, static_synthesis_constraint_artifact,
-    static_team_threshold_policy, validate_air_document_report,
-    validate_architecture_dynamics_metrics_report, validate_architecture_field_snapshot,
+    static_architecture_field_snapshot, static_artifact_descriptor,
+    static_calibration_review_record, static_custom_rule_plugin_registry,
+    static_detectable_values_reported_axes_catalog, static_dynamics_measurement_contract,
+    static_hypothesis_refresh_cycle, static_incident_correlation_monitor,
+    static_law_policy_template_registry, static_measurement_unit_registry,
+    static_no_solution_certificate, static_operation_proposal_log, static_organization_policy,
+    static_ownership_boundary_monitor, static_pr_force_report, static_repair_adoption_record,
+    static_repair_rule_registry, static_report_artifact_retention_manifest,
+    static_schema_version_catalog, static_signature_trajectory_report,
+    static_synthesis_constraint_artifact, static_team_threshold_policy,
+    validate_air_document_report, validate_architecture_dynamics_metrics_report,
+    validate_architecture_field_snapshot, validate_artifact_descriptor_report,
     validate_component_universe_report, validate_custom_rule_plugin_registry_report,
     validate_dynamics_measurement_contract_report, validate_law_policy_template_registry_report,
     validate_measurement_unit_registry_report, validate_no_solution_certificate_report,
@@ -660,6 +662,21 @@ enum Command {
         fixture: bool,
 
         /// Output proposal log or validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Emit or validate an artifact-descriptor-v0 artifact.
+    ArtifactDescriptor {
+        /// Optional ArtifactDescriptor JSON path to validate.
+        #[arg(long)]
+        input: Option<PathBuf>,
+
+        /// Emit the canonical minimal artifact-descriptor-v0 fixture.
+        #[arg(long)]
+        fixture: bool,
+
+        /// Output descriptor or validation report JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
     },
@@ -1408,6 +1425,35 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 .unwrap_or_else(|| "static-operation-proposal-log".to_string());
             let validation: OperationProposalLogValidationReportV0 =
                 validate_operation_proposal_log(&log, &input_path);
+            let failed = validation.summary.result == "fail";
+            write_json(out, &validation)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::ArtifactDescriptor {
+            input,
+            fixture,
+            out,
+        }) => {
+            if fixture {
+                let descriptor: ArtifactDescriptorV0 = static_artifact_descriptor();
+                write_json(out, &descriptor)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            let descriptor: ArtifactDescriptorV0 = input
+                .as_ref()
+                .map(read_json)
+                .transpose()?
+                .unwrap_or_else(static_artifact_descriptor);
+            let input_path = input
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "static-artifact-descriptor".to_string());
+            let validation: ArtifactDescriptorValidationReportV0 =
+                validate_artifact_descriptor_report(&descriptor, &input_path);
             let failed = validation.summary.result == "fail";
             write_json(out, &validation)?;
             Ok(if failed {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -80,6 +80,9 @@ pub const OWNERSHIP_BOUNDARY_MONITOR_SCHEMA_VERSION: &str = "ownership-boundary-
 pub const REPAIR_ADOPTION_RECORD_SCHEMA_VERSION: &str = "repair-adoption-record-v0";
 pub const INCIDENT_CORRELATION_MONITOR_SCHEMA_VERSION: &str = "incident-correlation-monitor-v0";
 pub const HYPOTHESIS_REFRESH_CYCLE_SCHEMA_VERSION: &str = "hypothesis-refresh-cycle-v0";
+pub const ARTIFACT_DESCRIPTOR_SCHEMA_VERSION: &str = "artifact-descriptor-v0";
+pub const ARTIFACT_DESCRIPTOR_VALIDATION_REPORT_SCHEMA_VERSION: &str =
+    "artifact-descriptor-validation-report-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const FRAMEWORK_ADAPTER_EVIDENCE_SCHEMA_VERSION: &str = "framework-adapter-evidence-v0";
@@ -3659,6 +3662,114 @@ pub struct OperationProposalLogValidationSummary {
     pub result: String,
     pub proposal_count: usize,
     pub source_ref_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorV0 {
+    pub schema_version: String,
+    pub descriptor_id: String,
+    pub artifact_kind: String,
+    pub artifact_title: String,
+    pub source_refs: Vec<ArtifactDescriptorSourceRefV0>,
+    pub action_class_candidates: Vec<ArtifactActionClassCandidateV0>,
+    pub scope: ArtifactDescriptorScopeV0,
+    pub missing_evidence: Vec<ArtifactDescriptorMissingEvidenceV0>,
+    pub measurement_boundary: ArtifactDescriptorMeasurementBoundaryV0,
+    pub forecast_non_conclusions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorSourceRefV0 {
+    pub source_ref_id: String,
+    pub source_kind: String,
+    pub path_or_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stable_ref: Option<String>,
+    pub evidence_role: String,
+    pub retained_fields: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactActionClassCandidateV0 {
+    pub candidate_id: String,
+    pub action_class: String,
+    pub confidence: String,
+    pub source_ref_ids: Vec<String>,
+    pub rationale: String,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorScopeV0 {
+    pub scope_id: String,
+    pub selected_region_refs: Vec<String>,
+    pub excluded_region_refs: Vec<String>,
+    pub target_audience: Vec<String>,
+    pub artifact_boundary: String,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorMissingEvidenceV0 {
+    pub evidence_id: String,
+    pub evidence_kind: String,
+    pub reason: String,
+    pub effect: String,
+    pub status: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorMeasurementBoundaryV0 {
+    pub boundary_id: String,
+    pub measured_layers: Vec<String>,
+    pub measured_axes: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub selected_region_refs: Vec<String>,
+    pub assumptions: Vec<String>,
+    pub unsupported_constructs: Vec<String>,
+    pub missing_evidence_ids: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorValidationReportV0 {
+    pub schema_version: String,
+    pub input: ArtifactDescriptorValidationInput,
+    pub descriptor: ArtifactDescriptorV0,
+    pub summary: ArtifactDescriptorValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub descriptor_id: String,
+    pub artifact_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactDescriptorValidationSummary {
+    pub result: String,
+    pub source_ref_count: usize,
+    pub action_class_candidate_count: usize,
+    pub missing_evidence_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -6765,6 +6765,127 @@ fn cli_report_artifacts_validates_static_manifest_and_input_fixture() {
 }
 
 #[test]
+fn cli_artifact_descriptor_emits_fixture_and_validates_boundaries() {
+    let root = fixture_root();
+    let out_dir = temp_dir("artifact-descriptor");
+    let static_validation = out_dir.join("artifact-descriptor-static-validation.json");
+    let fixture_artifact = out_dir.join("artifact-descriptor-fixture.json");
+    let fixture_validation = out_dir.join("artifact-descriptor-validation.json");
+    let invalid_descriptor = out_dir.join("artifact-descriptor-invalid.json");
+    let invalid_validation = out_dir.join("artifact-descriptor-invalid-validation.json");
+
+    run_sig0(&[
+        "artifact-descriptor",
+        "--out",
+        static_validation
+            .to_str()
+            .expect("static validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "artifact-descriptor",
+        "--fixture",
+        "--out",
+        fixture_artifact.to_str().expect("fixture path is utf-8"),
+    ]);
+    run_sig0(&[
+        "artifact-descriptor",
+        "--input",
+        root.join("artifact_descriptor.json")
+            .to_str()
+            .expect("fixture input path is utf-8"),
+        "--out",
+        fixture_validation
+            .to_str()
+            .expect("fixture validation path is utf-8"),
+    ]);
+
+    let static_json = read_json(&static_validation);
+    assert_eq!(
+        static_json["schemaVersion"],
+        "artifact-descriptor-validation-report-v0"
+    );
+    assert_eq!(static_json["summary"]["result"], "pass");
+    assert_eq!(static_json["summary"]["actionClassCandidateCount"], 3);
+    assert!(
+        static_json["descriptor"]["nonConclusions"]
+            .as_array()
+            .expect("nonConclusions is array")
+            .iter()
+            .any(|conclusion| {
+                conclusion == "artifact descriptor does not provide a causal forecast"
+            })
+    );
+
+    let artifact = read_json(&fixture_artifact);
+    assert_eq!(artifact["schemaVersion"], "artifact-descriptor-v0");
+    assert_eq!(artifact["artifactKind"], "issue");
+    assert!(
+        artifact["actionClassCandidates"]
+            .as_array()
+            .expect("actionClassCandidates is array")
+            .iter()
+            .any(|candidate| candidate["actionClass"] == "tooling-validation")
+    );
+    assert!(
+        artifact["forecastNonConclusions"]
+            .as_array()
+            .expect("forecastNonConclusions is array")
+            .iter()
+            .any(|conclusion| {
+                conclusion == "descriptor boundary does not assign probability to future outcomes"
+            })
+    );
+
+    let validation = read_json(&fixture_validation);
+    assert_eq!(validation["summary"]["result"], "pass");
+    assert!(
+        validation["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| {
+                check["id"] == "artifact-descriptor-scope-and-measurement-boundary"
+                    && check["result"] == "pass"
+            })
+    );
+
+    let mut invalid = artifact;
+    invalid["forecastNonConclusions"] = serde_json::json!([]);
+    fs::write(
+        &invalid_descriptor,
+        serde_json::to_string_pretty(&invalid).expect("invalid descriptor serializes"),
+    )
+    .expect("invalid descriptor is written");
+    let output = run_sig0_output(&[
+        "artifact-descriptor",
+        "--input",
+        invalid_descriptor
+            .to_str()
+            .expect("invalid descriptor path is utf-8"),
+        "--out",
+        invalid_validation
+            .to_str()
+            .expect("invalid validation path is utf-8"),
+    ]);
+    assert!(
+        !output.status.success(),
+        "missing forecast non-conclusions should fail validation"
+    );
+    let invalid_report = read_json(&invalid_validation);
+    assert_eq!(invalid_report["summary"]["result"], "fail");
+    assert!(
+        invalid_report["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| {
+                check["id"] == "artifact-descriptor-non-conclusions-preserved"
+                    && check["result"] == "fail"
+            })
+    );
+}
+
+#[test]
 fn cli_baseline_suppression_reports_deltas_without_resolving_suppressed_witnesses() {
     let fixture = fixture_root();
     let air = air_fixture_root();

--- a/tools/archsig/tests/fixtures/minimal/artifact_descriptor.json
+++ b/tools/archsig/tests/fixtures/minimal/artifact_descriptor.json
@@ -1,0 +1,237 @@
+{
+  "schemaVersion": "artifact-descriptor-v0",
+  "descriptorId": "fixture-artifact-descriptor-v0",
+  "artifactKind": "issue",
+  "artifactTitle": "B12.1 ArtifactDescriptor schema",
+  "sourceRefs": [
+    {
+      "sourceRefId": "source:issue-733",
+      "sourceKind": "issue",
+      "pathOrUrl": "https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/733",
+      "stableRef": "GitHub Issue #733",
+      "evidenceRole": "primary artifact request",
+      "retainedFields": [
+        "title",
+        "body",
+        "completion criteria",
+        "Lean status",
+        "related docs"
+      ],
+      "nonConclusions": [
+        "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+        "artifact descriptor is not a ground truth architecture object",
+        "artifact descriptor does not provide a causal forecast",
+        "missing evidence and unsupported constructs are not measured zero",
+        "forecast non-conclusions must be preserved by downstream SFT artifacts"
+      ]
+    },
+    {
+      "sourceRefId": "source:roadmap-b12",
+      "sourceKind": "doc",
+      "pathOrUrl": "docs/tool/roadmap.md#phase-b12-sft-forecasting-mvp",
+      "stableRef": "Phase B12 / B12.1",
+      "evidenceRole": "forecasting MVP boundary",
+      "retainedFields": [
+        "pipeline",
+        "minimal output",
+        "B12.1 milestone"
+      ],
+      "nonConclusions": [
+        "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+        "artifact descriptor is not a ground truth architecture object",
+        "artifact descriptor does not provide a causal forecast",
+        "missing evidence and unsupported constructs are not measured zero",
+        "forecast non-conclusions must be preserved by downstream SFT artifacts"
+      ]
+    },
+    {
+      "sourceRefId": "source:sft-computational-problems",
+      "sourceKind": "doc",
+      "pathOrUrl": "docs/sft/software_field_theory.md#20-sft-computational-problems",
+      "stableRef": "SFT Computational Problems",
+      "evidenceRole": "theory boundary",
+      "retainedFields": [
+        "ArtifactDescriptor role",
+        "ConsequenceEnvelope simulator boundary",
+        "non-conclusions"
+      ],
+      "nonConclusions": [
+        "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+        "artifact descriptor is not a ground truth architecture object",
+        "artifact descriptor does not provide a causal forecast",
+        "missing evidence and unsupported constructs are not measured zero",
+        "forecast non-conclusions must be preserved by downstream SFT artifacts"
+      ]
+    }
+  ],
+  "actionClassCandidates": [
+    {
+      "candidateId": "candidate:add-schema",
+      "actionClass": "schema-definition",
+      "confidence": "high",
+      "sourceRefIds": [
+        "source:issue-733",
+        "source:roadmap-b12"
+      ],
+      "rationale": "Issue requests a Rust schema for artifact-descriptor-v0.",
+      "assumptions": [
+        "candidate was inferred from selected source refs only",
+        "candidate does not imply an operation support estimate"
+      ],
+      "nonConclusions": [
+        "descriptor action classes are candidates, not forecasted effects",
+        "descriptor scope does not prove operation support completeness",
+        "descriptor boundary does not assign probability to future outcomes",
+        "descriptor evidence does not establish causal prediction"
+      ]
+    },
+    {
+      "candidateId": "candidate:add-validator",
+      "actionClass": "tooling-validation",
+      "confidence": "high",
+      "sourceRefIds": [
+        "source:issue-733"
+      ],
+      "rationale": "Issue requires a canonical fixture and validator.",
+      "assumptions": [
+        "candidate was inferred from selected source refs only",
+        "candidate does not imply an operation support estimate"
+      ],
+      "nonConclusions": [
+        "descriptor action classes are candidates, not forecasted effects",
+        "descriptor scope does not prove operation support completeness",
+        "descriptor boundary does not assign probability to future outcomes",
+        "descriptor evidence does not establish causal prediction"
+      ]
+    },
+    {
+      "candidateId": "candidate:add-cli-entrypoint",
+      "actionClass": "cli-entrypoint",
+      "confidence": "medium",
+      "sourceRefIds": [
+        "source:issue-733"
+      ],
+      "rationale": "Issue names an archsig artifact-descriptor entrypoint.",
+      "assumptions": [
+        "candidate was inferred from selected source refs only",
+        "candidate does not imply an operation support estimate"
+      ],
+      "nonConclusions": [
+        "descriptor action classes are candidates, not forecasted effects",
+        "descriptor scope does not prove operation support completeness",
+        "descriptor boundary does not assign probability to future outcomes",
+        "descriptor evidence does not establish causal prediction"
+      ]
+    }
+  ],
+  "scope": {
+    "scopeId": "scope:b12.1-artifact-descriptor",
+    "selectedRegionRefs": [
+      "tools/archsig",
+      "docs/tool/roadmap.md#phase-b12-sft-forecasting-mvp",
+      "docs/sft/software_field_theory.md#21-prd-to-consequenceenvelope-simulator"
+    ],
+    "excludedRegionRefs": [
+      "operation-support-estimate",
+      "forecast-cone-probability",
+      "causal-outcome-prediction"
+    ],
+    "targetAudience": [
+      "archsig-cli",
+      "sft-forecaster-pipeline",
+      "review-ci"
+    ],
+    "artifactBoundary": "normalizes PRD / Spec / Issue / AI proposal input before operation support",
+    "assumptions": [
+      "source refs are retained as bounded tooling evidence",
+      "action class candidates are used only as downstream estimation input"
+    ],
+    "nonConclusions": [
+      "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+      "artifact descriptor is not a ground truth architecture object",
+      "artifact descriptor does not provide a causal forecast",
+      "missing evidence and unsupported constructs are not measured zero",
+      "forecast non-conclusions must be preserved by downstream SFT artifacts"
+    ]
+  },
+  "missingEvidence": [
+    {
+      "evidenceId": "missing:prd-body",
+      "evidenceKind": "prd",
+      "reason": "fixture has no full PRD body",
+      "effect": "operation support cannot be treated as complete",
+      "status": "missing",
+      "nonConclusions": [
+        "missing evidence and unsupported constructs are not measured zero",
+        "missing descriptor evidence remains a downstream forecast boundary item"
+      ]
+    },
+    {
+      "evidenceId": "missing:runtime-impact",
+      "evidenceKind": "runtime-evidence",
+      "reason": "runtime traces are outside B12.1 descriptor normalization",
+      "effect": "runtime propagation remains a downstream boundary item",
+      "status": "unmeasured",
+      "nonConclusions": [
+        "missing evidence and unsupported constructs are not measured zero",
+        "missing descriptor evidence remains a downstream forecast boundary item"
+      ]
+    }
+  ],
+  "measurementBoundary": {
+    "boundaryId": "boundary:b12.1-artifact-descriptor",
+    "measuredLayers": [
+      "artifact-normalization"
+    ],
+    "measuredAxes": [
+      "sourceRefs",
+      "actionClassCandidates",
+      "scope",
+      "missingEvidence",
+      "forecastNonConclusions"
+    ],
+    "sourceRefIds": [
+      "source:issue-733",
+      "source:roadmap-b12",
+      "source:sft-computational-problems"
+    ],
+    "selectedRegionRefs": [
+      "tools/archsig",
+      "docs/tool/roadmap.md#phase-b12-sft-forecasting-mvp",
+      "docs/sft/software_field_theory.md#21-prd-to-consequenceenvelope-simulator"
+    ],
+    "assumptions": [
+      "descriptor validation checks structure and boundary preservation only",
+      "descriptor validation does not run a repository extractor"
+    ],
+    "unsupportedConstructs": [
+      "operation support probability",
+      "ground truth architecture reconstruction",
+      "future outcome causality"
+    ],
+    "missingEvidenceIds": [
+      "missing:prd-body",
+      "missing:runtime-impact"
+    ],
+    "nonConclusions": [
+      "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+      "artifact descriptor is not a ground truth architecture object",
+      "artifact descriptor does not provide a causal forecast",
+      "missing evidence and unsupported constructs are not measured zero",
+      "forecast non-conclusions must be preserved by downstream SFT artifacts"
+    ]
+  },
+  "forecastNonConclusions": [
+    "descriptor action classes are candidates, not forecasted effects",
+    "descriptor scope does not prove operation support completeness",
+    "descriptor boundary does not assign probability to future outcomes",
+    "descriptor evidence does not establish causal prediction"
+  ],
+  "nonConclusions": [
+    "artifact descriptor is tooling input normalization, not a Lean theorem claim",
+    "artifact descriptor is not a ground truth architecture object",
+    "artifact descriptor does not provide a causal forecast",
+    "missing evidence and unsupported constructs are not measured zero",
+    "forecast non-conclusions must be preserved by downstream SFT artifacts"
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #733

B12.1 の `artifact-descriptor-v0` を ArchSig tooling に追加しました。PRD / Spec / Issue / AI proposal を、source refs、action class candidates、scope、missing evidence、measurement boundary、forecast non-conclusions を持つ入力 descriptor として正規化します。

この descriptor は B12 forecasting pipeline の入力境界であり、operation support、ForecastCone、probability、causal forecast、ground truth architecture object、Lean theorem claim は生成しません。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

補足: `lake build` は既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning を 2 件再表示しましたが、build は成功しました。広い forbidden-token scan は docs の通常語 `unsafe` も拾うため、Lean 宣言形に絞った scan で新規 `axiom` / `admit` / `sorry` / `unsafe` 宣言がないことを確認しました。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている

Lean status: empirical hypothesis / tooling validation.
