### PR TITLE
AAT website を web-native preprint として補強する

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -23,6 +23,12 @@ Zenn, Hashnode, and Qiita are outreach surfaces for motivation and intuition;
 they are not where the full theory, theorem boundaries, or claim discipline are
 maintained.
 
+The AAT section should be treated as a web-native preprint / monograph surface:
+the place where the theory can be published carefully before a slower
+arXiv-style paper is prepared. Its purpose is to give readers a complete,
+accurate, and stable account of the theory, including definitions, assumptions,
+theorem patterns, examples, counterexamples, Lean status, and non-conclusions.
+
 When expanding AAT and SFT pages:
 
 - Treat `docs/aat/mathematical_theory.md` and
@@ -30,6 +36,12 @@ When expanding AAT and SFT pages:
 - Preserve definitions, assumptions, non-conclusions, and claim levels.
 - Prefer theorem-style structure: definitions, interpretation, examples,
   boundaries, and links to Lean status where appropriate.
+- Keep AAT pages strong enough to stand alone as web theory sections, not only
+  as summaries of the repository documents.
+- Record an AAT release snapshot on public theory pages: last updated date,
+  source commit, and Lean status snapshot. Links from theory pages to canonical
+  docs should use commit-pinned GitHub URLs for public releases, not
+  `blob/main`, so the website and cited source text do not drift silently.
 - Do not compress formal distinctions into slogans or general software advice.
 - Keep ArchSig and tooling evidence separate from AAT / SFT theorem claims.
 - For ArchSig pages, separate the Core, Review, SFT, and Operational product

--- a/website/SITEMAP.md
+++ b/website/SITEMAP.md
@@ -13,6 +13,12 @@ SEO 用の `sitemap.xml` ではない。
 - 数学本文、Lean status、proof obligation、tooling claim、empirical hypothesis を混同しない。
 - AAT は first-class formal theory article として、`docs/aat/mathematical_theory.md`
   に忠実な論文調の本文を章クラスタ単位で見せる。
+- AAT website は web-native preprint / monograph として扱う。Hashnode、Zenn、
+  Qiita のような outreach surface では維持しにくい定義、前提、theorem boundary、
+  反例、Lean status、non-conclusions を一箇所で読めるようにする。
+- AAT の公開 theory pages は release snapshot を表示し、参照元 docs への GitHub
+  links は公開時点の commit に固定する。`blob/main` は作業中の便宜には使えても、
+  paper-grade public reference の citation としては使わない。
 - SFT は first-class research monograph として、`docs/sft/software_field_theory.md`
   に忠実な論文調の本文を Part 単位で見せる。
 - AAT / SFT page は marketing summary や一般向け article ではなく、定義、前提、

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -69,6 +69,8 @@
                 <li><a href="#operation-laws">Operation laws</a></li>
                 <li><a href="#feature-extension">Feature extension</a></li>
                 <li><a href="#operation-families">Operation families</a></li>
+                <li><a href="#proof-obligations">Proof obligations</a></li>
+                <li><a href="#extension-theorem">Extension theorem schema</a></li>
                 <li><a href="#extension-evidence">Extension evidence</a></li>
                 <li><a href="#lean-status">Lean status</a></li>
               </ol>
@@ -77,11 +79,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#9-architecture-calculus">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#9-architecture-calculus">
                     Chapters 9-10 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -188,6 +201,95 @@
   + theorem boundary
   -&gt; bounded conclusion</code></pre>
               </figure>
+            </section>
+
+            <section id="proof-obligations" class="article-section">
+              <h2>Proof obligations</h2>
+              <p>
+                To turn an architecture operation into a theorem package, the
+                operation must expose the data that a proof can actually use.
+                This is the calculus-level version of claim discipline.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Well-formed support</strong>
+                  <span>The source, target, and affected sub-universe are explicit enough to state the transition.</span>
+                </li>
+                <li>
+                  <strong>Precondition and transition</strong>
+                  <span>The operation says when it is allowed and what relation connects source and target.</span>
+                </li>
+                <li>
+                  <strong>Invariant and witness mapping</strong>
+                  <span>The proof states which invariant is preserved and how selected witnesses are removed, preserved, introduced, or transferred.</span>
+                </li>
+                <li>
+                  <strong>Conclusion boundary</strong>
+                  <span>The theorem records which axes are not claimed to improve and which evidence remains outside the operation.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="extension-theorem" class="article-section">
+              <h2>Extension theorem schema</h2>
+              <p>
+                Feature extension is the running operation family because it
+                forces all boundaries to appear at once: inherited core
+                structure, feature-local behavior, interaction with the core,
+                lifting through declared interfaces, semantic filling, and
+                residual coverage.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Extension reading</figcaption>
+                <pre><code>FeatureExtension X X'
+  + StaticSplitFeatureExtension evidence
+  + selected feature-view section laws
+  + SplitExtensionLiftingData
+  + runtime / semantic preservation evidence
+  + theorem boundary B
+  -&gt; bounded extension claim within B</code></pre>
+              </figure>
+              <p>
+                The structural extension formula classifies where a witness
+                comes from. It does not say the classes are disjoint and does
+                not provide global witness completeness by itself.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>`ArchitectureOperation` / proof-obligation schema</td>
+                      <td>`defined only` / `proved` for schema accessor theorems</td>
+                      <td>Operation support, precondition, transition relation, invariant family, witness mapping, and boundary record.</td>
+                      <td>A named operation tag is not by itself a theorem.</td>
+                      <td>Lean theorem index, architecture operation entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Bounded operation laws</td>
+                      <td>`defined only` / `proved` for bounded accessor packages</td>
+                      <td>Fixed observation and theorem-boundary compatibility.</td>
+                      <td>Does not provide unrestricted replacement, migration, protection, or synthesis laws.</td>
+                      <td>Lean theorem index, architecture calculus laws.</td>
+                    </tr>
+                    <tr>
+                      <td>Structural extension formula</td>
+                      <td>`defined only` / `proved` for structural entrypoints</td>
+                      <td>Selected split-extension, lifting, filling, complexity-transfer, and residual-coverage evidence.</td>
+                      <td>Not a disjoint decomposition, global witness-completeness theorem, or proof that every feature extension is safe.</td>
+                      <td>Lean theorem index, Chapter 10 entrypoint.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="extension-evidence" class="article-section">

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -66,6 +66,8 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#canonical-examples">Canonical examples</a></li>
+                <li><a href="#example-template">Example template</a></li>
+                <li><a href="#coupon-case-study">Coupon case study</a></li>
                 <li><a href="#counterexamples">Counterexamples</a></li>
                 <li><a href="#aat-boundary">AAT boundary</a></li>
                 <li><a href="#coupon-reading">Coupon reading</a></li>
@@ -77,11 +79,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#15-canonical-examples-and-counterexamples">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#15-canonical-examples-and-counterexamples">
                     Chapters 15-16 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -114,6 +127,135 @@
                   <span>An observation difference caused by rounding or discount application order.</span>
                 </li>
               </ul>
+            </section>
+
+            <section id="example-template" class="article-section">
+              <h2>Example template</h2>
+              <p>
+                Each canonical example should expose the same proof-relevant
+                structure. The example is not merely a story about a system; it
+                is a bounded object, a selected operation, a witness universe,
+                a signature reading, and a list of conclusions that do not
+                follow.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Paper-style example record</figcaption>
+                <pre><code>Example
+  = selected architecture object
+  + selected operation or extension
+  + invariant family under test
+  + witness universe
+  + measured signature axes
+  + theorem boundary
+  + counterexample or non-conclusion</code></pre>
+              </figure>
+              <p>
+                This template is why the coupon example can carry static,
+                semantic, and runtime readings without collapsing them into a
+                single quality judgment.
+              </p>
+            </section>
+
+            <section id="coupon-case-study" class="article-section">
+              <h2>Coupon case study</h2>
+              <p>
+                The coupon example is the smallest useful running case because
+                it exposes the separation between static structure, semantic
+                behavior, runtime behavior, and measurement boundary.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Selected component graph</figcaption>
+                <pre><code>CheckoutService
+  -&gt; CouponService
+  -&gt; PaymentPort
+  -&gt; PaymentAdapter
+
+bad static edge:
+  CouponService -&gt; PaymentAdapter
+
+semantic diagram:
+  apply coupon ; round
+    ?= round ; apply coupon
+
+runtime exposure:
+  retry / cache / callback crosses selected boundary</code></pre>
+              </figure>
+              <ul class="status-list">
+                <li>
+                  <strong>Object</strong>
+                  <span>A selected checkout universe containing coupon code, a declared payment interface, payment core components, and selected relations among them.</span>
+                </li>
+                <li>
+                  <strong>Good extension</strong>
+                  <span>Coupon computation is added through the declared interface, with a feature view and selected section laws recording how the feature is observed.</span>
+                </li>
+                <li>
+                  <strong>Static obstruction</strong>
+                  <span>A direct dependency from coupon code into payment adapters, caches, or private payment internals violates the selected static split or boundary policy.</span>
+                </li>
+                <li>
+                  <strong>Semantic obstruction</strong>
+                  <span>Two implementation paths produce different totals, rounding traces, error observations, or discount ordering observations under the selected client context.</span>
+                </li>
+                <li>
+                  <strong>Runtime obstruction</strong>
+                  <span>A retry, callback, cache invalidation, or protection failure crosses a runtime boundary not represented by the static dependency graph.</span>
+                </li>
+                <li>
+                  <strong>Non-conclusion</strong>
+                  <span>A static split report does not prove semantic commutativity, runtime protection, product outcome improvement, or complete extraction of the real repository.</span>
+                </li>
+              </ul>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Example field</th>
+                      <th>Coupon instantiation</th>
+                      <th>Claim level</th>
+                      <th>Boundary / non-conclusion</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>`ComponentUniverse`</td>
+                      <td>`CheckoutService`, `CouponService`, `PaymentPort`, selected payment core / adapter components, and selected static / runtime relations.</td>
+                      <td>Tooling / formal when backed by proof-carrying finite universe data.</td>
+                      <td>Does not claim complete repository extraction.</td>
+                    </tr>
+                    <tr>
+                      <td>Selected good static edges</td>
+                      <td>`CheckoutService -> CouponService`, `CouponService -> PaymentPort`, `PaymentPort -> PaymentAdapter` under declared interface policy.</td>
+                      <td>Formal or tooling depending on evidence source.</td>
+                      <td>Only selected static relations are covered.</td>
+                    </tr>
+                    <tr>
+                      <td>Bad static witness set</td>
+                      <td>Direct `CouponService -> PaymentAdapter` or `CouponService -> PaymentCache` edge bypassing the declared boundary.</td>
+                      <td>`proved` only after finite witness list and bad predicate are connected by the theorem package.</td>
+                      <td>Absence in one report is not global absence.</td>
+                    </tr>
+                    <tr>
+                      <td>Semantic observation mismatch</td>
+                      <td>Different total, rounding trace, error result, or discount ordering under selected checkout contexts.</td>
+                      <td>Defined / proved only for selected observation bridges; otherwise tooling or empirical evidence.</td>
+                      <td>Static split does not imply semantic commutativity.</td>
+                    </tr>
+                    <tr>
+                      <td>Runtime exposure witness</td>
+                      <td>Retry, callback, cache invalidation, or protection failure crossing a runtime boundary.</td>
+                      <td>Defined / proved for selected runtime bridge packages; empirical for real incidents.</td>
+                      <td>Runtime flatness is separate from static flatness.</td>
+                    </tr>
+                    <tr>
+                      <td>Signature coordinates</td>
+                      <td>Static obstruction count, semantic witness status, runtime exposure status, residual coverage gap.</td>
+                      <td>Multi-axis diagnostic.</td>
+                      <td>Coordinates do not collapse into one quality score.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="counterexamples" class="article-section">
@@ -221,6 +363,42 @@ retry leaks across boundary
                   which slogan-like implications are invalid and keep public
                   explanations aligned with the bounded Lean status.
                 </p>
+              </div>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>SOLID-style local contracts do not imply decomposability</td>
+                      <td>`proved` for representative finite counterexamples</td>
+                      <td>Selected abstract / concrete graph examples and local compatibility predicates.</td>
+                      <td>Does not classify every natural-language SOLID usage.</td>
+                      <td>Lean theorem index, SOLID counterexamples.</td>
+                    </tr>
+                    <tr>
+                      <td>Static flatness does not imply semantic flatness</td>
+                      <td>`defined only` / `proved` for selected bridge and counterexample packages</td>
+                      <td>Selected static graph and selected semantic diagram universe.</td>
+                      <td>Does not prove all semantic failures are static failures.</td>
+                      <td>Lean theorem index and proof obligations.</td>
+                    </tr>
+                    <tr>
+                      <td>Coupon worked example</td>
+                      <td>Mixed: theorem-backed finite packages plus tooling / example-level readings</td>
+                      <td>Selected component universe, selected witnesses, selected observation contexts.</td>
+                      <td>Not complete extraction from every real coupon repository.</td>
+                      <td>AAT mathematical theory and ArchSig example docs.</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </section>
 

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -67,6 +67,8 @@
               <ol>
                 <li><a href="#central-proposition">Central proposition</a></li>
                 <li><a href="#architecture-object">Architecture object</a></li>
+                <li><a href="#definition-spine">Definition spine</a></li>
+                <li><a href="#foundational-claims">Foundational claims</a></li>
                 <li><a href="#universe-boundary">Universe boundary</a></li>
                 <li><a href="#formal-reading">Formal reading</a></li>
                 <li><a href="#example-boundary">Example boundary</a></li>
@@ -77,11 +79,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#1-%E4%B8%AD%E5%BF%83%E5%91%BD%E9%A1%8C">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#1-%E4%B8%AD%E5%BF%83%E5%91%BD%E9%A1%8C">
                     Chapters 1-2 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see Status for proved / defined-only boundaries.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -141,6 +154,114 @@
                   <span>Observation model, semantic diagram universe, and selected measurement universe.</span>
                 </li>
               </ul>
+            </section>
+
+            <section id="definition-spine" class="article-section">
+              <h2>Definition spine</h2>
+              <p>
+                The foundational record is deliberately small. AAT does not
+                begin with every fact about a repository; it begins with the
+                selected carrier, the policies used to read that carrier, and
+                the observation context that states what evidence is in scope.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Architecture object schema</figcaption>
+                <pre><code>ArchitectureCarrier
+  = components
+  + static dependency relation
+  + runtime dependency relation
+
+ArchitecturePolicy
+  = boundary policy
+  + abstraction policy
+
+ArchitectureObservationContext
+  = observation model
+  + semantic diagram universe
+  + selected measurement universe
+
+ArchitectureObject
+  = ArchitectureCarrier
+  + ArchitecturePolicy
+  + ArchitectureObservationContext</code></pre>
+              </figure>
+              <p>
+                This schema is the first theorem-boundary guard. A claim about
+                the object is never stronger than the carrier, policy, and
+                observation context that presented it.
+              </p>
+            </section>
+
+            <section id="foundational-claims" class="article-section">
+              <h2>Foundational claims</h2>
+              <p>
+                The first layer of the theory establishes a disciplined
+                replacement for the phrase "the architecture." The object of
+                reasoning is not an entire repository, but a selected
+                presentation with explicit evidence and scope.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Definition</strong>
+                  <span>An `ArchitectureObject` is a carrier plus policy plus observation context.</span>
+                </li>
+                <li>
+                  <strong>Interpretation</strong>
+                  <span>An `ArchitectureCore` presents the object through evidence, but presentation is not assumed complete or injective.</span>
+                </li>
+                <li>
+                  <strong>Boundary</strong>
+                  <span>A `ComponentUniverse` is a selected measurement universe; outside it, zero and absence are not inferred.</span>
+                </li>
+                <li>
+                  <strong>Non-conclusion</strong>
+                  <span>No theorem here states that a real-code extractor has found every relevant component, relation, runtime effect, or semantic diagram.</span>
+                </li>
+              </ul>
+              <figure class="code-panel">
+                <figcaption>Foundational proposition schema</figcaption>
+                <pre><code>selected carrier
+  + selected policy
+  + selected observation context
+  + coverage / exactness boundary
+  -&gt; bounded ArchitectureObject claim</code></pre>
+              </figure>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Static graph, reachability, layering, and decomposability vocabulary</td>
+                      <td>`defined only` / `proved` for the static structural bridge theorems</td>
+                      <td>Selected graph and explicit structural assumptions.</td>
+                      <td>Does not certify complete extraction from a real repository.</td>
+                      <td>Lean theorem index, static core entries.</td>
+                    </tr>
+                    <tr>
+                      <td>`ComponentCategory` as thin reachability category</td>
+                      <td>`defined only` / `proved` for selected bridge facts</td>
+                      <td>Reachability existence is retained; path count and walk length are intentionally forgotten.</td>
+                      <td>Quantitative path metrics require `Walk`, `Path`, matrix, or finite metric representations.</td>
+                      <td>AAT mathematical theory, Chapter 2.</td>
+                    </tr>
+                    <tr>
+                      <td>`ComponentUniverse` as measurement scope</td>
+                      <td>`defined only` / `proved` for finite-universe bridge packages</td>
+                      <td>Selected components, selected relations, coverage boundary, and exactness boundary.</td>
+                      <td>Universe outside is not read as zero or absent.</td>
+                      <td>Lean theorem index and proof obligations.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="universe-boundary" class="article-section">

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -60,7 +60,7 @@
             <span>AAT</span>
           </nav>
           <p class="eyebrow">Algebraic Architecture Theory</p>
-          <h1>A local algebra for software architecture.</h1>
+          <h1>Algebraic Architecture Theory.</h1>
           <p class="lede">
             AAT treats architecture as a bounded object of reasoning: operations
             preserve or break invariant families, obstruction witnesses explain
@@ -76,6 +76,9 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#abstract">Abstract</a></li>
+                <li><a href="#main-contributions">Main contributions</a></li>
+                <li><a href="#publication-purpose">Publication purpose</a></li>
                 <li><a href="#reading-order">Reading order</a></li>
                 <li><a href="#claim-discipline">Claim discipline</a></li>
                 <li><a href="#canonical-sources">Canonical sources</a></li>
@@ -85,20 +88,100 @@
               <h2>Canonical sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md">
                     AAT mathematical theory
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/README.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/README.md">
                     AAT repository entry
                   </a>
                 </li>
               </ul>
             </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see Status for proved / defined-only boundaries.</dd>
+              </dl>
+            </div>
           </aside>
 
           <div class="article-main">
+            <section id="abstract" class="article-section">
+              <h2>Abstract</h2>
+              <p>
+                Algebraic Architecture Theory formalizes software architecture
+                as a bounded mathematical object equipped with operations,
+                invariant families, obstruction witnesses, signature axes, and
+                theorem boundaries. Its basic claim is that architectural
+                quality should be read through preserved invariants and
+                explicit witnesses of failure, not through slogans, framework
+                names, or a single scalar score.
+              </p>
+              <p>
+                The theory is local by design. Every claim is relative to a
+                selected universe, observation context, coverage boundary, and
+                exactness assumption. This makes AAT useful for precise design
+                review: it can say what is preserved, what is broken, what was
+                measured, what was not measured, and which theorem package
+                licenses the conclusion.
+              </p>
+            </section>
+
+            <section id="main-contributions" class="article-section">
+              <h2>Main contributions</h2>
+              <ul class="status-list">
+                <li>
+                  <strong>Architecture as bounded algebra</strong>
+                  <span>AAT treats architecture objects and operations as typed, evidence-bounded mathematical data rather than as informal descriptions of whole codebases.</span>
+                </li>
+                <li>
+                  <strong>Obstruction-first quality</strong>
+                  <span>Quality failure is represented by selected obstruction witnesses: forbidden edges, boundary violations, projection failures, semantic non-commutativity, runtime exposure, lifting failure, and residual coverage gaps.</span>
+                </li>
+                <li>
+                  <strong>Multi-axis signature</strong>
+                  <span>Architecture Signature records measured coordinates and measurement status per axis, keeping unmeasured, out-of-scope, private, and zero evidence distinct.</span>
+                </li>
+                <li>
+                  <strong>Theorem-boundary discipline</strong>
+                  <span>Every theorem candidate records assumptions, coverage, exactness, conclusion, and non-conclusions so static, runtime, semantic, tooling, and empirical readings are not collapsed.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="publication-purpose" class="article-section">
+              <h2>Publication purpose</h2>
+              <p>
+                This website is the canonical public reading surface for AAT:
+                a web-native theory text that sits between outreach posts and
+                a future conventional paper. Blog platforms are useful for
+                motivation, but AAT needs a stable place for definitions,
+                assumptions, theorem boundaries, examples, counterexamples,
+                Lean status, and non-conclusions to remain together.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Not a blog summary</strong>
+                  <span>The pages preserve formal distinctions instead of compressing them into general software advice.</span>
+                </li>
+                <li>
+                  <strong>Not a product landing page</strong>
+                  <span>The primary object is the theory: its vocabulary, theorem shape, examples, and boundaries.</span>
+                </li>
+                <li>
+                  <strong>Preprint-style surface</strong>
+                  <span>The site makes AAT readable before a slower arXiv-style paper is prepared, while keeping claim discipline explicit.</span>
+                </li>
+              </ul>
+            </section>
+
             <section id="reading-order" class="article-section">
               <h2>Reading order</h2>
               <p>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -67,6 +67,8 @@
                 <li><a href="#invariant-families">Invariant families</a></li>
                 <li><a href="#obstruction-witnesses">Obstruction witnesses</a></li>
                 <li><a href="#zero-curvature">Zero-curvature reading</a></li>
+                <li><a href="#theorem-pattern">Theorem pattern</a></li>
+                <li><a href="#main-theorem">Main theorem schema</a></li>
                 <li><a href="#law-universe">Law universe</a></li>
                 <li><a href="#examples">Examples</a></li>
                 <li><a href="#lean-status">Lean status</a></li>
@@ -76,11 +78,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#3-invariant-%E3%81%A8-law-universe">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#3-invariant-%E3%81%A8-law-universe">
                     Chapters 3-4 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -114,7 +127,7 @@
                 </li>
                 <li>
                   <strong>State and runtime layers</strong>
-                  <span>Event Sourcing, Saga, Circuit Breaker, and Replicated Log carry replay, compensation, protection, ordering, and convergence laws.</span>
+                  <span>Event Sourcing, Saga, CRUD, Circuit Breaker, and Replicated Log carry replay, compensation, overwrite, protection, ordering, and convergence laws.</span>
                 </li>
               </ul>
             </section>
@@ -165,6 +178,113 @@ violationCount bad xs = 0
                   It is one local-contract family among distinct global,
                   state-transition, runtime, and distributed invariant families.
                 </p>
+              </div>
+            </section>
+
+            <section id="theorem-pattern" class="article-section">
+              <h2>Theorem pattern</h2>
+              <p>
+                The law-to-witness connection is not definitional. A finite
+                witness report becomes a semantic lawfulness claim only after
+                the theorem boundary supplies the missing exactness and
+                coverage hypotheses.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Semantic predicate</strong>
+                  <span>`SemanticLawful X L` says the selected law universe is satisfied under the selected observation.</span>
+                </li>
+                <li>
+                  <strong>Witness predicate</strong>
+                  <span>`NoRequiredWitness X W` says no required bad witness appears in the selected finite witness family.</span>
+                </li>
+                <li>
+                  <strong>Signature predicate</strong>
+                  <span>`RequiredSignatureAxesZero X S` says the required measured axes are zero, not that every possible axis is safe.</span>
+                </li>
+              </ul>
+              <figure class="code-panel">
+                <figcaption>Bridge assumptions</figcaption>
+                <pre><code>WitnessComplete(L, W)
+  + AxisExact(W, S)
+  + CoverageComplete(boundary)
+  + ObservationExact(context)
+  -&gt;
+  SemanticLawful X L
+    &lt;-&gt; NoRequiredWitness X W
+    &lt;-&gt; RequiredSignatureAxesZero X S</code></pre>
+              </figure>
+            </section>
+
+            <section id="main-theorem" class="article-section">
+              <h2>Main theorem schema</h2>
+              <p>
+                The zero-curvature theorem is the central lawfulness bridge.
+                It is stated as a schema because the law universe, witness
+                family, signature axes, and observation model vary across
+                structural, projection, semantic, runtime, and extension
+                readings.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Required obstruction vanishing theorem</figcaption>
+                <pre><code>Given:
+  finite law universe L
+  selected witness family W
+  selected signature axes S
+  theorem boundary B
+
+Assuming:
+  WitnessComplete(L, W)
+  AxisExact(W, S)
+  CoverageComplete(B)
+  ObservationExact(B)
+
+Then, within B:
+  SemanticLawful X L
+    &lt;-&gt; NoRequiredWitness X W
+    &lt;-&gt; RequiredSignatureAxesZero X S</code></pre>
+              </figure>
+              <p>
+                This theorem shape is also the guardrail for readability. A
+                dashboard zero, a passing local contract, or a missing witness
+                list becomes a lawfulness statement only when the stated
+                completeness and exactness assumptions are available.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Finite witness-count zero kernel</td>
+                      <td>`proved`</td>
+                      <td>Selected finite witness list and bad predicate.</td>
+                      <td>Does not prove global absence outside the selected list.</td>
+                      <td>Lean theorem index, flatness / witness-count entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Required law / required axis exactness bridge</td>
+                      <td>`proved` for current static structural core</td>
+                      <td>Explicit law-family, witness-coverage, axis-exactness, universe, coverage, and observation assumptions.</td>
+                      <td>Does not automatically include runtime, semantic, empirical, or extractor-completeness claims.</td>
+                      <td>AAT Status page and proof-obligation ledger.</td>
+                    </tr>
+                    <tr>
+                      <td>General zero-curvature schema across all law families</td>
+                      <td>`future proof obligation` / theorem schema</td>
+                      <td>Requires a law-specific witness family, axis exactness, and observation exactness.</td>
+                      <td>Not a universal theorem for every design principle or repository.</td>
+                      <td>AAT mathematical theory and proof obligations.</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </section>
 
@@ -225,7 +345,7 @@ violationCount bad xs = 0
                 exactness bridge are part of the current proved static core.
                 The broader design-principle classification remains a boundary
                 discipline: SOLID, Layered, Clean Architecture, Event Sourcing,
-                Saga, Circuit Breaker, and Replicated Log are organized as
+                Saga, CRUD, Circuit Breaker, and Replicated Log are organized as
                 different invariant families, not one Lean theorem scheme.
               </p>
               <div class="claim-strip">

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -66,9 +66,11 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#projection-observation">Projection and observation</a></li>
+                <li><a href="#projection-theorem">Projection theorem schema</a></li>
                 <li><a href="#lsp-dip">LSP and DIP</a></li>
                 <li><a href="#three-layer-flatness">Three-layer flatness</a></li>
                 <li><a href="#assumption-strength">Assumption strength</a></li>
+                <li><a href="#non-implication-map">Non-implication map</a></li>
                 <li><a href="#contract-example">Contract example</a></li>
                 <li><a href="#lean-status">Lean status</a></li>
               </ol>
@@ -77,11 +79,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#7-projection-observation-lsp-dip">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#7-projection-observation-lsp-dip">
                     Chapters 7-8 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -112,6 +125,69 @@ F(x) = F(y) -&gt; Obs(x) ~= Obs(y)
 
 ker(F) &lt;= ker(Obs)</code></pre>
               </figure>
+            </section>
+
+            <section id="projection-theorem" class="article-section">
+              <h2>Projection theorem schema</h2>
+              <p>
+                Projection claims become architecture claims only after the
+                strength of the projection is stated. Soundness, completeness,
+                exactness, and representative stability support different
+                conclusions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Projection bridge</figcaption>
+                <pre><code>ProjectionSound F
+  -&gt; concrete dependency evidence is represented abstractly
+
+ProjectionComplete F
+  -&gt; abstract dependency evidence has concrete representatives
+
+ProjectionExact F + RepresentativeStable F
+  -&gt; quotient-style or replacement-style readings may be stated</code></pre>
+              </figure>
+              <p>
+                For LSP-style claims, the same discipline appears as selected
+                client contexts and selected observations. Equal abstractions
+                must preserve observations only for the contexts and
+                equivalence relation named in the theorem boundary.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Projection / DIP soundness bridge</td>
+                      <td>`proved` for soundness bridges</td>
+                      <td>Concrete dependency evidence and selected abstract graph.</td>
+                      <td>Soundness alone does not imply completeness, exactness, or global layering.</td>
+                      <td>Lean theorem index, projection / DIP entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Observation / LSP violation-count bridge</td>
+                      <td>`proved` for finite selected observations</td>
+                      <td>Selected client-context universe and observation equivalence.</td>
+                      <td>Does not prove substitutability for all possible clients or effects.</td>
+                      <td>Lean theorem index, observation / LSP entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Three-layer flatness connection</td>
+                      <td>`future proof obligation` unless a theorem boundary connects layers</td>
+                      <td>Static, runtime, and semantic evidence packages must be named separately.</td>
+                      <td>Static flatness does not imply runtime or semantic flatness.</td>
+                      <td>AAT mathematical theory, Chapters 7-8.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="lsp-dip" class="article-section">
@@ -185,6 +261,35 @@ ProjectionComplete
   does not imply
 ProjectionExact + RepresentativeStable</code></pre>
               </figure>
+            </section>
+
+            <section id="non-implication-map" class="article-section">
+              <h2>Non-implication map</h2>
+              <p>
+                Local law packages are useful because they make a precise claim
+                small enough to prove. They are dangerous only when their
+                conclusion is promoted into a different invariant family without
+                a bridge theorem.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Separate invariant families</figcaption>
+                <pre><code>LSP-compatible selected contexts
+  does not imply
+global decomposability
+
+DIP-compatible dependency direction
+  does not imply
+abstract layer acyclicity
+
+StaticFlatWithin X U
+  does not imply
+RuntimeFlatWithin X or SemanticFlatWithin X</code></pre>
+              </figure>
+              <p>
+                AAT keeps these failures as theory content. The point is not to
+                weaken design principles, but to place each principle in the
+                invariant family where it can be stated and checked correctly.
+              </p>
             </section>
 
             <section id="contract-example" class="article-section">

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -66,6 +66,8 @@
               <ol>
                 <li><a href="#repair">Repair and synthesis</a></li>
                 <li><a href="#complexity-transfer">Complexity transfer</a></li>
+                <li><a href="#repair-theorem">Repair theorem schema</a></li>
+                <li><a href="#signature-trajectory">Signature trajectory</a></li>
                 <li><a href="#paths-and-filling">Paths and filling</a></li>
                 <li><a href="#no-solution">No-solution boundary</a></li>
                 <li><a href="#path-example">Path example</a></li>
@@ -76,11 +78,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#11-repair-synthesis-complexity-transfer">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#11-repair-synthesis-complexity-transfer">
                     Chapters 11-12 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -134,6 +147,92 @@
                   non-increasing unless that theorem boundary says so.
                 </p>
               </div>
+            </section>
+
+            <section id="repair-theorem" class="article-section">
+              <h2>Repair theorem schema</h2>
+              <p>
+                A repair theorem is intentionally narrow. It states that a
+                selected measure decreases or a selected witness disappears,
+                while preserving named invariants and recording all axes whose
+                behavior is not concluded.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Selected repair theorem</figcaption>
+                <pre><code>RepairStep X Y
+  + selected witness universe W
+  + obstruction measure m
+  + invariant family I
+  + side-effect boundary E
+  -&gt;
+  m(Y) &lt; m(X)
+  + I is preserved within B
+  + non-conclusions for untracked axes</code></pre>
+              </figure>
+              <p>
+                Synthesis has a stronger burden. A generated candidate needs
+                satisfaction evidence, while a no-solution claim needs a finite
+                complete candidate universe and a checked decision procedure.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Repair step decreases selected measure</td>
+                      <td>`defined only` / `proved` for bounded packages</td>
+                      <td>Selected witness universe, obstruction measure, preserved invariant, and side-effect boundary.</td>
+                      <td>Does not prove all signature axes are non-increasing.</td>
+                      <td>Lean theorem index, repair entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Repair synthesis / no-solution soundness</td>
+                      <td>`defined only` / `proved` for bounded schema accessors</td>
+                      <td>Finite complete candidate universe, explicit constraints, decision procedure, and coverage boundary.</td>
+                      <td>Solver failure alone is not a mathematical no-solution certificate.</td>
+                      <td>Lean theorem index and proof-obligation ledger.</td>
+                    </tr>
+                    <tr>
+                      <td>Path homotopy and diagram filling</td>
+                      <td>`defined only` / `proved` for selected observation-invariance bridges</td>
+                      <td>Selected generators, selected observations, and diagram universe.</td>
+                      <td>Does not prove global semantic completeness or preservation of every observation axis.</td>
+                      <td>Lean theorem index, Chapter 8-9 entrypoints.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section id="signature-trajectory" class="article-section">
+              <h2>Signature trajectory</h2>
+              <p>
+                A repair is best read as a movement through signature space.
+                The theorem may prove a decrease on one selected coordinate,
+                while the trajectory records unchanged, transferred,
+                introduced, or unmeasured coordinates elsewhere.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Repair trajectory</figcaption>
+                <pre><code>ArchitecturePath X0 Xn
+  + selected repair steps
+  + signature coordinates at each step
+  + transferred or residual witnesses
+  + non-conclusions
+  -&gt; bounded repair reading</code></pre>
+              </figure>
+              <p>
+                This trajectory view is what prevents a local repair theorem
+                from becoming a total quality claim.
+              </p>
             </section>
 
             <section id="paths-and-filling" class="article-section">

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -66,7 +66,9 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#graph-matrix">Graph and matrix</a></li>
+                <li><a href="#graph-theorem">Graph theorem schema</a></li>
                 <li><a href="#analytic-representation">Analytic representation</a></li>
+                <li><a href="#representation-pattern">Representation pattern</a></li>
                 <li><a href="#state-effects">State transitions and effects</a></li>
                 <li><a href="#valuation-boundary">Valuation boundary</a></li>
                 <li><a href="#effect-examples">Effect examples</a></li>
@@ -77,11 +79,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#13-graph-matrix-analytic-representation">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#13-graph-matrix-analytic-representation">
                     Chapters 13-14 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -111,6 +124,80 @@
               </figure>
             </section>
 
+            <section id="graph-theorem" class="article-section">
+              <h2>Graph theorem schema</h2>
+              <p>
+                The graph and matrix bridge is a representation theorem for a
+                finite unweighted static universe. It connects several views of
+                the same structural condition without redefining
+                `Decomposable` and without importing runtime propagation into
+                the static theorem.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Finite static bridge</figcaption>
+                <pre><code>finite measured static universe
+  + coverage assumptions
+  -&gt;
+  Acyclic
+    &lt;-&gt; no nonempty closed walk
+    &lt;-&gt; adjacency nilpotence</code></pre>
+              </figure>
+              <p>
+                Cost, latency, propagation, and operational risk require
+                separate observation models or analytic representations. They
+                are not consequences of this static bridge alone.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Boundary diagram</figcaption>
+                <pre><code>Decomposable = StrictLayered
+  separate from
+acyclicity
+  &lt;-&gt; closed-walk absence
+  &lt;-&gt; adjacency nilpotence
+  -&gt; spectral radius zero under finite matrix assumptions
+
+runtime propagation
+  requires runtime graph / propagation model
+  and is not built into Decomposable</code></pre>
+              </figure>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Finite graph / matrix bridge</td>
+                      <td>`proved`</td>
+                      <td>Finite unweighted static universe with coverage assumptions.</td>
+                      <td>Not the definition of `Decomposable` and not a runtime theorem.</td>
+                      <td>Lean theorem index, matrix bridge entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Spectral bridge</td>
+                      <td>`proved` for finite complex adjacency matrices</td>
+                      <td>mathlib-backed finite matrix representation.</td>
+                      <td>Does not turn cost, risk, or latency into theorem-level signature axes.</td>
+                      <td>Lean theorem index, spectral radius entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Runtime propagation bridge</td>
+                      <td>`defined only` / `proved` for selected 0/1 runtime graph zero bridges</td>
+                      <td>Separate runtime universe and propagation model.</td>
+                      <td>Does not follow from static acyclicity alone.</td>
+                      <td>Lean theorem index and proof obligations.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
             <section id="analytic-representation" class="article-section">
               <h2>Analytic representation</h2>
               <p>
@@ -136,14 +223,43 @@
               </ul>
             </section>
 
+            <section id="representation-pattern" class="article-section">
+              <h2>Representation pattern</h2>
+              <p>
+                A representation theorem has two directions that must not be
+                conflated. Preserving sends a structural zero or witness into
+                the representation. Reflecting reads a represented zero or
+                obstruction back into the structural world, and therefore needs
+                stronger assumptions.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Preserve versus reflect</figcaption>
+                <pre><code>structural zero
+  -[preserving]-&gt;
+analytic zero
+
+analytic zero
+  + coverage
+  + witness completeness
+  + semantic contract coverage
+  -[reflecting]-&gt;
+structural zero</code></pre>
+              </figure>
+              <p>
+                This pattern also explains why dashboards and numerical
+                summaries are useful but insufficient: an aggregate can guide
+                attention without by itself proving structural flatness.
+              </p>
+            </section>
+
             <section id="state-effects" class="article-section">
               <h2>State transitions and effects</h2>
               <p>
                 The state-transition layer treats commands, events, retries,
-                compensations, snapshots, and migrations as generators, with
-                laws expressed as relations. Event Sourcing, Saga, retry safety,
-                snapshot consistency, and migration naturality are projections
-                of this algebra.
+                compensations, snapshots, CRUD overwrites, and migrations as
+                generators, with laws expressed as relations. Event Sourcing,
+                Saga, CRUD, retry safety, snapshot consistency, and migration
+                naturality are projections of this algebra.
               </p>
               <p>
                 The effect boundary captures obstruction that a dependency
@@ -156,6 +272,20 @@
 compensate ; action ~= id
 decode ; encode ~= id</code></pre>
               </figure>
+              <ul class="term-list">
+                <li>
+                  <strong>Circuit Breaker</strong>
+                  <span>Runtime protection law: selected failures should not propagate beyond the protected boundary while the breaker is open.</span>
+                </li>
+                <li>
+                  <strong>Replicated Log</strong>
+                  <span>Distributed ordering law: replicas converge only under the selected quorum, ordering, and failure-model assumptions.</span>
+                </li>
+                <li>
+                  <strong>CRUD</strong>
+                  <span>Overwrite law: update and delete behavior must be read against the selected state and observation relation, not against event replay by default.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="valuation-boundary" class="article-section">

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -66,6 +66,8 @@
               <ol>
                 <li><a href="#signature">Architecture Signature</a></li>
                 <li><a href="#measurement-status">Measurement status</a></li>
+                <li><a href="#signature-record">Signature record</a></li>
+                <li><a href="#measurement-semantics">Measurement semantics</a></li>
                 <li><a href="#theorem-boundary">Theorem boundary</a></li>
                 <li><a href="#claim-levels">Claim levels</a></li>
                 <li><a href="#comparison-rules">Comparison rules</a></li>
@@ -76,11 +78,22 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md#5-architecture-signature">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#5-architecture-signature">
                     Chapters 5-6 in the AAT text
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -131,6 +144,101 @@
                   <span>Cost and product outcomes are not required zero axes inside AAT.</span>
                 </li>
               </ul>
+            </section>
+
+            <section id="signature-record" class="article-section">
+              <h2>Signature record</h2>
+              <p>
+                A signature coordinate is a typed claim, not just a number in a
+                dashboard. The coordinate records the axis, the measured or
+                unmeasured status, the claim level, the universe in which it was
+                produced, the evidence that supports it, and the claims that are
+                explicitly not being made.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Coordinate shape</figcaption>
+                <pre><code>SignatureCoordinate
+  = axis
+  + measurement status
+  + value when measured
+  + claim level
+  + universe / coverage boundary
+  + evidence references
+  + non-conclusions</code></pre>
+              </figure>
+              <p>
+                This is why two reports cannot be compared merely because they
+                both contain a value. The coordinate must be read together with
+                its boundary and its axis-specific order.
+              </p>
+            </section>
+
+            <section id="measurement-semantics" class="article-section">
+              <h2>Measurement semantics</h2>
+              <p>
+                A signature is useful only if its coordinates preserve the
+                difference between value and status. The value says what was
+                measured on an axis; the status says whether that measurement
+                can be read as evidence for a claim.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>`measured_zero`</strong>
+                  <span>The selected witness universe has a zero value for that axis under the recorded boundary.</span>
+                </li>
+                <li>
+                  <strong>`measured_nonzero(value)`</strong>
+                  <span>A selected obstruction or risk coordinate was measured and remains nonzero.</span>
+                </li>
+                <li>
+                  <strong>`unmeasured`</strong>
+                  <span>The axis has not been observed; this is not the same claim as zero.</span>
+                </li>
+                <li>
+                  <strong>`out_of_scope` / `not_applicable`</strong>
+                  <span>The axis is outside the selected universe or does not apply to the object being read.</span>
+                </li>
+              </ul>
+              <p>
+                This semantics lets AAT compare architectures without turning
+                unknowns into zeros or forcing all axes into one total order.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Non-conclusion</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Architecture Signature as multi-axis diagnostic</td>
+                      <td>`defined only` / `proved` for required-axis bridge packages</td>
+                      <td>Selected axes, measurement status, and explicit theorem boundary.</td>
+                      <td>Does not rank architectures by one scalar quality value.</td>
+                      <td>Lean theorem index, signature entries.</td>
+                    </tr>
+                    <tr>
+                      <td>Measured zero versus unmeasured status</td>
+                      <td>`proved` for current required-axis availability / zero bridges</td>
+                      <td>Axis availability and exactness assumptions must be recorded.</td>
+                      <td>`none`, missing, private, or out-of-scope evidence is not zero.</td>
+                      <td>AAT Status and theorem index.</td>
+                    </tr>
+                    <tr>
+                      <td>Empirical cost or product outcome reading</td>
+                      <td>`empirical hypothesis`</td>
+                      <td>Requires separate dataset, calibration protocol, and artifact boundary.</td>
+                      <td>Not a Lean theorem and not a required zero-axis claim.</td>
+                      <td>Proof-obligation ledger.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="theorem-boundary" class="article-section">

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -66,7 +66,9 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#source-map">Source map</a></li>
+                <li><a href="#formal-claim-map">Formal claim map</a></li>
                 <li><a href="#status-vocabulary">Status vocabulary</a></li>
+                <li><a href="#promotion-rule">Promotion rule</a></li>
                 <li><a href="#qed-boundary">Current QED boundary</a></li>
               </ol>
             </nav>
@@ -74,16 +76,27 @@
               <h2>Status sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/lean_theorem_index.md">
                     Lean theorem index
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/proof_obligations.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/proof_obligations.md">
                     Proof obligations
                   </a>
                 </li>
               </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dt>Lean status</dt>
+                <dd>`lake build` passed for this snapshot; existing linter warnings are tracked outside this page.</dd>
+              </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
@@ -121,6 +134,61 @@
               </ul>
             </section>
 
+            <section id="formal-claim-map" class="article-section">
+              <h2>Formal claim map</h2>
+              <p>
+                The website states AAT as a theory, but only some parts are
+                current Lean-proved claims. The status boundary is part of the
+                exposition, not an implementation appendix.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Current proved core</strong>
+                  <span>Static structural theorem packages, finite witness-count bridges, selected required-axis exactness bridges, projection / LSP bridges, graph / matrix finite-universe bridges, and representative counterexamples tracked in the theorem index.</span>
+                </li>
+                <li>
+                  <strong>Defined-only surfaces</strong>
+                  <span>Operation schemas, extension schemas, analytic representation records, valuation records, repair and synthesis records, and tooling-facing metadata where the carrier exists but full correctness or completeness theorem packages are not universal.</span>
+                </li>
+                <li>
+                  <strong>Future proof obligations</strong>
+                  <span>Broader semantic completeness, global filling completeness, universe-wide obstruction coverage, and stronger operation laws that require additional theorem work.</span>
+                </li>
+                <li>
+                  <strong>Empirical hypotheses</strong>
+                  <span>Real-code extraction completeness, cost correlation, operational outcome improvement, and repository-wide calibration claims.</span>
+                </li>
+              </ul>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Status phrase</th>
+                      <th>Meaning in this website</th>
+                      <th>Reader rule</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>`proved theorem`</td>
+                      <td>A Lean theorem, lemma, or example theorem establishes the claim under its stated assumptions.</td>
+                      <td>Read only within the universe, coverage, exactness, and observation assumptions of that theorem.</td>
+                    </tr>
+                    <tr>
+                      <td>`schema accessor theorem`</td>
+                      <td>Lean proves that a record or package exposes the intended field, boundary, or non-conclusion data.</td>
+                      <td>Do not promote this to the full correctness theorem for every instance of the schema.</td>
+                    </tr>
+                    <tr>
+                      <td>`defined-only carrier`</td>
+                      <td>A structure, predicate, executable metric, or representation exists as a formal carrier.</td>
+                      <td>It supports precise statement of future theorems, but does not by itself prove the intended semantic claim.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
             <section id="status-vocabulary" class="article-section">
               <h2>Status vocabulary</h2>
               <p>
@@ -154,6 +222,28 @@
               </div>
             </section>
 
+            <section id="promotion-rule" class="article-section">
+              <h2>Promotion rule</h2>
+              <p>
+                AAT promotes a claim only when the artifact that states it also
+                carries the boundary needed to read it. A theorem candidate in
+                the mathematical text, a Lean definition, a tool report, and a
+                proved theorem are different objects.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Claim promotion path</figcaption>
+                <pre><code>mathematical candidate
+  -&gt; defined Lean schema
+  -&gt; proved theorem under boundary B
+  -&gt; public claim with non-conclusions recorded</code></pre>
+              </figure>
+              <p>
+                Tooling evidence can support a claim, but it does not replace
+                the theorem boundary. Empirical validation can motivate or
+                calibrate a hypothesis, but it is not promoted to `proved`.
+              </p>
+            </section>
+
             <section id="qed-boundary" class="article-section">
               <h2>Current QED boundary</h2>
               <p>
@@ -164,7 +254,9 @@
               </p>
               <figure class="code-panel">
                 <figcaption>Static structural core</figcaption>
-                <pre><code>ArchitectureLawful X
+                <pre><code>under explicit boundary B:
+
+ArchitectureLawful X
   &lt;-&gt; RequiredSignatureAxesZero (ArchitectureLawModel.signatureOf X)
 
 ArchitectureLawful X

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -509,6 +509,7 @@ p {
 
 .toc-panel,
 .source-panel,
+.version-panel,
 .boundary-note {
   border-top: 3px solid var(--ink);
   padding-top: 16px;
@@ -516,6 +517,7 @@ p {
 
 .toc-panel h2,
 .source-panel h2,
+.version-panel h2,
 .boundary-note h2 {
   margin-bottom: 10px;
   font-family: var(--font-sans);
@@ -548,11 +550,33 @@ p {
 }
 
 .source-panel p,
+.version-panel p,
 .boundary-note p,
 .boundary-note li {
   color: var(--ink-muted);
   font-size: 0.96rem;
   line-height: 1.52;
+}
+
+.version-panel dl {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.version-panel dt {
+  color: var(--accent-blue);
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.version-panel dd {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.94rem;
+  line-height: 1.42;
 }
 
 .article-main {
@@ -643,6 +667,38 @@ p {
   font-size: 0.98rem;
   font-weight: 650;
   line-height: 1.52;
+}
+
+.article-table {
+  margin-top: 18px;
+  overflow-x: auto;
+}
+
+.article-table table {
+  width: 100%;
+  border-collapse: collapse;
+  border-top: 1px solid var(--rule-strong);
+  font-size: 0.98rem;
+}
+
+.article-table th,
+.article-table td {
+  border-bottom: 1px solid var(--rule);
+  padding: 12px 14px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.article-table th {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.article-table td {
+  color: var(--ink-muted);
 }
 
 .page-nav {


### PR DESCRIPTION
## 概要

Closes #781

AAT website を、単なる紹介ページではなく web-native preprint / monograph として読める密度に補強しました。論文レベルの精密さと Web としての読みやすさを両立させるため、各章に theorem schema、local Lean status table、boundary / non-conclusion を追加し、公開版としての release snapshot と commit-pinned source links を導入しています。

主な設計判断:

- AAT landing に Abstract / Main contributions / publication purpose を追加。
- 各章に Current Lean status / Boundary / Non-conclusion / Source の表を追加。
- Coupon example を worked example として、ComponentUniverse、selected edges、witness set、semantic mismatch、runtime exposure、signature coordinates まで展開。
- GitHub docs links を docs source commit `e4a27d9` に固定し、公開本文と参照元の drift を避ける。
- Architecture Signature は単一スコアではなく多軸診断として扱う方針を維持。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/index.html`
- `website/aat/foundations/index.html`
- `website/aat/laws-and-witnesses/index.html`
- `website/aat/signature-and-boundary/index.html`
- `website/aat/local-law-packages/index.html`
- `website/aat/calculus-and-extensions/index.html`
- `website/aat/repair-and-dynamics/index.html`
- `website/aat/representations-and-effects/index.html`
- `website/aat/examples-and-boundaries/index.html`
- `website/aat/status/index.html`
- `website/assets/site.css`
- `website/README.md`
- `website/SITEMAP.md`

## 実施したテスト

- [x] `lake build` 成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2 件のみ。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] AAT ページ内 href / anchor 簡易チェック

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
