### PR TITLE
AAT FoundationsのFormal anchors tableとアクセシビリティを改善する

### DIFF
--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -595,22 +595,34 @@ not selected:
                 The chapter text above is the mathematical reading. This table
                 is the audit trail: it records which Lean declarations anchor
                 the claims, what status they have, and which boundary remains
-                outside the theorem.
+                outside the theorem. Each row points back to the statement
+                anchors it audits, so the table remains an index rather than a
+                substitute for the chapter text.
               </p>
-              <div class="article-table">
+              <div class="article-table formal-anchors-table">
                 <table>
+                  <caption>Foundations formal-anchor audit trail</caption>
                   <thead>
                     <tr>
-                      <th>Claim group</th>
-                      <th>Formal anchor</th>
-                      <th>Current Lean status</th>
-                      <th>Boundary</th>
-                      <th>Primary index</th>
+                      <th scope="col">Claim group</th>
+                      <th scope="col">Formal anchor</th>
+                      <th scope="col">Current Lean status</th>
+                      <th scope="col">Boundary</th>
+                      <th scope="col">Primary index</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td>Architecture core presentation</td>
+                      <th scope="row">
+                        Architecture core presentation
+                        <span class="table-row-note">
+                          Audits
+                          <a href="#definition-1-1">Definition 1.1</a>,
+                          <a href="#proposition-2-1">Proposition 2.1</a>,
+                          <a href="#counterexample-2-2">Counterexample 2.2</a>,
+                          and <a href="#non-conclusion-2-3">Non-conclusion 2.3</a>.
+                        </span>
+                      </th>
                       <td>
                         <code>ArchitectureCore</code>,
                         <code>ArchitectureCore.component_mem_staticUniverse</code>,
@@ -625,7 +637,15 @@ not selected:
                       </td>
                     </tr>
                     <tr>
-                      <td>Finite universe bridge package</td>
+                      <th scope="row">
+                        Finite universe bridge package
+                        <span class="table-row-note">
+                          Audits
+                          <a href="#definition-3-1">Definition 3.1</a>,
+                          <a href="#proposition-3-2">Proposition 3.2</a>,
+                          and <a href="#counterexample-3-3">Counterexample 3.3</a>.
+                        </span>
+                      </th>
                       <td>
                         <code>ComponentUniverse</code>,
                         <code>ComponentUniverse.edgeClosed_of_covers</code>,
@@ -642,7 +662,13 @@ not selected:
                       </td>
                     </tr>
                     <tr>
-                      <td>Thin category and decomposability vocabulary</td>
+                      <th scope="row">
+                        Thin category and decomposability vocabulary
+                        <span class="table-row-note">
+                          Audits <a href="#remark-3-4">Remark 3.4</a> and
+                          the boundary vocabulary used by the bridge claims.
+                        </span>
+                      </th>
                       <td>
                         <code>ComponentCategory</code>,
                         <code>Decomposable</code>,

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -881,6 +881,17 @@ p {
   overflow-x: auto;
 }
 
+.article-table caption {
+  caption-side: top;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.96rem;
+  font-weight: 800;
+  line-height: 1.35;
+  padding: 0 0 10px;
+  text-align: left;
+}
+
 .article-table table {
   width: 100%;
   border-collapse: collapse;
@@ -904,8 +915,41 @@ p {
   text-transform: uppercase;
 }
 
+.article-table tbody th {
+  color: var(--ink);
+  font-size: 0.98rem;
+  line-height: 1.42;
+  text-transform: none;
+}
+
 .article-table td {
   color: var(--ink-muted);
+}
+
+.article-table code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.formal-anchors-table table {
+  min-width: 760px;
+}
+
+.table-row-note {
+  display: block;
+  margin-top: 6px;
+  color: var(--ink-muted);
+  font-size: 0.86rem;
+  font-weight: 500;
+  line-height: 1.42;
+}
+
+.table-row-note a {
+  color: var(--accent-blue);
+  font-weight: 750;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
 }
 
 .page-nav {


### PR DESCRIPTION
## 概要

Closes #824

- Foundations 章末の Formal anchors table を audit trail として明示し、本文 statement anchor への相互参照を追加しました。
- table caption、列 scope、行 scope を追加し、semantic table として読めるようにしました。
- 長い Lean identifier が narrow viewport で読めるように、table code の折り返しと table 専用スタイルを追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- website/aat/foundations/index.html
- website/assets/site.css

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）
- [x] website local preview: python3 -m http.server 8000 --directory website で起動し、curl -I で /aat/foundations/ と /assets/site.css の HTTP 200 を確認
- [x] Lean status / theorem index / proof obligations の整合確認: docs/aat/lean_theorem_index.md と docs/aat/proof_obligations.md の ArchitectureCore / ComponentUniverse 境界を照合

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている