### PR TITLE
websiteのOutreach記事一覧とページ送りを整理

### DIFF
--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -306,11 +306,7 @@
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../">
-                <span>Previous</span>
-                <strong>Home</strong>
-              </a>
-              <a href="foundations/">
+              <a class="page-nav-next" href="foundations/">
                 <span>Next</span>
                 <strong>Foundations</strong>
               </a>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -477,13 +477,9 @@ ArchitectureLawful X
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../related-work/">
+              <a class="page-nav-previous" href="../related-work/">
                 <span>Previous</span>
                 <strong>Related Work and Novelty</strong>
-              </a>
-              <a href="../../sft/">
-                <span>Next</span>
-                <strong>Software Field Theory</strong>
               </a>
             </nav>
           </div>

--- a/website/archsig/index.html
+++ b/website/archsig/index.html
@@ -238,11 +238,7 @@
               </div>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../sft/part-vii-research-program/">
-                <span>Previous</span>
-                <strong>SFT Part VII</strong>
-              </a>
-              <a href="getting-started/">
+              <a class="page-nav-next" href="getting-started/">
                 <span>Next</span>
                 <strong>Getting Started</strong>
               </a>

--- a/website/archsig/roadmap/index.html
+++ b/website/archsig/roadmap/index.html
@@ -207,13 +207,9 @@
               </div>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../examples/">
+              <a class="page-nav-previous" href="../examples/">
                 <span>Previous</span>
                 <strong>Examples</strong>
-              </a>
-              <a href="../../outreach/">
-                <span>Next</span>
-                <strong>Outreach</strong>
               </a>
             </nav>
           </div>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1682,6 +1682,16 @@ p {
   text-align: right;
 }
 
+.page-nav .page-nav-next {
+  grid-column: 2;
+  text-align: right;
+}
+
+.page-nav .page-nav-previous {
+  grid-column: 1;
+  text-align: left;
+}
+
 .page-nav span {
   color: var(--accent-blue);
   font-family: var(--font-sans);
@@ -1931,6 +1941,12 @@ p {
   }
 
   .page-nav a:last-child {
+    text-align: left;
+  }
+
+  .page-nav .page-nav-next,
+  .page-nav .page-nav-previous {
+    grid-column: 1;
     text-align: left;
   }
 

--- a/website/outreach/index.html
+++ b/website/outreach/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="Outreach hub for AAT, SFT, ArchSig articles, canonical return links, and publication boundary rules."
+      content="External articles and essays introducing AAT, SFT, ArchSig, and Attractor Engineering."
     >
     <title>Outreach</title>
     <link rel="alternate" hreflang="en" href="./">
@@ -46,12 +46,10 @@
             <span>Outreach</span>
           </nav>
           <p class="eyebrow">Outreach</p>
-          <h1>Entry points that return to the canonical theory.</h1>
+          <h1>Articles and essays on AAT, SFT, and ArchSig.</h1>
           <p class="lede">
-            Outreach articles introduce AAT, SFT, ArchSig, and attractor
-            engineering for public reading. They are publication routes, not a
-            second source of truth for definitions, theorem status, or tooling
-            claims.
+            Public introductions, essays, and platform articles for readers who
+            want the ideas before entering the full theory notes.
           </p>
         </div>
       </section>
@@ -62,157 +60,103 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
-                <li><a href="#publication-rule">Publication rule</a></li>
-                <li><a href="#article-routes">Article routes</a></li>
-                <li><a href="#canonical-returns">Canonical returns</a></li>
-                <li><a href="#seo-sitemap">SEO sitemap</a></li>
+                <li><a href="#featured">Featured</a></li>
+                <li><a href="#blogs">Blogs</a></li>
+                <li><a href="#japanese-articles">日本語記事</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Draft sources</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/main/docs/outreach">
-                    Outreach draft directory
-                  </a>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/en/aat_sft_hashnode_mvp_v_0_1.md">
-                    Hashnode English draft
-                  </a>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/qiita_intro_draft.md">
-                    Qiita Japanese draft
-                  </a>
-                </li>
-              </ul>
-            </div>
             <div class="boundary-note">
-              <h2>Boundary note</h2>
+              <h2>Platforms</h2>
               <ul>
-                <li>English website routes are canonical.</li>
-                <li>Japanese articles are outreach entries.</li>
-                <li>No partial <code>/ja/</code> mirror is published.</li>
-                <li>Formal claims return to AAT / SFT / ArchSig pages.</li>
+                <li>Blog: English long-form essays.</li>
+                <li>Zenn: Japanese technical articles.</li>
+                <li>This page lists public articles only.</li>
               </ul>
             </div>
           </aside>
 
           <div class="article-main">
-            <section id="publication-rule" class="article-section">
-              <h2>Publication rule</h2>
-              <p>
-                The public site keeps the technical source of truth in English.
-                Japanese essays on Qiita, Zenn, Hashnode, or similar media are
-                welcome as outreach, but they should point readers back to the
-                canonical English page before relying on definitions, theorem
-                status, measurement boundaries, or non-conclusions.
-              </p>
-              <div class="claim-strip">
-                <p>
-                  Outreach can explain motivation and intuition. It should not
-                  become a parallel place where theorem status, empirical
-                  hypotheses, or tooling claims drift away from the repository.
-                </p>
-              </div>
+            <section id="featured" class="article-section">
+              <h2>Featured</h2>
+              <a
+                class="featured-article"
+                href="https://blog.iroha1203.dev/software-architecture-as-a-field"
+              >
+                <img
+                  src="../assets/software-architecture-as-a-field.jpg"
+                  alt=""
+                  width="1672"
+                  height="941"
+                >
+                <span class="featured-article-copy">
+                  <span class="featured-article-label">Hashnode</span>
+                  <strong>
+                    Software Architecture as a Field: Asking Better Questions
+                    About Software Evolution
+                  </strong>
+                  <span>
+                    An English introduction to reading architecture as a field
+                    shaped by operations, feedback, and software evolution.
+                  </span>
+                </span>
+              </a>
             </section>
 
-            <section id="article-routes" class="article-section">
-              <h2>Article routes</h2>
+            <section id="blogs" class="article-section">
+              <h2>Blogs</h2>
               <p>
-                These routes collect the current public-article drafts and the
-                intended publication lanes. Platform copies should keep their
-                return links to this site or the corresponding repository
-                source.
+                English long-form essays for readers who want the practitioner
+                framing before entering the research pages.
               </p>
               <ul class="chapter-list">
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/en/aat_sft_hashnode_mvp_v_0_1.md">
-                    Hashnode: Software Architecture as a Field
+                  <a href="https://blog.iroha1203.dev/ai-agents-don-t-need-meetings-gotanda-style-for-stigmergic-software-maintenance">
+                    AI Agents Don't Need Meetings: Gotanda Style for Stigmergic Software Maintenance
                   </a>
-                  <span>English introduction to AAT, SFT, ArchSig, and software evolution.</span>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/en/design_principles_as_invariant_preservation.md">
-                    Hashnode: Design Principles as Invariant Preservation
-                  </a>
-                  <span>English article draft on SOLID, layered architecture, state transition patterns, and runtime protection.</span>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/software_architecture_as_a_field_ja_v2.md">
-                    Zenn: Software Architecture as a Field
-                  </a>
-                  <span>Japanese short-form draft for explaining SFT without turning forecasts into predictions.</span>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/qiita_intro_draft.md">
-                    Qiita: Architecture Zero-Curvature Introduction
-                  </a>
-                  <span>Japanese draft explaining design principles as invariant-preserving operations.</span>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/outreach/qiita_attractor.md">
-                    Qiita: Attractor Engineering
-                  </a>
-                  <span>Japanese draft introducing field-shaped development and support shaping.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="canonical-returns" class="article-section">
-              <h2>Canonical returns</h2>
-              <p>
-                Each outreach article should make the return path explicit.
-                The return target depends on the claim being made, not on the
-                platform where the article is published.
-              </p>
-              <ul class="term-list">
-                <li>
-                  <strong>AAT definitions and theorem status</strong>
                   <span>
-                    Return to <a href="../aat/">AAT</a>,
-                    <a href="../aat/status/">AAT Lean Status</a>, and the
-                    repository theorem index before making formal claims.
+                    A maintenance essay on stigmergic coordination and the
+                    Gotanda style for AI agents working through repository traces.
                   </span>
                 </li>
                 <li>
-                  <strong>SFT forecasts and field language</strong>
+                  <a href="https://blog.iroha1203.dev/attractor-engineering-seeing-software-development-as-field-dynamics">
+                    Attractor Engineering: Seeing Software Development as Field Dynamics
+                  </a>
                   <span>
-                    Return to <a href="../sft/">SFT</a> and the
-                    <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
-                      AAT / SFT interface
-                    </a>
-                    before reading field, force, attractor, or forecast as a theorem.
-                  </span>
-                </li>
-                <li>
-                  <strong>ArchSig measurements</strong>
-                  <span>
-                    Return to <a href="../archsig/">ArchSig</a> and
-                    <a href="../archsig/boundaries/">ArchSig Boundaries</a>
-                    before treating tool output as evidence for a broader conclusion.
+                    An English essay on codebases as fields, PRs as forces, and
+                    software development as shaped dynamics.
                   </span>
                 </li>
               </ul>
             </section>
 
-            <section id="seo-sitemap" class="article-section">
-              <h2>SEO sitemap</h2>
+            <section id="japanese-articles" class="article-section">
+              <h2>日本語記事</h2>
               <p>
-                The production <a href="../sitemap.xml">sitemap.xml</a> lists
-                the canonical public routes under <code>https://iroha1203.dev/</code>.
-                Outreach articles should link back to those canonical routes when
-                they rely on AAT, SFT, or ArchSig claims.
+                日本語記事では、AAT / SFT / ArchSig の研究プログラムを
+                実務寄りの視点から紹介しています。
               </p>
+              <ul class="chapter-list">
+                <li>
+                  <a href="https://zenn.dev/iroha1203/articles/93ee3d4c5d5174">
+                    五反田式: スティグマジーを応用した自律型マルチエージェントシステム【日本語訳】
+                  </a>
+                  <span>
+                    スティグマジーを応用した自律型マルチエージェントシステムについて解説するZenn記事です。
+                  </span>
+                </li>
+                <li>
+                  <a href="https://zenn.dev/iroha1203/articles/1452a2dcc2c38b">
+                    アトラクターエンジニアリングという発見
+                  </a>
+                  <span>
+                    ソフトウェア開発を場の力学として見て、AI 駆動開発と
+                    ArchSig を観測器として位置づける Zenn 記事です。
+                  </span>
+                </li>
+              </ul>
             </section>
 
-            <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../archsig/roadmap/">
-                <span>Previous</span>
-                <strong>ArchSig Roadmap</strong>
-              </a>
-            </nav>
           </div>
         </div>
       </section>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -215,11 +215,7 @@
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../aat/status/">
-                <span>Previous</span>
-                <strong>AAT Lean Status</strong>
-              </a>
-              <a href="part-i-new-object/">
+              <a class="page-nav-next" href="part-i-new-object/">
                 <span>Next</span>
                 <strong>Part I. The New Object</strong>
               </a>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -233,13 +233,9 @@ output:
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../part-vi-case-studies/">
+              <a class="page-nav-previous" href="../part-vi-case-studies/">
                 <span>Previous</span>
                 <strong>Part VI. Case Studies</strong>
-              </a>
-              <a href="../../archsig/">
-                <span>Next</span>
-                <strong>ArchSig Manual</strong>
               </a>
             </nav>
           </div>


### PR DESCRIPTION
## 概要

Outreach ページを外部向けの公開方針ページから、公開済み Blog / Zenn 記事の一覧ページへ整理しました。

- draft 記事、SEO sitemap、More reading、セクションまたぎの reading sequence を削除
- Blog と日本語記事の公開リンクを掲載
- AAT / SFT / ArchSig 間をまたぐ Previous / Next を削除
- 片側だけ残る page-nav の配置を CSS で調整

Issue 起点ではない website copy / navigation 調整のため、Closes 記載はありません。

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] `python3 -m html.parser` による変更 HTML のパース確認
- [ ] Playwright 静的ページ確認（Chromium 起動後にスクリプトがタイムアウトしたため未完了。残存プロセスなしは確認済み）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Issue 起点ではないため未記載）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている