### PR TITLE
FoundationsのFormal anchorsをカード化

### DIFF
--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -639,137 +639,195 @@ not selected:
             <section id="status-index" class="article-section">
               <h2>Formal anchors</h2>
               <p>
-                The chapter text above is the mathematical reading. This table
-                is the audit trail: it records which Lean declarations anchor
-                the claims, what status they have, and which boundary remains
-                outside the theorem. Each row points back to the statement
-                anchors it audits, so the table remains an index rather than a
-                substitute for the chapter text.
+                The chapter text above is the mathematical reading. These
+                cards are the audit trail: each one records the representative
+                Lean declarations, current status, and boundary for one claim
+                group. Full declaration lists stay folded by default, so this
+                section remains an index rather than a substitute for the
+                theorem index.
               </p>
-              <div class="article-table formal-anchors-table">
-                <table>
-                  <caption>Foundations formal-anchor audit trail</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">Claim group</th>
-                      <th scope="col">Formal anchor</th>
-                      <th scope="col">Current Lean status</th>
-                      <th scope="col">Boundary</th>
-                      <th scope="col">Primary index</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th scope="row">
-                        Selected presentation boundary
-                        <span class="table-row-note">
-                          Audits
-                          <a href="#proposition-1-2">Proposition 1.2</a>,
-                          <a href="#definition-2-0">Definition 2.0</a>,
-                          <a href="#proposition-2-1">Proposition 2.1</a>,
-                          and <a href="#counterexample-2-2">Counterexample 2.2</a>.
-                        </span>
-                      </th>
-                      <td data-label="Formal anchor">
-                        <code>SelectedPresentation</code>,
-                        <code>AATJudgement</code>,
-                        <code>aatJudgement_iff</code>,
-                        <code>CompleteForRelation</code>,
-                        <code>CompleteForGraph</code>,
-                        <code>completeForGraph_iff_completeForRelation</code>,
-                        <code>SameEdgeRestriction</code>,
-                        <code>CompleteExtractionCounterexample.selectedRestriction_same_but_completeExtraction_differs</code>
-                      </td>
-                      <td data-label="Current Lean status"><code>defined only</code> for vocabulary; judgement, graph bridge, and counterexample anchors <code>proved</code></td>
-                      <td data-label="Boundary">Selected presentation equality is not ambient repository completeness; real-code extraction, telemetry completeness, and semantic universe completeness remain separate premises.</td>
-                      <td data-label="Primary index">
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#selected-presentation--complete-extraction-boundary">
-                          Selected Presentation / Complete Extraction Boundary
-                        </a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">
-                        Architecture core presentation
-                        <span class="table-row-note">
-                          Audits
-                          <a href="#definition-1-1">Definition 1.1</a>,
-                          <a href="#proposition-2-1">Proposition 2.1</a>,
-                          <a href="#counterexample-2-2">Counterexample 2.2</a>,
-                          and <a href="#non-conclusion-2-3">Non-conclusion 2.3</a>.
-                        </span>
-                      </th>
-                      <td data-label="Formal anchor">
-                        <code>ArchitectureCore</code>,
-                        <code>ArchitectureCore.selectedPresentation</code>,
-                        <code>ArchitectureCore.selectedPresentationJudgement_iff</code>,
-                        <code>ArchitectureCore.staticGraphRestriction_eq_staticGraph</code>,
-                        <code>ArchitectureCore.runtimeGraphRestriction_eq_runtimeGraph</code>,
-                        <code>ArchitectureCore.staticCompleteForSelectedPresentation</code>,
-                        <code>ArchitectureCore.runtimeCompleteForSelectedPresentation</code>,
-                        <code>ArchitectureCore.staticCompleteGraphForSelectedPresentation</code>,
-                        <code>ArchitectureCore.runtimeCompleteGraphForSelectedPresentation</code>,
-                        <code>ArchitectureCore.component_mem_staticUniverse</code>,
-                        <code>ArchitectureCore.staticCoverageComplete</code>,
-                        <code>ArchitectureCore.SelectedClaimBoundary</code>,
-                        <code>ArchitectureCore.selectedClaimBoundary</code>
-                      </td>
-                      <td data-label="Current Lean status"><code>defined only</code> for <code>ArchitectureCore</code> and <code>SelectedClaimBoundary</code>; selected-presentation bridge and package theorem <code>proved</code></td>
-                      <td data-label="Boundary">Supplied finite universe and selected predicates; no global extraction completeness, runtime telemetry completeness, or global semantic universe completeness.</td>
-                      <td data-label="Primary index">
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">
-                          Architecture Core / Certified Architecture
-                        </a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">
-                        Finite universe bridge package
-                        <span class="table-row-note">
-                          Audits
-                          <a href="#definition-3-1">Definition 3.1</a>,
-                          <a href="#proposition-3-2">Proposition 3.2</a>,
-                          and <a href="#counterexample-3-3">Counterexample 3.3</a>.
-                        </span>
-                      </th>
-                      <td data-label="Formal anchor">
-                        <code>ComponentUniverse</code>,
-                        <code>ComponentUniverse.edgeClosed_of_covers</code>,
-                        <code>FiniteArchGraph.covers_components</code>,
-                        <code>FiniteArchGraph.edgeClosed_components</code>,
-                        <code>ComponentUniverse.reachable_exists_bounded_path</code>
-                      </td>
-                      <td data-label="Current Lean status"><code>defined only</code> / <code>proved</code> by declaration</td>
-                      <td data-label="Boundary">Finite component list, coverage, edge closure, and explicit graph assumptions.</td>
-                      <td data-label="Primary index">
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">
-                          Finite Universe / Bridge Theorems
-                        </a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">
-                        Thin category and decomposability vocabulary
-                        <span class="table-row-note">
-                          Audits <a href="#remark-3-4">Remark 3.4</a> and
-                          the boundary vocabulary used by the bridge claims.
-                        </span>
-                      </th>
-                      <td data-label="Formal anchor">
-                        <code>ComponentCategory</code>,
-                        <code>Decomposable</code>,
-                        <code>StrictLayered</code>
-                      </td>
-                      <td data-label="Current Lean status"><code>defined only</code> / selected bridge facts <code>proved</code></td>
-                      <td data-label="Boundary">Reachability existence and strict layering; path count, walk length, nilpotence, and spectral facts are separate.</td>
-                      <td data-label="Primary index">
-                        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/mathematical_theory.md#2-architecture-object">
-                          mathematical theory, Chapter 2
-                        </a>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="formal-anchor-cards" aria-label="Foundations formal-anchor audit trail">
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Claim group</span>
+                      <h3>Selected presentation boundary</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">defined / proved</span>
+                  </header>
+                  <p class="formal-anchor-audits">
+                    Audits <a href="#proposition-1-2">Proposition 1.2</a>,
+                    <a href="#definition-2-0">Definition 2.0</a>,
+                    <a href="#proposition-2-1">Proposition 2.1</a>, and
+                    <a href="#counterexample-2-2">Counterexample 2.2</a>.
+                  </p>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative anchors</dt>
+                      <dd><code>AATJudgement</code>, <code>CompleteForRelation</code>, <code>CompleteForGraph</code>, and <code>CompleteExtractionCounterexample.selectedRestriction_same_but_completeExtraction_differs</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Current Lean status</dt>
+                      <dd><code>defined only</code> for vocabulary; judgement, graph bridge, and counterexample anchors <code>proved</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Selected presentation equality is not ambient repository completeness; real-code extraction, telemetry completeness, and semantic universe completeness remain separate premises.</dd>
+                    </div>
+                    <div>
+                      <dt>Primary index</dt>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#selected-presentation--complete-extraction-boundary">Selected Presentation / Complete Extraction Boundary</a></dd>
+                    </div>
+                  </dl>
+                  <details class="formal-anchor-details">
+                    <summary>Full Lean anchor set</summary>
+                    <ul class="formal-anchor-code-list">
+                      <li><code>SelectedPresentation</code></li>
+                      <li><code>AATJudgement</code></li>
+                      <li><code>aatJudgement_iff</code></li>
+                      <li><code>CompleteForRelation</code></li>
+                      <li><code>CompleteForGraph</code></li>
+                      <li><code>completeForGraph_iff_completeForRelation</code></li>
+                      <li><code>SameEdgeRestriction</code></li>
+                      <li><code>CompleteExtractionCounterexample.selectedRestriction_same_but_completeExtraction_differs</code></li>
+                    </ul>
+                  </details>
+                </article>
+
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Claim group</span>
+                      <h3>Architecture core presentation</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">defined / proved</span>
+                  </header>
+                  <p class="formal-anchor-audits">
+                    Audits <a href="#definition-1-1">Definition 1.1</a>,
+                    <a href="#proposition-2-1">Proposition 2.1</a>,
+                    <a href="#counterexample-2-2">Counterexample 2.2</a>, and
+                    <a href="#non-conclusion-2-3">Non-conclusion 2.3</a>.
+                  </p>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative anchors</dt>
+                      <dd><code>ArchitectureCore.selectedPresentationJudgement_iff</code>, <code>ArchitectureCore.SelectedClaimBoundary</code>, and <code>ArchitectureCore.selectedClaimBoundary</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Current Lean status</dt>
+                      <dd><code>defined only</code> for <code>ArchitectureCore</code> and <code>SelectedClaimBoundary</code>; selected-presentation bridge and package theorem <code>proved</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Supplied finite universe and selected predicates; no global extraction completeness, runtime telemetry completeness, or global semantic universe completeness.</dd>
+                    </div>
+                    <div>
+                      <dt>Primary index</dt>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">Architecture Core / Certified Architecture</a></dd>
+                    </div>
+                  </dl>
+                  <details class="formal-anchor-details">
+                    <summary>Full Lean anchor set</summary>
+                    <ul class="formal-anchor-code-list">
+                      <li><code>ArchitectureCore</code></li>
+                      <li><code>ArchitectureCore.selectedPresentation</code></li>
+                      <li><code>ArchitectureCore.selectedPresentationJudgement_iff</code></li>
+                      <li><code>ArchitectureCore.staticGraphRestriction_eq_staticGraph</code></li>
+                      <li><code>ArchitectureCore.runtimeGraphRestriction_eq_runtimeGraph</code></li>
+                      <li><code>ArchitectureCore.staticCompleteForSelectedPresentation</code></li>
+                      <li><code>ArchitectureCore.runtimeCompleteForSelectedPresentation</code></li>
+                      <li><code>ArchitectureCore.staticCompleteGraphForSelectedPresentation</code></li>
+                      <li><code>ArchitectureCore.runtimeCompleteGraphForSelectedPresentation</code></li>
+                      <li><code>ArchitectureCore.component_mem_staticUniverse</code></li>
+                      <li><code>ArchitectureCore.staticCoverageComplete</code></li>
+                      <li><code>ArchitectureCore.SelectedClaimBoundary</code></li>
+                      <li><code>ArchitectureCore.selectedClaimBoundary</code></li>
+                    </ul>
+                  </details>
+                </article>
+
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Claim group</span>
+                      <h3>Finite universe bridge package</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">defined / proved</span>
+                  </header>
+                  <p class="formal-anchor-audits">
+                    Audits <a href="#definition-3-1">Definition 3.1</a>,
+                    <a href="#proposition-3-2">Proposition 3.2</a>, and
+                    <a href="#counterexample-3-3">Counterexample 3.3</a>.
+                  </p>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative anchors</dt>
+                      <dd><code>ComponentUniverse.edgeClosed_of_covers</code>, <code>FiniteArchGraph.edgeClosed_components</code>, and <code>ComponentUniverse.reachable_exists_bounded_path</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Current Lean status</dt>
+                      <dd><code>defined only</code> / <code>proved</code> by declaration.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Finite component list, coverage, edge closure, and explicit graph assumptions.</dd>
+                    </div>
+                    <div>
+                      <dt>Primary index</dt>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">Finite Universe / Bridge Theorems</a></dd>
+                    </div>
+                  </dl>
+                  <details class="formal-anchor-details">
+                    <summary>Full Lean anchor set</summary>
+                    <ul class="formal-anchor-code-list">
+                      <li><code>ComponentUniverse</code></li>
+                      <li><code>ComponentUniverse.edgeClosed_of_covers</code></li>
+                      <li><code>FiniteArchGraph.covers_components</code></li>
+                      <li><code>FiniteArchGraph.edgeClosed_components</code></li>
+                      <li><code>ComponentUniverse.reachable_exists_bounded_path</code></li>
+                    </ul>
+                  </details>
+                </article>
+
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Claim group</span>
+                      <h3>Thin category and decomposability vocabulary</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">defined / proved</span>
+                  </header>
+                  <p class="formal-anchor-audits">
+                    Audits <a href="#remark-3-4">Remark 3.4</a> and the
+                    boundary vocabulary used by the bridge claims.
+                  </p>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative anchors</dt>
+                      <dd><code>ComponentCategory</code>, <code>Decomposable</code>, and <code>StrictLayered</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Current Lean status</dt>
+                      <dd><code>defined only</code> / selected bridge facts <code>proved</code>.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Reachability existence and strict layering; path count, walk length, nilpotence, and spectral facts are separate.</dd>
+                    </div>
+                    <div>
+                      <dt>Primary index</dt>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/mathematical_theory.md#2-architecture-object">mathematical theory, Chapter 2</a></dd>
+                    </div>
+                  </dl>
+                  <details class="formal-anchor-details">
+                    <summary>Full Lean anchor set</summary>
+                    <ul class="formal-anchor-code-list">
+                      <li><code>ComponentCategory</code></li>
+                      <li><code>Decomposable</code></li>
+                      <li><code>StrictLayered</code></li>
+                    </ul>
+                  </details>
+                </article>
               </div>
               <div class="claim-strip">
                 <p>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -915,6 +915,117 @@ p {
   overflow-wrap: anywhere;
 }
 
+.formal-anchor-cards {
+  display: grid;
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.formal-anchor-card {
+  border: 1px solid var(--rule);
+  border-left: 5px solid var(--accent-blue);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 18px;
+}
+
+.formal-anchor-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 10px;
+}
+
+.formal-anchor-card-label {
+  display: block;
+  color: var(--accent-warm);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.formal-anchor-card h3 {
+  margin-top: 4px;
+  font-size: 1.22rem;
+  line-height: 1.18;
+}
+
+.formal-anchor-audits {
+  margin: 0 0 14px;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: 0.92rem;
+  line-height: 1.48;
+}
+
+.formal-anchor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 18px;
+  margin: 0;
+}
+
+.formal-anchor-grid > div {
+  min-width: 0;
+}
+
+.formal-anchor-card dt {
+  color: var(--accent-blue);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.formal-anchor-card dd {
+  margin: 4px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.96rem;
+  line-height: 1.46;
+}
+
+.formal-anchor-card code {
+  overflow-wrap: anywhere;
+}
+
+.formal-anchor-details {
+  border-top: 1px solid var(--rule);
+  margin-top: 14px;
+  padding-top: 12px;
+}
+
+.formal-anchor-details summary {
+  cursor: pointer;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  font-weight: 850;
+  line-height: 1.3;
+}
+
+.formal-anchor-details summary:hover {
+  color: var(--accent-blue);
+}
+
+.formal-anchor-code-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 16px;
+  margin: 12px 0 0;
+  padding-left: 18px;
+}
+
+.formal-anchor-code-list li {
+  min-width: 0;
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+  line-height: 1.36;
+}
+
 .article-table {
   margin-top: 18px;
   overflow-x: auto;
@@ -969,26 +1080,6 @@ p {
   overflow-wrap: anywhere;
   white-space: normal;
   word-break: break-word;
-}
-
-.formal-anchors-table table {
-  min-width: 760px;
-}
-
-.table-row-note {
-  display: block;
-  margin-top: 6px;
-  color: var(--ink-muted);
-  font-size: 0.86rem;
-  font-weight: 500;
-  line-height: 1.42;
-}
-
-.table-row-note a {
-  color: var(--accent-blue);
-  font-weight: 750;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
 }
 
 .page-nav {
@@ -1100,52 +1191,13 @@ p {
     grid-template-columns: 1fr;
   }
 
-  .reader-model {
+  .formal-anchor-grid,
+  .formal-anchor-code-list {
     grid-template-columns: 1fr;
   }
 
-  .formal-anchors-table {
-    overflow-x: visible;
-  }
-
-  .formal-anchors-table table {
-    min-width: 0;
-    border-top: 0;
-  }
-
-  .formal-anchors-table thead {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
-  }
-
-  .formal-anchors-table tbody tr {
-    display: block;
-    border-top: 1px solid var(--rule-strong);
-    padding: 14px 0;
-  }
-
-  .formal-anchors-table th[scope="row"],
-  .formal-anchors-table td {
-    display: block;
-    border-bottom: 0;
-    padding: 6px 0;
-  }
-
-  .formal-anchors-table td::before {
-    content: attr(data-label);
-    display: block;
-    color: var(--accent-blue);
-    font-family: var(--font-sans);
-    font-size: 0.7rem;
-    font-weight: 850;
-    line-height: 1.2;
-    margin-bottom: 3px;
-    text-transform: uppercase;
+  .reader-model {
+    grid-template-columns: 1fr;
   }
 
   h1 {
@@ -1203,6 +1255,14 @@ p {
   }
 
   .theorem-card-header {
+    display: grid;
+  }
+
+  .formal-anchor-card {
+    padding: 16px 14px;
+  }
+
+  .formal-anchor-card-header {
     display: grid;
   }
 


### PR DESCRIPTION
## 概要

Closes #843

Foundations の Formal anchors table を、anchor card + 折りたたみ詳細へ置き換えました。通常表示では claim group ごとに representative anchors / current Lean status / boundary / primary index だけを見せ、長い Lean declaration list は各カードの `details` に退避しています。

横長 table 依存をなくし、mobile でもカードが縦に読めるように CSS を追加しました。未使用になった `formal-anchors-table` / `table-row-note` 用 CSS も削除しています。

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/foundations/index.html`
- `website/assets/site.css`

## 実施したテスト

- [x] `python3 -m http.server 8000 --directory website` による local preview
- [x] `curl -L --fail http://127.0.0.1:8000/aat/foundations/`
- [x] `curl -L --fail http://127.0.0.1:8000/assets/site.css`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] Lean source 変更なしのため `lake build` は未実施

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている