### PR TITLE
AAT章ページをcanonical theoryに沿って増補する

### DIFF
--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -68,6 +68,9 @@
                 <li><a href="#architecture-operation">Architecture operation</a></li>
                 <li><a href="#operation-laws">Operation laws</a></li>
                 <li><a href="#feature-extension">Feature extension</a></li>
+                <li><a href="#operation-families">Operation families</a></li>
+                <li><a href="#extension-evidence">Extension evidence</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -154,6 +157,79 @@
                 <p>
                   The formula is explanatory, not a disjoint decomposition. One
                   measured witness can belong to multiple obstruction classes.
+                </p>
+              </div>
+            </section>
+
+            <section id="operation-families" class="article-section">
+              <h2>Operation families</h2>
+              <p>
+                The calculus treats common refactoring and architecture moves
+                as operation families sharing the same boundary-indexed shape.
+                `compose`, `replace`, `refine`, `abstract`, `split`, `merge`,
+                `isolate`, `protect`, `migrate`, `reverse`, `contract`,
+                `repair`, and `synthesize` can each be useful, but the family
+                name is not itself a proof.
+              </p>
+              <p>
+                Each operation needs its own support, precondition, transition
+                relation, invariant preservation claim, witness mapping, and
+                non-conclusions. A replacement theorem, a migration theorem,
+                and a protection theorem may share notation while requiring
+                different observation and exactness assumptions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Boundary-indexed operation</figcaption>
+                <pre><code>operation tag
+  + selected support
+  + precondition
+  + invariant family
+  + witness mapping
+  + theorem boundary
+  -&gt; bounded conclusion</code></pre>
+              </figure>
+            </section>
+
+            <section id="extension-evidence" class="article-section">
+              <h2>Extension evidence</h2>
+              <p>
+                A base `FeatureExtension` only says that an existing core has
+                been embedded into a larger object with a feature view. Stronger
+                readings require additional evidence packages: static split,
+                declared interface use, selected feature-view section laws,
+                lifting data, runtime preservation, and semantic preservation.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>StaticSplitFeatureExtension</strong>
+                  <span>Evidence about static relations and boundary policy for the extension.</span>
+                </li>
+                <li>
+                  <strong>FeatureViewSectionPackage</strong>
+                  <span>Evidence that the feature view reads the selected feature correctly under the observation model.</span>
+                </li>
+                <li>
+                  <strong>SplitExtensionLiftingData</strong>
+                  <span>Evidence that selected feature steps lift through the declared interface.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                The Lean API contains defined operation schemas, accessor
+                theorems, bounded calculus laws, feature-extension structures,
+                split-extension lifting APIs, and structural extension formula
+                entrypoints. Some components are proved theorem packages and
+                some remain defined-only APIs or docs-facing metadata.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  The structural extension formula explains obstruction
+                  sources; it is not a disjoint decomposition, not a global
+                  witness-completeness theorem, and not evidence that every
+                  feature extension is safe.
                 </p>
               </div>
             </section>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -68,6 +68,9 @@
                 <li><a href="#canonical-examples">Canonical examples</a></li>
                 <li><a href="#counterexamples">Counterexamples</a></li>
                 <li><a href="#aat-boundary">AAT boundary</a></li>
+                <li><a href="#coupon-reading">Coupon reading</a></li>
+                <li><a href="#solid-boundary">SOLID boundary</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -150,6 +153,73 @@ all axes are non-increasing</code></pre>
                   Empirical cost and product outcome readings belong to
                   separate empirical protocols, not to the required zero-axis
                   theorem package.
+                </p>
+              </div>
+            </section>
+
+            <section id="coupon-reading" class="article-section">
+              <h2>Coupon reading</h2>
+              <p>
+                The coupon example is intentionally small enough to expose the
+                theorem boundary. A static report can measure whether coupon
+                code bypasses a declared payment interface. A semantic report
+                can measure whether discount and rounding observations commute.
+                A runtime report can measure retry, cache, or callback
+                exposure. These are connected readings, not one measurement.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Layered example reading</figcaption>
+                <pre><code>static direct adapter call
+  -&gt; static obstruction witness
+
+different rounding trace
+  -&gt; semantic obstruction witness
+
+retry leaks across boundary
+  -&gt; runtime obstruction witness</code></pre>
+              </figure>
+            </section>
+
+            <section id="solid-boundary" class="article-section">
+              <h2>SOLID boundary</h2>
+              <p>
+                SOLID-style contracts are useful local law packages, but they
+                are not a complete architecture theory. A component can satisfy
+                selected substitution tests and interface separation checks
+                while the abstract dependency layer is cyclic. Conversely, a
+                layered graph can be acyclic while selected LSP observations
+                still fail.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Local success</strong>
+                  <span>A selected client context or interface contract satisfies its observation law.</span>
+                </li>
+                <li>
+                  <strong>Global failure</strong>
+                  <span>Layering, decomposition, acyclicity, or boundary preservation fails outside the local contract.</span>
+                </li>
+                <li>
+                  <strong>Cross-layer caution</strong>
+                  <span>One law family cannot be promoted into another without a theorem boundary.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                The theorem index records proved SOLID-style counterexamples,
+                static / semantic counterexamples, flatness packages, and
+                coupon-oriented bridge APIs. Their purpose on this page is to
+                fix non-implications, not to claim that every real repository
+                example has been extracted completely.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Counterexamples are positive theory content. They identify
+                  which slogan-like implications are invalid and keep public
+                  explanations aligned with the bounded Lean status.
                 </p>
               </div>
             </section>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -68,6 +68,9 @@
                 <li><a href="#central-proposition">Central proposition</a></li>
                 <li><a href="#architecture-object">Architecture object</a></li>
                 <li><a href="#universe-boundary">Universe boundary</a></li>
+                <li><a href="#formal-reading">Formal reading</a></li>
+                <li><a href="#example-boundary">Example boundary</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -160,6 +163,79 @@
                   finite propagation, nilpotence, and spectral conditions are
                   connected by separate theorems or representations, not mixed
                   into the definition.
+                </p>
+              </div>
+            </section>
+
+            <section id="formal-reading" class="article-section">
+              <h2>Formal reading</h2>
+              <p>
+                The foundational move is to replace an unbounded repository
+                question with a typed object plus explicit evidence scope. A
+                static dependency graph, a runtime graph, an abstraction policy,
+                and a semantic observation model may all present the same
+                bounded `ArchitectureObject`, but none of those presentations
+                is automatically complete.
+              </p>
+              <p>
+                This is why `ArchitectureCore` is read as an evidence-aware
+                carrier rather than as the architecture itself. The map from a
+                core presentation to the object it presents is not assumed to be
+                injective or complete: two presentations can be equivalent under
+                the selected observation, and either presentation can omit
+                relations outside its coverage boundary.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Relativized object claim</figcaption>
+                <pre><code>ArchitectureObject claim
+  = selected carrier
+  + selected policy
+  + selected observation context
+  + coverage and exactness boundary</code></pre>
+              </figure>
+            </section>
+
+            <section id="example-boundary" class="article-section">
+              <h2>Example boundary</h2>
+              <p>
+                A repository slice containing a coupon service, a payment
+                interface, and a payment adapter can be a valid component
+                universe for a static split theorem. That same slice is not, by
+                itself, evidence about runtime retries, cache invalidation,
+                rounding order, or operational incidents. Those require their
+                own observation contexts.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Measured zero</strong>
+                  <span>No selected violating relation was found inside the chosen universe and exactness boundary.</span>
+                </li>
+                <li>
+                  <strong>Unmeasured outside</strong>
+                  <span>No claim is made about components, relations, effects, or observations outside that boundary.</span>
+                </li>
+                <li>
+                  <strong>Presentation equivalence</strong>
+                  <span>Different carriers can present the same object only relative to the selected observation model.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                The Lean side already fixes the static graph, reachability,
+                layering, decomposability, thin-category, finite-universe, and
+                bridge vocabulary used by this page. The important boundary is
+                that these declarations do not certify complete extraction from
+                a real repository.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Read the current QED core through the AAT Status page:
+                  static structural bridge theorems are proved under explicit
+                  assumptions, while real-code extraction completeness remains
+                  outside the theorem claim.
                 </p>
               </div>
             </section>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -67,6 +67,9 @@
                 <li><a href="#invariant-families">Invariant families</a></li>
                 <li><a href="#obstruction-witnesses">Obstruction witnesses</a></li>
                 <li><a href="#zero-curvature">Zero-curvature reading</a></li>
+                <li><a href="#law-universe">Law universe</a></li>
+                <li><a href="#examples">Examples</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -161,6 +164,75 @@ violationCount bad xs = 0
                   SOLID is not treated as a universal architecture principle.
                   It is one local-contract family among distinct global,
                   state-transition, runtime, and distributed invariant families.
+                </p>
+              </div>
+            </section>
+
+            <section id="law-universe" class="article-section">
+              <h2>Law universe</h2>
+              <p>
+                A `LawUniverse` collects required laws, optional laws, derived
+                laws, witness families, and the observation boundary used to
+                read them. AAT does not identify lawfulness with witness
+                absence at the definition level; the equivalence is a theorem
+                package that needs completeness and exactness assumptions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Lawful-within reading</figcaption>
+                <pre><code>ArchitectureLawfulWithin X B
+  := SemanticLawful X B.lawUniverse
+     under B.coverage / B.exactness / B.observation</code></pre>
+              </figure>
+              <p>
+                This distinction prevents a finite report from silently turning
+                into a global claim. The report may certify the absence of
+                selected required witnesses; the theorem boundary states when
+                that absence is enough to read semantic lawfulness inside the
+                chosen universe.
+              </p>
+            </section>
+
+            <section id="examples" class="article-section">
+              <h2>Examples</h2>
+              <p>
+                A local LSP contract can be lawful for selected client
+                contexts while the overall dependency graph remains cyclic. A
+                layered ranking can be lawful for static dependencies while a
+                runtime callback still crosses a protected boundary. A Saga law
+                can hold for a compensation relation without proving anything
+                about distributed convergence.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Local contract witness</strong>
+                  <span>An observation mismatch for a selected client context.</span>
+                </li>
+                <li>
+                  <strong>Global structure witness</strong>
+                  <span>A forbidden dependency direction, cycle, or boundary crossing in the selected static universe.</span>
+                </li>
+                <li>
+                  <strong>Runtime witness</strong>
+                  <span>A propagation, exposure, retry, or protection failure in a separate runtime observation layer.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                The generic witness-count kernel and required law / axis
+                exactness bridge are part of the current proved static core.
+                The broader design-principle classification remains a boundary
+                discipline: SOLID, Layered, Clean Architecture, Event Sourcing,
+                Saga, Circuit Breaker, and Replicated Log are organized as
+                different invariant families, not one Lean theorem scheme.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A zero witness count means zero selected bad witnesses in the
+                  measured finite universe. It does not erase unmeasured axes,
+                  optional laws, runtime evidence gaps, or empirical risk.
                 </p>
               </div>
             </section>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -68,6 +68,9 @@
                 <li><a href="#projection-observation">Projection and observation</a></li>
                 <li><a href="#lsp-dip">LSP and DIP</a></li>
                 <li><a href="#three-layer-flatness">Three-layer flatness</a></li>
+                <li><a href="#assumption-strength">Assumption strength</a></li>
+                <li><a href="#contract-example">Contract example</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -155,6 +158,80 @@ ker(F) &lt;= ker(Obs)</code></pre>
   + no unmeasured required axis
   + coverage / exactness boundary</code></pre>
               </figure>
+            </section>
+
+            <section id="assumption-strength" class="article-section">
+              <h2>Assumption strength</h2>
+              <p>
+                Projection claims come in different strengths. `ProjectionSound`
+                says concrete dependency evidence is represented abstractly.
+                `ProjectionComplete` says abstract dependencies have concrete
+                representatives. `ProjectionExact` and
+                `RepresentativeStable` add stronger assumptions needed for
+                quotient-style or replacement-style readings.
+              </p>
+              <p>
+                The page therefore separates local abstraction soundness from
+                global layering. A DIP-style statement may be true because
+                concrete calls depend on declared interfaces, while the
+                interface layer itself still contains a cycle or a semantic
+                mismatch outside the local contract.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Strength ladder</figcaption>
+                <pre><code>ProjectionSound
+  does not imply
+ProjectionComplete
+  does not imply
+ProjectionExact + RepresentativeStable</code></pre>
+              </figure>
+            </section>
+
+            <section id="contract-example" class="article-section">
+              <h2>Contract example</h2>
+              <p>
+                In a coupon extension, replacing a discount implementation by
+                another implementation can be LSP-sound for selected checkout
+                clients if the observed totals, rounding trace, and error
+                behavior remain equivalent. That does not prove that the
+                coupon service respects a global dependency ranking, nor that
+                background jobs, caches, or payment callbacks preserve the same
+                observations.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Client context universe</strong>
+                  <span>The selected callers and call shapes for which substitutability is checked.</span>
+                </li>
+                <li>
+                  <strong>Observation equivalence</strong>
+                  <span>The chosen equality or tolerance on visible behavior.</span>
+                </li>
+                <li>
+                  <strong>Missing layer claim</strong>
+                  <span>Runtime and semantic flatness require separate evidence packages.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                Projection / DIP bridges and finite observation / LSP
+                violation-count bridges are tracked as Lean APIs and theorem
+                packages. Three-layer flatness is a boundary discipline: static
+                flatness, runtime flatness, and semantic flatness remain
+                separate claims unless a theorem boundary explicitly connects
+                them.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Soundness-only projection is enough for some local readings,
+                  but exactness, completeness, and representative stability are
+                  separate assumptions and should not be inferred from the
+                  word "projection" alone.
+                </p>
+              </div>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -67,6 +67,9 @@
                 <li><a href="#repair">Repair and synthesis</a></li>
                 <li><a href="#complexity-transfer">Complexity transfer</a></li>
                 <li><a href="#paths-and-filling">Paths and filling</a></li>
+                <li><a href="#no-solution">No-solution boundary</a></li>
+                <li><a href="#path-example">Path example</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -152,6 +155,77 @@
                 <pre><code>Obs(lhs) != Obs(rhs)
   -&gt; NonFillabilityWitness D</code></pre>
               </figure>
+            </section>
+
+            <section id="no-solution" class="article-section">
+              <h2>No-solution boundary</h2>
+              <p>
+                Synthesis can produce a candidate object, a repair sequence, or
+                a no-solution certificate. The last case is the strongest and
+                therefore needs the clearest boundary: a finite complete search
+                universe, an explicit constraint language, a decision
+                procedure, refuted candidate cases, and coverage assumptions.
+              </p>
+              <p>
+                Solver failure alone is not a mathematical certificate. It may
+                be a tooling result, a timeout, or an unsupported-construct
+                boundary. AAT keeps those cases separate from a proved
+                no-solution theorem.
+              </p>
+              <figure class="code-panel">
+                <figcaption>No-solution certificate</figcaption>
+                <pre><code>finite complete candidate universe
+  + explicit constraints
+  + decision procedure
+  + refuted candidates
+  + coverage boundary
+  -&gt; no selected solution</code></pre>
+              </figure>
+            </section>
+
+            <section id="path-example" class="article-section">
+              <h2>Path example</h2>
+              <p>
+                Two coupon implementations can reach the same visible checkout
+                result while following different paths: one introduces a
+                declared discount interface first, then adds the feature; the
+                other adds a direct adapter call and later repairs the static
+                graph. The final feature may look equivalent while the witness
+                history and signature trajectory differ.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Path invariant</strong>
+                  <span>A property preserved at every step of the selected operation sequence.</span>
+                </li>
+                <li>
+                  <strong>Homotopy generator</strong>
+                  <span>A permitted rewrite between operation fragments under a selected observation model.</span>
+                </li>
+                <li>
+                  <strong>Non-fillability witness</strong>
+                  <span>Evidence that two paths fail to agree on the selected observation.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                Repair steps, repair synthesis, architecture paths, homotopy
+                skeletons, diagram fillers, non-fillability witnesses, and
+                selected observation-invariance bridges are tracked in the Lean
+                theorem index. The public reading is bounded: global semantic
+                completeness and all-axis improvement are not current
+                conclusions.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A repair theorem may prove a selected measure decreases. It
+                  does not prove total architecture improvement unless the
+                  theorem boundary explicitly covers every relevant axis.
+                </p>
+              </div>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -68,6 +68,9 @@
                 <li><a href="#graph-matrix">Graph and matrix</a></li>
                 <li><a href="#analytic-representation">Analytic representation</a></li>
                 <li><a href="#state-effects">State transitions and effects</a></li>
+                <li><a href="#valuation-boundary">Valuation boundary</a></li>
+                <li><a href="#effect-examples">Effect examples</a></li>
+                <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -153,6 +156,77 @@
 compensate ; action ~= id
 decode ; encode ~= id</code></pre>
               </figure>
+            </section>
+
+            <section id="valuation-boundary" class="article-section">
+              <h2>Valuation boundary</h2>
+              <p>
+                `ObstructionValuation` maps selected witnesses to numeric or
+                ordered values. Aggregates can be useful for dashboards, but an
+                aggregate zero reflects witness-level zero only when the value
+                domain and aggregation are zero-reflecting under the selected
+                assumptions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Zero reflection guard</figcaption>
+                <pre><code>witnesses -&gt; values -&gt; aggregate
+
+aggregate = 0
+  + zero-reflecting valuation
+  + complete selected witness coverage
+  -&gt; selected witnesses are zero</code></pre>
+              </figure>
+              <p>
+                This is the same boundary discipline as matrix and analytic
+                representations: preserving zero is weaker than reflecting
+                zero, and reflecting an obstruction requires coverage and
+                semantic contract assumptions.
+              </p>
+            </section>
+
+            <section id="effect-examples" class="article-section">
+              <h2>Effect examples</h2>
+              <p>
+                A dependency graph may show that checkout depends only on a
+                payment interface, while the effect layer reveals a hidden
+                authority boundary: a retry command is not idempotent, a
+                compensation does not undo the action, a snapshot omits a
+                required event, or a migration fails to commute with the old
+                projection.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Replay law</strong>
+                  <span>Projection after appending events agrees with replaying the prior projection through those events.</span>
+                </li>
+                <li>
+                  <strong>Compensation law</strong>
+                  <span>A compensation sequence is observationally equivalent to the relevant identity behavior.</span>
+                </li>
+                <li>
+                  <strong>Migration naturality</strong>
+                  <span>Old and new projections commute with the migration relation under stated assumptions.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="lean-status" class="article-section">
+              <h2>Lean status</h2>
+              <p>
+                Matrix bridges, finite-universe bridges, analytic
+                representation strength APIs, and state-transition / effect
+                boundary laws are indexed separately. Cost interpretation,
+                runtime completeness, and empirical outcome claims remain
+                outside the structural theorem package.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  Acyclicity, closed-walk absence, and adjacency nilpotence are
+                  connected for finite unweighted structure. They are not the
+                  definition of `Decomposable`, and they do not by themselves
+                  settle finite propagation or runtime semantics.
+                </p>
+              </div>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -67,6 +67,9 @@
                 <li><a href="#signature">Architecture Signature</a></li>
                 <li><a href="#measurement-status">Measurement status</a></li>
                 <li><a href="#theorem-boundary">Theorem boundary</a></li>
+                <li><a href="#claim-levels">Claim levels</a></li>
+                <li><a href="#comparison-rules">Comparison rules</a></li>
+                <li><a href="#non-conclusions">Non-conclusions</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -156,6 +159,71 @@
                 <p>
                   Static split does not imply runtime or semantic flatness, and
                   absence of a selected witness does not imply global absence.
+                </p>
+              </div>
+            </section>
+
+            <section id="claim-levels" class="article-section">
+              <h2>Claim levels</h2>
+              <p>
+                A signature coordinate is not only a number. It also carries a
+                claim level and a measurement boundary. A formal coordinate is
+                backed by a theorem boundary; a tooling coordinate is produced
+                by an extractor or validator; an empirical coordinate belongs
+                to a dataset or calibration protocol; a hypothesis is a future
+                research claim.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>formal</strong>
+                  <span>A Lean-backed or theorem-boundary-backed statement under explicit assumptions.</span>
+                </li>
+                <li>
+                  <strong>tooling</strong>
+                  <span>An artifact produced by a scanner, validator, report, or workflow with its own evidence boundary.</span>
+                </li>
+                <li>
+                  <strong>empirical / hypothesis</strong>
+                  <span>A repository, operation, or outcome claim that is not promoted to theorem status.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="comparison-rules" class="article-section">
+              <h2>Comparison rules</h2>
+              <p>
+                Signature comparison is axis-local. Two reports are comparable
+                only where the same axis is present on both sides, measured
+                under compatible assumptions, and equipped with a meaningful
+                order. Missing evidence, private evidence, or a changed
+                measurement universe breaks that comparison rather than
+                contributing a numeric zero.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Comparable-axis guard</figcaption>
+                <pre><code>ComparableAxes(S1, S2)
+  + MeasuredOnBoth(axis)
+  + AxisOrder(axis)
+  + compatible boundary
+  -&gt; compare selected measured axes</code></pre>
+              </figure>
+            </section>
+
+            <section id="non-conclusions" class="article-section">
+              <h2>Non-conclusions</h2>
+              <p>
+                `ArchitectureSignature` does not rank architectures by one
+                scalar quality value. It does not make unmeasured axes safe,
+                turn private evidence into measured zero, infer runtime or
+                semantic flatness from a static split, or claim empirical cost
+                reduction from a formal zero-axis theorem.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  The public site treats Signature as a multi-axis diagnostic.
+                  Any product, cost, or workflow reading must preserve the
+                  theorem boundary and the artifact boundary that produced the
+                  coordinate.
                 </p>
               </div>
             </section>


### PR DESCRIPTION
## 概要

Closes #772

- `website/aat/` 配下の 8 章ページに、canonical AAT theory に沿った definition / formal reading / examples / non-conclusions / Lean status 接続を追加した。
- `ArchitectureSignature` は単一スコアではなく multi-axis diagnostic として扱い、tooling / empirical / theorem claim の境界を維持した。
- Lean 変更はなく、Lean status は docs expansion / theorem-boundary preserving exposition。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/foundations/index.html`
- `website/aat/laws-and-witnesses/index.html`
- `website/aat/signature-and-boundary/index.html`
- `website/aat/local-law-packages/index.html`
- `website/aat/calculus-and-extensions/index.html`
- `website/aat/repair-and-dynamics/index.html`
- `website/aat/representations-and-effects/index.html`
- `website/aat/examples-and-boundaries/index.html`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan: 該当なし
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan: 変更対象 HTML で該当なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
