### PR TITLE
websiteのInterface導線と理論本文方針を整理する

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -14,6 +14,25 @@ The public site uses English as the source of truth. Japanese explanations
 should be handled as outreach articles on Qiita, Zenn, Hashnode, or similar
 media, with links back to the canonical English pages.
 
+## Content Policy
+
+AAT and SFT pages are first-class theory pages, not promotional summaries.
+They should stay faithful to the repository's canonical theory documents and
+use a precise, paper-like expository style. Public article platforms such as
+Zenn, Hashnode, and Qiita are outreach surfaces for motivation and intuition;
+they are not where the full theory, theorem boundaries, or claim discipline are
+maintained.
+
+When expanding AAT and SFT pages:
+
+- Treat `docs/aat/mathematical_theory.md` and
+  `docs/sft/software_field_theory.md` as the source texts.
+- Preserve definitions, assumptions, non-conclusions, and claim levels.
+- Prefer theorem-style structure: definitions, interpretation, examples,
+  boundaries, and links to Lean status where appropriate.
+- Do not compress formal distinctions into slogans or general software advice.
+- Keep ArchSig and tooling evidence separate from AAT / SFT theorem claims.
+
 ## Intended Site Structure
 
 ```text
@@ -109,6 +128,12 @@ This is a text-first research site. Typography is the main interface:
 - Navigation and compact labels use `Inter` with Japanese sans fallbacks.
 - Code and Lean-like fragments use `IBM Plex Mono`.
 - Math is rendered with MathJax CommonHTML.
+
+AAT and SFT prose should read like long-form research exposition. The target is
+a technically careful reader who needs the actual theory, not a short popular
+explanation. Outreach pages can be lighter; canonical AAT / SFT pages should be
+substantive enough to stand on their own while still linking back to the source
+documents.
 
 Avoid adding a heavy frontend framework unless the site starts needing behavior
 that plain HTML, CSS, and a small script cannot handle cleanly.

--- a/website/README.md
+++ b/website/README.md
@@ -62,12 +62,11 @@ The committed `website/.nojekyll` file keeps GitHub Pages from treating
 underscore-prefixed paths or future generated assets as Jekyll input.
 
 AAT chapter-cluster pages are implemented as static directory routes under
-`aat/`. SFT Part pages are implemented as static directory routes under
-`sft/`. ArchSig manual and reference pages are implemented as static directory
-routes under `archsig/`. Profile and outreach pages are implemented as
-top-level static directory routes. Remaining major sections still point
-readers back to canonical repository documents until their public routes are
-added.
+`aat/`. The AAT / SFT interface is implemented as `interface/`. SFT Part pages
+are implemented as static directory routes under `sft/`. ArchSig manual and
+reference pages are implemented as static directory routes under `archsig/`.
+Profile and outreach pages are implemented as top-level static directory
+routes.
 
 ## SEO Sitemap Policy
 

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -171,8 +171,8 @@ SEO 用の `sitemap.xml` ではない。
 ```text
 Home
 AAT
-SFT
 Interface
+SFT
 ArchSig
 Outreach
 Profile
@@ -480,6 +480,7 @@ implemented:
   /aat/representations-and-effects/
   /aat/examples-and-boundaries/
   /aat/status/
+  /interface/
   /sft/
   /sft/part-i-new-object/
   /sft/part-ii-basis/
@@ -500,9 +501,6 @@ implemented:
   /archsig/roadmap/
   /outreach/
   /profile/
-
-planned:
-  /interface/
 ```
 
 ## Later SEO Sitemap

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -11,8 +11,12 @@ SEO 用の `sitemap.xml` ではない。
 - 日本語は Qiita、Zenn、Hashnode などの outreach article として扱い、site mirror は作らない。
 - `docs/` は source of truth、`website/` は public reading surface として扱う。
 - 数学本文、Lean status、proof obligation、tooling claim、empirical hypothesis を混同しない。
-- AAT は formal theory article を章クラスタ単位で分割して見せる。
-- SFT は theory site / research monograph として Part 単位で見せる。
+- AAT は first-class formal theory article として、`docs/aat/mathematical_theory.md`
+  に忠実な論文調の本文を章クラスタ単位で見せる。
+- SFT は first-class research monograph として、`docs/sft/software_field_theory.md`
+  に忠実な論文調の本文を Part 単位で見せる。
+- AAT / SFT page は marketing summary や一般向け article ではなく、定義、前提、
+  theorem boundary、non-conclusions、例、Lean status への接続を持つ技術本文として書く。
 - ArchSig は standalone manual / reference section として扱う。
 - Hashnode / Zenn / Qiita は outreach 導線であり、canonical claim の置き場にしない。
 
@@ -161,6 +165,9 @@ SEO 用の `sitemap.xml` ではない。
 - Do not add a language switch unless a real Japanese site strategy exists.
 - Japanese explanations should live as outreach articles on Qiita, Zenn, Hashnode, or similar media.
 - Outreach articles should point back to the canonical English page for formal claims.
+- Outreach articles may simplify motivation, but AAT / SFT website pages should
+  keep paper-level precision and should not omit assumptions or theorem
+  boundaries for readability.
 - AAT / SFT terminology should not be translated aggressively. Keep core terms such as `ArchitectureObject`, `Invariant`, `ObstructionWitness`, `ArchitectureSignature`, `ForecastCone`, and `ConsequenceEnvelope` in English when that avoids ambiguity.
 - Japanese articles may explain motivation and intuition, but theorem status, claim boundaries, and canonical definitions remain on the English site and repository docs.
 

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -43,8 +43,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../">Home</a>
           <a class="is-active" href="./">AAT</a>
+          <a href="../interface/">Interface</a>
           <a href="../sft/">SFT</a>
-          <a href="../#documents">Interface</a>
           <a href="../archsig/">ArchSig</a>
           <a href="../outreach/">Outreach</a>
           <a href="../profile/">Profile</a>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>
@@ -183,9 +183,9 @@ ArchitectureLawful X
                 <span>Previous</span>
                 <strong>Examples and Boundaries</strong>
               </a>
-              <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+              <a href="../../interface/">
                 <span>Next</span>
-                <strong>AAT / SFT Interface source</strong>
+                <strong>AAT / SFT Interface</strong>
               </a>
             </nav>
           </div>

--- a/website/archsig/artifacts/index.html
+++ b/website/archsig/artifacts/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/boundaries/index.html
+++ b/website/archsig/boundaries/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/commands/index.html
+++ b/website/archsig/commands/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/examples/index.html
+++ b/website/archsig/examples/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/getting-started/index.html
+++ b/website/archsig/getting-started/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/index.html
+++ b/website/archsig/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../">Home</a>
           <a href="../aat/">AAT</a>
+          <a href="../interface/">Interface</a>
           <a href="../sft/">SFT</a>
-          <a href="../#documents">Interface</a>
           <a class="is-active" href="./">ArchSig</a>
           <a href="../outreach/">Outreach</a>
           <a href="../profile/">Profile</a>

--- a/website/archsig/operational-feedback/index.html
+++ b/website/archsig/operational-feedback/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/roadmap/index.html
+++ b/website/archsig/roadmap/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/schemas/index.html
+++ b/website/archsig/schemas/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/archsig/workflows/index.html
+++ b/website/archsig/workflows/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a href="../../sft/">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a class="is-active" href="../">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/assets/site.js
+++ b/website/assets/site.js
@@ -1,4 +1,18 @@
 const navLinks = Array.from(document.querySelectorAll(".site-nav a"));
+
+if (window.location.protocol === "file:") {
+  document.querySelectorAll('a[href$="/"]').forEach((link) => {
+    const href = link.getAttribute("href");
+
+    if (!href || href.startsWith("http")) return;
+
+    link.addEventListener("click", (event) => {
+      event.preventDefault();
+      window.location.href = new URL(`${href}index.html`, window.location.href);
+    });
+  });
+}
+
 const hashNavLinks = navLinks.filter((link) =>
   link.getAttribute("href")?.startsWith("#")
 );

--- a/website/index.html
+++ b/website/index.html
@@ -17,18 +17,6 @@
       rel="stylesheet"
     >
     <link rel="stylesheet" href="assets/site.css">
-    <script>
-      window.MathJax = {
-        tex: {
-          inlineMath: [["\\(", "\\)"]],
-          displayMath: [["\\[", "\\]"]]
-        },
-        chtml: {
-          matchFontHeight: false
-        }
-      };
-    </script>
-    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
     <script defer src="assets/site.js"></script>
   </head>
   <body>
@@ -43,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="#top">Home</a>
           <a href="aat/">AAT</a>
+          <a href="interface/">Interface</a>
           <a href="sft/">SFT</a>
-          <a href="#documents">Interface</a>
           <a href="archsig/">ArchSig</a>
           <a href="outreach/">Outreach</a>
           <a href="profile/">Profile</a>
@@ -73,6 +61,10 @@
                 <span>Local algebra of software architecture.</span>
               </li>
               <li>
+                <strong>Interface</strong>
+                <span>One-way bridge from AAT local algebra to SFT field models.</span>
+              </li>
+              <li>
                 <strong>SFT</strong>
                 <span>Computable theory of field-shaped software evolution.</span>
               </li>
@@ -89,7 +81,7 @@
         <div class="site-shell section-grid">
           <div class="section-heading">
             <p class="eyebrow">Research</p>
-            <h2>Three layers, one claim discipline.</h2>
+            <h2>Four entry points, one claim discipline.</h2>
           </div>
           <div class="research-list" aria-label="Research areas">
             <article class="research-item">
@@ -106,6 +98,19 @@
             </article>
             <article class="research-item">
               <p class="item-index">02</p>
+              <h3>AAT / SFT Interface</h3>
+              <p>
+                The interface fixes the direction of dependency: AAT provides
+                local algebra, while SFT uses that algebra as architecture
+                projections, observables, local law premises, and claim
+                boundaries.
+              </p>
+              <a href="interface/">
+                Read the interface
+              </a>
+            </article>
+            <article class="research-item">
+              <p class="item-index">03</p>
               <h3>Software Field Theory</h3>
               <p>
                 SFT treats software evolution as bounded computation over field
@@ -117,7 +122,7 @@
               </a>
             </article>
             <article class="research-item">
-              <p class="item-index">03</p>
+              <p class="item-index">04</p>
               <h3>ArchSig</h3>
               <p>
                 ArchSig connects repository artifacts to measurable signature
@@ -132,13 +137,54 @@
         </div>
       </section>
 
-      <section id="documents" class="section-band section-band-muted">
+      <section id="reading-paths" class="section-band section-band-muted">
         <div class="site-shell section-grid">
           <div class="section-heading">
-            <p class="eyebrow">Canonical documents</p>
-            <h2>Primary sources live with the repository.</h2>
+            <p class="eyebrow">Reading paths</p>
+            <h2>The nav follows the intended sequence.</h2>
             <p>
-              The public website is a reading surface. The repository documents
+              The top-level pages are not independent slogans. They form the
+              public reading route from formal architecture theory, through the
+              AAT-to-SFT interface, into field-shaped software evolution and
+              bounded observation artifacts.
+            </p>
+          </div>
+          <div class="document-table" role="list">
+            <a role="listitem" href="aat/">
+              <span>For theory readers</span>
+              <strong>Start with AAT, then read the chapter clusters and Lean status.</strong>
+            </a>
+            <a role="listitem" href="interface/">
+              <span>For boundary readers</span>
+              <strong>Use the interface before translating AAT claims into SFT terms.</strong>
+            </a>
+            <a role="listitem" href="sft/">
+              <span>For SFT readers</span>
+              <strong>Read SFT after the dependency and claim boundary are explicit.</strong>
+            </a>
+            <a role="listitem" href="archsig/">
+              <span>For tooling readers</span>
+              <strong>Use ArchSig as measurement and reporting, not theorem promotion.</strong>
+            </a>
+            <a role="listitem" href="outreach/">
+              <span>For public articles</span>
+              <strong>Route outreach essays back to the canonical English pages.</strong>
+            </a>
+            <a role="listitem" href="profile/">
+              <span>For maintainer context</span>
+              <strong>Use the profile for author identity, contact routes, and publication boundary.</strong>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section id="sources" class="section-band">
+        <div class="site-shell section-grid">
+          <div class="section-heading">
+            <p class="eyebrow">Canonical sources</p>
+            <h2>Primary claims still live with the repository.</h2>
+            <p>
+              The public website is a reading surface. Repository documents
               remain the source of truth for definitions, proof status, tooling
               boundaries, and empirical hypotheses.
             </p>
@@ -150,15 +196,15 @@
             </a>
             <a role="listitem" href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md">
               <span>AAT Mathematical Theory</span>
-              <strong>Objects, invariants, witnesses, signatures</strong>
-            </a>
-            <a role="listitem" href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
-              <span>SFT Monograph</span>
-              <strong>Computable software evolution and governance</strong>
+              <strong>Objects, operations, invariants, witnesses, and signatures</strong>
             </a>
             <a role="listitem" href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
               <span>AAT / SFT Interface</span>
-              <strong>One-way dependency and claim translation</strong>
+              <strong>One-way dependency, translation rules, and forbidden readings</strong>
+            </a>
+            <a role="listitem" href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+              <span>SFT Monograph</span>
+              <strong>Computable software evolution, forecast boundaries, and governance</strong>
             </a>
             <a role="listitem" href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md">
               <span>Lean Theorem Index</span>
@@ -168,47 +214,6 @@
               <span>Proof Obligations</span>
               <strong>Future proof work and empirical hypotheses</strong>
             </a>
-          </div>
-        </div>
-      </section>
-
-      <section id="samples" class="section-band">
-        <div class="site-shell notation-grid">
-          <div class="section-heading">
-            <p class="eyebrow">Notation</p>
-            <h2>Math and code should read like first-class content.</h2>
-            <p>
-              The site uses a serif text face for long reading, a restrained
-              sans face for navigation, MathJax for equations, and a dedicated
-              monospace face for Lean-like fragments and reports.
-            </p>
-          </div>
-
-          <div class="sample-stack">
-            <figure class="math-panel">
-              <figcaption>Selected lawfulness bridge</figcaption>
-              <div class="math-block">
-                \[
-                  \operatorname{ArchitectureLawful}(X)
-                  \Longleftrightarrow
-                  \operatorname{RequiredSignatureAxesZero}
-                    (\operatorname{signatureOf}(X))
-                \]
-              </div>
-            </figure>
-
-            <figure class="code-panel">
-              <figcaption>Boundary-aware reading</figcaption>
-              <button class="copy-code" type="button" data-copy-code aria-label="Copy code block">
-                Copy
-              </button>
-              <pre><code>ArchitectureObject
-  + ArchitectureOperation
-  + InvariantFamily
-  + ObstructionWitness
-  + ArchitectureSignature
-  + theorem boundary / non-conclusions</code></pre>
-            </figure>
           </div>
         </div>
       </section>

--- a/website/interface/index.html
+++ b/website/interface/index.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT to SFT interface: one-way dependency, claim translation rules, ArchSig bridge, and forbidden readings."
+    >
+    <title>AAT / SFT Interface</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../assets/site.css">
+    <script defer src="../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../">Home</a>
+          <a href="../aat/">AAT</a>
+          <a class="is-active" href="./">Interface</a>
+          <a href="../sft/">SFT</a>
+          <a href="../archsig/">ArchSig</a>
+          <a href="../outreach/">Outreach</a>
+          <a href="../profile/">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../">Home</a>
+            <span>Interface</span>
+          </nav>
+          <p class="eyebrow">AAT / SFT Interface</p>
+          <h1>A one-way bridge from local algebra to field-shaped evolution.</h1>
+          <p class="lede">
+            AAT provides the local algebra of architecture objects, operations,
+            invariants, witnesses, signatures, and theorem boundaries. SFT uses
+            that algebra as a premise for bounded software-evolution models
+            without making AAT depend on SFT.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Interface page navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#dependency-direction">Dependency direction</a></li>
+                <li><a href="#translation-rules">Translation rules</a></li>
+                <li><a href="#forbidden-readings">Forbidden readings</a></li>
+                <li><a href="#archsig-bridge">ArchSig bridge</a></li>
+                <li><a href="#canonical-sources">Canonical sources</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                    AAT / SFT interface
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md">
+                    AAT mathematical theory
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                    SFT monograph
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                Interface translation preserves claim level. It does not turn
+                AAT theorems into empirical forecasts, ArchSig output into Lean
+                proof, or SFT forecast boundaries into architecture lawfulness.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="dependency-direction" class="article-section">
+              <h2>Dependency direction</h2>
+              <p>
+                The dependency is fixed: AAT does not depend on SFT; SFT
+                depends on AAT. AAT remains an independent mathematical theory
+                of local architecture structure, while SFT reads selected AAT
+                concepts as architecture projections, observable coordinates,
+                local transition premises, and admissibility boundaries.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Direction of dependency</figcaption>
+                <pre><code>AAT -&gt; SFT
+
+AAT provides local algebra.
+SFT uses that algebra to make software evolution computable.</code></pre>
+              </figure>
+            </section>
+
+            <section id="translation-rules" class="article-section">
+              <h2>Translation rules</h2>
+              <p>
+                Interface terms are mappings, not redefinitions. SFT may use
+                AAT vocabulary as local premises and observation axes, but SFT
+                trajectory, forecast, policy, and feedback concepts remain SFT
+                concepts.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong><code>ArchitectureObject</code></strong>
+                  <span>Read in SFT as the architecture projection of a field state.</span>
+                </li>
+                <li>
+                  <strong><code>ArchitectureOperation</code></strong>
+                  <span>Read as a local law premise for an accepted or proposed transition.</span>
+                </li>
+                <li>
+                  <strong><code>InvariantFamily</code></strong>
+                  <span>Read as a constraint family the field attempts to preserve.</span>
+                </li>
+                <li>
+                  <strong><code>ObstructionWitness</code></strong>
+                  <span>Read as a selected unsafe, costly, or blocked trajectory coordinate.</span>
+                </li>
+                <li>
+                  <strong><code>ArchitectureSignature</code></strong>
+                  <span>Read as a partial coordinate system for observing trajectories.</span>
+                </li>
+                <li>
+                  <strong>Theorem boundary / non-conclusions</strong>
+                  <span>Read as the claim boundary that SFT forecasts and governance reports must not cross.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="forbidden-readings" class="article-section">
+              <h2>Forbidden readings</h2>
+              <p>
+                The interface exists to prevent accidental claim promotion.
+                Local architecture facts do not become global software-history
+                facts merely because they are useful premises in an SFT model.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>AAT lawfulness</strong>
+                  <span>Do not read it as future trajectory safety.</span>
+                </li>
+                <li>
+                  <strong>AAT measured zero</strong>
+                  <span>Do not read it as safety for unmeasured axes.</span>
+                </li>
+                <li>
+                  <strong>AAT operation preservation</strong>
+                  <span>Do not read it as global policy safety.</span>
+                </li>
+                <li>
+                  <strong>SFT <code>ForecastCone</code> narrowing</strong>
+                  <span>Do not read it as global risk reduction.</span>
+                </li>
+                <li>
+                  <strong>ArchSig extraction</strong>
+                  <span>Do not read it as a ground-truth architecture object.</span>
+                </li>
+                <li>
+                  <strong>SFT forecast</strong>
+                  <span>Do not read it as a Lean theorem.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="archsig-bridge" class="article-section">
+              <h2>ArchSig bridge</h2>
+              <p>
+                ArchSig is neither AAT nor SFT. It is the observation and
+                reporting layer that maps real repository artifacts into AAT
+                observables and SFT field estimates with explicit measurement
+                status, coverage, warning, and non-conclusion boundaries.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Observation bridge</figcaption>
+                <pre><code>real artifacts
+  -&gt; ArchSig
+  -&gt; AAT observables
+  -&gt; SFT field model</code></pre>
+              </figure>
+              <div class="claim-strip">
+                <p>
+                  ArchSig output can guide review and forecasting work. It does
+                  not strengthen an AAT theorem or make an SFT forecast into a
+                  theorem.
+                </p>
+              </div>
+            </section>
+
+            <section id="canonical-sources" class="article-section">
+              <h2>Canonical sources</h2>
+              <p>
+                This page summarizes the interface for the public site. The
+                repository document remains the authoritative statement of the
+                mapping tables, claim levels, and non-confusion rules.
+              </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                    AAT / SFT interface source
+                  </a>
+                  <span>Full dependency, translation, non-confusion, and ArchSig bridge rules.</span>
+                </li>
+                <li>
+                  <a href="../aat/status/">
+                    AAT Lean Status
+                  </a>
+                  <span>How to read proved declarations, defined-only surfaces, and proof obligations.</span>
+                </li>
+                <li>
+                  <a href="../sft/">
+                    Software Field Theory
+                  </a>
+                  <span>Computable software evolution after the interface boundary is explicit.</span>
+                </li>
+              </ul>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../aat/status/">
+                <span>Previous</span>
+                <strong>AAT Lean Status</strong>
+              </a>
+              <a href="../sft/">
+                <span>Next</span>
+                <strong>Software Field Theory</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/outreach/index.html
+++ b/website/outreach/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../">Home</a>
           <a href="../aat/">AAT</a>
+          <a href="../interface/">Interface</a>
           <a href="../sft/">SFT</a>
-          <a href="../#documents">Interface</a>
           <a href="../archsig/">ArchSig</a>
           <a class="is-active" href="./">Outreach</a>
           <a href="../profile/">Profile</a>

--- a/website/profile/index.html
+++ b/website/profile/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../">Home</a>
           <a href="../aat/">AAT</a>
+          <a href="../interface/">Interface</a>
           <a href="../sft/">SFT</a>
-          <a href="../#documents">Interface</a>
           <a href="../archsig/">ArchSig</a>
           <a href="../outreach/">Outreach</a>
           <a class="is-active" href="./">Profile</a>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../">Home</a>
           <a href="../aat/">AAT</a>
+          <a href="../interface/">Interface</a>
           <a class="is-active" href="./">SFT</a>
-          <a href="../#documents">Interface</a>
           <a href="../archsig/">ArchSig</a>
           <a href="../outreach/">Outreach</a>
           <a href="../profile/">Profile</a>
@@ -211,9 +211,9 @@
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../aat/status/">
+              <a href="../interface/">
                 <span>Previous</span>
-                <strong>AAT Lean Status</strong>
+                <strong>AAT / SFT Interface</strong>
               </a>
               <a href="part-i-new-object/">
                 <span>Next</span>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -31,8 +31,8 @@
         <nav class="site-nav" aria-label="Primary navigation">
           <a href="../../">Home</a>
           <a href="../../aat/">AAT</a>
+          <a href="../../interface/">Interface</a>
           <a class="is-active" href="../">SFT</a>
-          <a href="../../#documents">Interface</a>
           <a href="../../archsig/">ArchSig</a>
           <a href="../../outreach/">Outreach</a>
           <a href="../../profile/">Profile</a>


### PR DESCRIPTION
## 概要

Closes #775

website のトップ導線と global nav を `AAT -> Interface -> SFT` の読み順に合わせ、`/interface/` route を追加しました。あわせて、AAT / SFT pages を Zenn / Hashnode / Qiita 向けの一般解説ではなく、canonical docs に忠実な first-class theory surface として増補する方針を `website/README.md` と `website/SITEMAP.md` に明記しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/index.html`
- `website/interface/index.html`
- `website/assets/site.js`
- `website/README.md`
- `website/SITEMAP.md`
- `website/aat/**/index.html`
- `website/sft/**/index.html`
- `website/archsig/**/index.html`
- `website/outreach/index.html`
- `website/profile/index.html`

## 実施したテスト

- [ ] `lake build` - website-only の変更で Lean source / import に影響しないため未実施
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `node --check website/assets/site.js`
- [x] website local link resolution check
- [x] local HTTP HEAD check: `/`, `/interface/`, `/sft/`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした、または Lean theorem 変更なしとして扱った
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている