### PR TITLE
Outreach / profile / SEO sitemap 導線を website に追加する

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -64,8 +64,18 @@ underscore-prefixed paths or future generated assets as Jekyll input.
 AAT chapter-cluster pages are implemented as static directory routes under
 `aat/`. SFT Part pages are implemented as static directory routes under
 `sft/`. ArchSig manual and reference pages are implemented as static directory
-routes under `archsig/`. Remaining major sections still point readers back to
-canonical repository documents until their public routes are added.
+routes under `archsig/`. Profile and outreach pages are implemented as
+top-level static directory routes. Remaining major sections still point
+readers back to canonical repository documents until their public routes are
+added.
+
+## SEO Sitemap Policy
+
+Do not commit a production `sitemap.xml` until the public domain or GitHub
+Pages base URL is fixed. Once the domain is chosen, generate or manually add
+`website/sitemap.xml` from the routes in `website/SITEMAP.md`, using the final
+public root as the URL base. Until then, avoid placeholder hosts in metadata,
+links, and sitemap entries.
 
 ## Local Preview
 

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -498,14 +498,15 @@ implemented:
   /archsig/operational-feedback/
   /archsig/examples/
   /archsig/roadmap/
+  /outreach/
+  /profile/
 
 planned:
-  /profile/
   /interface/
-  /outreach/
 ```
 
 ## Later SEO Sitemap
 
 公開ドメインが決まった後で、別途 `sitemap.xml` を作る。
 その時点では、この設計図の route を URL 化し、GitHub Pages の公開 root から参照できるようにする。
+ドメイン未確定の段階では placeholder host を含む `sitemap.xml` を公開しない。

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -46,8 +46,8 @@
           <a href="../sft/">SFT</a>
           <a href="../#documents">Interface</a>
           <a href="../archsig/">ArchSig</a>
-          <a href="../#outreach">Outreach</a>
-          <a href="../#profile">Profile</a>
+          <a href="../outreach/">Outreach</a>
+          <a href="../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/artifacts/index.html
+++ b/website/archsig/artifacts/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/boundaries/index.html
+++ b/website/archsig/boundaries/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/commands/index.html
+++ b/website/archsig/commands/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/examples/index.html
+++ b/website/archsig/examples/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/getting-started/index.html
+++ b/website/archsig/getting-started/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/index.html
+++ b/website/archsig/index.html
@@ -34,8 +34,8 @@
           <a href="../sft/">SFT</a>
           <a href="../#documents">Interface</a>
           <a class="is-active" href="./">ArchSig</a>
-          <a href="../#outreach">Outreach</a>
-          <a href="../#profile">Profile</a>
+          <a href="../outreach/">Outreach</a>
+          <a href="../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/operational-feedback/index.html
+++ b/website/archsig/operational-feedback/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/roadmap/index.html
+++ b/website/archsig/roadmap/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>
@@ -183,7 +183,7 @@
                 <span>Previous</span>
                 <strong>Examples</strong>
               </a>
-              <a href="../../#outreach">
+              <a href="../../outreach/">
                 <span>Next</span>
                 <strong>Outreach</strong>
               </a>

--- a/website/archsig/schemas/index.html
+++ b/website/archsig/schemas/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/archsig/workflows/index.html
+++ b/website/archsig/workflows/index.html
@@ -34,8 +34,8 @@
           <a href="../../sft/">SFT</a>
           <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/index.html
+++ b/website/index.html
@@ -46,8 +46,8 @@
           <a href="sft/">SFT</a>
           <a href="#documents">Interface</a>
           <a href="archsig/">ArchSig</a>
-          <a href="#outreach">Outreach</a>
-          <a href="#profile">Profile</a>
+          <a href="outreach/">Outreach</a>
+          <a href="profile/">Profile</a>
         </nav>
       </div>
     </header>
@@ -225,6 +225,9 @@
             </p>
           </div>
           <div class="link-list">
+            <a href="outreach/">
+              Outreach hub
+            </a>
             <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/main/docs/outreach">
               Outreach drafts
             </a>
@@ -243,10 +246,11 @@
           </div>
           <div class="profile-copy">
             <p>
-              This area will hold the public author profile, contact links, and
-              publication notes for the AAT / SFT research program.
+              The public profile records the maintainer identity, repository
+              contact routes, and publication boundary for the AAT / SFT
+              research program.
             </p>
-            <a href="https://github.com/iroha1203">GitHub: iroha1203</a>
+            <a href="profile/">Read the profile</a>
           </div>
         </div>
       </section>

--- a/website/outreach/index.html
+++ b/website/outreach/index.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Outreach hub for AAT, SFT, ArchSig articles, canonical return links, and publication boundary rules."
+    >
+    <title>Outreach</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../assets/site.css">
+    <script defer src="../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../">Home</a>
+          <a href="../aat/">AAT</a>
+          <a href="../sft/">SFT</a>
+          <a href="../#documents">Interface</a>
+          <a href="../archsig/">ArchSig</a>
+          <a class="is-active" href="./">Outreach</a>
+          <a href="../profile/">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../">Home</a>
+            <span>Outreach</span>
+          </nav>
+          <p class="eyebrow">Outreach</p>
+          <h1>Entry points that return to the canonical theory.</h1>
+          <p class="lede">
+            Outreach articles introduce AAT, SFT, ArchSig, and attractor
+            engineering for public reading. They are publication routes, not a
+            second source of truth for definitions, theorem status, or tooling
+            claims.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Outreach page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#publication-rule">Publication rule</a></li>
+                <li><a href="#article-routes">Article routes</a></li>
+                <li><a href="#canonical-returns">Canonical returns</a></li>
+                <li><a href="#seo-sitemap">SEO sitemap</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Draft sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/main/docs/outreach">
+                    Outreach draft directory
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/en/aat_sft_hashnode_mvp_v_0_1.md">
+                    Hashnode English draft
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/qiita_intro_draft.md">
+                    Qiita Japanese draft
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <ul>
+                <li>English website routes are canonical.</li>
+                <li>Japanese articles are outreach entries.</li>
+                <li>No partial <code>/ja/</code> mirror is published.</li>
+                <li>Formal claims return to AAT / SFT / ArchSig pages.</li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="publication-rule" class="article-section">
+              <h2>Publication rule</h2>
+              <p>
+                The public site keeps the technical source of truth in English.
+                Japanese essays on Qiita, Zenn, Hashnode, or similar media are
+                welcome as outreach, but they should point readers back to the
+                canonical English page before relying on definitions, theorem
+                status, measurement boundaries, or non-conclusions.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Outreach can explain motivation and intuition. It should not
+                  become a parallel place where theorem status, empirical
+                  hypotheses, or tooling claims drift away from the repository.
+                </p>
+              </div>
+            </section>
+
+            <section id="article-routes" class="article-section">
+              <h2>Article routes</h2>
+              <p>
+                These routes collect the current public-article drafts and the
+                intended publication lanes. Platform copies should keep their
+                return links to this site or the corresponding repository
+                source.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/en/aat_sft_hashnode_mvp_v_0_1.md">
+                    Hashnode: Software Architecture as a Field
+                  </a>
+                  <span>English introduction to AAT, SFT, ArchSig, and software evolution.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/en/design_principles_as_invariant_preservation.md">
+                    Hashnode: Design Principles as Invariant Preservation
+                  </a>
+                  <span>English article draft on SOLID, layered architecture, state transition patterns, and runtime protection.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/software_architecture_as_a_field_ja_v2.md">
+                    Zenn: Software Architecture as a Field
+                  </a>
+                  <span>Japanese short-form draft for explaining SFT without turning forecasts into predictions.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/qiita_intro_draft.md">
+                    Qiita: Architecture Zero-Curvature Introduction
+                  </a>
+                  <span>Japanese draft explaining design principles as invariant-preserving operations.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/qiita_attractor.md">
+                    Qiita: Attractor Engineering
+                  </a>
+                  <span>Japanese draft introducing field-shaped development and support shaping.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="canonical-returns" class="article-section">
+              <h2>Canonical returns</h2>
+              <p>
+                Each outreach article should make the return path explicit.
+                The return target depends on the claim being made, not on the
+                platform where the article is published.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>AAT definitions and theorem status</strong>
+                  <span>
+                    Return to <a href="../aat/">AAT</a>,
+                    <a href="../aat/status/">AAT Lean Status</a>, and the
+                    repository theorem index before making formal claims.
+                  </span>
+                </li>
+                <li>
+                  <strong>SFT forecasts and field language</strong>
+                  <span>
+                    Return to <a href="../sft/">SFT</a> and the
+                    <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                      AAT / SFT interface
+                    </a>
+                    before reading field, force, attractor, or forecast as a theorem.
+                  </span>
+                </li>
+                <li>
+                  <strong>ArchSig measurements</strong>
+                  <span>
+                    Return to <a href="../archsig/">ArchSig</a> and
+                    <a href="../archsig/boundaries/">ArchSig Boundaries</a>
+                    before treating tool output as evidence for a broader conclusion.
+                  </span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="seo-sitemap" class="article-section">
+              <h2>SEO sitemap</h2>
+              <p>
+                This repository does not commit a production <code>sitemap.xml</code>
+                until the public domain is chosen. After the domain is fixed,
+                the sitemap should be generated or manually written from
+                <code>website/SITEMAP.md</code>, using the GitHub Pages public
+                root as the URL base.
+              </p>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../archsig/roadmap/">
+                <span>Previous</span>
+                <strong>ArchSig Roadmap</strong>
+              </a>
+              <a href="../profile/">
+                <span>Next</span>
+                <strong>Profile</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/profile/index.html
+++ b/website/profile/index.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Author profile and public contact routes for the AAT, SFT, and ArchSig research program."
+    >
+    <title>Author Profile</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../assets/site.css">
+    <script defer src="../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../">Home</a>
+          <a href="../aat/">AAT</a>
+          <a href="../sft/">SFT</a>
+          <a href="../#documents">Interface</a>
+          <a href="../archsig/">ArchSig</a>
+          <a href="../outreach/">Outreach</a>
+          <a class="is-active" href="./">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../">Home</a>
+            <span>Profile</span>
+          </nav>
+          <p class="eyebrow">Author Profile</p>
+          <h1>A public profile for the AAT / SFT research program.</h1>
+          <p class="lede">
+            This profile identifies the public research surface for Algebraic
+            Architecture Theory, Software Field Theory, and ArchSig. The
+            canonical record remains the repository and its linked documents.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Profile page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#public-identity">Public identity</a></li>
+                <li><a href="#research-program">Research program</a></li>
+                <li><a href="#contact-routes">Contact routes</a></li>
+                <li><a href="#publication-boundary">Publication boundary</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Public links</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203">
+                    GitHub profile
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+                    AAT / SFT repository
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/research_goal.md">
+                    Research goal
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                The profile is an orientation page. Definitions, theorem
+                status, proof obligations, and tooling claims are resolved by
+                the canonical pages and repository documents.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="public-identity" class="article-section">
+              <h2>Public identity</h2>
+              <p>
+                The public maintainer identity for this research surface is
+                <a href="https://github.com/iroha1203">iroha1203 on GitHub</a>.
+                The repository is the shared record for theory documents,
+                Lean formalization, ArchSig tooling, website pages, and issue
+                tracking.
+              </p>
+            </section>
+
+            <section id="research-program" class="article-section">
+              <h2>Research program</h2>
+              <p>
+                The program studies software architecture as an object of
+                change. AAT asks which architecture invariants are preserved or
+                broken by an operation. SFT asks how artifacts, policy, review,
+                tooling, feedback, and AI proposals shape reachable software
+                futures. ArchSig is the observation layer that records bounded
+                signatures, witnesses, reports, and non-conclusions.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>AAT</strong>
+                  <span>Local algebra of architecture objects, operations, invariants, witnesses, and signatures.</span>
+                </li>
+                <li>
+                  <strong>SFT</strong>
+                  <span>Computable theory of bounded, field-shaped software evolution.</span>
+                </li>
+                <li>
+                  <strong>ArchSig</strong>
+                  <span>Tooling and artifact layer for measuring selected signature axes with explicit claim boundaries.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="contact-routes" class="article-section">
+              <h2>Contact routes</h2>
+              <p>
+                Repository discussion should stay close to the artifact it
+                concerns. Use GitHub Issues for tracked work and GitHub Pull
+                Requests for proposed changes. Public essays and short
+                explanations are routed through the outreach hub.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues">
+                    GitHub Issues
+                  </a>
+                  <span>Tracked research, formalization, documentation, tooling, and website tasks.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/pulls">
+                    GitHub Pull Requests
+                  </a>
+                  <span>Concrete changes to Lean source, documentation, tooling, and public website pages.</span>
+                </li>
+                <li>
+                  <a href="../outreach/">
+                    Outreach
+                  </a>
+                  <span>Public article lanes for Hashnode, Zenn, Qiita, and related short-form explanations.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="publication-boundary" class="article-section">
+              <h2>Publication boundary</h2>
+              <p>
+                The English website and repository documents carry canonical
+                definitions and boundary rules. Japanese articles are outreach
+                material and should return to the relevant canonical route
+                before making formal or measurement-heavy claims.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  No language switch or partial Japanese mirror is published
+                  from this profile. Public Japanese writing belongs in the
+                  outreach lane until a complete Japanese site strategy exists.
+                </p>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../outreach/">
+                <span>Previous</span>
+                <strong>Outreach</strong>
+              </a>
+              <a href="../">
+                <span>Next</span>
+                <strong>Home</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="./">SFT</a>
           <a href="../#documents">Interface</a>
           <a href="../archsig/">ArchSig</a>
-          <a href="../#outreach">Outreach</a>
-          <a href="../#profile">Profile</a>
+          <a href="../outreach/">Outreach</a>
+          <a href="../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -34,8 +34,8 @@
           <a class="is-active" href="../">SFT</a>
           <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
-          <a href="../../#outreach">Outreach</a>
-          <a href="../../#profile">Profile</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## 概要

Closes #760
Refs #759

- `website/outreach/` を追加し、Hashnode / Zenn / Qiita 向け記事導線と canonical English page へ戻る方針を明示した。
- `website/profile/` を追加し、GitHub profile、repository、Issue / PR、outreach hub への公開導線を整理した。
- 既存 website 全体の global nav と ArchSig roadmap の次ページ導線を、`#outreach` / `#profile` anchor ではなく実 route に更新した。
- 公開ドメイン確定後に `website/sitemap.xml` を生成または手動追加する方針を `website/README.md` と `website/SITEMAP.md` に明記した。

## 証明した定理

- なし

## 編集したドキュメント

- `website/outreach/index.html`
- `website/profile/index.html`
- `website/index.html`
- `website/README.md`
- `website/SITEMAP.md`
- `website/aat/**/index.html`
- `website/sft/**/index.html`
- `website/archsig/**/index.html`

## 実施したテスト

- [x] `lake build` 成功
  - 既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` に linter warning 2 件あり
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan 成功
- [x] website HTML local link check 成功

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
  - Lean status: docs / publication task。Lean theorem claim なし。
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
