### PR TITLE
SFT workbenchの最小設計とphase planを追加

### DIFF
--- a/docs/sft/software_field_theory.md
+++ b/docs/sft/software_field_theory.md
@@ -1441,3 +1441,58 @@ SFT Workbench
 
 SFT は開発者を置き換えるものではない。
 ソフトウェア進化を、観測し、計算し、統治できる対象として見えるようにする。
+
+最小の deployed closed-loop workbench は、単一の自動判断器ではなく、既存の
+ArchSig-SFT artifact と operational feedback artifact を review cycle に束ねる
+bounded workflow である。
+
+```text
+PRD / design memo / issue plan / AI proposal
+  + existing codebase / ArchitectureSignature snapshot
+  + review / CI / PR / incident / ownership trace
+  + AI agent policy
+  -> ArtifactDescriptor
+  -> OperationSupportEstimate
+  -> ForecastConeSkeleton family
+  -> ConsequenceEnvelope report
+  -> AI proposal governance / lifecycle decision surface
+  -> review / CI / issue decomposition intervention
+  -> observed PR / review / CI / outcome refs
+  -> ForecastCalibrationHook + B10 operational feedback
+  -> field update note / hypothesis refresh input
+```
+
+最小 artifact flow は、次の責務を分ける。
+
+| layer | 入力 | 出力 | 境界 |
+| --- | --- | --- | --- |
+| input normalization | PRD、Issue、AI proposal、source refs | `ArtifactDescriptor` | source refs と missing evidence を保存する。 |
+| forecast construction | descriptor、policy constraints、bounded horizon | `OperationSupportEstimate`、`ForecastConeSkeleton` | finite support と unknown remainder を保存する。 |
+| review projection | cone family、signature axes、theorem boundary | `ConsequenceEnvelope` | reviewer-facing report であり、causal forecast ではない。 |
+| governance projection | AI policy、review / CI mediation refs | AI proposal governance / lifecycle decision surface | allowed / forbidden / unknown support を分ける。 |
+| feedback join | observed PR / review / CI / outcome refs、B10 artifact | `ForecastCalibrationHook`、calibration review、hypothesis refresh input | observation linkage であり、forecast correctness の証明ではない。 |
+
+依存関係は次の通りである。
+
+- B12 / B13 SFT forecasting が `ConsequenceEnvelope` までの bounded forecast artifact を作る。
+- future adapters は GitHub Issue JSON、AI proposal JSON、framework semantics、runtime / incident
+  trace を supplied evidence として正規化する。
+- B10 operational feedback は observed outcome、calibration review、threshold、ownership、
+  repair adoption、incident correlation、hypothesis refresh を保存する。
+- calibration hook は forecast item refs と observed refs を対応付け、benchmark protocol へ渡す。
+- deployed workbench はこれらを一つの review cycle に束ねるが、実組織 deployment、
+  automatic governance correctness、または causal theorem を追加しない。
+
+phase plan は次の最小順序で進める。
+
+| phase | 目的 | 次に必要なもの |
+| --- | --- | --- |
+| W0 artifact inventory | 既存 B10 / B12 / B13 / governance artifact と missing adapter を一覧化する。 | workbench run manifest の設計。 |
+| W1 offline bundle | 1 件の PRD / Issue / AI proposal と既存 trace refs から workbench bundle を手動生成する。 | artifact refs、excluded inputs、non-conclusions の manifest 化。 |
+| W2 review-loop dry run | generated envelope と governance projection を review / CI checklist に接続する。 | reviewer decision と CI outcome refs の収集。 |
+| W3 calibration join | forecast items と observed refs を `ForecastCalibrationHook` / B10 artifact に接続する。 | held-out / prospective benchmark set。 |
+| W4 deployed pilot | selected repository で scheduler と policy threshold を運用する。 | 組織別 calibration と incident / rollback / MTTR との継続照合。 |
+
+W4 でも、workbench は forecast correctness、global risk reduction、AI safety、
+automatic governance correctness、または real organization outcome の因果説明を結論しない。
+その主張には、別途 calibration dataset、confounder 管理、prospective validation が必要である。

--- a/docs/tool/roadmap.md
+++ b/docs/tool/roadmap.md
@@ -242,6 +242,53 @@ calibration refs、non-conclusions を保持する。schema、fixture、validato
 future trajectory safety、global risk reduction、forecast correctness は non-conclusions として
 保持する。
 
+## Phase B16: Closed-loop SFT workbench
+
+Closed-loop SFT workbench は、B10 operational feedback、B12 / B13 SFT forecast artifact、
+AI proposal governance、lifecycle decision surface、future adapters、calibration hook を
+一つの review cycle に束ねる deployed workflow の最小設計である。目的は自動判断ではなく、
+入力、bounded forecast、governance intervention、observed outcome、calibration input を
+同じ artifact graph として追跡できるようにすることである。
+
+最小 input / output boundary は次である。
+
+```text
+PRD / design memo / Issue / AI proposal refs
+  + codebase / ArchitectureSignature snapshot refs
+  + review / CI / PR / incident / ownership trace refs
+  + AI agent policy refs
+  -> SFT forecast artifact bundle
+  -> ConsequenceEnvelope / governance / lifecycle projections
+  -> review / CI / issue decomposition intervention refs
+  -> observed outcome refs
+  -> ForecastCalibrationHook + B10 operational feedback refs
+  -> field update note / hypothesis refresh input
+```
+
+### B16 dependency map
+
+| 依存 | workbench での役割 | 境界 |
+| --- | --- | --- |
+| B10 operational feedback | outcome ledger、calibration review、threshold、ownership、incident correlation、hypothesis refresh を保存する。 | correlation と operational observation であり、causal theorem ではない。 |
+| B12 / B13 SFT forecast | descriptor、support estimate、cone skeleton、envelope report を生成する。 | bounded forecast artifact であり、probability や forecast correctness ではない。 |
+| calibration hook | forecast item refs と observed refs を対応付ける。 | match / unmatched / unavailable / private / notComparable を保存するだけで、自動採点しない。 |
+| future adapters | GitHub Issue、AI proposal、framework semantics、runtime / incident trace を正規化する。 | supplied evidence adapter であり、private field 復元や extractor completeness を主張しない。 |
+| governance / lifecycle projections | review / CI / issue decomposition、AI proposal constraint、repair / migration / deletion comparison を出す。 | reviewer-facing intervention surface であり、自動 governance correctness ではない。 |
+
+### B16 phase plan
+
+| Phase | 成果物 | 次の実装 Issue 候補 |
+| --- | --- | --- |
+| B16.0 artifact inventory | B10 / B12 / B13 / governance / lifecycle artifact refs と missing adapters の一覧。 | workbench run manifest schema を作る。 |
+| B16.1 offline workbench bundle | 1 件の PRD / Issue / AI proposal から forecast bundle、governance projection、feedback refs を手動結合する。 | `workbench-run-manifest-v0` fixture / validator。 |
+| B16.2 review-loop dry run | envelope と governance projection を review / CI checklist、issue decomposition refs に接続する。 | review intervention record schema。 |
+| B16.3 calibration join | observed refs を `ForecastCalibrationHook` と B10 artifact に接続する。 | calibration join report / benchmark fixture。 |
+| B16.4 deployed pilot | scheduler、team threshold、ownership / incident monitor と接続する。 | prospective dataset と organization-specific calibration policy。 |
+
+B16 は real organization deployment、automatic governance correctness、forecast quality、
+AI safety、global risk reduction を完了条件にしない。これらは実 dataset と prospective
+validation が揃った後の empirical research task として扱う。
+
 ### B12 milestones
 
 | Milestone | 目標 |

--- a/docs/tool/workflows.md
+++ b/docs/tool/workflows.md
@@ -80,3 +80,27 @@ architecture field snapshot
 
 probabilistic operation distribution は empirical reading として扱い、formal core では
 finite support と bounded script を明示する。
+
+## Closed-loop SFT workbench
+
+Closed-loop SFT workbench は、SFT forecast artifact、governance projection、operational
+feedback、calibration hook を一つの review cycle に束ねる workflow である。
+
+```text
+PRD / design memo / Issue / AI proposal
+  + codebase / ArchitectureSignature snapshot
+  + review / CI / incident / ownership trace
+  + AI agent policy
+  -> sft-forecast artifact bundle
+  -> ConsequenceEnvelope report
+  -> AI proposal governance / lifecycle decision projection
+  -> review / CI / issue decomposition intervention
+  -> observed PR / review / CI / outcome refs
+  -> forecast calibration hook
+  -> B10 operational feedback
+  -> hypothesis refresh / field update note
+```
+
+workbench flow は loop 全体で artifact refs と non-conclusions を保持する。
+forecast report を probability claim にせず、review decision を formal theorem にせず、
+observed operational correlation を causal proof にしない。

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -431,6 +431,14 @@ unknown remainder、non-conclusions が B13 pipeline 内で保持されたこと
 probability、causal prediction、global safety、Lean theorem claim、extractor
 completeness、forecast correctness は結論しない。
 
+Closed-loop SFT workbench の最小設計では、この `sft-forecast` 出力を
+AI proposal governance、lifecycle decision surface、`forecast-calibration-hook-v0`、
+B10 operational feedback artifact と束ねて読む。現時点では workbench 専用 CLI はなく、
+workbench run manifest、review intervention record、calibration join report は将来の
+schema / fixture / validator 候補である。`sft-forecast` の成功や B10 artifact との接続は、
+deployed governance correctness、forecast quality、global risk reduction、または incident
+causality を意味しない。
+
 B5 repair / synthesis artifact を検査する。
 
 ```bash

--- a/tools/archsig/docs/operational-feedback.md
+++ b/tools/archsig/docs/operational-feedback.md
@@ -67,6 +67,13 @@ SFT `ConsequenceEnvelope` の calibration / benchmark protocol は
 observed PR / review / CI / outcome refs と false positive / false negative review を保持する
 入力であり、forecast correctness や causal proof ではない。
 
+Closed-loop SFT workbench では、B10 artifact は forecast 後の観測面を担当する。最小 flow は
+`sft-forecast` が生成した `ConsequenceEnvelope` / forecast item refs、review / CI
+intervention refs、observed PR / review / CI / incident refs を
+`forecast-calibration-hook-v0` と B10 artifact に接続し、hypothesis refresh の入力として
+保存することである。この接続は deployment evidence の台帳であり、自動 governance
+correctness、forecast quality、global risk reduction、または incident causality を結論しない。
+
 - unavailable / private / missing / unmeasured outcome data を measured-zero evidence に丸めない。
 - reviewer decision は threshold / CI policy の empirical calibration input として読む。
 - team threshold は formal theorem precondition discharge ではない。


### PR DESCRIPTION
## 概要

Closes #881

- closed-loop SFT workbench を、B10 operational feedback、B12 / B13 SFT forecast、calibration hook、future adapters、governance / lifecycle projection を束ねる bounded workflow として定義しました。
- minimal artifact flow、dependency map、B16 phase plan を追加し、次に切る実装 Issue 候補として run manifest、review intervention record、calibration join report を明記しました。
- deployment は forecast correctness、causal theorem、automatic governance correctness、global risk reduction を意味しないことを明記しました。

## 証明した定理

- なし

## 編集したドキュメント

- docs/sft/software_field_theory.md
- docs/tool/roadmap.md
- docs/tool/workflows.md
- tools/archsig/docs/commands.md
- tools/archsig/docs/operational-feedback.md

## 実施したテスト

- [ ] lake build（docs のみの変更のため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean ソース未変更のため未実施）

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている