### PR TITLE
SFT Part III/IV を statement 形式へ増補

### DIFF
--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -63,11 +63,13 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#reading-model">Reading model</a></li>
                 <li><a href="#software-field">SoftwareField</a></li>
                 <li><a href="#artifact-action">Artifact action</a></li>
                 <li><a href="#support-policy">Support and policy</a></li>
                 <li><a href="#forecast-envelope">Forecast and envelope</a></li>
                 <li><a href="#feedback">Feedback update</a></li>
+                <li><a href="#core-anchors">Anchors</a></li>
                 <li><a href="#core-boundary">Boundary</a></li>
               </ol>
             </nav>
@@ -75,7 +77,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/cc3b18de69d5dce422f4d68b82092f2f359c9732/docs/sft/software_field_theory.md#part-iii-the-sft-coresft-%E3%81%AE%E4%B8%AD%E6%A0%B8">
                     Part III source
                   </a>
                 </li>
@@ -92,12 +94,60 @@
           </aside>
 
           <div class="article-main">
+            <section id="reading-model" class="article-section">
+              <h2>Reading model</h2>
+              <div class="reader-model">
+                <div>
+                  <h3>SFT does not say</h3>
+                  <p>
+                    A PRD, issue, or AI proposal applies a physical force to a
+                    codebase, determines one future, or carries its own
+                    forecast. A field update is not an automatic accuracy
+                    improvement theorem.
+                  </p>
+                </div>
+                <div>
+                  <h3>SFT says</h3>
+                  <p>
+                    Inside a selected field model, artifacts induce bounded
+                    candidate updates. Support, policy, observation, and
+                    governance determine reachable path sets and the reportable
+                    consequence envelope.
+                  </p>
+                </div>
+              </div>
+              <p id="non-conclusion-iii-0" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-iii-0">Non-conclusion III.0.</a>
+                Part III is a theorem-bearing computational fragment, not a
+                complete model of social organization, runtime causality, or
+                empirical prediction quality.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Non-conclusion III.0">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-future">boundary statement</span>
+                <span>Website exposition of the SFT source boundary; no Lean theorem is added here.</span>
+              </p>
+            </section>
+
             <section id="software-field" class="article-section">
               <h2>SoftwareField and architecture projection</h2>
               <p>
                 `SoftwareField` is a computable slice of a development field.
                 It is not itself an AAT `ArchitectureObject`; the AAT object is
                 obtained through architecture projection.
+              </p>
+              <p id="definition-iii-1" class="statement">
+                <a class="statement-anchor" href="#definition-iii-1">Definition III.1.</a>
+                A <code>SoftwareField</code> is the selected computable state:
+                contextual dynamics, architecture projection, observed
+                signature record, history, support, policy, constraints,
+                observation model, governance model, and exogenous artifact
+                inputs.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.1">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">conceptual schema</span>
+                <span>Defined in the SFT source document; not a Lean structure in this PR.</span>
               </p>
               <figure class="code-panel">
                 <figcaption>Field projection</figcaption>
@@ -137,6 +187,18 @@
                 reading. PRDs, specs, issues, and AI proposals can produce
                 multiple candidate updates rather than a single next field.
               </p>
+              <p id="definition-iii-2" class="statement">
+                <a class="statement-anchor" href="#definition-iii-2">Definition III.2.</a>
+                An <code>ArtifactAction</code> maps a field to a set of
+                candidate update hypotheses under an explicit interpretation
+                boundary. A deterministic action is only the singleton special
+                case.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.2">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">set-valued schema</span>
+                <span>Forecasted effects are outputs of forecasting, not fields of the raw action.</span>
+              </p>
               <figure class="code-panel">
                 <figcaption>Set-valued action</figcaption>
                 <pre><code>ArtifactAction a
@@ -170,6 +232,19 @@
                 appear natural, possible, low cost, or likely to be selected in
                 a field.
               </p>
+              <p id="definition-iii-3" class="statement">
+                <a class="statement-anchor" href="#definition-iii-3">Definition III.3.</a>
+                <code>OperationSupport(F)</code> is the admissible operation
+                set after constraints and governance interventions.
+                <code>OperationPolicy(F)</code> is a preorder, cost, selection
+                relation, or explicitly supplied probability distribution on
+                that support.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.3">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">computational schema</span>
+                <span>Probability semantics are not assumed unless a distribution is part of the model.</span>
+              </p>
               <ul class="status-list">
                 <li>
                   <strong>OperationSupport</strong>
@@ -194,6 +269,18 @@
                 set-valued artifact actions, SFT forms a family of cones and
                 summarizes them for practice as a `ConsequenceEnvelope`.
               </p>
+              <p id="definition-iii-4" class="statement">
+                <a class="statement-anchor" href="#definition-iii-4">Definition III.4.</a>
+                <code>ForecastCone(F, U, h)</code> is the set of field paths
+                starting at <code>F</code>, bounded by horizon <code>h</code>,
+                whose adjacent transitions are realized by operations selected
+                from support <code>U</code>.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.4">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">formal object schema</span>
+                <span>The cone is set-valued reachability, not a point prediction.</span>
+              </p>
               <figure class="code-panel">
                 <figcaption>ConsequenceEnvelope</figcaption>
                 <pre><code>ConsequenceEnvelope
@@ -215,6 +302,19 @@ U_u := U(F_u)
 ForecastConeFamilyAfterAction(F, a, h)
   = { ForecastCone(F_u, U_u, h) | u in alpha_a(F) }</code></pre>
               </figure>
+              <p id="definition-iii-5" class="statement">
+                <a class="statement-anchor" href="#definition-iii-5">Definition III.5.</a>
+                A <code>ConsequenceEnvelope</code> is the report form that
+                gathers selected forecast cones, reachable path classes,
+                affected architecture regions, comparable signature axes,
+                obstruction witnesses, missing boundaries, recommendations,
+                forecast boundary, and unknown remainder.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.5">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">report schema</span>
+                <span>The envelope interprets one or more cones for diagnosis and tooling.</span>
+              </p>
             </section>
 
             <section id="feedback" class="article-section">
@@ -229,6 +329,18 @@ ForecastConeFamilyAfterAction(F, a, h)
                 observation: signature delta, unexpected witnesses, review or
                 CI outcome, runtime feedback, missing evidence, and
                 non-conclusions.
+              </p>
+              <p id="definition-iii-6" class="statement">
+                <a class="statement-anchor" href="#definition-iii-6">Definition III.6.</a>
+                An <code>ObservationBoundary</code> records measured axes,
+                unavailable evidence, private evidence, extractor version, and
+                non-conclusions. A <code>GovernanceIntervention</code> changes
+                support, policy, observation, feedback update, or escalation.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.6">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">boundary schema</span>
+                <span>Review, CI, type checking, architecture rules, AI policy, and runtime guards are modeled here.</span>
               </p>
               <ul class="status-list">
                 <li>
@@ -254,6 +366,68 @@ ForecastConeFamilyAfterAction(F, a, h)
                   It does not automatically prove that future forecasts become
                   more accurate.
                 </p>
+              </div>
+              <p id="schema-iii-7" class="statement">
+                <a class="statement-anchor" href="#schema-iii-7">Schema III.7.</a>
+                A <code>FieldUpdate</code> takes a prior field, a forecast cone
+                or envelope, observed signature delta, unexpected witnesses,
+                review / CI outcome, and runtime feedback, then produces a
+                posterior field that records the forecast boundary and
+                non-conclusions.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema III.7">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-future">closed-loop schema</span>
+                <span>Record preservation is the claim; forecast-quality calibration remains separate.</span>
+              </p>
+            </section>
+
+            <section id="core-anchors" class="article-section">
+              <h2>Formal and computational anchors</h2>
+              <p>
+                Part III currently names website-level and source-document
+                anchors for future formalization. These anchors prevent the
+                public text from reading SFT as an already-proved Lean theory.
+              </p>
+              <div class="formal-anchor-cards" aria-label="SFT Part III computational anchors">
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Field core</span>
+                      <h3>State, projection, and support</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">source schema</span>
+                  </header>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative terms</dt>
+                      <dd><code>SoftwareField</code>, <code>arch</code>, <code>OperationSupport</code>, <code>OperationPolicy</code></dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Architecture claims pass through projection; support and policy are relative to the selected field model.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Forecast core</span>
+                      <h3>Reachable paths and report boundary</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">source schema</span>
+                  </header>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative terms</dt>
+                      <dd><code>ArtifactAction</code>, <code>ForecastCone</code>, <code>ConsequenceEnvelope</code>, <code>FieldUpdate</code></dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Reachability is set-valued and bounded; empirical accuracy requires calibration outside Part III.</dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -62,11 +62,13 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#reading-model">Reading model</a></li>
                 <li><a href="#cone-narrowing">Cone narrowing</a></li>
                 <li><a href="#support-safety">Support safety</a></li>
                 <li><a href="#proposal-accounting">Proposal accounting</a></li>
                 <li><a href="#feedback-update">Feedback update</a></li>
                 <li><a href="#stable-regions">Stable regions</a></li>
+                <li><a href="#principle-anchors">Anchors</a></li>
                 <li><a href="#principle-boundary">Boundary</a></li>
               </ol>
             </nav>
@@ -74,7 +76,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/cc3b18de69d5dce422f4d68b82092f2f359c9732/docs/sft/software_field_theory.md#part-iv-principles-and-theorems%E5%8E%9F%E7%90%86%E3%81%A8%E5%AE%9A%E7%90%86">
                     Part IV source
                   </a>
                 </li>
@@ -91,6 +93,41 @@
           </aside>
 
           <div class="article-main">
+            <section id="reading-model" class="article-section">
+              <h2>Reading model</h2>
+              <div class="reader-model">
+                <div>
+                  <h3>SFT does not say</h3>
+                  <p>
+                    A theorem-shaped schema is not a global safety theorem, a
+                    Lean theorem, or an empirical accuracy claim. Cone
+                    narrowing can move risk to another witness family or an
+                    unmeasured axis.
+                  </p>
+                </div>
+                <div>
+                  <h3>SFT says</h3>
+                  <p>
+                    Under explicit support semantics, simulations, safe
+                    regions, coverage policies, observation boundaries, and
+                    horizons, selected reachable path sets and records satisfy
+                    relative schemas.
+                  </p>
+                </div>
+              </div>
+              <p id="schema-iv-0" class="statement">
+                <a class="statement-anchor" href="#schema-iv-0">Schema IV.0.</a>
+                Every Part IV claim must carry its preconditions, conclusion,
+                claim level, and non-conclusions. Without those fields it is
+                only an intuition, not an SFT schema.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.0">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-future">boundary schema</span>
+                <span>Website exposition of SFT claim discipline; no Lean theorem is added here.</span>
+              </p>
+            </section>
+
             <section id="cone-narrowing" class="article-section">
               <h2>ForecastCone narrowing</h2>
               <p>
@@ -98,6 +135,19 @@
                 intended feature direction, and excludes a selected witness
                 family, then the relevant cone narrows under the selected
                 support semantics.
+              </p>
+              <p id="schema-iv-1" class="statement">
+                <a class="statement-anchor" href="#schema-iv-1">Schema IV.1.</a>
+                If <code>PointwiseSupportInclusion(U2, U1)</code>,
+                <code>StepSimulation(U2, U1, relation)</code>, and the initial
+                relation between <code>F2</code> and <code>F1</code> hold, then
+                <code>ForecastCone(F2, U2, h)</code> projects into
+                <code>ForecastCone(F1, U1, h)</code> for the selected horizon.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.1">
+                <span class="statement-status-label">Claim level</span>
+                <span class="status-badge status-badge-defined">L2 schema</span>
+                <span>L3 requires transition-kernel semantics; L4 requires dataset calibration.</span>
               </p>
               <figure class="code-panel">
                 <figcaption>Set-valued schema</figcaption>
@@ -111,6 +161,14 @@
                 The proof idea is induction on horizon. Each accepted U2-step
                 is simulated by a U1-step while the relation between fields is
                 maintained.
+              </p>
+              <p id="proof-iv-1" class="statement-proof">
+                <a class="statement-anchor" href="#proof-iv-1">Proof idea.</a>
+                At horizon zero the related fields satisfy the assumed
+                relation. At horizon successor, simulate the first
+                <code>U2</code> step by a <code>U1</code> step, preserve the
+                relation for the next field, and apply the induction
+                hypothesis to the remaining horizon.
               </p>
               <p>
                 The claim level is L2 for set-valued support semantics and
@@ -126,6 +184,19 @@
                 operation names alone. Support safety says that selected
                 accepted operations preserve a selected safe region under a
                 selected observation model.
+              </p>
+              <p id="schema-iv-2" class="statement">
+                <a class="statement-anchor" href="#schema-iv-2">Schema IV.2.</a>
+                If the current field is in safe region <code>R</code> under
+                observation <code>O</code>, accepted steps are selected from
+                support <code>U</code>, and those support operations preserve
+                <code>R</code>, then the accepted trajectory remains in
+                <code>R</code>.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.2">
+                <span class="statement-status-label">Claim level</span>
+                <span class="status-badge status-badge-defined">L2 schema</span>
+                <span>The claim is relative to selected safe regions and accepted trajectories.</span>
               </p>
               <ul class="status-list">
                 <li>
@@ -159,6 +230,18 @@
                 Review, CI, type checking, and architecture rules produce
                 records that feed field update and governance design.
               </p>
+              <p id="schema-iv-3" class="statement">
+                <a class="statement-anchor" href="#schema-iv-3">Schema IV.3.</a>
+                <code>ProposalAccounting</code> classifies proposal pressure as
+                accepted, rejected, delayed, unresolved, coordination record,
+                runtime pressure estimate, or unaccounted remainder under an
+                explicit coverage and overlap policy.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.3">
+                <span class="statement-status-label">Claim level</span>
+                <span class="status-badge status-badge-future">L1-L2 schema</span>
+                <span>L1 for trace records; L2 only when coverage and overlap policy are explicit.</span>
+              </p>
               <figure class="code-panel">
                 <figcaption>ProposalAccounting</figcaption>
                 <pre><code>ProposalAccounting(raw_proposal_universe)
@@ -180,6 +263,17 @@
                 review outcome, CI outcome, and runtime feedback can update
                 the posterior field by making forecast error and missing
                 evidence explicit.
+              </p>
+              <p id="schema-iv-4" class="statement">
+                <a class="statement-anchor" href="#schema-iv-4">Schema IV.4.</a>
+                Feedback boundary update preserves observed transition,
+                forecast error, missing evidence, unexpected witnesses, policy
+                drift, and non-conclusions in the posterior field record.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.4">
+                <span class="statement-status-label">Claim level</span>
+                <span class="status-badge status-badge-defined">L2 record schema</span>
+                <span>Forecast-quality improvement is L4 only after dataset calibration.</span>
               </p>
               <figure class="code-panel">
                 <figcaption>Boundary-aware update</figcaption>
@@ -206,6 +300,19 @@
                 stable region, and reachable preimage before adding
                 probability or recurrence claims.
               </p>
+              <p id="schema-iv-5" class="statement">
+                <a class="statement-anchor" href="#schema-iv-5">Schema IV.5.</a>
+                In the set-valued core, <code>MayReach</code>,
+                <code>MustReach</code>, <code>StableRegion</code>, and
+                <code>ReachablePreimage</code> are separate predicates. Strong
+                attractor or basin claims require added recurrence, policy, or
+                probability semantics.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.5">
+                <span class="statement-status-label">Claim level</span>
+                <span class="status-badge status-badge-defined">L2 schema</span>
+                <span>L3 requires transition kernels; L4 requires trace calibration.</span>
+              </p>
               <figure class="code-panel">
                 <figcaption>Minimal vocabulary</figcaption>
                 <pre><code>MayReach_h(F, U, A)
@@ -220,6 +327,55 @@ ReachablePreimage_h(U, A)</code></pre>
                 `DefaultPath`, `RecurrentPattern`, `StableRegion`, and
                 `ReachablePreimage`.
               </p>
+            </section>
+
+            <section id="principle-anchors" class="article-section">
+              <h2>Formal and computational anchors</h2>
+              <p>
+                Part IV is organized as theorem-shaped schemas. The anchors
+                below state what each schema needs before it can be read as a
+                formal, probabilistic, or empirical claim.
+              </p>
+              <div class="formal-anchor-cards" aria-label="SFT Part IV schema anchors">
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Reachability</span>
+                      <h3>Cone narrowing and support safety</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">L2 schemas</span>
+                  </header>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative anchors</dt>
+                      <dd><code>PointwiseSupportInclusion</code>, <code>StepSimulation</code>, <code>SupportOperationsPreserveSafeRegion</code></dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No global risk reduction, no safety for unmeasured axes, and no guarantee beyond the selected horizon.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="formal-anchor-card">
+                  <header class="formal-anchor-card-header">
+                    <div>
+                      <span class="formal-anchor-card-label">Feedback</span>
+                      <h3>Accounting, update, and stable regions</h3>
+                    </div>
+                    <span class="status-badge status-badge-future">L1-L4 boundary</span>
+                  </header>
+                  <dl class="formal-anchor-grid">
+                    <div>
+                      <dt>Representative anchors</dt>
+                      <dd><code>ProposalAccounting</code>, <code>FieldUpdate</code>, <code>StableRegion</code>, <code>ReachablePreimage</code></dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>Trace records, set-valued schemas, transition kernels, and calibrated forecasts remain distinct claim levels.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
             </section>
 
             <section id="principle-boundary" class="article-section">


### PR DESCRIPTION
## 概要

Closes #866

- `website/sft/part-iii-core/index.html` に reading model、numbered definition / schema、formal and computational anchors を追加しました。
- `website/sft/part-iv-principles/index.html` に theorem-shaped schema、claim level、proof idea、non-conclusion、anchor cards を追加しました。
- source reference を `blob/main` ではなく現在の `main` commit 固定リンクへ更新しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/part-iii-core/index.html`
- `website/sft/part-iv-principles/index.html`

## 実施したテスト

- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `website/sft/part-iii-core/index.html website/sft/part-iv-principles/index.html`
- [x] root-absolute path / `blob/main` scan: 対象 2 ファイルで該当なし
- [x] Playwright 静的表示確認: Part III / IV の title, h1, statement 数, anchor card 数, console error なし
- [x] Playwright desktop / mobile overflow 確認: 1366px / 390px とも横 overflow なし
- [ ] `lake build`: Lean 変更なしのため未実施
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan: Lean 変更なしのため未実施

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている