### PR TITLE
SFT Part V/VI の website 解説を増補する

### DIFF
--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -172,11 +172,11 @@
                 </li>
                 <li>
                   <a href="part-v-computing-systems/">Part V. Computing Systems Built from SFT</a>
-                  <span>Computational problems, simulator maturity, AI governance, review systems, lifecycle, and benchmarks.</span>
+                  <span>Computational problems, ArchSig-SFT B12/B13 pipeline, simulator maturity, AI governance, review systems, lifecycle, and benchmarks.</span>
                 </li>
                 <li>
                   <a href="part-vi-case-studies/">Part VI. Case Studies</a>
-                  <span>Coupon PRD, migration, incident response, AI-generated shortcut, and end-of-life decision.</span>
+                  <span>Coupon PRD worked example, migration, incident response, AI-generated shortcut, end-of-life decision, and case boundary matrix.</span>
                 </li>
                 <li>
                   <a href="part-vii-research-program/">Part VII. Non-Conclusions and Research Program</a>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -64,6 +64,7 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#computational-problems">Computational problems</a></li>
+                <li><a href="#archsig-sft-pipeline">ArchSig-SFT pipeline</a></li>
                 <li><a href="#simulator">PRD simulator</a></li>
                 <li><a href="#ai-governance">AI governance</a></li>
                 <li><a href="#review-systems">Review systems</a></li>
@@ -156,6 +157,72 @@
               </p>
             </section>
 
+            <section id="archsig-sft-pipeline" class="article-section">
+              <h2>ArchSig-SFT pipeline</h2>
+              <p>
+                The current ArchSig-SFT tooling turns Markdown PRD, Spec,
+                Issue, or AI proposal text into a bounded chain of forecast
+                artifacts. This is a tooling estimate: it preserves source
+                refs, selected support, finite horizon, unknown remainder, and
+                non-conclusions rather than claiming a future outcome.
+              </p>
+              <figure class="code-panel">
+                <figcaption>B13 implemented pipeline</figcaption>
+                <pre><code>real PRD / Spec / Issue / AI proposal
+  -> ArtifactDescriptor builder
+  -> OperationSupportEstimate generator
+  -> ForecastConeSkeleton generator
+  -> ConsequenceEnvelope generator
+  -> end-to-end sft-forecast command</code></pre>
+              </figure>
+              <div class="article-table">
+                <table>
+                  <caption>Input, output, and boundary by stage</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Stage</th>
+                      <th scope="col">Input</th>
+                      <th scope="col">Output</th>
+                      <th scope="col">Soundness boundary</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row"><code>ArtifactDescriptor</code></th>
+                      <td>Selected artifact text and source refs.</td>
+                      <td>Action class, scope, target regions, missing evidence.</td>
+                      <td>Not a ground-truth architecture object.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>OperationSupportEstimate</code></th>
+                      <td>Descriptor refs and policy hints.</td>
+                      <td>Candidate operation families, known forbidden support, unknown remainder.</td>
+                      <td>Not accepted PR history or actual future support.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>ForecastConeSkeleton</code></th>
+                      <td>Operation support and bounded horizon config.</td>
+                      <td>Finite-support path class candidates.</td>
+                      <td>No probability, global risk reduction, or trajectory-level safety claim.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>ConsequenceEnvelope</code></th>
+                      <td>Forecast skeleton and reporting boundary.</td>
+                      <td>Affected axes, obstruction candidates, missing boundaries, review / CI recommendation.</td>
+                      <td>Not a causal proof, Lean theorem, or forecast correctness certificate.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p>
+                The public ArchSig pages describe the same surface from the
+                tooling side: see the <a href="../../archsig/workflows/">workflow
+                overview</a>, <a href="../../archsig/artifacts/">artifact
+                catalog</a>, and <a href="../../archsig/roadmap/">B12/B13
+                roadmap</a>.
+              </p>
+            </section>
+
             <section id="simulator" class="article-section">
               <h2>PRD-to-ConsequenceEnvelope simulator</h2>
               <p>
@@ -179,6 +246,15 @@
                 decomposition recommendations. Empirical prediction claims
                 depend on later weighting and calibration.
               </p>
+              <div class="claim-strip">
+                <p>
+                  Current B12/B13 artifacts support bounded descriptor,
+                  support, cone, envelope, and calibration-hook records. They
+                  do not support probability weighting, causal forecast,
+                  extractor completeness, or framework-specific semantic
+                  completeness without additional adapters and datasets.
+                </p>
+              </div>
               <ul class="status-list">
                 <li>
                   <strong>Level 3 minimum</strong>
@@ -193,6 +269,35 @@
                   <span>Observed issue, PR, review, CI, or incident outcomes are compared against the report and used for field update.</span>
                 </li>
               </ul>
+              <div class="article-table">
+                <table>
+                  <caption>Current capability and remaining gaps</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Surface</th>
+                      <th scope="col">Current capability</th>
+                      <th scope="col">Remaining gap</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Markdown PRD / Spec</th>
+                      <td>Can be converted through the B13 pipeline into forecast artifacts and a report.</td>
+                      <td>Real dataset calibration and held-out outcome validation remain future work.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">GitHub Issue / AI proposal</th>
+                      <td>Representable as artifact text under the same boundary vocabulary.</td>
+                      <td>Native GitHub Issue JSON and AI proposal JSON adapters remain planned gaps.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Review / CI recommendation</th>
+                      <td>Report can name missing boundaries, theorem boundaries, and decomposition targets.</td>
+                      <td>Recommendation quality is not a theorem and needs empirical feedback loops.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="ai-governance" class="article-section">

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -68,6 +68,7 @@
                 <li><a href="#incident-response">Incident response</a></li>
                 <li><a href="#ai-shortcut">AI shortcut</a></li>
                 <li><a href="#end-of-life">End-of-life</a></li>
+                <li><a href="#case-matrix">Case matrix</a></li>
                 <li><a href="#case-boundary">Boundary</a></li>
               </ol>
             </nav>
@@ -152,6 +153,65 @@
                   <span>Specification tightening narrows selected witness families; it does not prove global risk reduction.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>Coupon PRD worked example flow</figcaption>
+                <pre><code>RawArtifactAction
+  -> ArtifactDescriptor
+  -> ForceDescriptor candidates
+  -> OperationSupportEstimate
+  -> ForecastConeSkeleton path classes
+  -> ConsequenceEnvelope
+  -> review / CI / issue decomposition recommendation
+  -> observed outcome
+  -> FieldUpdate</code></pre>
+              </figure>
+              <div class="article-table">
+                <table>
+                  <caption>Coupon PRD from artifact action to field update</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Step</th>
+                      <th scope="col">Reading</th>
+                      <th scope="col">Boundary preserved</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row"><code>RawArtifactAction</code></th>
+                      <td>Coupon feature addition targets Checkout / Payment requirements and operation support.</td>
+                      <td>No pricing strategy, marketing success, or fraud model conclusion.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>ForceDescriptor</code></th>
+                      <td>Candidate forces include DiscountPolicy insertion, PaymentAdapter patching, repository dependency, and UI-only flag paths.</td>
+                      <td>These are candidates under selected text, not an exhaustive repository extraction.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>OperationSupportEstimate</code></th>
+                      <td>Lawful policy insertion can become cheaper when rounding, composition, authorization, and refund semantics are explicit.</td>
+                      <td>Support estimates do not imply accepted PR history or future implementation choices.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>ConsequenceEnvelope</code></th>
+                      <td>Path classes expose hidden dependency, rounding obstruction, UI drift, and unknown remainder risks.</td>
+                      <td>The envelope is not a causal proof or a single forecast.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row"><code>FieldUpdate</code></th>
+                      <td>Observed PR, review, CI, or incident outcome can revise missing invariant and support records.</td>
+                      <td>Update quality depends on observed evidence and calibration, not on the case narrative alone.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="claim-strip">
+                <p>
+                  A useful Coupon PRD report should recommend specification
+                  tightening, review owners, CI checks, or issue decomposition
+                  without presenting the recommendation as a Lean theorem,
+                  causal forecast, or complete extractor result.
+                </p>
+              </div>
             </section>
 
             <section id="migration" class="article-section">
@@ -256,6 +316,66 @@
   + ConsequenceEnvelope
   + non-conclusions</code></pre>
               </figure>
+            </section>
+
+            <section id="case-matrix" class="article-section">
+              <h2>Case-study matrix</h2>
+              <p>
+                The cases use the same SFT vocabulary but exercise different
+                boundaries. The matrix is a reading guide for what each case is
+                allowed to support and what it leaves open.
+              </p>
+              <div class="article-table">
+                <table>
+                  <caption>Comparative case boundaries</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Case</th>
+                      <th scope="col">Primary input</th>
+                      <th scope="col">Envelope focus</th>
+                      <th scope="col">Review / governance output</th>
+                      <th scope="col">Non-conclusion</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Coupon PRD</th>
+                      <td>Feature PRD and selected checkout/payment boundary.</td>
+                      <td>Policy insertion, hidden dependencies, rounding obstruction, UI drift.</td>
+                      <td>Spec tightening, review ownership, CI assertions, issue split.</td>
+                      <td>No market, fraud, or global risk claim.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Migration</th>
+                      <td>Old/new component boundary and compatibility constraints.</td>
+                      <td>Bridge, dual-run, replacement, rollback, projection mismatch.</td>
+                      <td>Migration plan boundaries, comparison checks, rollback support.</td>
+                      <td>No guarantee that migration is economically optimal.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Incident response</th>
+                      <td>Runtime observation and post-incident evidence.</td>
+                      <td>Root-cause witness, missing invariant, governance update, forecast revision.</td>
+                      <td>New observation axes, tests, review rules, incident feedback records.</td>
+                      <td>No future trajectory safety proof.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">AI shortcut</th>
+                      <td>Prompt boundary, generated proposal, theorem and review boundary.</td>
+                      <td>Shortcut path, missed theorem boundary, obstruction witness.</td>
+                      <td>Proposal restriction, review / CI mediation, posterior update.</td>
+                      <td>No general AI safety or model quality theorem.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">End-of-life</th>
+                      <td>Architecture signature, repair cost, migration support, ownership capacity.</td>
+                      <td>Repair, migration, contraction, deletion futures.</td>
+                      <td>Decision boundary and evidence record for lifecycle governance.</td>
+                      <td>No human intention or market success prediction.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="case-boundary" class="article-section">


### PR DESCRIPTION
## 概要

Closes #867

SFT Part V / VI の website copy を増補し、ArchSig-SFT B12/B13 pipeline と Coupon PRD worked example を website 上で追えるようにしました。

- Part V に ArchSig-SFT pipeline の stage 別 input / output / soundness boundary と、current capability / remaining gaps の表を追加
- Part VI に Coupon PRD の `RawArtifactAction` から `FieldUpdate` までの worked example flow と、Migration / Incident / AI Shortcut / End-of-Life の比較 matrix を追加
- SFT overview の Part V / VI 説明を更新

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/index.html`
- `website/sft/part-v-computing-systems/index.html`
- `website/sft/part-vi-case-studies/index.html`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] Playwright 静的表示確認: `website/sft/part-v-computing-systems/index.html`, `website/sft/part-vi-case-studies/index.html`
- [x] Playwright モバイル幅確認: Part V / VI で page-level 横はみ出しなし
- [x] 対象 SFT ページの相対リンク実在確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
