### PR TITLE
SFTページのサイドバーを整理

### DIFF
--- a/website/sft/glossary/index.html
+++ b/website/sft/glossary/index.html
@@ -87,14 +87,6 @@
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                A term becomes computational only after its model, support,
-                policy, horizon, observation axes, and missing-evidence
-                boundary are named.
-              </p>
-            </div>
           </aside>
 
           <div class="article-main">

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -129,14 +129,6 @@
                 </li>
               </ul>
             </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                Field, force, attractor, and forecast are formal or diagnostic
-                modeling terms here. They are not physical quantities, Lean
-                theorem claims, or empirical prediction theorems by default.
-              </p>
-            </div>
           </aside>
 
           <div class="article-main">

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -74,26 +74,11 @@
                 <li><a href="#part-boundary">Boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
-                    Part I source
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
-                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-i-new-object/" aria-current="page">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
@@ -103,14 +88,6 @@
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                A reachable future is relative to an explicit model, horizon,
-                operation support, policy, and observation boundary. It is not
-                a prophecy about what the project will do.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -77,42 +77,12 @@
                 <li><a href="#canonical-sources">Canonical sources</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical sources</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
-                    Part II source
-                  </a>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">
-                    AAT / SFT interface
-                  </a>
-                </li>
-                <li>
-                  <a href="../../aat/">
-                    AAT website
-                  </a>
-                </li>
-                <li>
-                  <a href="../../archsig/">
-                    ArchSig website
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
-                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-ii-basis/" aria-current="page">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
@@ -121,14 +91,6 @@
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                AAT theorem status is not converted into empirical prediction
-                status. SFT uses AAT results as local premises inside bounded
-                field models.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -76,28 +76,13 @@
                 <li><a href="#core-boundary">Boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md#part-iii-the-sft-coresft-%E3%81%AE%E4%B8%AD%E6%A0%B8">
-                    Part III source
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
-                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iii-core/" aria-current="page">Part III. SFT Core</a></li>
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
@@ -105,14 +90,6 @@
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                `ForecastCone` is a set of reachable field paths under a
-                selected support relation and horizon. `ConsequenceEnvelope` is
-                the report form for readers and tools.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -75,43 +75,20 @@
                 <li><a href="#principle-boundary">Boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md#part-iv-principles-and-theorems%E5%8E%9F%E7%90%86%E3%81%A8%E5%AE%9A%E7%90%86">
-                    Part IV source
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/" aria-current="page">Part IV. Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                Cone narrowing is relative to selected support, witness
-                families, and horizon. It does not imply global risk reduction
-                or safety for unmeasured axes.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -75,43 +75,20 @@
                 <li><a href="#systems-boundary">Boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
-                    Part V source
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
-                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-v-computing-systems/" aria-current="page">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                SFT tools return bounded reports and estimates. They do not
-                become ground truth, Lean proofs, or general AI safety
-                guarantees.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -75,23 +75,8 @@
                 <li><a href="#case-boundary">Boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
-                    Part VI source
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
@@ -99,19 +84,11 @@
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
-                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vi-case-studies/" aria-current="page">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                Case studies illustrate bounded diagnosis. They do not claim
-                market prediction, exhaustive causality, or complete extraction
-                from real repositories.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -73,23 +73,8 @@
                 <li><a href="#research-boundary">Boundary</a></li>
               </ol>
             </nav>
-            <div class="source-panel">
-              <h2>Canonical source</h2>
-              <ul>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
-                    Part VII source
-                  </a>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="source-panel sft-sequence-panel">
-              <h2>SFT reading sequence</h2>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
               <ul>
                 <li><a href="../">SFT overview</a></li>
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
@@ -98,18 +83,10 @@
                 <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
-                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../part-vii-research-program/" aria-current="page">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
-            </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                SFT has a large scope, so its public reading surface must keep
-                non-conclusions visible. Scope is not the same as proof or
-                empirical validation.
-              </p>
             </div>
           </aside>
 

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -88,13 +88,6 @@
                 <li><a href="./" aria-current="page">Status and claim boundary</a></li>
               </ul>
             </div>
-            <div class="boundary-note">
-              <h2>Boundary note</h2>
-              <p>
-                A claim level names the evidence and semantics currently
-                available. It does not upgrade the claim to a stronger level.
-              </p>
-            </div>
           </aside>
 
           <div class="article-main">


### PR DESCRIPTION
## 概要

SFT ページ群のサイドバーを AAT と同じ方針に揃えました。

- サイドバーをページ内リンクと SFT チャプターリンクのみに整理
- Canonical source(s) パネルと Boundary note パネルをサイドバーから削除
- SFT チャプターリンクの見出しを `SFT chapters` に統一
- 現在ページのチャプターリンクに `aria-current="page"` を付与

対象 Issue: なし（会話起点の website 調整）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [x] `playwright --version`（Version 1.60.0）
- [x] Chromium / Playwright で `website/sft/index.html` と `website/sft/part-i-new-object/index.html` のサイドバー構成を確認
- [x] 全 SFT ページのサイドバー見出しが `On this page | SFT chapters` のみであることを確認
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan（`website/sft`）
- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている（該当記述変更なし）