### PR TITLE
AAT Foundations に番号付きアンカーを追加する

### DIFF
--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -65,7 +65,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
-                <li><a href="#central-proposition">Central proposition</a></li>
+                <li><a href="#central-decomposition">Central decomposition</a></li>
                 <li><a href="#object-definition">Object definition</a></li>
                 <li><a href="#core-proposition">Core proposition</a></li>
                 <li><a href="#universe-proposition">Universe proposition</a></li>
@@ -73,6 +73,17 @@
                 <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
+            <div class="source-panel">
+              <h2>Citable statements</h2>
+              <ul>
+                <li><a href="#definition-1-1">Definition 1.1</a></li>
+                <li><a href="#proposition-1-2">Proposition 1.2</a></li>
+                <li><a href="#proposition-2-1">Proposition 2.1</a></li>
+                <li><a href="#definition-3-1">Definition 3.1</a></li>
+                <li><a href="#proposition-3-2">Proposition 3.2</a></li>
+                <li><a href="#counterexample-3-3">Counterexample 3.3</a></li>
+              </ul>
+            </div>
             <div class="source-panel">
               <h2>Canonical source</h2>
               <ul>
@@ -106,8 +117,8 @@
           </aside>
 
           <div class="article-main">
-            <section id="central-proposition" class="article-section">
-              <h2>Central proposition</h2>
+            <section id="central-decomposition" class="article-section">
+              <h2>Central decomposition</h2>
               <p>
                 AAT formalizes software architecture as a local algebra of
                 objects, operations, invariant families, obstruction witnesses,
@@ -126,6 +137,12 @@
   + ArchitectureSignature
   + theorem boundary / non-conclusions</code></pre>
               </figure>
+              <p class="statement-note">
+                This is a decomposition of the theory surface, not a theorem
+                whose proof is carried by the current Lean package. The
+                theorem-grade claims in this chapter begin with the numbered
+                definitions and propositions below.
+              </p>
             </section>
 
             <section id="object-definition" class="article-section">
@@ -162,22 +179,25 @@ ArchitectureObject
                 the object is never stronger than the carrier, policy, and
                 observation context that presented it.
               </p>
-              <p>
-                <strong>Definition.</strong> A bounded
+              <p id="definition-1-1" class="statement">
+                <a class="statement-anchor" href="#definition-1-1">Definition 1.1.</a>
+                A bounded
                 <code>ArchitectureObject</code> is the mathematical object
                 selected by a carrier, a policy, and an observation context.
                 It is cut from code, specifications, review evidence, or
                 operational observations, but it is not the unbounded real
                 codebase itself.
               </p>
-              <p>
-                <strong>Proposition.</strong> Object claims are relativized
+              <p id="proposition-1-2" class="statement">
+                <a class="statement-anchor" href="#proposition-1-2">Proposition 1.2.</a>
+                Object claims are relativized
                 claims. A sentence about an architecture object is licensed
                 only inside the carrier, policy, and observation context that
                 present it.
               </p>
-              <p>
-                <strong>Proof.</strong> Unfold the object schema:
+              <p id="proof-1-2" class="statement-proof">
+                <a class="statement-anchor" href="#proof-1-2">Proof idea.</a>
+                Unfold the object schema:
                 <code>ArchitectureObject</code> is presented as
                 <code>ArchitectureCarrier</code> plus
                 <code>ArchitecturePolicy</code> plus
@@ -216,7 +236,8 @@ ArchitectureObject
                   </dl>
                 </article>
               </div>
-              <p>
+              <p id="remark-1-3" class="statement">
+                <a class="statement-anchor" href="#remark-1-3">Remark 1.3.</a>
                 If the observation context is erased, a static import graph
                 and a runtime call graph can be read as the same object even
                 when they support different claims. The theorem boundary then
@@ -243,15 +264,17 @@ ArchitectureObject
   + runtime dependency role
   + measured semantic diagram universe</code></pre>
               </figure>
-              <p>
-                <strong>Proposition.</strong> Core presentations do not imply
+              <p id="proposition-2-1" class="statement">
+                <a class="statement-anchor" href="#proposition-2-1">Proposition 2.1.</a>
+                Core presentations do not imply
                 complete extraction. A core can expose the evidence needed by
                 a theorem package while still omitting relations outside its
                 declared coverage boundary. Presentation equivalence is
                 therefore relative to the selected observation model.
               </p>
-              <p>
-                <strong>Proof.</strong> A core presentation contains exactly
+              <p id="proof-2-1" class="statement-proof">
+                <a class="statement-anchor" href="#proof-2-1">Proof idea.</a>
+                A core presentation contains exactly
                 the evidence selected for the chapter: a carrier, policies,
                 observation data, and a bounded measurement universe. A claim
                 derivable from that presentation can only use those selected
@@ -263,7 +286,8 @@ ArchitectureObject
                 bounded claims inside its declared universe, but it does not
                 imply complete extraction.
               </p>
-              <p>
+              <p id="non-conclusion-2-2" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-2-2">Non-conclusion 2.2.</a>
                 This distinction is essential. Reading
                 <code>ArchitectureCore</code> as complete extraction would
                 promote every omitted runtime edge into evidence of absence.
@@ -311,19 +335,22 @@ ArchitectureObject
                 Outside that universe, AAT does not infer zero, absence,
                 flatness, split, or lawfulness.
               </p>
-              <p>
-                <strong>Definition.</strong> A finite measurement universe
+              <p id="definition-3-1" class="statement">
+                <a class="statement-anchor" href="#definition-3-1">Definition 3.1.</a>
+                A finite measurement universe
                 supplies the bounded component list and the proof obligations
                 needed to read graph-level evidence as in-scope evidence.
               </p>
-              <p>
-                <strong>Proposition.</strong> Finite bridges are
+              <p id="proposition-3-2" class="statement">
+                <a class="statement-anchor" href="#proposition-3-2">Proposition 3.2.</a>
+                Finite bridges are
                 coverage-relative. Executable or graph-level facts become
                 proposition-level facts only under their supplied universe and
                 closure assumptions.
               </p>
-              <p>
-                <strong>Proof.</strong> A finite universe supplies a measured
+              <p id="proof-3-2" class="statement-proof">
+                <a class="statement-anchor" href="#proof-3-2">Proof idea.</a>
+                A finite universe supplies a measured
                 list of components together with the assertion that the
                 relevant graph evidence is covered by that list. Closure says
                 that an in-scope edge does not leave the measured list. Under
@@ -335,13 +362,15 @@ ArchitectureObject
                 can be witnessed by a finite path inside the supplied universe,
                 rather than by an unbounded search over an unspecified system.
               </p>
-              <p>
+              <p id="counterexample-3-3" class="statement">
+                <a class="statement-anchor" href="#counterexample-3-3">Counterexample 3.3.</a>
                 Without coverage, a bounded search can miss a component that
                 carries the only violating edge. Without edge closure, an
                 in-scope source can point to an out-of-scope target, so a zero
                 result on the list is not a graph-level zero claim.
               </p>
-              <p>
+              <p id="remark-3-4" class="statement">
+                <a class="statement-anchor" href="#remark-3-4">Remark 3.4.</a>
                 The same boundary explains the role of
                 <code>ComponentCategory</code>: it remembers whether
                 reachability exists and intentionally forgets path count and
@@ -385,7 +414,8 @@ ArchitectureObject
 
             <section id="example-counterexample" class="article-section">
               <h2>Example and counterexample</h2>
-              <p>
+              <p id="example-4-1" class="statement">
+                <a class="statement-anchor" href="#example-4-1">Example 4.1.</a>
                 A repository slice containing a coupon service, a payment
                 interface, a payment adapter, and selected adapter internals
                 can be a valid component universe for a static split theorem.
@@ -430,7 +460,8 @@ not selected:
                   <span>Different carriers can present the same object only relative to the selected observation model.</span>
                 </li>
               </ul>
-              <p>
+              <p id="bounded-reading-4-2" class="statement">
+                <a class="statement-anchor" href="#bounded-reading-4-2">Bounded reading 4.2.</a>
                 In the good static presentation, the coupon service reaches the
                 payment implementation only through the declared payment port.
                 If the theorem package supplies the required coverage and
@@ -438,7 +469,8 @@ not selected:
                 the selected evidence contains no coupon-to-internal-cache
                 edge.
               </p>
-              <p>
+              <p id="non-conclusion-4-3" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-4-3">Non-conclusion 4.3.</a>
                 The conclusion is deliberately narrow. A runtime trace could
                 still show <code>CouponService</code> calling
                 <code>PaymentAdapter.publicApi</code> through a retry helper,

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -685,6 +685,39 @@ p {
   margin-top: 22px;
 }
 
+.statement,
+.statement-proof,
+.statement-note {
+  scroll-margin-top: 108px;
+}
+
+.statement-anchor {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.statement-anchor:hover {
+  color: var(--accent-blue);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.statement-proof .statement-anchor {
+  color: var(--accent-blue);
+}
+
+.statement-note {
+  border-left: 4px solid var(--rule-strong);
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: 0.98rem;
+  line-height: 1.52;
+  padding-left: 16px;
+}
+
 .theorem-card {
   border: 1px solid var(--rule);
   border-left: 5px solid var(--accent-blue);


### PR DESCRIPTION
## 概要

Closes #820

AAT Foundations の本文を citation しやすい publication edition に寄せるため、主要な Definition / Proposition / Proof idea / Counterexample / Non-conclusion に番号付きラベルと安定 HTML anchor を追加しました。

設計判断:
- `Central proposition` は theorem-grade claim ではなく理論表面の分解なので、`Central decomposition` に改称しました。
- サイドバーに主要 statement だけを集めた `Citable statements` を追加しました。
- Lean status は格上げせず、既存の theorem card / Formal anchors の status と整合する範囲に留めました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/foundations/index.html`
- `website/assets/site.css`

## 実施したテスト

- [ ] `lake build` は未実施。Lean 変更なし。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `website/aat/foundations/index.html`, `website/assets/site.css`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan は未実施。Lean 変更なし。
- [x] website local preview: `python3 -m http.server 8000 --directory website` で `/aat/foundations/` が `200 OK`、主要 statement 表示を確認。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている