### PR TITLE
AAT websiteのサイドバー導線を整理する

### DIFF
--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -77,66 +77,65 @@
                 <li><a href="#formal-anchors">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-9-1">Definition 9.1</a></li>
-                <li><a href="#proposition-9-2">Proposition 9.2</a></li>
-                <li><a href="#proposition-9-3">Proposition 9.3</a></li>
-                <li><a href="#definition-10-1">Definition 10.1</a></li>
-                <li><a href="#proposition-10-2">Proposition 10.2</a></li>
-                <li><a href="#proposition-10-3">Proposition 10.3</a></li>
-                <li><a href="#non-conclusion-10-4">Non-conclusion 10.4</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/mathematical_theory.md#L429">
-                    Chapter 9 in the AAT text
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/mathematical_theory.md#L499">
-                    Chapter 10 in the AAT text
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/proof_obligations.md#L165-L173">
-                    Proof-obligation status ledger
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L453">
-                    Operation Lean index
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L280">
-                    Feature-extension Lean index
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/" aria-current="page">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/5a90d46853ae2ee6ad014438ea0ad242869bdb37">5a90d46</a></dd>
-                <dt>Lean status</dt>
-                <dd>No new Lean theorem is added here; status badges cite the proof-obligation and theorem-index snapshot.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                An operation tag, an extension schema, or an observed metric is
-                not a preservation theorem. AAT asks which selected evidence
-                discharges which selected theorem boundary.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/examples-and-boundaries/index.html
+++ b/website/aat/examples-and-boundaries/index.html
@@ -79,46 +79,65 @@
                 <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-15-0">Definition 15.0</a></li>
-                <li><a href="#example-15-1">Example 15.1</a></li>
-                <li><a href="#signature-reading-15-2">Signature reading 15.2</a></li>
-                <li><a href="#counterexample-15-3">Counterexample 15.3</a></li>
-                <li><a href="#counterexample-15-4">Counterexample 15.4</a></li>
-                <li><a href="#counterexample-15-5">Counterexample 15.5</a></li>
-                <li><a href="#non-conclusion-16-1">Non-conclusion 16.1</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/mathematical_theory.md#15-canonical-examples-and-counterexamples">
-                    Chapters 15-16 in the AAT text
+                  <a href="../">
+                    AAT overview
+                  </a>
+                </li>
+                <li>
+                  <a href="../foundations/">
+                    Foundations
+                  </a>
+                </li>
+                <li>
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/" aria-current="page">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/920c07d50500b06f98ef4bc6ab32f82760903323">920c07d</a></dd>
-                <dt>Lean status</dt>
-                <dd><code>lake build</code> passed for this snapshot; see local status notes and Status page.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                Counterexamples are part of the theory surface. They keep AAT
-                from claiming runtime, semantic, empirical, or global results
-                from a theorem package that only proves a selected static claim.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -74,51 +74,65 @@
                 <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-1-1">Definition 1.1</a></li>
-                <li><a href="#proposition-1-2">Proposition 1.2</a></li>
-                <li><a href="#definition-2-0">Definition 2.0</a></li>
-                <li><a href="#proposition-2-1">Proposition 2.1</a></li>
-                <li><a href="#counterexample-2-2">Counterexample 2.2</a></li>
-                <li><a href="#non-conclusion-2-3">Non-conclusion 2.3</a></li>
-                <li><a href="#definition-3-1">Definition 3.1</a></li>
-                <li><a href="#proposition-3-2">Proposition 3.2</a></li>
-                <li><a href="#counterexample-3-3">Counterexample 3.3</a></li>
-                <li><a href="#example-4-1">Example 4.1</a></li>
-                <li><a href="#bounded-reading-4-2">Bounded reading 4.2</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/mathematical_theory.md#1-%E4%B8%AD%E5%BF%83%E5%91%BD%E9%A1%8C">
-                    Chapters 1-2 in the AAT text
+                  <a href="../">
+                    AAT overview
+                  </a>
+                </li>
+                <li>
+                  <a href="../foundations/" aria-current="page">
+                    Foundations
+                  </a>
+                </li>
+                <li>
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/6709857b5cf840218f3a88a3a776c184dbf825d4">6709857</a></dd>
-                <dt>Lean status</dt>
-                <dd><code>lake build</code> passed for this snapshot; see Status for proved / defined-only boundaries.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                AAT does not claim complete extraction from real codebases.
-                <code>ComponentUniverse</code> is proof-carrying measurement
-                scope, not a promise that all components and relations have
-                been observed.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -76,201 +76,83 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#reading-order">Reading order</a></li>
                 <li><a href="#abstract">Abstract</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
-                <li><a href="#publication-purpose">Publication purpose</a></li>
                 <li><a href="#formal-anchor">Formal anchor</a></li>
                 <li><a href="#worked-example">Worked example</a></li>
                 <li><a href="#related-work">Related work</a></li>
-                <li><a href="#reading-order">Reading order</a></li>
-                <li><a href="#claim-discipline">Claim discipline</a></li>
-                <li><a href="#canonical-sources">Canonical sources</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical sources</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md">
-                    AAT mathematical theory
+                  <a href="./" aria-current="page">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/README.md">
-                    AAT repository entry
+                  <a href="foundations/">
+                    Foundations
+                  </a>
+                </li>
+                <li>
+                  <a href="laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-15</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
-                <dt>Lean status</dt>
-                <dd>`lake build` and audit scan meanings are explained on the Status page.</dd>
-              </dl>
             </div>
           </aside>
 
           <div class="article-main">
-            <section id="abstract" class="article-section">
-              <h2>Abstract</h2>
-              <p>
-                Algebraic Architecture Theory formalizes software architecture
-                as a bounded mathematical object equipped with operations,
-                invariant families, obstruction witnesses, signature axes, and
-                theorem boundaries. Its basic claim is that architectural
-                quality should be read through preserved invariants and
-                explicit witnesses of failure, not through slogans, framework
-                names, or a single scalar score.
-              </p>
-              <p>
-                The theory is local by design. Every claim is relative to a
-                selected universe, observation context, coverage boundary, and
-                exactness assumption. This makes AAT useful for precise design
-                review: it can say what is preserved, what is broken, what was
-                measured, what was not measured, and which theorem package
-                licenses the conclusion.
-              </p>
-            </section>
-
-            <section id="main-contributions" class="article-section">
-              <h2>Main contributions</h2>
-              <ul class="status-list">
-                <li>
-                  <strong>Architecture as bounded algebra</strong>
-                  <span>AAT treats architecture objects and operations as typed, evidence-bounded mathematical data rather than as informal descriptions of whole codebases.</span>
-                </li>
-                <li>
-                  <strong>Obstruction-first quality</strong>
-                  <span>Quality failure is represented by selected obstruction witnesses: forbidden edges, boundary violations, projection failures, semantic non-commutativity, runtime exposure, lifting failure, and residual coverage gaps.</span>
-                </li>
-                <li>
-                  <strong>Multi-axis signature</strong>
-                  <span>Architecture Signature records measured coordinates and measurement status per axis, keeping unmeasured, out-of-scope, private, and zero evidence distinct.</span>
-                </li>
-                <li>
-                  <strong>Theorem-boundary discipline</strong>
-                  <span>Every theorem candidate records assumptions, coverage, exactness, conclusion, and non-conclusions so static, runtime, semantic, tooling, and empirical readings are not collapsed.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="publication-purpose" class="article-section">
-              <h2>Publication purpose</h2>
-              <p>
-                This website is the canonical public reading surface for AAT:
-                a web-native systematic exposition that sits between outreach
-                posts and a future conventional paper. Blog platforms are
-                useful for motivation, but AAT needs a stable place for
-                definitions, assumptions, theorem boundaries, examples,
-                counterexamples, Lean status, and non-conclusions to remain
-                together.
-              </p>
-              <ul class="status-list">
-                <li>
-                  <strong>Not a blog summary</strong>
-                  <span>The pages preserve formal distinctions instead of compressing them into general software advice.</span>
-                </li>
-                <li>
-                  <strong>Not a product landing page</strong>
-                  <span>The primary object is the theory: its vocabulary, theorem shape, examples, and boundaries.</span>
-                </li>
-                <li>
-                  <strong>Preprint-style surface</strong>
-                  <span>The site makes AAT readable before a slower arXiv-style paper is prepared, while keeping claim discipline explicit.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="formal-anchor" class="article-section">
-              <h2>Formal anchor</h2>
-              <p>
-                Lean formalization is not a replacement for the whole AAT
-                exposition. Its role is to provide inspectable anchor theorem
-                packages inside the broader theory, so claims can be read with
-                explicit universe, coverage, exactness, and non-conclusion
-                boundaries.
-              </p>
-              <p>
-                The current paper-facing anchor is the finite static
-                structural core. It is a proved Lean package for selected
-                static lawfulness, required obstruction witnesses, and required
-                signature axes under stated assumptions, not the only main
-                theorem of AAT and not a substitute for the operation,
-                invariant, witness, signature, calculus, repair, and empirical
-                parts of the theory.
-              </p>
-              <ul class="status-list">
-                <li>
-                  <strong>Inspectable package</strong>
-                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a> lists the boundary, Lean declarations, derived diagnostics, and non-conclusions.</span>
-                </li>
-                <li>
-                  <strong>Zero-curvature terminology</strong>
-                  <span>Within this anchor, zero-curvature means the required obstruction valuation is zero for the selected law universe. It is not a numerical or differential-geometric curvature claim.</span>
-                </li>
-                <li>
-                  <strong>Reader rule</strong>
-                  <span>Use the Status page and theorem index whenever a public sentence depends on Lean, CI, audit scans, or theorem-boundary evidence.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="worked-example" class="article-section">
-              <h2>Worked example</h2>
-              <p>
-                Readers who want the shortest complete pass through AAT should
-                start with the coupon worked example. It keeps the finite
-                component universe, selected static edges, semantic mismatch,
-                runtime exposure, witness list, signature coordinates, theorem
-                references, and non-conclusions on one page.
-              </p>
-              <ul class="status-list">
-                <li>
-                  <strong><a href="examples-and-boundaries/#coupon-case-study">Five-minute coupon example</a></strong>
-                  <span>Shows how a direct `CouponService -> PaymentAdapter.internalCache` edge becomes a measured nonzero static witness while repaired static split, semantic ordering, and runtime exposure remain separate axes.</span>
-                </li>
-                <li>
-                  <strong>Reader rule</strong>
-                  <span>`measured_zero`, `measured_nonzero`, `unmeasured`, and `out_of_scope` are different evidence states, not values on one scalar quality scale.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="related-work" class="article-section">
-              <h2>Related work</h2>
-              <p>
-                AAT sits next to architecture description standards,
-                scenario-based evaluation, dependency analysis, architecture
-                metrics, formal methods, and category-theoretic software
-                models. Its novelty claim is not that those areas are replaced,
-                but that their evidence can be read through invariant
-                families, obstruction witnesses, multi-axis signatures, and
-                explicit theorem boundaries.
-              </p>
-              <ul class="status-list">
-                <li>
-                  <strong><a href="related-work/">Related Work and Novelty</a></strong>
-                  <span>Compares AAT with ISO 42010, ATAM, architecture metrics, graph dependency analysis, formal methods, and category-theoretic modeling.</span>
-                </li>
-                <li>
-                  <strong>Reader rule</strong>
-                  <span>AAT does not turn a view, scenario, graph metric, or model-checking result into a global architecture claim without a recorded boundary.</span>
-                </li>
-              </ul>
-            </section>
-
             <section id="reading-order" class="article-section">
               <h2>Reading order</h2>
               <p>
-                The repository keeps AAT as one first-class mathematical text.
-                The website splits that text into chapter clusters so readers
-                can keep their current position and move through the theory in
-                a stable order.
+                Start with Foundations for the main line. Use the coupon
+                example when you want a concrete pass first, and use Status
+                when you need the Lean and audit evidence behind a claim.
               </p>
               <ul class="chapter-list">
                 <li>
@@ -316,54 +198,111 @@
               </ul>
             </section>
 
-            <section id="claim-discipline" class="article-section">
-              <h2>Claim discipline</h2>
+            <section id="abstract" class="article-section">
+              <h2>Abstract</h2>
               <p>
-                AAT does not identify architecture quality with a slogan, a
-                framework name, or a scalar score. It asks which invariant is
-                required, which universe is being observed, which witness shows
-                a failure, and which theorem boundary permits the conclusion.
+                Algebraic Architecture Theory formalizes software architecture
+                as a bounded mathematical object equipped with operations,
+                invariant families, obstruction witnesses, signature axes, and
+                theorem boundaries. Its basic claim is that architectural
+                quality should be read through preserved invariants and
+                explicit witnesses of failure, not through slogans, framework
+                names, or a single scalar score.
               </p>
-              <figure class="code-panel">
-                <figcaption>Central decomposition</figcaption>
-                <pre><code>software architecture
-  = ArchitectureObject
-  + ArchitectureOperation
-  + InvariantFamily
-  + ObstructionWitness
-  + ArchitectureSignature
-  + theorem boundary / non-conclusions</code></pre>
-              </figure>
-              <div class="claim-strip">
-                <p>
-                  This website is a public reading surface. Formal status,
-                  issue tracking, tooling evidence, and empirical validation
-                  stay separate from the mathematical text. Use the Status
-                  page when a claim depends on Lean, CI, or audit scan evidence.
-                </p>
-              </div>
+              <p>
+                The theory is local by design. Every claim is relative to a
+                selected universe, observation context, coverage boundary, and
+                exactness assumption. This makes AAT useful for precise design
+                review: it can say what is preserved, what is broken, what was
+                measured, what was not measured, and which theorem package
+                licenses the conclusion.
+              </p>
             </section>
 
-            <section id="canonical-sources" class="article-section">
-              <h2>Canonical sources</h2>
+            <section id="main-contributions" class="article-section">
+              <h2>Main contributions</h2>
+              <ul class="status-list">
+                <li>
+                  <strong>Architecture as bounded algebra</strong>
+                  <span>AAT treats architecture objects and operations as typed, evidence-bounded mathematical data rather than as informal descriptions of whole codebases.</span>
+                </li>
+                <li>
+                  <strong>Obstruction-first quality</strong>
+                  <span>Quality failure is represented by selected obstruction witnesses: forbidden edges, boundary violations, projection failures, semantic non-commutativity, runtime exposure, lifting failure, and residual coverage gaps.</span>
+                </li>
+                <li>
+                  <strong>Multi-axis signature</strong>
+                  <span>Architecture Signature records measured coordinates and measurement status per axis, keeping unmeasured, out-of-scope, private, and zero evidence distinct.</span>
+                </li>
+                <li>
+                  <strong>Theorem-boundary discipline</strong>
+                  <span>Every theorem candidate records assumptions, coverage, exactness, conclusion, and non-conclusions so static, runtime, semantic, tooling, and empirical readings are not collapsed.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="formal-anchor" class="article-section">
+              <h2>Formal anchor</h2>
               <p>
-                The mathematical source of truth is the repository document.
-                Lean theorem status is intentionally separated into the theorem
-                index and proof-obligation ledger so public prose does not turn
-                a theorem candidate into a proved Lean claim.
+                Lean formalization is not a replacement for the whole AAT
+                exposition. Its role is to provide inspectable anchor theorem
+                packages inside the broader theory, so claims can be read with
+                explicit universe, coverage, exactness, and non-conclusion
+                boundaries.
               </p>
-              <ul class="term-list">
+              <p>
+                The current paper-facing anchor is the finite static
+                structural core. It is a proved Lean package for selected
+                static lawfulness, required obstruction witnesses, and required
+                signature axes under stated assumptions, not the only main
+                theorem of AAT and not a substitute for the operation,
+                invariant, witness, signature, calculus, repair, and empirical
+                parts of the theory.
+              </p>
+              <ul class="status-list">
                 <li>
-                  <strong>Mathematical text</strong>
-                  <span>`docs/aat/mathematical_theory.md` defines the AAT theory surface.</span>
+                  <strong>Inspectable package</strong>
+                  <span><a href="status/#formal-anchor-package">Formal anchor theorem package</a> lists the boundary, Lean declarations, derived diagnostics, and non-conclusions.</span>
                 </li>
                 <li>
-                  <strong>Lean status</strong>
-                  <span>`docs/aat/lean_theorem_index.md` lists implemented definitions and theorems.</span>
+                  <strong>Zero-curvature terminology</strong>
+                  <span>Within this anchor, zero-curvature means the required obstruction valuation is zero for the selected law universe. It is not a numerical or differential-geometric curvature claim.</span>
                 </li>
+              </ul>
+            </section>
+
+            <section id="worked-example" class="article-section">
+              <h2>Worked example</h2>
+              <p>
+                Readers who want the shortest complete pass through AAT should
+                start with the coupon worked example. It keeps the finite
+                component universe, selected static edges, semantic mismatch,
+                runtime exposure, witness list, signature coordinates, theorem
+                references, and non-conclusions on one page.
+              </p>
+              <ul class="status-list">
                 <li>
-                  <strong>Proof obligations</strong>
-                  <span>`docs/aat/proof_obligations.md` separates proved, defined only, future proof obligation, and empirical hypothesis.</span>
+                  <strong><a href="examples-and-boundaries/#coupon-case-study">Five-minute coupon example</a></strong>
+                  <span>Shows how a direct `CouponService -> PaymentAdapter.internalCache` edge becomes a measured nonzero static witness while repaired static split, semantic ordering, and runtime exposure remain separate axes.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="related-work" class="article-section">
+              <h2>Related work</h2>
+              <p>
+                AAT sits next to architecture description standards,
+                scenario-based evaluation, dependency analysis, architecture
+                metrics, formal methods, and category-theoretic software
+                models. Its novelty claim is not that those areas are replaced,
+                but that their evidence can be read through invariant
+                families, obstruction witnesses, multi-axis signatures, and
+                explicit theorem boundaries.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong><a href="related-work/">Related Work and Novelty</a></strong>
+                  <span>Compares AAT with ISO 42010, ATAM, architecture metrics, graph dependency analysis, formal methods, and category-theoretic modeling.</span>
                 </li>
               </ul>
             </section>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -74,45 +74,65 @@
                 <li><a href="#lean-status">Lean status</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/mathematical_theory.md#3-invariant-%E3%81%A8-law-universe">
-                    Chapters 3-4 in the AAT text
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/lean_theorem_index.md#lawfulness-bridge">
-                    Lawfulness bridge in the Lean theorem index
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/89b4502b6fc01937bfafa409155a7b4a194a80fe/docs/aat/proof_obligations.md#lean-proof-obligation-index">
-                    Proof-obligation ledger
+                  <a href="../laws-and-witnesses/" aria-current="page">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-15</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/89b4502b6fc01937bfafa409155a7b4a194a80fe">89b4502</a></dd>
-                <dt>Lean status</dt>
-                <dd><code>lake build</code> passed for this snapshot; see local status notes and Status page.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                Zero curvature names required obstruction-free status inside a
-                selected law universe. It is not an unconditional claim about
-                runtime behavior, semantic flatness, empirical risk, or
-                differential-geometric curvature.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -76,66 +76,65 @@
                 <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-7-1">Definition 7.1</a></li>
-                <li><a href="#proposition-7-2">Proposition 7.2</a></li>
-                <li><a href="#definition-7-3">Definition 7.3</a></li>
-                <li><a href="#proposition-7-4">Proposition 7.4</a></li>
-                <li><a href="#definition-7-5">Definition 7.5</a></li>
-                <li><a href="#proposition-7-6">Proposition 7.6</a></li>
-                <li><a href="#proposition-7-7">Proposition 7.7</a></li>
-                <li><a href="#definition-8-1">Definition 8.1</a></li>
-                <li><a href="#proposition-8-2">Proposition 8.2</a></li>
-                <li><a href="#non-conclusion-8-3">Non-conclusion 8.3</a></li>
-                <li><a href="#example-8-4">Example 8.4</a></li>
-                <li><a href="#counterexample-8-5">Counterexample 8.5</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/mathematical_theory.md#L347">
-                    Chapters 7-8 in the AAT text
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/proof_obligations.md#L176-L222">
-                    Projection, LSP, and SOLID boundary ledger
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#projection--dip">
-                    Projection / DIP Lean index
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#flatness">
-                    Flatness Lean index
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/" aria-current="page">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/3bf99081cf64d10ca230ed89d13ec734cf15cae6">3bf9908</a></dd>
-                <dt>Lean status</dt>
-                <dd>No new Lean theorem is added here; status badges cite the proof-obligation and theorem-index snapshot.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                SOLID-style local contracts are local contract-layer packages.
-                They do not by themselves prove global decomposability,
-                acyclicity, runtime protection, or semantic flatness.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/related-work/index.html
+++ b/website/aat/related-work/index.html
@@ -79,63 +79,65 @@
                 <li><a href="#formal-anchors">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#positioning-a-1">Positioning A.1</a></li>
-                <li><a href="#non-replacement-a-2">Non-replacement A.2</a></li>
-                <li><a href="#signature-boundary-a-3">Signature boundary A.3</a></li>
-                <li><a href="#formal-anchor-a-4">Formal anchor A.4</a></li>
-                <li><a href="#novelty-boundary-a-5">Novelty boundary A.5</a></li>
-                <li><a href="#non-conclusion-a-6">Non-conclusion A.6</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical sources</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/mathematical_theory.md">
-                    AAT mathematical theory
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/research_goal.md">
-                    Research goal
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/proof_obligations.md">
-                    Proof obligations
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md">
-                    Lean theorem index
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/" aria-current="page">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/44d6266ec321ef19f0c00da53f60bde92ea7a18b">44d6266</a></dd>
-                <dt>Lean status</dt>
-                <dd>Website synthesis only. It introduces no new Lean theorem and audits existing formal anchors.</dd>
-                <dt>Claim level</dt>
-                <dd>Conceptual comparison, source-boundary map, and non-replacement claim; not an empirical validation result.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                This page states how AAT should be read relative to adjacent
-                work. It does not claim that AAT replaces architecture
-                description standards, review methods, model checking, or
-                empirical architecture metrics.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -76,57 +76,65 @@
                 <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-11-1">Definition 11.1</a></li>
-                <li><a href="#proposition-11-2">Proposition 11.2</a></li>
-                <li><a href="#proposition-11-3">Proposition 11.3</a></li>
-                <li><a href="#counterexample-11-4">Counterexample 11.4</a></li>
-                <li><a href="#definition-12-1">Definition 12.1</a></li>
-                <li><a href="#proposition-12-2">Proposition 12.2</a></li>
-                <li><a href="#proposition-12-3">Proposition 12.3</a></li>
-                <li><a href="#example-12-4">Example 12.4</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/mathematical_theory.md#11-repair-synthesis-complexity-transfer">
-                    Chapter 11 in the AAT text
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/mathematical_theory.md#12-path-homotopy-diagram-filling">
-                    Chapter 12 in the AAT text
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/proof_obligations.md#lean-proof-obligation-index">
-                    Proof-obligation ledger
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/" aria-current="page">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/b697cff13ab629d5bcb173ac6db8bd8d124f873b">b697cff</a></dd>
-                <dt>Lean status</dt>
-                <dd><code>lake build</code> passed for this snapshot; this page adds no Lean theorem.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                A repair theorem may prove selected decrease. It does not
-                prove total improvement, solver completeness, extractor
-                completeness, or preservation of every semantic axis.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -75,57 +75,65 @@
                 <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-13-1">Definition 13.1</a></li>
-                <li><a href="#proposition-13-2">Proposition 13.2</a></li>
-                <li><a href="#non-conclusion-13-3">Non-conclusion 13.3</a></li>
-                <li><a href="#definition-13-4">Definition 13.4</a></li>
-                <li><a href="#proposition-13-5">Proposition 13.5</a></li>
-                <li><a href="#proposition-13-6">Proposition 13.6</a></li>
-                <li><a href="#definition-14-1">Definition 14.1</a></li>
-                <li><a href="#proposition-14-2">Proposition 14.2</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/mathematical_theory.md#L613-L655">
-                    Chapter 13 in the AAT text
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/mathematical_theory.md#L658-L681">
-                    Chapter 14 in the AAT text
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/proof_obligations.md#lean-proof-obligation-index">
-                    Proof-obligation ledger
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/" aria-current="page">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/d1431f766df424332617ed84cb88dd17a11e9c0c">d1431f7</a></dd>
-                <dt>Lean status</dt>
-                <dd><code>lake build</code> passed for this snapshot; this page adds no Lean theorem.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                A represented zero is not automatically a structural zero.
-                Reflection needs coverage, witness completeness, semantic
-                contract coverage, and the selected measurement boundary.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/signature-and-boundary/index.html
+++ b/website/aat/signature-and-boundary/index.html
@@ -75,59 +75,65 @@
                 <li><a href="#status-index">Formal anchors</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Citable statements</h2>
-              <ul>
-                <li><a href="#definition-5-1">Definition 5.1</a></li>
-                <li><a href="#proposition-5-2">Proposition 5.2</a></li>
-                <li><a href="#definition-5-3">Definition 5.3</a></li>
-                <li><a href="#proposition-5-4">Proposition 5.4</a></li>
-                <li><a href="#definition-5-5">Definition 5.5</a></li>
-                <li><a href="#definition-6-1">Definition 6.1</a></li>
-                <li><a href="#proposition-6-2">Proposition 6.2</a></li>
-                <li><a href="#definition-6-3">Definition 6.3</a></li>
-                <li><a href="#proposition-6-4">Proposition 6.4</a></li>
-                <li><a href="#non-conclusion-6-5">Non-conclusion 6.5</a></li>
-              </ul>
-            </div>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/mathematical_theory.md#5-architecture-signature">
-                    Chapters 5-6 in the AAT text
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/proof_obligations.md#L107">
-                    Current QED boundary
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#signature-integrated-lawfulness">
-                    Signature-integrated lawfulness index
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../signature-and-boundary/" aria-current="page">
+                    Signature and Theorem Boundary
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/3bf99081cf64d10ca230ed89d13ec734cf15cae6">3bf9908</a></dd>
-                <dt>Lean status</dt>
-                <dd><code>lake build</code> passed for this snapshot; see local status notes and Status page.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                A missing axis is not a zero axis. Signature comparison is valid
-                only where the same axes are measured on both sides and an
-                axis-specific order is defined.
-              </p>
             </div>
           </aside>
 

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -66,6 +66,7 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#source-map">Source map</a></li>
+                <li><a href="#release-snapshot">Release snapshot</a></li>
                 <li><a href="#audit-snapshot">Audit snapshot</a></li>
                 <li><a href="#formal-claim-map">Formal claim map</a></li>
                 <li><a href="#formal-anchor-package">Formal anchor package</a></li>
@@ -75,58 +76,65 @@
                 <li><a href="#qed-boundary">Current QED boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Status sources</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md">
-                    Lean theorem index
+                  <a href="../">
+                    AAT overview
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/proof_obligations.md">
-                    Proof obligations
+                  <a href="../foundations/">
+                    Foundations
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#selected-presentation--complete-extraction-boundary">
-                    Selected presentation boundary
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">
-                    Architecture core claim boundary
+                  <a href="../signature-and-boundary/">
+                    Signature and Theorem Boundary
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">
-                    Formal anchor theorem package
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../examples-and-boundaries/">
+                    Examples and Boundaries
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/" aria-current="page">
+                    Status
                   </a>
                 </li>
               </ul>
-            </div>
-            <div class="version-panel">
-              <h2>AAT release snapshot</h2>
-              <dl>
-                <dt>Updated</dt>
-                <dd>2026-05-16</dd>
-                <dt>Lean toolchain</dt>
-                <dd><code>leanprover/lean4:v4.28.0</code></dd>
-                <dt>Docs source commit</dt>
-                <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/6709857b5cf840218f3a88a3a776c184dbf825d4">6709857</a></dd>
-                <dt>Build evidence</dt>
-                <dd><code>lake build</code> is the whole-repository check used for Lean PRs and release snapshots.</dd>
-                <dt>Audit scans</dt>
-                <dd>Placeholder, unsafe Lean keyword, and hidden Unicode scans are separate checks; a passing build is not a substitute for them.</dd>
-              </dl>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                Mathematical theorem candidates are not automatically current
-                Lean theorems. The theorem index and proof-obligation document
-                provide the status boundary.
-              </p>
             </div>
           </aside>
 
@@ -146,14 +154,60 @@
                   <span>`docs/aat/mathematical_theory.md` is the first-class theory text.</span>
                 </li>
                 <li>
-                  <strong>Implemented Lean API</strong>
-                  <span>`docs/aat/lean_theorem_index.md` lists declarations, file paths, meanings, and status.</span>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md">Implemented Lean API</a></strong>
+                  <span>The theorem index lists declarations, file paths, meanings, and status.</span>
                 </li>
                 <li>
-                  <strong>Future work and empirical hypotheses</strong>
-                  <span>`docs/aat/proof_obligations.md` tracks proof obligations and empirical boundaries.</span>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/proof_obligations.md">Future work and empirical hypotheses</a></strong>
+                  <span>The proof-obligation ledger tracks future proof work and empirical boundaries.</span>
+                </li>
+                <li>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#selected-presentation--complete-extraction-boundary">Selected presentation boundary</a></strong>
+                  <span>Records the formal boundary between selected presentation-level reading and ambient complete extraction.</span>
+                </li>
+                <li>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">Architecture core claim boundary</a></strong>
+                  <span>Records the current formal boundary for architecture core and certified architecture claims.</span>
+                </li>
+                <li>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Formal anchor theorem package</a></strong>
+                  <span>Maps the finite static structural anchor to Lean declarations, derived diagnostics, and non-conclusions.</span>
                 </li>
               </ul>
+            </section>
+
+            <section id="release-snapshot" class="article-section">
+              <h2>Release snapshot</h2>
+              <p>
+                This status page is tied to a named repository snapshot and
+                toolchain. Read build and audit evidence at that boundary.
+              </p>
+              <div class="article-table">
+                <table>
+                  <tbody>
+                    <tr>
+                      <th>Updated</th>
+                      <td>2026-05-16</td>
+                    </tr>
+                    <tr>
+                      <th>Lean toolchain</th>
+                      <td><code>leanprover/lean4:v4.28.0</code></td>
+                    </tr>
+                    <tr>
+                      <th>Repository snapshot</th>
+                      <td><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/6709857b5cf840218f3a88a3a776c184dbf825d4">6709857</a></td>
+                    </tr>
+                    <tr>
+                      <th>Build evidence</th>
+                      <td><code>lake build</code> is the whole-repository check used for Lean PRs and release snapshots.</td>
+                    </tr>
+                    <tr>
+                      <th>Audit scans</th>
+                      <td>Placeholder, unsafe Lean keyword, and hidden Unicode scans are separate checks; a passing build is not a substitute for them.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="audit-snapshot" class="article-section">

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -505,7 +505,7 @@ p {
   position: sticky;
   top: 92px;
   display: grid;
-  gap: 22px;
+  gap: 18px;
   min-width: 0;
 }
 
@@ -513,19 +513,71 @@ p {
 .source-panel,
 .version-panel,
 .boundary-note {
-  border-top: 3px solid var(--ink);
-  padding-top: 16px;
+  border-top: 2px solid var(--rule-strong);
+  padding-top: 10px;
 }
 
 .toc-panel h2,
 .source-panel h2,
 .version-panel h2,
 .boundary-note h2 {
-  margin-bottom: 10px;
+  margin: 0;
   font-family: var(--font-sans);
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 850;
   text-transform: uppercase;
+}
+
+.toc-panel.is-open h2,
+.source-panel.is-open h2,
+.version-panel.is-open h2,
+.boundary-note.is-open h2 {
+  margin-bottom: 11px;
+}
+
+.sidebar-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-transform: inherit;
+  cursor: pointer;
+}
+
+.sidebar-toggle:hover {
+  color: var(--accent-strong);
+}
+
+.sidebar-toggle::after {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid var(--ink-muted);
+  border-bottom: 2px solid var(--ink-muted);
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform 140ms ease, border-color 140ms ease;
+}
+
+.sidebar-toggle[aria-expanded="true"]::after {
+  border-color: var(--accent-strong);
+  transform: rotate(225deg) translateY(-1px);
+}
+
+.sidebar-toggle:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 4px;
+}
+
+.sidebar-panel-content {
+  padding-top: 1px;
 }
 
 .toc-panel ol,
@@ -544,11 +596,40 @@ p {
 
 .toc-panel a,
 .source-panel a {
+  display: block;
   font-family: var(--font-sans);
   font-size: 0.9rem;
   font-weight: 700;
   line-height: 1.35;
   text-decoration: none;
+}
+
+.toc-panel li,
+.source-panel li {
+  position: relative;
+  padding-left: 12px;
+}
+
+.toc-panel li::before,
+.source-panel li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.72em;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--rule-strong);
+}
+
+.toc-panel a[aria-current="page"],
+.source-panel a[aria-current="page"] {
+  color: var(--accent-warm);
+}
+
+.toc-panel li:has(a[aria-current="page"])::before,
+.source-panel li:has(a[aria-current="page"])::before {
+  background: var(--accent-warm);
 }
 
 .source-panel p,

--- a/website/assets/site.js
+++ b/website/assets/site.js
@@ -58,6 +58,50 @@ navLinks
 document.querySelector("[data-current-year]").textContent =
   new Date().getFullYear();
 
+document
+  .querySelectorAll(
+    ".article-sidebar > .toc-panel, .article-sidebar > .source-panel, .article-sidebar > .version-panel, .article-sidebar > .boundary-note"
+  )
+  .forEach((panel, index) => {
+    const heading = panel.querySelector(":scope > h2");
+    if (!heading) return;
+
+    const panelId =
+      panel.id || `sidebar-panel-${index + 1}-${heading.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+    panel.id = panelId;
+
+    const content = document.createElement("div");
+    content.id = `${panelId}-content`;
+    content.className = "sidebar-panel-content";
+
+    Array.from(panel.children)
+      .filter((child) => child !== heading)
+      .forEach((child) => {
+        content.appendChild(child);
+      });
+    panel.appendChild(content);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "sidebar-toggle";
+    button.setAttribute("aria-controls", content.id);
+    button.textContent = heading.textContent;
+    heading.replaceChildren(button);
+
+    const expanded =
+      panel.classList.contains("toc-panel") || panel.dataset.sidebarOpen === "true";
+    button.setAttribute("aria-expanded", String(expanded));
+    panel.classList.toggle("is-open", expanded);
+    content.hidden = !expanded;
+
+    button.addEventListener("click", () => {
+      const nextExpanded = button.getAttribute("aria-expanded") !== "true";
+      button.setAttribute("aria-expanded", String(nextExpanded));
+      panel.classList.toggle("is-open", nextExpanded);
+      content.hidden = !nextExpanded;
+    });
+  });
+
 document.querySelectorAll("[data-copy-code]").forEach((button) => {
   const figure = button.closest(".code-panel");
   const code = figure?.querySelector("code");


### PR DESCRIPTION
## 概要\n\nCloses #857\n\nAAT website の初見読者向け導線を整理しました。AAT トップは Reading order を先頭にし、説明的なセクションを削減しています。AAT 各ページのサイドバーは `On this page` と `AAT chapters` を中心にし、canonical source / boundary note / citable statements は外しました。Status page では status source と release snapshot をサイドバーから本文へ移動しました。\n\n## 証明した定理\n\n- なし\n\n## 編集したドキュメント\n\n- `website/aat/index.html`\n- `website/aat/*/index.html`\n- `website/assets/site.css`\n- `website/assets/site.js`\n\n## 実施したテスト\n\n- [ ] `lake build`（未実施: website static HTML/CSS/JS のみ）\n- [x] `git diff --check -- website/aat website/assets/site.css website/assets/site.js`\n- [x] hidden / bidirectional Unicode scan\n- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（未実施: Lean ソース変更なし）\n- [x] `node --check website/assets/site.js`\n- [x] `python3 -m http.server 8001 --bind 127.0.0.1 --directory website` で preview し、`/aat/`, `/aat/foundations/`, `/aat/status/` の HTTP 200 を確認\n\n## チェックリスト\n\n- [x] 対象 Issue を `Closes #N` 形式で本文に記載した\n- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）\n- [x] `docs` の研究主張と Lean status が矛盾していない\n- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない\n- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている