### PR TITLE
SFTの横長比較表をsemantic card化する

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1323,6 +1323,85 @@ p {
   margin: 0;
 }
 
+.claim-pairs,
+.comparison-cards,
+.boundary-list {
+  display: grid;
+  gap: 14px;
+  margin: 18px 0 20px;
+  padding: 0;
+  list-style: none;
+}
+
+.claim-pair,
+.comparison-card,
+.boundary-list li {
+  border: 1px solid var(--rule);
+  border-left: 5px solid var(--accent-blue);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 18px;
+}
+
+.claim-pair {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.claim-pair > div,
+.comparison-card,
+.boundary-list li {
+  min-width: 0;
+}
+
+.claim-pair h3,
+.comparison-card h3,
+.boundary-list h3 {
+  margin: 0 0 8px;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 0.98rem;
+  font-weight: 850;
+  line-height: 1.24;
+}
+
+.claim-pair h4,
+.comparison-card dt {
+  margin: 0;
+  color: var(--accent-blue);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.claim-pair p,
+.comparison-card dd,
+.boundary-list p {
+  margin: 4px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.96rem;
+  line-height: 1.48;
+}
+
+.comparison-card dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px 18px;
+  margin: 0;
+}
+
+.comparison-card dl > div {
+  min-width: 0;
+}
+
+.comparison-card code,
+.boundary-list code {
+  overflow-wrap: anywhere;
+}
+
 .definition-list {
   padding-left: 0;
 }
@@ -1827,6 +1906,14 @@ p {
     grid-template-columns: 1fr;
   }
 
+  .claim-pair {
+    grid-template-columns: 1fr;
+  }
+
+  .comparison-card dl {
+    grid-template-columns: 1fr;
+  }
+
   h1 {
     font-size: clamp(2.62rem, 12vw, 4.2rem);
   }
@@ -1971,6 +2058,12 @@ p {
   }
 
   .theorem-card {
+    padding: 16px 14px;
+  }
+
+  .claim-pair,
+  .comparison-card,
+  .boundary-list li {
     padding: 16px 14px;
   }
 

--- a/website/sft/glossary/index.html
+++ b/website/sft/glossary/index.html
@@ -104,111 +104,223 @@
           <div class="article-main">
             <section id="reader-model" class="article-section">
               <h2>Reader model</h2>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>SFT does not say</th>
-                      <th>SFT says</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>Software evolution is governed by physical laws.</td>
-                      <td>Software evolution can be modeled as bounded computation over selected artifacts, practices, policies, observations, and feedback.</td>
-                    </tr>
-                    <tr>
-                      <td>A forecast is a single predicted future.</td>
-                      <td>A forecast is set-valued or report-valued under an explicit horizon, support relation, policy, and observation boundary.</td>
-                    </tr>
-                    <tr>
-                      <td>Tool output is an architecture theorem.</td>
-                      <td>Tool output is an observation, estimate, report, or review artifact with non-conclusions attached.</td>
-                    </tr>
-                    <tr>
-                      <td>Organization culture and human intention are fully modeled.</td>
-                      <td>The model records selected evidence and preserves unknown or unmodeled remainder.</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="claim-pairs" aria-label="SFT glossary reader model">
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>Software evolution is governed by physical laws.</p>
+                  </div>
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>Software evolution can be modeled as bounded computation over selected artifacts, practices, policies, observations, and feedback.</p>
+                  </div>
+                </article>
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>A forecast is a single predicted future.</p>
+                  </div>
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>A forecast is set-valued or report-valued under an explicit horizon, support relation, policy, and observation boundary.</p>
+                  </div>
+                </article>
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>Tool output is an architecture theorem.</p>
+                  </div>
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>Tool output is an observation, estimate, report, or review artifact with non-conclusions attached.</p>
+                  </div>
+                </article>
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>Organization culture and human intention are fully modeled.</p>
+                  </div>
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>The model records selected evidence and preserves unknown or unmodeled remainder.</p>
+                  </div>
+                </article>
               </div>
             </section>
 
             <section id="term-boundary" class="article-section">
               <h2>Term boundary</h2>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Term</th>
-                      <th>Formal or computational reading</th>
-                      <th>Avoided reading</th>
-                      <th>Related parts</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th><code>field</code></th>
-                      <td>A selected development context or <code>SoftwareField</code> slice containing codebase memory, artifacts, support, policy, observations, and feedback.</td>
-                      <td>A physical field or complete model of the organization.</td>
-                      <td><a href="../part-i-new-object/">Part I</a>, <a href="../part-iii-core/">Part III</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>force</code></th>
-                      <td>An informal name for artifact-mediated pressure that changes candidate field updates, operation support, policy, or observation components.</td>
-                      <td>A physical vector quantity or deterministic cause.</td>
-                      <td><a href="../part-iii-core/#artifact-action">Part III</a>, <a href="../part-vi-case-studies/">Part VI</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>dissipation</code></th>
-                      <td>Loss, leakage, or untracked remainder across a bounded model, such as missing evidence, review rework, or unobserved risk.</td>
-                      <td>Thermodynamic dissipation or automatic degradation law.</td>
-                      <td><a href="../status/#forecast-boundary">Status</a>, <a href="../part-vii-research-program/">Part VII</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>attractor</code></th>
-                      <td>A stable or preferred region only when stability, recurrence, policy, or probability semantics are supplied.</td>
-                      <td>A guaranteed destination or informal label for any good design.</td>
-                      <td><a href="../part-iv-principles/">Part IV</a>, <a href="../status/">Status</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>basin</code></th>
-                      <td>A reachable preimage or region of support that tends toward a selected stable region under named semantics.</td>
-                      <td>A vague danger zone without a transition, support, or policy definition.</td>
-                      <td><a href="../part-iv-principles/">Part IV</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>ForecastCone</code></th>
-                      <td>A set of reachable field paths relative to a field model, operation support, policy, horizon, and observation boundary.</td>
-                      <td>A point prediction, empirical forecast, or global risk proof without calibration.</td>
-                      <td><a href="../part-iii-core/">Part III</a>, <a href="../status/#forecast-boundary">Status</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>ConsequenceEnvelope</code></th>
-                      <td>A report form that summarizes selected cones, path classes, affected axes, witnesses, missing evidence, and non-conclusions.</td>
-                      <td>A Lean proof, causal proof, or complete impact analysis.</td>
-                      <td><a href="../part-v-computing-systems/">Part V</a>, <a href="../part-vi-case-studies/">Part VI</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>support</code></th>
-                      <td>The operation family considered possible, natural, low-cost, accepted, or generated under an explicit field model.</td>
-                      <td>Universal permission or proof that unsupported paths cannot occur in reality.</td>
-                      <td><a href="../part-iii-core/">Part III</a>, <a href="../part-iv-principles/">Part IV</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>policy</code></th>
-                      <td>A selection, preorder, cost, review, CI, AI, or governance rule over supported operations.</td>
-                      <td>A guarantee that all future choices are safe or compliant.</td>
-                      <td><a href="../part-iii-core/">Part III</a>, <a href="../part-v-computing-systems/">Part V</a></td>
-                    </tr>
-                    <tr>
-                      <th><code>calibration</code></th>
-                      <td>Comparison of forecast reports or model outputs against trace, PR, review, CI, incident, or dataset evidence.</td>
-                      <td>Proof of causality, universal validity, or Lean theorem status.</td>
-                      <td><a href="../part-v-computing-systems/">Part V</a>, <a href="../part-vii-research-program/">Part VII</a></td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="comparison-cards" aria-label="Term boundary">
+                <article class="comparison-card">
+                  <h3><code>field</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>A selected development context or <code>SoftwareField</code> slice containing codebase memory, artifacts, support, policy, observations, and feedback.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A physical field or complete model of the organization.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-i-new-object/">Part I</a>, <a href="../part-iii-core/">Part III</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>force</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>An informal name for artifact-mediated pressure that changes candidate field updates, operation support, policy, or observation components.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A physical vector quantity or deterministic cause.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-iii-core/#artifact-action">Part III</a>, <a href="../part-vi-case-studies/">Part VI</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>dissipation</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>Loss, leakage, or untracked remainder across a bounded model, such as missing evidence, review rework, or unobserved risk.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>Thermodynamic dissipation or automatic degradation law.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../status/#forecast-boundary">Status</a>, <a href="../part-vii-research-program/">Part VII</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>attractor</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>A stable or preferred region only when stability, recurrence, policy, or probability semantics are supplied.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A guaranteed destination or informal label for any good design.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-iv-principles/">Part IV</a>, <a href="../status/">Status</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>basin</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>A reachable preimage or region of support that tends toward a selected stable region under named semantics.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A vague danger zone without a transition, support, or policy definition.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-iv-principles/">Part IV</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>ForecastCone</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>A set of reachable field paths relative to a field model, operation support, policy, horizon, and observation boundary.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A point prediction, empirical forecast, or global risk proof without calibration.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-iii-core/">Part III</a>, <a href="../status/#forecast-boundary">Status</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>ConsequenceEnvelope</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>A report form that summarizes selected cones, path classes, affected axes, witnesses, missing evidence, and non-conclusions.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A Lean proof, causal proof, or complete impact analysis.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-v-computing-systems/">Part V</a>, <a href="../part-vi-case-studies/">Part VI</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>support</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>The operation family considered possible, natural, low-cost, accepted, or generated under an explicit field model.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>Universal permission or proof that unsupported paths cannot occur in reality.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-iii-core/">Part III</a>, <a href="../part-iv-principles/">Part IV</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>policy</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>A selection, preorder, cost, review, CI, AI, or governance rule over supported operations.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>A guarantee that all future choices are safe or compliant.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-iii-core/">Part III</a>, <a href="../part-v-computing-systems/">Part V</a></dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>calibration</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Formal reading</dt>
+                      <dd>Comparison of forecast reports or model outputs against trace, PR, review, CI, incident, or dataset evidence.</dd>
+                    </div>
+                    <div>
+                      <dt>Avoided reading</dt>
+                      <dd>Proof of causality, universal validity, or Lean theorem status.</dd>
+                    </div>
+                    <div>
+                      <dt>Related parts</dt>
+                      <dd><a href="../part-v-computing-systems/">Part V</a>, <a href="../part-vii-research-program/">Part VII</a></dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -114,34 +114,47 @@
                 to check what SFT is allowed to inherit from AAT, what SFT adds
                 on its own side, and which readings are explicitly blocked.
               </p>
-              <div class="article-table">
-                <table>
-                  <caption>SFT says / SFT does not say</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">SFT says</th>
-                      <th scope="col">SFT does not say</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>AAT supplies local algebra, theorem boundaries, and selected non-conclusions.</td>
-                      <td>AAT theorem status automatically becomes empirical forecast status.</td>
-                    </tr>
-                    <tr>
-                      <td>AAT claims may be used as local premises inside bounded SFT reachability or safety schemas.</td>
-                      <td>AAT lawfulness alone proves future trajectory safety for a software field.</td>
-                    </tr>
-                    <tr>
-                      <td>ArchSig supplies measured axes, missing axes, evidence boundaries, and tooling estimates.</td>
-                      <td>ArchSig output is a ground-truth architecture object or a Lean theorem.</td>
-                    </tr>
-                    <tr>
-                      <td>SFT introduces field state, trajectories, forecast boundaries, and feedback governance.</td>
-                      <td>SFT redefines AAT concepts or makes AAT depend on software-field dynamics.</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="claim-pairs" aria-label="SFT says and SFT does not say">
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>AAT supplies local algebra, theorem boundaries, and selected non-conclusions.</p>
+                  </div>
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>AAT theorem status automatically becomes empirical forecast status.</p>
+                  </div>
+                </article>
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>AAT claims may be used as local premises inside bounded SFT reachability or safety schemas.</p>
+                  </div>
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>AAT lawfulness alone proves future trajectory safety for a software field.</p>
+                  </div>
+                </article>
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>ArchSig supplies measured axes, missing axes, evidence boundaries, and tooling estimates.</p>
+                  </div>
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>ArchSig output is a ground-truth architecture object or a Lean theorem.</p>
+                  </div>
+                </article>
+                <article class="claim-pair">
+                  <div>
+                    <h3>SFT says</h3>
+                    <p>SFT introduces field state, trajectories, forecast boundaries, and feedback governance.</p>
+                  </div>
+                  <div>
+                    <h3>SFT does not say</h3>
+                    <p>SFT redefines AAT concepts or makes AAT depend on software-field dynamics.</p>
+                  </div>
+                </article>
               </div>
             </section>
 
@@ -258,44 +271,72 @@ local path skeleton      -> ArchitecturePath</code></pre>
                 They may use AAT projections and ArchSig observations, but they
                 are not AAT definitions.
               </p>
-              <div class="article-table">
-                <table>
-                  <caption>Concepts introduced by SFT</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">SFT concept</th>
-                      <th scope="col">Role</th>
-                      <th scope="col">Boundary</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th scope="row">field state / <code>SoftwareField</code></th>
-                      <td>The selected computable state of a development field.</td>
-                      <td>It is not itself an AAT <code>ArchitectureObject</code>; AAT sees the architecture projection.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">trajectory</th>
-                      <td>A modeled sequence or set of possible field transitions.</td>
-                      <td>It is not proven safe by local AAT lawfulness alone.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row"><code>ForecastCone</code></th>
-                      <td>A bounded set of possible future states under stated support.</td>
-                      <td>Cone narrowing is not global risk reduction without calibration and stated axes.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row"><code>ConsequenceEnvelope</code></th>
-                      <td>A boundary-aware report of expected effects, missing axes, and non-conclusions.</td>
-                      <td>It is a forecast artifact, not a theorem unless separately formalized as a schema.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">field update / feedback governance</th>
-                      <td>Rules for updating estimates and review policy from observations.</td>
-                      <td>Operational usefulness does not promote correlation to a formal or causal claim.</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="comparison-cards" aria-label="Concepts introduced by SFT">
+                <article class="comparison-card">
+                  <h3>field state / <code>SoftwareField</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Role</dt>
+                      <dd>The selected computable state of a development field.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>It is not itself an AAT <code>ArchitectureObject</code>; AAT sees the architecture projection.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>trajectory</h3>
+                  <dl>
+                    <div>
+                      <dt>Role</dt>
+                      <dd>A modeled sequence or set of possible field transitions.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>It is not proven safe by local AAT lawfulness alone.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>ForecastCone</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Role</dt>
+                      <dd>A bounded set of possible future states under stated support.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Cone narrowing is not global risk reduction without calibration and stated axes.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3><code>ConsequenceEnvelope</code></h3>
+                  <dl>
+                    <div>
+                      <dt>Role</dt>
+                      <dd>A boundary-aware report of expected effects, missing axes, and non-conclusions.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>It is a forecast artifact, not a theorem unless separately formalized as a schema.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>field update / feedback governance</h3>
+                  <dl>
+                    <div>
+                      <dt>Role</dt>
+                      <dd>Rules for updating estimates and review policy from observations.</dd>
+                    </div>
+                    <div>
+                      <dt>Boundary</dt>
+                      <dd>Operational usefulness does not promote correlation to a formal or causal claim.</dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 
@@ -386,49 +427,85 @@ local path skeleton      -> ArchitecturePath</code></pre>
                 Local architecture facts do not become global software-history
                 facts merely because they are useful premises in an SFT model.
               </p>
-              <div class="article-table">
-                <table>
-                  <caption>Claim-preserving readings and blocked promotions</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">AAT / tooling fact</th>
-                      <th scope="col">Allowed SFT reading</th>
-                      <th scope="col">Forbidden reading</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th scope="row">selected witness absence</th>
-                      <td>A selected local defect is not observed under the current measurement universe.</td>
-                      <td>Future trajectory safety, or absence of all latent action.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">signature axis zero / measured zero</th>
-                      <td>A selected measured coordinate is zero.</td>
-                      <td>Unmeasured axes are also safe or zero.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">operation preserves invariant</th>
-                      <td>One accepted transition is locally admissible under stated assumptions.</td>
-                      <td>The policy, organization, or future trajectory is globally safe.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">theorem boundary</th>
-                      <td>A premise boundary for SFT reachability or safety schema.</td>
-                      <td>An empirical prediction theorem.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">observed signature delta</th>
-                      <td>A comparable axis-wise trajectory observation.</td>
-                      <td>A unique causal identification of the artifact action.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">ArchSig extraction</th>
-                      <td>A tooling estimate with measured axes and non-conclusions.</td>
-                      <td>A ground-truth architecture object or a Lean proof.</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="comparison-cards" aria-label="Claim-preserving readings and blocked promotions">
+                <article class="comparison-card">
+                  <h3>selected witness absence</h3>
+                  <dl>
+                    <div>
+                      <dt>Allowed SFT reading</dt>
+                      <dd>A selected local defect is not observed under the current measurement universe.</dd>
+                    </div>
+                    <div>
+                      <dt>Forbidden reading</dt>
+                      <dd>Future trajectory safety, or absence of all latent action.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>signature axis zero / measured zero</h3>
+                  <dl>
+                    <div>
+                      <dt>Allowed SFT reading</dt>
+                      <dd>A selected measured coordinate is zero.</dd>
+                    </div>
+                    <div>
+                      <dt>Forbidden reading</dt>
+                      <dd>Unmeasured axes are also safe or zero.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>operation preserves invariant</h3>
+                  <dl>
+                    <div>
+                      <dt>Allowed SFT reading</dt>
+                      <dd>One accepted transition is locally admissible under stated assumptions.</dd>
+                    </div>
+                    <div>
+                      <dt>Forbidden reading</dt>
+                      <dd>The policy, organization, or future trajectory is globally safe.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>theorem boundary</h3>
+                  <dl>
+                    <div>
+                      <dt>Allowed SFT reading</dt>
+                      <dd>A premise boundary for SFT reachability or safety schema.</dd>
+                    </div>
+                    <div>
+                      <dt>Forbidden reading</dt>
+                      <dd>An empirical prediction theorem.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>observed signature delta</h3>
+                  <dl>
+                    <div>
+                      <dt>Allowed SFT reading</dt>
+                      <dd>A comparable axis-wise trajectory observation.</dd>
+                    </div>
+                    <div>
+                      <dt>Forbidden reading</dt>
+                      <dd>A unique causal identification of the artifact action.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>ArchSig extraction</h3>
+                  <dl>
+                    <div>
+                      <dt>Allowed SFT reading</dt>
+                      <dd>A tooling estimate with measured axes and non-conclusions.</dd>
+                    </div>
+                    <div>
+                      <dt>Forbidden reading</dt>
+                      <dd>A ground-truth architecture object or a Lean proof.</dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
               <ul class="term-list">
                 <li>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -152,50 +152,92 @@
                 signature trajectories, and consequence envelopes describe
                 reachable architecture futures.
               </p>
-              <div class="article-table">
-                <table>
-                  <caption>SFT compared with nearby frameworks</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">Nearby frame</th>
-                      <th scope="col">What it usually emphasizes</th>
-                      <th scope="col">What SFT adds</th>
-                      <th scope="col">Blocked reading</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th scope="row">Static metric</th>
-                      <td>A snapshot score or selected architecture coordinate.</td>
-                      <td>Trajectory, support, missing axes, and field updates across changes.</td>
-                      <td>A single number is not architecture quality.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Process model</th>
-                      <td>Stages, roles, handoffs, and delivery practice.</td>
-                      <td>The effect of artifacts and feedback on reachable architecture futures.</td>
-                      <td>Process maturity is not field lawfulness.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Technical debt taxonomy</th>
-                      <td>Named debt classes and remediation categories.</td>
-                      <td>Obstruction witnesses, affected axes, support constraints, and consequence envelopes.</td>
-                      <td>A taxonomy label is not a causal proof.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">AI benchmark</th>
-                      <td>Model performance on coding or review tasks.</td>
-                      <td>Proposal support, shortcut witnesses, policy boundaries, and review / CI feedback updates.</td>
-                      <td>AI policy compliance is not architecture lawfulness.</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Formal verification</th>
-                      <td>Checked local statements under explicit assumptions.</td>
-                      <td>A way to carry those theorem boundaries into forecast and governance reports.</td>
-                      <td>Local theorem status is not future trajectory safety.</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="comparison-cards" aria-label="SFT compared with nearby frameworks">
+                <article class="comparison-card">
+                  <h3>Static metric</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>A snapshot score or selected architecture coordinate.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>Trajectory, support, missing axes, and field updates across changes.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>A single number is not architecture quality.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>Process model</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>Stages, roles, handoffs, and delivery practice.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>The effect of artifacts and feedback on reachable architecture futures.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>Process maturity is not field lawfulness.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>Technical debt taxonomy</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>Named debt classes and remediation categories.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>Obstruction witnesses, affected axes, support constraints, and consequence envelopes.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>A taxonomy label is not a causal proof.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>AI benchmark</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>Model performance on coding or review tasks.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>Proposal support, shortcut witnesses, policy boundaries, and review / CI feedback updates.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>AI policy compliance is not architecture lawfulness.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>Formal verification</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>Checked local statements under explicit assumptions.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>A way to carry those theorem boundaries into forecast and governance reports.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>Local theorem status is not future trajectory safety.</dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -142,55 +142,109 @@
 
             <section id="claim-level-map" class="article-section">
               <h2>Claim level map</h2>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Level</th>
-                      <th>Readable claim</th>
-                      <th>Required boundary</th>
-                      <th>Not concluded</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>L0</td>
-                      <td>Conceptual or diagnostic interpretation.</td>
-                      <td>Named vocabulary, non-conclusions, and scope.</td>
-                      <td>Reachability, proof, or prediction.</td>
-                    </tr>
-                    <tr>
-                      <td>L1</td>
-                      <td>Trace-grounded field diagnosis.</td>
-                      <td>Artifact, trace, measurement, and missing-data boundary.</td>
-                      <td>Causal uniqueness or global completeness.</td>
-                    </tr>
-                    <tr>
-                      <td>L2</td>
-                      <td>Set-valued theorem schema.</td>
-                      <td>Support relation, step semantics, horizon, and observation axes.</td>
-                      <td>Probability, accuracy, or deployed safety.</td>
-                    </tr>
-                    <tr>
-                      <td>L3</td>
-                      <td>Transition-kernel or stochastic model claim.</td>
-                      <td>Transition kernel, assumptions, and inference rule.</td>
-                      <td>Dataset-calibrated correctness.</td>
-                    </tr>
-                    <tr>
-                      <td>L4</td>
-                      <td>Calibrated empirical forecast.</td>
-                      <td>Dataset, calibration protocol, held-out evidence, and failure modes.</td>
-                      <td>Lean theorem status or causal proof.</td>
-                    </tr>
-                    <tr>
-                      <td>Ops</td>
-                      <td>Deployed governance or review workflow.</td>
-                      <td>Policy, threshold, feedback loop, ownership, and audit record.</td>
-                      <td>Universal safety or market outcome prediction.</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <div class="comparison-cards" aria-label="Claim level map">
+                <article class="comparison-card">
+                  <h3>L0</h3>
+                  <dl>
+                    <div>
+                      <dt>Readable claim</dt>
+                      <dd>Conceptual or diagnostic interpretation.</dd>
+                    </div>
+                    <div>
+                      <dt>Required boundary</dt>
+                      <dd>Named vocabulary, non-conclusions, and scope.</dd>
+                    </div>
+                    <div>
+                      <dt>Not concluded</dt>
+                      <dd>Reachability, proof, or prediction.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>L1</h3>
+                  <dl>
+                    <div>
+                      <dt>Readable claim</dt>
+                      <dd>Trace-grounded field diagnosis.</dd>
+                    </div>
+                    <div>
+                      <dt>Required boundary</dt>
+                      <dd>Artifact, trace, measurement, and missing-data boundary.</dd>
+                    </div>
+                    <div>
+                      <dt>Not concluded</dt>
+                      <dd>Causal uniqueness or global completeness.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>L2</h3>
+                  <dl>
+                    <div>
+                      <dt>Readable claim</dt>
+                      <dd>Set-valued theorem schema.</dd>
+                    </div>
+                    <div>
+                      <dt>Required boundary</dt>
+                      <dd>Support relation, step semantics, horizon, and observation axes.</dd>
+                    </div>
+                    <div>
+                      <dt>Not concluded</dt>
+                      <dd>Probability, accuracy, or deployed safety.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>L3</h3>
+                  <dl>
+                    <div>
+                      <dt>Readable claim</dt>
+                      <dd>Transition-kernel or stochastic model claim.</dd>
+                    </div>
+                    <div>
+                      <dt>Required boundary</dt>
+                      <dd>Transition kernel, assumptions, and inference rule.</dd>
+                    </div>
+                    <div>
+                      <dt>Not concluded</dt>
+                      <dd>Dataset-calibrated correctness.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>L4</h3>
+                  <dl>
+                    <div>
+                      <dt>Readable claim</dt>
+                      <dd>Calibrated empirical forecast.</dd>
+                    </div>
+                    <div>
+                      <dt>Required boundary</dt>
+                      <dd>Dataset, calibration protocol, held-out evidence, and failure modes.</dd>
+                    </div>
+                    <div>
+                      <dt>Not concluded</dt>
+                      <dd>Lean theorem status or causal proof.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>Ops</h3>
+                  <dl>
+                    <div>
+                      <dt>Readable claim</dt>
+                      <dd>Deployed governance or review workflow.</dd>
+                    </div>
+                    <div>
+                      <dt>Required boundary</dt>
+                      <dd>Policy, threshold, feedback loop, ownership, and audit record.</dd>
+                    </div>
+                    <div>
+                      <dt>Not concluded</dt>
+                      <dd>Universal safety or market outcome prediction.</dd>
+                    </div>
+                  </dl>
+                </article>
               </div>
             </section>
 


### PR DESCRIPTION
## 概要

Closes #926

SFT website の重要な横長比較表を、モバイルとスクリーンリーダーで縦に読みやすい semantic card / pair 表現へ置き換えました。

- 共通 CSS に `claim-pairs` / `comparison-cards` / `boundary-list` を追加
- Part II の `SFT says / SFT does not say`、SFT-side concepts、forbidden readings を card 化
- Glossary の reader model と term boundary を card 化
- Status の claim level map を card 化
- Part VII の nearby framework 比較を card 化
- 表として意味が残る対応表・contract 表は残しています

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/part-ii-basis/index.html`
- `website/sft/glossary/index.html`
- `website/sft/status/index.html`
- `website/sft/part-vii-research-program/index.html`
- `website/assets/site.css`

## 実施したテスト

- [ ] `lake build`（website-only 変更のため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] Playwright で desktop / mobile の SFT Part II, Glossary, Status, Part VII を確認し、横スクロールなしを確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている