### PR TITLE
AATとArchSigとSFTの役割コピーを揃える

### DIFF
--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -90,6 +90,7 @@
               <ol>
                 <li><a href="#reading-order">Reading order</a></li>
                 <li><a href="#abstract">Abstract</a></li>
+                <li><a href="#division-of-work">AAT / ArchSig / SFT</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
                 <li><a href="#formal-anchor">Formal anchor</a></li>
                 <li><a href="#worked-example">Worked example</a></li>
@@ -229,6 +230,30 @@
                 measured, what was not measured, and which theorem package
                 licenses the conclusion.
               </p>
+            </section>
+
+            <section id="division-of-work" class="article-section">
+              <h2>AAT / ArchSig / SFT</h2>
+              <p>
+                AAT is the local algebra of architectural change. ArchSig is
+                the observation layer for signatures and witnesses. SFT uses
+                those bounded observations and AAT premises for field-shaped
+                computation over future architectural trajectories.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>AAT</strong>
+                  <span>Local algebra of architectural change under selected universe, assumptions, coverage, exactness, and non-conclusions.</span>
+                </li>
+                <li>
+                  <strong>ArchSig</strong>
+                  <span>Observation layer for signatures and witnesses, not a Lean proof engine or complete extractor.</span>
+                </li>
+                <li>
+                  <strong>SFT</strong>
+                  <span>Field-shaped computation over future architectural trajectories, not an empirical prediction theorem by itself.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="main-contributions" class="article-section">

--- a/website/archsig/index.html
+++ b/website/archsig/index.html
@@ -62,7 +62,10 @@
           <p class="eyebrow">ArchSig Manual</p>
           <h1>Architecture Signature tooling with explicit claim boundaries.</h1>
           <p class="lede">
-            ArchSig turns repository artifacts into bounded signature, report, workflow, and forecasting artifacts. It is a manual and reference section for using those artifacts without turning measurement output into Lean theorem status.
+            ArchSig is the observation layer for signatures and witnesses. It
+            turns repository artifacts into bounded signature, report, workflow,
+            and forecasting artifacts without turning measurement output into
+            Lean theorem status.
           </p>
         </div>
       </section>
@@ -118,9 +121,11 @@
               <h2>Reading order</h2>
               <p>
                 ArchSig is the observation and reporting layer for AAT / SFT.
-                Start with the minimal scan path, then read command and
-                artifact references before using reports for PR review or
-                SFT forecasting.
+                AAT provides the local algebra of architectural change, while
+                SFT reads selected observations as field-shaped computation
+                over future architectural trajectories. Start with the minimal
+                scan path, then read command and artifact references before
+                using reports for PR review or SFT forecasting.
               </p>
               <ul class="chapter-list">
                 <li>
@@ -170,6 +175,20 @@
                 same CLI family exposes four surfaces with different evidence
                 and claim boundaries.
               </p>
+              <ul class="term-list">
+                <li>
+                  <strong>AAT</strong>
+                  <span>Local algebra of architectural change.</span>
+                </li>
+                <li>
+                  <strong>ArchSig</strong>
+                  <span>Observation layer for signatures and witnesses.</span>
+                </li>
+                <li>
+                  <strong>SFT</strong>
+                  <span>Field-shaped computation over future architectural trajectories.</span>
+                </li>
+              </ul>
               <ul class="status-list">
                 <li>
                   <strong>ArchSig Core</strong>

--- a/website/index.html
+++ b/website/index.html
@@ -93,6 +93,20 @@
               preservation, obstruction witnesses, signature trajectories, and
               bounded software evolution.
             </p>
+            <ul class="status-list">
+              <li>
+                <strong>AAT</strong>
+                <span>Local algebra of architectural change.</span>
+              </li>
+              <li>
+                <strong>ArchSig</strong>
+                <span>Observation layer for signatures and witnesses.</span>
+              </li>
+              <li>
+                <strong>SFT</strong>
+                <span>Field-shaped computation over future architectural trajectories.</span>
+              </li>
+            </ul>
           </div>
           <aside class="hero-aside author-card" aria-labelledby="author-title">
             <h2 id="author-title">Author</h2>
@@ -117,8 +131,9 @@
           </div>
           <div class="research-detail">
             <p>
-              AAT turns design judgment into local questions: what object,
-              what operation, what invariant, what witness.
+              AAT is the local algebra of architectural change. It turns
+              design judgment into local questions: what object, what
+              operation, what invariant, what witness.
             </p>
             <a class="research-primary-link" href="aat/">Read AAT overview</a>
             <nav class="chapter-link-list" aria-label="AAT chapters">
@@ -150,10 +165,10 @@
           </div>
           <div class="research-detail">
             <p>
-              SFT asks how present artifacts shape the changes that become
-              easier, harder, safer, or more costly next. Its AAT interface is
-              handled inside Part II as the dependency and claim-boundary
-              discipline.
+              SFT is field-shaped computation over future architectural
+              trajectories: how present artifacts make changes easier, harder,
+              safer, or more costly next. Its AAT interface is handled inside
+              Part II as the dependency and claim-boundary discipline.
             </p>
             <a class="research-primary-link" href="sft/">Read SFT overview</a>
             <nav class="chapter-link-list" aria-label="SFT chapters">
@@ -182,8 +197,8 @@
           </div>
           <div class="research-detail">
             <p>
-              ArchSig keeps observation useful by keeping non-conclusions
-              visible.
+              ArchSig is the observation layer for signatures and witnesses.
+              It keeps reports useful by keeping non-conclusions visible.
             </p>
             <a class="research-primary-link" href="archsig/">Read ArchSig manual</a>
             <nav class="chapter-link-list" aria-label="ArchSig chapters">

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -314,22 +314,36 @@
               <h2>AAT / ArchSig / SFT</h2>
               <p>
                 SFT uses AAT and ArchSig, but it keeps their claim levels
-                separate. AAT supplies local algebra and theorem boundaries.
-                ArchSig supplies observations, signatures, witness candidates,
-                evidence status, and field estimates. SFT uses those inputs to
-                model reachable software-evolution futures under stated
-                support, policy, and forecast boundaries.
+                separate. AAT is the local algebra of architectural change.
+                ArchSig is the observation layer for signatures and witnesses.
+                SFT is field-shaped computation over future architectural
+                trajectories under stated support, policy, and forecast
+                boundaries.
               </p>
+              <ul class="term-list">
+                <li>
+                  <strong>AAT</strong>
+                  <span>Local algebra of architectural change.</span>
+                </li>
+                <li>
+                  <strong>ArchSig</strong>
+                  <span>Observation layer for signatures and witnesses.</span>
+                </li>
+                <li>
+                  <strong>SFT</strong>
+                  <span>Field-shaped computation over future architectural trajectories.</span>
+                </li>
+              </ul>
               <figure class="code-panel">
                 <figcaption>Division of work</figcaption>
                 <pre><code>AAT
-  -> local algebra of architecture
+  -> local algebra of architectural change
 
 ArchSig
-  -> observable signatures, witnesses, and field estimates
+  -> observation layer for signatures and witnesses
 
 SFT
-  -> bounded computation over reachable architecture futures</code></pre>
+  -> field-shaped computation over future architectural trajectories</code></pre>
               </figure>
               <ul class="term-list">
                 <li>


### PR DESCRIPTION
## 概要

Closes #924

- Home / AAT / SFT / ArchSig entry pages に、AAT / ArchSig / SFT の短い役割コピーを同じ語彙で配置しました。
- AAT を local algebra、ArchSig を observation layer、SFT を field-shaped computation として整理し、Lean proof engine / ground-truth extractor / empirical prediction theorem への昇格を避ける境界文を残しました。
- 大規模 redesign は行わず、既存の term-list / status-list 表現に合わせました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/index.html`
- `website/aat/index.html`
- `website/sft/index.html`
- `website/archsig/index.html`

## 実施したテスト

- [x] Playwright static check: Home / AAT / SFT / ArchSig entry pages を desktop 1366x900 と mobile 390x844 で確認
  - 三者コピー欠落なし
  - horizontal overflow なし
  - root-absolute asset/link なし
  - console error / warning なし
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #924` 形式で本文に記載した
- [x] Lean status を website copy tracking として扱い、Lean theorem へ昇格していない
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
