### PR TITLE
SFT websiteを第一級文書に合わせて拡充

### DIFF
--- a/website/sft/glossary/index.html
+++ b/website/sft/glossary/index.html
@@ -89,7 +89,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>

--- a/website/sft/glossary/index.html
+++ b/website/sft/glossary/index.html
@@ -80,7 +80,6 @@
                 <li><a href="#term-boundary">Term boundary</a></li>
                 <li><a href="#core-distinctions">Core distinctions</a></li>
                 <li><a href="#division-of-work">AAT / ArchSig / SFT</a></li>
-                <li><a href="#source-references">Source references</a></li>
               </ol>
             </nav>
             <div class="source-panel" data-sidebar-open="true">
@@ -376,24 +375,6 @@
                   </tbody>
                 </table>
               </div>
-            </section>
-
-            <section id="source-references" class="article-section">
-              <h2>Source references</h2>
-              <ul class="term-list">
-                <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/aeb84341e0cca42b98dde5795740209e230d2fc9/docs/sft/software_field_theory.md">SFT monograph source</a></strong>
-                  <span>Defines the field vocabulary, computable core, ForecastCone, ConsequenceEnvelope, support, policy, calibration, and non-conclusions.</span>
-                </li>
-                <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/aeb84341e0cca42b98dde5795740209e230d2fc9/docs/sft/aat_interface.md">AAT / SFT interface source</a></strong>
-                  <span>Defines one-way dependency, translation rules, forbidden readings, and the ArchSig bridge.</span>
-                </li>
-                <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/aeb84341e0cca42b98dde5795740209e230d2fc9/docs/tool/README.md">Tooling source</a></strong>
-                  <span>Separates ArchSig Core, Review, SFT, and Operational surfaces from proof and causal claims.</span>
-                </li>
-              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -173,7 +173,7 @@
                 </li>
                 <li>
                   <a href="part-v-computing-systems/">Part V. Computing Systems Built from SFT</a>
-                  <span>Computational problems, ArchSig-SFT B12/B13 pipeline, simulator maturity, AI governance, review systems, lifecycle, and benchmarks.</span>
+                  <span>Computational problems, ArchSig-SFT forecast pipeline, simulator maturity, AI governance, review systems, lifecycle, and benchmarks.</span>
                 </li>
                 <li>
                   <a href="part-vi-case-studies/">Part VI. Case Studies</a>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="Software Field Theory overview, central proposition, main contributions, chapter navigation, computable core, claim boundary, and worked example preview."
+      content="Software Field Theory overview, computational thesis, core pipeline, main contributions, chapter navigation, claim boundary, and worked example preview."
     >
     <title>Software Field Theory</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Software Field Theory">
-    <meta property="og:description" content="Software Field Theory overview, central proposition, main contributions, chapter navigation, computable core, claim boundary, and worked example preview.">
+    <meta property="og:description" content="Software Field Theory overview, computational thesis, core pipeline, main contributions, chapter navigation, claim boundary, and worked example preview.">
     <meta property="og:url" content="https://iroha1203.dev/sft/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Software Field Theory">
-    <meta name="twitter:description" content="Software Field Theory overview, central proposition, main contributions, chapter navigation, computable core, claim boundary, and worked example preview.">
+    <meta name="twitter:description" content="Software Field Theory overview, computational thesis, core pipeline, main contributions, chapter navigation, claim boundary, and worked example preview.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -77,10 +77,10 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#chapters">Chapters</a></li>
-                <li><a href="#abstract">Abstract</a></li>
+                <li><a href="#computational-thesis">Computational thesis</a></li>
+                <li><a href="#core-pipeline">Core pipeline</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
                 <li><a href="#division-of-work">AAT / ArchSig / SFT</a></li>
-                <li><a href="#computable-core">Computable core</a></li>
                 <li><a href="#worked-example-preview">Worked example preview</a></li>
                 <li><a href="#claim-boundary">Claim boundary</a></li>
               </ol>
@@ -110,7 +110,7 @@
                 </li>
                 <li>
                   <a href="part-iv-principles/">
-                    Part IV. Principles and Theorems
+                    Part IV. Attractor Engineering and Principles
                   </a>
                 </li>
                 <li>
@@ -165,11 +165,11 @@
                 </li>
                 <li>
                   <a href="part-iii-core/">Part III. SFT Core</a>
-                  <span>SoftwareField, artifact-mediated change, operation support, policy, ForecastCone, and FieldUpdate.</span>
+                  <span>SoftwareField, artifact-mediated change, operation support, policy, attractor engineering, ForecastCone, and FieldUpdate.</span>
                 </li>
                 <li>
-                  <a href="part-iv-principles/">Part IV. Principles and Theorems</a>
-                  <span>ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.</span>
+                  <a href="part-iv-principles/">Part IV. Attractor Engineering and Principles</a>
+                  <span>Attractor engineering schemas, ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.</span>
                 </li>
                 <li>
                   <a href="part-v-computing-systems/">Part V. Computing Systems Built from SFT</a>
@@ -198,26 +198,20 @@
               </ul>
             </section>
 
-            <section id="abstract" class="article-section">
-              <h2>Abstract</h2>
+            <section id="computational-thesis" class="article-section">
+              <h2>Computational thesis</h2>
               <p>
-                Software Field Theory studies software evolution as a bounded
-                computation over codebase memory, artifacts, practices, agents,
-                governance mechanisms, operational feedback, and lifecycle
-                pressure. Its central proposition is that a codebase does not
-                evolve only by receiving code diffs: the surrounding field
-                changes which architecture futures are reachable, natural,
-                cheap, risky, observable, or governable.
+                SFT makes software evolution a computable object. It studies
+                how codebase memory, artifacts, practices, agents, governance,
+                feedback, and lifecycle pressure reshape the operation space
+                from which future architecture paths are drawn.
               </p>
               <p>
-                SFT makes this proposition useful by naming a computable slice:
-                selected field model, operation support, policy, observation
-                axes, governance intervention, horizon, and forecast boundary.
-                Inside that boundary, SFT can discuss reachability, support
-                inference, ForecastCone generation, ConsequenceEnvelope
-                reporting, proposal accounting, and feedback update. Outside
-                that boundary, it records unknown or unmodeled remainder rather
-                than turning the forecast into a theorem.
+                The central move is to treat reachable architectural futures
+                as bounded objects of calculation: reconstruct a field slice,
+                infer supported operations, shape support and policy, generate
+                forecast cones, project them into consequence envelopes, and
+                feed observations back into the field.
               </p>
               <figure class="code-panel">
                 <figcaption>SFT central proposition</figcaption>
@@ -231,6 +225,40 @@
       + lifecycle pressure
   -> reachable architectural futures</code></pre>
               </figure>
+            </section>
+
+            <section id="core-pipeline" class="article-section">
+              <h2>Core pipeline</h2>
+              <p>
+                The core pipeline is the positive computational reading of
+                SFT. Artifacts and feedback do not select one future directly;
+                they reshape support, policy, observations, and governance so
+                that a family of reachable paths can be calculated and reported.
+              </p>
+              <figure class="code-panel">
+                <figcaption>SFT computation</figcaption>
+                <pre><code>SoftwareField estimate
+  + ArtifactMediatedChange
+  -> OperationSupport / OperationPolicy
+  -> ForecastCone family
+  -> ConsequenceEnvelope
+  -> GovernanceIntervention
+  -> FieldUpdate</code></pre>
+              </figure>
+              <ul class="status-list">
+                <li>
+                  <strong>Field reconstruction</strong>
+                  <span>Build a computable slice from codebase memory, artifacts, review, CI, incident, ownership, and runtime traces.</span>
+                </li>
+                <li>
+                  <strong>Attractor engineering</strong>
+                  <span>Make desirable paths natural, cheap, visible, and reviewable while making shortcuts unsupported, costly, or observable.</span>
+                </li>
+                <li>
+                  <strong>Envelope generation</strong>
+                  <span>Turn cone families into reviewer-facing path classes, affected axes, obstruction candidates, missing invariants, and governance questions.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="main-contributions" class="article-section">
@@ -293,35 +321,6 @@
                   <span>A bounded reachability or forecast statement whose status depends on the field model, support relation, calibration, and observation boundary.</span>
                 </li>
               </ul>
-            </section>
-
-            <section id="computable-core" class="article-section">
-              <h2>Computable core</h2>
-              <p>
-                SFT is not a claim that software history is fully determined.
-                Its computable core is the bounded slice obtained after a
-                modeling boundary, horizon, universe, observation axes,
-                support relation, and policy have been made explicit.
-              </p>
-              <figure class="code-panel">
-                <figcaption>Computable SFT fragment</figcaption>
-                <pre><code>SoftwareField
-  + arch projection
-  + ArtifactMediatedChange
-  + OperationSupport
-  + OperationPolicy
-  + StepRelation
-  + ObservationRecord
-  + GovernanceIntervention
-  + ForecastCone
-  + FieldUpdate</code></pre>
-              </figure>
-              <p>
-                The broad development field remains larger than this fragment.
-                The point of the core is to make selected questions finite,
-                bounded, and auditable rather than to erase unmodeled human,
-                organizational, or operational context.
-              </p>
             </section>
 
             <section id="worked-example-preview" class="article-section">

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -62,9 +62,10 @@
           <p class="eyebrow">Software Field Theory</p>
           <h1>A computational theory of field-shaped software evolution.</h1>
           <p class="lede">
-            SFT treats software evolution as bounded computation over field
-            models, operation support, policy, forecast cones, consequence
-            envelopes, governance interventions, and feedback updates.
+            SFT studies how PRDs, issues, reviews, CI, AI proposals, runtime
+            feedback, and governance rules change the supported paths of
+            software evolution under an explicit field model, policy, forecast
+            horizon, and observation boundary.
           </p>
         </div>
       </section>
@@ -75,15 +76,13 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
-                <li><a href="#sft-in-one-sentence">SFT in one sentence</a></li>
-                <li><a href="#reading-order">Reading order</a></li>
+                <li><a href="#chapters">Chapters</a></li>
                 <li><a href="#abstract">Abstract</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
                 <li><a href="#division-of-work">AAT / ArchSig / SFT</a></li>
                 <li><a href="#computable-core">Computable core</a></li>
                 <li><a href="#worked-example-preview">Worked example preview</a></li>
                 <li><a href="#claim-boundary">Claim boundary</a></li>
-                <li><a href="#source-references">Source references</a></li>
               </ol>
             </nav>
             <div class="source-panel" data-sidebar-open="true">
@@ -149,65 +148,11 @@
           </aside>
 
           <div class="article-main">
-            <section id="sft-in-one-sentence" class="article-section">
-              <h2>SFT in one sentence</h2>
+            <section id="chapters" class="article-section">
+              <h2>Chapters</h2>
               <p>
-                SFT studies how PRDs, issues, reviews, CI, AI proposals,
-                runtime feedback, and governance rules change the set of
-                supported software-evolution paths under an explicit modeling
-                boundary.
-              </p>
-              <div class="reader-model">
-                <div>
-                  <h3>What changes</h3>
-                  <p>
-                    An artifact does not choose one future. It can make some
-                    operation families supported, cheap, visible, or reviewable
-                    while leaving other paths unsupported or unknown.
-                  </p>
-                </div>
-                <div>
-                  <h3>What does not follow</h3>
-                  <p>
-                    A ForecastCone is not a point prediction, a
-                    ConsequenceEnvelope is not a causal proof, and ArchSig
-                    evidence is not a Lean theorem or a ground-truth extractor.
-                  </p>
-                </div>
-              </div>
-              <ul class="status-list">
-                <li>
-                  <strong>Inputs</strong>
-                  <span>PRDs, Issues, review traces, CI results, runtime observations, AI proposals, and selected codebase regions.</span>
-                </li>
-                <li>
-                  <strong>Modeling move</strong>
-                  <span>Name the field boundary, support relation, policy, observation axes, horizon, unavailable evidence, and unknown remainder.</span>
-                </li>
-                <li>
-                  <strong>Output surface</strong>
-                  <span>Reachable path classes, support estimates, ForecastCone candidates, ConsequenceEnvelope reports, and governance questions.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="reading-order" class="article-section">
-              <h2>Reading order</h2>
-              <p>
-                Read the short model above first: SFT is about supported
-                paths, costs, observations, and governance boundaries, not
-                about declaring a single future. Then read Part I and Part II
-                before using the core, computing-system, and case-study pages.
-                The SFT website is written as an independent monograph entry:
-                source documents remain available for audit, but the main
-                concepts, boundaries, and reading path are present on the
-                website itself.
-              </p>
-              <p>
-                Each Part page follows the same contract: it states the local
-                definitions, gives the formal or computational reading, names
-                examples and the coupon PRD running thread where relevant, and
-                keeps non-conclusions visible beside the positive claims.
+                The SFT pages are organized as a readable sequence, and each
+                chapter can also be opened directly from this index.
               </p>
               <ul class="chapter-list">
                 <li>
@@ -334,17 +279,6 @@
                   <span>Field-shaped computation over future architectural trajectories.</span>
                 </li>
               </ul>
-              <figure class="code-panel">
-                <figcaption>Division of work</figcaption>
-                <pre><code>AAT
-  -> local algebra of architectural change
-
-ArchSig
-  -> observation layer for signatures and witnesses
-
-SFT
-  -> field-shaped computation over future architectural trajectories</code></pre>
-              </figure>
               <ul class="term-list">
                 <li>
                   <strong>AAT theorem</strong>
@@ -424,45 +358,18 @@ SFT
             <section id="claim-boundary" class="article-section">
               <h2>Claim boundary</h2>
               <p>
-                SFT uses claim levels to separate conceptual interpretation,
-                trace-grounded diagnosis, set-valued theorem schema,
-                probabilistic transition models, calibrated empirical
-                forecasts, and deployed governance systems.
+                SFT claims are bounded by the stated field model, support
+                relation, horizon, evidence boundary, and claim level. A
+                <code>ForecastCone</code> names a set of reachable paths, not
+                a point prediction; a <code>ConsequenceEnvelope</code> is a
+                boundary-aware report, not a causal proof; and ArchSig output
+                remains measurement evidence, not a Lean theorem.
               </p>
-              <div class="claim-strip">
-                <p>
-                  A `ForecastCone` is not a point prediction. A
-                  `ConsequenceEnvelope` is a boundary-aware report. ArchSig
-                  output is a measurement or estimate, not a Lean proof.
-                  See the <a href="glossary/">SFT glossary</a> for terminology
-                  boundaries and the <a href="status/">SFT status page</a> for
-                  the full claim-level map.
-                </p>
-              </div>
-            </section>
-
-            <section id="source-references" class="article-section">
-              <h2>Source references</h2>
               <p>
-                These repository documents are audit references for the website
-                text. They are not required to understand this overview, and
-                they do not make website copy the source of truth for Lean
-                theorem status or tooling schema.
+                The <a href="glossary/">glossary</a> fixes terminology
+                boundaries, and the <a href="status/">status page</a> gives
+                the full claim-level map.
               </p>
-              <ul class="term-list">
-                <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">SFT monograph source</a></strong>
-                  <span>Long-form source for Software Field Theory, including the central proposition, field memory, core definitions, and research program.</span>
-                </li>
-                <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">AAT / SFT interface source</a></strong>
-                  <span>Defines the one-way dependency, translation rules, claim levels, and forbidden readings.</span>
-                </li>
-                <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/README.md">Repository entry source</a></strong>
-                  <span>Short source entry for SFT vocabulary, core questions, and AAT / ArchSig / SFT division of work.</span>
-                </li>
-              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -450,7 +450,7 @@ SoftwareFieldEstimate
               <p class="statement-status" aria-label="Claim status for Counterexample I.7">
                 <span class="statement-status-label">Claim status</span>
                 <span class="status-badge status-badge-proved">Lean proved wrapper</span>
-                <span>Finite witness packaged by #920; see the <a href="../theorem-candidates/#counterexample-anchors">counterexample anchors</a>.</span>
+                <span>Finite witness exposed through the <a href="../theorem-candidates/#counterexample-anchors">counterexample anchors</a>.</span>
               </p>
               <ul class="status-list">
                 <li>

--- a/website/sft/part-i-new-object/index.html
+++ b/website/sft/part-i-new-object/index.html
@@ -93,7 +93,7 @@
                 <li><a href="../part-i-new-object/" aria-current="page">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
@@ -180,6 +180,24 @@
                 supplies observation, and SFT asks how future operation space
                 changes under artifacts and feedback.
               </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Theory</strong>
+                  <span>Define software evolution as field-shaped computation.</span>
+                </li>
+                <li>
+                  <strong>Measurement</strong>
+                  <span>Use AAT / ArchSig to observe architecture objects, signatures, obstructions, theorem boundaries, and field estimates.</span>
+                </li>
+                <li>
+                  <strong>Computation</strong>
+                  <span>Make operation support, policy, ForecastCone, ConsequenceEnvelope, support safety, and feedback update calculable.</span>
+                </li>
+                <li>
+                  <strong>Governance</strong>
+                  <span>Read review, CI, type checking, AI policy, and runtime feedback as interventions that reshape codebase futures.</span>
+                </li>
+              </ul>
               <figure class="code-panel">
                 <figcaption>Computable in SFT</figcaption>
                 <pre><code>computable :=
@@ -244,6 +262,19 @@
                   <span>Past incidents, review rules, and migrations change the support and policy visible to new proposals.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>Codebase as Field Memory</figcaption>
+                <pre><code>Codebase as Field Memory
+  = implementation state
+  + sedimented requirements
+  + design decisions
+  + review and CI history
+  + incidents and repairs
+  + migrations and workarounds
+  + ownership boundaries
+  + tooling practices
+  + latent default paths</code></pre>
+              </figure>
               <div class="claim-strip">
                 <p>
                   Concrete reading: two checkout systems can share the same
@@ -292,8 +323,30 @@
                 <span class="status-badge status-badge-future">definition vocabulary</span>
               </p>
               <figure class="code-panel">
-                <figcaption>Boundary-aware estimate</figcaption>
-                <pre><code>model_B : DevelopmentField -> Partial SoftwareFieldEstimate
+                <figcaption>DevelopmentField and boundary-aware estimate</figcaption>
+                <pre><code>DevelopmentField
+  = codebase
+  + requirements and specs
+  + issues and planning artifacts
+  + design practices
+  + developers and AI agents
+  + review systems
+  + CI / type / test systems
+  + runtime observations
+  + incident and postmortem records
+  + lifecycle and migration pressure
+
+model_B : DevelopmentField -> Partial SoftwareFieldEstimate
+
+ModelingBoundary B
+  = selected artifacts
+  + selected codebase region
+  + selected architecture universe
+  + selected observation axes
+  + selected governance records
+  + selected time horizon
+  + unavailable evidence
+  + non-conclusions
 
 SoftwareFieldEstimate
   = modeling boundary

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -85,7 +85,6 @@
                 <li><a href="#archsig-bridge">ArchSig bridge</a></li>
                 <li><a href="#claim-levels">Claim levels</a></li>
                 <li><a href="#basis-boundary">Boundary</a></li>
-                <li><a href="#canonical-sources">Canonical sources</a></li>
               </ol>
             </nav>
             <div class="source-panel" data-sidebar-open="true">
@@ -180,20 +179,6 @@
                   <span>AAT theorem boundaries and non-conclusions become SFT forecast boundaries.</span>
                 </li>
               </ul>
-              <figure class="code-panel">
-                <figcaption>Direction of dependency</figcaption>
-                <pre><code>AAT does not depend on SFT.
-SFT depends on AAT.</code></pre>
-              </figure>
-              <div class="claim-strip">
-                <p>
-                  The dependency arrow is one-way: <a href="../../aat/">AAT</a>
-                  remains an independent local algebra of architecture, while
-                  <a href="../">SFT</a> uses selected AAT objects as premises,
-                  coordinates, and boundaries for bounded software-evolution
-                  models.
-                </p>
-              </div>
             </section>
 
             <section id="borrowed-from-aat" class="article-section">
@@ -252,16 +237,6 @@ SFT depends on AAT.</code></pre>
                   </tbody>
                 </table>
               </div>
-              <figure class="code-panel">
-                <figcaption>Minimal interface map</figcaption>
-                <pre><code>architecture projection   -> ArchitectureObject
-local transition law     -> ArchitectureOperation
-protected constraint     -> InvariantFamily
-defect / repair target   -> ObstructionWitness
-observable coordinate    -> ArchitectureSignature
-admissibility boundary   -> theorem boundary / non-conclusions
-local path skeleton      -> ArchitecturePath</code></pre>
-              </figure>
             </section>
 
             <section id="sft-side-concepts" class="article-section">
@@ -392,32 +367,6 @@ local path skeleton      -> ArchitecturePath</code></pre>
                   </tbody>
                 </table>
               </div>
-              <ul class="term-list">
-                <li>
-                  <strong><code>ArchitectureObject</code></strong>
-                  <span>Read in SFT as the architecture projection of a field state.</span>
-                </li>
-                <li>
-                  <strong><code>ArchitectureOperation</code></strong>
-                  <span>Read as a local law premise for an accepted or proposed transition.</span>
-                </li>
-                <li>
-                  <strong><code>InvariantFamily</code></strong>
-                  <span>Read as a constraint family the field attempts to preserve.</span>
-                </li>
-                <li>
-                  <strong><code>ObstructionWitness</code></strong>
-                  <span>Read as a selected unsafe, costly, or blocked trajectory coordinate.</span>
-                </li>
-                <li>
-                  <strong><code>ArchitectureSignature</code></strong>
-                  <span>Read as a partial coordinate system for observing trajectories.</span>
-                </li>
-                <li>
-                  <strong>Theorem boundary / non-conclusions</strong>
-                  <span>Read as the claim boundary that SFT forecasts and governance reports must not cross.</span>
-                </li>
-              </ul>
             </section>
 
             <section id="forbidden-readings" class="article-section">
@@ -507,32 +456,6 @@ local path skeleton      -> ArchitecturePath</code></pre>
                   </dl>
                 </article>
               </div>
-              <ul class="term-list">
-                <li>
-                  <strong>AAT lawfulness</strong>
-                  <span>Do not read it as future trajectory safety.</span>
-                </li>
-                <li>
-                  <strong>AAT measured zero</strong>
-                  <span>Do not read it as safety for unmeasured axes.</span>
-                </li>
-                <li>
-                  <strong>AAT operation preservation</strong>
-                  <span>Do not read it as global policy safety.</span>
-                </li>
-                <li>
-                  <strong>SFT <code>ForecastCone</code> narrowing</strong>
-                  <span>Do not read it as global risk reduction.</span>
-                </li>
-                <li>
-                  <strong>ArchSig extraction</strong>
-                  <span>Do not read it as a ground-truth architecture object.</span>
-                </li>
-                <li>
-                  <strong>SFT forecast</strong>
-                  <span>Do not read it as a Lean theorem.</span>
-                </li>
-              </ul>
             </section>
 
             <section id="archsig-bridge" class="article-section">
@@ -682,62 +605,6 @@ local path skeleton      -> ArchitecturePath</code></pre>
                 local premise, but it is not automatically software evolution
                 forecast status.
               </p>
-              <ul class="status-list">
-                <li>
-                  <strong>Formal claim</strong>
-                  <span>Lives in AAT or in a set-valued SFT schema with stated support and step semantics.</span>
-                </li>
-                <li>
-                  <strong>Tooling estimate</strong>
-                  <span>Records measured axes, missing axes, evidence boundaries, and non-conclusions.</span>
-                </li>
-                <li>
-                  <strong>Empirical forecast</strong>
-                  <span>Requires trace or dataset calibration; it is not obtained by renaming a theorem.</span>
-                </li>
-              </ul>
-            </section>
-
-            <section id="canonical-sources" class="article-section">
-              <h2>Canonical sources</h2>
-              <p>
-                This page is the website-level home for the AAT / SFT
-                interface. The repository document remains the authoritative
-                statement of mapping tables, claim levels, and non-confusion
-                rules.
-              </p>
-              <ul class="chapter-list">
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/aat_interface.md">
-                    AAT / SFT interface source
-                  </a>
-                  <span>Full dependency, translation, non-confusion, and ArchSig bridge rules.</span>
-                </li>
-                <li>
-                  <a href="../../aat/status/">
-                    AAT Lean Status
-                  </a>
-                  <span>How to read proved declarations, defined-only surfaces, and proof obligations.</span>
-                </li>
-                <li>
-                  <a href="../../archsig/">
-                    ArchSig website
-                  </a>
-                  <span>Tooling layer overview for measured axes, review artifacts, SFT forecasts, and operational feedback.</span>
-                </li>
-                <li>
-                  <a href="../">
-                    Software Field Theory
-                  </a>
-                  <span>Computable software evolution after the interface boundary is explicit.</span>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT status and claim boundary
-                  </a>
-                  <span>Claim level vocabulary for conceptual, trace-grounded, set-valued, calibrated, and deployed statements.</span>
-                </li>
-              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/part-ii-basis/index.html
+++ b/website/sft/part-ii-basis/index.html
@@ -94,7 +94,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/" aria-current="page">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
@@ -508,6 +508,18 @@
                 zero, and tool output is not a theorem.
               </p>
               <figure class="code-panel">
+                <figcaption>ObservedSignatureRecord and SignatureDelta</figcaption>
+                <pre><code>ObservedSignatureRecord
+  = measured ArchitectureSignature axes
+  + unmeasured axes
+  + out-of-scope axes
+  + evidence boundary
+  + measurement non-conclusions
+
+SignatureDelta(S_before, S_after)
+  is defined only for comparable measured axes</code></pre>
+              </figure>
+              <figure class="code-panel">
                 <figcaption>ArchSigSFTReport</figcaption>
                 <pre><code>ArchSigSFTReport
   = action_class_candidates
@@ -546,8 +558,16 @@
                   <span>Set-valued formal theorem schema.</span>
                 </li>
                 <li>
-                  <strong>Level 3 and above</strong>
-                  <span>Transition-kernel models, calibrated forecasts, or deployed closed-loop governance systems.</span>
+                  <strong>Level 3</strong>
+                  <span>Probabilistic or transition-kernel model.</span>
+                </li>
+                <li>
+                  <strong>Level 4</strong>
+                  <span>Dataset-calibrated empirical forecast.</span>
+                </li>
+                <li>
+                  <strong>Level 5</strong>
+                  <span>Deployed closed-loop governance system.</span>
                 </li>
               </ul>
               <p>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -77,7 +77,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
-                <li><a href="#reading-model">Reading model</a></li>
+                <li><a href="#reader-model">Reader model</a></li>
                 <li><a href="#software-field">SoftwareField</a></li>
                 <li><a href="#artifact-action">Artifact action</a></li>
                 <li><a href="#support-policy">Support and policy</a></li>
@@ -106,8 +106,8 @@
           </aside>
 
           <div class="article-main">
-            <section id="reading-model" class="article-section">
-              <h2>Reading model</h2>
+            <section id="reader-model" class="article-section">
+              <h2>Reader model</h2>
               <div class="reader-model">
                 <div>
                   <h3>SFT does not say</h3>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, ForecastCone, and FieldUpdate."
+      content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, attractor engineering, ForecastCone, and FieldUpdate."
     >
     <title>SFT Part III: SFT Core</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/part-iii-core/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="SFT Part III: SFT Core">
-    <meta property="og:description" content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, ForecastCone, and FieldUpdate.">
+    <meta property="og:description" content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, attractor engineering, ForecastCone, and FieldUpdate.">
     <meta property="og:url" content="https://iroha1203.dev/sft/part-iii-core/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="SFT Part III: SFT Core">
-    <meta name="twitter:description" content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, ForecastCone, and FieldUpdate.">
+    <meta name="twitter:description" content="SFT Part III: SoftwareField, artifact-mediated change, operation support, policy, attractor engineering, ForecastCone, and FieldUpdate.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -64,9 +64,9 @@
           <h1>The SFT Core</h1>
           <p class="lede">
             Part III defines the theorem-bearing fragment: `SoftwareField`,
-            artifact-mediated change, operation support, policy, governance
-            interventions, `ForecastCone`, `ConsequenceEnvelope`, and
-            closed-loop field update.
+            artifact-mediated change, operation support, policy, attractor
+            engineering, governance interventions, `ForecastCone`,
+            `ConsequenceEnvelope`, and closed-loop field update.
           </p>
         </div>
       </section>
@@ -81,6 +81,7 @@
                 <li><a href="#software-field">SoftwareField</a></li>
                 <li><a href="#artifact-action">Artifact action</a></li>
                 <li><a href="#support-policy">Support and policy</a></li>
+                <li><a href="#attractor-engineering">Attractor engineering</a></li>
                 <li><a href="#forecast-envelope">Forecast and envelope</a></li>
                 <li><a href="#feedback">Feedback update</a></li>
                 <li><a href="#core-anchors">Anchors</a></li>
@@ -94,7 +95,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/" aria-current="page">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
@@ -257,6 +258,35 @@
                 <span class="status-badge status-badge-defined">computational schema</span>
                 <span>Probability semantics are not assumed unless a distribution is part of the model.</span>
               </p>
+              <figure class="code-panel">
+                <figcaption>Supported operation and policy forms</figcaption>
+                <pre><code>SupportedOperation
+  = operation
+  + applicable theorem boundary
+  + precondition evidence
+  + expected witness mapping
+  + non-conclusions
+
+OperationSupport(F)
+  = admissible operation set after constraints / governance interventions
+
+OperationPolicy(F)
+  = preorder, cost, or selection relation on that support
+
+PolicyAsPreorder:
+  op1 <=_F op2 means op1 is no harder / no less natural than op2
+
+PolicyAsCost:
+  cost_F(op) : OrderedCost
+
+PolicyAsSelection:
+  Selected(F, op)</code></pre>
+              </figure>
+              <p>
+                A probability distribution
+                <code>mu_F : Distribution SupportedOperation</code> is added
+                only when the selected semantics explicitly includes one.
+              </p>
               <ul class="status-list">
                 <li>
                   <strong>OperationSupport</strong>
@@ -269,6 +299,65 @@
                 <li>
                   <strong>Attractor engineering</strong>
                   <span>Support and policy shaping, not a hidden physical force or automatic stability theorem.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="attractor-engineering" class="article-section">
+              <h2>Attractor engineering</h2>
+              <p>
+                SFT reads attractor engineering as support and policy shaping.
+                The goal is not to assert a hidden physical force; it is to
+                design a field in which desirable operation families become
+                natural, cheap, visible, reviewable, and repeatable.
+              </p>
+              <p id="definition-iii-3a" class="statement">
+                <a class="statement-anchor" href="#definition-iii-3a">Definition III.3a.</a>
+                <code>AttractorEngineering</code> is the deliberate shaping of
+                operation support, operation policy, observation, and
+                governance so that selected paths are easier to take and
+                selected shortcuts become unsupported, costly, visible, or
+                review-mediated.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Definition III.3a">
+                <span class="statement-status-label">Claim status</span>
+                <span class="status-badge status-badge-defined">computational reading</span>
+                <span>Stable-region or probabilistic attractor claims require additional semantics.</span>
+              </p>
+              <figure class="code-panel">
+                <figcaption>Attractor engineering as field design</figcaption>
+                <pre><code>AttractorEngineering(F, R)
+  = target region R
+  + support shaping
+  + policy shaping
+  + governance intervention
+  + observation boundary
+  + feedback update rule
+
+support shaping:
+  future operation support changes
+
+policy shaping:
+  lawful paths become lower cost or more reviewable
+
+observation shaping:
+  shortcut paths become visible to review / CI / runtime checks
+
+feedback shaping:
+  review / CI / incident outcome is saved in posterior field memory</code></pre>
+              </figure>
+              <ul class="status-list">
+                <li>
+                  <strong>Positive target</strong>
+                  <span>Make intended feature paths supported, low cost, observable, and easy to review.</span>
+                </li>
+                <li>
+                  <strong>Negative target</strong>
+                  <span>Make shortcut paths unsupported, high cost, visible, or subject to explicit governance.</span>
+                </li>
+                <li>
+                  <strong>Formal boundary</strong>
+                  <span>Attractor and basin become stronger claims only after stability, recurrence, policy, or probability semantics are supplied.</span>
                 </li>
               </ul>
             </section>
@@ -293,6 +382,23 @@
                 <span class="status-badge status-badge-defined">formal object schema</span>
                 <span>The cone is set-valued reachability, not a point prediction.</span>
               </p>
+              <figure class="code-panel">
+                <figcaption>Reachability vocabulary</figcaption>
+                <pre><code>FieldPath
+  = finite sequence in FieldSpace
+
+ReachableFieldPath(F, U, h, p)
+  = p starts at F
+  + length(p) <= h
+  + every adjacent pair is witnessed by a supported step
+
+StepRelation(F, op, F')
+  = operation op realizes a transition from F to F'
+    under the selected theorem boundary and field model
+
+ForecastCone(F, U, h)
+  = { p : FieldPath | ReachableFieldPath(F, U, h, p) }</code></pre>
+              </figure>
               <figure class="code-panel">
                 <figcaption>ConsequenceEnvelope</figcaption>
                 <pre><code>ConsequenceEnvelope
@@ -326,6 +432,26 @@ ForecastConeFamilyAfterAction(F, a, h)
                 <span class="statement-status-label">Claim status</span>
                 <span class="status-badge status-badge-defined">report schema</span>
                 <span>The envelope interprets one or more cones for diagnosis and tooling.</span>
+              </p>
+              <figure class="code-panel">
+                <figcaption>Envelope projection</figcaption>
+                <pre><code>ConeFamily
+  = nonempty selected set of ForecastCone(F_i, U_i, h_i)
+
+EnvelopeProjection(ConeFamily, ObservationBoundary)
+  = visible path classes
+  + affected region refs
+  + comparable signature axes
+  + expected axis delta ranges
+  + obstruction candidates
+  + missing boundary / theorem boundary items
+  + inherited non-conclusions
+  + unknown remainder</code></pre>
+              </figure>
+              <p>
+                The projection is one-way: a consequence envelope does not
+                uniquely recover the cone family and does not supply causal
+                correctness, probability, or calibrated point prediction.
               </p>
             </section>
 
@@ -368,10 +494,33 @@ ForecastConeFamilyAfterAction(F, a, h)
                   <span>Adds observation axes, tests, runtime checks, or evidence records.</span>
                 </li>
                 <li>
+                  <strong>Escalating intervention</strong>
+                  <span>Converts a proposal into a review, design, deferral, or incident record.</span>
+                </li>
+                <li>
                   <strong>Learning intervention</strong>
                   <span>Preserves observed outcomes and forecast error in posterior field memory.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>Observation and governance schemas</figcaption>
+                <pre><code>Observation
+  = obs : FieldSpace -> ObservedSignatureRecord
+
+ObservationBoundary
+  = measured axes
+  + unavailable evidence
+  + private evidence
+  + extractor version
+  + non-conclusions
+
+GovernanceIntervention
+  = support transformation
+  + policy transformation
+  + observation enrichment
+  + feedback update
+  + escalation / deferral rule</code></pre>
+              </figure>
               <div class="claim-strip">
                 <p>
                   Field update preserves forecast error and boundary evidence.
@@ -392,6 +541,21 @@ ForecastConeFamilyAfterAction(F, a, h)
                 <span class="status-badge status-badge-proved">Lean record package</span>
                 <span><code>Formal/Arch/Evolution/SFTFieldUpdate.lean</code> proves record-preservation accessors; forecast-quality calibration remains separate.</span>
               </p>
+              <figure class="code-panel">
+                <figcaption>FieldUpdate and UpdateSound</figcaption>
+                <pre><code>FieldUpdate
+  = prior field
+  + ForecastCone / ConsequenceEnvelope
+  + observed PR signature delta
+  + unexpected obstruction witnesses
+  + review / CI outcome
+  + runtime feedback
+  -> posterior field
+
+UpdateSound(update)
+  = observed delta / unexpected witness / review outcome
+    are recorded in the posterior field</code></pre>
+              </figure>
             </section>
 
             <section id="core-anchors" class="article-section">
@@ -468,7 +632,7 @@ ForecastConeFamilyAfterAction(F, a, h)
               </a>
               <a href="../part-iv-principles/">
                 <span>Next</span>
-                <strong>Part IV. Principles</strong>
+                <strong>Part IV. Attractor Engineering and Principles</strong>
               </a>
             </nav>
           </div>

--- a/website/sft/part-iii-core/index.html
+++ b/website/sft/part-iii-core/index.html
@@ -138,7 +138,7 @@
               <p class="statement-status" aria-label="Claim status for Non-conclusion III.0">
                 <span class="statement-status-label">Claim status</span>
                 <span class="status-badge status-badge-future">boundary statement</span>
-                <span>Website exposition of the SFT source boundary; checked Lean anchors are listed where available.</span>
+                <span>Checked Lean anchors are listed where available; empirical prediction quality remains outside this claim.</span>
               </p>
             </section>
 
@@ -160,7 +160,7 @@
               <p class="statement-status" aria-label="Claim status for Definition III.1">
                 <span class="statement-status-label">Claim status</span>
                 <span class="status-badge status-badge-defined">conceptual schema</span>
-                <span>Defined in the SFT source document; not a Lean structure in this PR.</span>
+                <span>Defined as SFT vocabulary; Lean formalization currently exposes selected supporting records and theorem boundaries.</span>
               </p>
               <figure class="code-panel">
                 <figcaption>Field projection</figcaption>
@@ -561,8 +561,8 @@ UpdateSound(update)
             <section id="core-anchors" class="article-section">
               <h2>Formal and computational anchors</h2>
               <p>
-                Part III combines source-document schemas with checked Lean
-                anchors for bounded fragments. These anchors prevent the public
+                Part III combines theory schemas with checked Lean anchors for
+                bounded fragments. These anchors prevent the public
                 text from reading SFT as an unqualified empirical prediction
                 theory.
               </p>
@@ -573,7 +573,7 @@ UpdateSound(update)
                       <span class="formal-anchor-card-label">Field core</span>
                       <h3>State, projection, and support</h3>
                     </div>
-                    <span class="status-badge status-badge-defined">source schema</span>
+                    <span class="status-badge status-badge-defined">theory schema</span>
                   </header>
                   <dl class="formal-anchor-grid">
                     <div>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -205,7 +205,20 @@
               </p>
               <figure class="code-panel">
                 <figcaption>Set-valued schema</figcaption>
-                <pre><code>PointwiseSupportInclusion(U2, U1)
+                <pre><code>sound constraint addition
+  + intended feature direction is preserved
+  + selected witness family is excluded
+  -> ForecastCone narrows for that witness family
+
+PointwiseSupportInclusion(U2, U1)
+  = for every reachable related field F2 relation F1,
+    U2(F2) subset U1(F1)
+
+StepSimulation(U2, U1, relation)
+  = every U2-step from F2 is simulated by a U1-step from F1
+    and the successor fields remain related
+
+PointwiseSupportInclusion(U2, U1)
   + StepSimulation(U2, U1, relation)
   + F2 relation F1
   -> ForecastCone(F2, U2, h)
@@ -264,7 +277,11 @@
               </ul>
               <figure class="code-panel">
                 <figcaption>Support safety schema</figcaption>
-                <pre><code>StateInSafeRegion(O, R, F)
+                <pre><code>SupportOperationsPreserveSafeRegion(U, O, R)
+  = every selected operation from U realizes only steps
+    that preserve safe region R under observation O
+
+StateInSafeRegion(O, R, F)
   + accepted steps are selected from U
   + SupportOperationsPreserveSafeRegion(U, O, R)
   -> accepted trajectory remains in R</code></pre>
@@ -308,7 +325,8 @@
               <figure class="code-panel">
                 <figcaption>ProposalAccounting</figcaption>
                 <pre><code>ProposalAccounting(raw_proposal_universe)
-  classifies proposal pressure as:
+  classifies proposal pressure under an explicit
+  coverage / overlap policy as:
     accepted
     rejected
     delayed
@@ -375,8 +393,8 @@
               <div class="claim-strip">
                 <p>
                   See the <a href="../theorem-candidates/#counterexample-anchors">Theorem Candidates counterexample index</a>
-                  and the <a href="../status/#lean-roadmap">SFT Lean Roadmap</a>
-                  for the source-of-truth status vocabulary.
+                  and the <a href="../status/#lean-status">SFT Lean status</a>
+                  for the status vocabulary.
                 </p>
               </div>
             </section>
@@ -441,9 +459,16 @@
               <figure class="code-panel">
                 <figcaption>Minimal vocabulary</figcaption>
                 <pre><code>MayReach_h(F, U, A)
+  = some U-accepted path from F reaches region A within h steps
+
 MustReach_h(F, U, A)
+  = every U-accepted path from F reaches region A within h steps
+
 StableRegion(U, A)
-ReachablePreimage_h(U, A)</code></pre>
+  = every U-accepted step from a field in A stays in A
+
+ReachablePreimage_h(U, A)
+  = { F | MayReach_h(F, U, A) }</code></pre>
               </figure>
               <p>
                 Attractor language is allowed only after the semantics needed

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -76,7 +76,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
-                <li><a href="#reading-model">Reading model</a></li>
+                <li><a href="#reader-model">Reader model</a></li>
                 <li><a href="#cone-narrowing">Cone narrowing</a></li>
                 <li><a href="#support-safety">Support safety</a></li>
                 <li><a href="#proposal-accounting">Proposal accounting</a></li>
@@ -106,8 +106,8 @@
           </aside>
 
           <div class="article-main">
-            <section id="reading-model" class="article-section">
-              <h2>Reading model</h2>
+            <section id="reader-model" class="article-section">
+              <h2>Reader model</h2>
               <div class="reader-model">
                 <div>
                   <h3>SFT does not say</h3>

--- a/website/sft/part-iv-principles/index.html
+++ b/website/sft/part-iv-principles/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="SFT Part IV: ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions."
+      content="SFT Part IV: attractor engineering, ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions."
     >
-    <title>SFT Part IV: Principles and Theorems</title>
+    <title>SFT Part IV: Attractor Engineering, Principles, and Theorems</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/part-iv-principles/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
-    <meta property="og:title" content="SFT Part IV: Principles and Theorems">
-    <meta property="og:description" content="SFT Part IV: ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.">
+    <meta property="og:title" content="SFT Part IV: Attractor Engineering, Principles, and Theorems">
+    <meta property="og:description" content="SFT Part IV: attractor engineering, ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.">
     <meta property="og:url" content="https://iroha1203.dev/sft/part-iv-principles/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="SFT Part IV: Principles and Theorems">
-    <meta name="twitter:description" content="SFT Part IV: ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.">
+    <meta name="twitter:title" content="SFT Part IV: Attractor Engineering, Principles, and Theorems">
+    <meta name="twitter:description" content="SFT Part IV: attractor engineering, ForecastCone narrowing, support safety, proposal accounting, feedback update, and stable regions.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -61,11 +61,11 @@
             <span>Part IV</span>
           </nav>
           <p class="eyebrow">SFT Part IV</p>
-          <h1>Principles and Theorems</h1>
+          <h1>Attractor Engineering, Principles, and Theorems</h1>
           <p class="lede">
-            Part IV records the theorem-shaped claims SFT can make only under
-            explicit support semantics, step simulation, safe regions,
-            coverage policy, and observation boundaries.
+            Part IV treats attractor engineering as support, policy,
+            observation, and governance shaping, then states the
+            theorem-shaped schemas that make those interventions calculable.
           </p>
         </div>
       </section>
@@ -77,6 +77,7 @@
               <h2 id="toc-title">On this page</h2>
               <ol>
                 <li><a href="#reader-model">Reader model</a></li>
+                <li><a href="#attractor-engineering">Attractor engineering</a></li>
                 <li><a href="#cone-narrowing">Cone narrowing</a></li>
                 <li><a href="#support-safety">Support safety</a></li>
                 <li><a href="#proposal-accounting">Proposal accounting</a></li>
@@ -94,7 +95,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/" aria-current="page">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/" aria-current="page">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
@@ -139,6 +140,46 @@
                 <span class="status-badge status-badge-future">boundary schema</span>
                 <span>Website exposition of SFT claim discipline; no Lean theorem is added here. See the <a href="../status/">status page</a>.</span>
               </p>
+            </section>
+
+            <section id="attractor-engineering" class="article-section">
+              <h2>Attractor engineering</h2>
+              <p>
+                Attractor engineering is the practical face of SFT principles:
+                change the field so that intended paths are supported,
+                low-cost, visible, and reviewable, while unsafe shortcuts are
+                unsupported, costly, observable, or governance-mediated.
+              </p>
+              <p id="schema-iv-a" class="statement">
+                <a class="statement-anchor" href="#schema-iv-a">Schema IV.A.</a>
+                An attractor-engineering intervention is a support, policy,
+                observation, or governance transformation whose intended effect
+                is to reshape the selected forecast cone without changing the
+                feature direction being preserved.
+              </p>
+              <p class="statement-status" aria-label="Claim status for Schema IV.A">
+                <span class="statement-status-label">Claim level</span>
+                <span class="status-badge status-badge-defined">principle schema</span>
+                <span>Formal claims require support inclusion, step simulation, safe-region, or recurrence semantics.</span>
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Support shaping</strong>
+                  <span>Add, remove, or condition operation families before they become accepted paths.</span>
+                </li>
+                <li>
+                  <strong>Policy shaping</strong>
+                  <span>Change cost, reviewability, priority, or selection order among supported operations.</span>
+                </li>
+                <li>
+                  <strong>Observation shaping</strong>
+                  <span>Add signatures, tests, runtime checks, or review prompts that make important paths visible.</span>
+                </li>
+                <li>
+                  <strong>Governance shaping</strong>
+                  <span>Escalate, split, block, or mediate operation families according to the selected field model.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="cone-narrowing" class="article-section">

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -210,7 +210,7 @@
                 non-conclusions rather than claiming a future outcome.
               </p>
               <figure class="code-panel">
-                <figcaption>B13 implemented pipeline</figcaption>
+                <figcaption>Forecast artifact pipeline</figcaption>
                 <pre><code>real PRD / Spec / Issue / AI proposal
   -> ArtifactDescriptor builder
   -> OperationSupportEstimate generator
@@ -261,7 +261,7 @@
                 The public ArchSig pages describe the same surface from the
                 tooling side: see the <a href="../../archsig/workflows/">workflow
                 overview</a>, <a href="../../archsig/artifacts/">artifact
-                catalog</a>, and <a href="../../archsig/roadmap/">B12/B13
+                catalog</a>, and <a href="../../archsig/roadmap/">tooling
                 roadmap</a>.
               </p>
             </section>
@@ -294,9 +294,9 @@
               </p>
               <div class="claim-strip">
                 <p>
-                  Current B12/B13 artifacts support bounded descriptor,
-                  support, cone, envelope, and calibration-hook records. They
-                  do not support probability weighting, causal forecast,
+                  The current artifact pipeline supports bounded descriptor,
+                  support, cone, envelope, and calibration-hook records. It
+                  does not support probability weighting, causal forecast,
                   extractor completeness, or framework-specific semantic
                   completeness without additional adapters and datasets.
                 </p>
@@ -366,7 +366,7 @@
               </div>
               <div class="article-table">
                 <table>
-                  <caption>Current capability and remaining gaps</caption>
+                  <caption>Capability and remaining boundary</caption>
                   <thead>
                     <tr>
                       <th scope="col">Surface</th>
@@ -377,13 +377,13 @@
                   <tbody>
                     <tr>
                       <th scope="row">Markdown PRD / Spec</th>
-                      <td>Can be converted through the B13 pipeline into forecast artifacts and a report.</td>
+                      <td>Can be converted through the forecast pipeline into forecast artifacts and a report.</td>
                       <td>Real dataset calibration and held-out outcome validation remain future work.</td>
                     </tr>
                     <tr>
                       <th scope="row">GitHub Issue / AI proposal</th>
                       <td>Representable as artifact text under the same boundary vocabulary.</td>
-                      <td>Native GitHub Issue JSON and AI proposal JSON adapters remain planned gaps.</td>
+                      <td>Native JSON adapters remain outside the current evidence claim.</td>
                     </tr>
                     <tr>
                       <th scope="row">Review / CI recommendation</th>

--- a/website/sft/part-v-computing-systems/index.html
+++ b/website/sft/part-v-computing-systems/index.html
@@ -93,7 +93,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/" aria-current="page">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>
@@ -126,6 +126,18 @@
                   <span>Translate PRDs, specs, issues, or AI proposals into reachable path classes and boundary reports.</span>
                 </li>
                 <li>
+                  <a href="../part-iv-principles/#cone-narrowing">Cone narrowing</a>
+                  <span>Synthesize specification, issue, or review constraints that exclude a selected witness family while preserving the intended feature direction.</span>
+                </li>
+                <li>
+                  <a href="../part-iv-principles/#support-safety">Support safety checking</a>
+                  <span>Check whether operation support or governance intervention preserves a selected safe region.</span>
+                </li>
+                <li>
+                  <a href="../part-iii-core/#feedback">Feedback update</a>
+                  <span>Update a posterior field model from forecast differences and observed PR, review, CI, incident, or runtime outcomes.</span>
+                </li>
+                <li>
                   <a href="#ai-governance">AI proposal governance</a>
                   <span>Keep generated proposal support inside a bounded field model and record shortcut witnesses.</span>
                 </li>
@@ -147,6 +159,45 @@
                 falsifiable. A result that cannot name its boundary is only an
                 explanatory heuristic, not a mature SFT computation.
               </p>
+              <div class="article-table">
+                <table>
+                  <caption>Representative problem contracts</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Problem</th>
+                      <th scope="col">Input</th>
+                      <th scope="col">Output</th>
+                      <th scope="col">Claim level</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Field reconstruction</th>
+                      <td><code>DevelopmentField</code>, modeling boundary, artifact / review / CI / incident traces.</td>
+                      <td><code>SoftwareFieldEstimate</code> with evidence categories and unknown remainder.</td>
+                      <td>L1 trace-grounded; L4 only after held-out validation.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">ConsequenceEnvelope generation</th>
+                      <td>Field estimate, artifact, observation boundary, support extractor, and horizon.</td>
+                      <td><code>ConsequenceEnvelope</code> with reachable path classes, affected axes, witness candidates, and missing invariants.</td>
+                      <td>L2 if set-valued reachability is defined; L4 after calibrated path and axis validation.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Cone narrowing</th>
+                      <td>Target artifact direction, selected witness family, support extractors, and step simulation relation.</td>
+                      <td>Constraint, specification, or review intervention that preserves the intended direction while excluding the selected witness family.</td>
+                      <td>L2 under support inclusion and step simulation; L4 only with calibration.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">AI proposal governance</th>
+                      <td>AI proposal stream, prompt / policy boundary, field estimate, theorem boundary, and review / CI traces.</td>
+                      <td>Bounded proposal support, shortcut witness report, review / CI intervention, and posterior field update.</td>
+                      <td>L1 when trace-grounded; L2 for formal support restriction; L4 for calibrated shortcut detection.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </section>
 
             <section id="archsig-sft-pipeline" class="article-section">
@@ -266,6 +317,55 @@
               </ul>
               <div class="article-table">
                 <table>
+                  <caption>Simulator maturity ladder</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Level</th>
+                      <th scope="col">Reading</th>
+                      <th scope="col">Minimal output</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">0</th>
+                      <td>Explanatory metaphor.</td>
+                      <td>Field / force language only.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">1</th>
+                      <td>Action classification.</td>
+                      <td>PRD action class or descriptor.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">2</th>
+                      <td>Support generation.</td>
+                      <td>Candidate operation support.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">3</th>
+                      <td>Cone generation.</td>
+                      <td>Bounded <code>ForecastCone</code> or path classes.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">4</th>
+                      <td><code>ConsequenceEnvelope</code>.</td>
+                      <td>Signature axes, obstruction witnesses, and missing boundaries.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">5</th>
+                      <td>Weighting.</td>
+                      <td>Path class weight, probability, and unknown remainder.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">6</th>
+                      <td>Calibration.</td>
+                      <td>Observed issue, PR, review, CI, or outcome comparison with field update.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="article-table">
+                <table>
                   <caption>Current capability and remaining gaps</caption>
                   <thead>
                     <tr>
@@ -311,12 +411,40 @@
                 </p>
               </div>
               <figure class="code-panel">
+                <figcaption>AI agent as field participant</figcaption>
+                <pre><code>AI agent
+  = artifact interpreter
+  + code proposal generator
+  + local pattern amplifier
+  + shortcut generator
+  + review load shifter
+  + hidden assumption reproducer
+  + field participant</code></pre>
+              </figure>
+              <figure class="code-panel">
+                <figcaption>AI Proposal Governance</figcaption>
+                <pre><code>AI Proposal Governance
+  = prompt / policy boundary
+  + allowed operation support
+  + theorem boundary
+  + review / CI feedback
+  + observed shortcut / witness report
+  + field update</code></pre>
+              </figure>
+              <figure class="code-panel">
                 <figcaption>AI proposal governance output</figcaption>
                 <pre><code>bounded proposal support
   + shortcut witness report
   + review / CI intervention
   + posterior field update</code></pre>
               </figure>
+              <p>
+                Allowed operation support is a bounded candidate set for
+                review. Shortcut witness reports name forbidden edges, missing
+                invariants, runtime boundaries, theorem boundaries, and review
+                load without turning AI capability evaluation into forecast
+                correctness.
+              </p>
             </section>
 
             <section id="review-systems" class="article-section">
@@ -341,6 +469,21 @@
                   <span>Add observation axes, tests, runtime checks, or evidence records.</span>
                 </li>
               </ul>
+              <figure class="code-panel">
+                <figcaption>GovernanceSystem</figcaption>
+                <pre><code>GovernanceSystem
+  = review rule
+  + CI / test / type checker
+  + architecture rule
+  + ownership boundary
+  + runtime guard
+  + feedback update rule</code></pre>
+              </figure>
+              <p>
+                Good governance does more than reject unsafe shortcuts: it
+                lowers the cost of lawful paths, finds missing invariants, and
+                writes the result back into field memory.
+              </p>
             </section>
 
             <section id="lifecycle" class="article-section">
@@ -358,7 +501,8 @@
               </p>
               <figure class="code-panel">
                 <figcaption>Lifecycle trajectory</figcaption>
-                <pre><code>birth
+                <pre><code>LifecycleTrajectory
+  = birth
   + growth
   + stabilization
   + drift
@@ -366,6 +510,80 @@
   + contraction
   + end-of-life</code></pre>
               </figure>
+              <figure class="code-panel">
+                <figcaption>LifecycleDecisionModel</figcaption>
+                <pre><code>LifecycleDecisionModel
+  = current LifecycleTrajectory
+  + ArchitectureSignature trajectory
+  + ConsequenceEnvelope family
+  + runtime / incident risk boundary
+  + ownership / staffing boundary
+  + selected intervention set
+  + non-conclusions
+
+SelectedIntervention
+  = repair | migration | contraction | deletion</code></pre>
+              </figure>
+              <div class="article-table">
+                <table>
+                  <caption>Lifecycle intervention comparison</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Intervention</th>
+                      <th scope="col">Reading</th>
+                      <th scope="col">Main comparison axes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Repair</th>
+                      <td>Keep the existing field and add local support or invariants.</td>
+                      <td>Repair adoption, missing invariant, runtime regression risk, ownership capacity.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Migration</th>
+                      <td>Move support and field memory from an old field into a new field.</td>
+                      <td>Projection mismatch, dual-run cost, consumer compatibility, rollback path.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Contraction</th>
+                      <td>Reduce an unsupported surface and reallocate field capacity.</td>
+                      <td>Removed operation families, affected user or runtime boundary, simplified signature axes.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Deletion</th>
+                      <td>Remove a field component or subsystem from the lifecycle.</td>
+                      <td>Dependent operation loss, data or API retirement boundary, incident avoidance, unknown remainder.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <ul class="status-list">
+                <li>
+                  <strong>PRD-to-Issue Benchmark</strong>
+                  <span>Checks whether artifact decomposition preserves feature direction, missing evidence, and reviewable boundaries.</span>
+                </li>
+                <li>
+                  <strong>Issue-to-PR Signature Benchmark</strong>
+                  <span>Compares forecast items with later signature deltas and affected architecture regions.</span>
+                </li>
+                <li>
+                  <strong>Review Mediation Benchmark</strong>
+                  <span>Tests whether envelope items become useful review comments, CI requests, or issue splits.</span>
+                </li>
+                <li>
+                  <strong>Incident Feedback Benchmark</strong>
+                  <span>Connects runtime or incident outcomes back to calibration hooks and field update records.</span>
+                </li>
+                <li>
+                  <strong>AI Shortcut Benchmark</strong>
+                  <span>Evaluates whether shortcut witnesses and governance constraints catch risky generated paths.</span>
+                </li>
+                <li>
+                  <strong>Lifecycle Decision Benchmark</strong>
+                  <span>Compares repair, migration, contraction, and deletion recommendations against later evidence.</span>
+                </li>
+              </ul>
             </section>
 
             <section id="systems-boundary" class="article-section">
@@ -396,7 +614,7 @@
             <nav class="page-nav" aria-label="Reading sequence">
               <a href="../part-iv-principles/">
                 <span>Previous</span>
-                <strong>Part IV. Principles</strong>
+                <strong>Part IV. Attractor Engineering and Principles</strong>
               </a>
               <a href="../part-vi-case-studies/">
                 <span>Next</span>

--- a/website/sft/part-vi-case-studies/index.html
+++ b/website/sft/part-vi-case-studies/index.html
@@ -93,7 +93,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/" aria-current="page">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -529,27 +529,27 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <th scope="row">W0 artifact inventory</th>
-                      <td>List existing operational, forecast, governance, and missing adapter artifacts.</td>
-                      <td>Workbench run manifest design.</td>
+                      <th scope="row">Artifact inventory</th>
+                      <td>List operational, forecast, governance, and unavailable adapter artifacts.</td>
+                      <td>Workbench run description.</td>
                     </tr>
                     <tr>
-                      <th scope="row">W1 offline bundle</th>
+                      <th scope="row">Offline bundle</th>
                       <td>Manually bundle one PRD, Issue, or AI proposal with available trace refs.</td>
                       <td>Manifest for artifact refs, excluded inputs, and non-conclusions.</td>
                     </tr>
                     <tr>
-                      <th scope="row">W2 review-loop dry run</th>
+                      <th scope="row">Review-loop rehearsal</th>
                       <td>Connect generated envelopes and governance projections to review / CI checklists.</td>
                       <td>Reviewer decision and CI outcome refs.</td>
                     </tr>
                     <tr>
-                      <th scope="row">W3 calibration join</th>
+                      <th scope="row">Calibration join</th>
                       <td>Join forecast items with observed refs through calibration hooks and operational artifacts.</td>
                       <td>Held-out or prospective benchmark set.</td>
                     </tr>
                     <tr>
-                      <th scope="row">W4 deployed pilot</th>
+                      <th scope="row">Deployed pilot</th>
                       <td>Run scheduler and policy thresholds on a selected repository.</td>
                       <td>Organization-specific calibration against incidents, rollback, and MTTR.</td>
                     </tr>
@@ -558,7 +558,7 @@
               </div>
               <ul class="term-list">
                 <li>
-                  <strong>B12 / B13 forecasting</strong>
+                  <strong>Forecast artifact pipeline</strong>
                   <span>Creates bounded forecast artifacts through <code>ConsequenceEnvelope</code>; it does not prove forecast correctness.</span>
                 </li>
                 <li>
@@ -566,7 +566,7 @@
                   <span>Normalize GitHub Issue JSON, AI proposal JSON, framework semantics, and runtime / incident traces as supplied evidence.</span>
                 </li>
                 <li>
-                  <strong>B10 operational feedback</strong>
+                  <strong>Operational feedback</strong>
                   <span>Stores observed outcome, calibration review, threshold, ownership, repair adoption, incident correlation, and hypothesis refresh.</span>
                 </li>
                 <li>

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -91,7 +91,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/" aria-current="page">Part VII. Research Program</a></li>
@@ -184,6 +184,40 @@
                     <div>
                       <dt>Blocked reading</dt>
                       <dd>Process maturity is not field lawfulness.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>DevOps maturity model</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>Operational capability, automation, deployment, and team practice maturity.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>How governance and feedback change operation support, policy, and reachable architecture futures.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>Delivery maturity is not a theorem about field safety.</dd>
+                    </div>
+                  </dl>
+                </article>
+                <article class="comparison-card">
+                  <h3>Socio-technical metaphor</h3>
+                  <dl>
+                    <div>
+                      <dt>Usual emphasis</dt>
+                      <dd>Useful language for people, teams, incentives, and systems.</dd>
+                    </div>
+                    <div>
+                      <dt>What SFT adds</dt>
+                      <dd>A bounded computational object: support, policy, observation boundary, cone, envelope, and field update.</dd>
+                    </div>
+                    <div>
+                      <dt>Blocked reading</dt>
+                      <dd>A metaphor alone is not a computation or claim level.</dd>
                     </div>
                   </dl>
                 </article>
@@ -350,6 +384,10 @@
               </div>
               <ul class="term-list">
                 <li>
+                  <strong>Canonical open-problem list</strong>
+                  <span>ForecastCone and support simulation; ConsequenceEnvelope-to-cone relation; trace-grounded field reconstruction; PRD-to-envelope calibration; review mediation and AI shortcut benchmarks; theorem-boundary integration; codebase field-memory studies; AI-mediated governance; lifecycle and end-of-life models; deployed closed-loop workbench.</span>
+                </li>
+                <li>
                   <strong>Next formal step</strong>
                   <span>Define the minimal core for reachable field paths, support inclusion, horizon, step simulation, and cone projection.</span>
                 </li>
@@ -416,6 +454,128 @@
                 <li>
                   <strong>What closes the loop</strong>
                   <span>Observed PR, review, CI, incident, and runtime traces must feed calibration hooks and posterior field updates.</span>
+                </li>
+              </ul>
+              <figure class="code-panel">
+                <figcaption>Closed-loop workbench flow</figcaption>
+                <pre><code>PRD / design memo / issue plan / AI proposal
+  + existing codebase / ArchitectureSignature snapshot
+  + review / CI / PR / incident / ownership trace
+  + AI agent policy
+  -> ArtifactDescriptor
+  -> OperationSupportEstimate
+  -> ForecastConeSkeleton family
+  -> ConsequenceEnvelope report
+  -> AI proposal governance / lifecycle decision surface
+  -> review / CI / issue decomposition intervention
+  -> observed PR / review / CI / outcome refs
+  -> ForecastCalibrationHook + operational feedback
+  -> field update note / hypothesis refresh input</code></pre>
+              </figure>
+              <div class="article-table">
+                <table>
+                  <caption>Minimal artifact flow</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Layer</th>
+                      <th scope="col">Input</th>
+                      <th scope="col">Output</th>
+                      <th scope="col">Boundary</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">Input normalization</th>
+                      <td>PRD, Issue, AI proposal, and source refs.</td>
+                      <td><code>ArtifactDescriptor</code>.</td>
+                      <td>Source refs and missing evidence are preserved.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Forecast construction</th>
+                      <td>Descriptor, policy constraints, and bounded horizon.</td>
+                      <td><code>OperationSupportEstimate</code> and <code>ForecastConeSkeleton</code>.</td>
+                      <td>Finite support and unknown remainder are preserved.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Review projection</th>
+                      <td>Cone family, signature axes, and theorem boundary.</td>
+                      <td><code>ConsequenceEnvelope</code>.</td>
+                      <td>Reviewer-facing report, not causal forecast.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Governance projection</th>
+                      <td>AI policy and review / CI mediation refs.</td>
+                      <td>AI proposal governance or lifecycle decision surface.</td>
+                      <td>Allowed, forbidden, and unknown support stay separate.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">Feedback join</th>
+                      <td>Observed PR, review, CI, outcome refs, and operational artifacts.</td>
+                      <td><code>ForecastCalibrationHook</code>, calibration review, and hypothesis refresh input.</td>
+                      <td>Observation linkage, not proof of forecast correctness.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="article-table">
+                <table>
+                  <caption>Workbench phase plan</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Phase</th>
+                      <th scope="col">Purpose</th>
+                      <th scope="col">Next required artifact</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">W0 artifact inventory</th>
+                      <td>List existing operational, forecast, governance, and missing adapter artifacts.</td>
+                      <td>Workbench run manifest design.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">W1 offline bundle</th>
+                      <td>Manually bundle one PRD, Issue, or AI proposal with available trace refs.</td>
+                      <td>Manifest for artifact refs, excluded inputs, and non-conclusions.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">W2 review-loop dry run</th>
+                      <td>Connect generated envelopes and governance projections to review / CI checklists.</td>
+                      <td>Reviewer decision and CI outcome refs.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">W3 calibration join</th>
+                      <td>Join forecast items with observed refs through calibration hooks and operational artifacts.</td>
+                      <td>Held-out or prospective benchmark set.</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">W4 deployed pilot</th>
+                      <td>Run scheduler and policy thresholds on a selected repository.</td>
+                      <td>Organization-specific calibration against incidents, rollback, and MTTR.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <ul class="term-list">
+                <li>
+                  <strong>B12 / B13 forecasting</strong>
+                  <span>Creates bounded forecast artifacts through <code>ConsequenceEnvelope</code>; it does not prove forecast correctness.</span>
+                </li>
+                <li>
+                  <strong>Future adapters</strong>
+                  <span>Normalize GitHub Issue JSON, AI proposal JSON, framework semantics, and runtime / incident traces as supplied evidence.</span>
+                </li>
+                <li>
+                  <strong>B10 operational feedback</strong>
+                  <span>Stores observed outcome, calibration review, threshold, ownership, repair adoption, incident correlation, and hypothesis refresh.</span>
+                </li>
+                <li>
+                  <strong>Calibration hook</strong>
+                  <span>Connects forecast item refs with observed refs and passes them to the benchmark protocol.</span>
+                </li>
+                <li>
+                  <strong>Deployed workbench boundary</strong>
+                  <span>Bundles artifacts into one review cycle, without adding deployment correctness, automatic governance correctness, or causal theorem status.</span>
                 </li>
               </ul>
               <div class="claim-strip">

--- a/website/sft/part-vii-research-program/index.html
+++ b/website/sft/part-vii-research-program/index.html
@@ -451,9 +451,9 @@
                 <span>Previous</span>
                 <strong>Part VI. Case Studies</strong>
               </a>
-              <a href="../status/">
-                <span>Appendix</span>
-                <strong>Status and Claim Boundary</strong>
+              <a href="../glossary/">
+                <span>Next</span>
+                <strong>Glossary</strong>
               </a>
             </nav>
           </div>

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -92,7 +92,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>

--- a/website/sft/status/index.html
+++ b/website/sft/status/index.html
@@ -80,7 +80,7 @@
                 <li><a href="#claim-level-map">Claim level map</a></li>
                 <li><a href="#forecast-boundary">Forecast boundary</a></li>
                 <li><a href="#archsig-sft-boundary">ArchSig-SFT boundary</a></li>
-                <li><a href="#lean-roadmap">SFT Lean Roadmap</a></li>
+                <li><a href="#lean-status">SFT Lean status</a></li>
                 <li><a href="#promotion-rules">Promotion rules</a></li>
                 <li><a href="#source-references">Source references</a></li>
               </ol>
@@ -229,7 +229,7 @@
                   </dl>
                 </article>
                 <article class="comparison-card">
-                  <h3>Ops</h3>
+                  <h3>L5</h3>
                   <dl>
                     <div>
                       <dt>Readable claim</dt>
@@ -317,8 +317,8 @@
               </ul>
             </section>
 
-            <section id="lean-roadmap" class="article-section">
-              <h2>SFT Lean Roadmap</h2>
+            <section id="lean-status" class="article-section">
+              <h2>SFT Lean Status</h2>
               <p>
                 The current SFT formal surface is intentionally staged. Each
                 stage names the Lean-backed reading that may be cited today
@@ -390,10 +390,10 @@
               </ul>
               <div class="claim-strip">
                 <p>
-                  Issues #907 and #913 completed the current Lean formal
-                  surface used by this roadmap. Issue #916 packages the
-                  docs-facing theorem metadata, and Issue #920 packages the
-                  SFT-native counterexample anchors.
+                  The current Lean surface supports selected definitions,
+                  accessors, theorem-boundary records, and counterexample
+                  anchors. It does not promote calibration, extraction
+                  completeness, or governance effectiveness to theorem status.
                 </p>
               </div>
             </section>
@@ -434,21 +434,21 @@
               <ul class="chapter-list">
                 <li>
                   <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b125514f99989acff580584fa69df361f6ba8ce4/Formal/Arch/Evolution/SFTTheoremPackages.lean">
-                    SFT theorem package entrypoint
+                    SFT theorem package
                   </a>
-                  <span>Docs-facing metadata for SFT candidate groups, representative declarations, schematic correspondences, and non-conclusion boundaries.</span>
+                  <span>Representative declarations, schematic correspondences, and non-conclusion boundaries for the checked SFT formal surface.</span>
                 </li>
                 <li>
                   <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b125514f99989acff580584fa69df361f6ba8ce4/docs/aat/lean_theorem_index.md#sft-theorem-package-entrypoint">
                     Lean theorem index
                   </a>
-                  <span>Checked Lean declaration status for the SFT formal surface and theorem-package entrypoint.</span>
+                  <span>Checked Lean declaration status for the SFT formal surface.</span>
                 </li>
                 <li>
                   <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b125514f99989acff580584fa69df361f6ba8ce4/docs/aat/proof_obligations.md">
                     Proof obligations
                   </a>
-                  <span>Source-of-truth vocabulary for proved, defined-only, future proof obligation, and empirical hypothesis status.</span>
+                  <span>Status vocabulary for proved, defined-only, future proof obligation, and empirical hypothesis claims.</span>
                 </li>
                 <li>
                   <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/sft/software_field_theory.md">
@@ -464,9 +464,9 @@
                 </li>
                 <li>
                   <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d7f18097bca0f71edb08b8ab0a33b009e68cd33d/docs/tool/roadmap.md">
-                    ArchSig tooling roadmap
+                    ArchSig tooling reference
                   </a>
-                  <span>Current ArchSig-SFT pipeline capability and remaining gaps.</span>
+                  <span>ArchSig-SFT pipeline capability and remaining evidence boundaries.</span>
                 </li>
                 <li>
                   <a href="../theorem-candidates/">

--- a/website/sft/theorem-candidates/index.html
+++ b/website/sft/theorem-candidates/index.html
@@ -106,9 +106,8 @@
               <p>
                 The candidate list is not a progress ledger copied from GitHub
                 Issues. It is the web-facing reading of the checked SFT formal
-                surface after the Lean package entrypoint stabilized. A row may
-                contain proved accessor theorems while the larger research
-                statement remains a theorem candidate.
+                surface. A row may contain proved accessor theorems while the
+                larger research statement remains a theorem candidate.
               </p>
               <div class="claim-strip">
                 <p>
@@ -130,7 +129,7 @@
                 </li>
                 <li>
                   <strong>Theorem candidate</strong>
-                  <span>A theorem-shaped SFT statement whose bounded reading is tracked by the package entrypoint.</span>
+                  <span>A theorem-shaped SFT statement whose bounded reading is tracked by the checked formal surface.</span>
                 </li>
                 <li>
                   <strong>Lean proved</strong>
@@ -142,7 +141,7 @@
                 </li>
                 <li>
                   <strong>Schema only</strong>
-                  <span>Website or source-document exposition only. It is not being presented as a Lean theorem.</span>
+                  <span>Expository theory schema only. It is not being presented as a Lean theorem.</span>
                 </li>
               </ul>
             </section>

--- a/website/sft/theorem-candidates/index.html
+++ b/website/sft/theorem-candidates/index.html
@@ -89,7 +89,7 @@
                 <li><a href="../part-i-new-object/">Part I. The New Object</a></li>
                 <li><a href="../part-ii-basis/">Part II. AAT / SFT Interface</a></li>
                 <li><a href="../part-iii-core/">Part III. SFT Core</a></li>
-                <li><a href="../part-iv-principles/">Part IV. Principles</a></li>
+                <li><a href="../part-iv-principles/">Part IV. Attractor Engineering and Principles</a></li>
                 <li><a href="../part-v-computing-systems/">Part V. Computing Systems</a></li>
                 <li><a href="../part-vi-case-studies/">Part VI. Case Studies</a></li>
                 <li><a href="../part-vii-research-program/">Part VII. Research Program</a></li>

--- a/website/sft/theorem-candidates/index.html
+++ b/website/sft/theorem-candidates/index.html
@@ -80,7 +80,6 @@
                 <li><a href="#status-legend">Status legend</a></li>
                 <li><a href="#candidate-index">Candidate index</a></li>
                 <li><a href="#counterexample-anchors">Counterexample anchors</a></li>
-                <li><a href="#source-references">Source references</a></li>
               </ol>
             </nav>
             <div class="source-panel" data-sidebar-open="true">
@@ -466,36 +465,6 @@
                   </p>
                 </article>
               </div>
-            </section>
-
-            <section id="source-references" class="article-section">
-              <h2>Source references</h2>
-              <ul class="chapter-list">
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/c58efc4b45beae6ca481c65674294d2c40205b72/Formal/Arch/Evolution/SFTTheoremPackages.lean">
-                    SFT theorem package entrypoint
-                  </a>
-                  <span>Docs-facing metadata for candidate groups, representative declarations, schematic correspondences, and non-conclusion boundaries.</span>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/c58efc4b45beae6ca481c65674294d2c40205b72/docs/aat/lean_theorem_index.md#sft-theorem-package-entrypoint">
-                    Lean theorem index
-                  </a>
-                  <span>Checked Lean status for SFT formal surface and counterexample packages.</span>
-                </li>
-                <li>
-                  <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/c58efc4b45beae6ca481c65674294d2c40205b72/docs/aat/proof_obligations.md">
-                    Proof obligations
-                  </a>
-                  <span>Lean status vocabulary and source-of-truth boundary for proved, defined-only, future, and empirical claims.</span>
-                </li>
-                <li>
-                  <a href="../status/">
-                    SFT Status and Claim Boundary
-                  </a>
-                  <span>Claim levels and promotion rules for reading SFT website statements.</span>
-                </li>
-              </ul>
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">


### PR DESCRIPTION
## 概要

SFT website を第一級文書の内容に合わせて拡充し、公開読書面として読める web-native monograph に整えました。

- SFT overview と Part I-VII の本文を再構成し、第一級文書の定義・schema・非主張・研究プログラムを website 側へ反映
- Part III / IV / V を中心に、ForecastCone、ConsequenceEnvelope、AttractorEngineering、FieldUpdate、AI governance、lifecycle / benchmark の説明を補強
- 読者向けでない Issue 番号、内部 roadmap ラベル、B10/B12/B13 などの作業管理語を削除し、公開読者向け表現に調整

対応 Issue: なし（ユーザー依頼による website 調整）

## 証明した定理

- なし

## 編集したドキュメント

- website/sft/index.html
- website/sft/part-i-new-object/index.html
- website/sft/part-ii-basis/index.html
- website/sft/part-iii-core/index.html
- website/sft/part-iv-principles/index.html
- website/sft/part-v-computing-systems/index.html
- website/sft/part-vi-case-studies/index.html
- website/sft/part-vii-research-program/index.html
- website/sft/glossary/index.html
- website/sft/theorem-candidates/index.html
- website/sft/status/index.html

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] SFT website local href / src / fragment 解決チェック
- [x] Playwright desktop / mobile 表示確認（12ページ、h1/textあり、アンカー切れなし、横 overflow なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
