### PR TITLE
SFT Part ページを canonical monograph に沿って増補

### DIFF
--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -540,7 +540,7 @@ AAT / SFT / ArchSig / Outreach / Profile は期待される成熟度が違うた
 | `/aat/status/` | implemented | proved / defined only / future proof obligation を読むための status appendix。 | route and status overview implemented。 | AAT chapter 増補後、本文からの参照と theorem index への導線を点検する。 |
 | `/interface/` | implemented | AAT theorem claim と SFT empirical / computational claim の translation boundary。 | route and boundary overview implemented。 | AAT / SFT 本文増補後、禁止される読み替えと依存方向の記述を再点検する。 |
 | `/sft/` landing | implemented | SFT の読む順序、computable object と claim boundary の入口。 | route and overview implemented。 | 子 Part の増補に合わせて computational reading と source docs への導線を維持する。 |
-| `/sft/part-*/` pages | implemented | canonical SFT monograph に忠実な research exposition。 | route implemented, overview-level content。 | #773 で定義、formal / computational reading、examples、claim boundary、non-conclusions、running example を Part ごとに増補する。 |
+| `/sft/part-*/` pages | implemented | canonical SFT monograph に忠実な research exposition。 | monograph-level exposition implemented with definitions, computational readings, examples, claim boundaries, non-conclusions, and running example connections。 | W3 で AAT theorem status と SFT empirical / forecast status の境界導線を継続点検する。 |
 | `/archsig/` and `/archsig/*/` | implemented | standalone manual / reference。tool output と formal claim を区別し、CLI、artifact、schema、workflow を読める。 | Core / Review / SFT / Operational surface と remaining gaps を整理済み。 | W3 で cross-link と boundary wording を継続点検する。 |
 | `/outreach/` | implemented | canonical technical pages へ戻す outreach index。 | route implemented。 | article が増えた時点でリンクと canonical return path を更新する。 |
 | `/profile/` | implemented | author profile and contact surface。 | route implemented。 | 研究成果・公開活動の変化に応じて更新する。 |
@@ -553,9 +553,9 @@ W2 first-class theory / manual surface:
     - route implementation for AAT, SFT, Interface, ArchSig, Outreach, Profile
     - content maturity tracking in this document
     - #774 ArchSig / tool docs: product surface and remaining gaps
+    - #773 SFT Part pages: monograph-level canonical exposition
   remaining:
     - #772 AAT chapter pages: paper-level canonical exposition
-    - #773 SFT Part pages: monograph-level canonical exposition
 
 W3 cross-link and boundary hardening:
   remaining:

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -108,6 +108,12 @@
                 theory without losing the boundary between exposition,
                 formalizable schema, tooling estimates, and empirical work.
               </p>
+              <p>
+                Each Part page follows the same contract: it states the local
+                definitions, gives the formal or computational reading, names
+                examples and the coupon PRD running thread where relevant, and
+                keeps non-conclusions visible beside the positive claims.
+              </p>
               <ul class="chapter-list">
                 <li>
                   <a href="part-i-new-object/">Part I. The New Object</a>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -68,6 +68,7 @@
                 <li><a href="#field-memory">Field memory</a></li>
                 <li><a href="#development-field">Development field</a></li>
                 <li><a href="#architecture-futures">Architecture futures</a></li>
+                <li><a href="#part-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -113,6 +114,21 @@
                 supplies observation, and SFT asks how future operation space
                 changes under artifacts and feedback.
               </p>
+              <figure class="code-panel">
+                <figcaption>Computable in SFT</figcaption>
+                <pre><code>computable :=
+  representable under an explicit modeling boundary
+  + bounded by a selected horizon, universe, and observation axes
+  + reducible to reachability, support inference,
+    cone generation, safety preservation,
+    proposal accounting, feedback update, or calibration</code></pre>
+              </figure>
+              <p>
+                This is a bounded-computation claim. SFT does not say the real
+                project history is fully decidable; it says selected questions
+                can be made finite, auditable, and explicitly relative to the
+                evidence and horizon that were chosen.
+              </p>
             </section>
 
             <section id="field-memory" class="article-section">
@@ -153,6 +169,16 @@
                 partial `SoftwareFieldEstimate` that records selected evidence,
                 unavailable evidence, and the unknown remainder.
               </p>
+              <figure class="code-panel">
+                <figcaption>Boundary-aware estimate</figcaption>
+                <pre><code>model_B : DevelopmentField -> Partial SoftwareFieldEstimate
+
+SoftwareFieldEstimate
+  = modeling boundary
+  + extracted SoftwareField
+  + evidence status
+  + unknown / unmodeled remainder</code></pre>
+              </figure>
               <div class="claim-strip">
                 <p>
                   The wide development field is the scope. The computable core
@@ -183,6 +209,30 @@
                 several paths visible: lawful policy insertion, payment adapter
                 shortcut, UI-only drift, and rounding semantics obstruction.
               </p>
+            </section>
+
+            <section id="part-boundary" class="article-section">
+              <h2>Claim boundary and non-conclusions</h2>
+              <p>
+                Part I introduces the object and its modeling discipline. It
+                does not prove that all relevant development context can be
+                extracted from a repository, that a field estimate is complete,
+                or that a reachable future is an empirical prediction.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Definition level</strong>
+                  <span>`DevelopmentField`, `SoftwareFieldEstimate`, `ArchitectureFuture`, and `SignatureTrajectory` are vocabulary for bounded modeling.</span>
+                </li>
+                <li>
+                  <strong>Computational reading</strong>
+                  <span>Inputs are selected artifacts, code regions, observations, governance records, unavailable evidence, and a horizon.</span>
+                </li>
+                <li>
+                  <strong>Running example</strong>
+                  <span>The coupon PRD is used as an artifact action whose possible paths are constrained only after the boundary is stated.</span>
+                </li>
+              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -67,6 +67,7 @@
                 <li><a href="#aat-dependency">AAT dependency</a></li>
                 <li><a href="#archsig-bridge">ArchSig bridge</a></li>
                 <li><a href="#claim-levels">Claim levels</a></li>
+                <li><a href="#basis-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -122,6 +123,16 @@
                 <pre><code>AAT does not depend on SFT.
 SFT depends on AAT.</code></pre>
               </figure>
+              <figure class="code-panel">
+                <figcaption>Minimal interface map</figcaption>
+                <pre><code>architecture projection   -> ArchitectureObject
+local transition law     -> ArchitectureOperation
+protected constraint     -> InvariantFamily
+defect / repair target   -> ObstructionWitness
+observable coordinate    -> ArchitectureSignature
+admissibility boundary   -> theorem boundary / non-conclusions
+local path skeleton      -> ArchitecturePath</code></pre>
+              </figure>
             </section>
 
             <section id="archsig-bridge" class="article-section">
@@ -144,6 +155,21 @@ SFT depends on AAT.</code></pre>
                 and axis-wise comparison is available. Unmeasured does not mean
                 zero, and tool output is not a theorem.
               </p>
+              <figure class="code-panel">
+                <figcaption>ArchSigSFTReport</figcaption>
+                <pre><code>ArchSigSFTReport
+  = action_class_candidates
+  + target_architecture_regions
+  + candidate_operation_families
+  + comparable_signature_axes
+  + expected_axis_delta_ranges
+  + selected_obstruction_witness_families
+  + missing_invariants
+  + theorem_boundary_items
+  + forecast_boundary
+  + unknown_unmodeled_remainder
+  + claim_level</code></pre>
+              </figure>
             </section>
 
             <section id="claim-levels" class="article-section">
@@ -172,6 +198,12 @@ SFT depends on AAT.</code></pre>
                   <span>Transition-kernel models, calibrated forecasts, or deployed closed-loop governance systems.</span>
                 </li>
               </ul>
+              <p>
+                The levels keep three claims apart: a formal AAT theorem, a
+                set-valued SFT schema over an explicit support relation, and an
+                empirical forecast validated against traces or deployed
+                outcomes.
+              </p>
               <div class="claim-strip">
                 <p>
                   A good specification may narrow a cone under support
@@ -179,6 +211,31 @@ SFT depends on AAT.</code></pre>
                   not an empirical prediction theorem.
                 </p>
               </div>
+            </section>
+
+            <section id="basis-boundary" class="article-section">
+              <h2>Basis boundary and non-conclusions</h2>
+              <p>
+                Part II is the bridge layer, so its main job is preventing
+                category errors. ArchSig evidence may inform a field estimate,
+                but it is not a Lean proof. AAT theorem status may supply a
+                local premise, but it is not automatically software evolution
+                forecast status.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Formal claim</strong>
+                  <span>Lives in AAT or in a set-valued SFT schema with stated support and step semantics.</span>
+                </li>
+                <li>
+                  <strong>Tooling estimate</strong>
+                  <span>Records measured axes, missing axes, evidence boundaries, and non-conclusions.</span>
+                </li>
+                <li>
+                  <strong>Empirical forecast</strong>
+                  <span>Requires trace or dataset calibration; it is not obtained by renaming a theorem.</span>
+                </li>
+              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -70,6 +70,7 @@
                 <li><a href="#support-policy">Support and policy</a></li>
                 <li><a href="#forecast-envelope">Forecast and envelope</a></li>
                 <li><a href="#feedback">Feedback update</a></li>
+                <li><a href="#core-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -104,6 +105,20 @@
                 <figcaption>Field projection</figcaption>
                 <pre><code>arch : SoftwareField -> ArchitectureObject</code></pre>
               </figure>
+              <figure class="code-panel">
+                <figcaption>Computable core</figcaption>
+                <pre><code>ComputableCore
+  = SoftwareField
+  + arch projection
+  + ArtifactMediatedChange
+  + OperationSupport
+  + OperationPolicy
+  + StepRelation
+  + ObservationRecord
+  + GovernanceIntervention
+  + ForecastCone
+  + FieldUpdate</code></pre>
+              </figure>
               <ul class="term-list">
                 <li>
                   <strong>Contextual state</strong>
@@ -134,6 +149,20 @@
                 raw action definition. This prevents an artifact from already
                 containing the forecast that it is supposed to generate.
               </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Raw action</strong>
+                  <span>Source artifact, target components, interpretation boundary, candidate updates, action boundary, and observable boundary.</span>
+                </li>
+                <li>
+                  <strong>Force descriptor</strong>
+                  <span>Action class, target regions, candidate support families, affected policy or governance components, and uncertainty boundary.</span>
+                </li>
+                <li>
+                  <strong>Observed effect</strong>
+                  <span>Transition, before / after signatures, comparable deltas, unexpected witnesses, and review / CI / runtime outcome.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="support-policy" class="article-section">
@@ -179,6 +208,15 @@
   + forecast boundary
   + unknown / unmodeled remainder</code></pre>
               </figure>
+              <figure class="code-panel">
+                <figcaption>Action-indexed cone family</figcaption>
+                <pre><code>u in alpha_a(F)
+F_u := applyUpdate(F, u)
+U_u := U(F_u)
+
+ForecastConeFamilyAfterAction(F, a, h)
+  = { ForecastCone(F_u, U_u, h) | u in alpha_a(F) }</code></pre>
+              </figure>
             </section>
 
             <section id="feedback" class="article-section">
@@ -194,6 +232,24 @@
                 CI outcome, runtime feedback, missing evidence, and
                 non-conclusions.
               </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Restrictive intervention</strong>
+                  <span>Removes unsafe support from later accepted operations.</span>
+                </li>
+                <li>
+                  <strong>Redirective intervention</strong>
+                  <span>Raises shortcut cost and lowers lawful path cost inside the selected field model.</span>
+                </li>
+                <li>
+                  <strong>Instrumenting intervention</strong>
+                  <span>Adds observation axes, tests, runtime checks, or evidence records.</span>
+                </li>
+                <li>
+                  <strong>Learning intervention</strong>
+                  <span>Preserves observed outcomes and forecast error in posterior field memory.</span>
+                </li>
+              </ul>
               <div class="claim-strip">
                 <p>
                   Field update preserves forecast error and boundary evidence.
@@ -201,6 +257,23 @@
                   more accurate.
                 </p>
               </div>
+            </section>
+
+            <section id="core-boundary" class="article-section">
+              <h2>Core boundary and non-conclusions</h2>
+              <p>
+                Part III defines the theorem-bearing fragment, not the whole
+                social reality of a development organization. `ForecastCone`
+                is a reachable path set under selected support and horizon;
+                `ConsequenceEnvelope` is the reader-facing report that explains
+                the cone family, unknown remainder, and forecast boundary.
+              </p>
+              <p>
+                The core does not assert that artifacts have unique effects,
+                that policy is probabilistic unless a distribution is supplied,
+                or that a field update automatically improves later forecast
+                quality.
+              </p>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -69,6 +69,7 @@
                 <li><a href="#proposal-accounting">Proposal accounting</a></li>
                 <li><a href="#feedback-update">Feedback update</a></li>
                 <li><a href="#stable-regions">Stable regions</a></li>
+                <li><a href="#principle-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -113,6 +114,11 @@
                 is simulated by a U1-step while the relation between fields is
                 maintained.
               </p>
+              <p>
+                The claim level is L2 for set-valued support semantics and
+                step simulation, L3 only after transition-kernel semantics are
+                supplied, and L4 only after dataset calibration.
+              </p>
             </section>
 
             <section id="support-safety" class="article-section">
@@ -133,6 +139,13 @@
                   <span>Unmodeled operations, missing axes, and different horizons remain outside the claim.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>Support safety schema</figcaption>
+                <pre><code>StateInSafeRegion(O, R, F)
+  + accepted steps are selected from U
+  + SupportOperationsPreserveSafeRegion(U, O, R)
+  -> accepted trajectory remains in R</code></pre>
+              </figure>
             </section>
 
             <section id="proposal-accounting" class="article-section">
@@ -148,6 +161,18 @@
                 Review, CI, type checking, and architecture rules produce
                 records that feed field update and governance design.
               </p>
+              <figure class="code-panel">
+                <figcaption>ProposalAccounting</figcaption>
+                <pre><code>ProposalAccounting(raw_proposal_universe)
+  classifies proposal pressure as:
+    accepted
+    rejected
+    delayed
+    unresolved
+    coordination_record
+    runtime_pressure_estimate
+    unaccounted_remainder</code></pre>
+              </figure>
             </section>
 
             <section id="feedback-update" class="article-section">
@@ -158,6 +183,15 @@
                 the posterior field by making forecast error and missing
                 evidence explicit.
               </p>
+              <figure class="code-panel">
+                <figcaption>Boundary-aware update</figcaption>
+                <pre><code>forecast
+  + observed transition
+  + forecast error
+  -> posterior field that records
+     missing evidence, unexpected witnesses,
+     policy drift, and non-conclusions</code></pre>
+              </figure>
               <div class="claim-strip">
                 <p>
                   This is update soundness as record preservation. It is not a
@@ -181,6 +215,39 @@ MustReach_h(F, U, A)
 StableRegion(U, A)
 ReachablePreimage_h(U, A)</code></pre>
               </figure>
+              <p>
+                Attractor language is allowed only after the semantics needed
+                for stability, recurrence, policy preference, or probability
+                have been made explicit. Otherwise the safe vocabulary is
+                `DefaultPath`, `RecurrentPattern`, `StableRegion`, and
+                `ReachablePreimage`.
+              </p>
+            </section>
+
+            <section id="principle-boundary" class="article-section">
+              <h2>Principle boundary and non-conclusions</h2>
+              <p>
+                Part IV contains theorem-shaped schemas, not unrestricted
+                guarantees about software projects. Cone narrowing is relative
+                to selected support, witness family, and horizon; support
+                safety is relative to accepted trajectories and measured safe
+                regions; proposal accounting depends on explicit coverage and
+                overlap policy.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Not global risk reduction</strong>
+                  <span>Complexity may move to another witness family or unmeasured axis.</span>
+                </li>
+                <li>
+                  <strong>Not automatic accuracy improvement</strong>
+                  <span>Feedback update preserves records; calibration is a separate empirical claim.</span>
+                </li>
+                <li>
+                  <strong>Not physical attractor dynamics</strong>
+                  <span>Attractor and basin require additional semantics before stronger claims are made.</span>
+                </li>
+              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -70,6 +70,7 @@
                 <li><a href="#ai-governance">AI governance</a></li>
                 <li><a href="#review-systems">Review systems</a></li>
                 <li><a href="#lifecycle">Lifecycle and benchmarks</a></li>
+                <li><a href="#systems-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -122,6 +123,19 @@
                   <span>Diagnose repair, migration, contraction, or end-of-life choices from signatures, costs, risk, and capacity.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>Problem contract pattern</figcaption>
+                <pre><code>Problem
+  input: selected field estimate, artifact, boundary, support, horizon
+  output: bounded estimate, report, intervention, or posterior update
+  soundness boundary: what the estimate records and what it does not claim
+  claim level: conceptual, trace-grounded, formal schema, calibrated, deployed</code></pre>
+              </figure>
+              <p>
+                This contract is what makes the computing-system layer
+                falsifiable. A result that cannot name its boundary is only an
+                explanatory heuristic, not a mature SFT computation.
+              </p>
             </section>
 
             <section id="simulator" class="article-section">
@@ -147,6 +161,20 @@
                 decomposition recommendations. Empirical prediction claims
                 depend on later weighting and calibration.
               </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Level 3 minimum</strong>
+                  <span>A bounded `ForecastCone` or reachable path class is generated from explicit support and horizon.</span>
+                </li>
+                <li>
+                  <strong>Level 4 practical report</strong>
+                  <span>`ConsequenceEnvelope` adds signature axes, witness candidates, missing boundaries, and recommendations.</span>
+                </li>
+                <li>
+                  <strong>Level 6 scientific loop</strong>
+                  <span>Observed issue, PR, review, CI, or incident outcomes are compared against the report and used for field update.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="ai-governance" class="article-section">
@@ -164,6 +192,13 @@
                   shortcut witness reports, and posterior field update.
                 </p>
               </div>
+              <figure class="code-panel">
+                <figcaption>AI proposal governance output</figcaption>
+                <pre><code>bounded proposal support
+  + shortcut witness report
+  + review / CI intervention
+  + posterior field update</code></pre>
+              </figure>
             </section>
 
             <section id="review-systems" class="article-section">
@@ -203,6 +238,41 @@
                 incident feedback, AI shortcut, and lifecycle decision
                 benchmarks give the workbench something falsifiable to test.
               </p>
+              <figure class="code-panel">
+                <figcaption>Lifecycle trajectory</figcaption>
+                <pre><code>birth
+  + growth
+  + stabilization
+  + drift
+  + repair / migration
+  + contraction
+  + end-of-life</code></pre>
+              </figure>
+            </section>
+
+            <section id="systems-boundary" class="article-section">
+              <h2>Systems boundary and non-conclusions</h2>
+              <p>
+                Part V describes computing systems that can be built from SFT,
+                but their outputs remain bounded estimates. A simulator is not
+                a PRD-to-PR predictor, an AI governance report is not general
+                AI safety, and benchmark calibration is required before
+                empirical forecast claims are promoted.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Input discipline</strong>
+                  <span>Reports must state the selected artifact, field estimate, observation boundary, support extractor, and horizon.</span>
+                </li>
+                <li>
+                  <strong>Output discipline</strong>
+                  <span>Outputs are envelopes, affected axes, witness candidates, missing boundaries, recommendations, and update records.</span>
+                </li>
+                <li>
+                  <strong>Claim discipline</strong>
+                  <span>Heuristic path classes, formal reachability, calibrated weights, and deployed governance outcomes remain separate statuses.</span>
+                </li>
+              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -70,6 +70,7 @@
                 <li><a href="#incident-response">Incident response</a></li>
                 <li><a href="#ai-shortcut">AI shortcut</a></li>
                 <li><a href="#end-of-life">End-of-life</a></li>
+                <li><a href="#case-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -114,6 +115,25 @@
                 semantics, support and policy can be shaped toward the lawful
                 path.
               </p>
+              <figure class="code-panel">
+                <figcaption>Coupon PRD descriptor</figcaption>
+                <pre><code>RawArtifactAction
+  source artifact = PRD
+  target field components = requirements, constraints, operation support
+  target architecture regions = Checkout / Payment
+  action boundary = coupon feature addition only
+  non-conclusions = pricing strategy, marketing success, fraud model</code></pre>
+              </figure>
+              <ul class="term-list">
+                <li>
+                  <strong>Missing invariants</strong>
+                  <span>Rounding order, discount composition law, payment authorization boundary, and refund / cancellation semantics.</span>
+                </li>
+                <li>
+                  <strong>Claim boundary</strong>
+                  <span>Specification tightening narrows selected witness families; it does not prove global risk reduction.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="migration" class="article-section">
@@ -138,6 +158,16 @@
                   <span>A supported path back from selected migration states.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>MigrationEnvelope</figcaption>
+                <pre><code>bridge path
+  + dual-run path
+  + replacement path
+  + rollback path
+  + old-new projection mismatch
+  + partial migration risk
+  + consumer compatibility boundary</code></pre>
+              </figure>
             </section>
 
             <section id="incident-response" class="article-section">
@@ -155,6 +185,15 @@
                   boundary visible.
                 </p>
               </div>
+              <figure class="code-panel">
+                <figcaption>IncidentFeedback</figcaption>
+                <pre><code>incident observation
+  + root-cause witness classification
+  + missing invariant discovery
+  + review / CI governance update
+  + runtime observation update
+  + forecast boundary revision</code></pre>
+              </figure>
             </section>
 
             <section id="ai-shortcut" class="article-section">
@@ -189,6 +228,41 @@
                 describes how repair, migration, contraction, or deletion
                 changes architecture futures and field capacity.
               </p>
+              <figure class="code-panel">
+                <figcaption>EndOfLifeDecision</figcaption>
+                <pre><code>current architecture signature
+  + repair cost
+  + migration support
+  + runtime risk
+  + ownership / staffing boundary
+  + ConsequenceEnvelope
+  + non-conclusions</code></pre>
+              </figure>
+            </section>
+
+            <section id="case-boundary" class="article-section">
+              <h2>Case-study boundary and non-conclusions</h2>
+              <p>
+                These cases show how the same formal vocabulary is used across
+                feature work, migration, incidents, AI proposals, and lifecycle
+                decisions. They are examples of bounded diagnosis, not claims
+                that the artifact caused every observed outcome or that the
+                repository has been completely reconstructed.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Coupon PRD</strong>
+                  <span>Demonstrates artifact action, missing invariants, and `ConsequenceEnvelope` path classes.</span>
+                </li>
+                <li>
+                  <strong>Migration and incident response</strong>
+                  <span>Demonstrate field transformation and runtime feedback as updates to support, observation, and governance.</span>
+                </li>
+                <li>
+                  <strong>AI shortcut and end-of-life</strong>
+                  <span>Demonstrate proposal governance and lifecycle reconfiguration without claiming general AI safety or market prediction.</span>
+                </li>
+              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -68,6 +68,7 @@
                 <li><a href="#non-claims">Non-claims</a></li>
                 <li><a href="#open-problems">Open problems</a></li>
                 <li><a href="#workbench">Workbench direction</a></li>
+                <li><a href="#research-boundary">Boundary</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -130,6 +131,18 @@
                   <strong>No ground truth extractor claim</strong>
                   <span>ArchSig extraction is not a complete `ComponentUniverse` or ground truth architecture object.</span>
                 </li>
+                <li>
+                  <strong>No causal uniqueness from observed deltas</strong>
+                  <span>An observed signature delta does not uniquely identify the artifact action that caused it.</span>
+                </li>
+                <li>
+                  <strong>No policy-to-lawfulness implication</strong>
+                  <span>AI policy compliance or review acceptance does not imply architecture lawfulness.</span>
+                </li>
+                <li>
+                  <strong>No human or market prediction</strong>
+                  <span>SFT does not predict human intention, organizational success, or market success.</span>
+                </li>
               </ul>
             </section>
 
@@ -153,6 +166,20 @@
   + lifecycle and AI proposal governance
   -> deployed SFT workbench</code></pre>
               </figure>
+              <ul class="term-list">
+                <li>
+                  <strong>Formal open problems</strong>
+                  <span>Lean formalization of `ForecastCone`, support simulation, and the relation from envelopes to one or more cones.</span>
+                </li>
+                <li>
+                  <strong>Empirical open problems</strong>
+                  <span>Trace-grounded reconstruction, simulator calibration, review mediation, AI shortcut detection, and field memory studies.</span>
+                </li>
+                <li>
+                  <strong>Tooling open problems</strong>
+                  <span>Theorem-boundary integration, lifecycle decision models, and a deployed closed-loop workbench.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="workbench" class="article-section">
@@ -166,6 +193,20 @@
                 CI interventions, AI proposal constraints, and calibration
                 plans.
               </p>
+              <figure class="code-panel">
+                <figcaption>Workbench contract</figcaption>
+                <pre><code>input:
+  PRD, design memo, issue plan, codebase,
+  architecture signature, review / CI history,
+  incident history, AI agent policy
+
+output:
+  ConsequenceEnvelope, affected axes,
+  witness families, missing boundaries,
+  risky default paths, issue decomposition,
+  governance interventions, AI constraints,
+  feedback / calibration plan</code></pre>
+              </figure>
               <div class="claim-strip">
                 <p>
                   SFT does not replace developers. It makes software evolution
@@ -173,6 +214,24 @@
                   governed, and revised.
                 </p>
               </div>
+            </section>
+
+            <section id="research-boundary" class="article-section">
+              <h2>Research boundary</h2>
+              <p>
+                The research program is deliberately split across formal,
+                tooling, and empirical tracks. Lean work can prove bounded
+                schemas; ArchSig and the workbench can produce evidence and
+                reports; calibration studies can test forecast quality. None
+                of these statuses should be collapsed into the others.
+              </p>
+              <p>
+                This page therefore treats SFT as a large computational
+                theory with visible non-conclusions. The scope is broad, but
+                every claim must still state whether it is defined only,
+                theorem-shaped, tool-supported, empirically calibrated, or
+                operationally deployed.
+              </p>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">


### PR DESCRIPTION
## 概要

Closes #773

`website/sft/` 配下の SFT Part pages を、`docs/sft/software_field_theory.md` の canonical monograph に沿って増補しました。
各 Part に、定義、formal / computational reading、examples、claim boundary、non-conclusions を明示する節やコードブロックを追加し、Coupon PRD などの running example との接続を補強しています。

Lean status: theorem status 変更なし。SFT forecast claims は empirical hypothesis / computational claim boundary preserving exposition として扱う。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/index.html`
- `website/sft/part-i-new-object/index.html`
- `website/sft/part-ii-basis/index.html`
- `website/sft/part-iii-core/index.html`
- `website/sft/part-iv-principles/index.html`
- `website/sft/part-v-computing-systems/index.html`
- `website/sft/part-vi-case-studies/index.html`
- `website/sft/part-vii-research-program/index.html`
- `website/SITEMAP.md`

## 実施したテスト

- [x] `lake build`
  - 成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` に関する linter warning 2 件は再表示。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
  - `^\s*(axiom|admit|sorry|unsafe)\b` で Lean 宣言位置を確認し、該当なし。
- [x] SFT HTML parse smoke test
  - `website/sft/**/index.html` 8 files を `html.parser` で parse。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
