### PR TITLE
B12 SFT forecasting MVP を実装する

### DIFF
--- a/docs/tool/roadmap.md
+++ b/docs/tool/roadmap.md
@@ -153,11 +153,19 @@ PRD / Spec / Issue / AI proposal
 measurement boundary を持つ level 3 相当の cone skeleton を作る。
 calibration 済みの weighting や field update は B10 / B11 artifact と接続した後に扱う。
 
-現在は `artifact-descriptor-v0` と `operation-support-estimate-v0` が schema + validator
-として実装済みである。`OperationSupportEstimate` は descriptor refs、candidate
-operation families、policy constraints、known forbidden support、unknown remainder、
-confidence / evidence boundary を保持するが、accepted PR history、actual future support、
-global policy safety、future trajectory safety は主張しない。
+現在は `artifact-descriptor-v0`、`operation-support-estimate-v0`、
+`forecast-cone-skeleton-v0`、`consequence-envelope-report-v0`、
+`forecast-calibration-hook-v0` が schema + validator として実装済みである。
+`OperationSupportEstimate` は descriptor refs、candidate operation families、policy
+constraints、known forbidden support、unknown remainder、confidence / evidence
+boundary を保持する。`ForecastConeSkeleton` は finite support と bounded horizon に相対化した
+path class candidates を保持する。`ConsequenceEnvelope` は affected architecture
+regions、comparable signature axes、expected axis delta ranges、selected obstruction
+witness candidates、missing boundary、theorem boundary、review / CI recommendation を
+report projection として保持する。`ForecastCalibrationHook` は forecast item refs と
+B10 / B11 の observed artifact refs を対応付ける。いずれも accepted PR history、actual
+future support、global policy safety、future trajectory safety、forecast correctness、
+causal proof、Lean theorem claim は主張しない。
 
 ### B12 milestones
 
@@ -165,9 +173,9 @@ global policy safety、future trajectory safety は主張しない。
 | --- | --- |
 | B12.1 ArtifactDescriptor | PRD / Issue / AI proposal の action class、scope、source refs、missing evidence を schema 化する。schema + validator 実装済み。 |
 | B12.2 OperationSupportEstimate | candidate operation family、policy constraints、known forbidden support、unknown remainder を出す。schema + validator 実装済み。 |
-| B12.3 ForecastCone skeleton | finite support と bounded horizon に相対化した path class skeleton を保持する。 |
-| B12.4 ConsequenceEnvelope report | signature axis、obstruction candidate、missing boundary、review / CI recommendation をまとめる。 |
-| B12.5 Calibration hook | observed PR / review / CI / outcome artifact と forecast item を対応付ける hook を置く。 |
+| B12.3 ForecastCone skeleton | finite support と bounded horizon に相対化した path class skeleton を保持する。schema + validator 実装済み。 |
+| B12.4 ConsequenceEnvelope report | signature axis、obstruction candidate、missing boundary、review / CI recommendation をまとめる。schema + validator 実装済み。 |
+| B12.5 Calibration hook | observed PR / review / CI / outcome artifact と forecast item を対応付ける hook を置く。schema + validator 実装済み。 |
 
 ## Standardization targets
 

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -17,8 +17,8 @@ PR comment、dataset generation などの後段 command に渡せる。
 - Sig0 output を validation し、revision snapshot と before / after diff を作る。
 - PR metadata、AIR、theorem precondition check、Feature Extension Report、policy decision、
   PR comment summary を生成する。
-- 実証研究用 dataset、B10 operational feedback artifact、B12 SFT forecasting input
-  descriptor を JSON として出力する。
+- 実証研究用 dataset、B10 operational feedback artifact、B12 SFT forecasting MVP の
+  descriptor / support estimate / cone / envelope / calibration hook を JSON として出力する。
 
 詳細な command と artifact は次に分けている。
 
@@ -94,6 +94,9 @@ scan
 | `pr-comment-summary-v0` | GitHub Checks / PR comment 向け Markdown summary。 |
 | `artifact-descriptor-v0` | PRD / Spec / Issue / AI proposal を SFT forecasting MVP の入力境界へ正規化する。 |
 | `operation-support-estimate-v0` | `artifact-descriptor-v0` から候補 operation family、policy constraints、known forbidden support、unknown remainder を保持する。 |
+| `forecast-cone-skeleton-v0` | finite support と bounded horizon に相対化した path class candidates と forecast boundary を保持する。 |
+| `consequence-envelope-report-v0` | signature axis、obstruction candidate、missing boundary、review / CI recommendation を report projection にまとめる。 |
+| `forecast-calibration-hook-v0` | forecast item refs と B10 / B11 の observed artifact refs を対応付ける。 |
 
 [Signature diff report workflow](../../.github/workflows/signature-diff.yml) は、PR / push /
 schedule / manual run で Sig0、validation、snapshot、`signature-diff-report-v0` を作り、

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -61,11 +61,21 @@ Lean status: `empirical hypothesis` / tooling output.
 | --- | --- | --- |
 | ArtifactDescriptor | `artifact-descriptor-v0` | PRD / Spec / Issue / AI proposal の source refs、action class candidates、scope、missing evidence、measurement boundary、forecast non-conclusions を保持する。 |
 | ArtifactDescriptor validation report | `artifact-descriptor-validation-report-v0` | descriptor が theorem claim、ground truth architecture object、causal forecast に昇格していないことを検査する。 |
+| OperationSupportEstimate | `operation-support-estimate-v0` | descriptor refs、candidate operation families、policy constraints、known forbidden support、unknown remainder、confidence / evidence boundary を保持する。 |
+| OperationSupportEstimate validation report | `operation-support-estimate-validation-report-v0` | unknown support と measured zero の混同、global policy safety / future trajectory safety への昇格を検査する。 |
+| ForecastConeSkeleton | `forecast-cone-skeleton-v0` | finite support refs、bounded horizon、path class candidates、forecast boundary、unknown remainder を保持する。 |
+| ForecastConeSkeleton validation report | `forecast-cone-skeleton-validation-report-v0` | probability claim、unmeasured axis の safe 扱い、support / horizon refs 欠落を検査する。 |
+| ConsequenceEnvelope | `consequence-envelope-report-v0` | affected regions、signature axes、axis delta ranges、obstruction candidates、missing / theorem boundary items、review / CI recommendation を保持する。 |
+| ConsequenceEnvelope validation report | `consequence-envelope-report-validation-report-v0` | source refs、measurement boundary、forecast non-conclusions、unknown remainder の欠落を検査する。 |
+| ForecastCalibrationHook | `forecast-calibration-hook-v0` | forecast item refs と observed PR / review / CI / outcome refs、B10 / B11 artifact boundary を対応付ける。 |
+| ForecastCalibrationHook validation report | `forecast-calibration-hook-validation-report-v0` | matched / unmatched / unavailable / private / notComparable を measured zero と混同していないことを検査する。 |
 
 `artifact-descriptor-v0` は B12 SFT forecasting MVP の最初の入力正規化 artifact である。
-この段階では operation support estimate、ForecastCone、ConsequenceEnvelope、
-probability、causal prediction は生成しない。missing evidence、unsupported constructs、
-forecast non-conclusions は後段 artifact に引き継ぐ境界として読む。
+後段では `operation-support-estimate-v0`、`forecast-cone-skeleton-v0`、
+`consequence-envelope-report-v0`、`forecast-calibration-hook-v0` が境界を引き継ぐ。
+これらは probability、causal prediction、global safety、forecast correctness、Lean theorem
+claim を生成しない。missing evidence、unsupported constructs、forecast non-conclusions は
+後段 artifact に引き継ぐ境界として読む。
 
 ## Measurement Boundary
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -246,6 +246,45 @@ policy constraints、known forbidden support、unknown remainder、confidence /
 evidence boundary を分離する。accepted PR history、actual future support、global
 policy safety、future trajectory safety はこの command では主張しない。
 
+B12 ForecastCone / ConsequenceEnvelope / CalibrationHook の canonical fixture を出力し、
+既存 artifact を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- forecast-cone-skeleton \
+  --fixture \
+  --out .lake/signature-current/forecast-cone-skeleton.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- forecast-cone-skeleton \
+  --input tools/archsig/tests/fixtures/minimal/forecast_cone_skeleton.json \
+  --out .lake/signature-current/forecast-cone-skeleton-validation.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- consequence-envelope \
+  --fixture \
+  --out .lake/signature-current/consequence-envelope-report.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- consequence-envelope \
+  --input tools/archsig/tests/fixtures/minimal/consequence_envelope_report.json \
+  --out .lake/signature-current/consequence-envelope-validation.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- forecast-calibration-hook \
+  --fixture \
+  --out .lake/signature-current/forecast-calibration-hook.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- forecast-calibration-hook \
+  --input tools/archsig/tests/fixtures/minimal/forecast_calibration_hook.json \
+  --out .lake/signature-current/forecast-calibration-hook-validation.json
+```
+
+`forecast-cone-skeleton-v0` は finite support refs、bounded horizon、
+path class candidates、operation support refs、source refs、forecast boundary、
+unknown remainder を保持する。`consequence-envelope-report-v0` は affected
+architecture regions、comparable signature axes、expected axis delta ranges、
+selected obstruction witness candidates、missing boundary items、theorem boundary
+items、review / CI / issue recommendation を保持する。`forecast-calibration-hook-v0`
+は forecast item refs と observed PR / review / CI / outcome refs、B10 / B11 artifact
+boundary を対応付ける。これらは probability、global risk reduction、trajectory-level
+safety、forecast correctness、causal proof、Lean theorem claim を主張しない。
+
 B5 repair / synthesis artifact を検査する。
 
 ```bash

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -36,6 +36,7 @@ pub mod schema;
 mod schema_catalog;
 mod schema_compatibility;
 mod schema_versioning;
+mod sft_forecasting;
 mod signature_trajectory_report;
 mod snapshot;
 mod synthesis_constraint;
@@ -114,6 +115,11 @@ pub use reported_axes_catalog::static_detectable_values_reported_axes_catalog;
 pub use schema::*;
 pub use schema_catalog::static_schema_version_catalog;
 pub use schema_compatibility::build_schema_compatibility_check_report;
+pub use sft_forecasting::{
+    static_consequence_envelope_report, static_forecast_calibration_hook,
+    static_forecast_cone_skeleton, validate_consequence_envelope_report,
+    validate_forecast_calibration_hook, validate_forecast_cone_skeleton,
+};
 pub use signature_trajectory_report::{
     static_signature_trajectory_report, validate_signature_trajectory_report,
 };

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -9,12 +9,15 @@ use archsig::{
     ArchitectureDynamicsMetricsReportValidationReportV0, ArchitectureFieldSnapshotV0,
     ArchitectureFieldSnapshotValidationReportV0, ArtifactDescriptorV0,
     ArtifactDescriptorValidationReportV0, CalibrationReviewRecordV0,
-    ComponentUniverseValidationReport, CustomRulePluginRegistryV0,
+    ComponentUniverseValidationReport, ConsequenceEnvelopeReportV0,
+    ConsequenceEnvelopeValidationReportV0, CustomRulePluginRegistryV0,
     CustomRulePluginRegistryValidationReportV0, DEFAULT_UNIVERSE_MODE,
     DetectableValuesReportedAxesCatalogV0, DriftLedgerAggregationWindowV0,
     DynamicsMeasurementContractV0, DynamicsMeasurementContractValidationReportV0,
-    EmpiricalDatasetInput, FeatureExtensionReportV0, FrameworkAdapterEvidenceV0,
-    HypothesisRefreshCycleV0, IncidentCorrelationMonitorV0, LawPolicyTemplateRegistryV0,
+    EmpiricalDatasetInput, FeatureExtensionReportV0, ForecastCalibrationHookV0,
+    ForecastCalibrationHookValidationReportV0, ForecastConeSkeletonV0,
+    ForecastConeSkeletonValidationReportV0, FrameworkAdapterEvidenceV0, HypothesisRefreshCycleV0,
+    IncidentCorrelationMonitorV0, LawPolicyTemplateRegistryV0,
     LawPolicyTemplateRegistryValidationReportV0, MeasurementUnitRegistryV0,
     MeasurementUnitRegistryValidationReportV0, NoSolutionCertificateV0,
     NoSolutionCertificateValidationReportV0, OperationProposalLogV0,
@@ -39,25 +42,28 @@ use archsig::{
     extract_relation_complexity_observation_from_file, extract_sig0_with_runtime,
     render_pr_comment_markdown, static_architecture_dynamics_metrics_report,
     static_architecture_field_snapshot, static_artifact_descriptor,
-    static_calibration_review_record, static_custom_rule_plugin_registry,
-    static_detectable_values_reported_axes_catalog, static_dynamics_measurement_contract,
-    static_hypothesis_refresh_cycle, static_incident_correlation_monitor,
-    static_law_policy_template_registry, static_measurement_unit_registry,
-    static_no_solution_certificate, static_operation_proposal_log,
-    static_operation_support_estimate, static_organization_policy,
+    static_calibration_review_record, static_consequence_envelope_report,
+    static_custom_rule_plugin_registry, static_detectable_values_reported_axes_catalog,
+    static_dynamics_measurement_contract, static_forecast_calibration_hook,
+    static_forecast_cone_skeleton, static_hypothesis_refresh_cycle,
+    static_incident_correlation_monitor, static_law_policy_template_registry,
+    static_measurement_unit_registry, static_no_solution_certificate,
+    static_operation_proposal_log, static_operation_support_estimate, static_organization_policy,
     static_ownership_boundary_monitor, static_pr_force_report, static_repair_adoption_record,
     static_repair_rule_registry, static_report_artifact_retention_manifest,
     static_schema_version_catalog, static_signature_trajectory_report,
     static_synthesis_constraint_artifact, static_team_threshold_policy,
     validate_air_document_report, validate_architecture_dynamics_metrics_report,
     validate_architecture_field_snapshot, validate_artifact_descriptor_report,
-    validate_component_universe_report, validate_custom_rule_plugin_registry_report,
-    validate_dynamics_measurement_contract_report, validate_law_policy_template_registry_report,
-    validate_measurement_unit_registry_report, validate_no_solution_certificate_report,
-    validate_operation_proposal_log, validate_operation_support_estimate,
-    validate_organization_policy_report, validate_pr_force_report,
-    validate_repair_rule_registry_report, validate_report_artifact_retention_report,
-    validate_signature_trajectory_report, validate_synthesis_constraint_artifact_report,
+    validate_component_universe_report, validate_consequence_envelope_report,
+    validate_custom_rule_plugin_registry_report, validate_dynamics_measurement_contract_report,
+    validate_forecast_calibration_hook, validate_forecast_cone_skeleton,
+    validate_law_policy_template_registry_report, validate_measurement_unit_registry_report,
+    validate_no_solution_certificate_report, validate_operation_proposal_log,
+    validate_operation_support_estimate, validate_organization_policy_report,
+    validate_pr_force_report, validate_repair_rule_registry_report,
+    validate_report_artifact_retention_report, validate_signature_trajectory_report,
+    validate_synthesis_constraint_artifact_report,
 };
 use clap::{Parser, Subcommand};
 
@@ -695,6 +701,51 @@ enum Command {
         fixture: bool,
 
         /// Output estimate or validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Emit or validate a forecast-cone-skeleton-v0 artifact.
+    ForecastConeSkeleton {
+        /// Optional ForecastCone skeleton JSON path to validate.
+        #[arg(long)]
+        input: Option<PathBuf>,
+
+        /// Emit the canonical minimal forecast-cone-skeleton-v0 fixture.
+        #[arg(long)]
+        fixture: bool,
+
+        /// Output cone or validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Emit or validate a consequence-envelope-report-v0 artifact.
+    ConsequenceEnvelope {
+        /// Optional ConsequenceEnvelope report JSON path to validate.
+        #[arg(long)]
+        input: Option<PathBuf>,
+
+        /// Emit the canonical minimal consequence-envelope-report-v0 fixture.
+        #[arg(long)]
+        fixture: bool,
+
+        /// Output report or validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Emit or validate a forecast-calibration-hook-v0 artifact.
+    ForecastCalibrationHook {
+        /// Optional ForecastCalibrationHook JSON path to validate.
+        #[arg(long)]
+        input: Option<PathBuf>,
+
+        /// Emit the canonical minimal forecast-calibration-hook-v0 fixture.
+        #[arg(long)]
+        fixture: bool,
+
+        /// Output hook or validation report JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
     },
@@ -1501,6 +1552,93 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 .unwrap_or_else(|| "static-operation-support-estimate".to_string());
             let validation: OperationSupportEstimateValidationReportV0 =
                 validate_operation_support_estimate(&estimate, &input_path);
+            let failed = validation.summary.result == "fail";
+            write_json(out, &validation)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::ForecastConeSkeleton {
+            input,
+            fixture,
+            out,
+        }) => {
+            if fixture {
+                let cone: ForecastConeSkeletonV0 = static_forecast_cone_skeleton();
+                write_json(out, &cone)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            let cone: ForecastConeSkeletonV0 = input
+                .as_ref()
+                .map(read_json)
+                .transpose()?
+                .unwrap_or_else(static_forecast_cone_skeleton);
+            let input_path = input
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "static-forecast-cone-skeleton".to_string());
+            let validation: ForecastConeSkeletonValidationReportV0 =
+                validate_forecast_cone_skeleton(&cone, &input_path);
+            let failed = validation.summary.result == "fail";
+            write_json(out, &validation)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::ConsequenceEnvelope {
+            input,
+            fixture,
+            out,
+        }) => {
+            if fixture {
+                let envelope: ConsequenceEnvelopeReportV0 = static_consequence_envelope_report();
+                write_json(out, &envelope)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            let envelope: ConsequenceEnvelopeReportV0 = input
+                .as_ref()
+                .map(read_json)
+                .transpose()?
+                .unwrap_or_else(static_consequence_envelope_report);
+            let input_path = input
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "static-consequence-envelope".to_string());
+            let validation: ConsequenceEnvelopeValidationReportV0 =
+                validate_consequence_envelope_report(&envelope, &input_path);
+            let failed = validation.summary.result == "fail";
+            write_json(out, &validation)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::ForecastCalibrationHook {
+            input,
+            fixture,
+            out,
+        }) => {
+            if fixture {
+                let hook: ForecastCalibrationHookV0 = static_forecast_calibration_hook();
+                write_json(out, &hook)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            let hook: ForecastCalibrationHookV0 = input
+                .as_ref()
+                .map(read_json)
+                .transpose()?
+                .unwrap_or_else(static_forecast_calibration_hook);
+            let input_path = input
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "static-forecast-calibration-hook".to_string());
+            let validation: ForecastCalibrationHookValidationReportV0 =
+                validate_forecast_calibration_hook(&hook, &input_path);
             let failed = validation.summary.result == "fail";
             write_json(out, &validation)?;
             Ok(if failed {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -86,6 +86,15 @@ pub const ARTIFACT_DESCRIPTOR_VALIDATION_REPORT_SCHEMA_VERSION: &str =
 pub const OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION: &str = "operation-support-estimate-v0";
 pub const OPERATION_SUPPORT_ESTIMATE_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "operation-support-estimate-validation-report-v0";
+pub const FORECAST_CONE_SKELETON_SCHEMA_VERSION: &str = "forecast-cone-skeleton-v0";
+pub const FORECAST_CONE_SKELETON_VALIDATION_REPORT_SCHEMA_VERSION: &str =
+    "forecast-cone-skeleton-validation-report-v0";
+pub const CONSEQUENCE_ENVELOPE_REPORT_SCHEMA_VERSION: &str = "consequence-envelope-report-v0";
+pub const CONSEQUENCE_ENVELOPE_REPORT_VALIDATION_REPORT_SCHEMA_VERSION: &str =
+    "consequence-envelope-report-validation-report-v0";
+pub const FORECAST_CALIBRATION_HOOK_SCHEMA_VERSION: &str = "forecast-calibration-hook-v0";
+pub const FORECAST_CALIBRATION_HOOK_VALIDATION_REPORT_SCHEMA_VERSION: &str =
+    "forecast-calibration-hook-validation-report-v0";
 pub const RUNTIME_EDGE_EVIDENCE_SCHEMA_VERSION: &str = "runtime-edge-evidence-v0";
 pub const RUNTIME_PROJECTION_RULE_VERSION: &str = "runtime-edge-projection-v0";
 pub const FRAMEWORK_ADAPTER_EVIDENCE_SCHEMA_VERSION: &str = "framework-adapter-evidence-v0";
@@ -3892,6 +3901,386 @@ pub struct OperationSupportEstimateValidationSummary {
     pub policy_constraint_count: usize,
     pub known_forbidden_support_count: usize,
     pub unknown_remainder_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastConeSkeletonV0 {
+    pub schema_version: String,
+    pub cone_id: String,
+    pub operation_support_ref: ForecastOperationSupportRefV0,
+    pub finite_support_refs: Vec<ForecastFiniteSupportRefV0>,
+    pub bounded_horizon: ForecastBoundedHorizonV0,
+    pub path_class_candidates: Vec<ForecastPathClassCandidateV0>,
+    pub forecast_boundary: ForecastBoundaryV0,
+    pub unknown_remainder: Vec<ForecastUnknownRemainderV0>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastOperationSupportRefV0 {
+    pub estimate_schema_version: String,
+    pub estimate_id: String,
+    pub descriptor_id: String,
+    pub candidate_operation_family_ids: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastFiniteSupportRefV0 {
+    pub support_ref_id: String,
+    pub support_kind: String,
+    pub operation_family_ids: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub boundary: String,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastBoundedHorizonV0 {
+    pub horizon_id: String,
+    pub horizon_kind: String,
+    pub max_steps: u32,
+    pub time_window: String,
+    pub source_ref_ids: Vec<String>,
+    pub boundary: String,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastPathClassCandidateV0 {
+    pub path_class_id: String,
+    pub path_class: String,
+    pub support_ref_ids: Vec<String>,
+    pub operation_family_ids: Vec<String>,
+    pub horizon_ref_id: String,
+    pub source_ref_ids: Vec<String>,
+    pub affected_axes: Vec<String>,
+    pub rationale: String,
+    pub probability_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastBoundaryV0 {
+    pub boundary_id: String,
+    pub source_ref_ids: Vec<String>,
+    pub measurement_boundary_refs: Vec<String>,
+    pub support_ref_ids: Vec<String>,
+    pub horizon_ref_ids: Vec<String>,
+    pub unsupported_constructs: Vec<String>,
+    pub assumptions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastUnknownRemainderV0 {
+    pub remainder_id: String,
+    pub affected_path_class_ids: Vec<String>,
+    pub source_ref_ids: Vec<String>,
+    pub unknown_axes: Vec<String>,
+    pub reason: String,
+    pub treatment: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastConeSkeletonValidationReportV0 {
+    pub schema_version: String,
+    pub input: ForecastConeSkeletonValidationInput,
+    pub cone: ForecastConeSkeletonV0,
+    pub summary: ForecastConeSkeletonValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastConeSkeletonValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub cone_id: String,
+    pub estimate_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastConeSkeletonValidationSummary {
+    pub result: String,
+    pub finite_support_ref_count: usize,
+    pub path_class_candidate_count: usize,
+    pub unknown_remainder_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceEnvelopeReportV0 {
+    pub schema_version: String,
+    pub envelope_id: String,
+    pub forecast_cone_ref: ConsequenceForecastConeRefV0,
+    pub affected_architecture_regions: Vec<AffectedArchitectureRegionV0>,
+    pub comparable_signature_axes: Vec<ComparableSignatureAxisV0>,
+    pub expected_axis_delta_ranges: Vec<ExpectedAxisDeltaRangeV0>,
+    pub obstruction_witness_candidates: Vec<SelectedObstructionWitnessCandidateV0>,
+    pub missing_boundary_items: Vec<ConsequenceMissingBoundaryItemV0>,
+    pub theorem_boundary_items: Vec<ConsequenceTheoremBoundaryItemV0>,
+    pub recommendations: ConsequenceEnvelopeRecommendationsV0,
+    pub summary_projection: ConsequenceEnvelopeSummaryProjectionV0,
+    pub unknown_remainder: Vec<ConsequenceUnknownRemainderV0>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceForecastConeRefV0 {
+    pub forecast_cone_schema_version: String,
+    pub cone_id: String,
+    pub operation_support_estimate_id: String,
+    pub source_ref_ids: Vec<String>,
+    pub forecast_boundary_refs: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AffectedArchitectureRegionV0 {
+    pub region_id: String,
+    pub region_ref: String,
+    pub effect_kind: String,
+    pub source_ref_ids: Vec<String>,
+    pub boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparableSignatureAxisV0 {
+    pub axis_id: String,
+    pub axis_name: String,
+    pub measurement_boundary_refs: Vec<String>,
+    pub comparability: String,
+    pub missing_invariant_refs: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExpectedAxisDeltaRangeV0 {
+    pub delta_id: String,
+    pub axis_id: String,
+    pub range_kind: String,
+    pub lower_bound: Option<String>,
+    pub upper_bound: Option<String>,
+    pub source_ref_ids: Vec<String>,
+    pub boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectedObstructionWitnessCandidateV0 {
+    pub candidate_id: String,
+    pub obstruction_kind: String,
+    pub region_ids: Vec<String>,
+    pub axis_ids: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub selection_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceMissingBoundaryItemV0 {
+    pub item_id: String,
+    pub item_kind: String,
+    pub affected_axis_ids: Vec<String>,
+    pub reason: String,
+    pub treatment: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceTheoremBoundaryItemV0 {
+    pub item_id: String,
+    pub theorem_or_claim_ref: String,
+    pub boundary: String,
+    pub required_evidence: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceEnvelopeRecommendationsV0 {
+    pub review: Vec<String>,
+    pub ci: Vec<String>,
+    pub issue_decomposition: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceEnvelopeSummaryProjectionV0 {
+    pub summary_id: String,
+    pub headline: String,
+    pub affected_region_count: usize,
+    pub comparable_axis_count: usize,
+    pub missing_boundary_count: usize,
+    pub reviewer_notes: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceUnknownRemainderV0 {
+    pub remainder_id: String,
+    pub affected_region_ids: Vec<String>,
+    pub affected_axis_ids: Vec<String>,
+    pub unknown_axes: Vec<String>,
+    pub treatment: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceEnvelopeValidationReportV0 {
+    pub schema_version: String,
+    pub input: ConsequenceEnvelopeValidationInput,
+    pub envelope: ConsequenceEnvelopeReportV0,
+    pub summary: ConsequenceEnvelopeValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceEnvelopeValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub envelope_id: String,
+    pub cone_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsequenceEnvelopeValidationSummary {
+    pub result: String,
+    pub affected_region_count: usize,
+    pub comparable_axis_count: usize,
+    pub obstruction_candidate_count: usize,
+    pub missing_boundary_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastCalibrationHookV0 {
+    pub schema_version: String,
+    pub hook_id: String,
+    pub envelope_ref: CalibrationEnvelopeRefV0,
+    pub forecast_item_refs: Vec<CalibrationForecastItemRefV0>,
+    pub observed_outcome_refs: Vec<CalibrationObservedOutcomeRefV0>,
+    pub matches: Vec<CalibrationMatchV0>,
+    pub reference_boundaries: CalibrationReferenceBoundariesV0,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationEnvelopeRefV0 {
+    pub envelope_schema_version: String,
+    pub envelope_id: String,
+    pub cone_id: String,
+    pub source_ref_ids: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationForecastItemRefV0 {
+    pub forecast_item_id: String,
+    pub item_kind: String,
+    pub envelope_item_ref: String,
+    pub source_ref_ids: Vec<String>,
+    pub comparison_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationObservedOutcomeRefV0 {
+    pub observed_ref_id: String,
+    pub observed_kind: String,
+    pub path_or_url: String,
+    pub status: String,
+    pub b10_refs: Vec<String>,
+    pub b11_refs: Vec<String>,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationMatchV0 {
+    pub match_id: String,
+    pub forecast_item_id: String,
+    pub observed_ref_id: Option<String>,
+    pub status: String,
+    pub rationale: String,
+    pub update_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationReferenceBoundariesV0 {
+    pub b10_refs: Vec<String>,
+    pub b11_refs: Vec<String>,
+    pub unavailable_refs: Vec<String>,
+    pub private_refs: Vec<String>,
+    pub measurement_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastCalibrationHookValidationReportV0 {
+    pub schema_version: String,
+    pub input: ForecastCalibrationHookValidationInput,
+    pub hook: ForecastCalibrationHookV0,
+    pub summary: ForecastCalibrationHookValidationSummary,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastCalibrationHookValidationInput {
+    pub schema_version: String,
+    pub path: String,
+    pub hook_id: String,
+    pub envelope_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForecastCalibrationHookValidationSummary {
+    pub result: String,
+    pub forecast_item_count: usize,
+    pub observed_outcome_count: usize,
+    pub match_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
 }

--- a/tools/archsig/src/sft_forecasting.rs
+++ b/tools/archsig/src/sft_forecasting.rs
@@ -1,0 +1,1310 @@
+use std::collections::BTreeSet;
+
+use crate::validation::{count_checks, generic_validation_example, validation_check};
+use crate::{
+    AffectedArchitectureRegionV0, CONSEQUENCE_ENVELOPE_REPORT_SCHEMA_VERSION,
+    CONSEQUENCE_ENVELOPE_REPORT_VALIDATION_REPORT_SCHEMA_VERSION, CalibrationEnvelopeRefV0,
+    CalibrationForecastItemRefV0, CalibrationMatchV0, CalibrationObservedOutcomeRefV0,
+    CalibrationReferenceBoundariesV0, ComparableSignatureAxisV0,
+    ConsequenceEnvelopeRecommendationsV0, ConsequenceEnvelopeReportV0,
+    ConsequenceEnvelopeSummaryProjectionV0, ConsequenceEnvelopeValidationInput,
+    ConsequenceEnvelopeValidationReportV0, ConsequenceEnvelopeValidationSummary,
+    ConsequenceForecastConeRefV0, ConsequenceMissingBoundaryItemV0,
+    ConsequenceTheoremBoundaryItemV0, ConsequenceUnknownRemainderV0, ExpectedAxisDeltaRangeV0,
+    FORECAST_CALIBRATION_HOOK_SCHEMA_VERSION,
+    FORECAST_CALIBRATION_HOOK_VALIDATION_REPORT_SCHEMA_VERSION,
+    FORECAST_CONE_SKELETON_SCHEMA_VERSION, FORECAST_CONE_SKELETON_VALIDATION_REPORT_SCHEMA_VERSION,
+    ForecastBoundaryV0, ForecastBoundedHorizonV0, ForecastCalibrationHookV0,
+    ForecastCalibrationHookValidationInput, ForecastCalibrationHookValidationReportV0,
+    ForecastCalibrationHookValidationSummary, ForecastConeSkeletonV0,
+    ForecastConeSkeletonValidationInput, ForecastConeSkeletonValidationReportV0,
+    ForecastConeSkeletonValidationSummary, ForecastFiniteSupportRefV0,
+    ForecastOperationSupportRefV0, ForecastPathClassCandidateV0, ForecastUnknownRemainderV0,
+    OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION, SelectedObstructionWitnessCandidateV0,
+    ValidationCheck,
+};
+
+const FORECAST_NON_CONCLUSIONS: [&str; 5] = [
+    "forecast cone skeleton is bounded by selected finite support and horizon",
+    "forecast cone skeleton does not assign probabilities",
+    "forecast cone skeleton does not prove global risk reduction",
+    "forecast cone skeleton does not prove trajectory-level safety",
+    "forecast cone skeleton is not an empirical prediction theorem",
+];
+
+const ENVELOPE_NON_CONCLUSIONS: [&str; 5] = [
+    "consequence envelope is a report projection, not a Lean theorem proof",
+    "consequence envelope does not identify a unique causal artifact action",
+    "consequence envelope does not prove global safety",
+    "unknown remainder is not measured zero",
+    "summary projection is for review and CI consumption only",
+];
+
+const CALIBRATION_NON_CONCLUSIONS: [&str; 5] = [
+    "calibration hook does not prove forecast correctness",
+    "calibration hook does not provide a causal proof",
+    "calibration hook is not a Lean theorem claim",
+    "calibration hook does not establish field completeness",
+    "unmatched, unavailable, private, and notComparable outcomes are not measured zero",
+];
+
+const CALIBRATION_STATUSES: [&str; 5] = [
+    "matched",
+    "unmatched",
+    "unavailable",
+    "private",
+    "notComparable",
+];
+
+pub fn static_forecast_cone_skeleton() -> ForecastConeSkeletonV0 {
+    let source_ref_ids = vec![
+        "source:issue-735".to_string(),
+        "source:operation-support-estimate-fixture".to_string(),
+        "source:roadmap-b12".to_string(),
+        "source:sft-consequence-envelope".to_string(),
+    ];
+    let family_ids = vec![
+        "family:schema-validation-artifact".to_string(),
+        "family:cli-fixture-validation".to_string(),
+    ];
+    let support_ref_ids = vec![
+        "support:schema-validation-artifact".to_string(),
+        "support:cli-fixture-validation".to_string(),
+    ];
+
+    ForecastConeSkeletonV0 {
+        schema_version: FORECAST_CONE_SKELETON_SCHEMA_VERSION.to_string(),
+        cone_id: "fixture-forecast-cone-skeleton-v0".to_string(),
+        operation_support_ref: ForecastOperationSupportRefV0 {
+            estimate_schema_version: OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION.to_string(),
+            estimate_id: "fixture-operation-support-estimate-v0".to_string(),
+            descriptor_id: "fixture-artifact-descriptor-v0".to_string(),
+            candidate_operation_family_ids: family_ids.clone(),
+            source_ref_ids: source_ref_ids.clone(),
+            non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+        },
+        finite_support_refs: vec![
+            finite_support_ref(
+                "support:schema-validation-artifact",
+                "finite-operation-family",
+                &["family:schema-validation-artifact"],
+                &[
+                    "source:issue-735",
+                    "source:operation-support-estimate-fixture",
+                ],
+                "schema and validator support is finite under the selected B12 fixture",
+            ),
+            finite_support_ref(
+                "support:cli-fixture-validation",
+                "finite-cli-support",
+                &["family:cli-fixture-validation"],
+                &["source:issue-735", "source:roadmap-b12"],
+                "CLI fixture validation support is finite and source-bound",
+            ),
+        ],
+        bounded_horizon: ForecastBoundedHorizonV0 {
+            horizon_id: "horizon:b12-mvp-skeleton".to_string(),
+            horizon_kind: "bounded-step".to_string(),
+            max_steps: 3,
+            time_window: "Phase B12 MVP issue chain".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            boundary: "bounded to B12.3 skeleton construction before probability or causal claims"
+                .to_string(),
+            assumptions: vec![
+                "horizon counts artifact pipeline steps, not calendar predictions".to_string(),
+                "downstream report and calibration artifacts remain separate".to_string(),
+            ],
+            non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+        },
+        path_class_candidates: vec![
+            path_class_candidate(
+                "path:schema-to-envelope",
+                "descriptor-estimate-cone-envelope",
+                &[
+                    "support:schema-validation-artifact",
+                    "support:cli-fixture-validation",
+                ],
+                &[
+                    "family:schema-validation-artifact",
+                    "family:cli-fixture-validation",
+                ],
+                &[
+                    "source:issue-735",
+                    "source:operation-support-estimate-fixture",
+                    "source:roadmap-b12",
+                    "source:sft-consequence-envelope",
+                ],
+                &["schemaCompleteness", "boundaryRetention"],
+                "The selected artifact path can feed a report skeleton without assigning probability.",
+            ),
+            path_class_candidate(
+                "path:cli-validation-feedback",
+                "fixture-validation-feedback",
+                &["support:cli-fixture-validation"],
+                &["family:cli-fixture-validation"],
+                &["source:issue-735", "source:roadmap-b12"],
+                &["validatorCoverage", "unknownRemainder"],
+                "CLI validation can expose missing boundaries while retaining unknown support.",
+            ),
+        ],
+        forecast_boundary: ForecastBoundaryV0 {
+            boundary_id: "boundary:b12.3-forecast-cone-skeleton".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            measurement_boundary_refs: vec![
+                "boundary:b12.2-operation-support-estimate".to_string(),
+                "docs/tool/roadmap.md#b123-forecastcone-skeleton".to_string(),
+            ],
+            support_ref_ids,
+            horizon_ref_ids: vec!["horizon:b12-mvp-skeleton".to_string()],
+            unsupported_constructs: vec![
+                "probability assignment".to_string(),
+                "global risk reduction proof".to_string(),
+                "trajectory-level safety proof".to_string(),
+                "empirical prediction theorem".to_string(),
+            ],
+            assumptions: vec![
+                "path classes are candidates under selected finite support".to_string(),
+                "unmeasured axes remain explicit unknown remainder".to_string(),
+            ],
+            non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+        },
+        unknown_remainder: vec![ForecastUnknownRemainderV0 {
+            remainder_id: "unknown:unmeasured-runtime-and-policy-axes".to_string(),
+            affected_path_class_ids: vec![
+                "path:schema-to-envelope".to_string(),
+                "path:cli-validation-feedback".to_string(),
+            ],
+            source_ref_ids,
+            unknown_axes: vec![
+                "runtime propagation".to_string(),
+                "private PRD constraints".to_string(),
+                "future reviewer behavior".to_string(),
+            ],
+            reason:
+                "selected B12.3 inputs do not measure runtime, private, or future feedback axes"
+                    .to_string(),
+            treatment: "retain as unknown forecast remainder under the selected horizon"
+                .to_string(),
+            non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+        }],
+        non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+    }
+}
+
+pub fn validate_forecast_cone_skeleton(
+    cone: &ForecastConeSkeletonV0,
+    input_path: &str,
+) -> ForecastConeSkeletonValidationReportV0 {
+    let checks = vec![
+        check_forecast_schema(cone),
+        check_forecast_support_refs(cone),
+        check_forecast_horizon(cone),
+        check_forecast_path_classes(cone),
+        check_forecast_boundary(cone),
+        check_forecast_unknown_remainder(cone),
+        check_required_non_conclusions(
+            "forecast-cone-skeleton-non-conclusions-preserved",
+            &cone.non_conclusions,
+            &FORECAST_NON_CONCLUSIONS,
+        ),
+    ];
+    let summary = ForecastConeSkeletonValidationSummary {
+        result: validation_result(&checks),
+        finite_support_ref_count: cone.finite_support_refs.len(),
+        path_class_candidate_count: cone.path_class_candidates.len(),
+        unknown_remainder_count: cone.unknown_remainder.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    ForecastConeSkeletonValidationReportV0 {
+        schema_version: FORECAST_CONE_SKELETON_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: ForecastConeSkeletonValidationInput {
+            schema_version: cone.schema_version.clone(),
+            path: input_path.to_string(),
+            cone_id: cone.cone_id.clone(),
+            estimate_id: cone.operation_support_ref.estimate_id.clone(),
+        },
+        cone: cone.clone(),
+        summary,
+        checks,
+    }
+}
+
+pub fn static_consequence_envelope_report() -> ConsequenceEnvelopeReportV0 {
+    let source_ref_ids = vec![
+        "source:issue-736".to_string(),
+        "source:forecast-cone-fixture".to_string(),
+        "source:roadmap-b12".to_string(),
+    ];
+
+    ConsequenceEnvelopeReportV0 {
+        schema_version: CONSEQUENCE_ENVELOPE_REPORT_SCHEMA_VERSION.to_string(),
+        envelope_id: "fixture-consequence-envelope-report-v0".to_string(),
+        forecast_cone_ref: ConsequenceForecastConeRefV0 {
+            forecast_cone_schema_version: FORECAST_CONE_SKELETON_SCHEMA_VERSION.to_string(),
+            cone_id: "fixture-forecast-cone-skeleton-v0".to_string(),
+            operation_support_estimate_id: "fixture-operation-support-estimate-v0".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            forecast_boundary_refs: vec!["boundary:b12.3-forecast-cone-skeleton".to_string()],
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        },
+        affected_architecture_regions: vec![
+            AffectedArchitectureRegionV0 {
+                region_id: "region:tools-archsig-sft".to_string(),
+                region_ref: "tools/archsig".to_string(),
+                effect_kind: "tooling-artifact-surface".to_string(),
+                source_ref_ids: source_ref_ids.clone(),
+                boundary: "region is selected by B12 tooling scope, not inferred as global architecture impact"
+                    .to_string(),
+                non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+            },
+            AffectedArchitectureRegionV0 {
+                region_id: "region:docs-sft-boundary".to_string(),
+                region_ref: "docs/sft".to_string(),
+                effect_kind: "claim-boundary-documentation".to_string(),
+                source_ref_ids: source_ref_ids.clone(),
+                boundary: "documentation boundary tracks non-conclusions only".to_string(),
+                non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+            },
+        ],
+        comparable_signature_axes: vec![
+            ComparableSignatureAxisV0 {
+                axis_id: "axis:boundary-retention".to_string(),
+                axis_name: "boundaryRetention".to_string(),
+                measurement_boundary_refs: vec![
+                    "boundary:b12.3-forecast-cone-skeleton".to_string(),
+                    "boundary:b12.4-consequence-envelope".to_string(),
+                ],
+                comparability: "comparable only across retained source refs and forecast boundary items"
+                    .to_string(),
+                missing_invariant_refs: vec!["missing:runtime-propagation-invariant".to_string()],
+                non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+            },
+            ComparableSignatureAxisV0 {
+                axis_id: "axis:unknown-remainder".to_string(),
+                axis_name: "unknownRemainder".to_string(),
+                measurement_boundary_refs: vec!["boundary:b12.4-consequence-envelope".to_string()],
+                comparability: "compares explicit unknown items, not absent or safe axes".to_string(),
+                missing_invariant_refs: vec!["missing:private-feedback-boundary".to_string()],
+                non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+            },
+        ],
+        expected_axis_delta_ranges: vec![
+            ExpectedAxisDeltaRangeV0 {
+                delta_id: "delta:boundary-retention-nonnegative".to_string(),
+                axis_id: "axis:boundary-retention".to_string(),
+                range_kind: "qualitative-nonnegative".to_string(),
+                lower_bound: Some("retained".to_string()),
+                upper_bound: Some("retained-plus-report-summary".to_string()),
+                source_ref_ids: source_ref_ids.clone(),
+                boundary: "expected range is qualitative and fixture-bound".to_string(),
+                non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+            },
+            ExpectedAxisDeltaRangeV0 {
+                delta_id: "delta:unknown-remainder-explicit".to_string(),
+                axis_id: "axis:unknown-remainder".to_string(),
+                range_kind: "qualitative-explicit".to_string(),
+                lower_bound: Some("unknown retained".to_string()),
+                upper_bound: None,
+                source_ref_ids: source_ref_ids.clone(),
+                boundary: "unknown remainder is reported, not resolved".to_string(),
+                non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+            },
+        ],
+        obstruction_witness_candidates: vec![SelectedObstructionWitnessCandidateV0 {
+            candidate_id: "obstruction:runtime-boundary-missing".to_string(),
+            obstruction_kind: "missing-runtime-boundary".to_string(),
+            region_ids: vec!["region:tools-archsig-sft".to_string()],
+            axis_ids: vec!["axis:unknown-remainder".to_string()],
+            evidence_refs: source_ref_ids.clone(),
+            selection_boundary:
+                "selected as a review candidate, not as a proved obstruction witness".to_string(),
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        }],
+        missing_boundary_items: vec![ConsequenceMissingBoundaryItemV0 {
+            item_id: "missing:runtime-propagation-invariant".to_string(),
+            item_kind: "missing-invariant".to_string(),
+            affected_axis_ids: vec!["axis:unknown-remainder".to_string()],
+            reason: "runtime propagation is outside B12.4 report evidence".to_string(),
+            treatment: "report as missing boundary item for review and issue decomposition"
+                .to_string(),
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        }],
+        theorem_boundary_items: vec![ConsequenceTheoremBoundaryItemV0 {
+            item_id: "theorem-boundary:no-lean-promotion".to_string(),
+            theorem_or_claim_ref: "AAT theorem boundary".to_string(),
+            boundary: "report does not upgrade forecast artifacts to Lean theorem claims".to_string(),
+            required_evidence: vec![
+                "formal theorem statement".to_string(),
+                "Lean proof".to_string(),
+                "separate empirical validation".to_string(),
+            ],
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        }],
+        recommendations: ConsequenceEnvelopeRecommendationsV0 {
+            review: vec![
+                "review retained source refs before treating any region as affected".to_string(),
+                "check missing boundary items before accepting axis deltas".to_string(),
+            ],
+            ci: vec!["run consequence-envelope validator on report artifacts".to_string()],
+            issue_decomposition: vec![
+                "split runtime propagation boundary into a downstream empirical issue".to_string(),
+            ],
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        },
+        summary_projection: ConsequenceEnvelopeSummaryProjectionV0 {
+            summary_id: "summary:b12.4-review-projection".to_string(),
+            headline: "B12 forecast report keeps boundary and unknown remainder explicit".to_string(),
+            affected_region_count: 2,
+            comparable_axis_count: 2,
+            missing_boundary_count: 1,
+            reviewer_notes: vec![
+                "No probability or causal safety claim is emitted.".to_string(),
+                "Unknown runtime and private feedback remain report items.".to_string(),
+            ],
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        },
+        unknown_remainder: vec![ConsequenceUnknownRemainderV0 {
+            remainder_id: "unknown:private-and-runtime-outcomes".to_string(),
+            affected_region_ids: vec!["region:tools-archsig-sft".to_string()],
+            affected_axis_ids: vec!["axis:unknown-remainder".to_string()],
+            unknown_axes: vec![
+                "private PRD decisions".to_string(),
+                "runtime outcome evidence".to_string(),
+                "future CI and review behavior".to_string(),
+            ],
+            treatment: "retain as unresolved report remainder under the selected boundary"
+                .to_string(),
+            non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+        }],
+        non_conclusions: strings(&ENVELOPE_NON_CONCLUSIONS),
+    }
+}
+
+pub fn validate_consequence_envelope_report(
+    envelope: &ConsequenceEnvelopeReportV0,
+    input_path: &str,
+) -> ConsequenceEnvelopeValidationReportV0 {
+    let checks = vec![
+        check_envelope_schema(envelope),
+        check_envelope_source_refs(envelope),
+        check_envelope_regions_and_axes(envelope),
+        check_envelope_boundaries(envelope),
+        check_envelope_unknown_remainder(envelope),
+        check_required_non_conclusions(
+            "consequence-envelope-non-conclusions-preserved",
+            &envelope.non_conclusions,
+            &ENVELOPE_NON_CONCLUSIONS,
+        ),
+    ];
+    let summary = ConsequenceEnvelopeValidationSummary {
+        result: validation_result(&checks),
+        affected_region_count: envelope.affected_architecture_regions.len(),
+        comparable_axis_count: envelope.comparable_signature_axes.len(),
+        obstruction_candidate_count: envelope.obstruction_witness_candidates.len(),
+        missing_boundary_count: envelope.missing_boundary_items.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    ConsequenceEnvelopeValidationReportV0 {
+        schema_version: CONSEQUENCE_ENVELOPE_REPORT_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: ConsequenceEnvelopeValidationInput {
+            schema_version: envelope.schema_version.clone(),
+            path: input_path.to_string(),
+            envelope_id: envelope.envelope_id.clone(),
+            cone_id: envelope.forecast_cone_ref.cone_id.clone(),
+        },
+        envelope: envelope.clone(),
+        summary,
+        checks,
+    }
+}
+
+pub fn static_forecast_calibration_hook() -> ForecastCalibrationHookV0 {
+    let source_ref_ids = vec![
+        "source:issue-737".to_string(),
+        "source:consequence-envelope-fixture".to_string(),
+        "source:b10-report-outcome-daily-ledger".to_string(),
+        "source:b11-signature-trajectory-report".to_string(),
+    ];
+
+    ForecastCalibrationHookV0 {
+        schema_version: FORECAST_CALIBRATION_HOOK_SCHEMA_VERSION.to_string(),
+        hook_id: "fixture-forecast-calibration-hook-v0".to_string(),
+        envelope_ref: CalibrationEnvelopeRefV0 {
+            envelope_schema_version: CONSEQUENCE_ENVELOPE_REPORT_SCHEMA_VERSION.to_string(),
+            envelope_id: "fixture-consequence-envelope-report-v0".to_string(),
+            cone_id: "fixture-forecast-cone-skeleton-v0".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+        },
+        forecast_item_refs: vec![
+            CalibrationForecastItemRefV0 {
+                forecast_item_id: "forecast-item:boundary-retention-delta".to_string(),
+                item_kind: "axis-delta-range".to_string(),
+                envelope_item_ref: "delta:boundary-retention-nonnegative".to_string(),
+                source_ref_ids: source_ref_ids.clone(),
+                comparison_boundary: "compare only retained report item ids and observed refs"
+                    .to_string(),
+                non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+            },
+            CalibrationForecastItemRefV0 {
+                forecast_item_id: "forecast-item:runtime-boundary-missing".to_string(),
+                item_kind: "missing-boundary".to_string(),
+                envelope_item_ref: "missing:runtime-propagation-invariant".to_string(),
+                source_ref_ids: source_ref_ids.clone(),
+                comparison_boundary: "missing boundary can remain unavailable or private".to_string(),
+                non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+            },
+        ],
+        observed_outcome_refs: vec![
+            CalibrationObservedOutcomeRefV0 {
+                observed_ref_id: "observed:b10-daily-ledger".to_string(),
+                observed_kind: "report-outcome-daily-ledger".to_string(),
+                path_or_url: "tools/archsig/tests/fixtures/minimal/report_outcome_daily_ledger.json"
+                    .to_string(),
+                status: "matched".to_string(),
+                b10_refs: vec!["b10:report-outcome-daily-ledger".to_string()],
+                b11_refs: Vec::new(),
+                evidence_boundary: "B10 ledger is fixture evidence, not correctness proof"
+                    .to_string(),
+                non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+            },
+            CalibrationObservedOutcomeRefV0 {
+                observed_ref_id: "observed:b11-trajectory-private".to_string(),
+                observed_kind: "signature-trajectory-report".to_string(),
+                path_or_url: "private-or-unavailable".to_string(),
+                status: "private".to_string(),
+                b10_refs: Vec::new(),
+                b11_refs: vec!["b11:signature-trajectory-report".to_string()],
+                evidence_boundary: "private trajectory evidence is retained as private, not zero"
+                    .to_string(),
+                non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+            },
+        ],
+        matches: vec![
+            CalibrationMatchV0 {
+                match_id: "match:boundary-retention-ledger".to_string(),
+                forecast_item_id: "forecast-item:boundary-retention-delta".to_string(),
+                observed_ref_id: Some("observed:b10-daily-ledger".to_string()),
+                status: "matched".to_string(),
+                rationale: "forecast item can be linked to a retained B10 ledger fixture".to_string(),
+                update_boundary: "link can seed calibration review but does not prove correctness"
+                    .to_string(),
+                non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+            },
+            CalibrationMatchV0 {
+                match_id: "match:runtime-boundary-private".to_string(),
+                forecast_item_id: "forecast-item:runtime-boundary-missing".to_string(),
+                observed_ref_id: Some("observed:b11-trajectory-private".to_string()),
+                status: "private".to_string(),
+                rationale: "runtime trajectory evidence is outside the public fixture boundary"
+                    .to_string(),
+                update_boundary: "private evidence remains unavailable to calibration scoring"
+                    .to_string(),
+                non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+            },
+        ],
+        reference_boundaries: CalibrationReferenceBoundariesV0 {
+            b10_refs: vec![
+                "outcome-linkage-dataset-v0".to_string(),
+                "report-outcome-daily-ledger-v0".to_string(),
+            ],
+            b11_refs: vec![
+                "signature-trajectory-report-v0".to_string(),
+                "architecture-dynamics-metrics-report-v0".to_string(),
+            ],
+            unavailable_refs: vec!["observed:future-review-outcome".to_string()],
+            private_refs: vec!["observed:b11-trajectory-private".to_string()],
+            measurement_boundary:
+                "calibration compares retained forecast and observed refs without treating gaps as zero"
+                    .to_string(),
+            non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+        },
+        non_conclusions: strings(&CALIBRATION_NON_CONCLUSIONS),
+    }
+}
+
+pub fn validate_forecast_calibration_hook(
+    hook: &ForecastCalibrationHookV0,
+    input_path: &str,
+) -> ForecastCalibrationHookValidationReportV0 {
+    let checks = vec![
+        check_calibration_schema(hook),
+        check_calibration_refs(hook),
+        check_calibration_statuses(hook),
+        check_calibration_boundaries(hook),
+        check_required_non_conclusions(
+            "forecast-calibration-hook-non-conclusions-preserved",
+            &hook.non_conclusions,
+            &CALIBRATION_NON_CONCLUSIONS,
+        ),
+    ];
+    let summary = ForecastCalibrationHookValidationSummary {
+        result: validation_result(&checks),
+        forecast_item_count: hook.forecast_item_refs.len(),
+        observed_outcome_count: hook.observed_outcome_refs.len(),
+        match_count: hook.matches.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    ForecastCalibrationHookValidationReportV0 {
+        schema_version: FORECAST_CALIBRATION_HOOK_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: ForecastCalibrationHookValidationInput {
+            schema_version: hook.schema_version.clone(),
+            path: input_path.to_string(),
+            hook_id: hook.hook_id.clone(),
+            envelope_id: hook.envelope_ref.envelope_id.clone(),
+        },
+        hook: hook.clone(),
+        summary,
+        checks,
+    }
+}
+
+fn finite_support_ref(
+    support_ref_id: &str,
+    support_kind: &str,
+    operation_family_ids: &[&str],
+    source_ref_ids: &[&str],
+    boundary: &str,
+) -> ForecastFiniteSupportRefV0 {
+    ForecastFiniteSupportRefV0 {
+        support_ref_id: support_ref_id.to_string(),
+        support_kind: support_kind.to_string(),
+        operation_family_ids: strings(operation_family_ids),
+        source_ref_ids: strings(source_ref_ids),
+        boundary: boundary.to_string(),
+        assumptions: vec![
+            "support is finite under selected fixture refs".to_string(),
+            "support does not imply operation support completeness".to_string(),
+        ],
+        non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+    }
+}
+
+fn path_class_candidate(
+    path_class_id: &str,
+    path_class: &str,
+    support_ref_ids: &[&str],
+    operation_family_ids: &[&str],
+    source_ref_ids: &[&str],
+    affected_axes: &[&str],
+    rationale: &str,
+) -> ForecastPathClassCandidateV0 {
+    ForecastPathClassCandidateV0 {
+        path_class_id: path_class_id.to_string(),
+        path_class: path_class.to_string(),
+        support_ref_ids: strings(support_ref_ids),
+        operation_family_ids: strings(operation_family_ids),
+        horizon_ref_id: "horizon:b12-mvp-skeleton".to_string(),
+        source_ref_ids: strings(source_ref_ids),
+        affected_axes: strings(affected_axes),
+        rationale: rationale.to_string(),
+        probability_boundary: "no probability is assigned by the skeleton".to_string(),
+        non_conclusions: strings(&FORECAST_NON_CONCLUSIONS),
+    }
+}
+
+fn check_forecast_schema(cone: &ForecastConeSkeletonV0) -> ValidationCheck {
+    let invalid = cone.schema_version != FORECAST_CONE_SKELETON_SCHEMA_VERSION
+        || cone.cone_id.trim().is_empty()
+        || cone.operation_support_ref.estimate_schema_version
+            != OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION
+        || cone.operation_support_ref.estimate_id.trim().is_empty()
+        || cone.operation_support_ref.source_ref_ids.is_empty();
+    let mut check = validation_check(
+        "forecast-cone-skeleton-schema-supported",
+        "forecast cone schema and operation support ref are supported",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(
+            "schemaVersion, coneId, operation support estimate schema, estimate id, and source refs are required"
+                .to_string(),
+        );
+    }
+    check
+}
+
+fn check_forecast_support_refs(cone: &ForecastConeSkeletonV0) -> ValidationCheck {
+    let sources = forecast_source_ids(cone);
+    let families = forecast_family_ids(cone);
+    let invalid = cone
+        .finite_support_refs
+        .iter()
+        .filter(|support| {
+            support.support_ref_id.trim().is_empty()
+                || support.operation_family_ids.is_empty()
+                || support.source_ref_ids.is_empty()
+                || support.boundary.trim().is_empty()
+                || support
+                    .operation_family_ids
+                    .iter()
+                    .any(|family| !families.contains(family.as_str()))
+                || support
+                    .source_ref_ids
+                    .iter()
+                    .any(|source| !sources.contains(source.as_str()))
+        })
+        .map(|support| support.support_ref_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "forecast-cone-finite-support-refs-retained",
+        "finite support refs are present and linked to operation support families",
+        if !cone.finite_support_refs.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if cone.finite_support_refs.is_empty() {
+        check.reason = Some("at least one finite support ref is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "finite support refs with missing or dangling refs: {}",
+            invalid.join(", ")
+        ));
+    }
+    check.count = Some(cone.finite_support_refs.len());
+    check
+}
+
+fn check_forecast_horizon(cone: &ForecastConeSkeletonV0) -> ValidationCheck {
+    let sources = forecast_source_ids(cone);
+    let horizon = &cone.bounded_horizon;
+    let invalid = horizon.horizon_id.trim().is_empty()
+        || horizon.max_steps == 0
+        || horizon.source_ref_ids.is_empty()
+        || horizon.boundary.trim().is_empty()
+        || horizon
+            .source_ref_ids
+            .iter()
+            .any(|source| !sources.contains(source.as_str()));
+    let mut check = validation_check(
+        "forecast-cone-bounded-horizon-present",
+        "bounded horizon is explicit and source-bound",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(
+            "horizon id, positive maxSteps, source refs, and a boundary are required".to_string(),
+        );
+    }
+    check
+}
+
+fn check_forecast_path_classes(cone: &ForecastConeSkeletonV0) -> ValidationCheck {
+    let sources = forecast_source_ids(cone);
+    let supports = support_ids(cone);
+    let families = forecast_family_ids(cone);
+    let invalid = cone
+        .path_class_candidates
+        .iter()
+        .filter(|path| {
+            path.path_class_id.trim().is_empty()
+                || path.support_ref_ids.is_empty()
+                || path.operation_family_ids.is_empty()
+                || path.horizon_ref_id != cone.bounded_horizon.horizon_id
+                || path.probability_boundary.trim().is_empty()
+                || overpromotes_probability(&path.probability_boundary)
+                || path
+                    .support_ref_ids
+                    .iter()
+                    .any(|support| !supports.contains(support.as_str()))
+                || path
+                    .operation_family_ids
+                    .iter()
+                    .any(|family| !families.contains(family.as_str()))
+                || path
+                    .source_ref_ids
+                    .iter()
+                    .any(|source| !sources.contains(source.as_str()))
+        })
+        .map(|path| path.path_class_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "forecast-cone-path-classes-bounded",
+        "path class candidates are finite, source-bound, and non-probabilistic",
+        if !cone.path_class_candidates.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if cone.path_class_candidates.is_empty() {
+        check.reason = Some("at least one path class candidate is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "path classes with missing refs or probability over-promotion: {}",
+            invalid.join(", ")
+        ));
+    }
+    check.count = Some(cone.path_class_candidates.len());
+    check
+}
+
+fn check_forecast_boundary(cone: &ForecastConeSkeletonV0) -> ValidationCheck {
+    let sources = forecast_source_ids(cone);
+    let supports = support_ids(cone);
+    let boundary = &cone.forecast_boundary;
+    let invalid = boundary.boundary_id.trim().is_empty()
+        || boundary.source_ref_ids.is_empty()
+        || boundary.measurement_boundary_refs.is_empty()
+        || boundary.support_ref_ids.is_empty()
+        || boundary.horizon_ref_ids.is_empty()
+        || boundary
+            .source_ref_ids
+            .iter()
+            .any(|source| !sources.contains(source.as_str()))
+        || boundary
+            .support_ref_ids
+            .iter()
+            .any(|support| !supports.contains(support.as_str()))
+        || !boundary
+            .horizon_ref_ids
+            .iter()
+            .any(|horizon| horizon == &cone.bounded_horizon.horizon_id);
+    let mut check = validation_check(
+        "forecast-cone-boundary-retained",
+        "forecast boundary retains support, horizon, measurement, and source refs",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(
+            "forecast boundary requires source refs, measurement refs, support refs, and horizon refs"
+                .to_string(),
+        );
+    }
+    check
+}
+
+fn check_forecast_unknown_remainder(cone: &ForecastConeSkeletonV0) -> ValidationCheck {
+    let sources = forecast_source_ids(cone);
+    let paths = path_ids(cone);
+    let invalid = cone
+        .unknown_remainder
+        .iter()
+        .filter(|remainder| {
+            remainder.remainder_id.trim().is_empty()
+                || remainder.affected_path_class_ids.is_empty()
+                || remainder.unknown_axes.is_empty()
+                || treats_unknown_as_zero(&remainder.treatment)
+                || remainder
+                    .affected_path_class_ids
+                    .iter()
+                    .any(|path| !paths.contains(path.as_str()))
+                || remainder
+                    .source_ref_ids
+                    .iter()
+                    .any(|source| !sources.contains(source.as_str()))
+        })
+        .map(|remainder| remainder.remainder_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "forecast-cone-unknown-remainder-not-measured-zero",
+        "unknown forecast axes remain explicit and are not treated as measured zero",
+        if !cone.unknown_remainder.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if cone.unknown_remainder.is_empty() {
+        check.reason = Some("at least one unknown remainder item is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "unknown remainder entries with missing refs or measured-zero treatment: {}",
+            invalid.join(", ")
+        ));
+    }
+    check.count = Some(cone.unknown_remainder.len());
+    check
+}
+
+fn check_envelope_schema(envelope: &ConsequenceEnvelopeReportV0) -> ValidationCheck {
+    let invalid = envelope.schema_version != CONSEQUENCE_ENVELOPE_REPORT_SCHEMA_VERSION
+        || envelope.envelope_id.trim().is_empty()
+        || envelope.forecast_cone_ref.forecast_cone_schema_version
+            != FORECAST_CONE_SKELETON_SCHEMA_VERSION
+        || envelope.forecast_cone_ref.cone_id.trim().is_empty()
+        || envelope.forecast_cone_ref.source_ref_ids.is_empty();
+    let mut check = validation_check(
+        "consequence-envelope-schema-supported",
+        "consequence envelope schema and forecast cone ref are supported",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(
+            "schemaVersion, envelopeId, forecast cone schema, cone id, and source refs are required"
+                .to_string(),
+        );
+    }
+    check
+}
+
+fn check_envelope_source_refs(envelope: &ConsequenceEnvelopeReportV0) -> ValidationCheck {
+    let sources = envelope_source_ids(envelope);
+    let dangling_regions = envelope
+        .affected_architecture_regions
+        .iter()
+        .filter(|region| {
+            region.source_ref_ids.is_empty()
+                || region
+                    .source_ref_ids
+                    .iter()
+                    .any(|source| !sources.contains(source.as_str()))
+        })
+        .map(|region| region.region_id.clone())
+        .collect::<Vec<_>>();
+    let dangling_deltas = envelope
+        .expected_axis_delta_ranges
+        .iter()
+        .filter(|delta| {
+            delta.source_ref_ids.is_empty()
+                || delta
+                    .source_ref_ids
+                    .iter()
+                    .any(|source| !sources.contains(source.as_str()))
+        })
+        .map(|delta| delta.delta_id.clone())
+        .collect::<Vec<_>>();
+    let invalid = !dangling_regions.is_empty() || !dangling_deltas.is_empty();
+    let mut check = validation_check(
+        "consequence-envelope-source-refs-retained",
+        "regions and delta ranges retain source refs",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(format!(
+            "dangling source refs in regions [{}] or deltas [{}]",
+            dangling_regions.join(", "),
+            dangling_deltas.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_envelope_regions_and_axes(envelope: &ConsequenceEnvelopeReportV0) -> ValidationCheck {
+    let region_ids = region_ids(envelope);
+    let axis_ids = axis_ids(envelope);
+    let invalid_regions = envelope
+        .affected_architecture_regions
+        .iter()
+        .filter(|region| {
+            region.region_id.trim().is_empty()
+                || region.region_ref.trim().is_empty()
+                || region.boundary.trim().is_empty()
+        })
+        .map(|region| region.region_id.clone())
+        .collect::<Vec<_>>();
+    let invalid_axes = envelope
+        .comparable_signature_axes
+        .iter()
+        .filter(|axis| {
+            axis.axis_id.trim().is_empty()
+                || axis.axis_name.trim().is_empty()
+                || axis.measurement_boundary_refs.is_empty()
+                || axis.comparability.trim().is_empty()
+        })
+        .map(|axis| axis.axis_id.clone())
+        .collect::<Vec<_>>();
+    let invalid_obstructions = envelope
+        .obstruction_witness_candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.candidate_id.trim().is_empty()
+                || candidate
+                    .region_ids
+                    .iter()
+                    .any(|id| !region_ids.contains(id.as_str()))
+                || candidate
+                    .axis_ids
+                    .iter()
+                    .any(|id| !axis_ids.contains(id.as_str()))
+                || candidate.selection_boundary.trim().is_empty()
+        })
+        .map(|candidate| candidate.candidate_id.clone())
+        .collect::<Vec<_>>();
+    let invalid = !invalid_regions.is_empty()
+        || !invalid_axes.is_empty()
+        || !invalid_obstructions.is_empty()
+        || envelope.affected_architecture_regions.is_empty()
+        || envelope.comparable_signature_axes.is_empty();
+    let mut check = validation_check(
+        "consequence-envelope-regions-axes-and-obstructions-linked",
+        "affected regions, comparable axes, and obstruction candidates are linked",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(format!(
+            "invalid regions [{}], axes [{}], or obstruction candidates [{}]",
+            invalid_regions.join(", "),
+            invalid_axes.join(", "),
+            invalid_obstructions.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_envelope_boundaries(envelope: &ConsequenceEnvelopeReportV0) -> ValidationCheck {
+    let axis_ids = axis_ids(envelope);
+    let invalid_missing = envelope
+        .missing_boundary_items
+        .iter()
+        .filter(|item| {
+            item.item_id.trim().is_empty()
+                || item.affected_axis_ids.is_empty()
+                || item
+                    .affected_axis_ids
+                    .iter()
+                    .any(|axis| !axis_ids.contains(axis.as_str()))
+                || treats_unknown_as_zero(&item.treatment)
+        })
+        .map(|item| item.item_id.clone())
+        .collect::<Vec<_>>();
+    let invalid_theorem = envelope
+        .theorem_boundary_items
+        .iter()
+        .filter(|item| item.item_id.trim().is_empty() || item.required_evidence.is_empty())
+        .map(|item| item.item_id.clone())
+        .collect::<Vec<_>>();
+    let has_summary = !envelope.summary_projection.summary_id.trim().is_empty()
+        && envelope.summary_projection.affected_region_count
+            == envelope.affected_architecture_regions.len()
+        && envelope.summary_projection.comparable_axis_count
+            == envelope.comparable_signature_axes.len()
+        && envelope.summary_projection.missing_boundary_count
+            == envelope.missing_boundary_items.len();
+    let invalid = invalid_missing.is_empty() && invalid_theorem.is_empty() && has_summary;
+    let mut check = validation_check(
+        "consequence-envelope-boundaries-and-summary-retained",
+        "missing boundaries, theorem boundaries, and summary projection are retained",
+        if invalid { "pass" } else { "fail" },
+    );
+    if !invalid {
+        check.reason = Some(format!(
+            "invalid missing boundary items [{}], theorem boundary items [{}], or summary counts",
+            invalid_missing.join(", "),
+            invalid_theorem.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_envelope_unknown_remainder(envelope: &ConsequenceEnvelopeReportV0) -> ValidationCheck {
+    let regions = region_ids(envelope);
+    let axes = axis_ids(envelope);
+    let invalid = envelope
+        .unknown_remainder
+        .iter()
+        .filter(|remainder| {
+            remainder.remainder_id.trim().is_empty()
+                || remainder.unknown_axes.is_empty()
+                || treats_unknown_as_zero(&remainder.treatment)
+                || remainder
+                    .affected_region_ids
+                    .iter()
+                    .any(|region| !regions.contains(region.as_str()))
+                || remainder
+                    .affected_axis_ids
+                    .iter()
+                    .any(|axis| !axes.contains(axis.as_str()))
+        })
+        .map(|remainder| remainder.remainder_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "consequence-envelope-unknown-remainder-not-measured-zero",
+        "unknown report remainder remains explicit and is not treated as measured zero",
+        if !envelope.unknown_remainder.is_empty() && invalid.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if envelope.unknown_remainder.is_empty() {
+        check.reason = Some("at least one unknown remainder item is required".to_string());
+    } else if !invalid.is_empty() {
+        check.reason = Some(format!(
+            "unknown remainder entries with missing refs or measured-zero treatment: {}",
+            invalid.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_calibration_schema(hook: &ForecastCalibrationHookV0) -> ValidationCheck {
+    let invalid = hook.schema_version != FORECAST_CALIBRATION_HOOK_SCHEMA_VERSION
+        || hook.hook_id.trim().is_empty()
+        || hook.envelope_ref.envelope_schema_version != CONSEQUENCE_ENVELOPE_REPORT_SCHEMA_VERSION
+        || hook.envelope_ref.envelope_id.trim().is_empty()
+        || hook.envelope_ref.source_ref_ids.is_empty();
+    let mut check = validation_check(
+        "forecast-calibration-hook-schema-supported",
+        "calibration hook schema and envelope ref are supported",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason = Some(
+            "schemaVersion, hookId, envelope schema, envelope id, and source refs are required"
+                .to_string(),
+        );
+    }
+    check
+}
+
+fn check_calibration_refs(hook: &ForecastCalibrationHookV0) -> ValidationCheck {
+    let sources = calibration_source_ids(hook);
+    let forecast_ids = forecast_item_ids(hook);
+    let observed_ids = observed_ref_ids(hook);
+    let invalid_forecast = hook
+        .forecast_item_refs
+        .iter()
+        .filter(|item| {
+            item.forecast_item_id.trim().is_empty()
+                || item.envelope_item_ref.trim().is_empty()
+                || item.source_ref_ids.is_empty()
+                || item
+                    .source_ref_ids
+                    .iter()
+                    .any(|source| !sources.contains(source.as_str()))
+        })
+        .map(|item| item.forecast_item_id.clone())
+        .collect::<Vec<_>>();
+    let invalid_matches = hook
+        .matches
+        .iter()
+        .filter(|item| {
+            item.match_id.trim().is_empty()
+                || !forecast_ids.contains(item.forecast_item_id.as_str())
+                || item
+                    .observed_ref_id
+                    .as_ref()
+                    .is_some_and(|observed| !observed_ids.contains(observed.as_str()))
+        })
+        .map(|item| item.match_id.clone())
+        .collect::<Vec<_>>();
+    let invalid = !hook.forecast_item_refs.is_empty()
+        && !hook.matches.is_empty()
+        && invalid_forecast.is_empty()
+        && invalid_matches.is_empty();
+    let mut check = validation_check(
+        "forecast-calibration-hook-forecast-and-observed-refs-linked",
+        "forecast items, observed refs, and matches are linked",
+        if invalid { "pass" } else { "fail" },
+    );
+    if !invalid {
+        check.reason = Some(format!(
+            "invalid forecast item refs [{}] or match refs [{}]",
+            invalid_forecast.join(", "),
+            invalid_matches.join(", ")
+        ));
+    }
+    check
+}
+
+fn check_calibration_statuses(hook: &ForecastCalibrationHookV0) -> ValidationCheck {
+    let allowed = CALIBRATION_STATUSES
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let invalid_observed = hook
+        .observed_outcome_refs
+        .iter()
+        .filter(|observed| {
+            !allowed.contains(observed.status.as_str())
+                || treats_unknown_as_zero(&observed.evidence_boundary)
+        })
+        .map(|observed| observed.observed_ref_id.clone())
+        .collect::<Vec<_>>();
+    let invalid_matches = hook
+        .matches
+        .iter()
+        .filter(|item| {
+            !allowed.contains(item.status.as_str()) || treats_unknown_as_zero(&item.update_boundary)
+        })
+        .map(|item| item.match_id.clone())
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        "forecast-calibration-hook-statuses-not-measured-zero",
+        "matched, unmatched, unavailable, private, and notComparable statuses are not measured zero",
+        if invalid_observed.is_empty() && invalid_matches.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if !invalid_observed.is_empty() || !invalid_matches.is_empty() {
+        check.reason = Some(format!(
+            "invalid observed statuses [{}] or match statuses [{}]",
+            invalid_observed.join(", "),
+            invalid_matches.join(", ")
+        ));
+        check.examples = invalid_observed
+            .iter()
+            .chain(invalid_matches.iter())
+            .map(|id| {
+                generic_validation_example(
+                    id,
+                    "status/updateBoundary",
+                    "allowed statuses must not be collapsed into measured zero",
+                )
+            })
+            .collect();
+    }
+    check
+}
+
+fn check_calibration_boundaries(hook: &ForecastCalibrationHookV0) -> ValidationCheck {
+    let invalid = hook.reference_boundaries.b10_refs.is_empty()
+        || hook.reference_boundaries.b11_refs.is_empty()
+        || hook
+            .reference_boundaries
+            .measurement_boundary
+            .trim()
+            .is_empty()
+        || treats_unknown_as_zero(&hook.reference_boundaries.measurement_boundary);
+    let mut check = validation_check(
+        "forecast-calibration-hook-b10-b11-boundaries-retained",
+        "B10 and B11 reference boundaries are retained",
+        if invalid { "fail" } else { "pass" },
+    );
+    if invalid {
+        check.reason =
+            Some("B10 refs, B11 refs, and non-zero measurement boundary are required".to_string());
+    }
+    check
+}
+
+fn check_required_non_conclusions(
+    id: &str,
+    actual: &[String],
+    required: &[&str],
+) -> ValidationCheck {
+    let missing = required
+        .iter()
+        .filter(|required| !actual.iter().any(|actual| actual == *required))
+        .copied()
+        .collect::<Vec<_>>();
+    let mut check = validation_check(
+        id,
+        "required non-conclusions are preserved",
+        if missing.is_empty() { "pass" } else { "fail" },
+    );
+    if !missing.is_empty() {
+        check.reason = Some(format!(
+            "missing required non-conclusions: {}",
+            missing.join(", ")
+        ));
+    }
+    check.count = Some(actual.len());
+    check
+}
+
+fn validation_result(checks: &[ValidationCheck]) -> String {
+    if checks.iter().any(|check| check.result == "fail") {
+        "fail".to_string()
+    } else if checks.iter().any(|check| check.result == "warn") {
+        "warn".to_string()
+    } else {
+        "pass".to_string()
+    }
+}
+
+fn forecast_source_ids(cone: &ForecastConeSkeletonV0) -> BTreeSet<&str> {
+    cone.operation_support_ref
+        .source_ref_ids
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+fn forecast_family_ids(cone: &ForecastConeSkeletonV0) -> BTreeSet<&str> {
+    cone.operation_support_ref
+        .candidate_operation_family_ids
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+fn support_ids(cone: &ForecastConeSkeletonV0) -> BTreeSet<&str> {
+    cone.finite_support_refs
+        .iter()
+        .map(|support| support.support_ref_id.as_str())
+        .collect()
+}
+
+fn path_ids(cone: &ForecastConeSkeletonV0) -> BTreeSet<&str> {
+    cone.path_class_candidates
+        .iter()
+        .map(|path| path.path_class_id.as_str())
+        .collect()
+}
+
+fn envelope_source_ids(envelope: &ConsequenceEnvelopeReportV0) -> BTreeSet<&str> {
+    envelope
+        .forecast_cone_ref
+        .source_ref_ids
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+fn region_ids(envelope: &ConsequenceEnvelopeReportV0) -> BTreeSet<&str> {
+    envelope
+        .affected_architecture_regions
+        .iter()
+        .map(|region| region.region_id.as_str())
+        .collect()
+}
+
+fn axis_ids(envelope: &ConsequenceEnvelopeReportV0) -> BTreeSet<&str> {
+    envelope
+        .comparable_signature_axes
+        .iter()
+        .map(|axis| axis.axis_id.as_str())
+        .collect()
+}
+
+fn calibration_source_ids(hook: &ForecastCalibrationHookV0) -> BTreeSet<&str> {
+    hook.envelope_ref
+        .source_ref_ids
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+fn forecast_item_ids(hook: &ForecastCalibrationHookV0) -> BTreeSet<&str> {
+    hook.forecast_item_refs
+        .iter()
+        .map(|item| item.forecast_item_id.as_str())
+        .collect()
+}
+
+fn observed_ref_ids(hook: &ForecastCalibrationHookV0) -> BTreeSet<&str> {
+    hook.observed_outcome_refs
+        .iter()
+        .map(|item| item.observed_ref_id.as_str())
+        .collect()
+}
+
+fn overpromotes_probability(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    (value.contains("probability") || value.contains("probabilistic"))
+        && !(value.contains("no probability") || value.contains("does not assign"))
+}
+
+fn treats_unknown_as_zero(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    value.contains("measured zero")
+        || value.contains("treated as zero")
+        || value.contains("safe")
+        || value.contains("absent")
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -7022,6 +7022,360 @@ fn cli_operation_support_estimate_emits_fixture_and_validates_boundaries() {
 }
 
 #[test]
+fn cli_forecast_cone_skeleton_emits_fixture_and_validates_boundaries() {
+    let root = fixture_root();
+    let out_dir = temp_dir("forecast-cone-skeleton");
+    let static_validation = out_dir.join("forecast-cone-static-validation.json");
+    let fixture_artifact = out_dir.join("forecast-cone-fixture.json");
+    let fixture_validation = out_dir.join("forecast-cone-validation.json");
+    let invalid_cone = out_dir.join("forecast-cone-invalid.json");
+    let invalid_validation = out_dir.join("forecast-cone-invalid-validation.json");
+
+    run_sig0(&[
+        "forecast-cone-skeleton",
+        "--out",
+        static_validation
+            .to_str()
+            .expect("static validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "forecast-cone-skeleton",
+        "--fixture",
+        "--out",
+        fixture_artifact.to_str().expect("fixture path is utf-8"),
+    ]);
+    run_sig0(&[
+        "forecast-cone-skeleton",
+        "--input",
+        root.join("forecast_cone_skeleton.json")
+            .to_str()
+            .expect("fixture input path is utf-8"),
+        "--out",
+        fixture_validation
+            .to_str()
+            .expect("fixture validation path is utf-8"),
+    ]);
+
+    let static_json = read_json(&static_validation);
+    assert_eq!(
+        static_json["schemaVersion"],
+        "forecast-cone-skeleton-validation-report-v0"
+    );
+    assert_eq!(static_json["summary"]["result"], "pass");
+    assert_eq!(static_json["summary"]["pathClassCandidateCount"], 2);
+    assert!(
+        static_json["cone"]["nonConclusions"]
+            .as_array()
+            .expect("nonConclusions is array")
+            .iter()
+            .any(|conclusion| conclusion == "forecast cone skeleton does not assign probabilities")
+    );
+
+    let artifact = read_json(&fixture_artifact);
+    assert_eq!(artifact["schemaVersion"], "forecast-cone-skeleton-v0");
+    assert_eq!(
+        artifact["operationSupportRef"]["estimateSchemaVersion"],
+        "operation-support-estimate-v0"
+    );
+    assert!(
+        artifact["forecastBoundary"]["unsupportedConstructs"]
+            .as_array()
+            .expect("unsupportedConstructs is array")
+            .iter()
+            .any(|construct| construct == "probability assignment")
+    );
+
+    let validation = read_json(&fixture_validation);
+    assert_eq!(validation["summary"]["result"], "pass");
+    assert!(
+        validation["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| {
+                check["id"] == "forecast-cone-unknown-remainder-not-measured-zero"
+                    && check["result"] == "pass"
+            })
+    );
+
+    let mut invalid = artifact;
+    invalid["boundedHorizon"]["maxSteps"] = serde_json::json!(0);
+    invalid["pathClassCandidates"][0]["probabilityBoundary"] = serde_json::json!("probability 0.8");
+    invalid["unknownRemainder"][0]["treatment"] = serde_json::json!("treated as zero");
+    fs::write(
+        &invalid_cone,
+        serde_json::to_string_pretty(&invalid).expect("invalid cone serializes"),
+    )
+    .expect("invalid cone is written");
+    let output = run_sig0_output(&[
+        "forecast-cone-skeleton",
+        "--input",
+        invalid_cone.to_str().expect("invalid cone path is utf-8"),
+        "--out",
+        invalid_validation
+            .to_str()
+            .expect("invalid validation path is utf-8"),
+    ]);
+    assert!(
+        !output.status.success(),
+        "zero horizon, probability claims, and measured-zero unknowns should fail validation"
+    );
+    let invalid_report = read_json(&invalid_validation);
+    assert_eq!(invalid_report["summary"]["result"], "fail");
+    for expected_check in [
+        "forecast-cone-bounded-horizon-present",
+        "forecast-cone-path-classes-bounded",
+        "forecast-cone-unknown-remainder-not-measured-zero",
+    ] {
+        assert!(
+            invalid_report["checks"]
+                .as_array()
+                .expect("checks is array")
+                .iter()
+                .any(|check| check["id"] == expected_check && check["result"] == "fail"),
+            "missing failed check {expected_check}"
+        );
+    }
+}
+
+#[test]
+fn cli_consequence_envelope_emits_fixture_and_validates_boundaries() {
+    let root = fixture_root();
+    let out_dir = temp_dir("consequence-envelope");
+    let static_validation = out_dir.join("consequence-envelope-static-validation.json");
+    let fixture_artifact = out_dir.join("consequence-envelope-fixture.json");
+    let fixture_validation = out_dir.join("consequence-envelope-validation.json");
+    let invalid_envelope = out_dir.join("consequence-envelope-invalid.json");
+    let invalid_validation = out_dir.join("consequence-envelope-invalid-validation.json");
+
+    run_sig0(&[
+        "consequence-envelope",
+        "--out",
+        static_validation
+            .to_str()
+            .expect("static validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "consequence-envelope",
+        "--fixture",
+        "--out",
+        fixture_artifact.to_str().expect("fixture path is utf-8"),
+    ]);
+    run_sig0(&[
+        "consequence-envelope",
+        "--input",
+        root.join("consequence_envelope_report.json")
+            .to_str()
+            .expect("fixture input path is utf-8"),
+        "--out",
+        fixture_validation
+            .to_str()
+            .expect("fixture validation path is utf-8"),
+    ]);
+
+    let static_json = read_json(&static_validation);
+    assert_eq!(
+        static_json["schemaVersion"],
+        "consequence-envelope-report-validation-report-v0"
+    );
+    assert_eq!(static_json["summary"]["result"], "pass");
+    assert_eq!(static_json["summary"]["affectedRegionCount"], 2);
+    assert!(
+        static_json["envelope"]["nonConclusions"]
+            .as_array()
+            .expect("nonConclusions is array")
+            .iter()
+            .any(|conclusion| conclusion == "consequence envelope does not prove global safety")
+    );
+
+    let artifact = read_json(&fixture_artifact);
+    assert_eq!(artifact["schemaVersion"], "consequence-envelope-report-v0");
+    assert!(
+        artifact["summaryProjection"]["reviewerNotes"]
+            .as_array()
+            .expect("reviewerNotes is array")
+            .iter()
+            .any(|note| note == "No probability or causal safety claim is emitted.")
+    );
+
+    let validation = read_json(&fixture_validation);
+    assert_eq!(validation["summary"]["result"], "pass");
+    assert!(
+        validation["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| {
+                check["id"] == "consequence-envelope-unknown-remainder-not-measured-zero"
+                    && check["result"] == "pass"
+            })
+    );
+
+    let mut invalid = artifact;
+    invalid["affectedArchitectureRegions"][0]["sourceRefIds"] =
+        serde_json::json!(["source:missing"]);
+    invalid["summaryProjection"]["affectedRegionCount"] = serde_json::json!(99);
+    invalid["unknownRemainder"][0]["treatment"] = serde_json::json!("safe and absent");
+    fs::write(
+        &invalid_envelope,
+        serde_json::to_string_pretty(&invalid).expect("invalid envelope serializes"),
+    )
+    .expect("invalid envelope is written");
+    let output = run_sig0_output(&[
+        "consequence-envelope",
+        "--input",
+        invalid_envelope
+            .to_str()
+            .expect("invalid envelope path is utf-8"),
+        "--out",
+        invalid_validation
+            .to_str()
+            .expect("invalid validation path is utf-8"),
+    ]);
+    assert!(
+        !output.status.success(),
+        "dangling source refs, summary mismatch, and measured-zero unknowns should fail validation"
+    );
+    let invalid_report = read_json(&invalid_validation);
+    assert_eq!(invalid_report["summary"]["result"], "fail");
+    for expected_check in [
+        "consequence-envelope-source-refs-retained",
+        "consequence-envelope-boundaries-and-summary-retained",
+        "consequence-envelope-unknown-remainder-not-measured-zero",
+    ] {
+        assert!(
+            invalid_report["checks"]
+                .as_array()
+                .expect("checks is array")
+                .iter()
+                .any(|check| check["id"] == expected_check && check["result"] == "fail"),
+            "missing failed check {expected_check}"
+        );
+    }
+}
+
+#[test]
+fn cli_forecast_calibration_hook_emits_fixture_and_validates_boundaries() {
+    let root = fixture_root();
+    let out_dir = temp_dir("forecast-calibration-hook");
+    let static_validation = out_dir.join("forecast-calibration-static-validation.json");
+    let fixture_artifact = out_dir.join("forecast-calibration-fixture.json");
+    let fixture_validation = out_dir.join("forecast-calibration-validation.json");
+    let invalid_hook = out_dir.join("forecast-calibration-invalid.json");
+    let invalid_validation = out_dir.join("forecast-calibration-invalid-validation.json");
+
+    run_sig0(&[
+        "forecast-calibration-hook",
+        "--out",
+        static_validation
+            .to_str()
+            .expect("static validation path is utf-8"),
+    ]);
+    run_sig0(&[
+        "forecast-calibration-hook",
+        "--fixture",
+        "--out",
+        fixture_artifact.to_str().expect("fixture path is utf-8"),
+    ]);
+    run_sig0(&[
+        "forecast-calibration-hook",
+        "--input",
+        root.join("forecast_calibration_hook.json")
+            .to_str()
+            .expect("fixture input path is utf-8"),
+        "--out",
+        fixture_validation
+            .to_str()
+            .expect("fixture validation path is utf-8"),
+    ]);
+
+    let static_json = read_json(&static_validation);
+    assert_eq!(
+        static_json["schemaVersion"],
+        "forecast-calibration-hook-validation-report-v0"
+    );
+    assert_eq!(static_json["summary"]["result"], "pass");
+    assert_eq!(static_json["summary"]["matchCount"], 2);
+    assert!(
+        static_json["hook"]["nonConclusions"]
+            .as_array()
+            .expect("nonConclusions is array")
+            .iter()
+            .any(|conclusion| conclusion == "calibration hook does not prove forecast correctness")
+    );
+
+    let artifact = read_json(&fixture_artifact);
+    assert_eq!(artifact["schemaVersion"], "forecast-calibration-hook-v0");
+    assert!(
+        artifact["referenceBoundaries"]["b10Refs"]
+            .as_array()
+            .expect("b10Refs is array")
+            .iter()
+            .any(|reference| reference == "report-outcome-daily-ledger-v0")
+    );
+    assert!(
+        artifact["matches"]
+            .as_array()
+            .expect("matches is array")
+            .iter()
+            .any(|item| item["status"] == "private")
+    );
+
+    let validation = read_json(&fixture_validation);
+    assert_eq!(validation["summary"]["result"], "pass");
+    assert!(
+        validation["checks"]
+            .as_array()
+            .expect("checks is array")
+            .iter()
+            .any(|check| {
+                check["id"] == "forecast-calibration-hook-statuses-not-measured-zero"
+                    && check["result"] == "pass"
+            })
+    );
+
+    let mut invalid = artifact;
+    invalid["matches"][0]["forecastItemId"] = serde_json::json!("forecast-item:missing");
+    invalid["matches"][1]["status"] = serde_json::json!("measuredZero");
+    invalid["referenceBoundaries"]["measurementBoundary"] =
+        serde_json::json!("unavailable refs are treated as zero");
+    fs::write(
+        &invalid_hook,
+        serde_json::to_string_pretty(&invalid).expect("invalid hook serializes"),
+    )
+    .expect("invalid hook is written");
+    let output = run_sig0_output(&[
+        "forecast-calibration-hook",
+        "--input",
+        invalid_hook.to_str().expect("invalid hook path is utf-8"),
+        "--out",
+        invalid_validation
+            .to_str()
+            .expect("invalid validation path is utf-8"),
+    ]);
+    assert!(
+        !output.status.success(),
+        "dangling forecast refs, invalid statuses, and measured-zero boundaries should fail validation"
+    );
+    let invalid_report = read_json(&invalid_validation);
+    assert_eq!(invalid_report["summary"]["result"], "fail");
+    for expected_check in [
+        "forecast-calibration-hook-forecast-and-observed-refs-linked",
+        "forecast-calibration-hook-statuses-not-measured-zero",
+        "forecast-calibration-hook-b10-b11-boundaries-retained",
+    ] {
+        assert!(
+            invalid_report["checks"]
+                .as_array()
+                .expect("checks is array")
+                .iter()
+                .any(|check| check["id"] == expected_check && check["result"] == "fail"),
+            "missing failed check {expected_check}"
+        );
+    }
+}
+
+#[test]
 fn cli_baseline_suppression_reports_deltas_without_resolving_suppressed_witnesses() {
     let fixture = fixture_root();
     let air = air_fixture_root();

--- a/tools/archsig/tests/fixtures/minimal/consequence_envelope_report.json
+++ b/tools/archsig/tests/fixtures/minimal/consequence_envelope_report.json
@@ -1,0 +1,273 @@
+{
+  "schemaVersion": "consequence-envelope-report-v0",
+  "envelopeId": "fixture-consequence-envelope-report-v0",
+  "forecastConeRef": {
+    "forecastConeSchemaVersion": "forecast-cone-skeleton-v0",
+    "coneId": "fixture-forecast-cone-skeleton-v0",
+    "operationSupportEstimateId": "fixture-operation-support-estimate-v0",
+    "sourceRefIds": [
+      "source:issue-736",
+      "source:forecast-cone-fixture",
+      "source:roadmap-b12"
+    ],
+    "forecastBoundaryRefs": [
+      "boundary:b12.3-forecast-cone-skeleton"
+    ],
+    "nonConclusions": [
+      "consequence envelope is a report projection, not a Lean theorem proof",
+      "consequence envelope does not identify a unique causal artifact action",
+      "consequence envelope does not prove global safety",
+      "unknown remainder is not measured zero",
+      "summary projection is for review and CI consumption only"
+    ]
+  },
+  "affectedArchitectureRegions": [
+    {
+      "regionId": "region:tools-archsig-sft",
+      "regionRef": "tools/archsig",
+      "effectKind": "tooling-artifact-surface",
+      "sourceRefIds": [
+        "source:issue-736",
+        "source:forecast-cone-fixture",
+        "source:roadmap-b12"
+      ],
+      "boundary": "region is selected by B12 tooling scope, not inferred as global architecture impact",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    },
+    {
+      "regionId": "region:docs-sft-boundary",
+      "regionRef": "docs/sft",
+      "effectKind": "claim-boundary-documentation",
+      "sourceRefIds": [
+        "source:issue-736",
+        "source:forecast-cone-fixture",
+        "source:roadmap-b12"
+      ],
+      "boundary": "documentation boundary tracks non-conclusions only",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "comparableSignatureAxes": [
+    {
+      "axisId": "axis:boundary-retention",
+      "axisName": "boundaryRetention",
+      "measurementBoundaryRefs": [
+        "boundary:b12.3-forecast-cone-skeleton",
+        "boundary:b12.4-consequence-envelope"
+      ],
+      "comparability": "comparable only across retained source refs and forecast boundary items",
+      "missingInvariantRefs": [
+        "missing:runtime-propagation-invariant"
+      ],
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    },
+    {
+      "axisId": "axis:unknown-remainder",
+      "axisName": "unknownRemainder",
+      "measurementBoundaryRefs": [
+        "boundary:b12.4-consequence-envelope"
+      ],
+      "comparability": "compares explicit unknown items, not absent or safe axes",
+      "missingInvariantRefs": [
+        "missing:private-feedback-boundary"
+      ],
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "expectedAxisDeltaRanges": [
+    {
+      "deltaId": "delta:boundary-retention-nonnegative",
+      "axisId": "axis:boundary-retention",
+      "rangeKind": "qualitative-nonnegative",
+      "lowerBound": "retained",
+      "upperBound": "retained-plus-report-summary",
+      "sourceRefIds": [
+        "source:issue-736",
+        "source:forecast-cone-fixture",
+        "source:roadmap-b12"
+      ],
+      "boundary": "expected range is qualitative and fixture-bound",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    },
+    {
+      "deltaId": "delta:unknown-remainder-explicit",
+      "axisId": "axis:unknown-remainder",
+      "rangeKind": "qualitative-explicit",
+      "lowerBound": "unknown retained",
+      "upperBound": null,
+      "sourceRefIds": [
+        "source:issue-736",
+        "source:forecast-cone-fixture",
+        "source:roadmap-b12"
+      ],
+      "boundary": "unknown remainder is reported, not resolved",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "obstructionWitnessCandidates": [
+    {
+      "candidateId": "obstruction:runtime-boundary-missing",
+      "obstructionKind": "missing-runtime-boundary",
+      "regionIds": [
+        "region:tools-archsig-sft"
+      ],
+      "axisIds": [
+        "axis:unknown-remainder"
+      ],
+      "evidenceRefs": [
+        "source:issue-736",
+        "source:forecast-cone-fixture",
+        "source:roadmap-b12"
+      ],
+      "selectionBoundary": "selected as a review candidate, not as a proved obstruction witness",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "missingBoundaryItems": [
+    {
+      "itemId": "missing:runtime-propagation-invariant",
+      "itemKind": "missing-invariant",
+      "affectedAxisIds": [
+        "axis:unknown-remainder"
+      ],
+      "reason": "runtime propagation is outside B12.4 report evidence",
+      "treatment": "report as missing boundary item for review and issue decomposition",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "theoremBoundaryItems": [
+    {
+      "itemId": "theorem-boundary:no-lean-promotion",
+      "theoremOrClaimRef": "AAT theorem boundary",
+      "boundary": "report does not upgrade forecast artifacts to Lean theorem claims",
+      "requiredEvidence": [
+        "formal theorem statement",
+        "Lean proof",
+        "separate empirical validation"
+      ],
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "recommendations": {
+    "review": [
+      "review retained source refs before treating any region as affected",
+      "check missing boundary items before accepting axis deltas"
+    ],
+    "ci": [
+      "run consequence-envelope validator on report artifacts"
+    ],
+    "issueDecomposition": [
+      "split runtime propagation boundary into a downstream empirical issue"
+    ],
+    "nonConclusions": [
+      "consequence envelope is a report projection, not a Lean theorem proof",
+      "consequence envelope does not identify a unique causal artifact action",
+      "consequence envelope does not prove global safety",
+      "unknown remainder is not measured zero",
+      "summary projection is for review and CI consumption only"
+    ]
+  },
+  "summaryProjection": {
+    "summaryId": "summary:b12.4-review-projection",
+    "headline": "B12 forecast report keeps boundary and unknown remainder explicit",
+    "affectedRegionCount": 2,
+    "comparableAxisCount": 2,
+    "missingBoundaryCount": 1,
+    "reviewerNotes": [
+      "No probability or causal safety claim is emitted.",
+      "Unknown runtime and private feedback remain report items."
+    ],
+    "nonConclusions": [
+      "consequence envelope is a report projection, not a Lean theorem proof",
+      "consequence envelope does not identify a unique causal artifact action",
+      "consequence envelope does not prove global safety",
+      "unknown remainder is not measured zero",
+      "summary projection is for review and CI consumption only"
+    ]
+  },
+  "unknownRemainder": [
+    {
+      "remainderId": "unknown:private-and-runtime-outcomes",
+      "affectedRegionIds": [
+        "region:tools-archsig-sft"
+      ],
+      "affectedAxisIds": [
+        "axis:unknown-remainder"
+      ],
+      "unknownAxes": [
+        "private PRD decisions",
+        "runtime outcome evidence",
+        "future CI and review behavior"
+      ],
+      "treatment": "retain as unresolved report remainder under the selected boundary",
+      "nonConclusions": [
+        "consequence envelope is a report projection, not a Lean theorem proof",
+        "consequence envelope does not identify a unique causal artifact action",
+        "consequence envelope does not prove global safety",
+        "unknown remainder is not measured zero",
+        "summary projection is for review and CI consumption only"
+      ]
+    }
+  ],
+  "nonConclusions": [
+    "consequence envelope is a report projection, not a Lean theorem proof",
+    "consequence envelope does not identify a unique causal artifact action",
+    "consequence envelope does not prove global safety",
+    "unknown remainder is not measured zero",
+    "summary projection is for review and CI consumption only"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/forecast_calibration_hook.json
+++ b/tools/archsig/tests/fixtures/minimal/forecast_calibration_hook.json
@@ -1,0 +1,163 @@
+{
+  "schemaVersion": "forecast-calibration-hook-v0",
+  "hookId": "fixture-forecast-calibration-hook-v0",
+  "envelopeRef": {
+    "envelopeSchemaVersion": "consequence-envelope-report-v0",
+    "envelopeId": "fixture-consequence-envelope-report-v0",
+    "coneId": "fixture-forecast-cone-skeleton-v0",
+    "sourceRefIds": [
+      "source:issue-737",
+      "source:consequence-envelope-fixture",
+      "source:b10-report-outcome-daily-ledger",
+      "source:b11-signature-trajectory-report"
+    ],
+    "nonConclusions": [
+      "calibration hook does not prove forecast correctness",
+      "calibration hook does not provide a causal proof",
+      "calibration hook is not a Lean theorem claim",
+      "calibration hook does not establish field completeness",
+      "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+    ]
+  },
+  "forecastItemRefs": [
+    {
+      "forecastItemId": "forecast-item:boundary-retention-delta",
+      "itemKind": "axis-delta-range",
+      "envelopeItemRef": "delta:boundary-retention-nonnegative",
+      "sourceRefIds": [
+        "source:issue-737",
+        "source:consequence-envelope-fixture",
+        "source:b10-report-outcome-daily-ledger",
+        "source:b11-signature-trajectory-report"
+      ],
+      "comparisonBoundary": "compare only retained report item ids and observed refs",
+      "nonConclusions": [
+        "calibration hook does not prove forecast correctness",
+        "calibration hook does not provide a causal proof",
+        "calibration hook is not a Lean theorem claim",
+        "calibration hook does not establish field completeness",
+        "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+      ]
+    },
+    {
+      "forecastItemId": "forecast-item:runtime-boundary-missing",
+      "itemKind": "missing-boundary",
+      "envelopeItemRef": "missing:runtime-propagation-invariant",
+      "sourceRefIds": [
+        "source:issue-737",
+        "source:consequence-envelope-fixture",
+        "source:b10-report-outcome-daily-ledger",
+        "source:b11-signature-trajectory-report"
+      ],
+      "comparisonBoundary": "missing boundary can remain unavailable or private",
+      "nonConclusions": [
+        "calibration hook does not prove forecast correctness",
+        "calibration hook does not provide a causal proof",
+        "calibration hook is not a Lean theorem claim",
+        "calibration hook does not establish field completeness",
+        "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+      ]
+    }
+  ],
+  "observedOutcomeRefs": [
+    {
+      "observedRefId": "observed:b10-daily-ledger",
+      "observedKind": "report-outcome-daily-ledger",
+      "pathOrUrl": "tools/archsig/tests/fixtures/minimal/report_outcome_daily_ledger.json",
+      "status": "matched",
+      "b10Refs": [
+        "b10:report-outcome-daily-ledger"
+      ],
+      "b11Refs": [],
+      "evidenceBoundary": "B10 ledger is fixture evidence, not correctness proof",
+      "nonConclusions": [
+        "calibration hook does not prove forecast correctness",
+        "calibration hook does not provide a causal proof",
+        "calibration hook is not a Lean theorem claim",
+        "calibration hook does not establish field completeness",
+        "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+      ]
+    },
+    {
+      "observedRefId": "observed:b11-trajectory-private",
+      "observedKind": "signature-trajectory-report",
+      "pathOrUrl": "private-or-unavailable",
+      "status": "private",
+      "b10Refs": [],
+      "b11Refs": [
+        "b11:signature-trajectory-report"
+      ],
+      "evidenceBoundary": "private trajectory evidence is retained as private, not zero",
+      "nonConclusions": [
+        "calibration hook does not prove forecast correctness",
+        "calibration hook does not provide a causal proof",
+        "calibration hook is not a Lean theorem claim",
+        "calibration hook does not establish field completeness",
+        "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+      ]
+    }
+  ],
+  "matches": [
+    {
+      "matchId": "match:boundary-retention-ledger",
+      "forecastItemId": "forecast-item:boundary-retention-delta",
+      "observedRefId": "observed:b10-daily-ledger",
+      "status": "matched",
+      "rationale": "forecast item can be linked to a retained B10 ledger fixture",
+      "updateBoundary": "link can seed calibration review but does not prove correctness",
+      "nonConclusions": [
+        "calibration hook does not prove forecast correctness",
+        "calibration hook does not provide a causal proof",
+        "calibration hook is not a Lean theorem claim",
+        "calibration hook does not establish field completeness",
+        "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+      ]
+    },
+    {
+      "matchId": "match:runtime-boundary-private",
+      "forecastItemId": "forecast-item:runtime-boundary-missing",
+      "observedRefId": "observed:b11-trajectory-private",
+      "status": "private",
+      "rationale": "runtime trajectory evidence is outside the public fixture boundary",
+      "updateBoundary": "private evidence remains unavailable to calibration scoring",
+      "nonConclusions": [
+        "calibration hook does not prove forecast correctness",
+        "calibration hook does not provide a causal proof",
+        "calibration hook is not a Lean theorem claim",
+        "calibration hook does not establish field completeness",
+        "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+      ]
+    }
+  ],
+  "referenceBoundaries": {
+    "b10Refs": [
+      "outcome-linkage-dataset-v0",
+      "report-outcome-daily-ledger-v0"
+    ],
+    "b11Refs": [
+      "signature-trajectory-report-v0",
+      "architecture-dynamics-metrics-report-v0"
+    ],
+    "unavailableRefs": [
+      "observed:future-review-outcome"
+    ],
+    "privateRefs": [
+      "observed:b11-trajectory-private"
+    ],
+    "measurementBoundary": "calibration compares retained forecast and observed refs without treating gaps as zero",
+    "nonConclusions": [
+      "calibration hook does not prove forecast correctness",
+      "calibration hook does not provide a causal proof",
+      "calibration hook is not a Lean theorem claim",
+      "calibration hook does not establish field completeness",
+      "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+    ]
+  },
+  "nonConclusions": [
+    "calibration hook does not prove forecast correctness",
+    "calibration hook does not provide a causal proof",
+    "calibration hook is not a Lean theorem claim",
+    "calibration hook does not establish field completeness",
+    "unmatched, unavailable, private, and notComparable outcomes are not measured zero"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/forecast_cone_skeleton.json
+++ b/tools/archsig/tests/fixtures/minimal/forecast_cone_skeleton.json
@@ -1,0 +1,233 @@
+{
+  "schemaVersion": "forecast-cone-skeleton-v0",
+  "coneId": "fixture-forecast-cone-skeleton-v0",
+  "operationSupportRef": {
+    "estimateSchemaVersion": "operation-support-estimate-v0",
+    "estimateId": "fixture-operation-support-estimate-v0",
+    "descriptorId": "fixture-artifact-descriptor-v0",
+    "candidateOperationFamilyIds": [
+      "family:schema-validation-artifact",
+      "family:cli-fixture-validation"
+    ],
+    "sourceRefIds": [
+      "source:issue-735",
+      "source:operation-support-estimate-fixture",
+      "source:roadmap-b12",
+      "source:sft-consequence-envelope"
+    ],
+    "nonConclusions": [
+      "forecast cone skeleton is bounded by selected finite support and horizon",
+      "forecast cone skeleton does not assign probabilities",
+      "forecast cone skeleton does not prove global risk reduction",
+      "forecast cone skeleton does not prove trajectory-level safety",
+      "forecast cone skeleton is not an empirical prediction theorem"
+    ]
+  },
+  "finiteSupportRefs": [
+    {
+      "supportRefId": "support:schema-validation-artifact",
+      "supportKind": "finite-operation-family",
+      "operationFamilyIds": [
+        "family:schema-validation-artifact"
+      ],
+      "sourceRefIds": [
+        "source:issue-735",
+        "source:operation-support-estimate-fixture"
+      ],
+      "boundary": "schema and validator support is finite under the selected B12 fixture",
+      "assumptions": [
+        "support is finite under selected fixture refs",
+        "support does not imply operation support completeness"
+      ],
+      "nonConclusions": [
+        "forecast cone skeleton is bounded by selected finite support and horizon",
+        "forecast cone skeleton does not assign probabilities",
+        "forecast cone skeleton does not prove global risk reduction",
+        "forecast cone skeleton does not prove trajectory-level safety",
+        "forecast cone skeleton is not an empirical prediction theorem"
+      ]
+    },
+    {
+      "supportRefId": "support:cli-fixture-validation",
+      "supportKind": "finite-cli-support",
+      "operationFamilyIds": [
+        "family:cli-fixture-validation"
+      ],
+      "sourceRefIds": [
+        "source:issue-735",
+        "source:roadmap-b12"
+      ],
+      "boundary": "CLI fixture validation support is finite and source-bound",
+      "assumptions": [
+        "support is finite under selected fixture refs",
+        "support does not imply operation support completeness"
+      ],
+      "nonConclusions": [
+        "forecast cone skeleton is bounded by selected finite support and horizon",
+        "forecast cone skeleton does not assign probabilities",
+        "forecast cone skeleton does not prove global risk reduction",
+        "forecast cone skeleton does not prove trajectory-level safety",
+        "forecast cone skeleton is not an empirical prediction theorem"
+      ]
+    }
+  ],
+  "boundedHorizon": {
+    "horizonId": "horizon:b12-mvp-skeleton",
+    "horizonKind": "bounded-step",
+    "maxSteps": 3,
+    "timeWindow": "Phase B12 MVP issue chain",
+    "sourceRefIds": [
+      "source:issue-735",
+      "source:operation-support-estimate-fixture",
+      "source:roadmap-b12",
+      "source:sft-consequence-envelope"
+    ],
+    "boundary": "bounded to B12.3 skeleton construction before probability or causal claims",
+    "assumptions": [
+      "horizon counts artifact pipeline steps, not calendar predictions",
+      "downstream report and calibration artifacts remain separate"
+    ],
+    "nonConclusions": [
+      "forecast cone skeleton is bounded by selected finite support and horizon",
+      "forecast cone skeleton does not assign probabilities",
+      "forecast cone skeleton does not prove global risk reduction",
+      "forecast cone skeleton does not prove trajectory-level safety",
+      "forecast cone skeleton is not an empirical prediction theorem"
+    ]
+  },
+  "pathClassCandidates": [
+    {
+      "pathClassId": "path:schema-to-envelope",
+      "pathClass": "descriptor-estimate-cone-envelope",
+      "supportRefIds": [
+        "support:schema-validation-artifact",
+        "support:cli-fixture-validation"
+      ],
+      "operationFamilyIds": [
+        "family:schema-validation-artifact",
+        "family:cli-fixture-validation"
+      ],
+      "horizonRefId": "horizon:b12-mvp-skeleton",
+      "sourceRefIds": [
+        "source:issue-735",
+        "source:operation-support-estimate-fixture",
+        "source:roadmap-b12",
+        "source:sft-consequence-envelope"
+      ],
+      "affectedAxes": [
+        "schemaCompleteness",
+        "boundaryRetention"
+      ],
+      "rationale": "The selected artifact path can feed a report skeleton without assigning probability.",
+      "probabilityBoundary": "no probability is assigned by the skeleton",
+      "nonConclusions": [
+        "forecast cone skeleton is bounded by selected finite support and horizon",
+        "forecast cone skeleton does not assign probabilities",
+        "forecast cone skeleton does not prove global risk reduction",
+        "forecast cone skeleton does not prove trajectory-level safety",
+        "forecast cone skeleton is not an empirical prediction theorem"
+      ]
+    },
+    {
+      "pathClassId": "path:cli-validation-feedback",
+      "pathClass": "fixture-validation-feedback",
+      "supportRefIds": [
+        "support:cli-fixture-validation"
+      ],
+      "operationFamilyIds": [
+        "family:cli-fixture-validation"
+      ],
+      "horizonRefId": "horizon:b12-mvp-skeleton",
+      "sourceRefIds": [
+        "source:issue-735",
+        "source:roadmap-b12"
+      ],
+      "affectedAxes": [
+        "validatorCoverage",
+        "unknownRemainder"
+      ],
+      "rationale": "CLI validation can expose missing boundaries while retaining unknown support.",
+      "probabilityBoundary": "no probability is assigned by the skeleton",
+      "nonConclusions": [
+        "forecast cone skeleton is bounded by selected finite support and horizon",
+        "forecast cone skeleton does not assign probabilities",
+        "forecast cone skeleton does not prove global risk reduction",
+        "forecast cone skeleton does not prove trajectory-level safety",
+        "forecast cone skeleton is not an empirical prediction theorem"
+      ]
+    }
+  ],
+  "forecastBoundary": {
+    "boundaryId": "boundary:b12.3-forecast-cone-skeleton",
+    "sourceRefIds": [
+      "source:issue-735",
+      "source:operation-support-estimate-fixture",
+      "source:roadmap-b12",
+      "source:sft-consequence-envelope"
+    ],
+    "measurementBoundaryRefs": [
+      "boundary:b12.2-operation-support-estimate",
+      "docs/tool/roadmap.md#b123-forecastcone-skeleton"
+    ],
+    "supportRefIds": [
+      "support:schema-validation-artifact",
+      "support:cli-fixture-validation"
+    ],
+    "horizonRefIds": [
+      "horizon:b12-mvp-skeleton"
+    ],
+    "unsupportedConstructs": [
+      "probability assignment",
+      "global risk reduction proof",
+      "trajectory-level safety proof",
+      "empirical prediction theorem"
+    ],
+    "assumptions": [
+      "path classes are candidates under selected finite support",
+      "unmeasured axes remain explicit unknown remainder"
+    ],
+    "nonConclusions": [
+      "forecast cone skeleton is bounded by selected finite support and horizon",
+      "forecast cone skeleton does not assign probabilities",
+      "forecast cone skeleton does not prove global risk reduction",
+      "forecast cone skeleton does not prove trajectory-level safety",
+      "forecast cone skeleton is not an empirical prediction theorem"
+    ]
+  },
+  "unknownRemainder": [
+    {
+      "remainderId": "unknown:unmeasured-runtime-and-policy-axes",
+      "affectedPathClassIds": [
+        "path:schema-to-envelope",
+        "path:cli-validation-feedback"
+      ],
+      "sourceRefIds": [
+        "source:issue-735",
+        "source:operation-support-estimate-fixture",
+        "source:roadmap-b12",
+        "source:sft-consequence-envelope"
+      ],
+      "unknownAxes": [
+        "runtime propagation",
+        "private PRD constraints",
+        "future reviewer behavior"
+      ],
+      "reason": "selected B12.3 inputs do not measure runtime, private, or future feedback axes",
+      "treatment": "retain as unknown forecast remainder under the selected horizon",
+      "nonConclusions": [
+        "forecast cone skeleton is bounded by selected finite support and horizon",
+        "forecast cone skeleton does not assign probabilities",
+        "forecast cone skeleton does not prove global risk reduction",
+        "forecast cone skeleton does not prove trajectory-level safety",
+        "forecast cone skeleton is not an empirical prediction theorem"
+      ]
+    }
+  ],
+  "nonConclusions": [
+    "forecast cone skeleton is bounded by selected finite support and horizon",
+    "forecast cone skeleton does not assign probabilities",
+    "forecast cone skeleton does not prove global risk reduction",
+    "forecast cone skeleton does not prove trajectory-level safety",
+    "forecast cone skeleton is not an empirical prediction theorem"
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #732
Closes #735
Closes #736
Closes #737

B12.3-B12.5 の `forecast-cone-skeleton-v0`、`consequence-envelope-report-v0`、`forecast-calibration-hook-v0` を追加しました。各 artifact は schema、canonical fixture、validator、CLI entrypoint、CLI regression test を持ちます。

Forecast artifact は finite support、bounded horizon、source refs、measurement / forecast boundary、unknown remainder、non-conclusions を保持し、probability、causal forecast、global safety、Lean theorem claim へ昇格しない設計にしています。

Lean status: empirical hypothesis / tooling validation

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/roadmap.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`

## 実施したテスト

- [x] `cargo test`（tools/archsig、48 lib tests + 75 CLI tests）
- [x] `lake build`（成功。既存 linter warning のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（既存コメント中の unsafe 語のみ検出、今回追加なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている