### PR TITLE
ArchSig manual / reference pages を website に追加

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -63,8 +63,9 @@ underscore-prefixed paths or future generated assets as Jekyll input.
 
 AAT chapter-cluster pages are implemented as static directory routes under
 `aat/`. SFT Part pages are implemented as static directory routes under
-`sft/`. Remaining major sections still point readers back to canonical
-repository documents until their public routes are added.
+`sft/`. ArchSig manual and reference pages are implemented as static directory
+routes under `archsig/`. Remaining major sections still point readers back to
+canonical repository documents until their public routes are added.
 
 ## Local Preview
 

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -488,10 +488,6 @@ implemented:
   /sft/part-v-computing-systems/
   /sft/part-vi-case-studies/
   /sft/part-vii-research-program/
-
-planned:
-  /profile/
-  /interface/
   /archsig/
   /archsig/getting-started/
   /archsig/commands/
@@ -502,6 +498,10 @@ planned:
   /archsig/operational-feedback/
   /archsig/examples/
   /archsig/roadmap/
+
+planned:
+  /profile/
+  /interface/
   /outreach/
 ```
 

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -45,7 +45,7 @@
           <a class="is-active" href="./">AAT</a>
           <a href="../sft/">SFT</a>
           <a href="../#documents">Interface</a>
-          <a href="../#research">ArchSig</a>
+          <a href="../archsig/">ArchSig</a>
           <a href="../#outreach">Outreach</a>
           <a href="../#profile">Profile</a>
         </nav>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -33,7 +33,7 @@
           <a class="is-active" href="../">AAT</a>
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/archsig/artifacts/index.html
+++ b/website/archsig/artifacts/index.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig artifact reference for Sig0, validation, reports, policy, datasets, operational feedback, and SFT forecasting artifacts."
+    >
+    <title>ArchSig Artifact Reference</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Artifacts</span>
+          </nav>
+          <p class="eyebrow">ArchSig Reference</p>
+          <h1>Artifacts carry evidence, status, and non-conclusions together.</h1>
+          <p class="lede">
+            ArchSig artifacts are JSON records for a bounded observation universe. Their role is to preserve source refs, measurement status, coverage gaps, theorem boundaries, and report projections across commands.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#primary">Primary artifacts</a></li>
+                <li><a href="#policy-registry">Policy and registry</a></li>
+                <li><a href="#datasets">Datasets and feedback</a></li>
+                <li><a href="#forecasting">SFT forecasting</a></li>
+                <li><a href="#diagnostics">Diagnostic reading</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/docs/artifacts-and-boundaries.md">
+                    Artifacts And Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/signature_artifacts.md">
+                    Signature artifacts
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/reports.md">
+                    Reports
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/air.md">
+                    AIR
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="primary" class="article-section">
+              <h2>Primary artifacts</h2>
+              <p>
+                The main review flow starts with Sig0 and ends with a PR
+                comment summary. Each step keeps claim level and measurement
+                status visible.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Sig0 output</strong>
+                  <span><code>archsig-sig0-v0</code>: component list, dependency edges, signature axes, and metric status for one revision.</span>
+                </li>
+                <li>
+                  <strong>Validation report</strong>
+                  <span><code>component-universe-validation-report-v0</code>: duplicate, closure, external target, and policy status checks.</span>
+                </li>
+                <li>
+                  <strong>Snapshot and diff</strong>
+                  <span><code>signature-snapshot-store-v0</code> and <code>signature-diff-report-v0</code>: revision persistence and before / after changes.</span>
+                </li>
+                <li>
+                  <strong>AIR and review reports</strong>
+                  <span><code>aat-air-v0</code>, theorem precondition check, Feature Extension Report, policy decision, and PR comment summary.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="policy-registry" class="article-section">
+              <h2>Policy and registry</h2>
+              <p>
+                Policy, registry, and schema artifacts let teams add local
+                thresholds and adapters without claiming that a policy pass is
+                architecture lawfulness.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Organization policy</strong>
+                  <span>Warn / fail / advisory rules plus formal claim promotion boundaries.</span>
+                </li>
+                <li>
+                  <strong>Law policy templates and custom rules</strong>
+                  <span>Reusable policy shape with theorem refs, boundary refs, and non-conclusions.</span>
+                </li>
+                <li>
+                  <strong>Schema compatibility report</strong>
+                  <span>Field mappings, deprecated fields, required assumptions, and preserved non-conclusions.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="datasets" class="article-section">
+              <h2>Datasets and feedback</h2>
+              <p>
+                Dataset artifacts are empirical records. They connect PR
+                metadata, reports, and outcome observations without turning
+                correlation into causality.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Empirical datasets</strong>
+                  <span>PR metadata, before / after signatures, feature reports, theorem checks, and outcome linkage.</span>
+                </li>
+                <li>
+                  <strong>Operational feedback</strong>
+                  <span>Daily ledger, calibration review, team threshold, ownership boundary, repair adoption, incident correlation, and hypothesis refresh artifacts.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="forecasting" class="article-section">
+              <h2>SFT forecasting</h2>
+              <p>
+                Forecasting artifacts bound the input, operation support,
+                finite support, horizon, unknown remainder, and review
+                recommendations for a proposed change.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>ArtifactDescriptor</strong>
+                  <span>Source refs, action class candidates, scope, missing evidence, measurement boundary, and forecast non-conclusions.</span>
+                </li>
+                <li>
+                  <strong>OperationSupportEstimate</strong>
+                  <span>Candidate operation families, policy constraints, known forbidden support, unknown remainder, and confidence boundary.</span>
+                </li>
+                <li>
+                  <strong>ForecastConeSkeleton and ConsequenceEnvelope</strong>
+                  <span>Bounded path candidates, affected regions, comparable axes, obstruction candidates, missing boundary, and review / CI recommendations.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="diagnostics" class="article-section">
+              <h2>Diagnostic reading</h2>
+              <p>
+                Single-revision diagnostics cover static cycles, SCC size,
+                max depth, fanout, reachable cone, boundary violations,
+                abstraction violations, runtime exposure, and relation
+                complexity. Diff diagnostics cover worsened axes, improved
+                axes, unmeasured axes, evidence diff, and PR attribution
+                candidates.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Diff attribution is a review cue. It is not causal proof
+                  that a PR caused an incident, rollback, or MTTR change.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../commands/">
+                <span>Previous</span>
+                <strong>Commands</strong>
+              </a>
+              <a href="../boundaries/">
+                <span>Next</span>
+                <strong>Boundaries</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/boundaries/index.html
+++ b/website/archsig/boundaries/index.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig measurement boundary, claim boundary, theorem promotion guardrails, and non-conclusions."
+    >
+    <title>ArchSig Boundaries</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Boundaries</span>
+          </nav>
+          <p class="eyebrow">ArchSig Reference</p>
+          <h1>Read every report through its boundary fields.</h1>
+          <p class="lede">
+            ArchSig is useful only when measurement, claim level, theorem promotion, and empirical non-conclusions stay explicit. This page records the guardrails for interpreting tool output.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#measurement">Measurement boundary</a></li>
+                <li><a href="#claim">Claim boundary</a></li>
+                <li><a href="#promotion">Formal promotion</a></li>
+                <li><a href="#non-conclusions">Non-conclusions</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/docs/artifacts-and-boundaries.md">
+                    Artifacts And Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/claim_boundary.md">
+                    Claim boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/theorem_preconditions.md">
+                    Theorem preconditions
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="measurement" class="article-section">
+              <h2>Measurement boundary</h2>
+              <p>
+                Measurement status is part of the artifact. A value and an
+                axis must be read together with the status that says whether
+                the value was measured, unmeasured, or out of scope.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>measuredZero</strong>
+                  <span>The axis was measured and the value is zero.</span>
+                </li>
+                <li>
+                  <strong>measuredNonzero</strong>
+                  <span>The axis was measured and the value is nonzero.</span>
+                </li>
+                <li>
+                  <strong>unmeasured</strong>
+                  <span>The axis was not measured. Placeholder zero must not be read as risk zero.</span>
+                </li>
+                <li>
+                  <strong>outOfScope</strong>
+                  <span>The artifact or universe does not cover that axis.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="claim" class="article-section">
+              <h2>Claim boundary</h2>
+              <p>
+                AIR and reports separate formal claims, measured witnesses,
+                blocked formal claims, empirical observations, and review
+                recommendations. These categories are intentionally not
+                interchangeable.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Claim categories</figcaption>
+                <pre><code>FORMAL_PROVED
+MEASURED_WITNESS
+BLOCKED_FORMAL_CLAIM
+empirical observation
+advisory review recommendation</code></pre>
+              </figure>
+            </section>
+
+            <section id="promotion" class="article-section">
+              <h2>Formal promotion</h2>
+              <p>
+                <code>theorem-check</code> can report whether a claim has the
+                registered theorem refs and bridge preconditions needed for a
+                formal/proved reading. Missing preconditions block promotion;
+                they are not defects in the measurement itself.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Required theorem refs</strong>
+                  <span>The report must point to the intended formal result rather than invent a theorem claim.</span>
+                </li>
+                <li>
+                  <strong>Bridge preconditions</strong>
+                  <span>The tooling universe must satisfy the assumptions needed to connect evidence to Lean-side definitions.</span>
+                </li>
+                <li>
+                  <strong>Coverage and exactness</strong>
+                  <span>Unsupported constructs, missing evidence, and unmeasured axes remain visible.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="non-conclusions" class="article-section">
+              <h2>Non-conclusions</h2>
+              <p>
+                ArchSig output does not claim arbitrary repository
+                completeness, extractor completeness, policy-lawfulness
+                equivalence, semantic preservation, causality, or a scalar
+                ranking of architecture quality.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Non-conclusions are part of the artifact contract. Dropping
+                  them during schema migration or report rendering changes the
+                  meaning of the artifact.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../artifacts/">
+                <span>Previous</span>
+                <strong>Artifacts</strong>
+              </a>
+              <a href="../workflows/">
+                <span>Next</span>
+                <strong>Workflows</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/commands/index.html
+++ b/website/archsig/commands/index.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig command reference for scan, validation, reports, policy, schema, datasets, operational feedback, and SFT forecasting."
+    >
+    <title>ArchSig Command Reference</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Commands</span>
+          </nav>
+          <p class="eyebrow">ArchSig Reference</p>
+          <h1>Commands are organized by artifact boundary.</h1>
+          <p class="lede">
+            ArchSig commands form a pipeline from scan output to validation, report generation, governance summaries, empirical datasets, operational feedback artifacts, repair artifacts, and bounded SFT forecasting estimates.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#scan-validate">Scan and validate</a></li>
+                <li><a href="#review-reports">Review reports</a></li>
+                <li><a href="#policy-schema">Policy and schema</a></li>
+                <li><a href="#dataset-feedback">Dataset and feedback</a></li>
+                <li><a href="#forecast-repair">Forecast and repair</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/docs/commands.md">
+                    Command Guide
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/README.md">
+                    ArchSig README
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="scan-validate" class="article-section">
+              <h2>Scan and validate</h2>
+              <p>
+                <code>scan</code> is the default command. It emits Sig0 for a
+                Lean or Python repository. <code>validate</code> checks an
+                existing Sig0 artifact without rescanning source files.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>scan</strong>
+                  <span>Uses <code>--root</code>, optional <code>--policy</code>, optional <code>--runtime-edges</code>, and optional <code>--language python</code>.</span>
+                </li>
+                <li>
+                  <strong>validate</strong>
+                  <span>Checks duplicate-free components, local edge closure, external targets, and policy metric status.</span>
+                </li>
+                <li>
+                  <strong>snapshot and signature-diff</strong>
+                  <span>Persist revision signatures and compare before / after snapshots with metric delta status.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="review-reports" class="article-section">
+              <h2>Review reports</h2>
+              <p>
+                The PR review chain normalizes evidence into AIR, checks
+                theorem promotion preconditions, summarizes extension quality,
+                applies organization policy, and renders a PR comment.
+              </p>
+              <figure class="code-panel">
+                <figcaption>PR review chain</figcaption>
+                <pre><code>air
+  -&gt; validate-air
+  -&gt; theorem-check
+  -&gt; feature-report
+  -&gt; policy-decision
+  -&gt; pr-comment</code></pre>
+              </figure>
+            </section>
+
+            <section id="policy-schema" class="article-section">
+              <h2>Policy and schema</h2>
+              <p>
+                Policy commands validate organization policy, law policy
+                templates, custom rule plugins, measurement units, retention
+                manifests, reported axes catalogs, and schema compatibility
+                reports. These commands preserve non-conclusions and coverage
+                boundaries during artifact evolution.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>organization-policy</strong>
+                  <span>Validates warn / fail / advisory policy and formal claim promotion boundaries.</span>
+                </li>
+                <li>
+                  <strong>schema-compatibility</strong>
+                  <span>Reports compatible, requiresMigration, notComparable, or blockedFormalClaimPromotion outcomes.</span>
+                </li>
+                <li>
+                  <strong>reported-axes-catalog</strong>
+                  <span>Emits the detectable values and reported axes catalog for reader compatibility.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="dataset-feedback" class="article-section">
+              <h2>Dataset and feedback</h2>
+              <p>
+                Dataset commands join PR metadata, signature artifacts,
+                Feature Extension Reports, theorem checks, and outcome
+                observations. Operational feedback commands produce bounded
+                B10 artifacts for calibration and review.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>dataset, pr-history-dataset, feature-extension-dataset, outcome-linkage-dataset</strong>
+                  <span>Build empirical records from repository, PR, report, and outcome inputs.</span>
+                </li>
+                <li>
+                  <strong>report-outcome-daily-ledger</strong>
+                  <span>Joins outcome linkage and architecture drift ledger inside an aggregation window.</span>
+                </li>
+                <li>
+                  <strong>calibration-review-record, team-threshold-policy, ownership-boundary-monitor</strong>
+                  <span>Emit operational feedback fixtures and validation outputs.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="forecast-repair" class="article-section">
+              <h2>Forecast and repair</h2>
+              <p>
+                SFT forecasting commands connect real PRD / Spec / Issue / AI
+                proposal text to a bounded <code>ConsequenceEnvelope</code>.
+                Repair commands validate repair registries, synthesis
+                constraints, and no-solution certificates.
+              </p>
+              <figure class="code-panel">
+                <figcaption>SFT forecast chain</figcaption>
+                <pre><code>artifact-descriptor
+  -&gt; operation-support-estimate
+  -&gt; forecast-cone-skeleton
+  -&gt; consequence-envelope
+  -&gt; forecast-calibration-hook
+  -&gt; sft-forecast</code></pre>
+              </figure>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../getting-started/">
+                <span>Previous</span>
+                <strong>Getting Started</strong>
+              </a>
+              <a href="../artifacts/">
+                <span>Next</span>
+                <strong>Artifacts</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/examples/index.html
+++ b/website/archsig/examples/index.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig examples for good extension, hidden interaction witness, semantic witness, Feature Extension Report reading, and dynamics reading."
+    >
+    <title>ArchSig Examples</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Examples</span>
+          </nav>
+          <p class="eyebrow">ArchSig Reference</p>
+          <h1>Examples show how to read reports without overclaiming.</h1>
+          <p class="lede">
+            The example set uses a coupon feature extension to show split extension, hidden interaction witness, semantic witness, Feature Extension Report reading, and architecture dynamics interpretation.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#good-extension">Good extension</a></li>
+                <li><a href="#hidden-interaction">Hidden interaction</a></li>
+                <li><a href="#semantic-witness">Semantic witness</a></li>
+                <li><a href="#report-reading">Report reading</a></li>
+                <li><a href="#dynamics">Dynamics reading</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/examples.md">
+                    Tooling examples
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/repair_suggestion.md">
+                    Repair suggestion
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="good-extension" class="article-section">
+              <h2>Good extension</h2>
+              <p>
+                A split coupon extension interacts through declared interfaces
+                rather than reaching into adapter internals. AIR can separate
+                embedding, feature view, interaction, static split, and
+                coverage claims.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Good extension shape</figcaption>
+                <pre><code>before:
+  OrderService -&gt; PaymentPort
+  PaymentAdapter implements PaymentPort
+
+feature:
+  Coupon calculation
+
+after:
+  OrderService -&gt; CouponPort
+  CouponService -&gt; CouponPort
+  CouponService -&gt; PaymentPort</code></pre>
+              </figure>
+            </section>
+
+            <section id="hidden-interaction" class="article-section">
+              <h2>Hidden interaction</h2>
+              <p>
+                A hidden interaction witness appears when the coupon feature
+                reaches through a boundary, such as direct access to an
+                internal payment cache. This is a static split failure
+                candidate, not runtime or semantic completeness.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Witness fragment</figcaption>
+                <pre><code>witnessId: coupon-hidden-payment-cache
+layer: static
+kind: hidden_interaction
+extensionClassification: non_split
+measurementBoundary: measuredNonzero</code></pre>
+              </figure>
+            </section>
+
+            <section id="semantic-witness" class="article-section">
+              <h2>Semantic witness</h2>
+              <p>
+                If rounding order changes the observable result, a selected
+                semantic diagram can become non-fillable. The witness is tied
+                to the selected diagram and measurement boundary.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Semantic non-fillability</figcaption>
+                <pre><code>apply coupon then round
+  is not equal to
+round then apply coupon</code></pre>
+              </figure>
+            </section>
+
+            <section id="report-reading" class="article-section">
+              <h2>Report reading</h2>
+              <p>
+                A Feature Extension Report can summarize split status,
+                introduced obstruction witnesses, repair suggestions, and
+                non-conclusions. The non-conclusions are part of the report,
+                not boilerplate.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>splitStatus</strong>
+                  <span>Whether the feature extension is split under the selected observation boundary.</span>
+                </li>
+                <li>
+                  <strong>introducedObstructionWitnesses</strong>
+                  <span>Measured witness candidates that explain why the extension may fail a law.</span>
+                </li>
+                <li>
+                  <strong>repairSuggestions</strong>
+                  <span>Advisory candidates such as introducing a port or moving access behind a contract.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="dynamics" class="article-section">
+              <h2>Dynamics reading</h2>
+              <p>
+                A good coupon example can act as a seed attractor, while a bad
+                shortcut can become a shortcut basin. This is an empirical /
+                tooling reading of future change pressure, not a causal
+                theorem.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Dynamics examples guide review and hypothesis formation.
+                  They do not prove global flatness preservation or future
+                  defect causality.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../operational-feedback/">
+                <span>Previous</span>
+                <strong>Operational Feedback</strong>
+              </a>
+              <a href="../roadmap/">
+                <span>Next</span>
+                <strong>Roadmap</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/getting-started/index.html
+++ b/website/archsig/getting-started/index.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Minimal ArchSig command path for fixture scan, validation, repository scan, and Python scan."
+    >
+    <title>ArchSig Getting Started</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Getting Started</span>
+          </nav>
+          <p class="eyebrow">ArchSig Manual</p>
+          <h1>Run the smallest useful ArchSig path first.</h1>
+          <p class="lede">
+            The first useful ArchSig session scans a fixture, validates the Sig0 output, scans the repository, and checks whether unmeasured axes are being preserved instead of silently treated as zero.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#fixture-scan">Fixture scan</a></li>
+                <li><a href="#validate">Validate Sig0</a></li>
+                <li><a href="#repository-scan">Repository scan</a></li>
+                <li><a href="#python-scan">Python scan</a></li>
+                <li><a href="#first-reading">First reading</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/README.md">
+                    ArchSig README
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="fixture-scan" class="article-section">
+              <h2>Fixture scan</h2>
+              <p>
+                Begin with the minimal fixture so the output shape is known
+                before running against an active repository.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Fixture scan</figcaption>
+                <pre><code>cargo run --manifest-path tools/archsig/Cargo.toml -- \
+  --root tools/archsig/tests/fixtures/minimal \
+  --policy tools/archsig/tests/fixtures/minimal/policy_measured_zero.json \
+  --runtime-edges tools/archsig/tests/fixtures/minimal/runtime_edges.json \
+  --out .lake/sig0-fixture.json</code></pre>
+              </figure>
+            </section>
+
+            <section id="validate" class="article-section">
+              <h2>Validate Sig0</h2>
+              <p>
+                Validation checks the component list, dependency edge closure,
+                external targets, and policy metric status in an existing Sig0
+                JSON file. It does not rescan source files.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Validation report</figcaption>
+                <pre><code>cargo run --manifest-path tools/archsig/Cargo.toml -- validate \
+  --input .lake/sig0-fixture.json \
+  --out .lake/sig0-fixture-validation.json \
+  --universe-mode local-only</code></pre>
+              </figure>
+            </section>
+
+            <section id="repository-scan" class="article-section">
+              <h2>Repository scan</h2>
+              <p>
+                A repository scan writes Sig0 for the current checkout. Keep
+                policy and runtime evidence explicit when those axes matter;
+                omitted inputs can leave placeholder values with unmeasured
+                status.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Current repository</figcaption>
+                <pre><code>cargo run --manifest-path tools/archsig/Cargo.toml -- \
+  --root . \
+  --out .lake/sig0.json</code></pre>
+              </figure>
+            </section>
+
+            <section id="python-scan" class="article-section">
+              <h2>Python scan</h2>
+              <p>
+                Python mode extracts <code>import</code> and
+                <code>from ... import ...</code> edges with the standard AST
+                parser. Dynamic import, plugin loading, and framework
+                conventions remain boundary items.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Python repository</figcaption>
+                <pre><code>cargo run --manifest-path tools/archsig/Cargo.toml -- \
+  --language python \
+  --root path/to/repository \
+  --source-root src \
+  --package-root src \
+  --out .lake/python-sig0.json</code></pre>
+              </figure>
+            </section>
+
+            <section id="first-reading" class="article-section">
+              <h2>First reading</h2>
+              <p>
+                Do not read the numeric signature alone. Read
+                <code>metricStatus</code>, <code>unmeasuredAxes</code>,
+                validation status, and non-conclusions before deciding whether
+                an axis is a measured zero, measured nonzero, unmeasured, or
+                out of scope.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A placeholder value of zero is not evidence that the risk is
+                  zero unless the corresponding metric status says it was
+                  measured.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../">
+                <span>Previous</span>
+                <strong>ArchSig Manual</strong>
+              </a>
+              <a href="../commands/">
+                <span>Next</span>
+                <strong>Commands</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/index.html
+++ b/website/archsig/index.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig manual landing, reading path, CLI scope, artifact boundary, and source mapping."
+    >
+    <title>ArchSig Manual</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../assets/site.css">
+    <script defer src="../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../">Home</a>
+          <a href="../aat/">AAT</a>
+          <a href="../sft/">SFT</a>
+          <a href="../#documents">Interface</a>
+          <a class="is-active" href="./">ArchSig</a>
+          <a href="../#outreach">Outreach</a>
+          <a href="../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../">Home</a>
+            <span>ArchSig</span>
+          </nav>
+          <p class="eyebrow">ArchSig Manual</p>
+          <h1>Architecture Signature tooling with explicit claim boundaries.</h1>
+          <p class="lede">
+            ArchSig turns repository artifacts into bounded signature, report, workflow, and forecasting artifacts. It is a manual and reference section for using those artifacts without turning measurement output into Lean theorem status.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#reading-order">Reading order</a></li>
+                <li><a href="#tool-scope">Tool scope</a></li>
+                <li><a href="#reference-map">Reference map</a></li>
+                <li><a href="#claim-discipline">Claim discipline</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/README.md">
+                    ArchSig README
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/README.md">
+                    Tooling documentation entry
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/principles.md">
+                    Tooling principles
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="reading-order" class="article-section">
+              <h2>Reading order</h2>
+              <p>
+                ArchSig is the observation and reporting layer for AAT / SFT.
+                Start with the minimal scan path, then read command and
+                artifact references before using reports for PR review or
+                SFT forecasting.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="getting-started/">Getting Started</a>
+                  <span>Fixture scan, validation, repository scan, and Python import graph scan.</span>
+                </li>
+                <li>
+                  <a href="commands/">Commands</a>
+                  <span>CLI reference for scan, reports, policy, dataset, operational feedback, repair, and SFT forecast commands.</span>
+                </li>
+                <li>
+                  <a href="artifacts/">Artifacts</a>
+                  <span>Sig0, validation, snapshots, diff reports, AIR, Feature Extension Report, policy decision, datasets, and SFT forecasting artifacts.</span>
+                </li>
+                <li>
+                  <a href="boundaries/">Boundaries</a>
+                  <span>Rules for measured zero, unmeasured axes, theorem promotion, non-conclusions, and lawfulness claims.</span>
+                </li>
+                <li>
+                  <a href="workflows/">Workflows</a>
+                  <span>First adoption, PR review, generated-change provenance, scheduled scan, architecture dynamics, and SFT forecast workflow.</span>
+                </li>
+                <li>
+                  <a href="schemas/">Schemas</a>
+                  <span>Schema version policy, compatibility outcomes, catalog families, and migration guardrails.</span>
+                </li>
+                <li>
+                  <a href="operational-feedback/">Operational Feedback</a>
+                  <span>B10 daily ledger, calibration, threshold, ownership, repair adoption, incident correlation, and hypothesis refresh artifacts.</span>
+                </li>
+                <li>
+                  <a href="examples/">Examples</a>
+                  <span>Good extension, hidden interaction witness, semantic witness, report reading, and dynamics reading.</span>
+                </li>
+                <li>
+                  <a href="roadmap/">Roadmap</a>
+                  <span>B0-B13 phases, current implementation snapshot, and standardization targets.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="tool-scope" class="article-section">
+              <h2>Tool scope</h2>
+              <p>
+                The CLI scans Lean import graphs and Python import graphs,
+                computes structural signature axes, applies optional policy
+                and runtime evidence, and writes JSON artifacts for later
+                validation, diffing, reporting, and forecasting commands.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Core flow</figcaption>
+                <pre><code>scan
+  -&gt; validate
+  -&gt; snapshot
+  -&gt; signature-diff
+  -&gt; AIR
+  -&gt; theorem-check
+  -&gt; feature-report
+  -&gt; policy-decision
+  -&gt; pr-comment</code></pre>
+              </figure>
+            </section>
+
+            <section id="reference-map" class="article-section">
+              <h2>Reference map</h2>
+              <p>
+                Website pages are summaries. The repository documents remain
+                the source of truth for command behavior, schema details,
+                artifact boundaries, and mutable roadmap status.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>CLI and artifact references</strong>
+                  <span><code>tools/archsig/README.md</code>, <code>tools/archsig/docs/commands.md</code>, and <code>tools/archsig/docs/artifacts-and-boundaries.md</code>.</span>
+                </li>
+                <li>
+                  <strong>Tooling theory boundary</strong>
+                  <span><code>docs/tool/README.md</code>, <code>docs/tool/claim_boundary.md</code>, <code>docs/tool/signature_artifacts.md</code>, and <code>docs/tool/reports.md</code>.</span>
+                </li>
+                <li>
+                  <strong>Operational and roadmap status</strong>
+                  <span><code>tools/archsig/docs/operational-feedback.md</code> and <code>docs/tool/roadmap.md</code>.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="claim-discipline" class="article-section">
+              <h2>Claim discipline</h2>
+              <p>
+                Architecture Signature is a multi-axis diagnostic, not a
+                scalar quality score. Every report must be read together with
+                measurement status, coverage gaps, theorem preconditions, and
+                non-conclusions.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A measured witness can guide review. It does not by itself
+                  discharge a Lean theorem, prove extractor completeness, or
+                  establish architecture lawfulness.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../sft/part-vii-research-program/">
+                <span>Previous</span>
+                <strong>SFT Part VII</strong>
+              </a>
+              <a href="getting-started/">
+                <span>Next</span>
+                <strong>Getting Started</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/operational-feedback/index.html
+++ b/website/archsig/operational-feedback/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig operational feedback manual for B10 artifacts, commands, reading rules, and non-conclusions."
+    >
+    <title>ArchSig Operational Feedback</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Operational Feedback</span>
+          </nav>
+          <p class="eyebrow">ArchSig Manual</p>
+          <h1>Operational feedback is empirical evidence with guardrails.</h1>
+          <p class="lede">
+            B10 artifacts let teams review outcomes, calibration, thresholds, ownership erosion, repair adoption, incident correlation, and hypothesis refresh without converting operational records into causal or formal claims.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#commands">Commands</a></li>
+                <li><a href="#artifacts">Artifacts</a></li>
+                <li><a href="#reading-rules">Reading rules</a></li>
+                <li><a href="#non-conclusions">Non-conclusions</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/docs/operational-feedback.md">
+                    Operational Feedback
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/reports.md">
+                    Reports
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="commands" class="article-section">
+              <h2>Commands</h2>
+              <p>
+                The daily ledger joins outcome linkage and drift ledger inputs
+                inside a specified aggregation window. Other B10 commands emit
+                canonical operational artifacts for calibration and review.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>report-outcome-daily-ledger</strong>
+                  <span>Aggregates outcome linkage and architecture drift ledger records for a bounded window.</span>
+                </li>
+                <li>
+                  <strong>calibration-review-record and team-threshold-policy</strong>
+                  <span>Track false positive / false negative review and team-specific CI policy tuning.</span>
+                </li>
+                <li>
+                  <strong>ownership-boundary-monitor, repair-adoption-record, incident-correlation-monitor, hypothesis-refresh-cycle</strong>
+                  <span>Track operational boundary signals, repair decisions, correlations, and empirical hypothesis updates.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="artifacts" class="article-section">
+              <h2>Artifacts</h2>
+              <p>
+                Operational artifacts are empirical and process records. They
+                preserve unavailable, private, missing, and unmeasured data
+                states instead of rounding them to measured zero.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Report outcome daily ledger</strong>
+                  <span>Daily aggregation over outcome linkage and drift evidence.</span>
+                </li>
+                <li>
+                  <strong>Calibration and threshold artifacts</strong>
+                  <span>Review evidence for tuning report sensitivity and CI modes.</span>
+                </li>
+                <li>
+                  <strong>Ownership, repair, incident, and hypothesis artifacts</strong>
+                  <span>Operational records that support review, not formal theorem promotion.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="reading-rules" class="article-section">
+              <h2>Reading rules</h2>
+              <p>
+                Reviewer decisions, team thresholds, ownership signals, repair
+                adoption, incident correlation, and retained hypotheses are
+                calibration inputs. They are not proof that a report, policy,
+                or repair is correct.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Unavailable, private, missing, and unmeasured outcome data
+                  must stay separate from measured-zero evidence.
+                </p>
+              </div>
+            </section>
+
+            <section id="non-conclusions" class="article-section">
+              <h2>Non-conclusions</h2>
+              <p>
+                B10 artifacts do not conclude incident causality, formal claim
+                promotion, theorem precondition discharge, extractor
+                completeness, architecture lawfulness, or semantic
+                preservation.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../schemas/">
+                <span>Previous</span>
+                <strong>Schemas</strong>
+              </a>
+              <a href="../examples/">
+                <span>Next</span>
+                <strong>Examples</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/roadmap/index.html
+++ b/website/archsig/roadmap/index.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig roadmap for B0-B13 phases, current implementation status, and standardization targets."
+    >
+    <title>ArchSig Roadmap</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Roadmap</span>
+          </nav>
+          <p class="eyebrow">ArchSig Roadmap</p>
+          <h1>Roadmap status stays separate from theorem status.</h1>
+          <p class="lede">
+            The roadmap tracks tooling phases, implemented pipelines, schema and validator coverage, advisory reports, empirical feedback, planned gaps, and standardization targets. It is mutable planning, not mathematical proof status.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#current">Current snapshot</a></li>
+                <li><a href="#phases">B0-B13 phases</a></li>
+                <li><a href="#forecasting">SFT forecasting</a></li>
+                <li><a href="#targets">Standardization targets</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/roadmap.md">
+                    Tooling roadmap
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="current" class="article-section">
+              <h2>Current snapshot</h2>
+              <p>
+                ArchSig is beyond a minimal AAT diagnostic tool. It includes
+                Lean and Python graph extraction, policy and runtime evidence,
+                AIR / Feature Extension Report, PR / CI governance artifacts,
+                empirical feedback artifacts, Architecture Dynamics artifacts,
+                and a bounded SFT forecasting pipeline.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Implemented pipeline</strong>
+                  <span>CLI and workflow paths that generate artifacts from real inputs.</span>
+                </li>
+                <li>
+                  <strong>Schema + validator</strong>
+                  <span>Artifacts with fixed shape and validation, but limited inference from real inputs.</span>
+                </li>
+                <li>
+                  <strong>Empirical / operational</strong>
+                  <span>Dataset, calibration, feedback, and outcome records that do not imply causal theorem status.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="phases" class="article-section">
+              <h2>B0-B13 phases</h2>
+              <p>
+                The phase list moves from AIR boundary and static reports
+                through runtime, semantic, generated-change, repair,
+                empirical, CI, policy ecosystem, schema, operational feedback,
+                dynamics, and SFT forecast work.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>B0-B5</strong>
+                  <span>AIR, Feature Extension Report, runtime / semantic integration, generated-change provenance, repair and synthesis prototype.</span>
+                </li>
+                <li>
+                  <strong>B6-B10</strong>
+                  <span>Empirical validation, PR review integration, extractor / policy ecosystem, schema compatibility, and operational feedback loop.</span>
+                </li>
+                <li>
+                  <strong>B11-B13</strong>
+                  <span>Architecture Dynamics tooling, SFT forecasting MVP, and implemented SFT forecaster pipeline.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="forecasting" class="article-section">
+              <h2>SFT forecasting</h2>
+              <p>
+                B12 fixed ArtifactDescriptor, OperationSupportEstimate,
+                ForecastConeSkeleton, ConsequenceEnvelope, and
+                ForecastCalibrationHook as schema + validator artifacts. B13
+                connects real Markdown PRD / Spec / Issue / AI proposal input
+                to the bounded pipeline.
+              </p>
+              <figure class="code-panel">
+                <figcaption>B13 pipeline</figcaption>
+                <pre><code>real PRD / Spec / Issue / AI proposal
+  -&gt; ArtifactDescriptor builder
+  -&gt; OperationSupportEstimate generator
+  -&gt; ForecastConeSkeleton generator
+  -&gt; ConsequenceEnvelope generator
+  -&gt; end-to-end sft-forecast command</code></pre>
+              </figure>
+            </section>
+
+            <section id="targets" class="article-section">
+              <h2>Standardization targets</h2>
+              <p>
+                Standardization targets include artifact schema naming, claim
+                boundary vocabulary, measurement boundary vocabulary,
+                non-conclusion preservation, schema compatibility policy,
+                example fixtures, report consumer contract, forecast input /
+                output contract, and forecast boundary vocabulary.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Roadmap progress does not create a Lean theorem claim. It
+                  records the implementation and validation surface of the
+                  tooling layer.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../examples/">
+                <span>Previous</span>
+                <strong>Examples</strong>
+              </a>
+              <a href="../../#outreach">
+                <span>Next</span>
+                <strong>Outreach</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/schemas/index.html
+++ b/website/archsig/schemas/index.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig schema versioning, compatibility outcomes, schema catalog, and migration rules."
+    >
+    <title>ArchSig Schemas</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Schemas</span>
+          </nav>
+          <p class="eyebrow">ArchSig Reference</p>
+          <h1>Schema compatibility is claim-boundary compatibility.</h1>
+          <p class="lede">
+            Schema evolution is not only field-shape migration. It must preserve assumptions, coverage, exactness metadata, and non-conclusions so reports keep the same claim boundary after migration.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#version-policy">Version policy</a></li>
+                <li><a href="#outcomes">Compatibility outcomes</a></li>
+                <li><a href="#catalog">Catalog</a></li>
+                <li><a href="#migration">Migration rules</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/schema_compatibility.md">
+                    Schema compatibility
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/air.md">
+                    AIR
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/signature_artifacts.md">
+                    Signature artifacts
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="version-policy" class="article-section">
+              <h2>Version policy</h2>
+              <p>
+                A schema compatibility policy names the artifact, version,
+                field mappings, deprecated fields, required assumptions,
+                coverage / exactness boundaries, and non-conclusions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Compatibility policy shape</figcaption>
+                <pre><code>schema-compatibility-policy-v0 :=
+  artifactId
+  + schemaVersion
+  + fieldMappings
+  + deprecatedFields
+  + requiredAssumptions
+  + coverageExactnessBoundaries
+  + nonConclusions</code></pre>
+              </figure>
+            </section>
+
+            <section id="outcomes" class="article-section">
+              <h2>Compatibility outcomes</h2>
+              <p>
+                <code>notComparable</code> is a valid boundary outcome, not a
+                generic failure. If schema, unit, projection, or coverage does
+                not align, the tool should avoid inventing a delta.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>compatible</strong>
+                  <span>The artifact can be read under the mapped schema while preserving boundaries.</span>
+                </li>
+                <li>
+                  <strong>requiresMigration</strong>
+                  <span>A migration path is needed before comparison or reporting is meaningful.</span>
+                </li>
+                <li>
+                  <strong>notComparable</strong>
+                  <span>The artifacts are not comparable under the available projection or coverage.</span>
+                </li>
+                <li>
+                  <strong>blockedFormalClaimPromotion</strong>
+                  <span>The migration would strengthen a weak boundary into a formal claim without required preconditions.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="catalog" class="article-section">
+              <h2>Catalog</h2>
+              <p>
+                The catalog includes Sig0, AIR, Feature Extension Report,
+                obstruction witnesses, drift ledgers, reported axes, B10
+                operational feedback artifacts, and Architecture Dynamics
+                reports such as PR force, signature trajectory, and dynamics
+                metrics.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Core artifacts</strong>
+                  <span><code>archsig-sig0-v0</code>, <code>aat-air-v0</code>, <code>feature-extension-report-v0</code>, and <code>obstruction-witness-v0</code>.</span>
+                </li>
+                <li>
+                  <strong>Operational artifacts</strong>
+                  <span>Daily ledger, calibration review, team threshold, ownership monitor, repair adoption, incident correlation, and hypothesis refresh.</span>
+                </li>
+                <li>
+                  <strong>Dynamics artifacts</strong>
+                  <span><code>pr-force-report-v0</code>, <code>signature-trajectory-report-v0</code>, and <code>architecture-dynamics-metrics-report-v0</code>.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="migration" class="article-section">
+              <h2>Migration rules</h2>
+              <p>
+                A migration is not safe if it removes an older non-conclusion,
+                silently discharges a new required assumption, or loses
+                coverage and exactness metadata.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A weak boundary must not become a strong claim during schema
+                  migration. The migration must preserve or strengthen
+                  non-conclusions, not erase them.
+                </p>
+              </div>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../workflows/">
+                <span>Previous</span>
+                <strong>Workflows</strong>
+              </a>
+              <a href="../operational-feedback/">
+                <span>Next</span>
+                <strong>Operational Feedback</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/archsig/workflows/index.html
+++ b/website/archsig/workflows/index.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="ArchSig workflow manual for first adoption, PR review, generated-change provenance, scheduled scan, architecture dynamics, and SFT forecasting."
+    >
+    <title>ArchSig Workflows</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../#documents">Interface</a>
+          <a class="is-active" href="../">ArchSig</a>
+          <a href="../../#outreach">Outreach</a>
+          <a href="../../#profile">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">ArchSig</a>
+            <span>Workflows</span>
+          </nav>
+          <p class="eyebrow">ArchSig Manual</p>
+          <h1>Workflows preserve boundaries while reports move between tools.</h1>
+          <p class="lede">
+            A workflow is an artifact sequence with source refs, validation, coverage gaps, and non-conclusions preserved from step to step. This page lists the main operating paths.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="ArchSig page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#first-adoption">First adoption</a></li>
+                <li><a href="#pr-review">PR review</a></li>
+                <li><a href="#generated-change">Generated change</a></li>
+                <li><a href="#scheduled-scan">Scheduled scan</a></li>
+                <li><a href="#dynamics-forecast">Dynamics and forecast</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/workflows.md">
+                    Workflows
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/tools/archsig/README.md">
+                    ArchSig README
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li><code>archsig</code> is not a Lean prover.</li>
+                <li>Tool output is not a Lean theorem.</li>
+                <li>Extractor output is not a complete <code>ComponentUniverse</code>.</li>
+                <li>Measured zero is different from unmeasured.</li>
+                <li>Policy pass does not imply architecture lawfulness.</li>
+                <li>Report warning does not imply incident causality.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="first-adoption" class="article-section">
+              <h2>First adoption</h2>
+              <p>
+                First adoption establishes a baseline without pretending that
+                unsupported axes are safe. The useful result is a first report
+                with unmeasured axes and unsupported constructs made explicit.
+              </p>
+              <figure class="code-panel">
+                <figcaption>First adoption flow</figcaption>
+                <pre><code>scan
+  -&gt; validate
+  -&gt; snapshot
+  -&gt; baseline policy
+  -&gt; first signature report</code></pre>
+              </figure>
+            </section>
+
+            <section id="pr-review" class="article-section">
+              <h2>PR review</h2>
+              <p>
+                PR review compares before and after artifacts, then turns the
+                difference into AIR, theorem precondition checks, Feature
+                Extension Report, policy decision, and PR comment summary.
+              </p>
+              <figure class="code-panel">
+                <figcaption>PR review flow</figcaption>
+                <pre><code>before scan
+  -&gt; after scan
+  -&gt; signature diff
+  -&gt; AIR
+  -&gt; theorem precondition check
+  -&gt; feature extension report
+  -&gt; policy decision
+  -&gt; PR comment summary</code></pre>
+              </figure>
+            </section>
+
+            <section id="generated-change" class="article-section">
+              <h2>Generated change</h2>
+              <p>
+                AI-generated change provenance records provider, model,
+                prompt ref, generated patch, and human review boundary. The
+                provenance record supports review and reproducibility; it does
+                not decide whether the change is good or bad.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Prompt and generated patch</strong>
+                  <span>Evidence refs for the generated action and its proposed scope.</span>
+                </li>
+                <li>
+                  <strong>Human review boundary</strong>
+                  <span>Whether the generated change was reviewed, and what review evidence is available.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="scheduled-scan" class="article-section">
+              <h2>Scheduled scan</h2>
+              <p>
+                Scheduled scans update drift ledgers and operational feedback
+                artifacts. Daily drift is a trend artifact, not proof that a
+                report warning caused an operational outcome.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Scheduled scan flow</figcaption>
+                <pre><code>scheduled scan
+  -&gt; signature snapshot
+  -&gt; drift ledger
+  -&gt; ownership boundary monitor
+  -&gt; operational feedback</code></pre>
+              </figure>
+            </section>
+
+            <section id="dynamics-forecast" class="article-section">
+              <h2>Dynamics and forecast</h2>
+              <p>
+                Architecture Dynamics and SFT forecasting workflows hold
+                finite support, bounded horizon, proposal refs, unknown
+                remainder, and review recommendations apart from probability
+                or causal forecast claims.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Dynamics and forecast</figcaption>
+                <pre><code>architecture field snapshot
+  + operation proposal log
+  + PR force report
+  -&gt; signature trajectory report
+  -&gt; architecture dynamics metrics report
+
+PRD / Spec / Issue / AI proposal
+  -&gt; ArtifactDescriptor
+  -&gt; OperationSupportEstimate
+  -&gt; ForecastConeSkeleton
+  -&gt; ConsequenceEnvelope</code></pre>
+              </figure>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../boundaries/">
+                <span>Previous</span>
+                <strong>Boundaries</strong>
+              </a>
+              <a href="../schemas/">
+                <span>Next</span>
+                <strong>Schemas</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -45,7 +45,7 @@
           <a href="aat/">AAT</a>
           <a href="sft/">SFT</a>
           <a href="#documents">Interface</a>
-          <a href="#research">ArchSig</a>
+          <a href="archsig/">ArchSig</a>
           <a href="#outreach">Outreach</a>
           <a href="#profile">Profile</a>
         </nav>
@@ -124,8 +124,8 @@
                 axes, witness candidates, theorem precondition reports, and
                 explicit non-conclusions.
               </p>
-              <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/tool/README.md">
-                Read the ArchSig entry
+              <a href="archsig/">
+                Read the ArchSig manual
               </a>
             </article>
           </div>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -33,7 +33,7 @@
           <a href="../aat/">AAT</a>
           <a class="is-active" href="./">SFT</a>
           <a href="../#documents">Interface</a>
-          <a href="../#research">ArchSig</a>
+          <a href="../archsig/">ArchSig</a>
           <a href="../#outreach">Outreach</a>
           <a href="../#profile">Profile</a>
         </nav>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -33,7 +33,7 @@
           <a href="../../aat/">AAT</a>
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
-          <a href="../../#research">ArchSig</a>
+          <a href="../../archsig/">ArchSig</a>
           <a href="../../#outreach">Outreach</a>
           <a href="../../#profile">Profile</a>
         </nav>
@@ -180,9 +180,9 @@
                 <span>Previous</span>
                 <strong>Part VI. Case Studies</strong>
               </a>
-              <a href="../../#research">
+              <a href="../../archsig/">
                 <span>Next</span>
-                <strong>ArchSig Overview</strong>
+                <strong>ArchSig Manual</strong>
               </a>
             </nav>
           </div>


### PR DESCRIPTION
## 概要

Closes #763

- `website/archsig/` に ArchSig manual / reference section を追加しました。
- Getting Started、Commands、Artifacts、Boundaries、Workflows、Schemas、Operational Feedback、Examples、Roadmap の各 route を実装しました。
- 既存の AAT / SFT / top page navigation から ArchSig manual へ移動できるようにしました。
- `website/SITEMAP.md` と `website/README.md` の実装状況を更新しました。

Lean status: tooling documentation. Lean theorem claim なし。

## 証明した定理

- なし

## 編集したドキュメント

- `website/archsig/`
- `website/index.html`
- `website/aat/`
- `website/sft/`
- `website/SITEMAP.md`
- `website/README.md`

## 実施したテスト

- [x] `lake build` 成功（既存の linter warning 2 件のみ）
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 一致なし
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 一致なし
- [x] website local link check: 29 HTML files, missing local href/src なし
- [x] `python3 -m http.server 8000 --directory website` で `/archsig/`, `/archsig/commands/`, `/archsig/roadmap/` が HTTP 200

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている