### PR TITLE
SFT overviewに3分導入を追加する

### DIFF
--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -75,6 +75,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
+                <li><a href="#sft-in-one-sentence">SFT in one sentence</a></li>
                 <li><a href="#reading-order">Reading order</a></li>
                 <li><a href="#abstract">Abstract</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
@@ -148,10 +149,54 @@
           </aside>
 
           <div class="article-main">
+            <section id="sft-in-one-sentence" class="article-section">
+              <h2>SFT in one sentence</h2>
+              <p>
+                SFT studies how PRDs, issues, reviews, CI, AI proposals,
+                runtime feedback, and governance rules change the set of
+                supported software-evolution paths under an explicit modeling
+                boundary.
+              </p>
+              <div class="reader-model">
+                <div>
+                  <h3>What changes</h3>
+                  <p>
+                    An artifact does not choose one future. It can make some
+                    operation families supported, cheap, visible, or reviewable
+                    while leaving other paths unsupported or unknown.
+                  </p>
+                </div>
+                <div>
+                  <h3>What does not follow</h3>
+                  <p>
+                    A ForecastCone is not a point prediction, a
+                    ConsequenceEnvelope is not a causal proof, and ArchSig
+                    evidence is not a Lean theorem or a ground-truth extractor.
+                  </p>
+                </div>
+              </div>
+              <ul class="status-list">
+                <li>
+                  <strong>Inputs</strong>
+                  <span>PRDs, Issues, review traces, CI results, runtime observations, AI proposals, and selected codebase regions.</span>
+                </li>
+                <li>
+                  <strong>Modeling move</strong>
+                  <span>Name the field boundary, support relation, policy, observation axes, horizon, unavailable evidence, and unknown remainder.</span>
+                </li>
+                <li>
+                  <strong>Output surface</strong>
+                  <span>Reachable path classes, support estimates, ForecastCone candidates, ConsequenceEnvelope reports, and governance questions.</span>
+                </li>
+              </ul>
+            </section>
+
             <section id="reading-order" class="article-section">
               <h2>Reading order</h2>
               <p>
-                Start here for the full map, then read Part I and Part II
+                Read the short model above first: SFT is about supported
+                paths, costs, observations, and governance boundaries, not
+                about declaring a single future. Then read Part I and Part II
                 before using the core, computing-system, and case-study pages.
                 The SFT website is written as an independent monograph entry:
                 source documents remain available for audit, but the main


### PR DESCRIPTION
## 概要

Closes #925

- SFT overview の冒頭に `SFT in one sentence` を追加し、初見読者が PRD / Issue / review / CI / AI proposal を単一未来の決定ではなく supported paths / costs / observations / governance boundaries の変化として読める導線を追加しました。
- `ForecastCone`、`ConsequenceEnvelope`、ArchSig evidence の claim boundary を導入内で明示し、Reading order の冒頭もこの reader model を受ける構成へ整理しました。
- 計画変更: なし。期待する成果物である 3 分導入、claim boundary、ForecastCone / ConsequenceEnvelope への導線、mobile 表示確認をこの PR で扱っています。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/index.html`

## 実施したテスト

- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `LC_ALL=C rg -n "[\x{200B}\x{200C}\x{200D}\x{200E}\x{200F}\x{202A}\x{202B}\x{202C}\x{202D}\x{202E}\x{2066}\x{2067}\x{2068}\x{2069}\x{FEFF}]" website/sft/index.html`
- [x] Playwright static check: desktop / mobile で `website/sft/index.html` の intro 表示、次ページリンク、横スクロールなしを確認
- [ ] `lake build`: website-only 変更のため未実施
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan: Lean 変更なしのため未実施

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
