### PR TITLE
SFT Part VIIの研究境界を増補する

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1235,6 +1235,32 @@ p {
   line-height: 1.48;
 }
 
+.numbered-status-list {
+  counter-reset: numbered-status;
+  list-style: none;
+}
+
+.numbered-status-list li {
+  counter-increment: numbered-status;
+  display: grid;
+  grid-template-columns: 2.2rem minmax(0, 1fr);
+  column-gap: 12px;
+}
+
+.numbered-status-list li::before {
+  content: counter(numbered-status, decimal-leading-zero);
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.52;
+}
+
+.numbered-status-list strong,
+.numbered-status-list span {
+  grid-column: 2;
+}
+
 .article-section code,
 .article-table code {
   font-family: var(--font-mono);

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -62,6 +62,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#reader-model">Reader model</a></li>
                 <li><a href="#positioning">Positioning</a></li>
                 <li><a href="#non-claims">Non-claims</a></li>
                 <li><a href="#open-problems">Open problems</a></li>
@@ -110,6 +111,41 @@
           </aside>
 
           <div class="article-main">
+            <section id="reader-model" class="article-section">
+              <h2>Reader model</h2>
+              <p>
+                Part VII is the exit chapter for SFT. It tells a reader how to
+                use the theory without turning it into a universal explanation
+                of software, an automatic forecasting system, or a substitute
+                for local proof and empirical validation.
+              </p>
+              <div class="reader-model">
+                <div>
+                  <h3>SFT does not say</h3>
+                  <p>
+                    A field vocabulary, a forecast cone, or a workbench report
+                    proves the future behavior of a software organization.
+                  </p>
+                </div>
+                <div>
+                  <h3>SFT says</h3>
+                  <p>
+                    Software evolution can be modeled as bounded operations,
+                    observable trajectories, feedback-mediated field updates,
+                    and boundary-aware consequence reports.
+                  </p>
+                </div>
+              </div>
+              <div class="claim-strip">
+                <p>
+                  Broad scope raises the standard for boundaries: every SFT
+                  claim must say whether it is vocabulary, theorem-shaped,
+                  tool-supported, empirically calibrated, or operationally
+                  deployed.
+                </p>
+              </div>
+            </section>
+
             <section id="positioning" class="article-section">
               <h2>Positioning</h2>
               <p>
@@ -124,18 +160,72 @@
                 signature trajectories, and consequence envelopes describe
                 reachable architecture futures.
               </p>
+              <div class="article-table">
+                <table>
+                  <caption>SFT compared with nearby frameworks</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Nearby frame</th>
+                      <th scope="col">What it usually emphasizes</th>
+                      <th scope="col">What SFT adds</th>
+                      <th scope="col">Blocked reading</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Static metric</th>
+                      <td>A snapshot score or selected architecture coordinate.</td>
+                      <td>Trajectory, support, missing axes, and field updates across changes.</td>
+                      <td>A single number is not architecture quality.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Process model</th>
+                      <td>Stages, roles, handoffs, and delivery practice.</td>
+                      <td>The effect of artifacts and feedback on reachable architecture futures.</td>
+                      <td>Process maturity is not field lawfulness.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Technical debt taxonomy</th>
+                      <td>Named debt classes and remediation categories.</td>
+                      <td>Obstruction witnesses, affected axes, support constraints, and consequence envelopes.</td>
+                      <td>A taxonomy label is not a causal proof.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">AI benchmark</th>
+                      <td>Model performance on coding or review tasks.</td>
+                      <td>Proposal support, shortcut witnesses, policy boundaries, and review / CI feedback updates.</td>
+                      <td>AI policy compliance is not architecture lawfulness.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Formal verification</th>
+                      <td>Checked local statements under explicit assumptions.</td>
+                      <td>A way to carry those theorem boundaries into forecast and governance reports.</td>
+                      <td>Local theorem status is not future trajectory safety.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="non-claims" class="article-section">
               <h2>What SFT does not claim</h2>
-              <ul class="status-list">
+              <p>
+                These are not caveats after the fact; they are part of the
+                theory surface. A report that drops them is not preserving the
+                SFT claim boundary.
+              </p>
+              <ol class="status-list numbered-status-list">
                 <li>
                   <strong>No mechanical future determinism</strong>
                   <span>SFT does not claim that future software behavior is mechanically determined.</span>
                 </li>
                 <li>
+                  <strong>No complete organizational model</strong>
+                  <span>Not every organizational effect, incentive, or coordination failure is formalized by the field model.</span>
+                </li>
+                <li>
                   <strong>No automatic empirical forecast</strong>
-                  <span>A `ForecastCone` does not become an empirical prediction without calibration.</span>
+                  <span>A <code>ForecastCone</code> does not become an empirical prediction without calibration.</span>
                 </li>
                 <li>
                   <strong>No trajectory safety from AAT alone</strong>
@@ -147,7 +237,7 @@
                 </li>
                 <li>
                   <strong>No ground truth extractor claim</strong>
-                  <span>ArchSig extraction is not a complete `ComponentUniverse` or ground truth architecture object.</span>
+                  <span>ArchSig extraction is not a complete <code>ComponentUniverse</code> or ground truth architecture object.</span>
                 </li>
                 <li>
                   <strong>No causal uniqueness from observed deltas</strong>
@@ -158,22 +248,23 @@
                   <span>AI policy compliance or review acceptance does not imply architecture lawfulness.</span>
                 </li>
                 <li>
+                  <strong>No global risk reduction from cone narrowing</strong>
+                  <span>A narrower modeled cone can still hide unmeasured axes, missing evidence, and external runtime effects.</span>
+                </li>
+                <li>
                   <strong>No human or market prediction</strong>
                   <span>SFT does not predict human intention, organizational success, or market success.</span>
                 </li>
-              </ul>
+              </ol>
             </section>
 
             <section id="open-problems" class="article-section">
               <h2>Open problems</h2>
               <p>
-                The research program includes Lean formalization of
-                `ForecastCone` and support simulation, the relation between
-                `ConsequenceEnvelope` and cones, trace-grounded field
-                reconstruction, simulator calibration, review mediation and AI
-                shortcut benchmarks, theorem-boundary integration, field
-                memory studies, lifecycle models, and deployed closed-loop
-                workbench design.
+                The research program is split so that formalization, tooling,
+                calibration, governance, and lifecycle questions can move
+                independently. The list below restates the open problems as
+                executable research tasks rather than slogans.
               </p>
               <figure class="code-panel">
                 <figcaption>Research direction</figcaption>
@@ -184,18 +275,57 @@
   + lifecycle and AI proposal governance
   -> deployed SFT workbench</code></pre>
               </figure>
+              <div class="article-table">
+                <table>
+                  <caption>Open problems grouped by work track</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Track</th>
+                      <th scope="col">Research tasks</th>
+                      <th scope="col">Output boundary</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Formalization</th>
+                      <td><code>ForecastCone</code>, support simulation, and the relation between <code>ConsequenceEnvelope</code> and one or more cones.</td>
+                      <td>Lean definitions and theorem schemas, not calibrated forecasts.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Tooling</th>
+                      <td>Artifact adapters, theorem-boundary integration, report projection, and workbench artifact flow.</td>
+                      <td>Evidence-bearing reports, not ground-truth architecture objects.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Calibration</th>
+                      <td>PRD-to-envelope simulator evaluation, held-out traces, false positive / false negative categories, and real dataset protocols.</td>
+                      <td>Empirical forecast-quality evidence, not causal theorem status.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Governance</th>
+                      <td>Review mediation, AI shortcut detection, allowed operation support, proposal constraints, and posterior field updates.</td>
+                      <td>Governance design artifacts, not general AI safety claims.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Lifecycle</th>
+                      <td>Codebase-as-field-memory studies, migration trajectories, contraction, deletion, and end-of-life decisions.</td>
+                      <td>Decision boundaries over selected inputs, not market or staffing predictions.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
               <ul class="term-list">
                 <li>
-                  <strong>Formal open problems</strong>
-                  <span>Lean formalization of `ForecastCone`, support simulation, and the relation from envelopes to one or more cones.</span>
+                  <strong>Next formal step</strong>
+                  <span>Define the minimal core for reachable field paths, support inclusion, horizon, step simulation, and cone projection.</span>
                 </li>
                 <li>
-                  <strong>Empirical open problems</strong>
-                  <span>Trace-grounded reconstruction, simulator calibration, review mediation, AI shortcut detection, and field memory studies.</span>
+                  <strong>Next empirical step</strong>
+                  <span>Record which traces are available, private, unavailable, or unknown before calling an estimate reconstructed.</span>
                 </li>
                 <li>
-                  <strong>Tooling open problems</strong>
-                  <span>Theorem-boundary integration, lifecycle decision models, and a deployed closed-loop workbench.</span>
+                  <strong>Next tooling step</strong>
+                  <span>Keep artifact source references, missing evidence, theorem boundaries, and non-conclusions attached through the pipeline.</span>
                 </li>
               </ul>
             </section>
@@ -211,20 +341,49 @@
                 CI interventions, AI proposal constraints, and calibration
                 plans.
               </p>
-              <figure class="code-panel">
-                <figcaption>Workbench contract</figcaption>
-                <pre><code>input:
-  PRD, design memo, issue plan, codebase,
-  architecture signature, review / CI history,
-  incident history, AI agent policy
-
-output:
-  ConsequenceEnvelope, affected axes,
-  witness families, missing boundaries,
-  risky default paths, issue decomposition,
-  governance interventions, AI constraints,
-  feedback / calibration plan</code></pre>
-              </figure>
+              <div class="article-table">
+                <table>
+                  <caption>Minimal workbench contract</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Surface</th>
+                      <th scope="col">Selected contents</th>
+                      <th scope="col">Boundary to preserve</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Inputs</th>
+                      <td>PRD, design memo, issue plan, codebase state, architecture signature, review / CI history, incident history, and AI agent policy.</td>
+                      <td>Private evidence, unavailable evidence, stale evidence, and unknown remainder must be explicit.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Intermediate artifacts</th>
+                      <td>Artifact descriptor, operation support estimate, forecast cone skeleton, theorem-boundary items, and calibration hooks.</td>
+                      <td>Intermediate success is not extractor completeness or forecast correctness.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Outputs</th>
+                      <td><code>ConsequenceEnvelope</code>, affected axes, witness families, missing boundaries, risky default paths, issue decomposition, governance interventions, AI constraints, and feedback plan.</td>
+                      <td>Outputs are review and planning artifacts, not a causal proof of the future.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <ul class="status-list">
+                <li>
+                  <strong>What it can make visible</strong>
+                  <span>Which axes are affected, which witnesses are plausible, which evidence is missing, and which review / CI gates should be strengthened.</span>
+                </li>
+                <li>
+                  <strong>What it cannot certify</strong>
+                  <span>That the selected proposal is safe, that all runtime effects are covered, or that the organization will choose the modeled path.</span>
+                </li>
+                <li>
+                  <strong>What closes the loop</strong>
+                  <span>Observed PR, review, CI, incident, and runtime traces must feed calibration hooks and posterior field updates.</span>
+                </li>
+              </ul>
               <div class="claim-strip">
                 <p>
                   SFT does not replace developers. It makes software evolution


### PR DESCRIPTION
## 概要

Closes #869

SFT Part VII を website-only の出口章として増補し、reader model、既存 framework との比較、具体的な non-conclusions、open problems の分類、SFT Workbench の input / output / boundary を追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- website/sft/part-vii-research-program/index.html
- website/assets/site.css

## 実施したテスト

- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [x] Playwright による file://website/sft/part-vii-research-program/index.html の desktop / mobile 静的表示確認
- [ ] lake build（Lean 変更なしのため未実施）
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を website copy / research-program tracking として Issue 範囲に保った
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている