### PR TITLE
SFT theorem candidatesページを追加する

### DIFF
--- a/website/sft/glossary/index.html
+++ b/website/sft/glossary/index.html
@@ -95,6 +95,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="./" aria-current="page">Glossary and terminology boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>
@@ -288,9 +289,9 @@
                 <span>Previous</span>
                 <strong>Part VII. Research Program</strong>
               </a>
-              <a href="../status/">
+              <a href="../theorem-candidates/">
                 <span>Next</span>
-                <strong>Status and Claim Boundary</strong>
+                <strong>Theorem Candidates</strong>
               </a>
             </nav>
           </div>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -134,6 +134,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="theorem-candidates/">
+                    Theorem Candidates
+                  </a>
+                </li>
+                <li>
                   <a href="status/">
                     Status and Claim Boundary
                   </a>
@@ -191,6 +196,10 @@
                 <li>
                   <a href="glossary/">Glossary and Terminology Boundary</a>
                   <span>Formal readings, avoided readings, and Part references for field, force, attractor, basin, ForecastCone, ConsequenceEnvelope, support, policy, and calibration.</span>
+                </li>
+                <li>
+                  <a href="theorem-candidates/">Theorem Candidates</a>
+                  <span>Main SFT theorem-shaped statements, Lean status, bounded readings, and non-conclusion anchors.</span>
                 </li>
                 <li>
                   <a href="status/">Status and Claim Boundary</a>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -97,6 +97,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -100,6 +100,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -99,6 +99,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -98,6 +98,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -98,6 +98,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -98,6 +98,7 @@
                 <li><a href="../part-vi-case-studies/" aria-current="page">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -96,6 +96,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/" aria-current="page">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="../status/">Status and Claim Boundary</a></li>
               </ul>
             </div>

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -96,6 +96,7 @@
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
                 <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="../theorem-candidates/">Theorem Candidates</a></li>
                 <li><a href="./" aria-current="page">Status and claim boundary</a></li>
               </ul>
             </div>
@@ -314,6 +315,12 @@
                   <span>Current ArchSig-SFT pipeline capability and remaining gaps.</span>
                 </li>
                 <li>
+                  <a href="../theorem-candidates/">
+                    SFT Theorem Candidates
+                  </a>
+                  <span>Main theorem-shaped statements, Lean status, bounded readings, and non-conclusion anchors.</span>
+                </li>
+                <li>
                   <a href="../../aat/status/">
                     AAT Lean Status
                   </a>
@@ -323,9 +330,9 @@
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a class="page-nav-previous" href="../part-vii-research-program/">
+              <a class="page-nav-previous" href="../theorem-candidates/">
                 <span>Previous</span>
-                <strong>Part VII. Research Program</strong>
+                <strong>Theorem Candidates</strong>
               </a>
               <a href="../">
                 <span>Back to</span>

--- a/website/sft/theorem-candidates/index.html
+++ b/website/sft/theorem-candidates/index.html
@@ -1,0 +1,517 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="SFT theorem candidates, Lean status, bounded readings, and non-conclusion boundaries for ForecastCone, support safety, FieldUpdate, ConsequenceEnvelope, and counterexamples."
+    >
+    <title>SFT Theorem Candidates</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/theorem-candidates/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT Theorem Candidates">
+    <meta property="og:description" content="SFT theorem candidates, Lean status, bounded readings, and non-conclusion boundaries.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/theorem-candidates/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT Theorem Candidates">
+    <meta name="twitter:description" content="SFT theorem candidates, Lean status, bounded readings, and non-conclusion boundaries.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a href="../../aat/">AAT</a>
+          <a class="is-active" href="../">SFT</a>
+          <a href="../../archsig/">ArchSig</a>
+          <a href="../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">SFT</a>
+            <span>Theorem Candidates</span>
+          </nav>
+          <p class="eyebrow">SFT Appendix</p>
+          <h1>Theorem Candidates</h1>
+          <p class="lede">
+            This page indexes the main SFT theorem-shaped statements, their
+            current Lean status, and the boundary that prevents a bounded
+            theorem package from becoming a forecast, causal, or tooling claim.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#reader-contract">Reader contract</a></li>
+                <li><a href="#status-legend">Status legend</a></li>
+                <li><a href="#candidate-index">Candidate index</a></li>
+                <li><a href="#counterexample-anchors">Counterexample anchors</a></li>
+                <li><a href="#source-references">Source references</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>SFT chapters</h2>
+              <ul>
+                <li><a href="../">SFT overview</a></li>
+                <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
+                <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
+                <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
+                <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
+                <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
+                <li><a href="../glossary/">Glossary and Terminology Boundary</a></li>
+                <li><a href="./" aria-current="page">Theorem Candidates</a></li>
+                <li><a href="../status/">Status and claim boundary</a></li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="reader-contract" class="article-section">
+              <h2>Reader contract</h2>
+              <p>
+                The candidate list is not a progress ledger copied from GitHub
+                Issues. It is the web-facing reading of the checked SFT formal
+                surface after the Lean package entrypoint stabilized. A row may
+                contain proved accessor theorems while the larger research
+                statement remains a theorem candidate.
+              </p>
+              <div class="claim-strip">
+                <p>
+                  A Lean proved accessor means the named record, projection, or
+                  bounded witness preserves a stated boundary. It does not
+                  imply probability, calibrated forecast correctness, extractor
+                  completeness, governance effectiveness, or global future
+                  trajectory safety.
+                </p>
+              </div>
+            </section>
+
+            <section id="status-legend" class="article-section">
+              <h2>Status legend</h2>
+              <ul class="status-list">
+                <li>
+                  <strong>Definition candidate</strong>
+                  <span>A stable SFT concept or record shape. Lean may define the carrier while leaving substantive bridge theorems separate.</span>
+                </li>
+                <li>
+                  <strong>Theorem candidate</strong>
+                  <span>A theorem-shaped SFT statement whose bounded reading is tracked by the package entrypoint.</span>
+                </li>
+                <li>
+                  <strong>Lean proved</strong>
+                  <span>A checked theorem exists for the named bounded accessor, bridge, or counterexample wrapper.</span>
+                </li>
+                <li>
+                  <strong>Future proof obligation</strong>
+                  <span>A stronger or more general claim is intentionally left outside the current Lean package.</span>
+                </li>
+                <li>
+                  <strong>Schema only</strong>
+                  <span>Website or source-document exposition only. It is not being presented as a Lean theorem.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="candidate-index" class="article-section">
+              <h2>Candidate index</h2>
+              <div class="theorem-card-list">
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Definition candidate</span>
+                      <h3>SoftwareField projection boundary</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">defined + accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>SoftwareField</code>, <code>SoftwareFieldEstimate</code>, <code>ArchitectureProjectionBoundary</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>Selected field estimates have a one-way architecture projection boundary.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No complete development-field model, reconstruction completeness, or extractor completeness.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Definition records and projection-boundary accessors are tracked as Lean API.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Theorem candidate</span>
+                      <h3>ForecastCone core and projection</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>ForecastCone</code>, <code>ForecastCone.monotone_horizon</code>, <code>ForecastConeProjection.forecastCone_projects_of_supportInclusion_and_horizon_le</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>Finite field-path membership is preserved under selected support inclusion, step simulation, and horizon extension.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No transition kernel, probability, calibration, causal proof, risk-reduction theorem, or global safety theorem.</dd>
+                    </div>
+                    <div>
+                      <dt>Future obligation</dt>
+                      <dd>Relational generalization across different field models remains outside the current package.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Definition candidate</span>
+                      <h3>Artifact action and after-action cones</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">defined + accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>ArtifactAction</code>, <code>DeterministicArtifactAction</code>, <code>ForecastConeFamilyAfterAction</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>An artifact constrains candidate updates and points to cone families after selected field updates.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No unique future, market success, human-intention model, causal proof, or candidate completeness.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Candidate membership and deterministic special-case accessors are checked.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Theorem candidate</span>
+                      <h3>Governance narrows selected support</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>GovernanceIntervention.restrictive_supportInclusion</code>, <code>GovernanceIntervention.restrictive_forecastCone_projects</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>Restrictive governance can be read as a selected support transformation connected to cone projection.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>Policy pass, review, CI, type checking, runtime guard, or AI policy does not prove architecture lawfulness or empirical risk reduction.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Boundary accessors are Lean proved; operational effectiveness remains outside theorem status.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Theorem candidate</span>
+                      <h3>Reachability and stable regions</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>MayReach</code>, <code>MustReach</code>, <code>StableRegion</code>, <code>ReachablePreimage</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>Selected finite-cone reachability and one-step stable-region closure can be stated and accessed.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No global basin, recurrence, convergence, strong attractor, calibrated future prediction, or global safety.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Reachability accessors and stable-region closure facts are checked under selected assumptions.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved</span>
+                      <h3>Support safety under package assumptions</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>SFTSupportSafetyPackage.AcceptedSupportedTrajectory.forecastCone_and_supportSafety</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>A realized supported script stays in the selected safe region when support preservation is supplied.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>Accepted-step evidence alone is not support preservation, and endpoint safety does not imply path safety.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Unmeasured axes, empirical review capacity, forecast correctness, calibration, and global safety remain outside the theorem.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved</span>
+                      <h3>FieldUpdate record preservation</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>FieldUpdate.UpdateSound.fieldUpdate_preserves_forecastError_and_missingEvidence</code>, <code>FieldUpdate.UpdateSound.fieldUpdate_records_calibrationBoundary</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>A caller-supplied sound update preserves recorded forecast error, missing evidence, unexpected witnesses, policy drift, and non-conclusions.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No posterior accuracy improvement, empirical calibration theorem, governance effectiveness, or feedback extractor completeness.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Record-preservation accessors are checked; calibration remains empirical.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Theorem candidate</span>
+                      <h3>ConsequenceEnvelope projection</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>ConsequenceEnvelope</code>, <code>EnvelopeProjection.envelope_does_not_strengthen_forecast_claim</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>A loss-aware report projection preserves selected cone count, missing boundary, theorem boundary, unknown remainder, and forecast non-conclusions.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No invertible reconstruction of the cone family, probability, causal proof, calibrated forecast correctness, or tooling artifact as Lean witness.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Report-boundary accessors are checked; the envelope remains a report form.</dd>
+                    </div>
+                  </dl>
+                </article>
+
+                <article class="theorem-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Boundary theorem candidate</span>
+                      <h3>AAT and ArchSig boundary preservation</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved accessors</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>Lean anchor</dt>
+                      <dd><code>AATToSFTInterfaceBoundary</code>, <code>ArchSigSFTReportEstimateBoundary</code></dd>
+                    </div>
+                    <div>
+                      <dt>Bounded reading</dt>
+                      <dd>AAT theorem status and ArchSig report output can be carried into SFT as local premise or estimate boundary without strengthening the claim.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No automatic trajectory-safety promotion, ground-truth architecture object, calibrated forecast, or extractor completeness.</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>Non-promotion and report-boundary accessors are Lean proved.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
+            </section>
+
+            <section id="counterexample-anchors" class="article-section">
+              <h2>Counterexample anchors</h2>
+              <p>
+                The counterexample package is part of the theorem surface
+                because it names forbidden readings directly. These are
+                finite Lean witnesses, not empirical claims.
+              </p>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved wrapper</span>
+                      <h3>Endpoint safety is not path safety</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <p>
+                    <code>SFTCounterexamples.endpoint_safe_zero_delta_not_path_safe</code>
+                    records that endpoint delta zero and safe endpoints do not
+                    imply that the selected trajectory stayed inside the safe
+                    region.
+                  </p>
+                </article>
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved wrapper</span>
+                      <h3>Accepted preservation is not support preservation</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <p>
+                    <code>SFTCounterexamples.accepted_preservation_not_support_preservation</code>
+                    separates accepted-step evidence from a theorem that every
+                    operation in finite support preserves the selected safe
+                    region.
+                  </p>
+                </article>
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved wrapper</span>
+                      <h3>Same current signature is not same future trajectory</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <p>
+                    <code>SFTCounterexamples.same_observed_signature_different_future_trajectory</code>
+                    keeps current observation separate from future operation
+                    support and future signature trajectory.
+                  </p>
+                </article>
+              </div>
+            </section>
+
+            <section id="source-references" class="article-section">
+              <h2>Source references</h2>
+              <ul class="chapter-list">
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/c58efc4b45beae6ca481c65674294d2c40205b72/Formal/Arch/Evolution/SFTTheoremPackages.lean">
+                    SFT theorem package entrypoint
+                  </a>
+                  <span>Docs-facing metadata for candidate groups, representative declarations, schematic correspondences, and non-conclusion boundaries.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/c58efc4b45beae6ca481c65674294d2c40205b72/docs/aat/lean_theorem_index.md#sft-theorem-package-entrypoint">
+                    Lean theorem index
+                  </a>
+                  <span>Checked Lean status for SFT formal surface and counterexample packages.</span>
+                </li>
+                <li>
+                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/c58efc4b45beae6ca481c65674294d2c40205b72/docs/aat/proof_obligations.md">
+                    Proof obligations
+                  </a>
+                  <span>Lean status vocabulary and source-of-truth boundary for proved, defined-only, future, and empirical claims.</span>
+                </li>
+                <li>
+                  <a href="../status/">
+                    SFT Status and Claim Boundary
+                  </a>
+                  <span>Claim levels and promotion rules for reading SFT website statements.</span>
+                </li>
+              </ul>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../glossary/">
+                <span>Previous</span>
+                <strong>Glossary</strong>
+              </a>
+              <a href="../status/">
+                <span>Next</span>
+                <strong>Status and Claim Boundary</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -94,6 +94,9 @@
     <loc>https://iroha1203.dev/sft/part-vii-research-program/</loc>
   </url>
   <url>
+    <loc>https://iroha1203.dev/sft/theorem-candidates/</loc>
+  </url>
+  <url>
     <loc>https://iroha1203.dev/sft/status/</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## 概要

Closes #929

- SFT Theorem Candidates ページを追加し、#916 の `SFTTheoremPackages.Candidate` と Lean theorem index に沿って、`ForecastCone`、cone projection、support safety、`FieldUpdate`、`ConsequenceEnvelope`、AAT / ArchSig boundary、counterexample package の claim status と non-conclusion を整理しました。
- SFT overview、各 SFT chapter sidebar、Glossary、Status、`sitemap.xml` から新ページへ到達できるようにしました。
- 未証明 schema を Lean theorem として表示せず、proved accessor / proved under package assumptions / proved wrappers / defined only の粒度で読める構成にしています。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/theorem-candidates/index.html`
- `website/sft/index.html`
- `website/sft/status/index.html`
- `website/sft/glossary/index.html`
- `website/sft/part-*/index.html`
- `website/sitemap.xml`

## 実施したテスト

- [ ] `lake build`（website-only 変更のため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（既存コメントの `unsafe drift` のみ検出）
- [x] Playwright file:// 確認: `website/sft/theorem-candidates/index.html`, `website/sft/index.html`, `website/sft/status/index.html` を desktop 1440px / mobile 390px で確認し、タイトル・H1・新ページ導線・横スクロールなしを確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている