### PR TITLE
AAT websiteのsource linkをrelease snapshotに固定する

### DIFF
--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -79,7 +79,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#9-architecture-calculus">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#9-architecture-calculus">
                     Chapters 9-10 in the AAT text
                   </a>
                 </li>
@@ -91,7 +91,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -81,7 +81,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#15-canonical-examples-and-counterexamples">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#15-canonical-examples-and-counterexamples">
                     Chapters 15-16 in the AAT text
                   </a>
                 </li>
@@ -93,7 +93,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -79,7 +79,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#1-%E4%B8%AD%E5%BF%83%E5%91%BD%E9%A1%8C">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#1-%E4%B8%AD%E5%BF%83%E5%91%BD%E9%A1%8C">
                     Chapters 1-2 in the AAT text
                   </a>
                 </li>
@@ -91,7 +91,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see Status for proved / defined-only boundaries.</dd>
               </dl>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -91,12 +91,12 @@
               <h2>Canonical sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md">
                     AAT mathematical theory
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/README.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/README.md">
                     AAT repository entry
                   </a>
                 </li>
@@ -108,7 +108,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` and audit scan meanings are explained on the Status page.</dd>
               </dl>
@@ -207,7 +207,7 @@
               <ul class="status-list">
                 <li>
                   <strong>Inspectable package</strong>
-                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> lists the boundary, Lean declarations, derived diagnostics, and non-conclusions.</span>
+                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> lists the boundary, Lean declarations, derived diagnostics, and non-conclusions.</span>
                 </li>
                 <li>
                   <strong>Zero-curvature terminology</strong>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -78,7 +78,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#3-invariant-%E3%81%A8-law-universe">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#3-invariant-%E3%81%A8-law-universe">
                     Chapters 3-4 in the AAT text
                   </a>
                 </li>
@@ -90,7 +90,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -79,7 +79,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#7-projection-observation-lsp-dip">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#7-projection-observation-lsp-dip">
                     Chapters 7-8 in the AAT text
                   </a>
                 </li>
@@ -91,7 +91,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/related-work/index.html
+++ b/website/aat/related-work/index.html
@@ -80,17 +80,17 @@
               <h2>Canonical sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/mathematical_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md">
                     AAT mathematical theory
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/research_goal.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/research_goal.md">
                     Research goal
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md">
                     Lean theorem index
                   </a>
                 </li>
@@ -101,6 +101,8 @@
               <dl>
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>Related-work synthesis. It introduces no new Lean theorem.</dd>
                 <dt>Claim level</dt>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -78,7 +78,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#11-repair-synthesis-complexity-transfer">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#11-repair-synthesis-complexity-transfer">
                     Chapters 11-12 in the AAT text
                   </a>
                 </li>
@@ -90,7 +90,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -79,7 +79,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#13-graph-matrix-analytic-representation">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#13-graph-matrix-analytic-representation">
                     Chapters 13-14 in the AAT text
                   </a>
                 </li>
@@ -91,7 +91,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -78,7 +78,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/e4a27d95a6564a2a62305cd0c10dd12f5b131e88/docs/aat/mathematical_theory.md#5-architecture-signature">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#5-architecture-signature">
                     Chapters 5-6 in the AAT text
                   </a>
                 </li>
@@ -90,7 +90,7 @@
                 <dt>Updated</dt>
                 <dd>2026-05-15</dd>
                 <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/e4a27d95a6564a2a62305cd0c10dd12f5b131e88">e4a27d9</a></dd>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
                 <dd>`lake build` passed for this snapshot; see local status notes and Status page.</dd>
               </dl>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -79,17 +79,17 @@
               <h2>Status sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/ea0ade69aea34484453501b459bca6c99c14ae89/docs/aat/lean_theorem_index.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md">
                     Lean theorem index
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/ea0ade69aea34484453501b459bca6c99c14ae89/docs/aat/proof_obligations.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/proof_obligations.md">
                     Proof obligations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">
                     Formal anchor theorem package
                   </a>
                 </li>
@@ -102,8 +102,8 @@
                 <dd>2026-05-15</dd>
                 <dt>Lean toolchain</dt>
                 <dd><code>leanprover/lean4:v4.28.0</code></dd>
-                <dt>Source snapshot</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/ea0ade69aea34484453501b459bca6c99c14ae89">ea0ade69aea3</a> plus the published page revision.</dd>
+                <dt>Docs source commit</dt>
+                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Build evidence</dt>
                 <dd><code>lake build</code> is the whole-repository check used for Lean PRs and release snapshots.</dd>
                 <dt>Audit scans</dt>
@@ -282,7 +282,7 @@
                 </li>
                 <li>
                   <strong>Theorem index entry</strong>
-                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> is the public map from this website text to the Lean declarations, derived diagnostics, and non-conclusions.</span>
+                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> is the public map from this website text to the Lean declarations, derived diagnostics, and non-conclusions.</span>
                 </li>
               </ul>
               <div class="claim-strip">
@@ -306,7 +306,7 @@
               <ul class="status-list">
                 <li>
                   <strong>Static structural core</strong>
-                  <span><code>ArchitectureZeroCurvatureTheoremPackage</code> and <code>ArchitectureSignature.architectureLawful_iff_architectureZeroCurvatureTheoremPackage</code> state the current static core under explicit boundary assumptions; the theorem index records the <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">formal anchor boundary</a>.</span>
+                  <span><code>ArchitectureZeroCurvatureTheoremPackage</code> and <code>ArchitectureSignature.architectureLawful_iff_architectureZeroCurvatureTheoremPackage</code> state the current static core under explicit boundary assumptions; the theorem index records the <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">formal anchor boundary</a>.</span>
                 </li>
                 <li>
                   <strong>Required-axis exactness bridges</strong>


### PR DESCRIPTION
## 概要

Closes #807

AAT website の canonical source link と release snapshot 表示を publication-grade に統一しました。

- `website/aat/**` の docs source link を `blob/main` や旧 snapshot から `89b4502b6fc01937bfafa409155a7b4a194a80fe` 固定 URL に更新
- AAT 各ページの `AAT release snapshot` に同一の `Docs source commit` を表示
- `related-work` と `status` の snapshot 表示を他の AAT ページと揃え、silent drift を避ける形に整理

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/index.html`
- `website/aat/status/index.html`
- `website/aat/related-work/index.html`
- `website/aat/foundations/index.html`
- `website/aat/laws-and-witnesses/index.html`
- `website/aat/signature-and-boundary/index.html`
- `website/aat/local-law-packages/index.html`
- `website/aat/calculus-and-extensions/index.html`
- `website/aat/repair-and-dynamics/index.html`
- `website/aat/representations-and-effects/index.html`
- `website/aat/examples-and-boundaries/index.html`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] website local preview: `python3 -m http.server 8001 --directory website`
- [x] `curl -I http://127.0.0.1:8001/aat/`
- [x] `curl -I http://127.0.0.1:8001/aat/status/`
- [x] `curl -I http://127.0.0.1:8001/aat/related-work/`
- [x] `curl -I http://127.0.0.1:8001/assets/site.css`
- [x] `rg -n "blob/main|e4a27d|ea0ade|Source snapshot|plus the published page revision" website/aat`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
