### PR TITLE
GitHub Pages 公開 workflow を追加する

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Website Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "website/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy website
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload website artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/README.md
+++ b/website/README.md
@@ -38,7 +38,17 @@ media, with links back to the canonical English pages.
 
 ## Publishing Target
 
-Initial target: GitHub Pages with a custom domain.
+Initial target: GitHub Pages, deployed from the `website/` directory by the
+`Website Pages` GitHub Actions workflow.
+
+Repository settings should use GitHub Actions as the Pages source. The workflow
+uploads `website/` as the Pages artifact and deploys it to the `github-pages`
+environment on pushes to `main` that change `website/**` or the workflow file.
+It can also be run manually with `workflow_dispatch`.
+
+A custom domain can be added later by committing `website/CNAME` after the DNS
+target is chosen. Until then, do not hard-code the final public host in site
+links or metadata.
 
 This directory currently uses a no-build static stack:
 
@@ -48,8 +58,36 @@ This directory currently uses a no-build static stack:
 - MathJax from a CDN for TeX rendering
 - Google Fonts for the primary Latin serif, sans, and monospace faces
 
+The committed `website/.nojekyll` file keeps GitHub Pages from treating
+underscore-prefixed paths or future generated assets as Jekyll input.
+
 Until the site generator copies or renders repository documents into public
 routes, the top page links to the canonical documents on GitHub.
+
+## Local Preview
+
+From the repository root:
+
+```bash
+python3 -m http.server 8000 --directory website
+```
+
+Then open `http://localhost:8000/`.
+
+Directly opening `website/index.html` also works for the current top page, but
+the local server is closer to the GitHub Pages serving model and should be used
+when directory routes are added.
+
+## Path Rules
+
+- Use relative asset paths such as `assets/site.css` and `assets/site.js`.
+- Avoid root-absolute paths such as `/assets/site.css`; project Pages sites may
+  be served below a repository path.
+- Use directory routes with local `index.html` files for public pages.
+- Link repository source documents with absolute GitHub URLs until those
+  documents are rendered into `website/`.
+- Keep canonical public pages in English. Japanese explanations belong in
+  outreach articles that link back to the canonical site.
 
 ## Design Notes
 


### PR DESCRIPTION
## 概要

Closes #761

- `website/` を GitHub Pages artifact として deploy する `Website Pages` workflow を追加しました。
- `website/README.md` に GitHub Actions を Pages source とする公開方針、ローカル確認方法、`.nojekyll`、相対パス規約、custom domain の扱いを追記しました。
- no-build static site の前提を維持し、公開ホストの hard-code は避ける方針にしています。

## 証明した定理

- なし

## 編集したドキュメント

- `website/README.md`

## 実施したテスト

- [x] `lake build` 成功（既存 Lean ファイルの linter warning 2 件のみ）
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功（検出なし）
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 実施（既存コメントの `unsafe drift` のみ検出、今回差分への混入なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（tooling / docs task、Lean theorem claim なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている