### PR TITLE
Issue #764 SFT Part pages を website に追加

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -62,7 +62,8 @@ The committed `website/.nojekyll` file keeps GitHub Pages from treating
 underscore-prefixed paths or future generated assets as Jekyll input.
 
 AAT chapter-cluster pages are implemented as static directory routes under
-`aat/`. Remaining major sections still point readers back to canonical
+`aat/`. SFT Part pages are implemented as static directory routes under
+`sft/`. Remaining major sections still point readers back to canonical
 repository documents until their public routes are added.
 
 ## Local Preview

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -480,10 +480,6 @@ implemented:
   /aat/representations-and-effects/
   /aat/examples-and-boundaries/
   /aat/status/
-
-planned:
-  /profile/
-  /interface/
   /sft/
   /sft/part-i-new-object/
   /sft/part-ii-basis/
@@ -492,6 +488,10 @@ planned:
   /sft/part-v-computing-systems/
   /sft/part-vi-case-studies/
   /sft/part-vii-research-program/
+
+planned:
+  /profile/
+  /interface/
   /archsig/
   /archsig/getting-started/
   /archsig/commands/

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -43,7 +43,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../">Home</a>
           <a class="is-active" href="./">AAT</a>
-          <a href="../#research">SFT</a>
+          <a href="../sft/">SFT</a>
           <a href="../#documents">Interface</a>
           <a href="../#research">ArchSig</a>
           <a href="../#outreach">Outreach</a>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -31,7 +31,7 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
-          <a href="../../#research">SFT</a>
+          <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../#research">ArchSig</a>
           <a href="../../#outreach">Outreach</a>

--- a/website/index.html
+++ b/website/index.html
@@ -41,10 +41,11 @@
           <span class="brand-text">Research Notes</span>
         </a>
         <nav class="site-nav" aria-label="Primary navigation">
-          <a href="#research">Research</a>
+          <a href="#top">Home</a>
           <a href="aat/">AAT</a>
-          <a href="#documents">Documents</a>
-          <a href="#samples">Notation</a>
+          <a href="sft/">SFT</a>
+          <a href="#documents">Interface</a>
+          <a href="#research">ArchSig</a>
           <a href="#outreach">Outreach</a>
           <a href="#profile">Profile</a>
         </nav>
@@ -111,8 +112,8 @@
                 models, operation support, policy, forecast cones, consequence
                 envelopes, and feedback updates.
               </p>
-              <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/README.md">
-                Read the SFT entry
+              <a href="sft/">
+                Read the SFT pages
               </a>
             </article>
             <article class="research-item">

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Software Field Theory reading path, computable core, claim boundary, and canonical SFT sources."
+    >
+    <title>Software Field Theory</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../assets/site.css">
+    <script defer src="../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../">Home</a>
+          <a href="../aat/">AAT</a>
+          <a class="is-active" href="./">SFT</a>
+          <a href="../#documents">Interface</a>
+          <a href="../#research">ArchSig</a>
+          <a href="../#outreach">Outreach</a>
+          <a href="../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../">Home</a>
+            <span>SFT</span>
+          </nav>
+          <p class="eyebrow">Software Field Theory</p>
+          <h1>A computational theory of field-shaped software evolution.</h1>
+          <p class="lede">
+            SFT treats software evolution as bounded computation over field
+            models, operation support, policy, forecast cones, consequence
+            envelopes, governance interventions, and feedback updates.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#reading-order">Reading order</a></li>
+                <li><a href="#computable-core">Computable core</a></li>
+                <li><a href="#claim-boundary">Claim boundary</a></li>
+                <li><a href="#canonical-sources">Canonical sources</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    SFT monograph
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/README.md">
+                    SFT repository entry
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                    AAT / SFT interface
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Field, force, attractor, and forecast are formal or diagnostic
+                modeling terms here. They are not physical quantities, Lean
+                theorem claims, or empirical prediction theorems by default.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="reading-order" class="article-section">
+              <h2>Reading order</h2>
+              <p>
+                The repository keeps the SFT monograph as the source of truth.
+                The website splits it by Part so readers can move through the
+                theory without losing the boundary between exposition,
+                formalizable schema, tooling estimates, and empirical work.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="part-i-new-object/">Part I. The New Object</a>
+                  <span>Software evolution as a computable object, codebase as field memory, development fields, and signature trajectories.</span>
+                </li>
+                <li>
+                  <a href="part-ii-basis/">Part II. Algebraic and Observational Basis</a>
+                  <span>AAT dependency, ArchSig observation, claim levels, and the one-way interface discipline.</span>
+                </li>
+                <li>
+                  <a href="part-iii-core/">Part III. SFT Core</a>
+                  <span>SoftwareField, artifact-mediated change, operation support, policy, ForecastCone, and FieldUpdate.</span>
+                </li>
+                <li>
+                  <a href="part-iv-principles/">Part IV. Principles and Theorems</a>
+                  <span>ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.</span>
+                </li>
+                <li>
+                  <a href="part-v-computing-systems/">Part V. Computing Systems Built from SFT</a>
+                  <span>Computational problems, simulator maturity, AI governance, review systems, lifecycle, and benchmarks.</span>
+                </li>
+                <li>
+                  <a href="part-vi-case-studies/">Part VI. Case Studies</a>
+                  <span>Coupon PRD, migration, incident response, AI-generated shortcut, and end-of-life decision.</span>
+                </li>
+                <li>
+                  <a href="part-vii-research-program/">Part VII. Non-Conclusions and Research Program</a>
+                  <span>Positioning, non-claims, open problems, and the SFT workbench direction.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="computable-core" class="article-section">
+              <h2>Computable core</h2>
+              <p>
+                SFT is not a claim that software history is fully determined.
+                Its computable core is the bounded slice obtained after a
+                modeling boundary, horizon, universe, observation axes,
+                support relation, and policy have been made explicit.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Computable SFT fragment</figcaption>
+                <pre><code>SoftwareField
+  + arch projection
+  + ArtifactMediatedChange
+  + OperationSupport
+  + OperationPolicy
+  + StepRelation
+  + ObservationRecord
+  + GovernanceIntervention
+  + ForecastCone
+  + FieldUpdate</code></pre>
+              </figure>
+              <p>
+                The broad development field remains larger than this fragment.
+                The point of the core is to make selected questions finite,
+                bounded, and auditable rather than to erase unmodeled human,
+                organizational, or operational context.
+              </p>
+            </section>
+
+            <section id="claim-boundary" class="article-section">
+              <h2>Claim boundary</h2>
+              <p>
+                SFT uses claim levels to separate conceptual interpretation,
+                trace-grounded diagnosis, set-valued theorem schema,
+                probabilistic transition models, calibrated empirical
+                forecasts, and deployed governance systems.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A `ForecastCone` is not a point prediction. A
+                  `ConsequenceEnvelope` is a boundary-aware report. ArchSig
+                  output is a measurement or estimate, not a Lean proof.
+                </p>
+              </div>
+            </section>
+
+            <section id="canonical-sources" class="article-section">
+              <h2>Canonical sources</h2>
+              <p>
+                SFT depends on AAT, but AAT does not depend on SFT. The
+                interface document keeps this direction explicit and prevents
+                AAT theorem status from being reinterpreted as empirical
+                software forecast status.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>SFT monograph</strong>
+                  <span>`docs/sft/software_field_theory.md` is the canonical long-form theory text.</span>
+                </li>
+                <li>
+                  <strong>AAT / SFT interface</strong>
+                  <span>`docs/sft/aat_interface.md` states the one-way dependency and forbidden readings.</span>
+                </li>
+                <li>
+                  <strong>Repository entry</strong>
+                  <span>`docs/sft/README.md` gives the short entry point and vocabulary list.</span>
+                </li>
+              </ul>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../aat/status/">
+                <span>Previous</span>
+                <strong>AAT Lean Status</strong>
+              </a>
+              <a href="part-i-new-object/">
+                <span>Next</span>
+                <strong>Part I. The New Object</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part I: software evolution as a computable object, codebase as field memory, development fields, and architecture futures."
+    >
+    <title>SFT Part I: The New Object</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part I</span>
+          </nav>
+          <p class="eyebrow">SFT Part I</p>
+          <h1>The New Object</h1>
+          <p class="lede">
+            Part I introduces software evolution itself as the object of SFT:
+            a bounded, field-shaped computation over codebase memory,
+            development context, reachable futures, and signature trajectories.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#computable-object">Computable object</a></li>
+                <li><a href="#field-memory">Field memory</a></li>
+                <li><a href="#development-field">Development field</a></li>
+                <li><a href="#architecture-futures">Architecture futures</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part I source
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                A reachable future is relative to an explicit model, horizon,
+                operation support, policy, and observation boundary. It is not
+                a prophecy about what the project will do.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="computable-object" class="article-section">
+              <h2>Software evolution as a computable object</h2>
+              <p>
+                SFT moves from observing past code states to asking which
+                architecture futures are reachable under a selected field
+                model. Computable means bounded by explicit modeling choices,
+                not completely decidable in reality.
+              </p>
+              <figure class="code-panel">
+                <figcaption>SFT central proposition</figcaption>
+                <pre><code>software evolution
+  = artifact-shaped operation space
+  + governance-shaped selection policy
+  + observable signature trajectory
+  + feedback-updated field memory</code></pre>
+              </figure>
+              <p>
+                The theory is organized into theory, measurement, computation,
+                and governance layers. AAT supplies local algebra, ArchSig
+                supplies observation, and SFT asks how future operation space
+                changes under artifacts and feedback.
+              </p>
+            </section>
+
+            <section id="field-memory" class="article-section">
+              <h2>Codebase as field memory</h2>
+              <p>
+                A codebase records more than implementation state. It also
+                carries requirements, design decisions, review patterns,
+                incidents, workarounds, migrations, ownership boundaries,
+                tooling practice, and latent default paths.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Static shape is not enough</strong>
+                  <span>The same module graph can support different future operations when field memory differs.</span>
+                </li>
+                <li>
+                  <strong>Local patterns matter</strong>
+                  <span>Old shortcuts and AI-readable local conventions can make unsafe paths look natural or low cost.</span>
+                </li>
+                <li>
+                  <strong>History constrains future work</strong>
+                  <span>Past incidents, review rules, and migrations change the support and policy visible to new proposals.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="development-field" class="article-section">
+              <h2>Development field</h2>
+              <p>
+                `DevelopmentField` names the broad field around a codebase:
+                requirements, planning artifacts, design practices, developers,
+                AI agents, review systems, CI, runtime observations, incidents,
+                and lifecycle pressure.
+              </p>
+              <p>
+                SFT does not claim to fully model human intention or
+                organization culture. It takes a modeling boundary and builds a
+                partial `SoftwareFieldEstimate` that records selected evidence,
+                unavailable evidence, and the unknown remainder.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  The wide development field is the scope. The computable core
+                  is the bounded slice where selected questions can be stated
+                  as finite or explicitly constrained problems.
+                </p>
+              </div>
+            </section>
+
+            <section id="architecture-futures" class="article-section">
+              <h2>Architecture futures and signature trajectories</h2>
+              <p>
+                SFT tracks trajectories, not only endpoints. A safe final state
+                does not imply a safe path, and a net signature delta of zero
+                can hide unsafe intermediate excursions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>ArchitectureFuture</figcaption>
+                <pre><code>ArchitectureFuture
+  = field path
+  + architecture projection path
+  + observed signature trajectory
+  + obstruction witness candidates
+  + forecast boundary</code></pre>
+              </figure>
+              <p>
+                The coupon PRD running example shows how one artifact can make
+                several paths visible: lawful policy insertion, payment adapter
+                shortcut, UI-only drift, and rounding semantics obstruction.
+              </p>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../">
+                <span>Previous</span>
+                <strong>SFT Landing</strong>
+              </a>
+              <a href="../part-ii-basis/">
+                <span>Next</span>
+                <strong>Part II. Basis</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part II: AAT dependency, ArchSig observation, and claim boundaries for Software Field Theory."
+    >
+    <title>SFT Part II: Algebraic and Observational Basis</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part II</span>
+          </nav>
+          <p class="eyebrow">SFT Part II</p>
+          <h1>Algebraic and Observational Basis</h1>
+          <p class="lede">
+            Part II fixes the dependency direction: AAT provides local
+            algebra, ArchSig provides observations and field estimates, and
+            SFT keeps claim levels explicit.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#aat-dependency">AAT dependency</a></li>
+                <li><a href="#archsig-bridge">ArchSig bridge</a></li>
+                <li><a href="#claim-levels">Claim levels</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part II source
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                    AAT / SFT interface
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                AAT theorem status is not converted into empirical prediction
+                status. SFT uses AAT results as local premises inside bounded
+                field models.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="aat-dependency" class="article-section">
+              <h2>AAT dependency</h2>
+              <p>
+                SFT sits on AAT, but AAT does not depend on SFT. AAT turns
+                software architecture into local algebra. SFT uses that algebra
+                as architecture projection, local transition law, observable
+                coordinate, and admissibility boundary.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Architecture projection</strong>
+                  <span>SFT reads `ArchitectureObject` as the architecture object projected from a `SoftwareField`.</span>
+                </li>
+                <li>
+                  <strong>Local transition premise</strong>
+                  <span>`ArchitectureOperation` becomes a local premise for accepted or proposed field transitions.</span>
+                </li>
+                <li>
+                  <strong>Forecast boundary</strong>
+                  <span>AAT theorem boundaries and non-conclusions become SFT forecast boundaries.</span>
+                </li>
+              </ul>
+              <figure class="code-panel">
+                <figcaption>Direction of dependency</figcaption>
+                <pre><code>AAT does not depend on SFT.
+SFT depends on AAT.</code></pre>
+              </figure>
+            </section>
+
+            <section id="archsig-bridge" class="article-section">
+              <h2>ArchSig bridge</h2>
+              <p>
+                ArchSig is the observation layer between real artifacts, AAT
+                observables, and SFT field estimates. It reports measured axes,
+                unmeasured axes, out-of-scope axes, evidence boundaries, and
+                measurement non-conclusions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Observation bridge</figcaption>
+                <pre><code>real artifacts
+  -> ArchSig
+  -> AAT observables
+  -> SFT field estimates</code></pre>
+              </figure>
+              <p>
+                Signature deltas are defined only where both sides are measured
+                and axis-wise comparison is available. Unmeasured does not mean
+                zero, and tool output is not a theorem.
+              </p>
+            </section>
+
+            <section id="claim-levels" class="article-section">
+              <h2>Claim levels</h2>
+              <p>
+                SFT claims must state their observation, model, and calibration
+                basis. The same sentence can have different status depending
+                on whether it is conceptual, trace-grounded, set-valued,
+                probabilistic, calibrated, or operationally deployed.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Level 0</strong>
+                  <span>Conceptual or diagnostic interpretation.</span>
+                </li>
+                <li>
+                  <strong>Level 1</strong>
+                  <span>Trace-grounded field diagnosis.</span>
+                </li>
+                <li>
+                  <strong>Level 2</strong>
+                  <span>Set-valued formal theorem schema.</span>
+                </li>
+                <li>
+                  <strong>Level 3 and above</strong>
+                  <span>Transition-kernel models, calibrated forecasts, or deployed closed-loop governance systems.</span>
+                </li>
+              </ul>
+              <div class="claim-strip">
+                <p>
+                  A good specification may narrow a cone under support
+                  inclusion and step simulation. Without calibration, that is
+                  not an empirical prediction theorem.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../part-i-new-object/">
+                <span>Previous</span>
+                <strong>Part I. The New Object</strong>
+              </a>
+              <a href="../part-iii-core/">
+                <span>Next</span>
+                <strong>Part III. SFT Core</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, ForecastCone, and FieldUpdate."
+    >
+    <title>SFT Part III: SFT Core</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part III</span>
+          </nav>
+          <p class="eyebrow">SFT Part III</p>
+          <h1>The SFT Core</h1>
+          <p class="lede">
+            Part III defines the theorem-bearing fragment: `SoftwareField`,
+            artifact-mediated change, operation support, policy, governance
+            interventions, `ForecastCone`, `ConsequenceEnvelope`, and
+            closed-loop field update.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#software-field">SoftwareField</a></li>
+                <li><a href="#artifact-action">Artifact action</a></li>
+                <li><a href="#support-policy">Support and policy</a></li>
+                <li><a href="#forecast-envelope">Forecast and envelope</a></li>
+                <li><a href="#feedback">Feedback update</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part III source
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                `ForecastCone` is a set of reachable field paths under a
+                selected support relation and horizon. `ConsequenceEnvelope` is
+                the report form for readers and tools.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="software-field" class="article-section">
+              <h2>SoftwareField and architecture projection</h2>
+              <p>
+                `SoftwareField` is a computable slice of a development field.
+                It is not itself an AAT `ArchitectureObject`; the AAT object is
+                obtained through architecture projection.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Field projection</figcaption>
+                <pre><code>arch : SoftwareField -> ArchitectureObject</code></pre>
+              </figure>
+              <ul class="term-list">
+                <li>
+                  <strong>Contextual state</strong>
+                  <span>History, constraints, observations, governance, and exogenous artifact inputs belong to the field.</span>
+                </li>
+                <li>
+                  <strong>Architecture projection</strong>
+                  <span>AAT reasoning applies to the projected architecture object, not to every field component at once.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="artifact-action" class="article-section">
+              <h2>Artifact-mediated change</h2>
+              <p>
+                The formal term is `ArtifactAction` or
+                `ArtifactMediatedChange`. Force remains an informal field-level
+                reading. PRDs, specs, issues, and AI proposals can produce
+                multiple candidate updates rather than a single next field.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Set-valued action</figcaption>
+                <pre><code>ArtifactAction a
+  := alpha_a : FieldSpace -> Set FieldSpaceUpdateHypothesis</code></pre>
+              </figure>
+              <p>
+                Forecasted effects are outputs of forecasting, not part of the
+                raw action definition. This prevents an artifact from already
+                containing the forecast that it is supposed to generate.
+              </p>
+            </section>
+
+            <section id="support-policy" class="article-section">
+              <h2>Operation support and policy</h2>
+              <p>
+                SFT asks which operations are lawful, but also which operations
+                appear natural, possible, low cost, or likely to be selected in
+                a field.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>OperationSupport</strong>
+                  <span>The admissible operation set after constraints and governance interventions.</span>
+                </li>
+                <li>
+                  <strong>OperationPolicy</strong>
+                  <span>A preorder, cost, selection relation, or explicitly probabilistic distribution on supported operations.</span>
+                </li>
+                <li>
+                  <strong>Attractor engineering</strong>
+                  <span>Support and policy shaping, not a hidden physical force or automatic stability theorem.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="forecast-envelope" class="article-section">
+              <h2>ForecastCone and ConsequenceEnvelope</h2>
+              <p>
+                `ForecastCone` is the formal set of reachable field paths from
+                a starting field, support relation, and horizon. For
+                set-valued artifact actions, SFT forms a family of cones and
+                summarizes them for practice as a `ConsequenceEnvelope`.
+              </p>
+              <figure class="code-panel">
+                <figcaption>ConsequenceEnvelope</figcaption>
+                <pre><code>ConsequenceEnvelope
+  = selected ForecastCones
+  + reachable path classes
+  + affected architecture regions
+  + comparable signature axes
+  + obstruction witness candidates
+  + missing invariants / boundaries
+  + forecast boundary
+  + unknown / unmodeled remainder</code></pre>
+              </figure>
+            </section>
+
+            <section id="feedback" class="article-section">
+              <h2>Observation, governance, and FieldUpdate</h2>
+              <p>
+                Review, CI, type checking, architecture rules, AI policy, and
+                runtime guards are governance interventions because they can
+                change support, policy, observation, and feedback update.
+              </p>
+              <p>
+                `FieldUpdate` records the difference between forecast and
+                observation: signature delta, unexpected witnesses, review or
+                CI outcome, runtime feedback, missing evidence, and
+                non-conclusions.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Field update preserves forecast error and boundary evidence.
+                  It does not automatically prove that future forecasts become
+                  more accurate.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../part-ii-basis/">
+                <span>Previous</span>
+                <strong>Part II. Basis</strong>
+              </a>
+              <a href="../part-iv-principles/">
+                <span>Next</span>
+                <strong>Part IV. Principles</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part IV: ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions."
+    >
+    <title>SFT Part IV: Principles and Theorems</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part IV</span>
+          </nav>
+          <p class="eyebrow">SFT Part IV</p>
+          <h1>Principles and Theorems</h1>
+          <p class="lede">
+            Part IV records the theorem-shaped claims SFT can make only under
+            explicit support semantics, step simulation, safe regions,
+            coverage policy, and observation boundaries.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#cone-narrowing">Cone narrowing</a></li>
+                <li><a href="#support-safety">Support safety</a></li>
+                <li><a href="#proposal-accounting">Proposal accounting</a></li>
+                <li><a href="#feedback-update">Feedback update</a></li>
+                <li><a href="#stable-regions">Stable regions</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part IV source
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Cone narrowing is relative to selected support, witness
+                families, and horizon. It does not imply global risk reduction
+                or safety for unmeasured axes.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="cone-narrowing" class="article-section">
+              <h2>ForecastCone narrowing</h2>
+              <p>
+                If a specification adds sound constraints, preserves the
+                intended feature direction, and excludes a selected witness
+                family, then the relevant cone narrows under the selected
+                support semantics.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Set-valued schema</figcaption>
+                <pre><code>PointwiseSupportInclusion(U2, U1)
+  + StepSimulation(U2, U1, relation)
+  + F2 relation F1
+  -> ForecastCone(F2, U2, h)
+     projects into ForecastCone(F1, U1, h)</code></pre>
+              </figure>
+              <p>
+                The proof idea is induction on horizon. Each accepted U2-step
+                is simulated by a U1-step while the relation between fields is
+                maintained.
+              </p>
+            </section>
+
+            <section id="support-safety" class="article-section">
+              <h2>Support safety</h2>
+              <p>
+                Safe regions live on state or signature observations, not on
+                operation names alone. Support safety says that selected
+                accepted operations preserve a selected safe region under a
+                selected observation model.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Relative guarantee</strong>
+                  <span>The claim applies to accepted trajectories and selected safe regions.</span>
+                </li>
+                <li>
+                  <strong>No global future safety</strong>
+                  <span>Unmodeled operations, missing axes, and different horizons remain outside the claim.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="proposal-accounting" class="article-section">
+              <h2>Proposal accounting and review mediation</h2>
+              <p>
+                Dissipation is not a formal conservation law. The formal
+                vocabulary is `ProposalAccounting` and `ReviewMediation`:
+                classifying proposal pressure as accepted, rejected, delayed,
+                unresolved, coordination record, runtime pressure estimate, or
+                unaccounted remainder.
+              </p>
+              <p>
+                Review, CI, type checking, and architecture rules produce
+                records that feed field update and governance design.
+              </p>
+            </section>
+
+            <section id="feedback-update" class="article-section">
+              <h2>Feedback boundary update</h2>
+              <p>
+                Observed transitions, signature deltas, obstruction witnesses,
+                review outcome, CI outcome, and runtime feedback can update
+                the posterior field by making forecast error and missing
+                evidence explicit.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  This is update soundness as record preservation. It is not a
+                  theorem that every update narrows the next forecast.
+                </p>
+              </div>
+            </section>
+
+            <section id="stable-regions" class="article-section">
+              <h2>Stable regions and recurrent paths</h2>
+              <p>
+                Attractor and basin language requires extra semantics. The
+                set-valued core separates may reachability, must reachability,
+                stable region, and reachable preimage before adding
+                probability or recurrence claims.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Minimal vocabulary</figcaption>
+                <pre><code>MayReach_h(F, U, A)
+MustReach_h(F, U, A)
+StableRegion(U, A)
+ReachablePreimage_h(U, A)</code></pre>
+              </figure>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../part-iii-core/">
+                <span>Previous</span>
+                <strong>Part III. SFT Core</strong>
+              </a>
+              <a href="../part-v-computing-systems/">
+                <span>Next</span>
+                <strong>Part V. Computing Systems</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part V: computational problems, PRD-to-ConsequenceEnvelope simulator, AI governance, review systems, lifecycle, and benchmarks."
+    >
+    <title>SFT Part V: Computing Systems Built from SFT</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part V</span>
+          </nav>
+          <p class="eyebrow">SFT Part V</p>
+          <h1>Computing Systems Built from SFT</h1>
+          <p class="lede">
+            Part V turns SFT into families of computing problems and tool
+            systems: field reconstruction, operation support inference,
+            ConsequenceEnvelope generation, AI proposal governance, lifecycle
+            decision, and calibration benchmarks.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#computational-problems">Computational problems</a></li>
+                <li><a href="#simulator">PRD simulator</a></li>
+                <li><a href="#ai-governance">AI governance</a></li>
+                <li><a href="#review-systems">Review systems</a></li>
+                <li><a href="#lifecycle">Lifecycle and benchmarks</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part V source
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                SFT tools return bounded reports and estimates. They do not
+                become ground truth, Lean proofs, or general AI safety
+                guarantees.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="computational-problems" class="article-section">
+              <h2>SFT computational problems</h2>
+              <p>
+                SFT defines problem families instead of remaining a metaphor.
+                Each problem should name inputs, outputs, soundness boundary,
+                and claim level.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="#computational-problems">Field reconstruction</a>
+                  <span>Build a bounded `SoftwareFieldEstimate` from artifacts, codebase, review, CI, and incident traces.</span>
+                </li>
+                <li>
+                  <a href="#computational-problems">Operation support inference</a>
+                  <span>Estimate which operation families are natural, possible, risky, or low cost in the current field.</span>
+                </li>
+                <li>
+                  <a href="#simulator">ConsequenceEnvelope generation</a>
+                  <span>Translate PRDs, specs, issues, or AI proposals into reachable path classes and boundary reports.</span>
+                </li>
+                <li>
+                  <a href="#ai-governance">AI proposal governance</a>
+                  <span>Keep generated proposal support inside a bounded field model and record shortcut witnesses.</span>
+                </li>
+                <li>
+                  <a href="#lifecycle">Lifecycle decision</a>
+                  <span>Diagnose repair, migration, contraction, or end-of-life choices from signatures, costs, risk, and capacity.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="simulator" class="article-section">
+              <h2>PRD-to-ConsequenceEnvelope simulator</h2>
+              <p>
+                The simulator is a way of making SFT computational. It is not a
+                PRD-to-PR predictor; it generates bounded consequence envelopes
+                rather than a single future.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Simulator path</figcaption>
+                <pre><code>PRD / Spec / Issue / AI Proposal
+  -> ArtifactDescriptor
+  -> OperationSupport
+  -> ForecastCone / ConsequenceEnvelope
+  -> Signature Axis and Witness Candidate report
+  -> Review / CI / Issue Decomposition recommendation
+  -> Calibration by observed outcome</code></pre>
+              </figure>
+              <p>
+                Practical value starts when the tool reports affected axes,
+                witness candidates, missing boundaries, and review or issue
+                decomposition recommendations. Empirical prediction claims
+                depend on later weighting and calibration.
+              </p>
+            </section>
+
+            <section id="ai-governance" class="article-section">
+              <h2>AI-agent governance</h2>
+              <p>
+                SFT reads an AI coding agent as a field participant: artifact
+                interpreter, proposal generator, local pattern amplifier,
+                shortcut generator, review load shifter, and hidden assumption
+                reproducer.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  SFT does not prove general AI safety. It bounds proposal
+                  support with prompt, policy, theorem boundary, review, CI,
+                  shortcut witness reports, and posterior field update.
+                </p>
+              </div>
+            </section>
+
+            <section id="review-systems" class="article-section">
+              <h2>Review, CI, and type systems</h2>
+              <p>
+                Review, CI, type systems, architecture rules, ownership
+                boundaries, and runtime guards are governance interventions.
+                They shape future operation support and selection policy, not
+                just pass or fail a change.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Restrictive</strong>
+                  <span>Remove unsafe support from the accepted operation set.</span>
+                </li>
+                <li>
+                  <strong>Redirective</strong>
+                  <span>Raise shortcut cost and lower lawful path cost.</span>
+                </li>
+                <li>
+                  <strong>Instrumenting</strong>
+                  <span>Add observation axes, tests, runtime checks, or evidence records.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lifecycle" class="article-section">
+              <h2>Lifecycle and benchmarks</h2>
+              <p>
+                SFT includes birth, growth, stabilization, drift, repair,
+                migration, contraction, and end-of-life. End-of-life can be a
+                field reconfiguration decision rather than failure.
+              </p>
+              <p>
+                Benchmarking is required before calibrated empirical status:
+                PRD-to-issue, issue-to-PR signature, review mediation,
+                incident feedback, AI shortcut, and lifecycle decision
+                benchmarks give the workbench something falsifiable to test.
+              </p>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../part-iv-principles/">
+                <span>Previous</span>
+                <strong>Part IV. Principles</strong>
+              </a>
+              <a href="../part-vi-case-studies/">
+                <span>Next</span>
+                <strong>Part VI. Case Studies</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part VI: Coupon PRD, migration, incident response, AI-generated shortcut, and end-of-life decision case studies."
+    >
+    <title>SFT Part VI: Case Studies</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part VI</span>
+          </nav>
+          <p class="eyebrow">SFT Part VI</p>
+          <h1>Case Studies</h1>
+          <p class="lede">
+            Part VI uses concrete cases to show how SFT reads artifacts,
+            migrations, incidents, AI-generated shortcuts, and end-of-life
+            decisions as changes to operation support, policy, observations,
+            and field memory.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#coupon-prd">Coupon PRD</a></li>
+                <li><a href="#migration">Migration</a></li>
+                <li><a href="#incident-response">Incident response</a></li>
+                <li><a href="#ai-shortcut">AI shortcut</a></li>
+                <li><a href="#end-of-life">End-of-life</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part VI source
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Case studies illustrate bounded diagnosis. They do not claim
+                market prediction, exhaustive causality, or complete extraction
+                from real repositories.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="coupon-prd" class="article-section">
+              <h2>Coupon PRD</h2>
+              <p>
+                The coupon PRD is the running example. It targets checkout and
+                payment as a feature addition artifact action, but an
+                underspecified PRD can expose several operation families.
+              </p>
+              <figure class="code-panel">
+                <figcaption>ConsequenceEnvelope path classes</figcaption>
+                <pre><code>lawful policy insertion path
+  + hidden PaymentAdapter dependency path
+  + rounding semantic obstruction path
+  + UI-only discount drift path
+  + unknown / unmodeled remainder</code></pre>
+              </figure>
+              <p>
+                When the specification states rounding order, discount
+                composition, payment authorization boundaries, and refund
+                semantics, support and policy can be shaped toward the lawful
+                path.
+              </p>
+            </section>
+
+            <section id="migration" class="article-section">
+              <h2>Migration</h2>
+              <p>
+                Migration is a field transformation with old-new projection
+                mismatch and partial migration risk. SFT reads migration as
+                reconfiguration of field memory and operation support, not just
+                replacement work.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Bridge path</strong>
+                  <span>A temporary relation between old and new projections.</span>
+                </li>
+                <li>
+                  <strong>Dual-run path</strong>
+                  <span>A field state where two implementations coexist under a comparison boundary.</span>
+                </li>
+                <li>
+                  <strong>Rollback path</strong>
+                  <span>A supported path back from selected migration states.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="incident-response" class="article-section">
+              <h2>Incident response</h2>
+              <p>
+                Incident response forces a field update through runtime
+                observation. The incident can classify root-cause witnesses,
+                reveal missing invariants, update review or CI governance, and
+                revise the forecast boundary.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A local post-incident fix does not prove future trajectory
+                  safety. SFT keeps the missing invariant and observation
+                  boundary visible.
+                </p>
+              </div>
+            </section>
+
+            <section id="ai-shortcut" class="article-section">
+              <h2>AI-generated shortcut</h2>
+              <p>
+                AI-generated proposals can amplify local patterns and make
+                shortcut paths look cheap. SFT evaluates them against both AAT
+                theorem boundaries and SFT consequence envelopes.
+              </p>
+              <figure class="code-panel">
+                <figcaption>AIShortcutCase</figcaption>
+                <pre><code>prompt boundary
+  + generated operation support
+  + selected shortcut path
+  + missed theorem boundary
+  + review / CI mediation
+  + observed obstruction witness
+  + posterior field update</code></pre>
+              </figure>
+            </section>
+
+            <section id="end-of-life" class="article-section">
+              <h2>End-of-life decision</h2>
+              <p>
+                End-of-life is a lifecycle governance choice. SFT compares
+                architecture signature, repair cost, migration support,
+                runtime risk, ownership boundary, staffing boundary, and the
+                consequence envelope.
+              </p>
+              <p>
+                It does not predict human intention or market success. It
+                describes how repair, migration, contraction, or deletion
+                changes architecture futures and field capacity.
+              </p>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../part-v-computing-systems/">
+                <span>Previous</span>
+                <strong>Part V. Computing Systems</strong>
+              </a>
+              <a href="../part-vii-research-program/">
+                <span>Next</span>
+                <strong>Part VII. Research Program</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT Part VII: non-conclusions, positioning, open problems, and the SFT workbench research program."
+    >
+    <title>SFT Part VII: Non-Conclusions and Research Program</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a href="../../#research">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Part VII</span>
+          </nav>
+          <p class="eyebrow">SFT Part VII</p>
+          <h1>Non-Conclusions and Research Program</h1>
+          <p class="lede">
+            Part VII states what SFT is not, what it does not claim, which
+            formal and empirical problems remain open, and how the workbench
+            direction ties the theory back to tooling.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#positioning">Positioning</a></li>
+                <li><a href="#non-claims">Non-claims</a></li>
+                <li><a href="#open-problems">Open problems</a></li>
+                <li><a href="#workbench">Workbench direction</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical source</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    Part VII source
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                SFT has a large scope, so its public reading surface must keep
+                non-conclusions visible. Scope is not the same as proof or
+                empirical validation.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="positioning" class="article-section">
+              <h2>Positioning</h2>
+              <p>
+                SFT is not a static architecture metric, software process
+                model, DevOps maturity model, technical debt taxonomy, AI
+                coding benchmark, or replacement for formal verification.
+              </p>
+              <p>
+                Its difference is that software evolution itself becomes the
+                computational object: artifacts and feedback reshape support,
+                governance changes selection policy, observation determines
+                signature trajectories, and consequence envelopes describe
+                reachable architecture futures.
+              </p>
+            </section>
+
+            <section id="non-claims" class="article-section">
+              <h2>What SFT does not claim</h2>
+              <ul class="status-list">
+                <li>
+                  <strong>No mechanical future determinism</strong>
+                  <span>SFT does not claim that future software behavior is mechanically determined.</span>
+                </li>
+                <li>
+                  <strong>No automatic empirical forecast</strong>
+                  <span>A `ForecastCone` does not become an empirical prediction without calibration.</span>
+                </li>
+                <li>
+                  <strong>No trajectory safety from AAT alone</strong>
+                  <span>AAT theorem status does not imply future field trajectory safety.</span>
+                </li>
+                <li>
+                  <strong>No safety from unmeasured axes</strong>
+                  <span>Observed zero and unmeasured are different statuses.</span>
+                </li>
+                <li>
+                  <strong>No ground truth extractor claim</strong>
+                  <span>ArchSig extraction is not a complete `ComponentUniverse` or ground truth architecture object.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="open-problems" class="article-section">
+              <h2>Open problems</h2>
+              <p>
+                The research program includes Lean formalization of
+                `ForecastCone` and support simulation, the relation between
+                `ConsequenceEnvelope` and cones, trace-grounded field
+                reconstruction, simulator calibration, review mediation and AI
+                shortcut benchmarks, theorem-boundary integration, field
+                memory studies, lifecycle models, and deployed closed-loop
+                workbench design.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Research direction</figcaption>
+                <pre><code>formal core
+  + observable field estimates
+  + calibrated simulator benchmarks
+  + review / CI governance integration
+  + lifecycle and AI proposal governance
+  -> deployed SFT workbench</code></pre>
+              </figure>
+            </section>
+
+            <section id="workbench" class="article-section">
+              <h2>Workbench direction</h2>
+              <p>
+                The SFT workbench should take PRDs, design memos, issue plans,
+                codebase state, architecture signatures, review and CI history,
+                incident history, and AI policy. It should return a
+                consequence envelope, affected axes, witness families, missing
+                boundaries, risky default paths, issue decomposition, review or
+                CI interventions, AI proposal constraints, and calibration
+                plans.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  SFT does not replace developers. It makes software evolution
+                  visible as something that can be observed, bounded, computed,
+                  governed, and revised.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../part-vi-case-studies/">
+                <span>Previous</span>
+                <strong>Part VI. Case Studies</strong>
+              </a>
+              <a href="../../#research">
+                <span>Next</span>
+                <strong>ArchSig Overview</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## 概要

Closes #764

SFT の公開 reading surface として、`/sft/` landing と Part I から Part VII までの directory route を追加しました。各ページに local table of contents、canonical source link、previous / next navigation、claim boundary note を置き、`field`、`force`、`attractor`、`ForecastCone` を物理量・Lean theorem・経験的予測定理として誤読しない構成にしています。

既存ホームと AAT ページの SFT 導線を、GitHub docs / anchor ではなく新設した `/sft/` route へ更新しました。`website/SITEMAP.md` と `website/README.md` も実装状態に合わせて更新しています。

Lean status: public website / tooling documentation task. Lean theorem claim なし。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/index.html`
- `website/sft/part-i-new-object/index.html`
- `website/sft/part-ii-basis/index.html`
- `website/sft/part-iii-core/index.html`
- `website/sft/part-iv-principles/index.html`
- `website/sft/part-v-computing-systems/index.html`
- `website/sft/part-vi-case-studies/index.html`
- `website/sft/part-vii-research-program/index.html`
- `website/index.html`
- `website/aat/*/index.html`
- `website/SITEMAP.md`
- `website/README.md`

## 実施したテスト

- [x] `lake build` 成功（既存 linter warning 2 件のみ）
- [x] `git diff --check` / `git diff --cached --check` 成功
- [x] hidden / bidirectional Unicode scan: match なし
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan: 新規混入なし（既存 Lean コメント / 識別子の `unsafe` 文字列のみ）
- [x] local href check: 19 HTML files, all local href targets exist
- [x] browser preview: `/sft/` と `/sft/part-vii-research-program/` の主要 heading / nav / boundary note を確認、console error なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている