### PR TITLE
AAT website の Foundations を DA 型本文へ改稿する

### DIFF
--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -232,6 +232,16 @@ ArchitectureObject
                       the object being discussed.
                     </p>
                   </div>
+                  <div class="counterexample-note">
+                    <h4>Why the assumptions matter</h4>
+                    <p>
+                      If the observation context is erased, a static import
+                      graph and a runtime call graph can be read as the same
+                      object even when they support different claims. The
+                      theorem boundary then has no way to say whether "no edge"
+                      means measured absence or simply unobserved evidence.
+                    </p>
+                  </div>
                   <dl class="claim-meta">
                     <div>
                       <dt>Assumptions</dt>
@@ -298,6 +308,17 @@ ArchitectureObject
                       membership and static coverage facts from that record,
                       but the record has no field stating global telemetry or
                       extractor completeness.
+                    </p>
+                  </div>
+                  <div class="counterexample-note">
+                    <h4>Why the assumptions matter</h4>
+                    <p>
+                      Reading <code>ArchitectureCore</code> as complete
+                      extraction would promote every omitted runtime edge into
+                      evidence of absence. That is stronger than the Lean
+                      record: the record proves facts about the supplied
+                      universe, not about every edge a production system could
+                      emit.
                     </p>
                   </div>
                   <dl class="claim-meta">
@@ -413,6 +434,16 @@ ArchitectureObject
                       bounded list or boolean computation to a graph statement.
                     </p>
                   </div>
+                  <div class="counterexample-note">
+                    <h4>Why the assumptions matter</h4>
+                    <p>
+                      Without coverage, a bounded search can miss a component
+                      that carries the only violating edge. Without edge
+                      closure, an in-scope source can point to an out-of-scope
+                      target, so a zero result on the list is not a graph-level
+                      zero claim.
+                    </p>
+                  </div>
                   <dl class="claim-meta">
                     <div>
                       <dt>Lean names</dt>
@@ -469,6 +500,20 @@ ArchitectureObject
                 rounding order, or operational incidents. Those require their
                 own observation contexts.
               </p>
+              <figure class="code-panel">
+                <figcaption>Minimal bounded universe</figcaption>
+                <pre><code>components = {CouponService, PaymentPort, PaymentAdapter}
+static edges observed:
+  CouponService -&gt; PaymentPort
+  PaymentAdapter -&gt; PaymentPort
+
+selected claim:
+  no observed static edge CouponService -&gt; PaymentAdapter
+
+not selected:
+  retry behavior, cache invalidation, rounding order,
+  incident telemetry, semantic workflow completeness</code></pre>
+              </figure>
               <ul class="term-list">
                 <li>
                   <strong>Measured zero</strong>
@@ -495,6 +540,16 @@ ArchitectureObject
                     theorem can read only the selected static edges and their
                     closure evidence.
                   </p>
+                  <div class="proof-idea">
+                    <h4>What is concluded</h4>
+                    <p>
+                      Inside this finite universe, the selected static relation
+                      can support a bounded statement such as "the service does
+                      not directly depend on the adapter" when the theorem
+                      package supplies the required coverage and closure
+                      assumptions.
+                    </p>
+                  </div>
                   <dl class="claim-meta">
                     <div>
                       <dt>Reading path</dt>
@@ -528,6 +583,17 @@ ArchitectureObject
                     incidents, or semantic workflow completeness unless those
                     observations are separately selected.
                   </p>
+                  <div class="counterexample-note">
+                    <h4>What is not concluded</h4>
+                    <p>
+                      A runtime trace could still show
+                      <code>CouponService</code> calling
+                      <code>PaymentAdapter</code> through a retry helper. That
+                      would not contradict the static split reading; it would
+                      be a different observation context and a different
+                      theorem boundary.
+                    </p>
+                  </div>
                   <dl class="claim-meta">
                     <div>
                       <dt>Boundary</dt>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -70,7 +70,7 @@
                 <li><a href="#core-proposition">Core proposition</a></li>
                 <li><a href="#universe-proposition">Universe proposition</a></li>
                 <li><a href="#example-counterexample">Example and counterexample</a></li>
-                <li><a href="#status-index">Status index</a></li>
+                <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -162,126 +162,38 @@ ArchitectureObject
                 the object is never stronger than the carrier, policy, and
                 observation context that presented it.
               </p>
-              <div class="theorem-stack">
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Definition</p>
-                    <h3>Bounded ArchitectureObject</h3>
-                  </div>
-                  <p>
-                    An <code>ArchitectureObject</code> is the mathematical
-                    object selected by a carrier, a policy, and an observation
-                    context. It is cut from code, specifications, review
-                    evidence, or operational observations, but it is not the
-                    unbounded real codebase itself.
-                  </p>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Docs source</dt>
-                      <dd>
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#2-architecture-object">
-                          mathematical theory, Chapter 2
-                        </a>
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Lean correspondence</dt>
-                      <dd>
-                        <code>ArchitectureCore</code> is the proof-carrying
-                        presentation used by the current Lean surface.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Status</dt>
-                      <dd><code>defined only</code> for the core record.</dd>
-                    </div>
-                    <div>
-                      <dt>Boundary</dt>
-                      <dd>
-                        Relative to selected components, relations, policy,
-                        observation model, and measurement universe.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Non-conclusion</dt>
-                      <dd>
-                        No extractor completeness, repository-wide semantics,
-                        or global architecture quality claim follows.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Proposition</p>
-                    <h3>Object claims are relativized claims</h3>
-                  </div>
-                  <p>
-                    A sentence about an architecture object is licensed only
-                    inside the carrier, policy, and observation context that
-                    present it. This is a reading rule from the canonical
-                    theory text, not a new website theorem.
-                  </p>
-                  <div class="proof-idea">
-                    <h4>Proof idea</h4>
-                    <p>
-                      Every later lawfulness, zero, split, flatness, or
-                      witness claim names the selected universe and its
-                      exactness boundary. Dropping that boundary would change
-                      the object being discussed.
-                    </p>
-                  </div>
-                  <div class="proof-idea">
-                    <h4>Proof</h4>
-                    <p>
-                      Unfold the object schema from the canonical text:
-                      <code>ArchitectureObject</code> is presented as
-                      <code>ArchitectureCarrier</code> plus
-                      <code>ArchitecturePolicy</code> plus
-                      <code>ArchitectureObservationContext</code>. Any later
-                      theorem consumes one of these selected presentations as
-                      an input. Therefore its conclusion is indexed by that
-                      carrier, policy, and observation context; changing any
-                      one of them changes the proposition being proved.
-                    </p>
-                  </div>
-                  <div class="counterexample-note">
-                    <h4>Why the assumptions matter</h4>
-                    <p>
-                      If the observation context is erased, a static import
-                      graph and a runtime call graph can be read as the same
-                      object even when they support different claims. The
-                      theorem boundary then has no way to say whether "no edge"
-                      means measured absence or simply unobserved evidence.
-                    </p>
-                  </div>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Assumptions</dt>
-                      <dd>
-                        A selected <code>ArchitectureCarrier</code>,
-                        <code>ArchitecturePolicy</code>, and
-                        <code>ArchitectureObservationContext</code>.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Lean status</dt>
-                      <dd>
-                        Enforced by explicit inputs in Lean definitions and
-                        theorem assumptions; no stronger theorem is claimed.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Non-conclusion</dt>
-                      <dd>
-                        The same repository may have another presentation
-                        with a different observation boundary.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-              </div>
+              <p>
+                <strong>Definition.</strong> A bounded
+                <code>ArchitectureObject</code> is the mathematical object
+                selected by a carrier, a policy, and an observation context.
+                It is cut from code, specifications, review evidence, or
+                operational observations, but it is not the unbounded real
+                codebase itself.
+              </p>
+              <p>
+                <strong>Proposition.</strong> Object claims are relativized
+                claims. A sentence about an architecture object is licensed
+                only inside the carrier, policy, and observation context that
+                present it.
+              </p>
+              <p>
+                <strong>Proof.</strong> Unfold the object schema:
+                <code>ArchitectureObject</code> is presented as
+                <code>ArchitectureCarrier</code> plus
+                <code>ArchitecturePolicy</code> plus
+                <code>ArchitectureObservationContext</code>. Later theorems
+                consume such a selected presentation as input. Their
+                conclusions are therefore indexed by the selected carrier,
+                policy, and observation context; changing any one of these
+                changes the proposition being proved.
+              </p>
+              <p>
+                If the observation context is erased, a static import graph
+                and a runtime call graph can be read as the same object even
+                when they support different claims. The theorem boundary then
+                has no way to say whether "no edge" means measured absence or
+                simply unobserved evidence.
+              </p>
             </section>
 
             <section id="core-proposition" class="article-section">
@@ -302,95 +214,34 @@ ArchitectureObject
   + runtime dependency role
   + measured semantic diagram universe</code></pre>
               </figure>
-              <div class="theorem-stack">
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Proposition</p>
-                    <h3>Core presentations do not imply complete extraction</h3>
-                  </div>
-                  <p>
-                    A core presentation can expose the evidence needed by a
-                    theorem package while still omitting relations outside its
-                    declared coverage boundary. Presentation equivalence is
-                    therefore relative to the selected observation model.
-                  </p>
-                  <div class="proof-idea">
-                    <h4>Proof idea</h4>
-                    <p>
-                      The Lean record carries a static universe and selected
-                      predicates as fields. Accessor theorems can recover
-                      membership and static coverage facts from that record,
-                      but the record has no field stating global telemetry or
-                      extractor completeness.
-                    </p>
-                  </div>
-                  <div class="proof-idea">
-                    <h4>Proof</h4>
-                    <p>
-                      In Lean, the proof is by projection from the supplied
-                      <code>ArchitectureCore</code>. The theorem
-                      <code>ArchitectureCore.component_mem_staticUniverse</code>
-                      recovers component membership from the core's
-                      <code>ComponentUniverse.covers</code> evidence, and
-                      <code>ArchitectureCore.staticCoverageComplete</code>
-                      recovers static coverage from the same bounded universe.
-                      No field or theorem in this block quantifies over all
-                      repository components or all runtime observations.
-                    </p>
-                  </div>
-                  <div class="counterexample-note">
-                    <h4>Why the assumptions matter</h4>
-                    <p>
-                      Reading <code>ArchitectureCore</code> as complete
-                      extraction would promote every omitted runtime edge into
-                      evidence of absence. That is stronger than the Lean
-                      record: the record proves facts about the supplied
-                      universe, not about every edge a production system could
-                      emit.
-                    </p>
-                  </div>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Lean names</dt>
-                      <dd>
-                        <code>ArchitectureCore</code>,
-                        <code>ArchitectureCore.component_mem_staticUniverse</code>,
-                        <code>ArchitectureCore.staticCoverageComplete</code>
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Status</dt>
-                      <dd>
-                        <code>defined only</code> for the core record;
-                        <code>proved</code> for the listed accessor theorems.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Index</dt>
-                      <dd>
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">
-                          Architecture Core / Certified Architecture
-                        </a>
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Boundary</dt>
-                      <dd>
-                        Static coverage is read from the supplied finite
-                        universe; runtime and semantic completeness are not
-                        promoted.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Non-conclusion</dt>
-                      <dd>
-                        A core is not proof that every component, runtime edge,
-                        operational effect, or semantic diagram was observed.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-              </div>
+              <p>
+                <strong>Proposition.</strong> Core presentations do not imply
+                complete extraction. A core can expose the evidence needed by
+                a theorem package while still omitting relations outside its
+                declared coverage boundary. Presentation equivalence is
+                therefore relative to the selected observation model.
+              </p>
+              <p>
+                <strong>Proof.</strong> In the Lean formalization this is
+                reflected by projection from the supplied
+                <code>ArchitectureCore</code>. The theorem
+                <code>ArchitectureCore.component_mem_staticUniverse</code>
+                recovers component membership from the core's
+                <code>ComponentUniverse.covers</code> evidence, and
+                <code>ArchitectureCore.staticCoverageComplete</code> recovers
+                static coverage from the same bounded universe. These
+                projections prove coverage facts about the supplied core; they
+                do not quantify over all repository components or all runtime
+                observations.
+              </p>
+              <p>
+                This distinction is essential. Reading
+                <code>ArchitectureCore</code> as complete extraction would
+                promote every omitted runtime edge into evidence of absence.
+                The record is intentionally weaker: it proves facts about the
+                supplied universe, not about every edge a production system
+                could emit.
+              </p>
             </section>
 
             <section id="universe-proposition" class="article-section">
@@ -402,136 +253,47 @@ ArchitectureObject
                 Outside that universe, AAT does not infer zero, absence,
                 flatness, split, or lawfulness.
               </p>
-              <div class="theorem-stack">
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Definition</p>
-                    <h3>Finite measurement universe</h3>
-                  </div>
-                  <p>
-                    A finite universe supplies the bounded component list and
-                    the proof obligations needed to read graph-level evidence
-                    as in-scope evidence.
-                  </p>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Lean names</dt>
-                      <dd>
-                        <code>ComponentUniverse</code>,
-                        <code>ComponentUniverse.full</code>,
-                        <code>FiniteArchGraph</code>
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Status</dt>
-                      <dd><code>defined only</code> for the universe records.</dd>
-                    </div>
-                    <div>
-                      <dt>Index</dt>
-                      <dd>
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">
-                          Finite Universe / Bridge Theorems
-                        </a>
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Non-conclusion</dt>
-                      <dd>
-                        Missing or unmeasured components are not silently
-                        converted into measured zero evidence.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Proposition</p>
-                    <h3>Finite bridges are coverage-relative</h3>
-                  </div>
-                  <p>
-                    The proved finite-universe bridge theorems connect
-                    executable or graph-level facts to proposition-level facts
-                    only under their supplied universe and closure assumptions.
-                  </p>
-                  <div class="proof-idea">
-                    <h4>Proof idea</h4>
-                    <p>
-                      The universe carries component coverage and edge closure.
-                      Bridge theorems consume those proofs to move from a
-                      bounded list or boolean computation to a graph statement.
-                    </p>
-                  </div>
-                  <div class="proof-idea">
-                    <h4>Proof</h4>
-                    <p>
-                      The finite universe supplies the measured component list
-                      and the coverage proof. For full universes,
-                      <code>ComponentUniverse.edgeClosed_of_covers</code>
-                      derives edge closure from coverage. Bundling the graph as
-                      a <code>FiniteArchGraph</code> exposes
-                      <code>FiniteArchGraph.covers_components</code> and
-                      <code>FiniteArchGraph.edgeClosed_components</code>.
-                      Reachability claims then use
-                      <code>ComponentUniverse.reachable_exists_bounded_path</code>
-                      to replace an unbounded reachability assertion with a
-                      bounded simple-path witness inside the supplied universe.
-                    </p>
-                  </div>
-                  <div class="counterexample-note">
-                    <h4>Why the assumptions matter</h4>
-                    <p>
-                      Without coverage, a bounded search can miss a component
-                      that carries the only violating edge. Without edge
-                      closure, an in-scope source can point to an out-of-scope
-                      target, so a zero result on the list is not a graph-level
-                      zero claim.
-                    </p>
-                  </div>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Lean names</dt>
-                      <dd>
-                        <code>ComponentUniverse.edgeClosed_of_covers</code>,
-                        <code>FiniteArchGraph.covers_components</code>,
-                        <code>ComponentUniverse.reachable_exists_bounded_path</code>
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Status</dt>
-                      <dd><code>proved</code> under explicit finite assumptions.</dd>
-                    </div>
-                    <div>
-                      <dt>Boundary</dt>
-                      <dd>
-                        Static graph and finite universe only; runtime,
-                        semantic, and empirical axes require separate evidence.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Non-conclusion</dt>
-                      <dd>
-                        The theorem does not claim complete extraction from a
-                        real repository or global architecture lawfulness.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-              </div>
-              <ul class="status-list">
-                <li>
-                  <strong>Thin category boundary</strong>
-                  <span><code>ComponentCategory</code> remembers whether reachability exists and intentionally forgets path count and walk length.</span>
-                </li>
-                <li>
-                  <strong>Quantitative boundary</strong>
-                  <span>Path counts, walk length, adjacency powers, finite metrics, and future free-category constructions live outside the thin-category claim.</span>
-                </li>
-                <li>
-                  <strong>Decomposability boundary</strong>
-                  <span>Current <code>Decomposable</code> means <code>StrictLayered</code>; acyclicity, finite propagation, nilpotence, and spectral conditions remain separate theorems or representations.</span>
-                </li>
-              </ul>
+              <p>
+                <strong>Definition.</strong> A finite measurement universe
+                supplies the bounded component list and the proof obligations
+                needed to read graph-level evidence as in-scope evidence.
+              </p>
+              <p>
+                <strong>Proposition.</strong> Finite bridges are
+                coverage-relative. Executable or graph-level facts become
+                proposition-level facts only under their supplied universe and
+                closure assumptions.
+              </p>
+              <p>
+                <strong>Proof.</strong> The finite universe supplies the
+                measured component list and the coverage proof. For full
+                universes, <code>ComponentUniverse.edgeClosed_of_covers</code>
+                derives edge closure from coverage. Bundling the graph as a
+                <code>FiniteArchGraph</code> exposes
+                <code>FiniteArchGraph.covers_components</code> and
+                <code>FiniteArchGraph.edgeClosed_components</code>. A
+                reachability claim is then made finite by
+                <code>ComponentUniverse.reachable_exists_bounded_path</code>,
+                which replaces an unbounded reachability assertion with a
+                bounded simple-path witness inside the supplied universe.
+              </p>
+              <p>
+                Without coverage, a bounded search can miss a component that
+                carries the only violating edge. Without edge closure, an
+                in-scope source can point to an out-of-scope target, so a zero
+                result on the list is not a graph-level zero claim.
+              </p>
+              <p>
+                The same boundary explains the role of
+                <code>ComponentCategory</code>: it remembers whether
+                reachability exists and intentionally forgets path count and
+                walk length. Path counts, adjacency powers, finite metrics, and
+                future free-category constructions live outside that
+                thin-category claim. Likewise, current
+                <code>Decomposable</code> means <code>StrictLayered</code>;
+                acyclicity, finite propagation, nilpotence, and spectral
+                conditions remain separate theorems or representations.
+              </p>
             </section>
 
             <section id="example-counterexample" class="article-section">
@@ -581,102 +343,36 @@ not selected:
                   <span>Different carriers can present the same object only relative to the selected observation model.</span>
                 </li>
               </ul>
-              <div class="theorem-stack">
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Example</p>
-                    <h3>Static split universe</h3>
-                  </div>
-                  <p>
-                    If the selected universe contains the coupon service,
-                    payment interface, and public adapter API, a static split
-                    theorem can read only the selected static edges and their
-                    closure evidence.
-                  </p>
-                  <div class="proof-idea">
-                    <h4>What is concluded</h4>
-                    <p>
-                      Inside this finite universe, the selected static relation
-                      can support a bounded statement such as "the coupon
-                      service uses the declared payment port and has no
-                      selected edge to adapter internals" when the theorem
-                      package supplies the required coverage and closure
-                      assumptions.
-                    </p>
-                  </div>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Reading path</dt>
-                      <dd>
-                        Continue with the
-                        <a href="../examples-and-boundaries/#coupon-case-study">
-                          coupon case study
-                        </a>
-                        for measured-zero, measured-nonzero, unmeasured, and
-                        out-of-scope coordinates.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Lean status</dt>
-                      <dd>
-                        Example-level readings are tied to the specific finite
-                        theorem packages cited there.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-
-                <article class="theorem-card">
-                  <div class="theorem-card-header">
-                    <p class="theorem-kicker">Counterexample / non-conclusion</p>
-                    <h3>Static evidence does not certify runtime behavior</h3>
-                  </div>
-                  <p>
-                    The same repository slice is not evidence about runtime
-                    retries, cache invalidation, rounding order, operational
-                    incidents, or semantic workflow completeness unless those
-                    observations are separately selected.
-                  </p>
-                  <div class="counterexample-note">
-                    <h4>What is not concluded</h4>
-                    <p>
-                      A runtime trace could still show
-                      <code>CouponService</code> calling
-                      <code>PaymentAdapter.publicApi</code> through a retry
-                      helper, or a static scan could reveal the bad edge
-                      <code>CouponService</code> to
-                      <code>PaymentAdapter.internalCache</code>. Neither case
-                      is erased by the good-universe reading; each requires its
-                      own observation context and theorem boundary.
-                    </p>
-                  </div>
-                  <dl class="claim-meta">
-                    <div>
-                      <dt>Boundary</dt>
-                      <dd>
-                        Static dependency evidence remains static dependency
-                        evidence.
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Non-conclusion</dt>
-                      <dd>
-                        No runtime flatness, semantic flatness, or empirical
-                        cost claim follows from this foundational page.
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-              </div>
+              <p>
+                In the good static presentation, the coupon service reaches the
+                payment implementation only through the declared payment port.
+                If the theorem package supplies the required coverage and
+                closure assumptions, this supports the bounded statement that
+                the selected evidence contains no coupon-to-internal-cache
+                edge.
+              </p>
+              <p>
+                The conclusion is deliberately narrow. A runtime trace could
+                still show <code>CouponService</code> calling
+                <code>PaymentAdapter.publicApi</code> through a retry helper,
+                or a later static scan could reveal the bad edge
+                <code>CouponService</code> to
+                <code>PaymentAdapter.internalCache</code>. Neither case is
+                erased by the good-universe reading; each requires its own
+                observation context and theorem boundary. The fuller worked
+                version appears in the
+                <a href="../examples-and-boundaries/#coupon-case-study">
+                  coupon case study</a>.
+              </p>
             </section>
 
             <section id="status-index" class="article-section">
-              <h2>Status index</h2>
+              <h2>Formal anchors</h2>
               <p>
-                The table is now an index helper. The theorem-grade claims
-                above carry their own source, Lean correspondence, status,
-                assumptions, boundary, and non-conclusion near the text that
-                uses them.
+                The chapter text above is the mathematical reading. This table
+                is the audit trail: it records which Lean declarations anchor
+                the claims, what status they have, and which boundary remains
+                outside the theorem.
               </p>
               <div class="article-table">
                 <table>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -66,13 +66,11 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#central-proposition">Central proposition</a></li>
-                <li><a href="#architecture-object">Architecture object</a></li>
-                <li><a href="#definition-spine">Definition spine</a></li>
-                <li><a href="#foundational-claims">Foundational claims</a></li>
-                <li><a href="#universe-boundary">Universe boundary</a></li>
-                <li><a href="#formal-reading">Formal reading</a></li>
-                <li><a href="#example-boundary">Example boundary</a></li>
-                <li><a href="#lean-status">Lean status</a></li>
+                <li><a href="#object-definition">Object definition</a></li>
+                <li><a href="#core-proposition">Core proposition</a></li>
+                <li><a href="#universe-proposition">Universe proposition</a></li>
+                <li><a href="#example-counterexample">Example and counterexample</a></li>
+                <li><a href="#status-index">Status index</a></li>
               </ol>
             </nav>
             <div class="source-panel">
@@ -93,15 +91,16 @@
                 <dt>Docs source commit</dt>
                 <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
                 <dt>Lean status</dt>
-                <dd>`lake build` passed for this snapshot; see Status for proved / defined-only boundaries.</dd>
+                <dd><code>lake build</code> passed for this snapshot; see Status for proved / defined-only boundaries.</dd>
               </dl>
             </div>
             <div class="boundary-note">
               <h2>Boundary note</h2>
               <p>
                 AAT does not claim complete extraction from real codebases.
-                `ComponentUniverse` is proof-carrying measurement scope, not a
-                promise that all components and relations have been observed.
+                <code>ComponentUniverse</code> is proof-carrying measurement
+                scope, not a promise that all components and relations have
+                been observed.
               </p>
             </div>
           </aside>
@@ -129,35 +128,8 @@
               </figure>
             </section>
 
-            <section id="architecture-object" class="article-section">
-              <h2>Architecture object</h2>
-              <p>
-                An `ArchitectureObject` is a bounded mathematical object cut
-                out from code, specifications, review evidence, or operational
-                observations. `ArchitectureCore` is a structured,
-                evidence-aware presentation of that object. It can include
-                static and runtime graphs, boundary policy, abstraction policy,
-                semantic diagrams, decidability assumptions, and a selected
-                measurement universe.
-              </p>
-              <ul class="term-list">
-                <li>
-                  <strong>ArchitectureCarrier</strong>
-                  <span>Components plus static and runtime dependency relations.</span>
-                </li>
-                <li>
-                  <strong>ArchitecturePolicy</strong>
-                  <span>Boundary and abstraction policies used to read lawfulness.</span>
-                </li>
-                <li>
-                  <strong>ArchitectureObservationContext</strong>
-                  <span>Observation model, semantic diagram universe, and selected measurement universe.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="definition-spine" class="article-section">
-              <h2>Definition spine</h2>
+            <section id="object-definition" class="article-section">
+              <h2>Object definition</h2>
               <p>
                 The foundational record is deliberately small. AAT does not
                 begin with every fact about a repository; it begins with the
@@ -190,134 +162,305 @@ ArchitectureObject
                 the object is never stronger than the carrier, policy, and
                 observation context that presented it.
               </p>
+              <div class="theorem-stack">
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Definition</p>
+                    <h3>Bounded ArchitectureObject</h3>
+                  </div>
+                  <p>
+                    An <code>ArchitectureObject</code> is the mathematical
+                    object selected by a carrier, a policy, and an observation
+                    context. It is cut from code, specifications, review
+                    evidence, or operational observations, but it is not the
+                    unbounded real codebase itself.
+                  </p>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Docs source</dt>
+                      <dd>
+                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#2-architecture-object">
+                          mathematical theory, Chapter 2
+                        </a>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Lean correspondence</dt>
+                      <dd>
+                        <code>ArchitectureCore</code> is the proof-carrying
+                        presentation used by the current Lean surface.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd><code>defined only</code> for the core record.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>
+                        Relative to selected components, relations, policy,
+                        observation model, and measurement universe.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>
+                        No extractor completeness, repository-wide semantics,
+                        or global architecture quality claim follows.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Proposition</p>
+                    <h3>Object claims are relativized claims</h3>
+                  </div>
+                  <p>
+                    A sentence about an architecture object is licensed only
+                    inside the carrier, policy, and observation context that
+                    present it. This is a reading rule from the canonical
+                    theory text, not a new website theorem.
+                  </p>
+                  <div class="proof-idea">
+                    <h4>Proof idea</h4>
+                    <p>
+                      Every later lawfulness, zero, split, flatness, or
+                      witness claim names the selected universe and its
+                      exactness boundary. Dropping that boundary would change
+                      the object being discussed.
+                    </p>
+                  </div>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd>
+                        A selected <code>ArchitectureCarrier</code>,
+                        <code>ArchitecturePolicy</code>, and
+                        <code>ArchitectureObservationContext</code>.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Lean status</dt>
+                      <dd>
+                        Enforced by explicit inputs in Lean definitions and
+                        theorem assumptions; no stronger theorem is claimed.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>
+                        The same repository may have another presentation
+                        with a different observation boundary.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
             </section>
 
-            <section id="foundational-claims" class="article-section">
-              <h2>Foundational claims</h2>
+            <section id="core-proposition" class="article-section">
+              <h2>Core proposition</h2>
               <p>
-                The first layer of the theory establishes a disciplined
-                replacement for the phrase "the architecture." The object of
-                reasoning is not an entire repository, but a selected
-                presentation with explicit evidence and scope.
+                <code>ArchitectureCore</code> is the Lean-side presentation
+                of the bounded object. It bundles static and runtime evidence,
+                boundary and abstraction policy, selected semantic diagrams,
+                decidability assumptions, and a finite
+                <code>ComponentUniverse</code>.
               </p>
+              <figure class="code-panel">
+                <figcaption>Core presentation schema</figcaption>
+                <pre><code>ArchitectureCore
+  = ArchitectureFlatnessModel
+  + static ComponentUniverse
+  + decidable static / runtime / policy predicates
+  + runtime dependency role
+  + measured semantic diagram universe</code></pre>
+              </figure>
+              <div class="theorem-stack">
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Proposition</p>
+                    <h3>Core presentations do not imply complete extraction</h3>
+                  </div>
+                  <p>
+                    A core presentation can expose the evidence needed by a
+                    theorem package while still omitting relations outside its
+                    declared coverage boundary. Presentation equivalence is
+                    therefore relative to the selected observation model.
+                  </p>
+                  <div class="proof-idea">
+                    <h4>Proof idea</h4>
+                    <p>
+                      The Lean record carries a static universe and selected
+                      predicates as fields. Accessor theorems can recover
+                      membership and static coverage facts from that record,
+                      but the record has no field stating global telemetry or
+                      extractor completeness.
+                    </p>
+                  </div>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Lean names</dt>
+                      <dd>
+                        <code>ArchitectureCore</code>,
+                        <code>ArchitectureCore.component_mem_staticUniverse</code>,
+                        <code>ArchitectureCore.staticCoverageComplete</code>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>
+                        <code>defined only</code> for the core record;
+                        <code>proved</code> for the listed accessor theorems.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Index</dt>
+                      <dd>
+                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">
+                          Architecture Core / Certified Architecture
+                        </a>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>
+                        Static coverage is read from the supplied finite
+                        universe; runtime and semantic completeness are not
+                        promoted.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>
+                        A core is not proof that every component, runtime edge,
+                        operational effect, or semantic diagram was observed.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
+            </section>
+
+            <section id="universe-proposition" class="article-section">
+              <h2>Universe proposition</h2>
+              <p>
+                <code>ComponentUniverse</code> is the measurement scope used
+                by finite bridge theorems. It records selected components,
+                selected relations, coverage boundary, and exactness boundary.
+                Outside that universe, AAT does not infer zero, absence,
+                flatness, split, or lawfulness.
+              </p>
+              <div class="theorem-stack">
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Definition</p>
+                    <h3>Finite measurement universe</h3>
+                  </div>
+                  <p>
+                    A finite universe supplies the bounded component list and
+                    the proof obligations needed to read graph-level evidence
+                    as in-scope evidence.
+                  </p>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Lean names</dt>
+                      <dd>
+                        <code>ComponentUniverse</code>,
+                        <code>ComponentUniverse.full</code>,
+                        <code>FiniteArchGraph</code>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd><code>defined only</code> for the universe records.</dd>
+                    </div>
+                    <div>
+                      <dt>Index</dt>
+                      <dd>
+                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">
+                          Finite Universe / Bridge Theorems
+                        </a>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>
+                        Missing or unmeasured components are not silently
+                        converted into measured zero evidence.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Proposition</p>
+                    <h3>Finite bridges are coverage-relative</h3>
+                  </div>
+                  <p>
+                    The proved finite-universe bridge theorems connect
+                    executable or graph-level facts to proposition-level facts
+                    only under their supplied universe and closure assumptions.
+                  </p>
+                  <div class="proof-idea">
+                    <h4>Proof idea</h4>
+                    <p>
+                      The universe carries component coverage and edge closure.
+                      Bridge theorems consume those proofs to move from a
+                      bounded list or boolean computation to a graph statement.
+                    </p>
+                  </div>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Lean names</dt>
+                      <dd>
+                        <code>ComponentUniverse.edgeClosed_of_covers</code>,
+                        <code>FiniteArchGraph.covers_components</code>,
+                        <code>ComponentUniverse.reachable_exists_bounded_path</code>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd><code>proved</code> under explicit finite assumptions.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>
+                        Static graph and finite universe only; runtime,
+                        semantic, and empirical axes require separate evidence.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>
+                        The theorem does not claim complete extraction from a
+                        real repository or global architecture lawfulness.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
               <ul class="status-list">
                 <li>
-                  <strong>Definition</strong>
-                  <span>An `ArchitectureObject` is a carrier plus policy plus observation context.</span>
+                  <strong>Thin category boundary</strong>
+                  <span><code>ComponentCategory</code> remembers whether reachability exists and intentionally forgets path count and walk length.</span>
                 </li>
                 <li>
-                  <strong>Interpretation</strong>
-                  <span>An `ArchitectureCore` presents the object through evidence, but presentation is not assumed complete or injective.</span>
+                  <strong>Quantitative boundary</strong>
+                  <span>Path counts, walk length, adjacency powers, finite metrics, and future free-category constructions live outside the thin-category claim.</span>
                 </li>
                 <li>
-                  <strong>Boundary</strong>
-                  <span>A `ComponentUniverse` is a selected measurement universe; outside it, zero and absence are not inferred.</span>
-                </li>
-                <li>
-                  <strong>Non-conclusion</strong>
-                  <span>No theorem here states that a real-code extractor has found every relevant component, relation, runtime effect, or semantic diagram.</span>
+                  <strong>Decomposability boundary</strong>
+                  <span>Current <code>Decomposable</code> means <code>StrictLayered</code>; acyclicity, finite propagation, nilpotence, and spectral conditions remain separate theorems or representations.</span>
                 </li>
               </ul>
-              <figure class="code-panel">
-                <figcaption>Foundational proposition schema</figcaption>
-                <pre><code>selected carrier
-  + selected policy
-  + selected observation context
-  + coverage / exactness boundary
-  -&gt; bounded ArchitectureObject claim</code></pre>
-              </figure>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Claim</th>
-                      <th>Current Lean status</th>
-                      <th>Boundary</th>
-                      <th>Non-conclusion</th>
-                      <th>Source</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>Static graph, reachability, layering, and decomposability vocabulary</td>
-                      <td>`defined only` / `proved` for the static structural bridge theorems</td>
-                      <td>Selected graph and explicit structural assumptions.</td>
-                      <td>Does not certify complete extraction from a real repository.</td>
-                      <td>Lean theorem index, static core entries.</td>
-                    </tr>
-                    <tr>
-                      <td>`ComponentCategory` as thin reachability category</td>
-                      <td>`defined only` / `proved` for selected bridge facts</td>
-                      <td>Reachability existence is retained; path count and walk length are intentionally forgotten.</td>
-                      <td>Quantitative path metrics require `Walk`, `Path`, matrix, or finite metric representations.</td>
-                      <td>AAT mathematical theory, Chapter 2.</td>
-                    </tr>
-                    <tr>
-                      <td>`ComponentUniverse` as measurement scope</td>
-                      <td>`defined only` / `proved` for finite-universe bridge packages</td>
-                      <td>Selected components, selected relations, coverage boundary, and exactness boundary.</td>
-                      <td>Universe outside is not read as zero or absent.</td>
-                      <td>Lean theorem index and proof obligations.</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
             </section>
 
-            <section id="universe-boundary" class="article-section">
-              <h2>Universe boundary</h2>
-              <p>
-                `ComponentUniverse` records selected components, selected
-                relations, coverage boundary, and exactness boundary. Outside
-                that universe, AAT does not infer zero, absence, flatness,
-                split, or lawfulness.
-              </p>
-              <p>
-                `ComponentCategory` is thin: it remembers whether a reachability
-                morphism exists and intentionally forgets path count and walk
-                length. Quantitative data belongs to `Walk`, `Path`, adjacency
-                matrix, finite metrics, or future free-category constructions.
-              </p>
-              <div class="claim-strip">
-                <p>
-                  Current `Decomposable` means `StrictLayered`. Acyclicity,
-                  finite propagation, nilpotence, and spectral conditions are
-                  connected by separate theorems or representations, not mixed
-                  into the definition.
-                </p>
-              </div>
-            </section>
-
-            <section id="formal-reading" class="article-section">
-              <h2>Formal reading</h2>
-              <p>
-                The foundational move is to replace an unbounded repository
-                question with a typed object plus explicit evidence scope. A
-                static dependency graph, a runtime graph, an abstraction policy,
-                and a semantic observation model may all present the same
-                bounded `ArchitectureObject`, but none of those presentations
-                is automatically complete.
-              </p>
-              <p>
-                This is why `ArchitectureCore` is read as an evidence-aware
-                carrier rather than as the architecture itself. The map from a
-                core presentation to the object it presents is not assumed to be
-                injective or complete: two presentations can be equivalent under
-                the selected observation, and either presentation can omit
-                relations outside its coverage boundary.
-              </p>
-              <figure class="code-panel">
-                <figcaption>Relativized object claim</figcaption>
-                <pre><code>ArchitectureObject claim
-  = selected carrier
-  + selected policy
-  + selected observation context
-  + coverage and exactness boundary</code></pre>
-              </figure>
-            </section>
-
-            <section id="example-boundary" class="article-section">
-              <h2>Example boundary</h2>
+            <section id="example-counterexample" class="article-section">
+              <h2>Example and counterexample</h2>
               <p>
                 A repository slice containing a coupon service, a payment
                 interface, and a payment adapter can be a valid component
@@ -340,32 +483,130 @@ ArchitectureObject
                   <span>Different carriers can present the same object only relative to the selected observation model.</span>
                 </li>
               </ul>
-              <div class="claim-strip">
-                <p>
-                  For a compact worked example, read the
-                  <a href="../examples-and-boundaries/#coupon-case-study">coupon case study</a>
-                  after this page. It shows the same finite universe discipline
-                  with `measured_zero`, `measured_nonzero`, `unmeasured`, and
-                  `out_of_scope` kept separate.
-                </p>
+              <div class="theorem-stack">
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Example</p>
+                    <h3>Static split universe</h3>
+                  </div>
+                  <p>
+                    If the selected universe contains the coupon service,
+                    payment interface, and payment adapter, a static split
+                    theorem can read only the selected static edges and their
+                    closure evidence.
+                  </p>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Reading path</dt>
+                      <dd>
+                        Continue with the
+                        <a href="../examples-and-boundaries/#coupon-case-study">
+                          coupon case study
+                        </a>
+                        for measured-zero, measured-nonzero, unmeasured, and
+                        out-of-scope coordinates.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Lean status</dt>
+                      <dd>
+                        Example-level readings are tied to the specific finite
+                        theorem packages cited there.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <p class="theorem-kicker">Counterexample / non-conclusion</p>
+                    <h3>Static evidence does not certify runtime behavior</h3>
+                  </div>
+                  <p>
+                    The same repository slice is not evidence about runtime
+                    retries, cache invalidation, rounding order, operational
+                    incidents, or semantic workflow completeness unless those
+                    observations are separately selected.
+                  </p>
+                  <dl class="claim-meta">
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>
+                        Static dependency evidence remains static dependency
+                        evidence.
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>
+                        No runtime flatness, semantic flatness, or empirical
+                        cost claim follows from this foundational page.
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 
-            <section id="lean-status" class="article-section">
-              <h2>Lean status</h2>
+            <section id="status-index" class="article-section">
+              <h2>Status index</h2>
               <p>
-                The Lean side already fixes the static graph, reachability,
-                layering, decomposability, thin-category, finite-universe, and
-                bridge vocabulary used by this page. The important boundary is
-                that these declarations do not certify complete extraction from
-                a real repository.
+                The table is now an index helper. The theorem-grade claims
+                above carry their own source, Lean correspondence, status,
+                assumptions, boundary, and non-conclusion near the text that
+                uses them.
               </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim group</th>
+                      <th>Current Lean status</th>
+                      <th>Boundary</th>
+                      <th>Primary index</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Architecture core presentation</td>
+                      <td><code>defined only</code> for <code>ArchitectureCore</code>; selected accessors <code>proved</code></td>
+                      <td>Supplied finite universe and selected predicates; no global extraction completeness.</td>
+                      <td>
+                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">
+                          Architecture Core / Certified Architecture
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Finite universe bridge package</td>
+                      <td><code>defined only</code> / <code>proved</code> by declaration</td>
+                      <td>Finite component list, coverage, edge closure, and explicit graph assumptions.</td>
+                      <td>
+                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">
+                          Finite Universe / Bridge Theorems
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Thin category and decomposability vocabulary</td>
+                      <td><code>defined only</code> / selected bridge facts <code>proved</code></td>
+                      <td>Reachability existence and strict layering; path count, walk length, nilpotence, and spectral facts are separate.</td>
+                      <td>
+                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#2-architecture-object">
+                          mathematical theory, Chapter 2
+                        </a>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
               <div class="claim-strip">
                 <p>
-                  Read the current QED core through the AAT Status page:
-                  static structural bridge theorems are proved under explicit
-                  assumptions, while real-code extraction completeness remains
-                  outside the theorem claim.
+                  Read the current QED core through the
+                  <a href="../status/">AAT Status page</a>: static structural
+                  bridge theorems are proved under explicit assumptions, while
+                  real-code extraction completeness remains outside the theorem
+                  claim.
                 </p>
               </div>
             </section>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -494,21 +494,30 @@ ArchitectureObject
               <h2>Example and counterexample</h2>
               <p>
                 A repository slice containing a coupon service, a payment
-                interface, and a payment adapter can be a valid component
-                universe for a static split theorem. That same slice is not, by
-                itself, evidence about runtime retries, cache invalidation,
-                rounding order, or operational incidents. Those require their
-                own observation contexts.
+                interface, a payment adapter, and selected adapter internals
+                can be a valid component universe for a static split theorem.
+                That same slice is not, by itself, evidence about runtime
+                retries, cache invalidation, rounding order, or operational
+                incidents. Those require their own observation contexts.
               </p>
               <figure class="code-panel">
                 <figcaption>Minimal bounded universe</figcaption>
-                <pre><code>components = {CouponService, PaymentPort, PaymentAdapter}
-static edges observed:
-  CouponService -&gt; PaymentPort
-  PaymentAdapter -&gt; PaymentPort
+                <pre><code>components:
+  CouponService
+  PaymentPort
+  PaymentAdapter.publicApi
+  PaymentAdapter.internalCache
 
-selected claim:
-  no observed static edge CouponService -&gt; PaymentAdapter
+selected good static edges:
+  CouponService -&gt; PaymentPort
+  PaymentPort -&gt; PaymentAdapter.publicApi
+
+counterexample static edge:
+  CouponService -&gt; PaymentAdapter.internalCache
+
+bounded good claim:
+  if the counterexample edge is absent from selected evidence,
+  the coupon service has no selected edge to adapter internals
 
 not selected:
   retry behavior, cache invalidation, rounding order,
@@ -536,7 +545,7 @@ not selected:
                   </div>
                   <p>
                     If the selected universe contains the coupon service,
-                    payment interface, and payment adapter, a static split
+                    payment interface, and public adapter API, a static split
                     theorem can read only the selected static edges and their
                     closure evidence.
                   </p>
@@ -544,8 +553,9 @@ not selected:
                     <h4>What is concluded</h4>
                     <p>
                       Inside this finite universe, the selected static relation
-                      can support a bounded statement such as "the service does
-                      not directly depend on the adapter" when the theorem
+                      can support a bounded statement such as "the coupon
+                      service uses the declared payment port and has no
+                      selected edge to adapter internals" when the theorem
                       package supplies the required coverage and closure
                       assumptions.
                     </p>
@@ -588,10 +598,12 @@ not selected:
                     <p>
                       A runtime trace could still show
                       <code>CouponService</code> calling
-                      <code>PaymentAdapter</code> through a retry helper. That
-                      would not contradict the static split reading; it would
-                      be a different observation context and a different
-                      theorem boundary.
+                      <code>PaymentAdapter.publicApi</code> through a retry
+                      helper, or a static scan could reveal the bad edge
+                      <code>CouponService</code> to
+                      <code>PaymentAdapter.internalCache</code>. Neither case
+                      is erased by the good-universe reading; each requires its
+                      own observation context and theorem boundary.
                     </p>
                   </div>
                   <dl class="claim-meta">

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -232,6 +232,20 @@ ArchitectureObject
                       the object being discussed.
                     </p>
                   </div>
+                  <div class="proof-idea">
+                    <h4>Proof</h4>
+                    <p>
+                      Unfold the object schema from the canonical text:
+                      <code>ArchitectureObject</code> is presented as
+                      <code>ArchitectureCarrier</code> plus
+                      <code>ArchitecturePolicy</code> plus
+                      <code>ArchitectureObservationContext</code>. Any later
+                      theorem consumes one of these selected presentations as
+                      an input. Therefore its conclusion is indexed by that
+                      carrier, policy, and observation context; changing any
+                      one of them changes the proposition being proved.
+                    </p>
+                  </div>
                   <div class="counterexample-note">
                     <h4>Why the assumptions matter</h4>
                     <p>
@@ -308,6 +322,20 @@ ArchitectureObject
                       membership and static coverage facts from that record,
                       but the record has no field stating global telemetry or
                       extractor completeness.
+                    </p>
+                  </div>
+                  <div class="proof-idea">
+                    <h4>Proof</h4>
+                    <p>
+                      In Lean, the proof is by projection from the supplied
+                      <code>ArchitectureCore</code>. The theorem
+                      <code>ArchitectureCore.component_mem_staticUniverse</code>
+                      recovers component membership from the core's
+                      <code>ComponentUniverse.covers</code> evidence, and
+                      <code>ArchitectureCore.staticCoverageComplete</code>
+                      recovers static coverage from the same bounded universe.
+                      No field or theorem in this block quantifies over all
+                      repository components or all runtime observations.
                     </p>
                   </div>
                   <div class="counterexample-note">
@@ -432,6 +460,22 @@ ArchitectureObject
                       The universe carries component coverage and edge closure.
                       Bridge theorems consume those proofs to move from a
                       bounded list or boolean computation to a graph statement.
+                    </p>
+                  </div>
+                  <div class="proof-idea">
+                    <h4>Proof</h4>
+                    <p>
+                      The finite universe supplies the measured component list
+                      and the coverage proof. For full universes,
+                      <code>ComponentUniverse.edgeClosed_of_covers</code>
+                      derives edge closure from coverage. Bundling the graph as
+                      a <code>FiniteArchGraph</code> exposes
+                      <code>FiniteArchGraph.covers_components</code> and
+                      <code>FiniteArchGraph.edgeClosed_components</code>.
+                      Reachability claims then use
+                      <code>ComponentUniverse.reachable_exists_bounded_path</code>
+                      to replace an unbounded reachability assertion with a
+                      bounded simple-path witness inside the supplied universe.
                     </p>
                   </div>
                   <div class="counterexample-note">

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -199,8 +199,8 @@ ArchitectureObject
             <section id="core-proposition" class="article-section">
               <h2>Core proposition</h2>
               <p>
-                <code>ArchitectureCore</code> is the Lean-side presentation
-                of the bounded object. It bundles static and runtime evidence,
+                <code>ArchitectureCore</code> is the proof-carrying
+                presentation of the bounded object. It bundles static and runtime evidence,
                 boundary and abstraction policy, selected semantic diagrams,
                 decidability assumptions, and a finite
                 <code>ComponentUniverse</code>.
@@ -222,17 +222,17 @@ ArchitectureObject
                 therefore relative to the selected observation model.
               </p>
               <p>
-                <strong>Proof.</strong> In the Lean formalization this is
-                reflected by projection from the supplied
-                <code>ArchitectureCore</code>. The theorem
-                <code>ArchitectureCore.component_mem_staticUniverse</code>
-                recovers component membership from the core's
-                <code>ComponentUniverse.covers</code> evidence, and
-                <code>ArchitectureCore.staticCoverageComplete</code> recovers
-                static coverage from the same bounded universe. These
-                projections prove coverage facts about the supplied core; they
-                do not quantify over all repository components or all runtime
-                observations.
+                <strong>Proof.</strong> A core presentation contains exactly
+                the evidence selected for the chapter: a carrier, policies,
+                observation data, and a bounded measurement universe. A claim
+                derivable from that presentation can only use those selected
+                fields. Completeness of a real repository would require an
+                additional statement saying that every relevant component,
+                dependency, runtime interaction, and semantic observation
+                factors through the presentation. Such a statement is not part
+                of the definition. Therefore a core presentation supports
+                bounded claims inside its declared universe, but it does not
+                imply complete extraction.
               </p>
               <p>
                 This distinction is essential. Reading
@@ -265,17 +265,17 @@ ArchitectureObject
                 closure assumptions.
               </p>
               <p>
-                <strong>Proof.</strong> The finite universe supplies the
-                measured component list and the coverage proof. For full
-                universes, <code>ComponentUniverse.edgeClosed_of_covers</code>
-                derives edge closure from coverage. Bundling the graph as a
-                <code>FiniteArchGraph</code> exposes
-                <code>FiniteArchGraph.covers_components</code> and
-                <code>FiniteArchGraph.edgeClosed_components</code>. A
-                reachability claim is then made finite by
-                <code>ComponentUniverse.reachable_exists_bounded_path</code>,
-                which replaces an unbounded reachability assertion with a
-                bounded simple-path witness inside the supplied universe.
+                <strong>Proof.</strong> A finite universe supplies a measured
+                list of components together with the assertion that the
+                relevant graph evidence is covered by that list. Closure says
+                that an in-scope edge does not leave the measured list. Under
+                these two assumptions, a finite computation over the measured
+                list can be read as a statement about the selected graph,
+                because every component and every selected edge needed by the
+                claim has already been accounted for. Reachability is likewise
+                bounded: once the universe is finite, a reachability assertion
+                can be witnessed by a finite path inside the supplied universe,
+                rather than by an unbounded search over an unspecified system.
               </p>
               <p>
                 Without coverage, a bounded search can miss a component that
@@ -379,6 +379,7 @@ not selected:
                   <thead>
                     <tr>
                       <th>Claim group</th>
+                      <th>Formal anchor</th>
                       <th>Current Lean status</th>
                       <th>Boundary</th>
                       <th>Primary index</th>
@@ -387,6 +388,11 @@ not selected:
                   <tbody>
                     <tr>
                       <td>Architecture core presentation</td>
+                      <td>
+                        <code>ArchitectureCore</code>,
+                        <code>ArchitectureCore.component_mem_staticUniverse</code>,
+                        <code>ArchitectureCore.staticCoverageComplete</code>
+                      </td>
                       <td><code>defined only</code> for <code>ArchitectureCore</code>; selected accessors <code>proved</code></td>
                       <td>Supplied finite universe and selected predicates; no global extraction completeness.</td>
                       <td>
@@ -397,6 +403,13 @@ not selected:
                     </tr>
                     <tr>
                       <td>Finite universe bridge package</td>
+                      <td>
+                        <code>ComponentUniverse</code>,
+                        <code>ComponentUniverse.edgeClosed_of_covers</code>,
+                        <code>FiniteArchGraph.covers_components</code>,
+                        <code>FiniteArchGraph.edgeClosed_components</code>,
+                        <code>ComponentUniverse.reachable_exists_bounded_path</code>
+                      </td>
                       <td><code>defined only</code> / <code>proved</code> by declaration</td>
                       <td>Finite component list, coverage, edge closure, and explicit graph assumptions.</td>
                       <td>
@@ -407,6 +420,11 @@ not selected:
                     </tr>
                     <tr>
                       <td>Thin category and decomposability vocabulary</td>
+                      <td>
+                        <code>ComponentCategory</code>,
+                        <code>Decomposable</code>,
+                        <code>StrictLayered</code>
+                      </td>
                       <td><code>defined only</code> / selected bridge facts <code>proved</code></td>
                       <td>Reachability existence and strict layering; path count, walk length, nilpotence, and spectral facts are separate.</td>
                       <td>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -654,103 +654,6 @@ p {
   line-height: 1.48;
 }
 
-.theorem-stack {
-  display: grid;
-  gap: 18px;
-  margin-top: 20px;
-}
-
-.theorem-card {
-  border: 1px solid var(--rule);
-  border-radius: 6px;
-  background: var(--surface);
-  padding: 22px;
-}
-
-.theorem-card-header {
-  display: grid;
-  gap: 6px;
-}
-
-.theorem-card-header h3 {
-  margin-top: 0;
-}
-
-.theorem-kicker {
-  margin: 0;
-  color: var(--accent-warm);
-  font-family: var(--font-sans);
-  font-size: 0.76rem;
-  font-weight: 850;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.theorem-card p {
-  color: var(--ink-muted);
-}
-
-.theorem-card h4 {
-  margin: 0 0 6px;
-  color: var(--ink);
-  font-family: var(--font-sans);
-  font-size: 0.84rem;
-  font-weight: 850;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.proof-idea {
-  border-left: 3px solid var(--accent-blue);
-  margin-top: 18px;
-  padding-left: 16px;
-}
-
-.counterexample-note {
-  border-left: 3px solid var(--accent-warm);
-  margin-top: 18px;
-  padding-left: 16px;
-}
-
-.proof-idea p,
-.counterexample-note p {
-  margin: 0;
-}
-
-.counterexample-note h4 {
-  color: var(--accent-warm);
-}
-
-.claim-meta {
-  display: grid;
-  gap: 12px;
-  margin: 20px 0 0;
-}
-
-.claim-meta div {
-  display: grid;
-  grid-template-columns: minmax(130px, 0.28fr) minmax(0, 1fr);
-  gap: 12px;
-  border-top: 1px solid var(--rule);
-  padding-top: 12px;
-}
-
-.claim-meta dt {
-  color: var(--accent-blue);
-  font-family: var(--font-sans);
-  font-size: 0.74rem;
-  font-weight: 850;
-  text-transform: uppercase;
-}
-
-.claim-meta dd {
-  margin: 0;
-  color: var(--ink-muted);
-  font-size: 0.96rem;
-  line-height: 1.48;
-}
-
-.claim-meta code,
 .article-section code,
 .article-table code {
   font-family: var(--font-mono);
@@ -957,11 +860,6 @@ p {
 
   .page-nav a:last-child {
     text-align: left;
-  }
-
-  .claim-meta div {
-    grid-template-columns: 1fr;
-    gap: 4px;
   }
 
   .math-block {

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -505,6 +505,7 @@ p {
   top: 92px;
   display: grid;
   gap: 22px;
+  min-width: 0;
 }
 
 .toc-panel,
@@ -581,12 +582,15 @@ p {
 
 .article-main {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 42px;
+  min-width: 0;
 }
 
 .article-section {
   border-top: 1px solid var(--rule-strong);
   padding-top: 28px;
+  min-width: 0;
 }
 
 .article-section h2 {

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -654,6 +654,98 @@ p {
   line-height: 1.48;
 }
 
+.theorem-stack {
+  display: grid;
+  gap: 18px;
+  margin-top: 20px;
+}
+
+.theorem-card {
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 22px;
+}
+
+.theorem-card-header {
+  display: grid;
+  gap: 6px;
+}
+
+.theorem-card-header h3 {
+  margin-top: 0;
+}
+
+.theorem-kicker {
+  margin: 0;
+  color: var(--accent-warm);
+  font-family: var(--font-sans);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.theorem-card p {
+  color: var(--ink-muted);
+}
+
+.theorem-card h4 {
+  margin: 0 0 6px;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  font-weight: 850;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.proof-idea {
+  border-left: 3px solid var(--accent-blue);
+  margin-top: 18px;
+  padding-left: 16px;
+}
+
+.proof-idea p {
+  margin: 0;
+}
+
+.claim-meta {
+  display: grid;
+  gap: 12px;
+  margin: 20px 0 0;
+}
+
+.claim-meta div {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.28fr) minmax(0, 1fr);
+  gap: 12px;
+  border-top: 1px solid var(--rule);
+  padding-top: 12px;
+}
+
+.claim-meta dt {
+  color: var(--accent-blue);
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.claim-meta dd {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.96rem;
+  line-height: 1.48;
+}
+
+.claim-meta code,
+.article-section code,
+.article-table code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
 .claim-strip {
   border-left: 4px solid var(--accent-warm);
   background: var(--surface);
@@ -854,6 +946,11 @@ p {
 
   .page-nav a:last-child {
     text-align: left;
+  }
+
+  .claim-meta div {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 
   .math-block {

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -706,8 +706,19 @@ p {
   padding-left: 16px;
 }
 
-.proof-idea p {
+.counterexample-note {
+  border-left: 3px solid var(--accent-warm);
+  margin-top: 18px;
+  padding-left: 16px;
+}
+
+.proof-idea p,
+.counterexample-note p {
   margin: 0;
+}
+
+.counterexample-note h4 {
+  color: var(--accent-warm);
 }
 
 .claim-meta {


### PR DESCRIPTION
## 概要

Closes #808

- `website/aat/foundations/index.html` を Definition -> Proposition -> Proof idea -> Example -> Counterexample / Non-conclusion -> Lean status の流れで読める章本文へ改稿しました。
- `ArchitectureObject`、`ArchitectureCore`、`ComponentUniverse` の命題単位に docs source、Lean 対応、status、仮定、境界、non-conclusion を近接表示しました。
- `website/assets/site.css` に Foundations 章で使う theorem/status card 用の軽量スタイルを追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/foundations/index.html`
- `website/assets/site.css`

## 実施したテスト

- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（website 変更範囲）
- [x] website local preview: `python3 -m http.server 8000 --directory website`、`/aat/foundations/` と `assets/site.css` が 200 OK
- [x] local href check: `website/aat/foundations/index.html` の 36 href を確認
- [ ] `lake build`（Lean ソース変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている