### PR TITLE
ヒーローの説明ブロックを削除

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -93,20 +93,6 @@
               preservation, obstruction witnesses, signature trajectories, and
               bounded software evolution.
             </p>
-            <ul class="status-list">
-              <li>
-                <strong>AAT</strong>
-                <span>Local algebra of architectural change.</span>
-              </li>
-              <li>
-                <strong>ArchSig</strong>
-                <span>Observation layer for signatures and witnesses.</span>
-              </li>
-              <li>
-                <strong>SFT</strong>
-                <span>Field-shaped computation over future architectural trajectories.</span>
-              </li>
-            </ul>
           </div>
           <aside class="hero-aside author-card" aria-labelledby="author-title">
             <h2 id="author-title">Author</h2>


### PR DESCRIPTION
## 概要

ホームページのヒーローから AAT / ArchSig / SFT の説明ブロックを削除し、見出しとリード文を中心にしたコンパクトな構成へ戻しました。

対応 Issue: なし（ユーザー依頼の website 微調整）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `rg -n "[\u202A-\u202E\u2066-\u2069\u200B\u200C\u200D\uFEFF]" website/index.html`（該当なし）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] website 静的表示確認: Playwright 1.60.0 で `website/index.html` を 1280x900 / 390x844 で確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている