### PR TITLE
SFT第1部のfieldページ群を実装

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1291,6 +1291,37 @@ p {
   font-weight: 850;
 }
 
+.question-card {
+  border: 1px solid var(--rule);
+  border-left: 5px solid var(--accent-warm);
+  border-radius: 6px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  margin: 0 0 28px;
+  padding: 20px 22px;
+}
+
+.question-card-label {
+  display: block;
+  color: var(--accent-warm);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.question-card p {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: clamp(1.06rem, 1.8vw, 1.22rem);
+  font-weight: 760;
+  line-height: 1.48;
+  margin: 0;
+}
+
 .reader-model {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/website/sft/field/agents/index.html
+++ b/website/sft/field/agents/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 1-3: developers and AI agents as field participants.">
+    <title>SFT 1-3: Developers and AI Agents</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/field/agents/">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../../">Home</a>
+          <a href="../../../aat/">AAT</a>
+          <a class="is-active" href="../../">SFT</a>
+          <a href="../../../archsig/">ArchSig</a>
+          <a href="../../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../../">Home</a>
+            <a href="../../">SFT</a>
+            <a href="../">Field</a>
+            <span>Agents</span>
+          </nav>
+          <p class="eyebrow">SFT 1-3</p>
+          <h1>Developers and AI Agents</h1>
+          <p class="lede">
+            Developers and AI agents both participate in the field. They
+            interpret artifacts, generate proposals, amplify local patterns,
+            and leave review and outcome traces that become future memory.
+          </p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT navigation">
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>Part 1 routes</h2>
+              <ul>
+                <li><a href="../">Part 1. Field</a></li>
+                <li><a href="../codebase-memory/">1-1. Codebase Memory</a></li>
+                <li><a href="../artifacts/">1-2. Artifacts</a></li>
+                <li><a href="./" aria-current="page">1-3. Agents</a></li>
+                <li><a href="../organization-structure/">1-4. Organization Structure</a></li>
+                <li><a href="../governance-feedback/">1-5. Governance Feedback</a></li>
+                <li><a href="../architecture-futures/">1-6. Architecture Futures</a></li>
+                <li><a href="../../computation/">Part 2. Computation</a></li>
+              </ul>
+            </div>
+          </aside>
+          <div class="article-main">
+            <section class="article-section">
+              <h2>Participants, not external tools</h2>
+              <p>
+                A developer reads artifacts through local knowledge, ownership,
+                deadlines, review expectations, and operational memory. An AI
+                agent reads a prompt, nearby code, repository conventions, and
+                policy constraints. Both turn the current field into candidate
+                operations.
+              </p>
+              <p>
+                SFT therefore treats agents as field participants. The point is
+                not to collapse human judgement into automation. It is to ask
+                where proposals came from, which boundary made them plausible,
+                and which mediation converted or rejected them.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Pattern amplification</h2>
+              <p>
+                A codebase is also a prompt. Strong local structure, clear
+                invariants, and explicit review rules make good changes easier
+                to imitate. Weak boundaries and repeated shortcuts also become
+                easy to imitate, especially when an AI agent selects the path
+                that looks most natural in the surrounding context.
+              </p>
+              <p>
+                This is a field question, not a general AI quality benchmark.
+                The relevant evidence is the proposal boundary, source artifact
+                refs, accepted and rejected changes, review comments, CI
+                results, and the posterior field update.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Boundary</h2>
+              <p>
+                SFT does not prove general AI safety. It gives a bounded way to
+                account for AI-mediated proposal pressure inside architecture
+                theorem boundaries, review mediation, and field updates.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../artifacts/"><span>Previous</span><strong>1-2. Artifacts Shape the Field</strong></a>
+              <a class="page-nav-next" href="../organization-structure/"><span>Next</span><strong>1-4. Organization Structure as Field</strong></a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/field/agents/index.html
+++ b/website/sft/field/agents/index.html
@@ -3,11 +3,29 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT 1-3: developers and AI agents as field participants.">
+    <meta name="description" content="SFT 1-3: developers and AI agents as field participants, proposal generators, interpreters, and local pattern amplifiers.">
     <title>SFT 1-3: Developers and AI Agents</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/agents/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 1-3: Developers and AI Agents">
+    <meta property="og:description" content="Developers and AI agents participate in the field as artifact interpreters, proposal generators, and local pattern amplifiers.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/agents/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 1-3: Developers and AI Agents">
+    <meta name="twitter:description" content="Developers and AI agents participate in the field as artifact interpreters, proposal generators, and local pattern amplifiers.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../../assets/site.css">
     <script defer src="../../../assets/site.js"></script>
   </head>
@@ -41,15 +59,26 @@
           <p class="eyebrow">SFT 1-3</p>
           <h1>Developers and AI Agents</h1>
           <p class="lede">
-            Developers and AI agents both participate in the field. They
-            interpret artifacts, generate proposals, amplify local patterns,
-            and leave review and outcome traces that become future memory.
+            Developers and AI agents are field participants. They interpret
+            artifacts, select from visible local patterns, generate proposals,
+            pass through governance, and leave traces that become future field
+            memory.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#agents-in-the-field">Agents in the field</a></li>
+                <li><a href="#agent-role">Agent role</a></li>
+                <li><a href="#amplification">Pattern amplification</a></li>
+                <li><a href="#governance">Governance trace</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
               <h2>Part 1 routes</h2>
               <ul>
@@ -65,44 +94,175 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
-              <h2>Participants, not external tools</h2>
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>When humans and AI agents propose changes, what field are they really sampling from?</p>
+            </aside>
+
+            <section id="agents-in-the-field" class="article-section">
+              <h2>Agents in the field</h2>
               <p>
-                A developer reads artifacts through local knowledge, ownership,
-                deadlines, review expectations, and operational memory. An AI
-                agent reads a prompt, nearby code, repository conventions, and
-                policy constraints. Both turn the current field into candidate
-                operations.
+                Developers do not approach a codebase as blank minds applying
+                pure design principles. They arrive with local memory, deadlines,
+                ownership rules, review expectations, fear of breaking runtime
+                behavior, and a sense of which changes will be accepted. Those
+                pressures are part of the field.
               </p>
               <p>
-                SFT therefore treats agents as field participants. The point is
-                not to collapse human judgement into automation. It is to ask
-                where proposals came from, which boundary made them plausible,
-                and which mediation converted or rejected them.
+                AI agents make the same point more visible. An agent does not
+                simply "write code." It samples nearby files, prompt text, issue
+                wording, tests, policy instructions, and repeated local idioms.
+                It then produces operations that are cheap under that surface.
+                If the surface contains good boundaries, the agent can amplify
+                them. If it contains hidden shortcuts, the agent can amplify
+                those too.
+              </p>
+              <p>
+                The lesson is not that humans are unreliable or that AI is
+                dangerous by nature. The lesson is that proposal generation is
+                field-shaped. To govern proposals, we must govern the field that
+                makes proposals natural.
+              </p>
+              <p>
+                This view also softens a false opposition between human judgment
+                and automation. Both participate in the same field, but with
+                different sensitivities. Humans carry organizational memory,
+                fear, taste, and responsibility. AI agents carry prompt context,
+                local code statistics, tool access, and policy wrappers. The
+                field determines how these sensitivities meet.
+              </p>
+              <p>
+                A proposal is therefore evidence. It reveals what the field made
+                available to an agent at that moment: the nearby pattern, the
+                missing boundary, the named invariant, the policy instruction,
+                the absent test. Even a bad proposal can be a useful instrument
+                if the field records why it was natural.
               </p>
             </section>
-            <section class="article-section">
+
+            <section id="agent-role" class="article-section">
+              <h2>Agent role</h2>
+              <p>
+                A developer does not act on source code alone. They act through
+                local knowledge, deadlines, ownership, review memory, incident
+                history, and available tooling. An AI agent similarly acts
+                through a prompt, source refs, repository patterns, policy
+                constraints, and the surface area it can inspect.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Field participant schema</figcaption>
+                <pre><code>FieldParticipant
+  = interpreter of artifacts
+  + proposal generator
+  + selector of visible local patterns
+  + subject of policy and review
+  + producer of accepted / rejected trace
+  + contributor to posterior field memory</code></pre>
+              </figure>
+              <p id="definition-1-7" class="statement">
+                <a class="statement-anchor" href="#definition-1-7">Definition 1.7.</a>
+                A field participant is any human or tool-mediated actor whose
+                proposals, interpretations, review responses, and observed
+                outcomes change the future support relation of the field.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.7">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>AI proposal governance is specified as tooling protocol, not as a general AI safety theorem.</span>
+              </p>
+            </section>
+
+            <section id="amplification" class="article-section">
               <h2>Pattern amplification</h2>
               <p>
-                A codebase is also a prompt. Strong local structure, clear
-                invariants, and explicit review rules make good changes easier
-                to imitate. Weak boundaries and repeated shortcuts also become
-                easy to imitate, especially when an AI agent selects the path
-                that looks most natural in the surrounding context.
+                The codebase is also a prompt. Clear boundaries, explicit
+                invariants, and strong tests make lawful paths easy to imitate.
+                Repeated shortcuts, hidden ownership, and missing invariants
+                also become easy to imitate. AI agents make this effect sharper
+                because they can reproduce locally plausible patterns quickly.
               </p>
               <p>
-                This is a field question, not a general AI quality benchmark.
-                The relevant evidence is the proposal boundary, source artifact
-                refs, accepted and rejected changes, review comments, CI
-                results, and the posterior field update.
+                This is one place where the language of attractors begins to
+                matter. A repeated pattern is not just repeated; it becomes a
+                low-friction destination for future proposals. The agent does
+                not need to know that the path is architecturally desirable. It
+                only needs the field to make that path nearby, legible, and
+                cheap.
+              </p>
+              <p>
+                This is the modern urgency of SFT. Before AI, a bad local
+                default might be copied slowly through habit. With AI-mediated
+                proposal streams, the same default can appear repeatedly and
+                confidently. The issue is not only whether one generated patch
+                passes review. The issue is whether the field is teaching many
+                patches to move toward the same bad basin.
+              </p>
+              <p>
+                Conversely, a well-shaped field can make AI useful in a deeper
+                way than "faster typing." If invariants are explicit, tests name
+                the right boundary, and examples show the intended operation
+                family, an agent can amplify good local laws. SFT therefore
+                treats AI governance as architecture governance: change the
+                support surface, and the proposal stream changes with it.
+              </p>
+              <p id="proposition-1-8" class="statement">
+                <a class="statement-anchor" href="#proposition-1-8">Proposition 1.8.</a>
+                AI mediation increases the importance of field design: the
+                existing field influences not only what humans judge acceptable,
+                but also what automated proposal generation treats as locally
+                natural.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Proposition 1.8">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-future">empirical / tooling hypothesis</span>
+                <span>Tracked through proposal refs, review mediation, CI results, and posterior field updates.</span>
               </p>
             </section>
-            <section class="article-section">
-              <h2>Boundary</h2>
+
+            <section id="governance" class="article-section">
+              <h2>Governance trace</h2>
               <p>
-                SFT does not prove general AI safety. It gives a bounded way to
-                account for AI-mediated proposal pressure inside architecture
-                theorem boundaries, review mediation, and field updates.
+                The unit of evidence is not the raw AI output. SFT separates
+                raw proposal pressure, accepted proposal, rejected proposal,
+                review-mediated transition, CI result, and posterior field
+                update. This prevents AI policy compliance from being mistaken
+                for architecture lawfulness.
+              </p>
+              <p>
+                This accounting matters because a rejected proposal is not
+                worthless. If the rejection reason is recorded, it becomes a
+                signal about unsupported paths. If it disappears, the field has
+                learned very little. The difference between those two outcomes
+                is not model quality; it is governance memory.
+              </p>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> Treat proposal streams as probes
+                of the field, not just outputs to accept or reject.
+              </p>
+              <dl class="term-list definition-list">
+                <div>
+                  <dt>prompt / policy boundary</dt>
+                  <dd>The declared objective, source refs, forbidden changes, and review requirements given to the agent.</dd>
+                </div>
+                <div>
+                  <dt>shortcut witness</dt>
+                  <dd>A proposal shape that follows local convenience while bypassing a missing invariant or governance premise.</dd>
+                </div>
+                <div>
+                  <dt>posterior field update</dt>
+                  <dd>The recorded evidence after review, CI, merge, rejection, incident, or follow-up changes the field memory.</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-1-9" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-9">Non-conclusion 1.9.</a>
+                This page does not claim general AI safety, model reliability,
+                or autonomous lawfulness. It claims that AI-mediated software
+                evolution must be read through field support, policy boundary,
+                review mediation, and observed outcomes.
               </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/field/architecture-futures/index.html
+++ b/website/sft/field/architecture-futures/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 1-6: reachable architecture futures.">
+    <title>SFT 1-6: Architecture Futures</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/field/architecture-futures/">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../../">Home</a>
+          <a href="../../../aat/">AAT</a>
+          <a class="is-active" href="../../">SFT</a>
+          <a href="../../../archsig/">ArchSig</a>
+          <a href="../../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../../">Home</a>
+            <a href="../../">SFT</a>
+            <a href="../">Field</a>
+            <span>Architecture Futures</span>
+          </nav>
+          <p class="eyebrow">SFT 1-6</p>
+          <h1>Architecture Futures</h1>
+          <p class="lede">
+            SFT studies reachable architecture futures, not a single predicted
+            endpoint. A future is read through trajectories, signature
+            movement, obstruction candidates, and default paths under an
+            explicit field boundary.
+          </p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT navigation">
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>Part 1 routes</h2>
+              <ul>
+                <li><a href="../">Part 1. Field</a></li>
+                <li><a href="../codebase-memory/">1-1. Codebase Memory</a></li>
+                <li><a href="../artifacts/">1-2. Artifacts</a></li>
+                <li><a href="../agents/">1-3. Agents</a></li>
+                <li><a href="../organization-structure/">1-4. Organization Structure</a></li>
+                <li><a href="../governance-feedback/">1-5. Governance Feedback</a></li>
+                <li><a href="./" aria-current="page">1-6. Architecture Futures</a></li>
+                <li><a href="../../computation/">Part 2. Computation</a></li>
+              </ul>
+            </div>
+          </aside>
+          <div class="article-main">
+            <section class="article-section">
+              <h2>Future as path family</h2>
+              <p>
+                An architecture future is not merely an end state. It is a
+                field path: a sequence of supported operations, observations,
+                review mediations, and feedback updates. The path matters
+                because a safe-looking endpoint can still require unsafe
+                intermediate states or hidden boundary crossings.
+              </p>
+              <p>
+                SFT therefore asks about trajectory, not only destination.
+                Which signature axes move? Which obstruction candidates appear?
+                Which default path becomes cheaper? Which missing invariant
+                prevents reviewers from comparing futures?
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Reachability, not certainty</h2>
+              <p>
+                A field changes which futures are reachable and which are
+                naturally selected, but it does not decide one future in
+                advance. The selected field model, operation support, policy,
+                observation boundary, and horizon define the bounded problem.
+              </p>
+              <p>
+                This is the bridge from Part 1 to Part 2. Once the development
+                organization is read as a field, SFT can make software
+                evolution computable by naming the slice, support relation,
+                step relation, ForecastCone, and report projection.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Boundary</h2>
+              <p>
+                ForecastCone is not defined on this page. Part 1 keeps the
+                reader at the level of field intuition and reachable futures;
+                Part 2 introduces the formal and tooling-facing objects.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../governance-feedback/"><span>Previous</span><strong>1-5. Governance and Feedback</strong></a>
+              <a class="page-nav-next" href="../../computation/"><span>Next</span><strong>Part 2. Making Software Evolution Computable</strong></a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/field/architecture-futures/index.html
+++ b/website/sft/field/architecture-futures/index.html
@@ -3,11 +3,29 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT 1-6: reachable architecture futures.">
+    <meta name="description" content="SFT 1-6: architecture futures as reachable trajectories, signature movement, obstruction candidates, and default paths under an explicit field boundary.">
     <title>SFT 1-6: Architecture Futures</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/architecture-futures/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 1-6: Architecture Futures">
+    <meta property="og:description" content="Architecture futures are reachable trajectories of supported operations, signature movement, obstruction candidates, and default paths under a field boundary.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/architecture-futures/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 1-6: Architecture Futures">
+    <meta name="twitter:description" content="SFT studies reachable architecture futures as trajectories, not as one predicted endpoint.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../../assets/site.css">
     <script defer src="../../../assets/site.js"></script>
   </head>
@@ -41,16 +59,26 @@
           <p class="eyebrow">SFT 1-6</p>
           <h1>Architecture Futures</h1>
           <p class="lede">
-            SFT studies reachable architecture futures, not a single predicted
-            endpoint. A future is read through trajectories, signature
-            movement, obstruction candidates, and default paths under an
-            explicit field boundary.
+            SFT studies reachable architecture futures rather than a single
+            predicted endpoint. A future is read as a trajectory of supported
+            operations, signature movement, obstruction candidates, default
+            paths, and feedback updates under an explicit field boundary.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#future-shape">The shape of a future</a></li>
+                <li><a href="#trajectory">Future as trajectory</a></li>
+                <li><a href="#signature">Signature movement</a></li>
+                <li><a href="#part-two">Bridge to Part 2</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
               <h2>Part 1 routes</h2>
               <ul>
@@ -66,43 +94,162 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
-              <h2>Future as path family</h2>
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>What if the future of a codebase is not a point to predict, but a shape of reachable paths?</p>
+            </aside>
+
+            <section id="future-shape" class="article-section">
+              <h2>The shape of a future</h2>
               <p>
-                An architecture future is not merely an end state. It is a
-                field path: a sequence of supported operations, observations,
-                review mediations, and feedback updates. The path matters
-                because a safe-looking endpoint can still require unsafe
-                intermediate states or hidden boundary crossings.
+                When people ask about the future of a codebase, they often ask
+                for a destination: will this architecture become cleaner or
+                worse, safer or more tangled, easier or harder to change? SFT
+                changes the question. A future is not only a destination. It is
+                a family of paths made reachable by the present field.
               </p>
               <p>
-                SFT therefore asks about trajectory, not only destination.
-                Which signature axes move? Which obstruction candidates appear?
-                Which default path becomes cheaper? Which missing invariant
-                prevents reviewers from comparing futures?
+                This is a crucial shift. Two teams can aim for the same endpoint
+                and travel through very different worlds. One path preserves
+                invariants as it moves. Another path reaches the same diagram by
+                passing through unreviewed boundaries, unmeasured runtime
+                assumptions, temporary shortcuts that become permanent, and
+                feedback that arrives too late.
+              </p>
+              <p>
+                The endpoint may look identical on a slide. The architecture
+                future is not identical.
+              </p>
+              <p>
+                This is the first place where the word "future" becomes
+                precise enough to be dangerous. SFT is not asking for prophecy.
+                It is asking which paths are open under the current field, which
+                paths are cheap, which paths require exceptional intervention,
+                and which paths are invisible because the field cannot observe
+                their relevant coordinates.
+              </p>
+              <p>
+                When a path stays cheap across many changes, it begins to behave
+                like an attractor. SFT does not need to claim physical
+                attraction to use the word. It only needs the repeated fact that
+                the field keeps presenting one family of operations as natural.
+                Part 3 will ask how to design fields where the useful attractors
+                are easy and the dangerous shortcuts become costly, visible, or
+                review-mediated.
+              </p>
+              <p>
+                This turns "the future" from a foggy noun into an object we can
+                reason about. Not the one thing that will happen, but the region
+                of paths the current field makes reachable.
               </p>
             </section>
-            <section class="article-section">
-              <h2>Reachability, not certainty</h2>
+
+            <section id="trajectory" class="article-section">
+              <h2>Future as trajectory</h2>
               <p>
-                A field changes which futures are reachable and which are
-                naturally selected, but it does not decide one future in
-                advance. The selected field model, operation support, policy,
-                observation boundary, and horizon define the bounded problem.
+                An architecture future is a path through the field: a sequence
+                of proposals, selected operations, review mediations, accepted
+                and rejected changes, observations, and feedback updates. This
+                path reading is essential because two futures may share a final
+                diagram while differing in risk, observability, rollback, and
+                invariant preservation along the way.
               </p>
-              <p>
-                This is the bridge from Part 1 to Part 2. Once the development
-                organization is read as a field, SFT can make software
-                evolution computable by naming the slice, support relation,
-                step relation, ForecastCone, and report projection.
+              <figure class="code-panel">
+                <figcaption>Architecture future reading</figcaption>
+                <pre><code>ArchitectureFuture
+  = start field
+  + supported operation path
+  + architecture projection path
+  + signature movement
+  + obstruction candidates
+  + feedback updates
+  + unknown remainder</code></pre>
+              </figure>
+              <p id="definition-1-16" class="statement">
+                <a class="statement-anchor" href="#definition-1-16">Definition 1.16.</a>
+                A reachable architecture future is a field-relative path family
+                whose architecture projection can be inspected through selected
+                signature axes, obstruction candidates, and governance evidence.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.16">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>Part 2 refines this reading into bounded path and forecast-cone objects.</span>
               </p>
             </section>
-            <section class="article-section">
+
+            <section id="signature" class="article-section">
+              <h2>Signature movement</h2>
+              <p>
+                SFT uses architecture futures to ask what moves, not only what
+                lands. Which signature axes improve, degrade, become measured,
+                or remain unknown? Which obstruction candidates appear before
+                the endpoint? Which default path becomes cheaper after the first
+                accepted change?
+              </p>
+              <p>
+                The answer is not a single score. It is a moving signature. Some
+                axes may improve while others become unmeasured. Some
+                obstruction candidates may disappear while new ones are made
+                possible by the path itself. The future is therefore a curve
+                through observation, not a label attached to the final state.
+              </p>
+              <p>
+                This is why "safe endpoint" reasoning is too weak. A migration
+                can end in a clean module boundary while losing rollback
+                capacity along the way. A refactor can improve dependency
+                direction while hiding runtime coupling. A policy can reduce
+                one obstruction while making another unmeasured. SFT wants the
+                trajectory because the trajectory is where the field pays.
+              </p>
+              <p id="proposition-1-17" class="statement">
+                <a class="statement-anchor" href="#proposition-1-17">Proposition 1.17.</a>
+                A safe endpoint does not imply a safe trajectory. A field path
+                may pass through unsupported operations, unmeasured boundaries,
+                or governance gaps even when its final architecture projection
+                appears acceptable.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Proposition 1.17">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-future">theorem candidate</span>
+                <span>Candidate counterexample anchor for Part 2 / formal-core: endpoint property without path safety.</span>
+              </p>
+            </section>
+
+            <section id="part-two" class="article-section">
+              <h2>Bridge to Part 2</h2>
+              <p class="plain-reading">
+                <strong>Plain reading.</strong> Part 1 names what the future is
+                about. Part 2 names the bounded objects that make it computable.
+              </p>
+              <p>
+                The next part introduces computable slices, architecture
+                projections, observation layers, operation support, step
+                relations, ForecastCone, ConsequenceEnvelope, support safety,
+                proposal accounting, and calibration. Those objects do not
+                erase the field; they make selected pieces of it precise enough
+                to calculate with.
+              </p>
+              <p>
+                The ambition is not to replace judgment with a number. It is to
+                give judgment a better object. Instead of arguing only about an
+                intended end state, SFT asks for the reachable shape of futures
+                and the evidence boundary under which that shape was computed.
+              </p>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> Do not ask only where the system
+                should end. Ask what paths the field can actually traverse.
+              </p>
+            </section>
+
+            <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p>
-                ForecastCone is not defined on this page. Part 1 keeps the
-                reader at the level of field intuition and reachable futures;
-                Part 2 introduces the formal and tooling-facing objects.
+              <p id="non-conclusion-1-18" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-18">Non-conclusion 1.18.</a>
+                This page does not define <code>ForecastCone</code> and does not
+                claim forecast correctness, probability weighting, or causal
+                proof. It closes Part 1 by making the field-relative future the
+                object that Part 2 will bound.
               </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/field/artifacts/index.html
+++ b/website/sft/field/artifacts/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 1-2: artifacts shape the field.">
+    <title>SFT 1-2: Artifacts Shape the Field</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/field/artifacts/">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../../">Home</a>
+          <a href="../../../aat/">AAT</a>
+          <a class="is-active" href="../../">SFT</a>
+          <a href="../../../archsig/">ArchSig</a>
+          <a href="../../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../../">Home</a>
+            <a href="../../">SFT</a>
+            <a href="../">Field</a>
+            <span>Artifacts</span>
+          </nav>
+          <p class="eyebrow">SFT 1-2</p>
+          <h1>Artifacts Shape the Field</h1>
+          <p class="lede">
+            PRDs, specs, issues, design notes, review comments, and incident
+            reports do not determine the next PR. They reshape which candidate
+            updates become visible, cheap, reviewable, and selected.
+          </p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT navigation">
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>Part 1 routes</h2>
+              <ul>
+                <li><a href="../">Part 1. Field</a></li>
+                <li><a href="../codebase-memory/">1-1. Codebase Memory</a></li>
+                <li><a href="./" aria-current="page">1-2. Artifacts</a></li>
+                <li><a href="../agents/">1-3. Agents</a></li>
+                <li><a href="../organization-structure/">1-4. Organization Structure</a></li>
+                <li><a href="../governance-feedback/">1-5. Governance Feedback</a></li>
+                <li><a href="../architecture-futures/">1-6. Architecture Futures</a></li>
+                <li><a href="../../computation/">Part 2. Computation</a></li>
+              </ul>
+            </div>
+          </aside>
+          <div class="article-main">
+            <section class="article-section">
+              <h2>Artifact-mediated force</h2>
+              <p>
+                An artifact is a field participant because it changes the
+                work that can be proposed and justified. A PRD may expose a
+                missing invariant. A spec may make a boundary observable. An
+                issue may split work along one ownership line rather than
+                another. A review comment may turn an implicit rule into a
+                reusable condition.
+              </p>
+              <p>
+                SFT uses force as an informal name for this field-level
+                reading. The artifact does not push the codebase along one
+                necessary path. It changes candidate updates, operation
+                support, selection policy, and observation boundary.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Reading artifacts without prediction theatre</h2>
+              <p>
+                The useful question is not "which PR will this PRD produce?"
+                The useful question is which paths become closer, which
+                obstructions become visible, which interfaces are likely to be
+                touched, and which evidence will be missing when reviewers try
+                to judge the change.
+              </p>
+              <p>
+                This keeps artifact analysis inside the SFT boundary. It is a
+                bounded account of supported futures, not a PRD-to-PR predictor
+                and not a causal proof about an organization.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Boundary</h2>
+              <p>
+                Part 1 treats artifacts as field-shaping inputs. The formal
+                objects for support, ForecastCone, and ConsequenceEnvelope are
+                introduced in Part 2.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../codebase-memory/"><span>Previous</span><strong>1-1. Codebase as Field Memory</strong></a>
+              <a class="page-nav-next" href="../agents/"><span>Next</span><strong>1-3. Developers and AI Agents</strong></a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/field/artifacts/index.html
+++ b/website/sft/field/artifacts/index.html
@@ -3,11 +3,29 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT 1-2: artifacts shape the field.">
+    <meta name="description" content="SFT 1-2: artifacts shape the field by changing candidate updates, support, selection policy, and observation boundaries.">
     <title>SFT 1-2: Artifacts Shape the Field</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/artifacts/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 1-2: Artifacts Shape the Field">
+    <meta property="og:description" content="PRDs, specs, issues, design notes, review comments, and incident reports change operation support, selection policy, and observation boundaries.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/artifacts/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 1-2: Artifacts Shape the Field">
+    <meta name="twitter:description" content="Artifacts change operation support, selection policy, and observation boundaries before code changes.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../../assets/site.css">
     <script defer src="../../../assets/site.js"></script>
   </head>
@@ -42,14 +60,26 @@
           <h1>Artifacts Shape the Field</h1>
           <p class="lede">
             PRDs, specs, issues, design notes, review comments, and incident
-            reports do not determine the next PR. They reshape which candidate
-            updates become visible, cheap, reviewable, and selected.
+            reports are not passive documents. They reshape the field by making
+            some updates expressible, some invariants visible, and some review
+            questions unavoidable.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#documents-that-push">Documents that push</a></li>
+                <li><a href="#artifact-action">Artifact action</a></li>
+                <li><a href="#force">Force without physics</a></li>
+                <li><a href="#support">Support and observation</a></li>
+                <li><a href="#counter-reading">Counter-reading</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
               <h2>Part 1 routes</h2>
               <ul>
@@ -65,44 +95,189 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
-              <h2>Artifact-mediated force</h2>
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>How can a document change software evolution before it changes a single line of code?</p>
+            </aside>
+
+            <section id="documents-that-push" class="article-section">
+              <h2>Documents that push</h2>
               <p>
-                An artifact is a field participant because it changes the
-                work that can be proposed and justified. A PRD may expose a
-                missing invariant. A spec may make a boundary observable. An
-                issue may split work along one ownership line rather than
-                another. A review comment may turn an implicit rule into a
-                reusable condition.
+                A requirement document is usually treated as a message: someone
+                asks for a feature, and engineers respond by changing code. SFT
+                reads it more dynamically. A document enters the development
+                field and changes the set of operations that people can name,
+                defend, split, review, test, and automate.
               </p>
               <p>
-                SFT uses force as an informal name for this field-level
-                reading. The artifact does not push the codebase along one
-                necessary path. It changes candidate updates, operation
-                support, selection policy, and observation boundary.
+                The interesting question is not whether an artifact uniquely
+                determines an implementation. It does not. The interesting
+                question is what the artifact makes easier to see. Does it name
+                the invariant? Does it expose the boundary? Does it make a
+                shortcut look harmless? Does it give reviewers a vocabulary for
+                refusing the wrong path? Does it leave the most important
+                observation outside the model?
+              </p>
+              <p>
+                This is why a short issue, a design note, or a review comment
+                can matter as much as a large spec. The artifact is a field
+                action. It pushes on the future without dictating it.
+              </p>
+              <p>
+                The most powerful artifacts are often not the longest ones.
+                They are the ones that change the coordinate system of the
+                conversation. After a good artifact, people stop arguing about
+                vague preference and start asking about a named boundary,
+                invariant, observation, or migration path. The future has not
+                been selected, but the field has been reoriented.
+              </p>
+              <p>
+                This is the intellectual turn: an artifact is not important only
+                because it contains information. It is important because it
+                changes the geometry of action. It can open a path, close a
+                shortcut, make an invariant observable, or leave the field with
+                too many cheap interpretations.
               </p>
             </section>
-            <section class="article-section">
-              <h2>Reading artifacts without prediction theatre</h2>
+
+            <section id="artifact-action" class="article-section">
+              <h2>Artifact action</h2>
               <p>
-                The useful question is not "which PR will this PRD produce?"
-                The useful question is which paths become closer, which
-                obstructions become visible, which interfaces are likely to be
-                touched, and which evidence will be missing when reviewers try
-                to judge the change.
+                A useful artifact changes the field before code changes. It
+                names a boundary, asks for a responsibility split, exposes a
+                missing invariant, records a previous failure, or makes a
+                review question reusable. Even an ambiguous artifact has field
+                effects: it may invite shortcut paths, create competing
+                interpretations, or hide the observation needed for reviewers
+                to distinguish safe and unsafe futures.
               </p>
-              <p>
-                This keeps artifact analysis inside the SFT boundary. It is a
-                bounded account of supported futures, not a PRD-to-PR predictor
-                and not a causal proof about an organization.
+              <figure class="code-panel">
+                <figcaption>Artifact-mediated field action</figcaption>
+                <pre><code>ArtifactAction
+  = source artifact refs
+  + target field components
+  + candidate field updates
+  + changed operation support
+  + changed selection policy
+  + changed observation boundary
+  + unknown remainder</code></pre>
+              </figure>
+              <p id="definition-1-4" class="statement">
+                <a class="statement-anchor" href="#definition-1-4">Definition 1.4.</a>
+                Artifact-mediated force is the field-level reading of how a
+                PRD, spec, issue, design note, review comment, or incident
+                report changes supported candidate updates.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.4">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>Formal support and cone objects are deferred to Part 2.</span>
               </p>
             </section>
-            <section class="article-section">
+
+            <section id="force" class="article-section">
+              <h2>Force without physics</h2>
+              <p>
+                The word <em>force</em> is useful because artifacts do not
+                merely sit beside the codebase. They push on the field. A
+                carefully written incident report can make an invariant hard to
+                ignore. A vague issue can make several incompatible paths look
+                equally legitimate. A review comment can turn one person's
+                judgment into a reusable selection rule. An AI proposal can
+                amplify a local pattern until it becomes the default candidate.
+              </p>
+              <p>
+                The force is not a vector and not a causal guarantee. Its
+                computable reading is smaller and sharper: which operation
+                families gained support, which lost support, which selection
+                policy changed, and which observations became possible or
+                remained missing.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Computable reading of artifact force</figcaption>
+                <pre><code>artifact-mediated force
+  -> operation support changes
+  -> selection policy changes
+  -> observation boundary changes
+  -> reachable future shape changes</code></pre>
+              </figure>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> Do not ask only what the artifact
+                requests. Ask what operations it makes newly easy to name.
+              </p>
+            </section>
+
+            <section id="support" class="article-section">
+              <h2>Support and observation</h2>
+              <p>
+                The key shift is from "artifact as requirement" to "artifact as
+                support transformation." A spec can make a lawful operation
+                cheap by stating its preconditions. A design note can make a
+                hidden coupling reviewable. An incident report can make a
+                previously unmeasured runtime axis visible. A review comment can
+                convert local judgement into durable field memory.
+              </p>
+              <p>
+                A weak artifact can do the opposite. It can ask for behavior
+                while hiding the boundary, demand speed while omitting the
+                invariant, or define success only at the UI surface while the
+                deeper state transition remains ambiguous. In that field, the
+                lowest-friction implementation may be locally reasonable and
+                globally expensive.
+              </p>
+              <p>
+                This is why SFT is careful with examples. A bad future is rarely
+                interesting merely because a reviewer could have stopped it. The
+                interesting question is why that future was easy to generate,
+                hard to distinguish early, or cheap to justify. Artifact quality
+                is therefore a question about future support, not about blaming
+                the author of a document.
+              </p>
+              <p id="proposition-1-5" class="statement">
+                <a class="statement-anchor" href="#proposition-1-5">Proposition 1.5.</a>
+                A strong artifact narrows ambiguity by moving relevant
+                assumptions from implicit field memory into observable support
+                and review vocabulary.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Proposition 1.5">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-future">theorem-shaped claim</span>
+                <span>Future formalization target: artifact actions as updates to operation support and observation boundary.</span>
+              </p>
+            </section>
+
+            <section id="counter-reading" class="article-section">
+              <h2>Counter-reading</h2>
+              <p class="plain-reading">
+                <strong>Plain reading.</strong> The artifact is not evaluated
+                by whether it maps to one ideal implementation. It is evaluated
+                by what it makes possible, cheap, visible, ambiguous, or
+                unmeasured.
+              </p>
+              <p>
+                This avoids a common failure mode: treating a PRD as a hidden
+                source file and then judging the theory by whether the PRD
+                predicts the merged diff. SFT asks which future paths moved
+                closer, which obstruction candidates appeared, and which
+                evidence remained outside the model.
+              </p>
+              <p>
+                A field reading can therefore say something useful before it
+                knows the final implementation. It can say: this artifact makes
+                boundary-preserving work easy to name; this one leaves rounding,
+                authorization, ownership, or rollback outside the observation
+                surface; this one converts an incident into durable review
+                vocabulary. Those are computationally relevant differences.
+              </p>
+            </section>
+
+            <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p>
-                Part 1 treats artifacts as field-shaping inputs. The formal
-                objects for support, ForecastCone, and ConsequenceEnvelope are
-                introduced in Part 2.
+              <p id="non-conclusion-1-6" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-6">Non-conclusion 1.6.</a>
+                Artifact analysis is not a PRD-to-PR predictor, not a causal
+                proof, and not a claim that every relevant field component was
+                observed.
               </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/field/codebase-memory/index.html
+++ b/website/sft/field/codebase-memory/index.html
@@ -3,11 +3,29 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT 1-1: codebase as field memory.">
+    <meta name="description" content="SFT 1-1: codebase as field memory, where requirements, design decisions, review traces, incidents, ownership, and tooling practice shape future support.">
     <title>SFT 1-1: Codebase as Field Memory</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/codebase-memory/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 1-1: Codebase as Field Memory">
+    <meta property="og:description" content="A codebase is field memory: requirements, design decisions, review traces, incidents, ownership, and tooling practice shape future support.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/codebase-memory/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 1-1: Codebase as Field Memory">
+    <meta name="twitter:description" content="A codebase is field memory: requirements, design decisions, review traces, incidents, ownership, and tooling practice shape future support.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../../assets/site.css">
     <script defer src="../../../assets/site.js"></script>
   </head>
@@ -41,16 +59,27 @@
           <p class="eyebrow">SFT 1-1</p>
           <h1>Codebase as Field Memory</h1>
           <p class="lede">
-            A codebase is not only an implementation state. It is accumulated
-            memory: requirements, design decisions, review history, incidents,
-            ownership, and tooling practices sediment into the next changes
-            that look natural.
+            A codebase is not only the current implementation. It is the
+            sedimented memory of requirements, design decisions, review
+            histories, incidents, ownership, and tooling practice. That memory
+            makes some next operations feel obvious and others too expensive to
+            attempt.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#repository-remembers">The repository remembers</a></li>
+                <li><a href="#memory-carrier">Memory carrier</a></li>
+                <li><a href="#same-graph">Same graph, different field</a></li>
+                <li><a href="#measurement">What can be observed</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
               <h2>Part 1 routes</h2>
               <ul>
@@ -66,48 +95,169 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
-              <h2>Memory beyond files</h2>
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>What does a codebase remember, and how does that memory make some future operations easier than others?</p>
+            </aside>
+
+            <section id="repository-remembers" class="article-section">
+              <h2>The repository remembers</h2>
               <p>
-                The source tree records more than functions and module edges.
-                It carries requirements that became defaults, design decisions
-                that became local idioms, review comments that hardened into
-                norms, incident fixes that became permanent workarounds, and
-                CI failures that changed what developers attempt first.
+                A codebase is often described as if it were a machine: modules,
+                functions, dependencies, tests. That description is useful, but
+                it misses the strange fact that a codebase also remembers how it
+                was changed. It remembers through names, through tests that ask
+                for one invariant and ignore another, through dead branches left
+                after a migration, through comments written after incidents, and
+                through APIs nobody touches because the last attempt was painful.
               </p>
               <p>
-                SFT calls this accumulated structure field memory. The memory
-                may be explicit, such as tests, comments, ADRs, and ownership
-                metadata. It may also be implicit, such as repeated copy-paste
-                patterns, review expectations, migration scars, and areas that
-                only one team is comfortable changing.
+                This memory does not sit in a separate diary. It is inside the
+                development surface itself. A duplicated idiom can become a
+                suggestion. A missing test can become permission. A carefully
+                named boundary can become a path. A half-finished migration can
+                become a gravitational pull toward more half-finished work.
+              </p>
+              <p>
+                Read this way, a repository is less like a filing cabinet and
+                more like an experimental plate. Past events have left tracks.
+                Some tracks are written as code. Others are written as things
+                nobody tries anymore, tests nobody removes, boundaries everyone
+                respects without naming, and fragile areas that quietly bend
+                future plans around themselves.
+              </p>
+              <p>
+                SFT treats this as field memory: past field actions remaining
+                active in the present by shaping the support, cost, visibility,
+                and reviewability of future operations.
+              </p>
+              <p>
+                This is a different way to look at technical debt. Debt is not
+                merely the amount of bad code present today. It is the way past
+                decisions change the menu of plausible next moves. A workaround
+                that everyone understands may be less dangerous than a clean
+                abstraction nobody can safely modify. A test that looks small
+                may matter because it keeps a whole family of future changes
+                visible. Field memory is about this active remainder of history.
               </p>
             </section>
-            <section class="article-section">
-              <h2>Same graph, different futures</h2>
+
+            <section id="memory-carrier" class="article-section">
+              <h2>Memory carrier</h2>
               <p>
-                Two systems can share a similar module graph while supporting
-                different next operations. In one field, adding a feature may
-                naturally start with a domain model change and a property test.
-                In another, the low-cost path may be another branch in a
-                controller because past incidents, missing ownership, and weak
-                test support made deeper changes expensive.
+                Codebase memory is a practical carrier of organizational
+                history. It includes explicit artifacts such as tests, comments,
+                ADRs, migration scripts, ownership files, deprecation notices,
+                and CI rules. It also includes implicit traces: duplicated
+                patterns, avoided modules, old workaround seams, naming
+                conventions, and the places where review always asks for the
+                same justification.
               </p>
-              <p>
-                This is why codebase memory is not a static metric. It changes
-                operation support and selection policy. It tells developers and
-                AI agents which local patterns look legitimate, which boundary
-                crossings feel costly, and which invariants are visible enough
-                to preserve.
+              <figure class="code-panel">
+                <figcaption>Codebase memory reading</figcaption>
+                <pre><code>CodebaseMemory
+  = implementation state
+  + requirement residue
+  + design decision residue
+  + review and CI history
+  + incident and workaround history
+  + ownership and tooling practice
+  + latent default paths</code></pre>
+              </figure>
+              <p id="definition-1-1" class="statement">
+                <a class="statement-anchor" href="#definition-1-1">Definition 1.1.</a>
+                Codebase memory is the selected code-adjacent field evidence
+                that changes the support, cost, visibility, and reviewability
+                of future operations.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.1">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>Source: SFT Part I section 2; formal extraction completeness is not claimed.</span>
               </p>
             </section>
-            <section class="article-section">
+
+            <section id="same-graph" class="article-section">
+              <h2>Same graph, different field</h2>
+              <p>
+                Two systems may have similar module graphs and still support
+                different next operations. In one system, a checkout change may
+                naturally begin with a domain invariant and a property test. In
+                another, the low-cost move may be another conditional in a
+                controller because previous incidents, missing ownership, and
+                weak tests made deeper change costly.
+              </p>
+              <p>
+                The graph is the same, but the field is not. The first system
+                has made the deeper operation visible and reviewable. The second
+                has made the local operation easier to justify. A static module
+                diagram cannot see that difference by itself, because the
+                difference lives in accumulated practice.
+              </p>
+              <p>
+                The difference also matters for AI. A model asked to edit the
+                second system does not see "the true architecture"; it sees
+                nearby code, tests, names, comments, and examples. If the field
+                memory says "patch here," automated proposal generation will
+                often comply. If the field memory says "this invariant is the
+                entry point," the generated proposal has a different basin to
+                fall into.
+              </p>
+              <p id="proposition-1-2" class="statement">
+                <a class="statement-anchor" href="#proposition-1-2">Proposition 1.2.</a>
+                Field memory is not reducible to the current module graph.
+                The same selected graph can have different supported operation
+                families when review history, incidents, ownership, and tooling
+                practice differ.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Proposition 1.2">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-future">theorem-shaped claim</span>
+                <span>Future formalization target: compare fields with the same architecture projection and different support relation.</span>
+              </p>
+            </section>
+
+            <section id="measurement" class="article-section">
+              <h2>What can be observed</h2>
+              <dl class="term-list definition-list">
+                <div>
+                  <dt>review trace</dt>
+                  <dd>Evidence of which invariants are routinely demanded, ignored, or negotiated.</dd>
+                </div>
+                <div>
+                  <dt>incident residue</dt>
+                  <dd>Operational failures that change later design defaults, test expectations, and risk language.</dd>
+                </div>
+                <div>
+                  <dt>ownership boundary</dt>
+                  <dd>The practical line that decides who can approve or safely attempt a change.</dd>
+                </div>
+                <div>
+                  <dt>local pattern</dt>
+                  <dd>A repeatable implementation idiom that becomes attractive to humans and AI agents because it is nearby and legible.</dd>
+                </div>
+              </dl>
+              <p>
+                None of these observations is complete. That is the point. SFT
+                begins with partial evidence and asks what that evidence can
+                responsibly support. A field estimate is not a photograph of the
+                whole organization. It is a selected reading of the traces that
+                still have force over future operations.
+              </p>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> When a change feels obvious, ask
+                what memory made it obvious.
+              </p>
+            </section>
+
+            <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p>
-                Codebase memory does not causally determine a future PR. It
-                gives a bounded reading of why some operations are supported,
-                cheap, and repeatable under a selected field model, while other
-                operations remain difficult or unobserved.
+              <p id="non-conclusion-1-3" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-3">Non-conclusion 1.3.</a>
+                Codebase memory does not prove what the next PR will be. It
+                explains why, under a selected field model, some operation
+                families are natural, cheap, visible, or reviewable while
+                others remain costly or unobserved.
               </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/field/codebase-memory/index.html
+++ b/website/sft/field/codebase-memory/index.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 1-1: codebase as field memory.">
+    <title>SFT 1-1: Codebase as Field Memory</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/field/codebase-memory/">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../../">Home</a>
+          <a href="../../../aat/">AAT</a>
+          <a class="is-active" href="../../">SFT</a>
+          <a href="../../../archsig/">ArchSig</a>
+          <a href="../../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../../">Home</a>
+            <a href="../../">SFT</a>
+            <a href="../">Field</a>
+            <span>Codebase Memory</span>
+          </nav>
+          <p class="eyebrow">SFT 1-1</p>
+          <h1>Codebase as Field Memory</h1>
+          <p class="lede">
+            A codebase is not only an implementation state. It is accumulated
+            memory: requirements, design decisions, review history, incidents,
+            ownership, and tooling practices sediment into the next changes
+            that look natural.
+          </p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT navigation">
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>Part 1 routes</h2>
+              <ul>
+                <li><a href="../">Part 1. Field</a></li>
+                <li><a href="./" aria-current="page">1-1. Codebase Memory</a></li>
+                <li><a href="../artifacts/">1-2. Artifacts</a></li>
+                <li><a href="../agents/">1-3. Agents</a></li>
+                <li><a href="../organization-structure/">1-4. Organization Structure</a></li>
+                <li><a href="../governance-feedback/">1-5. Governance Feedback</a></li>
+                <li><a href="../architecture-futures/">1-6. Architecture Futures</a></li>
+                <li><a href="../../computation/">Part 2. Computation</a></li>
+              </ul>
+            </div>
+          </aside>
+          <div class="article-main">
+            <section class="article-section">
+              <h2>Memory beyond files</h2>
+              <p>
+                The source tree records more than functions and module edges.
+                It carries requirements that became defaults, design decisions
+                that became local idioms, review comments that hardened into
+                norms, incident fixes that became permanent workarounds, and
+                CI failures that changed what developers attempt first.
+              </p>
+              <p>
+                SFT calls this accumulated structure field memory. The memory
+                may be explicit, such as tests, comments, ADRs, and ownership
+                metadata. It may also be implicit, such as repeated copy-paste
+                patterns, review expectations, migration scars, and areas that
+                only one team is comfortable changing.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Same graph, different futures</h2>
+              <p>
+                Two systems can share a similar module graph while supporting
+                different next operations. In one field, adding a feature may
+                naturally start with a domain model change and a property test.
+                In another, the low-cost path may be another branch in a
+                controller because past incidents, missing ownership, and weak
+                test support made deeper changes expensive.
+              </p>
+              <p>
+                This is why codebase memory is not a static metric. It changes
+                operation support and selection policy. It tells developers and
+                AI agents which local patterns look legitimate, which boundary
+                crossings feel costly, and which invariants are visible enough
+                to preserve.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Boundary</h2>
+              <p>
+                Codebase memory does not causally determine a future PR. It
+                gives a bounded reading of why some operations are supported,
+                cheap, and repeatable under a selected field model, while other
+                operations remain difficult or unobserved.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../"><span>Previous</span><strong>Part 1. Field</strong></a>
+              <a class="page-nav-next" href="../artifacts/"><span>Next</span><strong>1-2. Artifacts Shape the Field</strong></a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/field/governance-feedback/index.html
+++ b/website/sft/field/governance-feedback/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 1-5: governance and feedback update field memory.">
+    <title>SFT 1-5: Governance and Feedback</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/field/governance-feedback/">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../../">Home</a>
+          <a href="../../../aat/">AAT</a>
+          <a class="is-active" href="../../">SFT</a>
+          <a href="../../../archsig/">ArchSig</a>
+          <a href="../../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../../">Home</a>
+            <a href="../../">SFT</a>
+            <a href="../">Field</a>
+            <span>Governance Feedback</span>
+          </nav>
+          <p class="eyebrow">SFT 1-5</p>
+          <h1>Governance and Feedback</h1>
+          <p class="lede">
+            Review, CI, type checking, runtime observation, incidents,
+            postmortems, and lifecycle pressure are not only gates. They update
+            field memory and change which futures remain supported.
+          </p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT navigation">
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>Part 1 routes</h2>
+              <ul>
+                <li><a href="../">Part 1. Field</a></li>
+                <li><a href="../codebase-memory/">1-1. Codebase Memory</a></li>
+                <li><a href="../artifacts/">1-2. Artifacts</a></li>
+                <li><a href="../agents/">1-3. Agents</a></li>
+                <li><a href="../organization-structure/">1-4. Organization Structure</a></li>
+                <li><a href="./" aria-current="page">1-5. Governance Feedback</a></li>
+                <li><a href="../architecture-futures/">1-6. Architecture Futures</a></li>
+                <li><a href="../../computation/">Part 2. Computation</a></li>
+              </ul>
+            </div>
+          </aside>
+          <div class="article-main">
+            <section class="article-section">
+              <h2>Governance as field update</h2>
+              <p>
+                A governance system includes review, CI, type systems,
+                architecture rules, runtime guards, incident response, and AI
+                proposal policy. These systems can reject a change, but their
+                larger role is to decide which evidence is visible and which
+                supported paths become easier next time.
+              </p>
+              <p>
+                A failing test can turn an implicit invariant into a named
+                boundary. A review thread can expose a missing assumption. A
+                postmortem can move a runtime fact into design memory. A
+                lifecycle decision can shrink the field so that unsupported
+                surfaces no longer consume capacity.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Feedback changes support</h2>
+              <p>
+                SFT treats observed outcomes as inputs to the next field. The
+                accepted PR, rejected proposal, CI result, runtime event, and
+                incident follow-up become posterior evidence. They can narrow
+                a path family, reveal an obstruction candidate, or show that an
+                intended policy does not match the actual field.
+              </p>
+              <p>
+                Governance is therefore not only quality control at the edge of
+                development. It is part of the computation by which a field
+                updates its memory and changes future support.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Boundary</h2>
+              <p>
+                Detailed intervention design is left to Part 3. Here the
+                important distinction is that feedback is not a causal proof of
+                future behavior; it is bounded evidence for updating the field
+                model.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../organization-structure/"><span>Previous</span><strong>1-4. Organization Structure as Field</strong></a>
+              <a class="page-nav-next" href="../architecture-futures/"><span>Next</span><strong>1-6. Architecture Futures</strong></a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sft/field/governance-feedback/index.html
+++ b/website/sft/field/governance-feedback/index.html
@@ -3,11 +3,29 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT 1-5: governance and feedback update field memory.">
+    <meta name="description" content="SFT 1-5: governance and feedback as field updates through review, CI, type checking, runtime observation, incidents, postmortems, and lifecycle pressure.">
     <title>SFT 1-5: Governance and Feedback</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/governance-feedback/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 1-5: Governance and Feedback">
+    <meta property="og:description" content="Review, CI, type checking, runtime observation, incidents, postmortems, and lifecycle pressure update field memory and future support.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/governance-feedback/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 1-5: Governance and Feedback">
+    <meta name="twitter:description" content="Governance and feedback update field memory, observation boundaries, and future support.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../../assets/site.css">
     <script defer src="../../../assets/site.js"></script>
   </head>
@@ -42,14 +60,25 @@
           <h1>Governance and Feedback</h1>
           <p class="lede">
             Review, CI, type checking, runtime observation, incidents,
-            postmortems, and lifecycle pressure are not only gates. They update
-            field memory and change which futures remain supported.
+            postmortems, and lifecycle pressure are not merely gates at the end
+            of development. They update field memory and change which futures
+            are supported next.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#field-learns">How the field learns</a></li>
+                <li><a href="#governance-system">Governance system</a></li>
+                <li><a href="#feedback-loop">Feedback loop</a></li>
+                <li><a href="#evidence">Evidence classes</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
               <h2>Part 1 routes</h2>
               <ul>
@@ -65,45 +94,163 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
-              <h2>Governance as field update</h2>
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>What does a field learn from review, CI, incidents, and feedback after the immediate decision is over?</p>
+            </aside>
+
+            <section id="field-learns" class="article-section">
+              <h2>How the field learns</h2>
+              <p>
+                Governance is often pictured as a gate: a proposal comes in,
+                the gate opens or closes, and the story ends. SFT looks at the
+                residue. What did the review make visible? Which invariant did
+                CI finally name? Which runtime signal forced the team to redraw
+                a boundary? Which rejected proposal became a reusable warning?
+              </p>
+              <p>
+                A field learns when an event changes future support. A failing
+                test that merely blocks a PR is weak evidence. A failing test
+                that becomes a named invariant changes the field. A postmortem
+                that only assigns blame evaporates. A postmortem that changes
+                ownership, review questions, or runtime observation becomes
+                architecture memory.
+              </p>
+              <p>
+                The important unit is therefore not pass or fail. It is the
+                update left behind.
+              </p>
+              <p>
+                A field that does not learn can still look disciplined. It can
+                have strict checklists, slow approvals, and many rejected
+                changes. But if those events do not become better observations,
+                clearer invariants, or changed support, the same failures will
+                keep returning in new forms. SFT is interested in the memory
+                produced by governance, not only the decision made by governance.
+              </p>
+              <p>
+                The beautiful case is when a failure changes the future. A
+                confusing review becomes a checklist item. A runtime surprise
+                becomes a test. A rejected shortcut becomes a named anti-path.
+                A painful migration becomes ownership knowledge. The event is
+                over, but the field has acquired a new memory.
+              </p>
+            </section>
+
+            <section id="governance-system" class="article-section">
+              <h2>Governance system</h2>
               <p>
                 A governance system includes review, CI, type systems,
-                architecture rules, runtime guards, incident response, and AI
-                proposal policy. These systems can reject a change, but their
-                larger role is to decide which evidence is visible and which
-                supported paths become easier next time.
+                architecture rules, runtime guards, ownership policy, incident
+                response, and AI proposal policy. Each mechanism can stop a bad
+                change, but each can also make a future good change easier by
+                turning hidden assumptions into durable field memory.
               </p>
-              <p>
-                A failing test can turn an implicit invariant into a named
-                boundary. A review thread can expose a missing assumption. A
-                postmortem can move a runtime fact into design memory. A
-                lifecycle decision can shrink the field so that unsupported
-                surfaces no longer consume capacity.
+              <figure class="code-panel">
+                <figcaption>Governance as field process</figcaption>
+                <pre><code>GovernanceSystem
+  = proposal boundary
+  + review mediation
+  + static and runtime checks
+  + accepted / rejected outcome
+  + incident and postmortem evidence
+  + lifecycle pressure
+  -> posterior field update</code></pre>
+              </figure>
+              <p id="definition-1-13" class="statement">
+                <a class="statement-anchor" href="#definition-1-13">Definition 1.13.</a>
+                A governance feedback event is an observed mediation event that
+                changes the field estimate: a review decision, CI result,
+                runtime signal, incident, postmortem action, policy change, or
+                lifecycle decision.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.13">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>Closed-loop update and calibration are introduced later; no calibrated forecast claim is made here.</span>
               </p>
             </section>
-            <section class="article-section">
-              <h2>Feedback changes support</h2>
+
+            <section id="feedback-loop" class="article-section">
+              <h2>Feedback loop</h2>
               <p>
-                SFT treats observed outcomes as inputs to the next field. The
-                accepted PR, rejected proposal, CI result, runtime event, and
-                incident follow-up become posterior evidence. They can narrow
-                a path family, reveal an obstruction candidate, or show that an
-                intended policy does not match the actual field.
+                Feedback matters because it persists. A failing test can name a
+                missing invariant. A rejected PR can teach the field which
+                shortcut is no longer acceptable. A postmortem can turn a
+                runtime boundary into design memory. A lifecycle decision can
+                remove unsupported surface so that future support is not spent
+                preserving dead paths.
               </p>
               <p>
-                Governance is therefore not only quality control at the edge of
-                development. It is part of the computation by which a field
-                updates its memory and changes future support.
+                This turns review, CI, type systems, incident response, and
+                lifecycle pressure into one loop. They observe selected parts of
+                the field, mediate proposals, record outcomes, and change what
+                future proposals will naturally try. A good loop does not only
+                catch errors. It teaches the field how not to keep producing
+                them.
+              </p>
+              <p>
+                The loop is also selective. CI observes what its tests express.
+                Review observes what reviewers know to ask. Runtime telemetry
+                observes what instrumentation names. Postmortems observe what
+                the organization is willing to remember. Every feedback system
+                therefore has an observation boundary, and that boundary shapes
+                the futures the field can responsibly govern.
+              </p>
+              <p id="proposition-1-14" class="statement">
+                <a class="statement-anchor" href="#proposition-1-14">Proposition 1.14.</a>
+                Governance changes architecture futures by changing support,
+                not only by accepting or rejecting individual changes.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Proposition 1.14">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-future">theorem-shaped claim</span>
+                <span>Future formalization target: posterior field update and support relation refinement.</span>
               </p>
             </section>
-            <section class="article-section">
+
+            <section id="evidence" class="article-section">
+              <h2>Evidence classes</h2>
+              <dl class="term-list definition-list">
+                <div>
+                  <dt>accepted change</dt>
+                  <dd>A realized transition, not automatically evidence that future support was preserved.</dd>
+                </div>
+                <div>
+                  <dt>rejected proposal</dt>
+                  <dd>Evidence about unsupported or policy-violating paths, if the rejection reason is recorded.</dd>
+                </div>
+                <div>
+                  <dt>CI / type evidence</dt>
+                  <dd>Selected observations that make some invariants visible and leave others unmeasured.</dd>
+                </div>
+                <div>
+                  <dt>incident outcome</dt>
+                  <dd>Runtime feedback that can force boundary updates, policy changes, or lifecycle decisions.</dd>
+                </div>
+              </dl>
+              <p>
+                SFT keeps these evidence classes separate because they play
+                different roles. A merged PR shows that one transition occurred.
+                A rejected proposal shows something about policy and support.
+                An incident shows that the observation boundary was incomplete.
+                A lifecycle decision shows that maintaining a surface has become
+                part of the field cost. Collapsing them into "process health"
+                loses the dynamics.
+              </p>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> After governance acts, ask what
+                the field can now see or do that it could not see or do before.
+              </p>
+            </section>
+
+            <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p>
-                Detailed intervention design is left to Part 3. Here the
-                important distinction is that feedback is not a causal proof of
-                future behavior; it is bounded evidence for updating the field
-                model.
+              <p id="non-conclusion-1-15" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-15">Non-conclusion 1.15.</a>
+                Feedback is evidence for updating the field model, not causal
+                proof that the next future will be safe. Detailed intervention
+                design is the subject of Part 3.
               </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/field/index.html
+++ b/website/sft/field/index.html
@@ -3,11 +3,32 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT Part 1 index: the development organization as a field.">
-    <title>SFT Part 1: Field</title>
+    <meta
+      name="description"
+      content="SFT Part 1: the development organization as a field, with codebase memory, artifacts, agents, organization structure, governance feedback, and reachable architecture futures."
+    >
+    <title>SFT Part 1: The Development Organization as a Field</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT Part 1: The Development Organization as a Field">
+    <meta property="og:description" content="SFT reads a development organization as a field whose memory, artifacts, agents, governance, and feedback shape reachable architecture futures.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT Part 1: The Development Organization as a Field">
+    <meta name="twitter:description" content="SFT reads a development organization as a field whose memory, artifacts, agents, governance, and feedback shape reachable architecture futures.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../assets/site.css">
     <script defer src="../../assets/site.js"></script>
   </head>
@@ -40,20 +61,33 @@
           <p class="eyebrow">SFT Part 1</p>
           <h1>The Development Organization as a Field</h1>
           <p class="lede">
-            This part introduces the object SFT studies: a development
-            organization whose codebase memory, artifacts, people, agents,
-            ownership, review paths, feedback, and lifecycle pressure shape
-            reachable architecture futures.
+            SFT begins by changing the object of study. The object is not only
+            a codebase, and not only a process chart. It is a development field:
+            accumulated codebase memory, artifacts, developers, AI agents,
+            ownership, review, CI, governance, runtime feedback, and lifecycle
+            pressure that together shape which architecture futures become
+            reachable.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#strange-object">The strange object</a></li>
+                <li><a href="#field-decomposition">Field decomposition</a></li>
+                <li><a href="#first-experiment">A first experiment</a></li>
+                <li><a href="#charged-words">Charged words</a></li>
+                <li><a href="#chapter-index">Chapter index</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
-              <h2>SFT routes</h2>
+              <h2>Part 1 routes</h2>
               <ul>
-                <li><a href="../">Overview</a></li>
+                <li><a href="../">SFT overview</a></li>
                 <li><a href="./" aria-current="page">Part 1. Field</a></li>
                 <li><a href="codebase-memory/">1-1. Codebase Memory</a></li>
                 <li><a href="artifacts/">1-2. Artifacts</a></li>
@@ -67,17 +101,214 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>What if the unit of software evolution is not the codebase, but the whole field that makes some next changes natural?</p>
+            </aside>
+
+            <section id="strange-object" class="article-section">
+              <h2>The strange object</h2>
+              <p>
+                The first surprise of SFT is that the interesting object is not
+                the repository snapshot. A repository snapshot is like a single
+                frame of a storm. It tells us where the clouds are, but not why
+                the air is moving that way, which pressure systems are feeding
+                the motion, or what paths the next change can naturally take.
+              </p>
+              <p>
+                In software, the moving air is made from code, but also from
+                requirements, design decisions, issue boundaries, review habits,
+                CI failures, runtime incidents, ownership paths, agent behavior,
+                and deadlines. These are not decorations around development.
+                They change which operations become visible, cheap, justified,
+                repeatable, or nearly impossible.
+              </p>
+              <p>
+                SFT calls this whole evolving object a development field. The
+                name is deliberately large: the field is the thing that makes a
+                future reachable before anyone writes the next diff.
+              </p>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> Do not begin by asking only what
+                code exists. Ask what the present field is making easy, cheap,
+                visible, repeatable, or almost unthinkable.
+              </p>
+            </section>
+
+            <section id="field-decomposition" class="article-section">
+              <h2>Field decomposition</h2>
+              <p>
+                A development field is the evolving context in which software
+                changes are proposed, selected, reviewed, accepted, rejected,
+                deployed, observed, and remembered. The field includes code, but
+                code is only one component.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Development field surface</figcaption>
+                <pre><code>DevelopmentField
+  = codebase memory
+  + artifacts and issue decomposition
+  + developers and AI agents
+  + ownership and communication paths
+  + review, CI, type checking, and runtime feedback
+  + governance policy and lifecycle pressure
+  + architecture projection and reachable futures</code></pre>
+              </figure>
+              <p id="definition-1-0" class="statement">
+                <a class="statement-anchor" href="#definition-1-0">Definition 1.0.</a>
+                A development field is the selected organizational and technical
+                state from which SFT reads supported software-evolution paths.
+                It is broader than an AAT <code>ArchitectureObject</code>; AAT
+                appears later as a local algebra for the architecture projection
+                of this field.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.0">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual core</span>
+                <span>Documented in SFT prose; formal computation is introduced through bounded slices in Part 2.</span>
+              </p>
+              <p>
+                This is why SFT is larger than a design-principle catalog and
+                larger than a metrics dashboard. A metric can describe one
+                coordinate of the field. A principle can protect one family of
+                invariants. The field asks a different question: what does this
+                organization currently make easy to do next?
+              </p>
+            </section>
+
+            <section id="first-experiment" class="article-section">
+              <h2>A first experiment</h2>
+              <p>
+                Imagine two teams with nearly identical source trees. The same
+                modules exist. The same tests run. The same public APIs are
+                exposed. But the first team has a habit of recording invariants
+                in review, splitting risky work behind explicit boundaries, and
+                writing postmortems that become tests. The second team has the
+                same code shape, but every hard change crosses an owner nobody
+                can reach, every incident becomes local folklore, and AI agents
+                are allowed to patch nearby patterns without seeing the missing
+                invariant.
+              </p>
+              <p>
+                SFT expects these two systems to have different reachable
+                futures, even before the next feature arrives. Not because one
+                team is morally better, and not because an org chart determines
+                architecture, but because the field has different support. One
+                field makes boundary-preserving operations legible. The other
+                makes local shortcuts cheap and delayed failure hard to observe.
+              </p>
+              <p>
+                This is the smallest experiment in the theory. Hold the source
+                tree almost fixed, change the field memory and governance around
+                it, and the reachable futures change. The code did not move, but
+                the next possible moves did.
+              </p>
+              <p>
+                Part 1 builds this intuition. It explains how codebase memory,
+                artifacts, agents, organization structure, governance, feedback,
+                and architecture futures fit into one object. Part 2 will cut a
+                computable slice from that object. Part 3 will ask how to
+                intervene in it.
+              </p>
+            </section>
+
+            <section id="charged-words" class="article-section">
+              <h2>Charged words</h2>
+              <p>
+                SFT uses words that sound physical because ordinary software
+                vocabulary is too static. A codebase is not merely arranged. It
+                is under pressure. A document does not merely describe work. It
+                can apply force to the field by changing which operations are
+                named, cheap, reviewable, or hidden. A repeated local path is
+                not merely a habit. It can become an attractor: a direction of
+                change the field keeps making natural.
+              </p>
+              <p>
+                These words are not claims of physical law. They are handles for
+                a computational reading. <em>Field</em> means the selected
+                organizational and technical state. <em>Force</em> means an
+                artifact-mediated change in operation support, selection policy,
+                or observation boundary. <em>Attractor</em> means a recurrent
+                supported path pattern, not a mystical destiny.
+              </p>
+              <p class="plain-reading">
+                <strong>Plain reading.</strong> The words are allowed to be
+                vivid because the object is vivid. The boundary comes later:
+                Part 2 turns selected pieces of this vocabulary into computable
+                objects, and Part 3 uses them for intervention design.
+              </p>
+            </section>
+
+            <section id="chapter-index" class="article-section">
               <h2>Chapter index</h2>
               <ul class="chapter-list">
-                <li><a href="codebase-memory/">Codebase as Field Memory</a><span>Requirements, design decisions, review history, incidents, ownership, and tooling practices as accumulated memory.</span></li>
-                <li><a href="artifacts/">Artifacts Shape the Field</a><span>PRDs, specs, issues, design notes, review comments, and incident reports as artifact-mediated forces.</span></li>
-                <li><a href="agents/">Developers and AI Agents</a><span>Human developers and AI agents as interpreters, proposal generators, and pattern amplifiers.</span></li>
-                <li><a href="organization-structure/">Organization Structure as Field</a><span>Communication paths, ownership boundaries, review routes, and approval flows as recurrent architecture pressure.</span></li>
-                <li><a href="governance-feedback/">Governance and Feedback</a><span>Review, CI, type checking, runtime observation, incidents, postmortems, and lifecycle pressure as field updates.</span></li>
-                <li><a href="architecture-futures/">Architecture Futures</a><span>Reachable futures as trajectories, signature movement, and default paths rather than endpoint predictions.</span></li>
+                <li>
+                  <a href="codebase-memory/">1-1. Codebase as Field Memory</a>
+                  <span>Why requirements, design decisions, review traces, incidents, ownership, and tooling practices remain active in later changes.</span>
+                </li>
+                <li>
+                  <a href="artifacts/">1-2. Artifacts Shape the Field</a>
+                  <span>How PRDs, specs, issues, design notes, review comments, and incident reports change operation support without determining one PR.</span>
+                </li>
+                <li>
+                  <a href="agents/">1-3. Developers and AI Agents</a>
+                  <span>How human developers and AI agents interpret artifacts, generate proposals, and amplify local patterns inside the field.</span>
+                </li>
+                <li>
+                  <a href="organization-structure/">1-4. Organization Structure as Field</a>
+                  <span>How communication paths, ownership boundaries, review routes, and approval flows become recurrent pressure on architecture.</span>
+                </li>
+                <li>
+                  <a href="governance-feedback/">1-5. Governance and Feedback</a>
+                  <span>How review, CI, type checking, incidents, postmortems, and lifecycle pressure update field memory and future support.</span>
+                </li>
+                <li>
+                  <a href="architecture-futures/">1-6. Architecture Futures</a>
+                  <span>How reachable futures are read as trajectories, signature movement, obstruction candidates, and default paths.</span>
+                </li>
               </ul>
             </section>
+
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-1-0" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-0">Non-conclusion 1.0.</a>
+                Part 1 does not define <code>ForecastCone</code>, does not
+                claim calibrated prediction, and does not turn organizational
+                structure into a deterministic architecture generator. It
+                prepares the object that Part 2 will cut into computable slices.
+              </p>
+              <div class="theorem-card-list">
+                <article class="theorem-card lean-status-card">
+                  <div class="theorem-card-header">
+                    <div>
+                      <span class="theorem-card-label">Part boundary</span>
+                      <h3>Field reading before formal forecast objects</h3>
+                    </div>
+                    <span class="status-badge status-badge-defined">website rewrite tracking</span>
+                  </div>
+                  <dl class="theorem-card-grid">
+                    <div>
+                      <dt>In scope</dt>
+                      <dd>Codebase memory, artifacts, agents, organization structure, governance feedback, and reachable architecture futures.</dd>
+                    </div>
+                    <div>
+                      <dt>Deferred</dt>
+                      <dd><code>ForecastCone</code>, AAT/SFT formal interface, consequence envelopes, support safety, calibration, and intervention design.</dd>
+                    </div>
+                    <div>
+                      <dt>Non-conclusion</dt>
+                      <dd>No deterministic future, causal proof, organization score, or PRD-to-PR predictor is claimed.</dd>
+                    </div>
+                    <div>
+                      <dt>Next step</dt>
+                      <dd>Part 2 introduces the bounded objects that make this field reading computable.</dd>
+                    </div>
+                  </dl>
+                </article>
+              </div>
+            </section>
+
             <nav class="page-nav" aria-label="Reading sequence">
               <a class="page-nav-previous" href="../"><span>Previous</span><strong>SFT overview</strong></a>
               <a class="page-nav-next" href="codebase-memory/"><span>Next</span><strong>1-1. Codebase as Field Memory</strong></a>

--- a/website/sft/field/index.html
+++ b/website/sft/field/index.html
@@ -55,9 +55,14 @@
               <ul>
                 <li><a href="../">Overview</a></li>
                 <li><a href="./" aria-current="page">Part 1. Field</a></li>
+                <li><a href="codebase-memory/">1-1. Codebase Memory</a></li>
+                <li><a href="artifacts/">1-2. Artifacts</a></li>
+                <li><a href="agents/">1-3. Agents</a></li>
+                <li><a href="organization-structure/">1-4. Organization Structure</a></li>
+                <li><a href="governance-feedback/">1-5. Governance Feedback</a></li>
+                <li><a href="architecture-futures/">1-6. Architecture Futures</a></li>
                 <li><a href="../computation/">Part 2. Computation</a></li>
                 <li><a href="../intervention/">Part 3. Intervention</a></li>
-                <li><a href="../">Reference</a></li>
               </ul>
             </div>
           </aside>
@@ -65,17 +70,17 @@
             <section class="article-section">
               <h2>Chapter index</h2>
               <ul class="chapter-list">
-                <li><strong>Codebase as Field Memory</strong><span>Requirements, design decisions, review history, incidents, ownership, and tooling practices as accumulated memory.</span></li>
-                <li><strong>Artifacts Shape the Field</strong><span>PRDs, specs, issues, design notes, review comments, and incident reports as artifact-mediated forces.</span></li>
-                <li><strong>Developers and AI Agents</strong><span>Human developers and AI agents as interpreters, proposal generators, and pattern amplifiers.</span></li>
-                <li><strong>Organization Structure as Field</strong><span>Communication paths, ownership boundaries, review routes, and approval flows as recurrent architecture pressure.</span></li>
-                <li><strong>Governance and Feedback</strong><span>Review, CI, type checking, runtime observation, incidents, postmortems, and lifecycle pressure as field updates.</span></li>
-                <li><strong>Architecture Futures</strong><span>Reachable futures as trajectories, signature movement, and default paths rather than endpoint predictions.</span></li>
+                <li><a href="codebase-memory/">Codebase as Field Memory</a><span>Requirements, design decisions, review history, incidents, ownership, and tooling practices as accumulated memory.</span></li>
+                <li><a href="artifacts/">Artifacts Shape the Field</a><span>PRDs, specs, issues, design notes, review comments, and incident reports as artifact-mediated forces.</span></li>
+                <li><a href="agents/">Developers and AI Agents</a><span>Human developers and AI agents as interpreters, proposal generators, and pattern amplifiers.</span></li>
+                <li><a href="organization-structure/">Organization Structure as Field</a><span>Communication paths, ownership boundaries, review routes, and approval flows as recurrent architecture pressure.</span></li>
+                <li><a href="governance-feedback/">Governance and Feedback</a><span>Review, CI, type checking, runtime observation, incidents, postmortems, and lifecycle pressure as field updates.</span></li>
+                <li><a href="architecture-futures/">Architecture Futures</a><span>Reachable futures as trajectories, signature movement, and default paths rather than endpoint predictions.</span></li>
               </ul>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">
               <a class="page-nav-previous" href="../"><span>Previous</span><strong>SFT overview</strong></a>
-              <a class="page-nav-next" href="../computation/"><span>Next</span><strong>Part 2. Making Software Evolution Computable</strong></a>
+              <a class="page-nav-next" href="codebase-memory/"><span>Next</span><strong>1-1. Codebase as Field Memory</strong></a>
             </nav>
           </div>
         </div>

--- a/website/sft/field/organization-structure/index.html
+++ b/website/sft/field/organization-structure/index.html
@@ -3,11 +3,29 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT 1-4: organization structure as field.">
+    <meta name="description" content="SFT 1-4: organization structure as field, where communication paths, ownership, review routes, and approval flows shape recurrent PR structure.">
     <title>SFT 1-4: Organization Structure as Field</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/field/organization-structure/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 1-4: Organization Structure as Field">
+    <meta property="og:description" content="Communication paths, ownership boundaries, review routes, approval flows, and issue decomposition shape recurrent PR structure.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/field/organization-structure/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 1-4: Organization Structure as Field">
+    <meta name="twitter:description" content="Organization structure changes operation support by shaping communication, ownership, review routes, and recurrent PR structure.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../../assets/site.css">
     <script defer src="../../../assets/site.js"></script>
   </head>
@@ -41,15 +59,26 @@
           <p class="eyebrow">SFT 1-4</p>
           <h1>Organization Structure as Field</h1>
           <p class="lede">
-            Communication paths, ownership boundaries, review routes, approval
-            flows, on-call boundaries, and issue decomposition become recurrent
-            pressure on architecture futures.
+            Organization structure is not background context. Communication
+            paths, ownership boundaries, review routes, approval flows, on-call
+            boundaries, and issue decomposition make recurring change shapes
+            more or less natural.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#architecture-of-communication">Architecture of communication</a></li>
+                <li><a href="#conway">Conway through SFT</a></li>
+                <li><a href="#pr-shape">Recurrent PR shape</a></li>
+                <li><a href="#design">Design implication</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
               <h2>Part 1 routes</h2>
               <ul>
@@ -65,48 +94,161 @@
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>How does an organization make some architecture changes ordinary and others exceptional?</p>
+            </aside>
+
+            <section id="architecture-of-communication" class="article-section">
+              <h2>Architecture of communication</h2>
+              <p>
+                A software architecture is not only drawn in modules. It is also
+                drawn in communication. Which team can approve a boundary change?
+                Which reviewer sees the invariant? Which service has an owner?
+                Which migration has no sponsor? Which incident crosses an
+                on-call boundary and therefore becomes nobody's local memory?
+              </p>
+              <p>
+                These questions sound organizational, but in SFT they are also
+                architectural. They decide which operations can be attempted at
+                ordinary cost. A technically clean refactor that needs four
+                teams, two release windows, and an unclear owner may be less
+                supported than a messy local patch. Over time, repeated support
+                becomes shape.
+              </p>
+              <p>
+                This gives Conway's Law a field reading. The organization does
+                not mechanically print architecture. It changes the pressure
+                under which architecture futures become reachable.
+              </p>
+              <p>
+                Pressure is the right word here because the effect is rarely a
+                command. Nobody needs to order a team to preserve the old
+                boundary. The field can do it quietly by making every
+                alternative require more meetings, unclear approvals, uncertain
+                rollback, and ownership nobody wants to inherit.
+              </p>
+              <p>
+                This is why the same architecture recommendation can be trivial
+                in one organization and nearly impossible in another. "Extract
+                the service," "move the boundary," or "preserve the invariant"
+                are not just technical operations. They are paths through
+                communication, ownership, review, deployment, and operational
+                responsibility. The operation is supported only if those paths
+                exist at ordinary cost.
+              </p>
+              <p>
+                The org chart is only the visible skeleton. The field lives in
+                the actual routes by which work moves: who can be interrupted,
+                who can say no, who owns cleanup, who remembers production, and
+                which boundary has a review path instead of a heroic exception.
+              </p>
+            </section>
+
+            <section id="conway" class="article-section">
               <h2>Conway through SFT</h2>
               <p>
-                Conway's Law is usually read as the empirical observation that
-                systems reflect the communication structures of the
-                organizations that build them. SFT reads the same phenomenon as
-                a field effect: organizational structure changes operation
-                support, and operation support changes day-to-day design
-                changes.
+                Conway's Law is usually stated as an empirical relationship
+                between communication structure and system design. SFT reads it
+                as a field mechanism: communication paths and ownership
+                boundaries alter which changes are supported at ordinary cost.
               </p>
-              <p>
-                A team boundary can make a clean interface cheap or a cross-cut
-                refactor expensive. A review route can make one invariant
-                routinely visible and another invisible. An approval flow can
-                reward local patches while making architectural repair too slow
-                to attempt.
+              <figure class="code-panel">
+                <figcaption>Organization field mechanism</figcaption>
+                <pre><code>OrganizationField
+  = communication paths
+  + ownership boundaries
+  + review routes
+  + approval flows
+  + on-call boundaries
+  + issue decomposition
+  -> recurrent operation support
+  -> recurrent architecture pressure</code></pre>
+              </figure>
+              <p id="definition-1-10" class="statement">
+                <a class="statement-anchor" href="#definition-1-10">Definition 1.10.</a>
+                Organization structure is a field component when it changes the
+                cost, visibility, approval path, or ownership premise of an
+                architecture operation.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 1.10">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>Source: SFT reading of Conway-style organization pressure.</span>
               </p>
             </section>
-            <section class="article-section">
+
+            <section id="pr-shape" class="article-section">
               <h2>Recurrent PR shape</h2>
               <p>
-                Organization structure becomes visible in the repeated shape of
-                changes: which files move together, which owners are asked for
-                review, which issues are split apart, which runtime boundaries
-                are treated as somebody else's responsibility, and which
-                migrations never receive a shared owner.
+                Organization structure appears in repeated pull request shapes:
+                which files move together, which owners are requested, which
+                APIs are avoided, which teams need synchronous coordination,
+                which migrations never get a sponsor, and which operational
+                risks are treated as somebody else's boundary.
               </p>
               <p>
-                Those repeated shapes do not deterministically produce an
-                architecture. They make some futures natural and others
-                expensive. If a desirable architecture should become reachable
-                without heroic coordination, the organization field has to make
-                preserving changes low-cost and repeatable.
+                These repeated shapes are empirical clues. They reveal where the
+                field has made a path smooth and where it has made a path
+                exceptional. When the same awkward cross-boundary change keeps
+                being avoided, the field is telling us something about the
+                architecture future it can actually reach.
+              </p>
+              <p>
+                SFT therefore reads pull requests as more than code changes.
+                They are small experiments in organizational physics. Which
+                boundaries resisted movement? Which approvals were needed? Which
+                tests stood in for missing trust? Which files had to move
+                together because no social path existed for separating them?
+                The answer is a map of support.
+              </p>
+              <p id="proposition-1-11" class="statement">
+                <a class="statement-anchor" href="#proposition-1-11">Proposition 1.11.</a>
+                Recurrent PR shape is evidence of field support. It shows which
+                architecture changes have become repeatable under the current
+                organization, and which changes require exceptional effort.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Proposition 1.11">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-future">empirical / tooling hypothesis</span>
+                <span>Future evidence: PR traces, review routes, CODEOWNERS-like ownership, issue split, and incident follow-up.</span>
               </p>
             </section>
-            <section class="article-section">
-              <h2>Boundary</h2>
+
+            <section id="design" class="article-section">
+              <h2>Design implication</h2>
+              <p class="plain-reading">
+                <strong>Plain reading.</strong> If a desired architecture needs
+                repeated boundary-preserving changes, the organization field
+                must make those changes low-cost and reviewable.
+              </p>
               <p>
-                This is not a metaphor-only account, but it is also not a claim
-                that org charts predict systems. The claim is bounded: selected
-                communication and ownership structures can be read as field
-                components that reshape supported architecture paths.
+                A good architecture cannot remain natural if every lawful path
+                requires exceptional coordination while every shortcut is local,
+                cheap, and invisible. In SFT, organization design is therefore
+                architecture design through the field: it changes the support
+                relation before code is written.
+              </p>
+              <p>
+                This does not reduce architecture to management. It says the
+                opposite: architecture is too real to be protected only by
+                diagrams. If the organization cannot repeatedly enact the
+                boundary, the boundary is not yet a stable part of the field.
+              </p>
+              <p class="plain-reading">
+                <strong>Field habit.</strong> If the desired architecture is
+                never the low-friction path, redesign the field before blaming
+                the code.
+              </p>
+            </section>
+
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-1-12" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-1-12">Non-conclusion 1.12.</a>
+                Organization structure does not deterministically produce
+                architecture. It supplies bounded field evidence about which
+                operation families are cheap, selected, blocked, or invisible.
               </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">

--- a/website/sft/field/organization-structure/index.html
+++ b/website/sft/field/organization-structure/index.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 1-4: organization structure as field.">
+    <title>SFT 1-4: Organization Structure as Field</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/field/organization-structure/">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../../">Home</a>
+          <a href="../../../aat/">AAT</a>
+          <a class="is-active" href="../../">SFT</a>
+          <a href="../../../archsig/">ArchSig</a>
+          <a href="../../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../../">Home</a>
+            <a href="../../">SFT</a>
+            <a href="../">Field</a>
+            <span>Organization Structure</span>
+          </nav>
+          <p class="eyebrow">SFT 1-4</p>
+          <h1>Organization Structure as Field</h1>
+          <p class="lede">
+            Communication paths, ownership boundaries, review routes, approval
+            flows, on-call boundaries, and issue decomposition become recurrent
+            pressure on architecture futures.
+          </p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="SFT navigation">
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>Part 1 routes</h2>
+              <ul>
+                <li><a href="../">Part 1. Field</a></li>
+                <li><a href="../codebase-memory/">1-1. Codebase Memory</a></li>
+                <li><a href="../artifacts/">1-2. Artifacts</a></li>
+                <li><a href="../agents/">1-3. Agents</a></li>
+                <li><a href="./" aria-current="page">1-4. Organization Structure</a></li>
+                <li><a href="../governance-feedback/">1-5. Governance Feedback</a></li>
+                <li><a href="../architecture-futures/">1-6. Architecture Futures</a></li>
+                <li><a href="../../computation/">Part 2. Computation</a></li>
+              </ul>
+            </div>
+          </aside>
+          <div class="article-main">
+            <section class="article-section">
+              <h2>Conway through SFT</h2>
+              <p>
+                Conway's Law is usually read as the empirical observation that
+                systems reflect the communication structures of the
+                organizations that build them. SFT reads the same phenomenon as
+                a field effect: organizational structure changes operation
+                support, and operation support changes day-to-day design
+                changes.
+              </p>
+              <p>
+                A team boundary can make a clean interface cheap or a cross-cut
+                refactor expensive. A review route can make one invariant
+                routinely visible and another invisible. An approval flow can
+                reward local patches while making architectural repair too slow
+                to attempt.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Recurrent PR shape</h2>
+              <p>
+                Organization structure becomes visible in the repeated shape of
+                changes: which files move together, which owners are asked for
+                review, which issues are split apart, which runtime boundaries
+                are treated as somebody else's responsibility, and which
+                migrations never receive a shared owner.
+              </p>
+              <p>
+                Those repeated shapes do not deterministically produce an
+                architecture. They make some futures natural and others
+                expensive. If a desirable architecture should become reachable
+                without heroic coordination, the organization field has to make
+                preserving changes low-cost and repeatable.
+              </p>
+            </section>
+            <section class="article-section">
+              <h2>Boundary</h2>
+              <p>
+                This is not a metaphor-only account, but it is also not a claim
+                that org charts predict systems. The claim is bounded: selected
+                communication and ownership structures can be read as field
+                components that reshape supported architecture paths.
+              </p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../agents/"><span>Previous</span><strong>1-3. Developers and AI Agents</strong></a>
+              <a class="page-nav-next" href="../governance-feedback/"><span>Next</span><strong>1-5. Governance and Feedback</strong></a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -76,6 +76,24 @@
     <loc>https://iroha1203.dev/sft/field/</loc>
   </url>
   <url>
+    <loc>https://iroha1203.dev/sft/field/codebase-memory/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/field/artifacts/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/field/agents/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/field/organization-structure/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/field/governance-feedback/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/field/architecture-futures/</loc>
+  </url>
+  <url>
     <loc>https://iroha1203.dev/sft/computation/</loc>
   </url>
   <url>


### PR DESCRIPTION
## 概要

Closes #957

SFT rewrite 第1部として、開発組織全体を field として読むための `/sft/field/**` route を追加しました。

- `/sft/field/` の章一覧と sidebar を各章ページへリンク化
- `1-1 Codebase as Field Memory` から `1-6 Architecture Futures` までの 6 ページを追加
- `website/sitemap.xml` に第1部 route を追加
- deterministic prediction、causal proof、PRD-to-PR predictor、Coupon PRD の canonical example 化は避け、各ページ末尾で boundary を明示

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/field/index.html`
- `website/sft/field/codebase-memory/index.html`
- `website/sft/field/artifacts/index.html`
- `website/sft/field/agents/index.html`
- `website/sft/field/organization-structure/index.html`
- `website/sft/field/governance-feedback/index.html`
- `website/sft/field/architecture-futures/index.html`
- `website/sitemap.xml`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] Node による `website/sft/**` 相対リンク存在確認
- [x] Playwright による第1部 7 route の title / h1 / content / page-nav 表示確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Issue の Lean status は website rewrite tracking、Lean theorem 追加なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
