### PR TITLE
AAT website に formal anchor theorem の位置づけを反映

### DIFF
--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -79,6 +79,7 @@
                 <li><a href="#abstract">Abstract</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
                 <li><a href="#publication-purpose">Publication purpose</a></li>
+                <li><a href="#formal-anchor">Formal anchor</a></li>
                 <li><a href="#reading-order">Reading order</a></li>
                 <li><a href="#claim-discipline">Claim discipline</a></li>
                 <li><a href="#canonical-sources">Canonical sources</a></li>
@@ -160,11 +161,12 @@
               <h2>Publication purpose</h2>
               <p>
                 This website is the canonical public reading surface for AAT:
-                a web-native theory text that sits between outreach posts and
-                a future conventional paper. Blog platforms are useful for
-                motivation, but AAT needs a stable place for definitions,
-                assumptions, theorem boundaries, examples, counterexamples,
-                Lean status, and non-conclusions to remain together.
+                a web-native systematic exposition that sits between outreach
+                posts and a future conventional paper. Blog platforms are
+                useful for motivation, but AAT needs a stable place for
+                definitions, assumptions, theorem boundaries, examples,
+                counterexamples, Lean status, and non-conclusions to remain
+                together.
               </p>
               <ul class="status-list">
                 <li>
@@ -178,6 +180,40 @@
                 <li>
                   <strong>Preprint-style surface</strong>
                   <span>The site makes AAT readable before a slower arXiv-style paper is prepared, while keeping claim discipline explicit.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="formal-anchor" class="article-section">
+              <h2>Formal anchor</h2>
+              <p>
+                Lean formalization is not a replacement for the whole AAT
+                exposition. Its role is to provide inspectable anchor theorem
+                packages inside the broader theory, so claims can be read with
+                explicit universe, coverage, exactness, and non-conclusion
+                boundaries.
+              </p>
+              <p>
+                The current paper-facing anchor is the finite static
+                structural core. It is a proved Lean package for selected
+                static lawfulness, required obstruction witnesses, and required
+                signature axes under stated assumptions, not the only main
+                theorem of AAT and not a substitute for the operation,
+                invariant, witness, signature, calculus, repair, and empirical
+                parts of the theory.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Inspectable package</strong>
+                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> lists the boundary, Lean declarations, derived diagnostics, and non-conclusions.</span>
+                </li>
+                <li>
+                  <strong>Zero-curvature terminology</strong>
+                  <span>Within this anchor, zero-curvature means the required obstruction valuation is zero for the selected law universe. It is not a numerical or differential-geometric curvature claim.</span>
+                </li>
+                <li>
+                  <strong>Reader rule</strong>
+                  <span>Use the Status page and theorem index whenever a public sentence depends on Lean, CI, audit scans, or theorem-boundary evidence.</span>
                 </li>
               </ul>
             </section>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -68,6 +68,7 @@
                 <li><a href="#source-map">Source map</a></li>
                 <li><a href="#audit-snapshot">Audit snapshot</a></li>
                 <li><a href="#formal-claim-map">Formal claim map</a></li>
+                <li><a href="#formal-anchor-package">Formal anchor package</a></li>
                 <li><a href="#reader-anchors">Reader anchors</a></li>
                 <li><a href="#status-vocabulary">Status vocabulary</a></li>
                 <li><a href="#promotion-rule">Promotion rule</a></li>
@@ -78,13 +79,18 @@
               <h2>Status sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6f9ab7e0f8d0417729e0dc95202870e47ee8fc9a/docs/aat/lean_theorem_index.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/ea0ade69aea34484453501b459bca6c99c14ae89/docs/aat/lean_theorem_index.md">
                     Lean theorem index
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6f9ab7e0f8d0417729e0dc95202870e47ee8fc9a/docs/aat/proof_obligations.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/ea0ade69aea34484453501b459bca6c99c14ae89/docs/aat/proof_obligations.md">
                     Proof obligations
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">
+                    Formal anchor theorem package
                   </a>
                 </li>
               </ul>
@@ -97,7 +103,7 @@
                 <dt>Lean toolchain</dt>
                 <dd><code>leanprover/lean4:v4.28.0</code></dd>
                 <dt>Source snapshot</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/6f9ab7e0f8d0417729e0dc95202870e47ee8fc9a">6f9ab7e0f8d0</a> plus the published page revision.</dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/ea0ade69aea34484453501b459bca6c99c14ae89">ea0ade69aea3</a> plus the published page revision.</dd>
                 <dt>Build evidence</dt>
                 <dd><code>lake build</code> is the whole-repository check used for Lean PRs and release snapshots.</dd>
                 <dt>Audit scans</dt>
@@ -204,9 +210,10 @@
             <section id="formal-claim-map" class="article-section">
               <h2>Formal claim map</h2>
               <p>
-                The website states AAT as a theory, but only some parts are
-                current Lean-proved claims. The status boundary is part of the
-                exposition, not an implementation appendix.
+                The website states AAT as a systematic theory exposition, but
+                only some parts are current Lean-proved claims. Lean does not
+                replace the whole exposition; it supplies inspectable anchors
+                that keep public claims tied to explicit theorem boundaries.
               </p>
               <ul class="status-list">
                 <li>
@@ -256,6 +263,39 @@
               </div>
             </section>
 
+            <section id="formal-anchor-package" class="article-section">
+              <h2>Formal anchor package</h2>
+              <p>
+                The finite static structural core is the current paper-facing
+                formal anchor theorem package. It is a checked anchor for
+                claim discipline inside AAT, not a claim that the whole theory
+                has been reduced to a single static structural theorem.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Boundary</strong>
+                  <span>The package is relative to an <code>ArchitectureLawModel</code> with finite universe coverage, selected required law family, selected required witnesses, required signature axes, and coverage / exactness assumptions.</span>
+                </li>
+                <li>
+                  <strong>Core equivalence</strong>
+                  <span><code>architectureLawful_iff_requiredSignatureAxesZero</code> and <code>architectureLawful_iff_architectureZeroCurvatureTheoremPackage</code> connect selected required lawfulness with required signature axes being zero and with the bundled theorem package.</span>
+                </li>
+                <li>
+                  <strong>Theorem index entry</strong>
+                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> is the public map from this website text to the Lean declarations, derived diagnostics, and non-conclusions.</span>
+                </li>
+              </ul>
+              <div class="claim-strip">
+                <p>
+                  In this package, zero-curvature is terminology for required
+                  obstruction valuation zero inside the selected law universe.
+                  It is not a numerical curvature axis, a differential
+                  geometric curvature theorem, or a runtime completeness
+                  statement.
+                </p>
+              </div>
+            </section>
+
             <section id="reader-anchors" class="article-section">
               <h2>Reader anchors</h2>
               <p>
@@ -266,7 +306,7 @@
               <ul class="status-list">
                 <li>
                   <strong>Static structural core</strong>
-                  <span><code>ArchitectureZeroCurvatureTheoremPackage</code> and <code>ArchitectureSignature.architectureLawful_iff_architectureZeroCurvatureTheoremPackage</code> state the current static core under explicit boundary assumptions.</span>
+                  <span><code>ArchitectureZeroCurvatureTheoremPackage</code> and <code>ArchitectureSignature.architectureLawful_iff_architectureZeroCurvatureTheoremPackage</code> state the current static core under explicit boundary assumptions; the theorem index records the <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">formal anchor boundary</a>.</span>
                 </li>
                 <li>
                   <strong>Required-axis exactness bridges</strong>
@@ -342,7 +382,13 @@
               <h2>Current QED boundary</h2>
               <p>
                 The current Lean-proved core is the static structural theorem
-                package. It connects lawfulness with required signature axes
+                package. It functions as a formal anchor for AAT's claim
+                discipline, while the website remains the broader systematic
+                exposition of operations, invariants, witnesses, signatures,
+                theorem boundaries, examples, and non-conclusions.
+              </p>
+              <p>
+                The package connects lawfulness with required signature axes
                 zero under explicit law-family, witness-coverage, axis
                 exactness, universe, coverage, and observation assumptions.
               </p>


### PR DESCRIPTION
## 概要

Closes #790

AAT website の入口ページと Status ページに、finite static structural core formal anchor theorem package の読み方を追加しました。Lean formalization は AAT 全体の代替ではなく、claim discipline を支える検査可能な anchor であることを明記しています。

zero-curvature は selected law universe に対する required obstruction valuation が zero であるという用語であり、数値的 curvature や微分幾何学的 curvature と混同しないよう Status 側にも明記しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/index.html`
- `website/aat/status/index.html`

## 実施したテスト

- [x] `lake build` 成功
- [x] `git diff --check` 成功
- [x] hidden / bidirectional Unicode scan 成功
- [x] `axiom` / `admit` / `sorry` / `unsafe` declaration scan 成功

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている