### PR TITLE
docs: website 向け記述を研究 docs から分離する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@
 - `docs` の研究主張を変更する場合は、対応する Lean status を明確にする。
 - Lean status は、proved, defined only, future proof obligation, empirical hypothesis を区別する。
 - Lean で証明済みの主張と、実証研究で検証する主張を混同しない。
+- `docs` は研究上の定義、理論本文、Lean status、proof obligation、tooling specification、empirical protocol を管理する source として扱う。
+- 公開 website の本文、読者導線、landing page 向け説明は `docs` の責務にしない。website 側の説明は docs の研究上の境界を参照してよいが、docs を website copy の source of truth として扱わない。
+- `公開 API` や `public API` のように Lean / tooling API の公開性を指す語は、website 向け記述とは区別して扱う。
 - `docs/aat_v2_mathematical_design.md` は数学面の第一級設計書として扱い、Lean status、Issue 番号、実装済み API の進捗管理を本文に混ぜない。
 - Lean status や Issue との対応は `docs/proof_obligations.md` と `docs/lean_theorem_index.md` で管理する。
 - 数学設計書には、数学的な定義・定理候補・非目標・設計上の境界を記述し、実装済み / 証明済み / 未着手といった作業状態は別文書へ分離する。

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,9 @@
 
 このディレクトリは、AAT の数学理論、AAT / SFT の境界、SFT の場の理論、
 Lean 形式化 status、tooling / empirical protocol を分けて管理する。
+公開 website の本文、読者導線、landing page 向け説明は、この研究 docs の責務ではない。
+website 側の説明は、ここに置いた研究上の境界を参照してよいが、docs を website copy の
+source of truth として扱わない。
 
 第一級本文は次の 3 文書である。
 

--- a/docs/research_goal.md
+++ b/docs/research_goal.md
@@ -122,9 +122,6 @@ tool pass を Lean theorem として読まない。
 ## 詳細文書
 
 この文書はビジョンを述べる入口であり、詳細な定義や台帳は持たない。
-公開 website の本文、読者導線、landing page 向け説明は、この研究 docs の責務ではない。
-website 側の説明は、ここに置いた研究上の境界を参照してよいが、docs を website copy の
-source of truth として扱わない。
 第一級本文は次の 3 文書に固定する。
 
 1. [AAT 数学理論](aat/mathematical_theory.md)

--- a/docs/research_goal.md
+++ b/docs/research_goal.md
@@ -122,6 +122,9 @@ tool pass を Lean theorem として読まない。
 ## 詳細文書
 
 この文書はビジョンを述べる入口であり、詳細な定義や台帳は持たない。
+公開 website の本文、読者導線、landing page 向け説明は、この研究 docs の責務ではない。
+website 側の説明は、ここに置いた研究上の境界を参照してよいが、docs を website copy の
+source of truth として扱わない。
 第一級本文は次の 3 文書に固定する。
 
 1. [AAT 数学理論](aat/mathematical_theory.md)

--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -22,11 +22,13 @@ tool 側の文書群である。
 11. [Examples](examples.md)
 12. [Roadmap](roadmap.md)
 
-## Product surface
+## Tooling capability surface
 
-Tooling docs は、利用者が実行できる surface と、研究・校正・adapter gap を分けて読む。
+Tooling docs は、実行できる command / artifact / workflow と、研究・校正・adapter gap を
+分けて読む。ここでいう surface は website 向けの製品説明ではなく、tooling の現在の
+観測能力と non-conclusion boundary を管理するための区分である。
 
-| Surface | 主な文書 | 現在の product surface | Remaining gaps |
+| Surface | 主な文書 | 現在の tooling capability | Remaining gaps |
 | --- | --- | --- | --- |
 | ArchSig Core | `signature_artifacts.md`, `extraction.md`, `tools/archsig/README.md` | Lean / Python import graph scan、Sig0 validation、snapshot、signature diff。 | call graph、data dependency、dynamic import、plugin loading、framework semantics adapter。extractor completeness は主張しない。 |
 | ArchSig Review | `air.md`, `reports.md`, `claim_boundary.md`, `theorem_preconditions.md` | AIR、theorem precondition check、Feature Extension Report、policy decision、PR comment、baseline suppression。 | organization policy calibration、review workflow tuning、任意 invariant の自動判定。tool output は Lean theorem ではない。 |

--- a/docs/tool/roadmap.md
+++ b/docs/tool/roadmap.md
@@ -37,11 +37,12 @@ Markdown PRD / Spec / Issue / AI proposal から `ForecastConeSkeleton` と
 | Empirical feedback | PR history、feature dataset、outcome linkage、B10 operational artifacts がある。 | 実 dataset での calibration と hypothesis refresh の運用。 |
 | Architecture dynamics | PR force、trajectory、dynamics metrics、field snapshot、operation proposal log の schema / validator と bounded SFT forecast pipeline がある。 | GitHub Issue JSON / AI proposal JSON adapter と実 dataset での calibration。 |
 
-## Product surface and remaining gaps
+## Tooling capability surface and remaining gaps
 
-利用者向けには、ArchSig の現状を次の 4 surface に分ける。
+ArchSig の現状を、実行可能な command / artifact / workflow と remaining gaps に分ける。
+これは website 向けの公開導線ではなく、tooling roadmap 上の capability boundary である。
 
-| Surface | Product surface | Remaining gaps |
+| Surface | Current tooling capability | Remaining gaps |
 | --- | --- | --- |
 | ArchSig Core | `scan`、`validate`、`snapshot`、`signature-diff` による Sig0 と revision diff。Lean / Python import graph、policy JSON、runtime edge evidence を明示入力として扱う。 | call graph、data dependency、dynamic import、plugin loading、framework convention は adapter boundary。完全な architecture model 抽出は主張しない。 |
 | ArchSig Review | AIR、validate-air、theorem-check、Feature Extension Report、policy decision、PR comment、baseline suppression。review / CI の補助 report として読む。 | organization policy calibration、review practice tuning、任意 invariant の完全判定は未完成。formal claim promotion は Lean theorem refs と precondition が揃う場合だけ。 |


### PR DESCRIPTION
## 概要

Closes #792

- `docs/README.md` に、公開 website の本文・読者導線・landing page 向け説明は研究 docs の責務ではないことを明記した。
- `AGENTS.md` のドキュメントポリシーにも同じ運用境界を追記し、`公開 API` など Lean / tooling API の公開性は website 向け記述と区別する方針を明記した。
- `docs/tool/README.md` と `docs/tool/roadmap.md` の `Product surface` 表現を、tooling の実行可能 capability と remaining gap を管理する表現へ整理した。
- `docs/research_goal.md` は研究ビジョンの入口として保ち、website 責務境界の説明は置かない形に戻した。

## 証明した定理

- なし

## 編集したドキュメント

- `AGENTS.md`
- `docs/README.md`
- `docs/research_goal.md`
- `docs/tool/README.md`
- `docs/tool/roadmap.md`

## 実施したテスト

- [x] `lake build`（既存 linter warning 2 件あり、build は成功）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている