### PR TITLE
B12.2 OperationSupportEstimate schema と validator を追加

### DIFF
--- a/docs/tool/roadmap.md
+++ b/docs/tool/roadmap.md
@@ -23,7 +23,7 @@ workflow の計画だけを書く。
 
 ## Current status snapshot
 
-2026-05-09 時点の ArchSig は、AAT diagnostic / governance tooling としては
+2026-05-10 時点の ArchSig は、AAT diagnostic / governance tooling としては
 MVP を越えている。一方で、SFT forecast engine としては schema と validator が先行しており、
 PRD / Issue / AI proposal から `ForecastCone` や `ConsequenceEnvelope` を生成する
 pipeline は未完成である。
@@ -153,12 +153,18 @@ PRD / Spec / Issue / AI proposal
 measurement boundary を持つ level 3 相当の cone skeleton を作る。
 calibration 済みの weighting や field update は B10 / B11 artifact と接続した後に扱う。
 
+現在は `artifact-descriptor-v0` と `operation-support-estimate-v0` が schema + validator
+として実装済みである。`OperationSupportEstimate` は descriptor refs、candidate
+operation families、policy constraints、known forbidden support、unknown remainder、
+confidence / evidence boundary を保持するが、accepted PR history、actual future support、
+global policy safety、future trajectory safety は主張しない。
+
 ### B12 milestones
 
 | Milestone | 目標 |
 | --- | --- |
-| B12.1 ArtifactDescriptor | PRD / Issue / AI proposal の action class、scope、source refs、missing evidence を schema 化する。 |
-| B12.2 OperationSupportEstimate | candidate operation family、policy constraints、known forbidden support、unknown remainder を出す。 |
+| B12.1 ArtifactDescriptor | PRD / Issue / AI proposal の action class、scope、source refs、missing evidence を schema 化する。schema + validator 実装済み。 |
+| B12.2 OperationSupportEstimate | candidate operation family、policy constraints、known forbidden support、unknown remainder を出す。schema + validator 実装済み。 |
 | B12.3 ForecastCone skeleton | finite support と bounded horizon に相対化した path class skeleton を保持する。 |
 | B12.4 ConsequenceEnvelope report | signature axis、obstruction candidate、missing boundary、review / CI recommendation をまとめる。 |
 | B12.5 Calibration hook | observed PR / review / CI / outcome artifact と forecast item を対応付ける hook を置く。 |

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -93,6 +93,7 @@ scan
 | `policy-decision-report-v0` | organization policy に基づく pass / warn / fail / advisory decision。 |
 | `pr-comment-summary-v0` | GitHub Checks / PR comment 向け Markdown summary。 |
 | `artifact-descriptor-v0` | PRD / Spec / Issue / AI proposal を SFT forecasting MVP の入力境界へ正規化する。 |
+| `operation-support-estimate-v0` | `artifact-descriptor-v0` から候補 operation family、policy constraints、known forbidden support、unknown remainder を保持する。 |
 
 [Signature diff report workflow](../../.github/workflows/signature-diff.yml) は、PR / push /
 schedule / manual run で Sig0、validation、snapshot、`signature-diff-report-v0` を作り、

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -228,6 +228,24 @@ action class candidates、scope、missing evidence、measurement boundary、
 forecast non-conclusions に正規化する。operation support、ForecastCone、probability、
 causal forecast はこの command では生成しない。
 
+B12 OperationSupportEstimate の canonical fixture を出力し、既存 estimate を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- operation-support-estimate \
+  --fixture \
+  --out .lake/signature-current/operation-support-estimate.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- operation-support-estimate \
+  --input tools/archsig/tests/fixtures/minimal/operation_support_estimate.json \
+  --out .lake/signature-current/operation-support-estimate-validation.json
+```
+
+`operation-support-estimate-v0` は `artifact-descriptor-v0` の source refs と
+action class candidate refs を保持したまま、candidate operation families、
+policy constraints、known forbidden support、unknown remainder、confidence /
+evidence boundary を分離する。accepted PR history、actual future support、global
+policy safety、future trajectory safety はこの command では主張しない。
+
 B5 repair / synthesis artifact を検査する。
 
 ```bash

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -19,6 +19,7 @@ mod law_policy_template;
 mod measurement_unit;
 mod no_solution_certificate;
 mod obstruction_drift;
+mod operation_support_estimate;
 mod operational_feedback;
 mod organization_policy;
 mod outcome_linkage;
@@ -87,6 +88,9 @@ pub use no_solution_certificate::{
 };
 pub use obstruction_drift::{
     static_architecture_drift_ledger, static_obstruction_witness_artifact,
+};
+pub use operation_support_estimate::{
+    static_operation_support_estimate, validate_operation_support_estimate,
 };
 pub use operational_feedback::{
     ReportOutcomeDailyLedgerInput, build_report_outcome_daily_ledger,

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -18,7 +18,8 @@ use archsig::{
     LawPolicyTemplateRegistryValidationReportV0, MeasurementUnitRegistryV0,
     MeasurementUnitRegistryValidationReportV0, NoSolutionCertificateV0,
     NoSolutionCertificateValidationReportV0, OperationProposalLogV0,
-    OperationProposalLogValidationReportV0, OrganizationPolicyV0,
+    OperationProposalLogValidationReportV0, OperationSupportEstimateV0,
+    OperationSupportEstimateValidationReportV0, OrganizationPolicyV0,
     OrganizationPolicyValidationReportV0, OwnershipBoundaryMonitorV0, PolicyDecisionReportV0,
     PrForceReportV0, PrForceReportValidationReportV0, RepairAdoptionRecordV0, RepairRuleRegistryV0,
     RepairRuleRegistryValidationReportV0, ReportArtifactRetentionManifestV0,
@@ -42,7 +43,8 @@ use archsig::{
     static_detectable_values_reported_axes_catalog, static_dynamics_measurement_contract,
     static_hypothesis_refresh_cycle, static_incident_correlation_monitor,
     static_law_policy_template_registry, static_measurement_unit_registry,
-    static_no_solution_certificate, static_operation_proposal_log, static_organization_policy,
+    static_no_solution_certificate, static_operation_proposal_log,
+    static_operation_support_estimate, static_organization_policy,
     static_ownership_boundary_monitor, static_pr_force_report, static_repair_adoption_record,
     static_repair_rule_registry, static_report_artifact_retention_manifest,
     static_schema_version_catalog, static_signature_trajectory_report,
@@ -52,7 +54,8 @@ use archsig::{
     validate_component_universe_report, validate_custom_rule_plugin_registry_report,
     validate_dynamics_measurement_contract_report, validate_law_policy_template_registry_report,
     validate_measurement_unit_registry_report, validate_no_solution_certificate_report,
-    validate_operation_proposal_log, validate_organization_policy_report, validate_pr_force_report,
+    validate_operation_proposal_log, validate_operation_support_estimate,
+    validate_organization_policy_report, validate_pr_force_report,
     validate_repair_rule_registry_report, validate_report_artifact_retention_report,
     validate_signature_trajectory_report, validate_synthesis_constraint_artifact_report,
 };
@@ -677,6 +680,21 @@ enum Command {
         fixture: bool,
 
         /// Output descriptor or validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Emit or validate an operation-support-estimate-v0 artifact.
+    OperationSupportEstimate {
+        /// Optional OperationSupportEstimate JSON path to validate.
+        #[arg(long)]
+        input: Option<PathBuf>,
+
+        /// Emit the canonical minimal operation-support-estimate-v0 fixture.
+        #[arg(long)]
+        fixture: bool,
+
+        /// Output estimate or validation report JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
     },
@@ -1454,6 +1472,35 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 .unwrap_or_else(|| "static-artifact-descriptor".to_string());
             let validation: ArtifactDescriptorValidationReportV0 =
                 validate_artifact_descriptor_report(&descriptor, &input_path);
+            let failed = validation.summary.result == "fail";
+            write_json(out, &validation)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::OperationSupportEstimate {
+            input,
+            fixture,
+            out,
+        }) => {
+            if fixture {
+                let estimate: OperationSupportEstimateV0 = static_operation_support_estimate();
+                write_json(out, &estimate)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            let estimate: OperationSupportEstimateV0 = input
+                .as_ref()
+                .map(read_json)
+                .transpose()?
+                .unwrap_or_else(static_operation_support_estimate);
+            let input_path = input
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "static-operation-support-estimate".to_string());
+            let validation: OperationSupportEstimateValidationReportV0 =
+                validate_operation_support_estimate(&estimate, &input_path);
             let failed = validation.summary.result == "fail";
             write_json(out, &validation)?;
             Ok(if failed {

--- a/tools/archsig/src/operation_support_estimate.rs
+++ b/tools/archsig/src/operation_support_estimate.rs
@@ -1,0 +1,611 @@
+use std::collections::BTreeSet;
+
+use crate::validation::{count_checks, generic_validation_example, validation_check};
+use crate::{
+    ARTIFACT_DESCRIPTOR_SCHEMA_VERSION, CandidateOperationFamilyV0,
+    KnownForbiddenOperationSupportV0, OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION,
+    OPERATION_SUPPORT_ESTIMATE_VALIDATION_REPORT_SCHEMA_VERSION, OperationSupportDescriptorRefV0,
+    OperationSupportEstimateV0, OperationSupportEstimateValidationInput,
+    OperationSupportEstimateValidationReportV0, OperationSupportEstimateValidationSummary,
+    OperationSupportEvidenceBoundaryV0, OperationSupportPolicyConstraintV0,
+    OperationSupportUnknownRemainderV0, ValidationCheck,
+};
+
+const REQUIRED_NON_CONCLUSIONS: [&str; 5] = [
+    "operation support estimate is a bounded tooling estimate, not accepted PR history",
+    "operation support estimate is not actual future support",
+    "unknown support is not measured zero",
+    "policy constraints do not prove global policy safety",
+    "operation support estimate does not prove future trajectory safety",
+];
+
+const REQUIRED_EVIDENCE_BOUNDARY_NON_CONCLUSIONS: [&str; 3] = [
+    "confidence is relative to retained descriptor source refs",
+    "evidence boundary does not complete extractor coverage",
+    "unsupported constructs remain forecast boundary items",
+];
+
+pub fn static_operation_support_estimate() -> OperationSupportEstimateV0 {
+    let source_ref_ids = vec![
+        "source:issue-734".to_string(),
+        "source:artifact-descriptor-fixture".to_string(),
+        "source:roadmap-b12".to_string(),
+        "source:sft-aat-interface".to_string(),
+    ];
+    let action_class_candidate_ids = vec![
+        "candidate:add-schema".to_string(),
+        "candidate:add-validator".to_string(),
+        "candidate:add-cli-entrypoint".to_string(),
+    ];
+
+    OperationSupportEstimateV0 {
+        schema_version: OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION.to_string(),
+        estimate_id: "fixture-operation-support-estimate-v0".to_string(),
+        descriptor_ref: OperationSupportDescriptorRefV0 {
+            descriptor_schema_version: ARTIFACT_DESCRIPTOR_SCHEMA_VERSION.to_string(),
+            descriptor_id: "fixture-artifact-descriptor-v0".to_string(),
+            artifact_kind: "issue".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            action_class_candidate_ids: action_class_candidate_ids.clone(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        },
+        candidate_operation_families: vec![
+            candidate_family(
+                "family:schema-validation-artifact",
+                "schema-and-validator",
+                "supported-by-selected-issue",
+                &["candidate:add-schema", "candidate:add-validator"],
+                &["source:issue-734", "source:roadmap-b12"],
+                "high",
+                "Issue #734 requests a schema and validator before downstream forecast artifacts.",
+            ),
+            candidate_family(
+                "family:cli-fixture-validation",
+                "cli-fixture-validation",
+                "supported-by-selected-issue",
+                &["candidate:add-cli-entrypoint"],
+                &["source:issue-734", "source:artifact-descriptor-fixture"],
+                "medium",
+                "The estimate should be emitted and validated through an archsig CLI entrypoint.",
+            ),
+        ],
+        policy_constraints: vec![
+            policy_constraint(
+                "constraint:no-theorem-promotion",
+                "claim-boundary",
+                &[
+                    "family:schema-validation-artifact",
+                    "family:cli-fixture-validation",
+                ],
+                &["source:sft-aat-interface"],
+                "Do not promote tooling estimates to Lean theorem claims.",
+                "constraint is local to selected B12 operation support evidence",
+            ),
+            policy_constraint(
+                "constraint:no-causal-forecast",
+                "forecast-boundary",
+                &["family:schema-validation-artifact"],
+                &["source:roadmap-b12"],
+                "Do not treat support estimates as causal forecasts.",
+                "constraint prevents global safety and future trajectory safety claims",
+            ),
+        ],
+        known_forbidden_support: vec![KnownForbiddenOperationSupportV0 {
+            forbidden_id: "forbidden:probability-assignment".to_string(),
+            operation_family: "forecast-probability-assignment".to_string(),
+            source_ref_ids: vec!["source:roadmap-b12".to_string()],
+            constraint_refs: vec!["constraint:no-causal-forecast".to_string()],
+            reason: "B12.2 precedes ForecastCone and does not assign probabilities.".to_string(),
+            boundary: "probability and causal prediction remain outside operation support estimate"
+                .to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        }],
+        unknown_remainder: vec![OperationSupportUnknownRemainderV0 {
+            remainder_id: "unknown:runtime-and-private-history".to_string(),
+            affected_family_ids: vec![
+                "family:schema-validation-artifact".to_string(),
+                "family:cli-fixture-validation".to_string(),
+            ],
+            source_ref_ids: vec!["source:issue-734".to_string()],
+            unknown_axes: vec![
+                "private PRD details".to_string(),
+                "runtime traces".to_string(),
+                "future accepted PR history".to_string(),
+            ],
+            reason: "selected sources do not contain full PRD, runtime traces, or future history"
+                .to_string(),
+            treatment: "retain as unknown support remainder under the selected boundary"
+                .to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        }],
+        evidence_boundary: OperationSupportEvidenceBoundaryV0 {
+            boundary_id: "boundary:b12.2-operation-support-estimate".to_string(),
+            source_ref_ids,
+            measurement_boundary_refs: vec![
+                "boundary:b12.1-artifact-descriptor".to_string(),
+                "docs/tool/roadmap.md#b122-operationsupportestimate".to_string(),
+            ],
+            confidence_boundary: "confidence values are qualitative and source-bound".to_string(),
+            evidence_kinds: vec![
+                "issue-body".to_string(),
+                "artifact-descriptor-fixture".to_string(),
+                "roadmap-boundary".to_string(),
+            ],
+            unsupported_constructs: vec![
+                "accepted PR history completeness".to_string(),
+                "actual future operation support".to_string(),
+                "global policy safety proof".to_string(),
+            ],
+            assumptions: vec![
+                "artifact descriptor source refs are retained by id".to_string(),
+                "operation families are candidates under selected B12 inputs".to_string(),
+            ],
+            non_conclusions: strings(&REQUIRED_EVIDENCE_BOUNDARY_NON_CONCLUSIONS),
+        },
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+pub fn validate_operation_support_estimate(
+    estimate: &OperationSupportEstimateV0,
+    input_path: &str,
+) -> OperationSupportEstimateValidationReportV0 {
+    let checks = vec![
+        check_schema_version(estimate),
+        check_descriptor_ref(estimate),
+        check_candidate_operation_families(estimate),
+        check_policy_constraints(estimate),
+        check_forbidden_support(estimate),
+        check_unknown_remainder(estimate),
+        check_evidence_boundary(estimate),
+        check_non_conclusions(estimate),
+    ];
+    let summary = OperationSupportEstimateValidationSummary {
+        result: validation_result(&checks),
+        candidate_operation_family_count: estimate.candidate_operation_families.len(),
+        policy_constraint_count: estimate.policy_constraints.len(),
+        known_forbidden_support_count: estimate.known_forbidden_support.len(),
+        unknown_remainder_count: estimate.unknown_remainder.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    OperationSupportEstimateValidationReportV0 {
+        schema_version: OPERATION_SUPPORT_ESTIMATE_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: OperationSupportEstimateValidationInput {
+            schema_version: estimate.schema_version.clone(),
+            path: input_path.to_string(),
+            estimate_id: estimate.estimate_id.clone(),
+            descriptor_id: estimate.descriptor_ref.descriptor_id.clone(),
+        },
+        estimate: estimate.clone(),
+        summary,
+        checks,
+    }
+}
+
+fn candidate_family(
+    family_id: &str,
+    operation_family: &str,
+    support_kind: &str,
+    action_class_candidate_ids: &[&str],
+    source_ref_ids: &[&str],
+    confidence: &str,
+    rationale: &str,
+) -> CandidateOperationFamilyV0 {
+    CandidateOperationFamilyV0 {
+        family_id: family_id.to_string(),
+        operation_family: operation_family.to_string(),
+        support_kind: support_kind.to_string(),
+        action_class_candidate_ids: strings(action_class_candidate_ids),
+        source_ref_ids: strings(source_ref_ids),
+        confidence: confidence.to_string(),
+        rationale: rationale.to_string(),
+        assumptions: vec![
+            "operation family is inferred only from selected descriptor refs".to_string(),
+            "support estimate does not assert actual future support".to_string(),
+        ],
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn policy_constraint(
+    constraint_id: &str,
+    constraint_kind: &str,
+    applies_to_family_ids: &[&str],
+    source_ref_ids: &[&str],
+    rule: &str,
+    safety_claim_boundary: &str,
+) -> OperationSupportPolicyConstraintV0 {
+    OperationSupportPolicyConstraintV0 {
+        constraint_id: constraint_id.to_string(),
+        constraint_kind: constraint_kind.to_string(),
+        applies_to_family_ids: strings(applies_to_family_ids),
+        source_ref_ids: strings(source_ref_ids),
+        rule: rule.to_string(),
+        safety_claim_boundary: safety_claim_boundary.to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn check_schema_version(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let mut check = validation_check(
+        "operation-support-estimate-schema-version-supported",
+        "operation support estimate schema version is supported",
+        if estimate.schema_version == OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!(
+            "unsupported operation support estimate schemaVersion: {}",
+            estimate.schema_version
+        ));
+    }
+    check
+}
+
+fn check_descriptor_ref(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let descriptor = &estimate.descriptor_ref;
+    let invalid = estimate.estimate_id.trim().is_empty()
+        || descriptor.descriptor_schema_version != ARTIFACT_DESCRIPTOR_SCHEMA_VERSION
+        || descriptor.descriptor_id.trim().is_empty()
+        || descriptor.artifact_kind.trim().is_empty()
+        || descriptor.source_ref_ids.is_empty()
+        || descriptor.action_class_candidate_ids.is_empty();
+    let mut check = validation_check(
+        "operation-support-estimate-descriptor-refs-retained",
+        "descriptor refs retain source refs and action class candidate ids",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(
+            "estimateId, descriptor id, descriptor schema, source refs, and action candidates are required"
+                .to_string(),
+        );
+    }
+    check.count = Some(descriptor.source_ref_ids.len());
+    check
+}
+
+fn check_candidate_operation_families(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let source_ids = source_ids(estimate);
+    let candidate_ids = candidate_ids(estimate);
+    let invalid = estimate
+        .candidate_operation_families
+        .iter()
+        .filter(|family| {
+            family.family_id.trim().is_empty()
+                || family.operation_family.trim().is_empty()
+                || family.support_kind.trim().is_empty()
+                || family.action_class_candidate_ids.is_empty()
+                || family.source_ref_ids.is_empty()
+                || family
+                    .source_ref_ids
+                    .iter()
+                    .any(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+                || family
+                    .action_class_candidate_ids
+                    .iter()
+                    .any(|candidate_id| !candidate_ids.contains(candidate_id.as_str()))
+        })
+        .map(|family| family.family_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "operation-support-estimate-candidate-families-bounded",
+        "candidate operation families are source-bound and linked to descriptor action candidates",
+        if !estimate.candidate_operation_families.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if estimate.candidate_operation_families.is_empty() {
+        check.reason = Some("at least one candidate operation family is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "candidate operation families with missing fields or dangling refs: {}",
+            invalid.join(", ")
+        ));
+    }
+    check.count = Some(estimate.candidate_operation_families.len());
+    check
+}
+
+fn check_policy_constraints(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let source_ids = source_ids(estimate);
+    let family_ids = family_ids(estimate);
+    let invalid = estimate
+        .policy_constraints
+        .iter()
+        .filter(|constraint| {
+            constraint.constraint_id.trim().is_empty()
+                || constraint.constraint_kind.trim().is_empty()
+                || constraint.applies_to_family_ids.is_empty()
+                || constraint.source_ref_ids.is_empty()
+                || constraint.rule.trim().is_empty()
+                || constraint.safety_claim_boundary.trim().is_empty()
+                || overpromotes_policy_safety(&constraint.safety_claim_boundary)
+                || constraint
+                    .source_ref_ids
+                    .iter()
+                    .any(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+                || constraint
+                    .applies_to_family_ids
+                    .iter()
+                    .any(|family_id| !family_ids.contains(family_id.as_str()))
+        })
+        .map(|constraint| constraint.constraint_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "operation-support-estimate-policy-constraints-bounded",
+        "policy constraints are local and do not promote to global or future safety claims",
+        if invalid.is_empty() { "pass" } else { "fail" },
+    );
+    if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "policy constraints with missing refs or over-promoted safety boundaries: {}",
+            invalid.join(", ")
+        ));
+        check.examples = invalid
+            .iter()
+            .map(|constraint_id| {
+                generic_validation_example(
+                    constraint_id,
+                    "safetyClaimBoundary",
+                    "expected a local source-bound boundary, not a global/future safety claim",
+                )
+            })
+            .collect();
+    }
+    check.count = Some(estimate.policy_constraints.len());
+    check
+}
+
+fn check_forbidden_support(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let source_ids = source_ids(estimate);
+    let constraint_ids = constraint_ids(estimate);
+    let invalid = estimate
+        .known_forbidden_support
+        .iter()
+        .filter(|forbidden| {
+            forbidden.forbidden_id.trim().is_empty()
+                || forbidden.operation_family.trim().is_empty()
+                || forbidden.source_ref_ids.is_empty()
+                || forbidden.reason.trim().is_empty()
+                || forbidden.boundary.trim().is_empty()
+                || forbidden
+                    .source_ref_ids
+                    .iter()
+                    .any(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+                || forbidden
+                    .constraint_refs
+                    .iter()
+                    .any(|constraint_id| !constraint_ids.contains(constraint_id.as_str()))
+        })
+        .map(|forbidden| forbidden.forbidden_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "operation-support-estimate-known-forbidden-support-bounded",
+        "known forbidden support is source-bound and linked to policy constraints when provided",
+        if invalid.is_empty() { "pass" } else { "fail" },
+    );
+    if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "known forbidden support entries with missing fields or dangling refs: {}",
+            invalid.join(", ")
+        ));
+    }
+    check.count = Some(estimate.known_forbidden_support.len());
+    check
+}
+
+fn check_unknown_remainder(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let source_ids = source_ids(estimate);
+    let family_ids = family_ids(estimate);
+    let invalid = estimate
+        .unknown_remainder
+        .iter()
+        .filter(|remainder| {
+            remainder.remainder_id.trim().is_empty()
+                || remainder.affected_family_ids.is_empty()
+                || remainder.source_ref_ids.is_empty()
+                || remainder.unknown_axes.is_empty()
+                || remainder.reason.trim().is_empty()
+                || remainder.treatment.trim().is_empty()
+                || treats_unknown_as_zero(&remainder.treatment)
+                || remainder
+                    .source_ref_ids
+                    .iter()
+                    .any(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+                || remainder
+                    .affected_family_ids
+                    .iter()
+                    .any(|family_id| !family_ids.contains(family_id.as_str()))
+        })
+        .map(|remainder| remainder.remainder_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "operation-support-estimate-unknown-remainder-not-measured-zero",
+        "unknown and unmodeled support remains explicit and is not treated as measured zero",
+        if !estimate.unknown_remainder.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if estimate.unknown_remainder.is_empty() {
+        check.reason = Some("at least one unknown remainder item is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "unknown remainder entries with missing refs or measured-zero treatment: {}",
+            invalid.join(", ")
+        ));
+        check.examples = invalid
+            .iter()
+            .map(|remainder_id| {
+                generic_validation_example(
+                    remainder_id,
+                    "unknownRemainder.treatment",
+                    "unknown support must remain unknown/unmodeled, not safe, absent, or measured zero",
+                )
+            })
+            .collect();
+    }
+    check.count = Some(estimate.unknown_remainder.len());
+    check
+}
+
+fn check_evidence_boundary(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let source_ids = source_ids(estimate);
+    let boundary = &estimate.evidence_boundary;
+    let dangling_source_refs = boundary
+        .source_ref_ids
+        .iter()
+        .filter(|source_ref_id| !source_ids.contains(source_ref_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let invalid = boundary.boundary_id.trim().is_empty()
+        || boundary.source_ref_ids.is_empty()
+        || boundary.measurement_boundary_refs.is_empty()
+        || boundary.confidence_boundary.trim().is_empty()
+        || boundary.evidence_kinds.is_empty()
+        || boundary.assumptions.is_empty()
+        || boundary
+            .confidence_boundary
+            .to_ascii_lowercase()
+            .contains("complete");
+    let mut check = validation_check(
+        "operation-support-estimate-evidence-boundary-retained",
+        "evidence boundary keeps confidence and measurement boundary limits",
+        if !invalid && dangling_source_refs.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if invalid {
+        check.reason = Some(
+            "evidence boundary requires source refs, measurement refs, evidence kinds, assumptions, and incomplete confidence"
+                .to_string(),
+        );
+    } else if !dangling_source_refs.is_empty() {
+        check.reason = Some(format!(
+            "evidence boundary references unknown source refs: {}",
+            dangling_source_refs.join(", ")
+        ));
+    }
+    check.count = Some(boundary.source_ref_ids.len());
+    check
+}
+
+fn check_non_conclusions(estimate: &OperationSupportEstimateV0) -> ValidationCheck {
+    let missing_estimate = REQUIRED_NON_CONCLUSIONS
+        .iter()
+        .filter(|required| {
+            !estimate
+                .non_conclusions
+                .iter()
+                .any(|actual| actual == *required)
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    let missing_boundary = REQUIRED_EVIDENCE_BOUNDARY_NON_CONCLUSIONS
+        .iter()
+        .filter(|required| {
+            !estimate
+                .evidence_boundary
+                .non_conclusions
+                .iter()
+                .any(|actual| actual == *required)
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "operation-support-estimate-non-conclusions-preserved",
+        "operation support estimate preserves actual-support, policy-safety, and future-safety boundaries",
+        if missing_estimate.is_empty() && missing_boundary.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !missing_estimate.is_empty() {
+        check.reason = Some(format!(
+            "missing estimate non-conclusions: {}",
+            missing_estimate.join("; ")
+        ));
+    } else if !missing_boundary.is_empty() {
+        check.reason = Some(format!(
+            "missing evidence boundary non-conclusions: {}",
+            missing_boundary.join("; ")
+        ));
+    }
+    check
+}
+
+fn source_ids(estimate: &OperationSupportEstimateV0) -> BTreeSet<&str> {
+    estimate
+        .descriptor_ref
+        .source_ref_ids
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+fn candidate_ids(estimate: &OperationSupportEstimateV0) -> BTreeSet<&str> {
+    estimate
+        .descriptor_ref
+        .action_class_candidate_ids
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+fn family_ids(estimate: &OperationSupportEstimateV0) -> BTreeSet<&str> {
+    estimate
+        .candidate_operation_families
+        .iter()
+        .map(|family| family.family_id.as_str())
+        .collect()
+}
+
+fn constraint_ids(estimate: &OperationSupportEstimateV0) -> BTreeSet<&str> {
+    estimate
+        .policy_constraints
+        .iter()
+        .map(|constraint| constraint.constraint_id.as_str())
+        .collect()
+}
+
+fn overpromotes_policy_safety(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    value.contains("proves global")
+        || value.contains("global safety is guaranteed")
+        || value.contains("future trajectory is safe")
+        || value.contains("policy is globally safe")
+}
+
+fn treats_unknown_as_zero(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    value.contains("measured zero")
+        || value.contains("treated as zero")
+        || value.contains("safe by default")
+        || value.contains("known absent")
+}
+
+fn validation_result(checks: &[ValidationCheck]) -> String {
+    if checks.iter().any(|check| check.result == "fail") {
+        "fail".to_string()
+    } else if checks.iter().any(|check| check.result == "warn") {
+        "warn".to_string()
+    } else {
+        "pass".to_string()
+    }
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -83,6 +83,9 @@ pub const HYPOTHESIS_REFRESH_CYCLE_SCHEMA_VERSION: &str = "hypothesis-refresh-cy
 pub const ARTIFACT_DESCRIPTOR_SCHEMA_VERSION: &str = "artifact-descriptor-v0";
 pub const ARTIFACT_DESCRIPTOR_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "artifact-descriptor-validation-report-v0";
+pub const OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION: &str = "operation-support-estimate-v0";
+pub const OPERATION_SUPPORT_ESTIMATE_VALIDATION_REPORT_SCHEMA_VERSION: &str =
+    "operation-support-estimate-validation-report-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const FRAMEWORK_ADAPTER_EVIDENCE_SCHEMA_VERSION: &str = "framework-adapter-evidence-v0";
@@ -3770,6 +3773,125 @@ pub struct ArtifactDescriptorValidationSummary {
     pub source_ref_count: usize,
     pub action_class_candidate_count: usize,
     pub missing_evidence_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportEstimateV0 {
+    pub schema_version: String,
+    pub estimate_id: String,
+    pub descriptor_ref: OperationSupportDescriptorRefV0,
+    pub candidate_operation_families: Vec<CandidateOperationFamilyV0>,
+    pub policy_constraints: Vec<OperationSupportPolicyConstraintV0>,
+    pub known_forbidden_support: Vec<KnownForbiddenOperationSupportV0>,
+    pub unknown_remainder: Vec<OperationSupportUnknownRemainderV0>,
+    pub evidence_boundary: OperationSupportEvidenceBoundaryV0,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportDescriptorRefV0 {
+    pub descriptor_schema_version: String,
+    pub descriptor_id: String,
+    pub artifact_kind: String,
+    pub source_ref_ids: Vec<String>,
+    pub action_class_candidate_ids: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CandidateOperationFamilyV0 {
+    pub family_id: String,
+    pub operation_family: String,
+    pub support_kind: String,
+    pub action_class_candidate_ids: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub confidence: String,
+    pub rationale: String,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportPolicyConstraintV0 {
+    pub constraint_id: String,
+    pub constraint_kind: String,
+    pub applies_to_family_ids: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub rule: String,
+    pub safety_claim_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KnownForbiddenOperationSupportV0 {
+    pub forbidden_id: String,
+    pub operation_family: String,
+    pub source_ref_ids: Vec<String>,
+    pub constraint_refs: Vec<String>,
+    pub reason: String,
+    pub boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportUnknownRemainderV0 {
+    pub remainder_id: String,
+    pub affected_family_ids: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub unknown_axes: Vec<String>,
+    pub reason: String,
+    pub treatment: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportEvidenceBoundaryV0 {
+    pub boundary_id: String,
+    pub source_ref_ids: Vec<String>,
+    pub measurement_boundary_refs: Vec<String>,
+    pub confidence_boundary: String,
+    pub evidence_kinds: Vec<String>,
+    pub unsupported_constructs: Vec<String>,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportEstimateValidationReportV0 {
+    pub schema_version: String,
+    pub input: OperationSupportEstimateValidationInput,
+    pub estimate: OperationSupportEstimateV0,
+    pub summary: OperationSupportEstimateValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportEstimateValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub estimate_id: String,
+    pub descriptor_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSupportEstimateValidationSummary {
+    pub result: String,
+    pub candidate_operation_family_count: usize,
+    pub policy_constraint_count: usize,
+    pub known_forbidden_support_count: usize,
+    pub unknown_remainder_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -6886,6 +6886,142 @@ fn cli_artifact_descriptor_emits_fixture_and_validates_boundaries() {
 }
 
 #[test]
+fn cli_operation_support_estimate_emits_fixture_and_validates_boundaries() {
+    let root = fixture_root();
+    let out_dir = temp_dir("operation-support-estimate");
+    let static_validation = out_dir.join("operation-support-estimate-static-validation.json");
+    let fixture_artifact = out_dir.join("operation-support-estimate-fixture.json");
+    let fixture_validation = out_dir.join("operation-support-estimate-validation.json");
+    let invalid_estimate = out_dir.join("operation-support-estimate-invalid.json");
+    let invalid_validation = out_dir.join("operation-support-estimate-invalid-validation.json");
+
+    run_sig0(&[
+        "operation-support-estimate",
+        "--out",
+        static_validation
+            .to_str()
+            .expect("static validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "operation-support-estimate",
+        "--fixture",
+        "--out",
+        fixture_artifact.to_str().expect("fixture path is utf-8"),
+    ]);
+    run_sig0(&[
+        "operation-support-estimate",
+        "--input",
+        root.join("operation_support_estimate.json")
+            .to_str()
+            .expect("fixture input path is utf-8"),
+        "--out",
+        fixture_validation
+            .to_str()
+            .expect("fixture validation path is utf-8"),
+    ]);
+
+    let static_json = read_json(&static_validation);
+    assert_eq!(
+        static_json["schemaVersion"],
+        "operation-support-estimate-validation-report-v0"
+    );
+    assert_eq!(static_json["summary"]["result"], "pass");
+    assert_eq!(static_json["summary"]["candidateOperationFamilyCount"], 2);
+    assert!(
+        static_json["estimate"]["nonConclusions"]
+            .as_array()
+            .expect("nonConclusions is array")
+            .iter()
+            .any(|conclusion| {
+                conclusion == "operation support estimate is not actual future support"
+            })
+    );
+
+    let artifact = read_json(&fixture_artifact);
+    assert_eq!(artifact["schemaVersion"], "operation-support-estimate-v0");
+    assert_eq!(
+        artifact["descriptorRef"]["descriptorSchemaVersion"],
+        "artifact-descriptor-v0"
+    );
+    assert!(
+        artifact["candidateOperationFamilies"]
+            .as_array()
+            .expect("candidateOperationFamilies is array")
+            .iter()
+            .any(|family| family["operationFamily"] == "schema-and-validator")
+    );
+    assert!(
+        artifact["unknownRemainder"]
+            .as_array()
+            .expect("unknownRemainder is array")
+            .iter()
+            .any(|remainder| {
+                remainder["unknownAxes"]
+                    .as_array()
+                    .expect("unknownAxes is array")
+                    .iter()
+                    .any(|axis| axis == "future accepted PR history")
+            })
+    );
+
+    let validation = read_json(&fixture_validation);
+    assert_eq!(validation["summary"]["result"], "pass");
+    assert!(
+        validation["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| {
+                check["id"] == "operation-support-estimate-unknown-remainder-not-measured-zero"
+                    && check["result"] == "pass"
+            })
+    );
+
+    let mut invalid = artifact;
+    invalid["candidateOperationFamilies"][0]["sourceRefIds"] =
+        serde_json::json!(["source:missing"]);
+    invalid["policyConstraints"][0]["safetyClaimBoundary"] =
+        serde_json::json!("global safety is guaranteed");
+    invalid["unknownRemainder"][0]["treatment"] = serde_json::json!("treated as zero");
+    fs::write(
+        &invalid_estimate,
+        serde_json::to_string_pretty(&invalid).expect("invalid estimate serializes"),
+    )
+    .expect("invalid estimate is written");
+    let output = run_sig0_output(&[
+        "operation-support-estimate",
+        "--input",
+        invalid_estimate
+            .to_str()
+            .expect("invalid estimate path is utf-8"),
+        "--out",
+        invalid_validation
+            .to_str()
+            .expect("invalid validation path is utf-8"),
+    ]);
+    assert!(
+        !output.status.success(),
+        "dangling source refs, global safety claims, and measured-zero unknowns should fail validation"
+    );
+    let invalid_report = read_json(&invalid_validation);
+    assert_eq!(invalid_report["summary"]["result"], "fail");
+    for expected_check in [
+        "operation-support-estimate-candidate-families-bounded",
+        "operation-support-estimate-policy-constraints-bounded",
+        "operation-support-estimate-unknown-remainder-not-measured-zero",
+    ] {
+        assert!(
+            invalid_report["checks"]
+                .as_array()
+                .expect("checks is array")
+                .iter()
+                .any(|check| check["id"] == expected_check && check["result"] == "fail"),
+            "missing failed check {expected_check}"
+        );
+    }
+}
+
+#[test]
 fn cli_baseline_suppression_reports_deltas_without_resolving_suppressed_witnesses() {
     let fixture = fixture_root();
     let air = air_fixture_root();

--- a/tools/archsig/tests/fixtures/minimal/operation_support_estimate.json
+++ b/tools/archsig/tests/fixtures/minimal/operation_support_estimate.json
@@ -1,0 +1,208 @@
+{
+  "schemaVersion": "operation-support-estimate-v0",
+  "estimateId": "fixture-operation-support-estimate-v0",
+  "descriptorRef": {
+    "descriptorSchemaVersion": "artifact-descriptor-v0",
+    "descriptorId": "fixture-artifact-descriptor-v0",
+    "artifactKind": "issue",
+    "sourceRefIds": [
+      "source:issue-734",
+      "source:artifact-descriptor-fixture",
+      "source:roadmap-b12",
+      "source:sft-aat-interface"
+    ],
+    "actionClassCandidateIds": [
+      "candidate:add-schema",
+      "candidate:add-validator",
+      "candidate:add-cli-entrypoint"
+    ],
+    "nonConclusions": [
+      "operation support estimate is a bounded tooling estimate, not accepted PR history",
+      "operation support estimate is not actual future support",
+      "unknown support is not measured zero",
+      "policy constraints do not prove global policy safety",
+      "operation support estimate does not prove future trajectory safety"
+    ]
+  },
+  "candidateOperationFamilies": [
+    {
+      "familyId": "family:schema-validation-artifact",
+      "operationFamily": "schema-and-validator",
+      "supportKind": "supported-by-selected-issue",
+      "actionClassCandidateIds": [
+        "candidate:add-schema",
+        "candidate:add-validator"
+      ],
+      "sourceRefIds": [
+        "source:issue-734",
+        "source:roadmap-b12"
+      ],
+      "confidence": "high",
+      "rationale": "Issue #734 requests a schema and validator before downstream forecast artifacts.",
+      "assumptions": [
+        "operation family is inferred only from selected descriptor refs",
+        "support estimate does not assert actual future support"
+      ],
+      "nonConclusions": [
+        "operation support estimate is a bounded tooling estimate, not accepted PR history",
+        "operation support estimate is not actual future support",
+        "unknown support is not measured zero",
+        "policy constraints do not prove global policy safety",
+        "operation support estimate does not prove future trajectory safety"
+      ]
+    },
+    {
+      "familyId": "family:cli-fixture-validation",
+      "operationFamily": "cli-fixture-validation",
+      "supportKind": "supported-by-selected-issue",
+      "actionClassCandidateIds": [
+        "candidate:add-cli-entrypoint"
+      ],
+      "sourceRefIds": [
+        "source:issue-734",
+        "source:artifact-descriptor-fixture"
+      ],
+      "confidence": "medium",
+      "rationale": "The estimate should be emitted and validated through an archsig CLI entrypoint.",
+      "assumptions": [
+        "operation family is inferred only from selected descriptor refs",
+        "support estimate does not assert actual future support"
+      ],
+      "nonConclusions": [
+        "operation support estimate is a bounded tooling estimate, not accepted PR history",
+        "operation support estimate is not actual future support",
+        "unknown support is not measured zero",
+        "policy constraints do not prove global policy safety",
+        "operation support estimate does not prove future trajectory safety"
+      ]
+    }
+  ],
+  "policyConstraints": [
+    {
+      "constraintId": "constraint:no-theorem-promotion",
+      "constraintKind": "claim-boundary",
+      "appliesToFamilyIds": [
+        "family:schema-validation-artifact",
+        "family:cli-fixture-validation"
+      ],
+      "sourceRefIds": [
+        "source:sft-aat-interface"
+      ],
+      "rule": "Do not promote tooling estimates to Lean theorem claims.",
+      "safetyClaimBoundary": "constraint is local to selected B12 operation support evidence",
+      "nonConclusions": [
+        "operation support estimate is a bounded tooling estimate, not accepted PR history",
+        "operation support estimate is not actual future support",
+        "unknown support is not measured zero",
+        "policy constraints do not prove global policy safety",
+        "operation support estimate does not prove future trajectory safety"
+      ]
+    },
+    {
+      "constraintId": "constraint:no-causal-forecast",
+      "constraintKind": "forecast-boundary",
+      "appliesToFamilyIds": [
+        "family:schema-validation-artifact"
+      ],
+      "sourceRefIds": [
+        "source:roadmap-b12"
+      ],
+      "rule": "Do not treat support estimates as causal forecasts.",
+      "safetyClaimBoundary": "constraint prevents global safety and future trajectory safety claims",
+      "nonConclusions": [
+        "operation support estimate is a bounded tooling estimate, not accepted PR history",
+        "operation support estimate is not actual future support",
+        "unknown support is not measured zero",
+        "policy constraints do not prove global policy safety",
+        "operation support estimate does not prove future trajectory safety"
+      ]
+    }
+  ],
+  "knownForbiddenSupport": [
+    {
+      "forbiddenId": "forbidden:probability-assignment",
+      "operationFamily": "forecast-probability-assignment",
+      "sourceRefIds": [
+        "source:roadmap-b12"
+      ],
+      "constraintRefs": [
+        "constraint:no-causal-forecast"
+      ],
+      "reason": "B12.2 precedes ForecastCone and does not assign probabilities.",
+      "boundary": "probability and causal prediction remain outside operation support estimate",
+      "nonConclusions": [
+        "operation support estimate is a bounded tooling estimate, not accepted PR history",
+        "operation support estimate is not actual future support",
+        "unknown support is not measured zero",
+        "policy constraints do not prove global policy safety",
+        "operation support estimate does not prove future trajectory safety"
+      ]
+    }
+  ],
+  "unknownRemainder": [
+    {
+      "remainderId": "unknown:runtime-and-private-history",
+      "affectedFamilyIds": [
+        "family:schema-validation-artifact",
+        "family:cli-fixture-validation"
+      ],
+      "sourceRefIds": [
+        "source:issue-734"
+      ],
+      "unknownAxes": [
+        "private PRD details",
+        "runtime traces",
+        "future accepted PR history"
+      ],
+      "reason": "selected sources do not contain full PRD, runtime traces, or future history",
+      "treatment": "retain as unknown support remainder under the selected boundary",
+      "nonConclusions": [
+        "operation support estimate is a bounded tooling estimate, not accepted PR history",
+        "operation support estimate is not actual future support",
+        "unknown support is not measured zero",
+        "policy constraints do not prove global policy safety",
+        "operation support estimate does not prove future trajectory safety"
+      ]
+    }
+  ],
+  "evidenceBoundary": {
+    "boundaryId": "boundary:b12.2-operation-support-estimate",
+    "sourceRefIds": [
+      "source:issue-734",
+      "source:artifact-descriptor-fixture",
+      "source:roadmap-b12",
+      "source:sft-aat-interface"
+    ],
+    "measurementBoundaryRefs": [
+      "boundary:b12.1-artifact-descriptor",
+      "docs/tool/roadmap.md#b122-operationsupportestimate"
+    ],
+    "confidenceBoundary": "confidence values are qualitative and source-bound",
+    "evidenceKinds": [
+      "issue-body",
+      "artifact-descriptor-fixture",
+      "roadmap-boundary"
+    ],
+    "unsupportedConstructs": [
+      "accepted PR history completeness",
+      "actual future operation support",
+      "global policy safety proof"
+    ],
+    "assumptions": [
+      "artifact descriptor source refs are retained by id",
+      "operation families are candidates under selected B12 inputs"
+    ],
+    "nonConclusions": [
+      "confidence is relative to retained descriptor source refs",
+      "evidence boundary does not complete extractor coverage",
+      "unsupported constructs remain forecast boundary items"
+    ]
+  },
+  "nonConclusions": [
+    "operation support estimate is a bounded tooling estimate, not accepted PR history",
+    "operation support estimate is not actual future support",
+    "unknown support is not measured zero",
+    "policy constraints do not prove global policy safety",
+    "operation support estimate does not prove future trajectory safety"
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #734

B12.2 の `operation-support-estimate-v0` を追加しました。`ArtifactDescriptor` の source refs と action class candidate refs を保持し、candidate operation families、policy constraints、known forbidden support、unknown remainder、confidence / evidence boundary を schema と validator で扱います。

validator は missing source refs、unknown support を measured zero と混同する記述、global / future safety claim への過昇格を検出します。Lean status: empirical hypothesis / tooling validation。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/roadmap.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml` 成功
- [x] `lake build` 成功（既存 linter warning あり）
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 成功（今回の変更対象では該当なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている