### PR TITLE
AAT website に theorem card / Lean status tracking を導入する

### DIFF
--- a/docs/website/DESIGN.md
+++ b/docs/website/DESIGN.md
@@ -588,6 +588,11 @@ website で追加してよい内容は、正典本文に基づく説明、proof 
 `docs/aat/proof_obligations.md`、または `docs/aat/lean_theorem_index.md` の
 対応箇所を更新する。
 
+本文中の theorem-grade claim は、必要に応じて `theorem-card` / `lean-status-card` パターンで
+命題名、Lean anchor、status、仮定、境界、non-conclusion を近接表示する。
+章末 table は索引補助として残してよいが、`proved`、`defined only`、
+`future proof obligation`、`empirical hypothesis` の格上げや混同を避ける。
+
 ### セクションごとの期待値
 
 | Section | Route status | Expected maturity | Current maturity | Remaining work |

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -187,6 +187,35 @@ ArchitectureObject
                 policy, and observation context; changing any one of these
                 changes the proposition being proved.
               </p>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Proposition tracking</span>
+                      <h3>Object claims are relativized to a selected presentation</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">defined only</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>ArchitectureCore</code> and selected accessor declarations in the Architecture Core index.</dd>
+                    </div>
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd>Carrier, policy, observation context, and finite measurement universe are part of the claim input.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>The proposition is read inside the selected presentation, not as a claim about every repository fact.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No real-code extraction completeness or unobserved-edge absence follows from the carrier alone.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
               <p>
                 If the observation context is erased, a static import graph
                 and a runtime call graph can be read as the same object even
@@ -242,6 +271,35 @@ ArchitectureObject
                 supplied universe, not about every edge a production system
                 could emit.
               </p>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Proposition tracking</span>
+                      <h3>Core presentations support bounded claims, not complete extraction</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">defined only</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>ArchitectureCore.staticCoverageComplete</code> and core accessor facts.</dd>
+                    </div>
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd>Selected static and runtime evidence, policy predicates, diagrams, and component universe.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Coverage is the supplied finite coverage boundary; it is not global repository coverage.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>Omitted runtime interactions and semantic observations remain outside the theorem boundary.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
             </section>
 
             <section id="universe-proposition" class="article-section">
@@ -294,6 +352,35 @@ ArchitectureObject
                 acyclicity, finite propagation, nilpotence, and spectral
                 conditions remain separate theorems or representations.
               </p>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Bridge tracking</span>
+                      <h3>Finite universe facts are coverage-relative bridge claims</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved anchors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>ComponentUniverse.edgeClosed_of_covers</code>, <code>FiniteArchGraph.edgeClosed_components</code>, and <code>ComponentUniverse.reachable_exists_bounded_path</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd>Finite component list, selected graph relation, coverage, edge closure, and bounded reachability hypotheses.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Executable or graph-level zero readings apply only to the selected universe and relation.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No path count, walk length, nilpotence, spectral condition, or out-of-scope absence is inferred here.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
             </section>
 
             <section id="example-counterexample" class="article-section">

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -305,6 +305,62 @@ CompleteWitnessCoverage + RequiredAxisExact
                   </tbody>
                 </table>
               </div>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lemma tracking</span>
+                      <h3>Measured zero is only measured witness absence</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>lawViolationCount_eq_zero_iff_lawful</code> and the generic witness-count kernel.</dd>
+                    </div>
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd>A selected finite witness list, a bad-witness predicate, and the local law-family bridge.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>The zero count speaks about the measured finite list.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>It does not prove global witness absence or semantic lawfulness outside the measured list.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Bridge tracking</span>
+                      <h3>Coverage and axis exactness promote witness absence to required-axis zero</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>noRequiredObstruction_of_requiredWitnessCoverage_and_noMeasuredObstruction</code> and <code>requiredAxesAvailableAndZero_iff_noRequiredObstruction_of_requiredAxisExact</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd>Required witness coverage plus exact correspondence between required witnesses and required signature axes.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Unavailable axes and optional diagnostics are not treated as available zero required axes.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No runtime, semantic, empirical, or extractor-completeness claim is added by the bridge.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
             </section>
 
             <section id="main-theorem" class="article-section">
@@ -361,6 +417,35 @@ Then, within B:
                   It is one local-contract family among distinct global,
                   state-transition, runtime, and distributed invariant families.
                 </p>
+              </div>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Theorem schema tracking</span>
+                      <h3>Required obstruction vanishing is a bounded theorem schema</h3>
+                    </div>
+                    <span class="status-badge status-badge-future">schema</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd>Static instances are tracked under signature-integrated lawfulness and the finite static structural core formal anchor.</dd>
+                    </div>
+                    <div>
+                      <dt>Assumptions</dt>
+                      <dd><code>WitnessComplete</code>, <code>AxisExact</code>, <code>CoverageComplete</code>, and <code>ObservationExact</code> for the selected law universe.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>The equivalence is read inside the theorem boundary that supplies those assumptions.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>Witness absence is not global semantic lawfulness without the required coverage and exactness package.</dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -679,6 +679,110 @@ p {
   line-height: 1.52;
 }
 
+.theorem-card-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.theorem-card {
+  border: 1px solid var(--rule);
+  border-left: 5px solid var(--accent-blue);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 18px;
+}
+
+.lean-status-card {
+  border-left-color: var(--accent);
+}
+
+.theorem-card-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.theorem-card-label {
+  display: block;
+  color: var(--accent-warm);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.theorem-card h3 {
+  margin-top: 4px;
+  font-size: 1.24rem;
+  line-height: 1.18;
+}
+
+.status-badge {
+  flex: 0 0 auto;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1;
+  padding: 7px 10px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.status-badge-proved {
+  border-color: rgba(11, 111, 104, 0.38);
+  background: rgba(11, 111, 104, 0.1);
+  color: var(--accent-strong);
+}
+
+.status-badge-defined {
+  border-color: rgba(49, 95, 131, 0.38);
+  background: rgba(49, 95, 131, 0.1);
+  color: var(--accent-blue);
+}
+
+.status-badge-future {
+  border-color: rgba(139, 49, 68, 0.36);
+  background: rgba(139, 49, 68, 0.09);
+  color: var(--accent-warm);
+}
+
+.theorem-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 18px;
+}
+
+.theorem-card-grid > div {
+  min-width: 0;
+}
+
+.theorem-card dt {
+  color: var(--accent-blue);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.theorem-card dd {
+  margin: 4px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.96rem;
+  line-height: 1.46;
+}
+
+.theorem-card code {
+  overflow-wrap: anywhere;
+}
+
 .article-table {
   margin-top: 18px;
   overflow-x: auto;
@@ -816,6 +920,10 @@ p {
     position: static;
   }
 
+  .theorem-card-grid {
+    grid-template-columns: 1fr;
+  }
+
   h1 {
     font-size: clamp(2.62rem, 12vw, 4.2rem);
   }
@@ -864,6 +972,18 @@ p {
 
   .page-nav a:last-child {
     text-align: left;
+  }
+
+  .theorem-card {
+    padding: 16px 14px;
+  }
+
+  .theorem-card-header {
+    display: grid;
+  }
+
+  .status-badge {
+    justify-self: start;
   }
 
   .math-block {


### PR DESCRIPTION
## 概要

Closes #810

AAT website の chapter 本文で theorem-grade claim を命題単位に追跡できるように、共通の `theorem-card` / `lean-status-card` パターンを追加しました。Foundations と Laws and Witnesses に、本文名、Lean anchor、status、仮定、境界、non-conclusion を近接表示する代表カードを導入しています。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/website/DESIGN.md`: theorem card / Lean status card の運用方針を追記
- `website/assets/site.css`: theorem card / Lean status card / status badge の共通スタイルを追加
- `website/aat/foundations/index.html`: Foundations の主要命題に status tracking card を追加
- `website/aat/laws-and-witnesses/index.html`: witness bridge と theorem schema に status tracking card を追加

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] `python3 -m http.server 8000 --directory website` による local preview
- [x] `curl -I http://127.0.0.1:8000/aat/foundations/`
- [x] `curl -I http://127.0.0.1:8000/aat/laws-and-witnesses/`
- [x] `curl -I http://127.0.0.1:8000/assets/site.css`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている