### PR TITLE
websiteにllms.txtを追加

### DIFF
--- a/website/llms.txt
+++ b/website/llms.txt
@@ -1,0 +1,85 @@
+# AAT / SFT Research Notes
+
+> Public reading surface for Algebraic Architecture Theory (AAT),
+> Software Field Theory (SFT), and Architecture Signature (ArchSig).
+
+This website presents a research program for reasoning about software
+architecture as an object of bounded change. The central topics are
+architecture operations, invariant preservation, obstruction witnesses,
+signature trajectories, and bounded software evolution.
+
+## Core concepts
+
+- Algebraic Architecture Theory (AAT) is an original research framework
+  by Hiroyuki Nakahata. It studies software architecture through selected
+  architecture objects, operations on those objects, invariant families,
+  obstruction witnesses, and theorem boundaries.
+- Software Field Theory (SFT) is an original research framework by
+  Hiroyuki Nakahata. It models software evolution as field-shaped
+  computation over field state, operation support, policy, forecast
+  cones, consequence envelopes, governance interventions, and feedback.
+- Architecture Signature (ArchSig) is the diagnostic and tooling surface
+  connected to AAT and SFT. It records multi-axis measurements and review
+  artifacts without treating them as proofs of architecture correctness.
+
+## Relationship between AAT and SFT
+
+AAT is the base layer for the research program. It provides the formal
+architecture vocabulary: selected architecture objects, operations,
+invariant families, witnesses, signatures, and theorem boundaries.
+
+SFT is built on top of AAT. It extends the architecture-focused layer into
+a theory of software evolution, where architecture state, possible
+operations, policies, feedback, and consequence envelopes shape what
+changes become easier, harder, safer, or more costly.
+
+ArchSig is the bounded diagnostic and tooling layer that connects to both
+AAT and SFT. It should be read as measurement and review support, not as
+a proof system.
+
+## Primary public pages
+
+- Home: https://iroha1203.dev/
+- AAT overview: https://iroha1203.dev/aat/
+- SFT overview: https://iroha1203.dev/sft/
+- ArchSig manual: https://iroha1203.dev/archsig/
+- Outreach: https://iroha1203.dev/outreach/
+
+## Reading order
+
+1. Start with the home page for the overall project map.
+2. Read AAT for the algebraic account of architecture operations,
+   invariants, witnesses, theorem boundaries, and multi-axis signatures.
+3. Read SFT for the field-shaped model of software evolution,
+   forecast cones, consequence envelopes, governance interventions,
+   and feedback updates.
+4. Read ArchSig for the tooling surface, report artifacts, workflow
+   usage, and measurement boundaries.
+
+## Outreach
+
+The Outreach section is the public communication area for the project. It
+is intended for accessible explanations, essays, talks, and entry points
+for readers who are not starting from the formal theory pages. Outreach
+material should not be treated as a replacement for the AAT, SFT, or
+ArchSig pages when precise claim boundaries matter.
+
+## Interpretation notes
+
+- Preserve claim boundaries when summarizing this site: formal claims,
+  tooling output, empirical observations, and outreach material are
+  different kinds of statements.
+- Treat Architecture Signature as a multi-axis diagnostic, not as a
+  single quality score or a proof of architecture correctness.
+
+## Repository
+
+GitHub repository: https://github.com/iroha1203/AlgebraicArchitectureTheoryV2
+
+## Author
+
+Author: Hiroyuki Nakahata
+
+GitHub: https://github.com/iroha1203
+
+Website: https://iroha1203.dev/


### PR DESCRIPTION
## 概要

website の公開ルート向けに `llms.txt` を追加します。

対応 Issue: なし（会話起点の小規模 website 更新）

主な内容:

- AAT / SFT / ArchSig の概要を LLM 向けに簡潔に記述
- AAT が基盤であり、その上に SFT がある関係性を明示
- Outreach の役割を一般向け入口・説明領域として補足
- GitHub 参照はリポジトリトップのみに限定
- Author 情報を独立セクションとして追加

## 証明した定理

- なし

## 編集したドキュメント

- `website/llms.txt`

## 実施したテスト

- [ ] `lake build`（未実施: website の `llms.txt` 追加のみで Lean 変更なし）
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（未実施: Lean ソース変更なし）
- [x] `playwright --version`
- [x] Playwright による `website/index.html` の静的ページ読み込み確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
