### PR TITLE
SFT lifecycle decision modelを整理する

### DIFF
--- a/docs/sft/software_field_theory.md
+++ b/docs/sft/software_field_theory.md
@@ -1173,6 +1173,37 @@ LifecycleTrajectory :=
 End-of-life は失敗ではなく、lifecycle governance / field reconfiguration decision の一種である。
 修復コスト、migration path、runtime risk、organizational capacity for repair / migration、
 ConsequenceEnvelope の広がりを見て、repair、migration、deletion のどれを選ぶかを扱う。
+この判断は project management recommendation ではなく、選択された観測境界の下で
+architecture future と field capacity の変化を比較する bounded decision model である。
+
+```text
+LifecycleDecisionModel :=
+  current LifecycleTrajectory
+  + ArchitectureSignature trajectory
+  + ConsequenceEnvelope family
+  + runtime / incident risk boundary
+  + ownership / staffing boundary
+  + selected intervention set
+  + non-conclusions
+
+SelectedIntervention :=
+  repair | migration | contraction | deletion
+```
+
+比較軸は intervention ごとに異なる。
+
+| intervention | 読み | 主な比較軸 |
+| --- | --- | --- |
+| repair | 既存 field を保ち、局所的な support / invariant を補う。 | repair adoption、missing invariant、runtime regression risk、ownership capacity。 |
+| migration | old field から new field へ support と memory を写す。 | projection mismatch、dual-run cost、consumer compatibility、rollback path。 |
+| contraction | support できない surface を縮小し、field capacity を再配分する。 | removed operation family、affected user / runtime boundary、simplified signature axes。 |
+| deletion | field component または subsystem を lifecycle から外す。 | dependent operation loss、data / API retirement boundary、incident avoidance、unknown remainder。 |
+
+`ConsequenceEnvelope` は各 intervention の affected regions、signature axes、obstruction
+witness candidates、missing boundary を比較可能にする report projection である。
+field capacity は、available operation support、ownership / staffing boundary、runtime
+guard、migration support の組として読む。したがって、envelope が広いことは直ちに削除を
+意味しないし、repair cost が低いことは future trajectory safety を意味しない。
 
 SFT は benchmark と calibration を必要とする。
 
@@ -1300,6 +1331,7 @@ EndOfLifeDecision :=
   current architecture signature
   + repair cost
   + migration support
+  + contraction boundary
   + runtime risk
   + ownership / staffing boundary
   + ConsequenceEnvelope
@@ -1309,6 +1341,9 @@ EndOfLifeDecision :=
 SFT は market success や human intention を予測しない。
 扱うのは、repair、migration、contraction、deletion が architecture future と field capacity に
 与える影響である。
+decision artifact は、選択肢を rank する automated recommendation ではなく、selected inputs、
+excluded inputs、known missing evidence、non-conclusions を明示して reviewer / governance
+discussion に渡す bounded report である。
 
 ## Part VII. Non-Conclusions and Research Program（非主張と研究プログラム）
 

--- a/docs/tool/roadmap.md
+++ b/docs/tool/roadmap.md
@@ -36,6 +36,7 @@ Markdown PRD / Spec / Issue / AI proposal から `ForecastConeSkeleton` と
 | AI-generated change boundary | AI session metadata、generated patch provenance、human review boundary、formal claim block を扱う。 | proposal support 全体の制御や shortcut distribution の推定は未完成。 |
 | Empirical feedback | PR history、feature dataset、outcome linkage、B10 operational artifacts がある。SFT calibration / benchmark protocol は `docs/tool/sft_calibration_benchmark.md` で定義する。 | 実 dataset での継続 calibration と hypothesis refresh の運用。 |
 | Architecture dynamics | PR force、trajectory、dynamics metrics、field snapshot、operation proposal log の schema / validator と bounded SFT forecast pipeline がある。GitHub Issue JSON / AI proposal JSON adapter は supplied JSON artifact の正規化として実装済み。 | 実 dataset での calibration と framework semantics adapter。 |
+| Lifecycle decision | repair / migration / contraction / deletion を SFT lifecycle governance の decision surface として定義する。 | decision artifact schema、fixture、validator、実 dataset calibration は未実装。market / staffing success prediction は扱わない。 |
 
 ## Tooling capability surface and remaining gaps
 
@@ -48,6 +49,7 @@ ArchSig の現状を、実行可能な command / artifact / workflow と remaini
 | ArchSig Review | AIR、validate-air、theorem-check、Feature Extension Report、policy decision、PR comment、baseline suppression。review / CI の補助 report として読む。 | organization policy calibration、review practice tuning、任意 invariant の完全判定は未完成。formal claim promotion は Lean theorem refs と precondition が揃う場合だけ。 |
 | ArchSig SFT | Markdown PRD / Spec / Issue / AI proposal、GitHub Issue JSON、AI proposal JSON から `ArtifactDescriptor`、`OperationSupportEstimate`、`ForecastConeSkeleton`、`ConsequenceEnvelope`、validation report を生成する B13 pipeline。`docs/tool/software_field_reconstruction_protocol.md` は trace-grounded `SoftwareFieldEstimate` の evidence boundary を定義し、`docs/tool/sft_calibration_benchmark.md` は forecast item と observed refs の照合 protocol を定義し、`docs/tool/ai_proposal_governance.md` は AI proposal governance の allowed support / shortcut witness / review feedback boundary を定義する。 | real dataset calibration、framework semantics adapter。forecast、AI policy compliance、review pass は probability、causal proof、architecture lawfulness、global safety を結論しない。 |
 | ArchSig Operational | PR history dataset、Feature Extension dataset、outcome linkage、B10 daily ledger、calibration review、team threshold、ownership boundary、repair adoption、incident correlation、hypothesis refresh artifacts。`SoftwareFieldEstimate` 用 trace inventory は unavailable / private / unknown remainder を保持する。 | 実運用 dataset の継続収集、confounder 管理、incident / rollback / MTTR との組織別接続。 |
+| SFT Lifecycle | `LifecycleDecisionModel` / `EndOfLifeDecision` は repair、migration、contraction、deletion の selected inputs と non-conclusions を整理する planned decision surface。 | `lifecycle-decision-report-v0` 相当の schema / command は未実装。人間の意図、market success、project management recommendation は結論しない。 |
 
 ## Phase B0: AIR and boundary
 
@@ -210,6 +212,35 @@ prompt / policy boundary
 この phase の出力は reviewer-facing governance artifact であり、AI agent の一般的安全性、
 prompt / policy compliance からの architecture lawfulness、review pass / CI pass からの
 semantic preservation、または autonomous coding policy の本番 correctness を主張しない。
+
+## Phase B15: Lifecycle decision surface
+
+Lifecycle decision は、repair、migration、contraction、deletion を同じ比較面に置く
+SFT governance artifact として扱う。目的は project management の自動推薦ではなく、
+選択された architecture signature trajectory、runtime / incident evidence、
+ownership / staffing boundary、`ConsequenceEnvelope` family を束ね、intervention ごとの
+known support、obstruction witness、missing evidence、unknown remainder を読めるようにすること
+である。
+
+最小 input / output boundary は次である。
+
+```text
+ArchitectureSignature trajectory
+  + ConsequenceEnvelope family
+  + runtime / incident evidence refs
+  + ownership / staffing boundary refs
+  + migration / repair support refs
+  -> lifecycle decision report
+  -> intervention comparison
+  -> missing boundary / calibration hook
+```
+
+最小 report は、repair、migration、contraction、deletion それぞれについて selected inputs、
+affected regions、field capacity impact、runtime risk boundary、ownership boundary、
+calibration refs、non-conclusions を保持する。schema、fixture、validator、CLI はまだない。
+将来実装する場合でも、human intention、market success、staffing availability の予測、
+future trajectory safety、global risk reduction、forecast correctness は non-conclusions として
+保持する。
 
 ### B12 milestones
 

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -83,6 +83,7 @@ non-conclusions を落とさない。
 | ForecastCalibrationHook validation report | `forecast-calibration-hook-validation-report-v0` | matched / unmatched / unavailable / private / notComparable を measured zero と混同していないことを検査する。 |
 | AI Proposal Governance | `ai-proposal-governance-v0` | AI proposal の prompt / policy boundary、support taxonomy、shortcut witness、review / CI mediation、posterior field update を保持する。 |
 | AI Proposal Governance validation report | `ai-proposal-governance-validation-report-v0` | support category、shortcut witness、review / CI / posterior boundary、AI safety / forecast correctness / lawfulness non-conclusions を検査する。 |
+| Lifecycle Decision Report | planned `lifecycle-decision-report-v0` | repair / migration / contraction / deletion の selected inputs、field capacity impact、runtime / ownership boundary、non-conclusions を保持する将来候補。 |
 
 `artifact-descriptor-v0` は B12 SFT forecasting MVP の最初の入力正規化 artifact である。
 後段では `operation-support-estimate-v0`、`forecast-cone-skeleton-v0`、
@@ -117,6 +118,14 @@ prompt / policy boundary、allowed / conditionallyAllowed / forbidden / unknown 
 support、shortcut witness、review / CI mediation、posterior field update を接続するが、
 AI policy compliance、review pass、CI pass、schema validation pass を architecture lawfulness
 や forecast correctness に昇格しない。
+
+Lifecycle decision report は将来 artifact 候補であり、現時点では schema / validator / CLI を
+持たない。入力は ArchitectureSignature trajectory、`ConsequenceEnvelope` family、runtime /
+incident evidence refs、ownership / staffing boundary、repair / migration support refs に限定して
+読む。出力は intervention comparison であり、repair、migration、contraction、deletion を
+market success、human intention、staffing availability、project management recommendation として
+rank しない。実装時は selected inputs、excluded inputs、private / unavailable evidence、
+unknown remainder、calibration refs、non-conclusions を report に残す。
 
 `consequence-envelope-report-v0` は `forecast-cone-skeleton-v0` からの
 loss-aware report projection として読む。一つ以上の bounded cone skeleton から、


### PR DESCRIPTION
## 概要

Closes #879

- `LifecycleDecisionModel` と `SelectedIntervention` を SFT 本文に追加し、repair / migration / contraction / deletion の比較軸を整理しました。
- `EndOfLifeDecision` を contraction boundary まで含む decision artifact として補強し、selected inputs / excluded inputs / missing evidence / non-conclusions を残す bounded report と明記しました。
- tool roadmap と artifact boundary に planned `lifecycle-decision-report-v0` の input-output-boundary と未実装範囲を追加しました。
- 計画変更: なし。#879 の期待成果物は docs 設計として扱い、tool 実装・schema 追加は将来候補として明示しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/sft/software_field_theory.md`
- `docs/tool/roadmap.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`

## 実施したテスト

- [ ] `lake build`（docs-only のため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（既存の通常語・識別子への一致のみ。今回差分で forbidden construct 追加なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている

Lean status: empirical hypothesis / lifecycle design。