### PR TITLE
websiteの説明文を簡潔にする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@
 - `website` は GitHub Pages 向けの公開読書面であり、`docs` の研究・実装管理文書とは責務を分ける。
 - AAT / SFT の canonical page は宣伝文ではなく、web-native preprint / monograph として、定義・仮定・定理境界・例・反例・Lean status・non-conclusion を保つ。
 - website の説明は `docs/aat/mathematical_theory.md`, `docs/sft/software_field_theory.md`, `docs/sft/aat_interface.md`, `docs/tool` の claim boundary から逸脱しない。
+- claim boundary、Lean status、Issue 管理、repository / docs の責務分離は編集時の制約として扱い、公開コピーにそのまま出さない。読者向け本文では「何を読めるか」「何を理解できるか」「どの概念へ進むか」に翻訳する。
+- 公開ページで repository、docs、Lean status、Issue、内部運用方針に触れるのは、読者の理解や検証に必要な場合に限る。landing page や section copy では、内部の根拠管理・進捗管理を説明文として書かない。
 - public release で docs や Lean status にリンクする場合は、可能な限り commit-pinned GitHub URL を使い、`blob/main` による silent drift を避ける。
 - ArchSig website では Core, Review, SFT, Operational の product surface と、research gap / calibration gap / adapter boundary を分けて書く。
 - 現在の website は no-build static stack として扱う。重い frontend framework は、静的 HTML / CSS / 小さな JavaScript では足りない明確な理由がある場合だけ導入する。

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -25,6 +25,8 @@
 - 日本語の説明は Qiita、Zenn、Hashnode などの outreach article として扱い、必要に応じて canonical English pages へ戻す。
 - AAT / SFT の公開ページは宣伝文ではなく、web-native preprint / monograph として、定義、前提、定理境界、例、反例、Lean status、non-conclusion を保つ。
 - ArchSig ページでは Core、Review、SFT、Operational の product surface と、research gap / calibration gap / adapter boundary を分けて書く。
+- repository、docs、Lean status、Issue、claim boundary への言及は、公開コピーへそのまま出すための素材ではない。これらは編集時の制約として扱い、本文では読者にとって自然な研究内容、読書導線、概念説明へ翻訳する。
+- landing page や section copy では、内部の根拠管理、進捗管理、運用方針を説明しない。公開本文は「何を読めるか」「何を理解できるか」「どの概念へ進むか」を中心に書く。
 
 ## 公開設定
 

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -88,7 +88,7 @@
             <nav class="toc-panel" aria-labelledby="toc-title">
               <h2 id="toc-title">On this page</h2>
               <ol>
-                <li><a href="#reading-order">Reading order</a></li>
+                <li><a href="#reading-order">Chapters</a></li>
                 <li><a href="#abstract">Abstract</a></li>
                 <li><a href="#division-of-work">AAT / ArchSig / SFT</a></li>
                 <li><a href="#main-contributions">Main contributions</a></li>
@@ -161,7 +161,7 @@
 
           <div class="article-main">
             <section id="reading-order" class="article-section">
-              <h2>Reading order</h2>
+              <h2>Chapters</h2>
               <p>
                 Start with Foundations for the main line. Use the coupon
                 example when you want a concrete pass first, and use Status

--- a/website/index.html
+++ b/website/index.html
@@ -116,11 +116,6 @@
             </p>
           </div>
           <div class="research-detail">
-            <p>
-              AAT is the local algebra of architectural change. It turns
-              design judgment into local questions: what object, what
-              operation, what invariant, what witness.
-            </p>
             <a class="research-primary-link" href="aat/">Read AAT overview</a>
             <nav class="chapter-link-list" aria-label="AAT chapters">
               <a href="aat/foundations/">Foundations</a>
@@ -150,12 +145,6 @@
             </p>
           </div>
           <div class="research-detail">
-            <p>
-              SFT is field-shaped computation over future architectural
-              trajectories: how present artifacts make changes easier, harder,
-              safer, or more costly next. Its AAT interface is handled inside
-              Part II as the dependency and claim-boundary discipline.
-            </p>
             <a class="research-primary-link" href="sft/">Read SFT overview</a>
             <nav class="chapter-link-list" aria-label="SFT chapters">
               <a href="sft/part-i-new-object/">Part I. The New Object</a>
@@ -182,10 +171,6 @@
             </p>
           </div>
           <div class="research-detail">
-            <p>
-              ArchSig is the observation layer for signatures and witnesses.
-              It keeps reports useful by keeping non-conclusions visible.
-            </p>
             <a class="research-primary-link" href="archsig/">Read ArchSig manual</a>
             <nav class="chapter-link-list" aria-label="ArchSig chapters">
               <a href="archsig/getting-started/">Getting Started</a>
@@ -206,11 +191,10 @@
         <div class="site-shell section-grid">
           <div class="section-heading">
             <p class="eyebrow">Outreach</p>
-            <h2>Articles point back to the canonical theory.</h2>
+            <h2>Research Essays</h2>
             <p>
-              Hashnode, Zenn, Qiita, and other essays should act as entry
-              points. Formal claims, theorem status, and empirical boundaries
-              remain in the repository documents.
+              Articles and essays on AAT, SFT, ArchSig, and the design
+              questions behind bounded software evolution.
             </p>
           </div>
           <div class="outreach-stack">


### PR DESCRIPTION
## 概要

ホームページの AAT / SFT / ArchSig セクションから右カラム側の重複説明を削除し、Outreach セクションを Research Essays として簡潔にしました。

あわせて AAT ページの `Reading order` 表示を `Chapters` に変更し、website copy に内部運用方針をそのまま出さないルールを `AGENTS.md` と `docs/website/README.md` に追記しました。

対応 Issue: なし（ユーザー依頼の website copy 調整）

## 証明した定理

- なし

## 編集したドキュメント

- `AGENTS.md`
- `docs/website/README.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `AGENTS.md`, `docs/website/README.md`, `website/index.html`, `website/aat/index.html`（該当なし）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] website 静的表示確認: Playwright 1.60.0 で `website/index.html` と `website/aat/index.html` を 1280x900 / 390x844 で確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている