### PR TITLE
SFT反例アンカーをPart I / IVに前面化する

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1193,6 +1193,7 @@ p {
 .term-list li,
 .status-list li {
   border-bottom: 1px solid var(--rule);
+  min-width: 0;
   padding: 18px 0;
 }
 
@@ -1219,6 +1220,13 @@ p {
   color: var(--ink-muted);
   font-size: 0.98rem;
   line-height: 1.48;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.article-main p code,
+.article-main li code {
+  overflow-wrap: anywhere;
 }
 
 .numbered-status-list {

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -81,6 +81,7 @@
                 <li><a href="#field-memory">Field memory</a></li>
                 <li><a href="#development-field">Development field</a></li>
                 <li><a href="#architecture-futures">Architecture futures</a></li>
+                <li><a href="#counterexample-anchor">Counterexample anchor</a></li>
                 <li><a href="#formal-anchors">Formal anchors</a></li>
                 <li><a href="#part-boundary">Boundary</a></li>
               </ol>
@@ -374,6 +375,42 @@ SoftwareFieldEstimate
                 <li>
                   <strong>Rounding obstruction</strong>
                   <span>Ambiguous currency semantics can become an obstruction witness candidate before implementation starts.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="counterexample-anchor" class="article-section">
+              <h2>First counterexample anchor</h2>
+              <p>
+                The first forbidden reading is endpoint-only safety. A
+                trajectory can start safe, end safe, and have zero selected
+                endpoint delta while still leaving the safe region along the
+                way. SFT therefore keeps the observed path visible instead of
+                replacing it with a final-state summary.
+              </p>
+              <p id="counterexample-i-7" class="statement">
+                <a class="statement-anchor" href="#counterexample-i-7">Counterexample I.7.</a>
+                <code>SFTCounterexamples.endpoint_safe_zero_delta_not_path_safe</code>
+                is a Lean proved wrapper showing that endpoint delta zero and
+                safe endpoints do not imply selected path safety.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Counterexample I.7">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-proved">Lean proved wrapper</span>
+                <span>Finite witness packaged by #920; see the <a href="../theorem-candidates/#counterexample-anchors">counterexample anchors</a>.</span>
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Endpoint is not path</strong>
+                  <span>A final signature and a net delta do not record intermediate excursions.</span>
+                </li>
+                <li>
+                  <strong>Current signature is not future trajectory</strong>
+                  <span><code>SFTCounterexamples.same_observed_signature_different_future_trajectory</code> separates present observation from future support and signature path.</span>
+                </li>
+                <li>
+                  <strong>Counterexample is not frequency</strong>
+                  <span>The Lean witness marks a forbidden inference; it does not estimate how often the pattern occurs in repositories.</span>
                 </li>
               </ul>
             </section>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -80,6 +80,7 @@
                 <li><a href="#cone-narrowing">Cone narrowing</a></li>
                 <li><a href="#support-safety">Support safety</a></li>
                 <li><a href="#proposal-accounting">Proposal accounting</a></li>
+                <li><a href="#counterexample-anchors">Counterexample anchors</a></li>
                 <li><a href="#feedback-update">Feedback update</a></li>
                 <li><a href="#stable-regions">Stable regions</a></li>
                 <li><a href="#principle-anchors">Anchors</a></li>
@@ -227,6 +228,15 @@
   + SupportOperationsPreserveSafeRegion(U, O, R)
   -> accepted trajectory remains in R</code></pre>
               </figure>
+              <div class="claim-strip">
+                <p>
+                  The counterexample
+                  <a href="#counterexample-anchors">below</a> keeps accepted
+                  preservation separate from support preservation. Evidence
+                  about accepted steps does not prove that every operation in
+                  the finite support preserves the selected safe region.
+                </p>
+              </div>
             </section>
 
             <section id="proposal-accounting" class="article-section">
@@ -266,6 +276,68 @@
     runtime_pressure_estimate
     unaccounted_remainder</code></pre>
               </figure>
+            </section>
+
+            <section id="counterexample-anchors" class="article-section">
+              <h2>Counterexample anchors</h2>
+              <p>
+                These anchors are the theorem-boundary checks behind the Part
+                IV schemas. They are finite Lean witnesses exposed through the
+                SFT-native counterexample package, not empirical degradation
+                claims or repository-frequency estimates.
+              </p>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved wrapper</span>
+                      <h3>Endpoint safety is not path safety</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <p>
+                    <code>SFTCounterexamples.endpoint_safe_zero_delta_not_path_safe</code>
+                    blocks the inference from safe endpoints and zero selected
+                    endpoint delta to whole-trajectory safety.
+                  </p>
+                </article>
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved wrapper</span>
+                      <h3>Accepted preservation is not support preservation</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <p>
+                    <code>SFTCounterexamples.accepted_preservation_not_support_preservation</code>
+                    separates governance evidence about accepted steps from a
+                    theorem that every supported operation preserves the
+                    selected safe region.
+                  </p>
+                </article>
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Lean proved wrapper</span>
+                      <h3>Same current signature is not same future trajectory</h3>
+                    </div>
+                    <span class="status-badge status-badge-proved">proved</span>
+                  </div>
+                  <p>
+                    <code>SFTCounterexamples.same_observed_signature_different_future_trajectory</code>
+                    keeps current observation, future operation support, and
+                    future signature trajectory as separate claims.
+                  </p>
+                </article>
+              </div>
+              <div class="claim-strip">
+                <p>
+                  See the <a href="../theorem-candidates/#counterexample-anchors">Theorem Candidates counterexample index</a>
+                  and the <a href="../status/#lean-roadmap">SFT Lean Roadmap</a>
+                  for the source-of-truth status vocabulary.
+                </p>
+              </div>
             </section>
 
             <section id="feedback-update" class="article-section">

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -280,7 +280,11 @@
                     future counterexamples, and observation-expansion shocks
                     are Lean-defined with proved finite witnesses. They show
                     bounded non-conclusions; they do not estimate frequency,
-                    operational incident risk, or extractor completeness.
+                    operational incident risk, or extractor completeness. The
+                    website foregrounds these as
+                    <a href="../part-i-new-object/#counterexample-anchor">Part I</a>
+                    and <a href="../part-iv-principles/#counterexample-anchors">Part IV</a>
+                    counterexample anchors.
                   </span>
                 </li>
                 <li>

--- a/website/sft/theorem-candidates/index.html
+++ b/website/sft/theorem-candidates/index.html
@@ -412,6 +412,14 @@
                 because it names forbidden readings directly. These are
                 finite Lean witnesses, not empirical claims.
               </p>
+              <div class="claim-strip">
+                <p>
+                  First reading points: Part I introduces the
+                  <a href="../part-i-new-object/#counterexample-anchor">endpoint/path anchor</a>,
+                  and Part IV connects support safety and proposal accounting
+                  to the <a href="../part-iv-principles/#counterexample-anchors">counterexample anchors</a>.
+                </p>
+              </div>
               <div class="theorem-card-list">
                 <article class="theorem-card lean-status-card">
                   <div class="theorem-card-header">


### PR DESCRIPTION
## 概要

Closes #930

- SFT Part I に endpoint safe + zero delta でも path safe ではない first counterexample anchor を追加しました。
- SFT Part IV に counterexample anchors 節を追加し、support safety / proposal accounting から accepted preservation と support preservation の分離へ接続しました。
- Theorem Candidates と Status から Part I / Part IV の counterexample anchor に到達できるようにし、長い Lean 名が mobile で横 overflow を作らないよう inline code の折り返しを調整しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/part-i-new-object/index.html`
- `website/sft/part-iv-principles/index.html`
- `website/sft/theorem-candidates/index.html`
- `website/sft/status/index.html`
- `website/assets/site.css`

## 実施したテスト

- [ ] `lake build`（website-only 変更のため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（変更 HTML 内の通常語 `unsafe` のみ検出）
- [x] Playwright file:// 確認: Part I / Part IV / Theorem Candidates / Status を desktop 1440px と mobile 390px で確認し、title / H1 / 横 overflow なし / 主要カード表示を確認
- [x] Playwright file:// リンク確認: 変更 4 ページのローカルリンクと counterexample anchor hash に missing file / missing hash がないことを確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている