### PR TITLE
AAT Foundations に初回モデルを追加する

### DIFF
--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -65,6 +65,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#first-model">First model</a></li>
                 <li><a href="#central-decomposition">Central decomposition</a></li>
                 <li><a href="#object-definition">Object definition</a></li>
                 <li><a href="#core-proposition">Core proposition</a></li>
@@ -117,6 +118,63 @@
           </aside>
 
           <div class="article-main">
+            <section id="first-model" class="article-section">
+              <h2>First model</h2>
+              <div class="reader-model">
+                <div>
+                  <h3>AAT does not say</h3>
+                  <p>
+                    "This whole repository is clean." AAT does not turn a
+                    bounded scan, diagram, review note, or theorem package
+                    into a repository-wide quality certificate.
+                  </p>
+                </div>
+                <div>
+                  <h3>AAT says</h3>
+                  <p>
+                    Inside this selected universe, under this observation
+                    model, and with these coverage and exactness assumptions,
+                    this selected obstruction family is zero, nonzero, or
+                    unmeasured.
+                  </p>
+                </div>
+              </div>
+              <ul class="term-list">
+                <li>
+                  <strong>universe</strong>
+                  <span>The selected components, relations, diagrams, or measurements that a claim is allowed to quantify over.</span>
+                </li>
+                <li>
+                  <strong>coverage</strong>
+                  <span>The premise that the selected evidence contains the components or relations needed by the claim.</span>
+                </li>
+                <li>
+                  <strong>exactness</strong>
+                  <span>The premise that a measured value can be read as the intended in-scope relation, witness, or axis.</span>
+                </li>
+                <li>
+                  <strong>observation</strong>
+                  <span>The static, runtime, semantic, review, or operational model through which evidence is being read.</span>
+                </li>
+                <li>
+                  <strong>evidence boundary</strong>
+                  <span>The line between measured evidence and facts that remain outside the theorem package or report.</span>
+                </li>
+                <li>
+                  <strong>measured zero</strong>
+                  <span>The selected evidence was measured and no in-scope violating relation or witness was found.</span>
+                </li>
+                <li>
+                  <strong>unmeasured outside</strong>
+                  <span>The relation, effect, component, or observation was not selected, so absence is not asserted.</span>
+                </li>
+                <li>
+                  <strong>non-conclusion</strong>
+                  <span>A statement that does not follow, even when the bounded claim has been proved or measured.</span>
+                </li>
+              </ul>
+            </section>
+
             <section id="central-decomposition" class="article-section">
               <h2>Central decomposition</h2>
               <p>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -679,6 +679,38 @@ p {
   line-height: 1.52;
 }
 
+.reader-model {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 18px 0 20px;
+}
+
+.reader-model > div {
+  border: 1px solid var(--rule);
+  border-left: 5px solid var(--accent-blue);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 18px;
+}
+
+.reader-model > div:last-child {
+  border-left-color: var(--accent);
+}
+
+.reader-model h3 {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.94rem;
+  font-weight: 850;
+  line-height: 1.2;
+  margin: 0 0 8px;
+}
+
+.reader-model p {
+  margin: 0;
+}
+
 .theorem-card-list {
   display: grid;
   gap: 16px;
@@ -954,6 +986,10 @@ p {
   }
 
   .theorem-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .reader-model {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## 概要

Closes #821

AAT Foundations の冒頭に、初見読者が bounded claim の読み方を掴むための `First model` 節を追加しました。

設計判断:
- `AAT does not say` / `AAT says` の二分で、repository-wide quality certificate と bounded claim を分けました。
- `universe`, `coverage`, `exactness`, `observation`, `evidence boundary`, `measured zero`, `unmeasured outside`, `non-conclusion` を一行用語箱として追加しました。
- 既存の Boundary note は complete extraction 境界として残し、本文冒頭の読者導線と役割を分けました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/foundations/index.html`
- `website/assets/site.css`

## 実施したテスト

- [ ] `lake build` は未実施。Lean 変更なし。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `website/aat/foundations/index.html`, `website/assets/site.css`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan は未実施。Lean 変更なし。
- [x] website local preview: `python3 -m http.server 8000 --directory website` で `/aat/foundations/` が `200 OK`、`First model` と用語箱の表示を確認。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている