### PR TITLE
SFT website の横断ナビと参照を仕上げる

### DIFF
--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -367,15 +367,15 @@ SFT
               </p>
               <ul class="term-list">
                 <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/0741061d4b41c8c31305ca30f285065b5cbb8136/docs/sft/software_field_theory.md">SFT monograph source</a></strong>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">SFT monograph source</a></strong>
                   <span>Long-form source for Software Field Theory, including the central proposition, field memory, core definitions, and research program.</span>
                 </li>
                 <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/0741061d4b41c8c31305ca30f285065b5cbb8136/docs/sft/aat_interface.md">AAT / SFT interface source</a></strong>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">AAT / SFT interface source</a></strong>
                   <span>Defines the one-way dependency, translation rules, claim levels, and forbidden readings.</span>
                 </li>
                 <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/0741061d4b41c8c31305ca30f285065b5cbb8136/docs/sft/README.md">Repository entry source</a></strong>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/README.md">Repository entry source</a></strong>
                   <span>Short source entry for SFT vocabulary, core questions, and AAT / ArchSig / SFT division of work.</span>
                 </li>
               </ul>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -73,7 +73,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
                     Part I source
                   </a>
                 </li>
@@ -82,6 +82,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -75,12 +75,12 @@
               <h2>Canonical sources</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
                     Part II source
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">
                     AAT / SFT interface
                   </a>
                 </li>
@@ -89,6 +89,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">
@@ -327,7 +341,7 @@ local path skeleton      -> ArchitecturePath</code></pre>
               </p>
               <ul class="chapter-list">
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/aat_interface.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">
                     AAT / SFT interface source
                   </a>
                   <span>Full dependency, translation, non-confusion, and ArchSig bridge rules.</span>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -77,7 +77,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/cc3b18de69d5dce422f4d68b82092f2f359c9732/docs/sft/software_field_theory.md#part-iii-the-sft-coresft-%E3%81%AE%E4%B8%AD%E6%A0%B8">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md#part-iii-the-sft-coresft-%E3%81%AE%E4%B8%AD%E6%A0%B8">
                     Part III source
                   </a>
                 </li>
@@ -86,6 +86,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -76,7 +76,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/cc3b18de69d5dce422f4d68b82092f2f359c9732/docs/sft/software_field_theory.md#part-iv-principles-and-theorems%E5%8E%9F%E7%90%86%E3%81%A8%E5%AE%9A%E7%90%86">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md#part-iv-principles-and-theorems%E5%8E%9F%E7%90%86%E3%81%A8%E5%AE%9A%E7%90%86">
                     Part IV source
                   </a>
                 </li>
@@ -85,6 +85,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -75,7 +75,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
                     Part V source
                   </a>
                 </li>
@@ -84,6 +84,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -75,7 +75,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
                     Part VI source
                   </a>
                 </li>
@@ -84,6 +84,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -73,7 +73,7 @@
               <h2>Canonical source</h2>
               <ul>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/main/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
                     Part VII source
                   </a>
                 </li>
@@ -82,6 +82,20 @@
                     SFT status and claim boundary
                   </a>
                 </li>
+              </ul>
+            </div>
+            <div class="source-panel sft-sequence-panel">
+              <h2>SFT reading sequence</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
             <div class="boundary-note">

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -74,8 +74,12 @@
               <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="./" aria-current="page">Status and claim boundary</a></li>
               </ul>
@@ -264,19 +268,19 @@
               <h2>Source references</h2>
               <ul class="chapter-list">
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/31ea6b9d8e5ef2c5bb8687f42d2ce6c14aa78b68/docs/sft/software_field_theory.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
                     SFT monograph source
                   </a>
                   <span>Claim boundaries, Part IV schemas, Part V computational problems, and Part VII non-conclusions.</span>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/31ea6b9d8e5ef2c5bb8687f42d2ce6c14aa78b68/docs/sft/aat_interface.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">
                     AAT / SFT interface source
                   </a>
                   <span>Dependency direction, translation rules, and forbidden readings.</span>
                 </li>
                 <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/31ea6b9d8e5ef2c5bb8687f42d2ce6c14aa78b68/docs/tool/roadmap.md">
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/tool/roadmap.md">
                     ArchSig tooling roadmap
                   </a>
                   <span>Current ArchSig-SFT pipeline capability and remaining gaps.</span>


### PR DESCRIPTION
## 概要

Closes #873

SFT website 全体の横断 QA 仕上げとして、各 Part ページから全 SFT 章へ移動できる読書順ナビを追加しました。GitHub docs 参照は `blob/main` を避け、基準 commit へ固定しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/index.html`
- `website/sft/part-i-new-object/index.html`
- `website/sft/part-ii-basis/index.html`
- `website/sft/part-iii-core/index.html`
- `website/sft/part-iv-principles/index.html`
- `website/sft/part-v-computing-systems/index.html`
- `website/sft/part-vi-case-studies/index.html`
- `website/sft/part-vii-research-program/index.html`
- `website/sft/status/index.html`

## 実施したテスト

- [ ] `lake build`（website-only 変更のため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（変更範囲に Lean 追加なし。`unsafe` は website/docs の通常語彙としてのみ検出）
- [x] link / asset path script check: 32 HTML files
- [x] Playwright static QA: SFT 9 pages, desktop 1366px / mobile 390px

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（website QA / docs consistency tracking。Lean theorem 追加なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている