### PR TITLE
AAT websiteの関連研究と新規性境界を整理

### DIFF
--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -533,9 +533,9 @@ retry leaks across boundary
                 <span>Previous</span>
                 <strong>Representations and Effects</strong>
               </a>
-              <a href="../status/">
+              <a href="../related-work/">
                 <span>Next</span>
-                <strong>AAT Status</strong>
+                <strong>Related Work and Novelty</strong>
               </a>
             </nav>
           </div>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -81,6 +81,7 @@
                 <li><a href="#publication-purpose">Publication purpose</a></li>
                 <li><a href="#formal-anchor">Formal anchor</a></li>
                 <li><a href="#worked-example">Worked example</a></li>
+                <li><a href="#related-work">Related work</a></li>
                 <li><a href="#reading-order">Reading order</a></li>
                 <li><a href="#claim-discipline">Claim discipline</a></li>
                 <li><a href="#canonical-sources">Canonical sources</a></li>
@@ -240,6 +241,29 @@
               </ul>
             </section>
 
+            <section id="related-work" class="article-section">
+              <h2>Related work</h2>
+              <p>
+                AAT sits next to architecture description standards,
+                scenario-based evaluation, dependency analysis, architecture
+                metrics, formal methods, and category-theoretic software
+                models. Its novelty claim is not that those areas are replaced,
+                but that their evidence can be read through invariant
+                families, obstruction witnesses, multi-axis signatures, and
+                explicit theorem boundaries.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong><a href="related-work/">Related Work and Novelty</a></strong>
+                  <span>Compares AAT with ISO 42010, ATAM, architecture metrics, graph dependency analysis, formal methods, and category-theoretic modeling.</span>
+                </li>
+                <li>
+                  <strong>Reader rule</strong>
+                  <span>AAT does not turn a view, scenario, graph metric, or model-checking result into a global architecture claim without a recorded boundary.</span>
+                </li>
+              </ul>
+            </section>
+
             <section id="reading-order" class="article-section">
               <h2>Reading order</h2>
               <p>
@@ -280,6 +304,10 @@
                 <li>
                   <a href="examples-and-boundaries/">Examples and Boundaries</a>
                   <span>Five-minute coupon worked example, semantic counterexample, repair transfer, SOLID boundaries.</span>
+                </li>
+                <li>
+                  <a href="related-work/">Related Work and Novelty</a>
+                  <span>ISO 42010, ATAM, metrics, graph analysis, formal methods, category-theoretic models, and AAT contribution boundaries.</span>
                 </li>
                 <li>
                   <a href="status/">Status</a>

--- a/website/aat/related-work/index.html
+++ b/website/aat/related-work/index.html
@@ -1,0 +1,368 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT related work map: ISO 42010, ATAM, architecture metrics, graph analysis, formal methods, and novelty boundaries."
+    >
+    <title>AAT Related Work and Novelty</title>
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../interface/">Interface</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../archsig/">ArchSig</a>
+          <a href="../../outreach/">Outreach</a>
+          <a href="../../profile/">Profile</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Related Work</span>
+          </nav>
+          <p class="eyebrow">Appendix</p>
+          <h1>Related Work and Novelty</h1>
+          <p class="lede">
+            AAT reuses familiar architecture description, evaluation,
+            dependency, metric, and formal-methods ideas, but its contribution
+            is the bounded theorem discipline that connects invariants,
+            obstruction witnesses, multi-axis signatures, and explicit
+            non-conclusions.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#positioning">Positioning</a></li>
+                <li><a href="#iso-42010">ISO 42010</a></li>
+                <li><a href="#atam">ATAM</a></li>
+                <li><a href="#metrics">Architecture metrics</a></li>
+                <li><a href="#graph-analysis">Graph analysis</a></li>
+                <li><a href="#formal-methods">Formal methods</a></li>
+                <li><a href="#category-models">Category-theoretic models</a></li>
+                <li><a href="#novelty-claim">Novelty claim</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel">
+              <h2>Canonical sources</h2>
+              <ul>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md">
+                    AAT mathematical theory
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/research_goal.md">
+                    Research goal
+                  </a>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md">
+                    Lean theorem index
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="version-panel">
+              <h2>AAT release snapshot</h2>
+              <dl>
+                <dt>Updated</dt>
+                <dd>2026-05-15</dd>
+                <dt>Lean status</dt>
+                <dd>Related-work synthesis. It introduces no new Lean theorem.</dd>
+                <dt>Claim level</dt>
+                <dd>Conceptual comparison and novelty boundary, not an empirical validation result.</dd>
+              </dl>
+            </div>
+            <div class="boundary-note">
+              <h2>Boundary note</h2>
+              <p>
+                This page states how AAT should be read relative to adjacent
+                work. It does not claim that AAT replaces architecture
+                description standards, review methods, model checking, or
+                empirical architecture metrics.
+              </p>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="positioning" class="article-section">
+              <h2>Positioning</h2>
+              <p>
+                AAT is not a new notation for every architecture document, a
+                replacement for scenario-based review, or a single quality
+                metric. It is a local algebra for stating what architecture
+                operation is being considered, which invariant family is in
+                scope, which obstruction witnesses count as failures, and which
+                theorem boundary licenses a conclusion.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Novelty boundary</figcaption>
+                <pre><code>AAT contribution
+  = bounded architecture object
+  + invariant family
+  + obstruction witness universe
+  + multi-axis ArchitectureSignature
+  + theorem boundary and non-conclusions</code></pre>
+              </figure>
+            </section>
+
+            <section id="iso-42010" class="article-section">
+              <h2>ISO 42010</h2>
+              <p>
+                ISO/IEC/IEEE 42010 is the natural neighbor for architecture
+                description: stakeholders, concerns, viewpoints, views, and
+                model kinds organize how an architecture is documented. AAT
+                uses that kind of boundary discipline, but its object is not
+                primarily an architecture description package.
+              </p>
+              <p>
+                AAT asks a different question. Given a selected architecture
+                object and observation boundary, which invariant family is
+                required, which witness universe can expose a violation, which
+                signature coordinates were measured, and which theorem boundary
+                prevents over-reading the result?
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Neighbor concept</th>
+                      <th>AAT reading</th>
+                      <th>Boundary</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Viewpoint / view</td>
+                      <td>Selected observation context and evidence boundary.</td>
+                      <td>A view does not by itself prove invariant preservation.</td>
+                    </tr>
+                    <tr>
+                      <td>Model kind</td>
+                      <td>Carrier, graph, diagram, metric, or report shape used by a theorem or tool claim.</td>
+                      <td>Different model kinds require explicit bridge claims.</td>
+                    </tr>
+                    <tr>
+                      <td>Concern</td>
+                      <td>Invariant family, required law, or signature axis.</td>
+                      <td>A concern is not automatically a measured zero axis.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section id="atam" class="article-section">
+              <h2>ATAM</h2>
+              <p>
+                ATAM and related scenario-based methods organize quality
+                attribute reasoning around scenarios, risks, sensitivity
+                points, and tradeoffs. AAT does not replace that review
+                practice. It supplies a formal claim discipline for the parts
+                of a review that can be stated as bounded laws, witnesses,
+                signature axes, and theorem packages.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Quality attribute scenario</strong>
+                  <span>AAT can read a scenario as a selected observation context plus required invariant family when the evidence is precise enough.</span>
+                </li>
+                <li>
+                  <strong>Risk and tradeoff</strong>
+                  <span>AAT represents selected risks as obstruction witnesses or nonzero signature axes; tradeoffs are axis-local movements, not a global score.</span>
+                </li>
+                <li>
+                  <strong>Review conclusion</strong>
+                  <span>AAT requires the theorem boundary or artifact boundary to say what the conclusion does not cover.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="metrics" class="article-section">
+              <h2>Architecture metrics</h2>
+              <p>
+                Architecture metrics often summarize dependency, coupling,
+                complexity, volatility, or risk. AAT deliberately does not make
+                quality a single scalar. `ArchitectureSignature` is a
+                multi-axis diagnostic whose coordinates carry measurement
+                status, evidence, universe, and non-conclusions.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A lower value on one measured axis is not a total ordering of
+                  architectures. Static split, semantic commutativity, runtime
+                  exposure, projection exactness, and empirical outcomes remain
+                  separate axes unless a theorem or empirical protocol connects
+                  them.
+                </p>
+              </div>
+            </section>
+
+            <section id="graph-analysis" class="article-section">
+              <h2>Graph analysis</h2>
+              <p>
+                AAT reuses graph-level dependency analysis for selected static
+                and runtime relations: reachability, layering, acyclicity,
+                paths, adjacency-style representations, and finite metric
+                calculations. The distinctive move is to prevent those graph
+                facts from becoming stronger architecture claims without a
+                bridge.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Reused</strong>
+                  <span>Directed dependency graphs, finite component universes, reachability, witness counts, path and matrix-style representations.</span>
+                </li>
+                <li>
+                  <strong>Added by AAT</strong>
+                  <span>Law families, obstruction witnesses, signature status, and theorem boundaries that state which graph fact supports which architecture claim.</span>
+                </li>
+                <li>
+                  <strong>Non-conclusion</strong>
+                  <span>A clean selected graph does not imply complete extraction, semantic flatness, runtime safety, or empirical cost improvement.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="formal-methods" class="article-section">
+              <h2>Formal methods</h2>
+              <p>
+                Formal methods, model checking, type systems, theorem proving,
+                and refinement techniques provide ways to verify precise
+                specifications. AAT uses theorem proving as an anchor for
+                selected architecture statements, but the whole theory is not
+                reduced to a single model-checking problem.
+              </p>
+              <p>
+                The current Lean role is inspectable formal anchoring:
+                selected finite static lawfulness, selected required witnesses,
+                and selected required signature axes under explicit coverage
+                and exactness assumptions. Runtime extraction completeness,
+                semantic coverage, and empirical outcome claims remain outside
+                that anchor unless separate theorem packages are supplied.
+              </p>
+            </section>
+
+            <section id="category-models" class="article-section">
+              <h2>Category-theoretic models</h2>
+              <p>
+                AAT uses categorical vocabulary where it clarifies structure,
+                composition, projection, lifting, and obstruction. It does not
+                claim that every architecture concern is solved by naming a
+                category, and its current `ComponentCategory` is intentionally
+                thin: it forgets path counts and walk lengths.
+              </p>
+              <p>
+                Quantitative path information belongs to `Walk`, `Path`,
+                adjacency matrices, finite metric representations, or future
+                free-category constructions. This separation keeps categorical
+                structure from swallowing measurement semantics.
+              </p>
+            </section>
+
+            <section id="novelty-claim" class="article-section">
+              <h2>Novelty claim</h2>
+              <p>
+                The novelty claim is not that AAT invented architecture views,
+                scenario review, dependency graphs, software metrics, theorem
+                proving, or category theory. The claim is that AAT packages
+                them into a bounded architecture-reasoning discipline where
+                design principles are operations that preserve or improve
+                invariant families, failures are explicit obstruction
+                witnesses, and quality is read as a multi-axis signature under
+                theorem boundaries.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Area</th>
+                      <th>What AAT reuses</th>
+                      <th>What AAT contributes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Architecture description</td>
+                      <td>Views, model boundaries, and concern separation.</td>
+                      <td>Theorem boundary, witness universe, and signature status attached to claims.</td>
+                    </tr>
+                    <tr>
+                      <td>Architecture evaluation</td>
+                      <td>Scenario, risk, and tradeoff vocabulary.</td>
+                      <td>Bounded law and obstruction readings that prevent over-generalized review conclusions.</td>
+                    </tr>
+                    <tr>
+                      <td>Metrics</td>
+                      <td>Finite measurements and axis-specific readings.</td>
+                      <td>Multi-axis ArchitectureSignature with measured, unmeasured, out-of-scope, and non-conclusion states.</td>
+                    </tr>
+                    <tr>
+                      <td>Graphs and formal methods</td>
+                      <td>Dependency graphs, reachability, theorem proving, and bridge lemmas.</td>
+                      <td>Architecture-specific packaging of invariant preservation, witnesses, and proof boundaries.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a href="../examples-and-boundaries/">
+                <span>Previous</span>
+                <strong>Examples and Boundaries</strong>
+              </a>
+              <a href="../status/">
+                <span>Next</span>
+                <strong>AAT Status</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> AAT / SFT Research Notes.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -411,9 +411,9 @@ ArchitectureLawful X
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../examples-and-boundaries/">
+              <a href="../related-work/">
                 <span>Previous</span>
-                <strong>Examples and Boundaries</strong>
+                <strong>Related Work and Novelty</strong>
               </a>
               <a href="../../interface/">
                 <span>Next</span>


### PR DESCRIPTION
## 概要

Closes #784

AAT website に related work / novelty claim の章を追加し、ISO 42010、ATAM、architecture metrics、graph dependency analysis、formal methods、category-theoretic software modeling との関係を theorem boundary / witness / ArchitectureSignature の観点で整理しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/related-work/index.html`
- `website/aat/index.html`
- `website/aat/examples-and-boundaries/index.html`
- `website/aat/status/index.html`

## 実施したテスト

- [x] `lake build` 成功（既存の linter warning 2 件あり）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（宣言・placeholder 形に絞って該当なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている