### PR TITLE
AAT 章クラスタ公開ページを追加

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -61,8 +61,9 @@ This directory currently uses a no-build static stack:
 The committed `website/.nojekyll` file keeps GitHub Pages from treating
 underscore-prefixed paths or future generated assets as Jekyll input.
 
-Until the site generator copies or renders repository documents into public
-routes, the top page links to the canonical documents on GitHub.
+AAT chapter-cluster pages are implemented as static directory routes under
+`aat/`. Remaining major sections still point readers back to canonical
+repository documents until their public routes are added.
 
 ## Local Preview
 

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -470,9 +470,6 @@ ArchSig reference pages must keep these warnings visible:
 ```text
 implemented:
   /
-
-planned:
-  /profile/
   /aat/
   /aat/foundations/
   /aat/laws-and-witnesses/
@@ -483,6 +480,9 @@ planned:
   /aat/representations-and-effects/
   /aat/examples-and-boundaries/
   /aat/status/
+
+planned:
+  /profile/
   /interface/
   /sft/
   /sft/part-i-new-object/

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT calculus and extensions: ArchitectureOperation, operation laws, FeatureExtension, and extension obstruction."
+    >
+    <title>AAT Calculus and Extensions</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Calculus and Extensions</span>
+          </nav>
+          <p class="eyebrow">AAT Part V</p>
+          <h1>Calculus and Extensions</h1>
+          <p class="lede">
+            Architecture operations are boundary-indexed partial morphisms.
+            Feature extension is one important operation family, and its
+            obstruction formula records where an extension fails without
+            pretending that the categories are mutually exclusive.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#architecture-operation">Architecture operation</a></li>
+                <li><a href="#operation-laws">Operation laws</a></li>
+                <li><a href="#feature-extension">Feature extension</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#9-architecture-calculus">
+                    Chapters 9-10 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                An operation tag alone carries no theorem. Each operation must
+                state preconditions, preserved invariants, witness mapping,
+                conclusions, and non-conclusions.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="architecture-operation" class="article-section">
+              <h2>Architecture operation</h2>
+              <p>
+                `ArchitectureOperation` maps one architecture object to another
+                under a theorem boundary. The operation includes support,
+                precondition, transition relation, invariant preservation
+                claim, witness mapping, theorem boundary, and non-conclusions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Operation carrier</figcaption>
+                <pre><code>ArchitectureOperation X Y
+  = support
+  + precondition
+  + transition relation
+  + invariant preservation claim
+  + witness mapping
+  + theorem boundary
+  + non-conclusions</code></pre>
+              </figure>
+            </section>
+
+            <section id="operation-laws" class="article-section">
+              <h2>Operation laws</h2>
+              <p>
+                Under fixed observation and theorem-boundary compatibility,
+                operations can be read as a partial category with identity,
+                composition, and associativity under observation. Stronger laws
+                such as replacement equivalence, protection idempotence, repair
+                monotonicity, and synthesis soundness depend on their own
+                assumptions.
+              </p>
+              <p>
+                Operation families and invariant families also form a weak
+                Galois-style correspondence: requiring stronger invariants
+                reduces allowed operations, while allowing more operations
+                reduces the invariant family that can be guaranteed.
+              </p>
+            </section>
+
+            <section id="feature-extension" class="article-section">
+              <h2>Feature extension</h2>
+              <p>
+                `FeatureExtension` moves from an existing architecture into a
+                larger one while keeping a feature view. Static split,
+                interface declarations, lifting, runtime preservation, and
+                semantic preservation are not bundled into the base extension;
+                they are separate evidence packages.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Extension obstruction formula</figcaption>
+                <pre><code>ExtensionObstruction
+  = inherited core obstruction
+  + feature-local obstruction
+  + interaction obstruction
+  + lifting failure
+  + filling failure
+  + complexity transfer
+  + residual coverage gap</code></pre>
+              </figure>
+              <div class="claim-strip">
+                <p>
+                  The formula is explanatory, not a disjoint decomposition. One
+                  measured witness can belong to multiple obstruction classes.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../local-law-packages/">
+                <span>Previous</span>
+                <strong>Local Law Packages</strong>
+              </a>
+              <a href="../repair-and-dynamics/">
+                <span>Next</span>
+                <strong>Repair and Dynamics</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT examples and boundaries: coupon extension, semantic obstruction, repair transfer, SOLID counterexamples, and non-claims."
+    >
+    <title>AAT Examples and Boundaries</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Examples and Boundaries</span>
+          </nav>
+          <p class="eyebrow">AAT Part VIII</p>
+          <h1>Examples and Boundaries</h1>
+          <p class="lede">
+            Examples and counterexamples fix the limits of the theory. They
+            show why local contracts, static split, selected repair, and
+            measured zero must not be promoted into stronger claims without the
+            missing evidence.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#canonical-examples">Canonical examples</a></li>
+                <li><a href="#counterexamples">Counterexamples</a></li>
+                <li><a href="#aat-boundary">AAT boundary</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#15-canonical-examples-and-counterexamples">
+                    Chapters 15-16 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Counterexamples are part of the theory surface. They keep AAT
+                from claiming runtime, semantic, empirical, or global results
+                from a theorem package that only proves a selected static claim.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="canonical-examples" class="article-section">
+              <h2>Canonical examples</h2>
+              <p>
+                The coupon feature extension is the running minimal example. A
+                good extension routes coupon calculation through the declared
+                interface and keeps interaction with the payment core inside an
+                explicit boundary. A bad extension bypasses that boundary by
+                reaching into payment adapters, hidden caches, or implicit
+                rounding order.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Static witness</strong>
+                  <span>A hidden direct dependency from the coupon service into payment internals.</span>
+                </li>
+                <li>
+                  <strong>Semantic witness</strong>
+                  <span>An observation difference caused by rounding or discount application order.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="counterexamples" class="article-section">
+              <h2>Counterexamples</h2>
+              <p>
+                Static repair can satisfy selected static split while a
+                semantic diagram still fails to commute. A repair can reduce a
+                selected static obstruction while transferring risk to runtime
+                or semantic axes. SOLID-style local contracts can hold without
+                implying global decomposability or acyclicity.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Non-implications</figcaption>
+                <pre><code>StaticFlatWithin X U
+  does not imply
+SemanticFlatWithin X
+
+selected obstruction decreases
+  does not imply
+all axes are non-increasing</code></pre>
+              </figure>
+            </section>
+
+            <section id="aat-boundary" class="article-section">
+              <h2>AAT boundary</h2>
+              <p>
+                AAT is a local algebra for software architecture. It does not
+                claim complete extraction from real codebases, automatic
+                runtime or semantic flatness from static split, a single
+                architecture quality score, safety of unmeasured axes, full
+                formalization of every natural-language design principle, or
+                that empirical cost correlation is a Lean theorem.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Architecture Signature remains a multi-axis diagnostic.
+                  Empirical cost and product outcome readings belong to
+                  separate empirical protocols, not to the required zero-axis
+                  theorem package.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../representations-and-effects/">
+                <span>Previous</span>
+                <strong>Representations and Effects</strong>
+              </a>
+              <a href="../status/">
+                <span>Next</span>
+                <strong>AAT Status</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT foundations: central proposition, ArchitectureObject, ArchitectureCore, and ComponentUniverse."
+    >
+    <title>AAT Foundations</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Foundations</span>
+          </nav>
+          <p class="eyebrow">AAT Part I</p>
+          <h1>Foundations</h1>
+          <p class="lede">
+            The opening cluster fixes the object of the theory. AAT reasons
+            about bounded architecture objects, not whole real codebases, and
+            every zero or lawfulness claim is relative to a selected universe,
+            observation model, and evidence boundary.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#central-proposition">Central proposition</a></li>
+                <li><a href="#architecture-object">Architecture object</a></li>
+                <li><a href="#universe-boundary">Universe boundary</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#1-%E4%B8%AD%E5%BF%83%E5%91%BD%E9%A1%8C">
+                    Chapters 1-2 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                AAT does not claim complete extraction from real codebases.
+                `ComponentUniverse` is proof-carrying measurement scope, not a
+                promise that all components and relations have been observed.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="central-proposition" class="article-section">
+              <h2>Central proposition</h2>
+              <p>
+                AAT formalizes software architecture as a local algebra of
+                objects, operations, invariant families, obstruction witnesses,
+                signatures, and theorem boundaries. The review question is not
+                "is this design good?" but "which invariant is being required,
+                under which observation boundary, and which witness or theorem
+                package supports the claim?"
+              </p>
+              <figure class="code-panel">
+                <figcaption>AAT decomposition</figcaption>
+                <pre><code>software architecture
+  = ArchitectureObject
+  + ArchitectureOperation
+  + InvariantFamily
+  + ObstructionWitness
+  + ArchitectureSignature
+  + theorem boundary / non-conclusions</code></pre>
+              </figure>
+            </section>
+
+            <section id="architecture-object" class="article-section">
+              <h2>Architecture object</h2>
+              <p>
+                An `ArchitectureObject` is a bounded mathematical object cut
+                out from code, specifications, review evidence, or operational
+                observations. `ArchitectureCore` is a structured,
+                evidence-aware presentation of that object. It can include
+                static and runtime graphs, boundary policy, abstraction policy,
+                semantic diagrams, decidability assumptions, and a selected
+                measurement universe.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>ArchitectureCarrier</strong>
+                  <span>Components plus static and runtime dependency relations.</span>
+                </li>
+                <li>
+                  <strong>ArchitecturePolicy</strong>
+                  <span>Boundary and abstraction policies used to read lawfulness.</span>
+                </li>
+                <li>
+                  <strong>ArchitectureObservationContext</strong>
+                  <span>Observation model, semantic diagram universe, and selected measurement universe.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="universe-boundary" class="article-section">
+              <h2>Universe boundary</h2>
+              <p>
+                `ComponentUniverse` records selected components, selected
+                relations, coverage boundary, and exactness boundary. Outside
+                that universe, AAT does not infer zero, absence, flatness,
+                split, or lawfulness.
+              </p>
+              <p>
+                `ComponentCategory` is thin: it remembers whether a reachability
+                morphism exists and intentionally forgets path count and walk
+                length. Quantitative data belongs to `Walk`, `Path`, adjacency
+                matrix, finite metrics, or future free-category constructions.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Current `Decomposable` means `StrictLayered`. Acyclicity,
+                  finite propagation, nilpotence, and spectral conditions are
+                  connected by separate theorems or representations, not mixed
+                  into the definition.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../">
+                <span>Previous</span>
+                <strong>AAT landing</strong>
+              </a>
+              <a href="../laws-and-witnesses/">
+                <span>Next</span>
+                <strong>Laws and Witnesses</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Algebraic Architecture Theory reading path, chapter clusters, and claim boundaries."
+    >
+    <title>Algebraic Architecture Theory</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../assets/site.css">
+    <script>
+      window.MathJax = {
+        tex: {
+          inlineMath: [["\\(", "\\)"]],
+          displayMath: [["\\[", "\\]"]]
+        },
+        chtml: {
+          matchFontHeight: false
+        }
+      };
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+    <script defer src="../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../">Home</a>
+          <a class="is-active" href="./">AAT</a>
+          <a href="../#research">SFT</a>
+          <a href="../#documents">Interface</a>
+          <a href="../#research">ArchSig</a>
+          <a href="../#outreach">Outreach</a>
+          <a href="../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../">Home</a>
+            <span>AAT</span>
+          </nav>
+          <p class="eyebrow">Algebraic Architecture Theory</p>
+          <h1>A local algebra for software architecture.</h1>
+          <p class="lede">
+            AAT treats architecture as a bounded object of reasoning: operations
+            preserve or break invariant families, obstruction witnesses explain
+            the breakage, and Architecture Signature records the result as a
+            multi-axis diagnostic rather than a single quality score.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="AAT page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#reading-order">Reading order</a></li>
+                <li><a href="#claim-discipline">Claim discipline</a></li>
+                <li><a href="#canonical-sources">Canonical sources</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md">
+                    AAT mathematical theory
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/README.md">
+                    AAT repository entry
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="reading-order" class="article-section">
+              <h2>Reading order</h2>
+              <p>
+                The repository keeps AAT as one first-class mathematical text.
+                The website splits that text into chapter clusters so readers
+                can keep their current position and move through the theory in
+                a stable order.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="foundations/">Foundations</a>
+                  <span>Central proposition, ArchitectureObject, ArchitectureCore, ComponentUniverse.</span>
+                </li>
+                <li>
+                  <a href="laws-and-witnesses/">Laws and Witnesses</a>
+                  <span>Invariant families, LawUniverse, ObstructionWitness, zero-curvature reading.</span>
+                </li>
+                <li>
+                  <a href="signature-and-boundary/">Signature and Theorem Boundary</a>
+                  <span>ArchitectureSignature, MeasurementStatus, theorem boundary, non-conclusions.</span>
+                </li>
+                <li>
+                  <a href="local-law-packages/">Local Law Packages</a>
+                  <span>Projection, observation, LSP, DIP, and three-layer flatness.</span>
+                </li>
+                <li>
+                  <a href="calculus-and-extensions/">Calculus and Extensions</a>
+                  <span>ArchitectureOperation, operation laws, FeatureExtension, extension obstruction.</span>
+                </li>
+                <li>
+                  <a href="repair-and-dynamics/">Repair and Dynamics</a>
+                  <span>Repair, synthesis, complexity transfer, paths, homotopy, diagram filling.</span>
+                </li>
+                <li>
+                  <a href="representations-and-effects/">Representations and Effects</a>
+                  <span>Graph, matrix, analytic representation, state-transition algebra, effect boundary.</span>
+                </li>
+                <li>
+                  <a href="examples-and-boundaries/">Examples and Boundaries</a>
+                  <span>Coupon extension, semantic counterexample, repair transfer, SOLID boundaries.</span>
+                </li>
+                <li>
+                  <a href="status/">Status</a>
+                  <span>How to read Lean status, proof obligations, and implemented theorem packages.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="claim-discipline" class="article-section">
+              <h2>Claim discipline</h2>
+              <p>
+                AAT does not identify architecture quality with a slogan, a
+                framework name, or a scalar score. It asks which invariant is
+                required, which universe is being observed, which witness shows
+                a failure, and which theorem boundary permits the conclusion.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Central decomposition</figcaption>
+                <pre><code>software architecture
+  = ArchitectureObject
+  + ArchitectureOperation
+  + InvariantFamily
+  + ObstructionWitness
+  + ArchitectureSignature
+  + theorem boundary / non-conclusions</code></pre>
+              </figure>
+              <div class="claim-strip">
+                <p>
+                  This website is a public reading surface. Formal status,
+                  issue tracking, and tooling evidence stay separate from the
+                  mathematical text and are linked where they are needed.
+                </p>
+              </div>
+            </section>
+
+            <section id="canonical-sources" class="article-section">
+              <h2>Canonical sources</h2>
+              <p>
+                The mathematical source of truth is the repository document.
+                Lean theorem status is intentionally separated into the theorem
+                index and proof-obligation ledger so public prose does not turn
+                a theorem candidate into a proved Lean claim.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Mathematical text</strong>
+                  <span>`docs/aat/mathematical_theory.md` defines the AAT theory surface.</span>
+                </li>
+                <li>
+                  <strong>Lean status</strong>
+                  <span>`docs/aat/lean_theorem_index.md` lists implemented definitions and theorems.</span>
+                </li>
+                <li>
+                  <strong>Proof obligations</strong>
+                  <span>`docs/aat/proof_obligations.md` separates proved, defined only, future proof obligation, and empirical hypothesis.</span>
+                </li>
+              </ul>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../">
+                <span>Previous</span>
+                <strong>Home</strong>
+              </a>
+              <a href="foundations/">
+                <span>Next</span>
+                <strong>Foundations</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT laws and witnesses: invariant families, LawUniverse, obstruction witnesses, and zero-curvature reading."
+    >
+    <title>AAT Laws and Witnesses</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Laws and Witnesses</span>
+          </nav>
+          <p class="eyebrow">AAT Part II</p>
+          <h1>Laws and Witnesses</h1>
+          <p class="lede">
+            This cluster explains how design principles become invariant
+            families and how architecture breakage is represented by selected
+            obstruction witnesses rather than by a vague failure label.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#invariant-families">Invariant families</a></li>
+                <li><a href="#obstruction-witnesses">Obstruction witnesses</a></li>
+                <li><a href="#zero-curvature">Zero-curvature reading</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#3-invariant-%E3%81%A8-law-universe">
+                    Chapters 3-4 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Zero curvature names required obstruction-free status inside a
+                selected law universe. It is not an unconditional claim about
+                runtime behavior, semantic flatness, empirical risk, or
+                differential-geometric curvature.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="invariant-families" class="article-section">
+              <h2>Invariant families</h2>
+              <p>
+                An `Invariant` is a property an architecture object or operation
+                is expected to preserve. Design principles induce families of
+                operations that preserve, reflect, improve, localize, translate,
+                or transfer invariants; the principle itself is not treated as
+                one universal mathematical operation.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Local contract layer</strong>
+                  <span>SRP, OCP, LSP, ISP, and DIP organize contracts, abstraction, substitutability, and interface separation.</span>
+                </li>
+                <li>
+                  <strong>Global structure layer</strong>
+                  <span>Layered and Clean Architecture handle ranking, dependency direction, acyclicity, decomposition, and boundary preservation.</span>
+                </li>
+                <li>
+                  <strong>State and runtime layers</strong>
+                  <span>Event Sourcing, Saga, Circuit Breaker, and Replicated Log carry replay, compensation, protection, ordering, and convergence laws.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="obstruction-witnesses" class="article-section">
+              <h2>Obstruction witnesses</h2>
+              <p>
+                An `ObstructionWitness` structurally explains why a desired law
+                does not hold. A forbidden static edge, hidden interaction,
+                boundary policy violation, projection failure, LSP mismatch,
+                non-commuting semantic diagram, runtime exposure, lifting
+                failure, or residual coverage gap can all be witnesses when
+                they live in the selected universe.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Finite witness kernel</figcaption>
+                <pre><code>violatingWitnesses bad xs
+  = xs filtered by bad
+
+violationCount bad xs = 0
+  &lt;-&gt; every measured witness is not bad</code></pre>
+              </figure>
+            </section>
+
+            <section id="zero-curvature" class="article-section">
+              <h2>Zero-curvature reading</h2>
+              <p>
+                The central theorem package connects semantic lawfulness,
+                selected required witness absence, and selected required
+                signature axes being zero. The connection is nontrivial: it
+                requires witness completeness, axis exactness, coverage
+                completeness, and observation exactness.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Required obstruction vanishing</figcaption>
+                <pre><code>finite law universe
+  + theorem boundary B
+  + complete witness coverage
+  + required axis exactness
+  -&gt;
+  ArchitectureLawfulWithin X B
+    &lt;-&gt; no selected required obstruction witness
+    &lt;-&gt; required signature axes are zero</code></pre>
+              </figure>
+              <div class="claim-strip">
+                <p>
+                  SOLID is not treated as a universal architecture principle.
+                  It is one local-contract family among distinct global,
+                  state-transition, runtime, and distributed invariant families.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../foundations/">
+                <span>Previous</span>
+                <strong>Foundations</strong>
+              </a>
+              <a href="../signature-and-boundary/">
+                <span>Next</span>
+                <strong>Signature and Boundary</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT local law packages: projection, observation, LSP, DIP, and three-layer flatness."
+    >
+    <title>AAT Local Law Packages</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Local Law Packages</span>
+          </nav>
+          <p class="eyebrow">AAT Part IV</p>
+          <h1>Local Law Packages</h1>
+          <p class="lede">
+            Projection, observation, substitutability, abstraction, and flatness
+            are local packages with explicit assumptions. This page separates
+            local contract soundness from global structure and from runtime or
+            semantic flatness.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#projection-observation">Projection and observation</a></li>
+                <li><a href="#lsp-dip">LSP and DIP</a></li>
+                <li><a href="#three-layer-flatness">Three-layer flatness</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#7-projection-observation-lsp-dip">
+                    Chapters 7-8 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                A local contract can be sound without proving global
+                decomposability. Static flatness also does not provide runtime
+                or semantic flatness without separate evidence.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="projection-observation" class="article-section">
+              <h2>Projection and observation</h2>
+              <p>
+                A projection maps concrete structure to abstract structure. An
+                observation maps concrete structure or operation results to
+                selected observations. They are related by the claim that equal
+                abstractions should have equivalent observations in the selected
+                context.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Kernel inclusion</figcaption>
+                <pre><code>F : Concrete -&gt; Abstract
+Obs : Concrete -&gt; Observation
+
+F(x) = F(y) -&gt; Obs(x) ~= Obs(y)
+
+ker(F) &lt;= ker(Obs)</code></pre>
+              </figure>
+            </section>
+
+            <section id="lsp-dip" class="article-section">
+              <h2>LSP and DIP</h2>
+              <p>
+                LSP-style substitutability is read through a selected client
+                context universe. DIP and Clean Architecture style abstraction
+                soundness are read as concrete dependencies mapping soundly to
+                abstract dependencies, with stronger claims requiring
+                completeness, exactness, and representative stability.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>ProjectionSound</strong>
+                  <span>Concrete dependency evidence is represented in the abstract graph.</span>
+                </li>
+                <li>
+                  <strong>ProjectionComplete</strong>
+                  <span>Abstract dependencies have concrete representatives under stated assumptions.</span>
+                </li>
+                <li>
+                  <strong>RepresentativeStable</strong>
+                  <span>Chosen representatives remain stable for the claim being made.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="three-layer-flatness" class="article-section">
+              <h2>Three-layer flatness</h2>
+              <p>
+                AAT separates static flatness, runtime flatness, and semantic
+                flatness. Static flatness handles dependency direction,
+                boundary, and abstraction violations. Runtime flatness handles
+                protection, propagation, and exposure. Semantic flatness handles
+                observation-level commutativity, diagram filling, and contract
+                preservation.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Bounded flatness</figcaption>
+                <pre><code>ArchitectureFlatWithin
+  = StaticFlatWithin
+  + RuntimeFlatWithin
+  + SemanticFlatWithin
+  + no unmeasured required axis
+  + coverage / exactness boundary</code></pre>
+              </figure>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../signature-and-boundary/">
+                <span>Previous</span>
+                <strong>Signature and Boundary</strong>
+              </a>
+              <a href="../calculus-and-extensions/">
+                <span>Next</span>
+                <strong>Calculus and Extensions</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT repair and dynamics: repair steps, synthesis, complexity transfer, paths, homotopy, and diagram filling."
+    >
+    <title>AAT Repair and Dynamics</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Repair and Dynamics</span>
+          </nav>
+          <p class="eyebrow">AAT Part VI</p>
+          <h1>Repair and Dynamics</h1>
+          <p class="lede">
+            Repair, synthesis, operation paths, homotopy, and diagram filling
+            describe how architecture objects move. Each movement is read
+            through selected measures and explicit side-effect boundaries.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#repair">Repair and synthesis</a></li>
+                <li><a href="#complexity-transfer">Complexity transfer</a></li>
+                <li><a href="#paths-and-filling">Paths and filling</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#11-repair-synthesis-complexity-transfer">
+                    Chapters 11-12 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Repair is not total improvement. A selected obstruction can
+                decrease while another axis gains risk or remains unmeasured.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="repair" class="article-section">
+              <h2>Repair and synthesis</h2>
+              <p>
+                A `RepairStep` is an operation intended to reduce a selected
+                obstruction measure. A repair theorem must state which witness
+                universe decreases, which invariant is preserved, which axes
+                are not claimed to improve, and where side effects may appear.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Repair step</figcaption>
+                <pre><code>RepairStep
+  = source
+  + target
+  + selected obstruction measure
+  + decrease theorem boundary
+  + side-effect boundary</code></pre>
+              </figure>
+              <p>
+                Synthesis constructs an architecture object or operation
+                sequence satisfying constraints. A no-solution result needs a
+                finite complete search universe, explicit constraint language,
+                decision procedure, and coverage boundary; solver failure alone
+                is not a mathematical certificate.
+              </p>
+            </section>
+
+            <section id="complexity-transfer" class="article-section">
+              <h2>Complexity transfer</h2>
+              <p>
+                `ComplexityTransfer` captures the case where complexity or an
+                obstruction appears to disappear only because it moved to
+                another axis. AAT requires selected evidence, selected target,
+                residual gap, and non-conclusion boundary before calling an
+                obstruction eliminated.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A repair package may prove that one selected measure
+                  decreases. It does not prove that all signature axes are
+                  non-increasing unless that theorem boundary says so.
+                </p>
+              </div>
+            </section>
+
+            <section id="paths-and-filling" class="article-section">
+              <h2>Paths and filling</h2>
+              <p>
+                `ArchitecturePath` is an operation sequence. Two paths can
+                reach the same feature outcome while preserving different
+                invariants, introducing different witnesses, or tracing
+                different signature trajectories.
+              </p>
+              <p>
+                `PathHomotopy` compares paths under selected generators and an
+                observation model. Semantic diagram filling supplies evidence
+                that different implementation paths give the same observation;
+                a failed equality can become a `NonFillabilityWitness`.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Non-fillability witness</figcaption>
+                <pre><code>Obs(lhs) != Obs(rhs)
+  -&gt; NonFillabilityWitness D</code></pre>
+              </figure>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../calculus-and-extensions/">
+                <span>Previous</span>
+                <strong>Calculus and Extensions</strong>
+              </a>
+              <a href="../representations-and-effects/">
+                <span>Next</span>
+                <strong>Representations and Effects</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT representations and effects: graph, matrix, analytic representation, state transition algebra, and effect boundary."
+    >
+    <title>AAT Representations and Effects</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Representations and Effects</span>
+          </nav>
+          <p class="eyebrow">AAT Part VII</p>
+          <h1>Representations and Effects</h1>
+          <p class="lede">
+            Graph, matrix, analytic, and state-transition views are different
+            representations of selected architecture structure. The strength of
+            a representation depends on whether it preserves or reflects zeros
+            and obstructions under stated assumptions.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#graph-matrix">Graph and matrix</a></li>
+                <li><a href="#analytic-representation">Analytic representation</a></li>
+                <li><a href="#state-effects">State transitions and effects</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#13-graph-matrix-analytic-representation">
+                    Chapters 13-14 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Analytic values alone do not prove structural flatness. The
+                reflecting direction needs coverage, witness completeness, and
+                semantic contract coverage assumptions.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="graph-matrix" class="article-section">
+              <h2>Graph and matrix</h2>
+              <p>
+                On a finite unweighted universe, acyclicity, absence of closed
+                walks, and nilpotence of the adjacency matrix can express the
+                same static structure. Finite propagation is not baked into
+                that structural theorem; it depends on a walk universe and a
+                propagation model.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Finite unweighted bridge</figcaption>
+                <pre><code>acyclic
+  &lt;-&gt; no closed walk
+  &lt;-&gt; nilpotent adjacency matrix</code></pre>
+              </figure>
+            </section>
+
+            <section id="analytic-representation" class="article-section">
+              <h2>Analytic representation</h2>
+              <p>
+                `AnalyticRepresentation` maps a structural architecture object
+                into an analytic domain. The representation can be
+                zero-preserving, zero-reflecting, obstruction-preserving, or
+                obstruction-reflecting. These are different strengths, and the
+                reflecting directions are the ones that need stronger evidence.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>ZeroPreserving</strong>
+                  <span>Structural zero implies analytic zero.</span>
+                </li>
+                <li>
+                  <strong>ZeroReflecting</strong>
+                  <span>Analytic zero plus assumptions implies structural zero.</span>
+                </li>
+                <li>
+                  <strong>ObstructionReflecting</strong>
+                  <span>An analytic obstruction can be read back as structural only with explicit assumptions.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="state-effects" class="article-section">
+              <h2>State transitions and effects</h2>
+              <p>
+                The state-transition layer treats commands, events, retries,
+                compensations, snapshots, and migrations as generators, with
+                laws expressed as relations. Event Sourcing, Saga, retry safety,
+                snapshot consistency, and migration naturality are projections
+                of this algebra.
+              </p>
+              <p>
+                The effect boundary captures obstruction that a dependency
+                graph alone may miss: cross-boundary effects, implicit
+                authority, missing handlers, and non-commuting effect pairs.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Example relations</figcaption>
+                <pre><code>f ; f = f
+compensate ; action ~= id
+decode ; encode ~= id</code></pre>
+              </figure>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../repair-and-dynamics/">
+                <span>Previous</span>
+                <strong>Repair and Dynamics</strong>
+              </a>
+              <a href="../examples-and-boundaries/">
+                <span>Next</span>
+                <strong>Examples and Boundaries</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT Architecture Signature, theorem boundaries, measurement status, and non-conclusions."
+    >
+    <title>AAT Signature and Boundary</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Signature and Boundary</span>
+          </nav>
+          <p class="eyebrow">AAT Part III</p>
+          <h1>Signature and Theorem Boundary</h1>
+          <p class="lede">
+            Architecture Signature is a multi-axis diagnostic of selected
+            obstruction families. Theorem boundaries state what a package can
+            conclude and, just as importantly, what it does not conclude.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#signature">Architecture Signature</a></li>
+                <li><a href="#measurement-status">Measurement status</a></li>
+                <li><a href="#theorem-boundary">Theorem boundary</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#5-architecture-signature">
+                    Chapters 5-6 in the AAT text
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                A missing axis is not a zero axis. Signature comparison is valid
+                only where the same axes are measured on both sides and an
+                axis-specific order is defined.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="signature" class="article-section">
+              <h2>Architecture Signature</h2>
+              <p>
+                `ArchitectureSignature` records coordinates of selected
+                obstruction families. Static, boundary, abstraction, projection
+                or LSP, runtime, semantic, operation, extension, and analytic
+                axes may all appear, but they do not collapse into one score.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Signature reading</figcaption>
+                <pre><code>ArchitectureSignature(X)
+  = coordinates of selected obstruction families of X</code></pre>
+              </figure>
+            </section>
+
+            <section id="measurement-status" class="article-section">
+              <h2>Measurement status</h2>
+              <p>
+                Every axis carries a status. `measured_zero`,
+                `measured_nonzero(value)`, `unmeasured`, `out_of_scope`,
+                `private_unavailable`, and `not_applicable` are different claim
+                states. `unmeasured` is not simply a worse numeric value than
+                `measured_zero`; it is a boundary on what can be compared.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Structural coordinates</strong>
+                  <span>Static, boundary, abstraction, projection, and operation-level obstruction readings.</span>
+                </li>
+                <li>
+                  <strong>Semantic and runtime coordinates</strong>
+                  <span>Observation and runtime exposure readings that require their own evidence.</span>
+                </li>
+                <li>
+                  <strong>Empirical readings</strong>
+                  <span>Cost and product outcomes are not required zero axes inside AAT.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="theorem-boundary" class="article-section">
+              <h2>Theorem boundary</h2>
+              <p>
+                A theorem boundary packages selected universe, required laws,
+                invariant family, witness universe, coverage assumptions,
+                exactness assumptions, operation preconditions, conclusion, and
+                non-conclusions. It prevents a bounded formal result from being
+                read as a global architecture claim.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Boundary record</figcaption>
+                <pre><code>TheoremBoundary
+  = selected universe
+  + required laws
+  + invariant family
+  + witness universe
+  + coverage assumptions
+  + exactness assumptions
+  + operation preconditions
+  + conclusion
+  + non-conclusions</code></pre>
+              </figure>
+              <div class="claim-strip">
+                <p>
+                  Static split does not imply runtime or semantic flatness, and
+                  absence of a selected witness does not imply global absence.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../laws-and-witnesses/">
+                <span>Previous</span>
+                <strong>Laws and Witnesses</strong>
+              </a>
+              <a href="../local-law-packages/">
+                <span>Next</span>
+                <strong>Local Law Packages</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="How to read AAT Lean status, proof obligations, theorem index entries, and empirical hypotheses."
+    >
+    <title>AAT Lean Status</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../#research">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Status</span>
+          </nav>
+          <p class="eyebrow">Appendix</p>
+          <h1>AAT Lean Status</h1>
+          <p class="lede">
+            This page is deliberately separate from the mathematical article.
+            It explains how to read proved Lean declarations, defined-only API,
+            future proof obligations, tooling claims, and empirical hypotheses
+            without merging them into one status.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#source-map">Source map</a></li>
+                <li><a href="#status-vocabulary">Status vocabulary</a></li>
+                <li><a href="#qed-boundary">Current QED boundary</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Status sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md">
+                    Lean theorem index
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/proof_obligations.md">
+                    Proof obligations
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Mathematical theorem candidates are not automatically current
+                Lean theorems. The theorem index and proof-obligation document
+                provide the status boundary.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="source-map" class="article-section">
+              <h2>Source map</h2>
+              <p>
+                The AAT mathematical text stays focused on definitions,
+                theorem candidates, non-goals, and design boundaries. Lean
+                status and issue progress are managed elsewhere so a public
+                exposition cannot accidentally promote a future theorem into a
+                proved claim.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Mathematical definitions</strong>
+                  <span>`docs/aat/mathematical_theory.md` is the first-class theory text.</span>
+                </li>
+                <li>
+                  <strong>Implemented Lean API</strong>
+                  <span>`docs/aat/lean_theorem_index.md` lists declarations, file paths, meanings, and status.</span>
+                </li>
+                <li>
+                  <strong>Future work and empirical hypotheses</strong>
+                  <span>`docs/aat/proof_obligations.md` tracks proof obligations and empirical boundaries.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="status-vocabulary" class="article-section">
+              <h2>Status vocabulary</h2>
+              <p>
+                AAT uses a small status vocabulary to avoid mixing proof,
+                schema, tooling, and empirical claims.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>proved</strong>
+                  <span>A Lean declaration has been proved, including main theorems, accessors, bridge theorems, bounded completeness results, or examples.</span>
+                </li>
+                <li>
+                  <strong>defined only</strong>
+                  <span>A Lean schema, structure, predicate, or executable metric exists, but the corresponding correctness theorem is not complete.</span>
+                </li>
+                <li>
+                  <strong>future proof obligation</strong>
+                  <span>A mathematical claim intended for Lean proof later.</span>
+                </li>
+                <li>
+                  <strong>empirical hypothesis</strong>
+                  <span>A claim to test against repositories, operations, datasets, or case studies; it is not a Lean proof blocker.</span>
+                </li>
+              </ul>
+              <div class="claim-strip">
+                <p>
+                  Tool output, extractor output, generated patches, author
+                  provenance, and unmeasured axes do not become `proved` merely
+                  by appearing in a report.
+                </p>
+              </div>
+            </section>
+
+            <section id="qed-boundary" class="article-section">
+              <h2>Current QED boundary</h2>
+              <p>
+                The current Lean-proved core is the static structural theorem
+                package. It connects lawfulness with required signature axes
+                zero under explicit law-family, witness-coverage, axis
+                exactness, universe, coverage, and observation assumptions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Static structural core</figcaption>
+                <pre><code>ArchitectureLawful X
+  &lt;-&gt; RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X)
+
+ArchitectureLawful X
+  &lt;-&gt; ArchitectureZeroCurvatureTheoremPackage X</code></pre>
+              </figure>
+              <p>
+                This boundary excludes runtime metric completeness, general
+                numerical curvature as a signature axis, empirical cost
+                correlation, and any claim that a real-code extractor produces
+                a complete `ComponentUniverse`.
+              </p>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../examples-and-boundaries/">
+                <span>Previous</span>
+                <strong>Examples and Boundaries</strong>
+              </a>
+              <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                <span>Next</span>
+                <strong>AAT / SFT Interface source</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -463,6 +463,231 @@ p {
   font-weight: 750;
 }
 
+.article-hero {
+  padding: clamp(54px, 7vw, 92px) 0 clamp(40px, 6vw, 72px);
+}
+
+.article-hero .lede {
+  max-width: 840px;
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 18px;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.breadcrumb a {
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+.breadcrumb a::after {
+  content: "/";
+  margin-left: 8px;
+  color: var(--rule-strong);
+}
+
+.article-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.36fr) minmax(0, 1fr);
+  gap: clamp(32px, 6vw, 70px);
+  align-items: start;
+}
+
+.article-sidebar {
+  position: sticky;
+  top: 92px;
+  display: grid;
+  gap: 22px;
+}
+
+.toc-panel,
+.source-panel,
+.boundary-note {
+  border-top: 3px solid var(--ink);
+  padding-top: 16px;
+}
+
+.toc-panel h2,
+.source-panel h2,
+.boundary-note h2 {
+  margin-bottom: 10px;
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.toc-panel ol,
+.toc-panel ul,
+.source-panel ul,
+.boundary-note ul,
+.chapter-list,
+.term-list,
+.status-list {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.toc-panel a,
+.source-panel a {
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.35;
+  text-decoration: none;
+}
+
+.source-panel p,
+.boundary-note p,
+.boundary-note li {
+  color: var(--ink-muted);
+  font-size: 0.96rem;
+  line-height: 1.52;
+}
+
+.article-main {
+  display: grid;
+  gap: 42px;
+}
+
+.article-section {
+  border-top: 1px solid var(--rule-strong);
+  padding-top: 28px;
+}
+
+.article-section h2 {
+  font-size: clamp(1.65rem, 3vw, 2.45rem);
+}
+
+.article-section h3 {
+  margin-top: 26px;
+  font-size: clamp(1.16rem, 2vw, 1.42rem);
+}
+
+.article-section p,
+.article-section li {
+  color: var(--ink-muted);
+}
+
+.article-section p {
+  margin-top: 16px;
+}
+
+.article-section ul,
+.article-section ol {
+  margin: 16px 0 0;
+  padding-left: 1.2em;
+}
+
+.chapter-list,
+.term-list,
+.status-list {
+  gap: 0;
+  border-top: 1px solid var(--rule-strong);
+  margin: 16px 0 0;
+  padding: 0;
+}
+
+.chapter-list li,
+.term-list li,
+.status-list li {
+  border-bottom: 1px solid var(--rule);
+  padding: 18px 0;
+}
+
+.chapter-list a,
+.term-list strong,
+.status-list strong {
+  display: block;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.chapter-list a:hover {
+  color: var(--accent-warm);
+}
+
+.chapter-list span,
+.term-list span,
+.status-list span {
+  display: block;
+  margin-top: 4px;
+  color: var(--ink-muted);
+  font-size: 0.98rem;
+  line-height: 1.48;
+}
+
+.claim-strip {
+  border-left: 4px solid var(--accent-warm);
+  background: var(--surface);
+  padding: 18px 20px;
+}
+
+.claim-strip p {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.98rem;
+  font-weight: 650;
+  line-height: 1.52;
+}
+
+.page-nav {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  border-top: 1px solid var(--rule-strong);
+  padding-top: 24px;
+}
+
+.page-nav a {
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  color: var(--ink);
+  display: grid;
+  gap: 4px;
+  min-height: 104px;
+  padding: 16px;
+  text-decoration: none;
+}
+
+.page-nav a:last-child {
+  text-align: right;
+}
+
+.page-nav span {
+  color: var(--accent-blue);
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.page-nav strong {
+  align-self: end;
+  font-family: var(--font-serif);
+  font-size: clamp(1.12rem, 2vw, 1.34rem);
+  font-weight: 650;
+  line-height: 1.16;
+}
+
+.page-nav a:hover strong {
+  color: var(--accent-warm);
+}
+
 .site-footer {
   background: var(--ink);
   color: #d9e3df;
@@ -517,6 +742,14 @@ p {
     position: static;
   }
 
+  .article-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .article-sidebar {
+    position: static;
+  }
+
   h1 {
     font-size: clamp(2.62rem, 12vw, 4.2rem);
   }
@@ -557,6 +790,14 @@ p {
   .document-table a {
     grid-template-columns: 1fr;
     gap: 4px;
+  }
+
+  .page-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .page-nav a:last-child {
+    text-align: left;
   }
 
   .math-block {

--- a/website/assets/site.js
+++ b/website/assets/site.js
@@ -1,11 +1,14 @@
 const navLinks = Array.from(document.querySelectorAll(".site-nav a"));
-const sections = navLinks
+const hashNavLinks = navLinks.filter((link) =>
+  link.getAttribute("href")?.startsWith("#")
+);
+const sections = hashNavLinks
   .map((link) => document.querySelector(link.getAttribute("href")))
   .filter(Boolean);
 
 if ("IntersectionObserver" in window && sections.length > 0) {
   const activeById = new Map(
-    navLinks.map((link) => [link.getAttribute("href").slice(1), link])
+    hashNavLinks.map((link) => [link.getAttribute("href").slice(1), link])
   );
 
   const observer = new IntersectionObserver(
@@ -16,7 +19,7 @@ if ("IntersectionObserver" in window && sections.length > 0) {
 
       if (!visible) return;
 
-      navLinks.forEach((link) => link.classList.remove("is-active"));
+      hashNavLinks.forEach((link) => link.classList.remove("is-active"));
       activeById.get(visible.target.id)?.classList.add("is-active");
     },
     { rootMargin: "-20% 0px -65% 0px", threshold: [0.1, 0.35, 0.6] }
@@ -24,6 +27,19 @@ if ("IntersectionObserver" in window && sections.length > 0) {
 
   sections.forEach((section) => observer.observe(section));
 }
+
+const currentPath = window.location.pathname.replace(/index\.html$/, "");
+
+navLinks
+  .filter((link) => !link.getAttribute("href")?.startsWith("#"))
+  .forEach((link) => {
+    const target = new URL(link.getAttribute("href"), window.location.href);
+    const targetPath = target.pathname.replace(/index\.html$/, "");
+
+    if (targetPath === currentPath) {
+      link.classList.add("is-active");
+    }
+  });
 
 document.querySelector("[data-current-year]").textContent =
   new Date().getFullYear();

--- a/website/index.html
+++ b/website/index.html
@@ -42,6 +42,7 @@
         </a>
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="#research">Research</a>
+          <a href="aat/">AAT</a>
           <a href="#documents">Documents</a>
           <a href="#samples">Notation</a>
           <a href="#outreach">Outreach</a>
@@ -98,8 +99,8 @@
                 operations, invariant families, obstruction witnesses,
                 architecture signatures, and theorem boundaries.
               </p>
-              <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/README.md">
-                Read the AAT entry
+              <a href="aat/">
+                Read the AAT pages
               </a>
             </article>
             <article class="research-item">


### PR DESCRIPTION
## 概要

Closes #762

`website/SITEMAP.md` の AAT chapter-cluster 方針に沿って、`/aat/` landing と AAT 本文クラスタ pages、status page を no-build static site として追加しました。各ページは local table of contents、canonical source link、previous / next navigation、claim boundary note を持ち、数学本文と Lean status / empirical hypothesis を混同しない構成にしています。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/**/index.html`: AAT landing、8 本の chapter-cluster page、status page を追加
- `website/assets/site.css`: article layout、TOC、source panel、boundary note、previous / next navigation の style を追加
- `website/assets/site.js`: hash navigation と directory route navigation の両方に対応
- `website/index.html`: AAT 公開ページへの導線を追加
- `website/SITEMAP.md`: AAT routes を implemented に更新
- `website/README.md`: AAT routes 実装済みであることを追記

## 実施したテスト

- [x] `lake build` 成功（既存の linter warning 2 件のみ: `Formal/Arch/Extension/FeatureExtensionExamples.lean`）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean placeholder / unsafe command の該当なし）
- [x] static link check（HTML 11 files、root-absolute link なし、missing local link なし）
- [x] local preview HTTP spot check: `/aat/`, `/aat/foundations/`, `/aat/laws-and-witnesses/`, `/aat/status/`, `/assets/site.css` が 200 OK

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている