### PR TITLE
Issue 959 SFT第3部 Field Intervention and Control を実装

### DIFF
--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -135,6 +135,10 @@
                 <span>Jump to</span>
                 <strong>Part 2. Making Software Evolution Computable</strong>
               </a>
+              <a class="page-nav-next" href="intervention/">
+                <span>Jump to</span>
+                <strong>Part 3. Field Intervention and Control</strong>
+              </a>
             </nav>
           </div>
         </div>

--- a/website/sft/intervention/ai-governance/index.html
+++ b/website/sft/intervention/ai-governance/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 3-4: AI Proposal Governance inside bounded field models, theorem boundaries, review, CI, and field updates.">
+    <title>SFT 3-4: AI Proposal Governance</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/intervention/ai-governance/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 3-4: AI Proposal Governance">
+    <meta property="og:description" content="Controlling AI-generated proposal support through bounded field models, theorem boundaries, review and CI mediation, and posterior field updates.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/ai-governance/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 3-4: AI Proposal Governance">
+    <meta name="twitter:description" content="AI governance as bounded field intervention, not general AI safety.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <main id="main">
+      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>AI Governance</span></nav><p class="eyebrow">SFT 3-4</p><h1>AI Proposal Governance</h1><p class="lede">AI agents participate in the development field by interpreting artifacts, amplifying local patterns, generating proposals, and shifting review load. SFT governs that proposal stream inside explicit boundaries.</p></div></section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#scope">Scope</a></li><li><a href="#protocol">Protocol</a></li><li><a href="#witnesses">Shortcut witnesses</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
+            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="./" aria-current="page">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+          </aside>
+          <div class="article-main">
+            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>How can AI-generated proposal support remain bounded, reviewable, and useful as field evidence?</p></aside>
+            <section id="scope" class="article-section">
+              <h2>Scope</h2>
+              <p>This page is about AI proposal governance, not general AI safety. The object is the proposal stream created by an AI agent inside a selected development field. SFT asks which operation families the proposal claims to support, which theorem or forecast boundaries it touches, and which review or CI feedback later updates the field.</p>
+              <p>An AI proposal is not architecture lawfulness. It is a candidate field event. Its value depends on the prompt and policy boundary, source artifacts, allowed operation support, shortcut witnesses, theorem boundary, review mediation, observed outcome, and calibration linkage.</p>
+            </section>
+            <section id="protocol" class="article-section">
+              <h2>Protocol</h2>
+              <figure class="code-panel"><figcaption>AI proposal governance</figcaption><pre><code>prompt / policy boundary
+-&gt; proposal source normalization
+-&gt; allowed operation support check
+-&gt; shortcut witness classification
+-&gt; review / CI mediation
+-&gt; posterior field update
+-&gt; calibration / benchmark linkage</code></pre></figure>
+              <p>Allowed operation support is a bounded candidate set for reviewer evaluation. It distinguishes allowed candidates, conditionally allowed candidates, forbidden support, unknown support, and out-of-scope operations. Unknown support is not rounded into a safe path; it becomes review or issue-decomposition input.</p>
+              <p>The theorem boundary keeps proved AAT claims separate from unmet preconditions. The forecast boundary keeps SFT reachability artifacts separate from prediction correctness. Review and CI mediation record how the proposal was accepted, redirected, blocked, or left inconclusive.</p>
+            </section>
+            <section id="witnesses" class="article-section">
+              <h2>Shortcut witnesses</h2>
+              <p>AI agents can make a local pattern cheap even when the pattern crosses an architectural boundary. SFT records this as shortcut witness evidence: forbidden edges, missing invariants, hidden state, runtime boundary loss, theorem-boundary misuse, or review-load shifts.</p>
+              <p>A shortcut witness is a review cue, not a proof that the model is unsafe or that the proposal must fail. Its purpose is to make low-cost risky paths visible so governance can redirect, instrument, split, or block them.</p>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-4" class="statement"><a class="statement-anchor" href="#non-conclusion-3-4">Non-conclusion 3.4.</a> AI proposal governance does not evaluate model capability, prove autonomous coding safety, or promote policy compliance into architecture lawfulness. It records bounded proposal evidence for review, CI, field update, and later calibration.</p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../stable-regions/"><span>Previous</span><strong>3-3. Stable Regions</strong></a><a class="page-nav-next" href="../lifecycle/"><span>Next</span><strong>3-5. Lifecycle Decisions</strong></a></nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+  </body>
+</html>

--- a/website/sft/intervention/ai-governance/index.html
+++ b/website/sft/intervention/ai-governance/index.html
@@ -24,52 +24,152 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../../assets/site.css">
-    <script defer src="../../../assets/site.js"></script>
+    <script defer src="../../../assets/site.js">
+</script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <header class="site-header" data-site-header>
+<div class="site-shell header-inner">
+<a class="brand" href="../../../" aria-label="AAT SFT home">
+<img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+<span class="brand-mark">AAT/SFT</span>
+<span class="brand-text">Research Notes</span>
+</a>
+<nav class="site-nav" aria-label="Primary navigation">
+<a href="../../../">Home</a>
+<a href="../../../aat/">AAT</a>
+<a class="is-active" href="../../">SFT</a>
+<a href="../../../archsig/">ArchSig</a>
+<a href="../../../outreach/">Outreach</a>
+</nav>
+</div>
+</header>
     <main id="main">
-      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>AI Governance</span></nav><p class="eyebrow">SFT 3-4</p><h1>AI Proposal Governance</h1><p class="lede">AI agents participate in the development field by interpreting artifacts, amplifying local patterns, generating proposals, and shifting review load. SFT governs that proposal stream inside explicit boundaries.</p></div></section>
+      <section class="article-hero section-band">
+<div class="site-shell">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="../../../">Home</a>
+<a href="../../">SFT</a>
+<a href="../">Intervention</a>
+<span>AI Governance</span>
+</nav>
+<p class="eyebrow">SFT 3-4</p>
+<h1>AI Proposal Governance</h1>
+<p class="lede">AI agents participate in the development field by interpreting artifacts, amplifying local patterns, generating proposals, and shifting review load. SFT governs that proposal stream inside explicit boundaries.</p>
+</div>
+</section>
       <section class="section-band">
         <div class="site-shell article-layout">
           <aside class="article-sidebar" aria-label="Local navigation">
-            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#scope">Scope</a></li><li><a href="#protocol">Protocol</a></li><li><a href="#witnesses">Shortcut witnesses</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
-            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="./" aria-current="page">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+            <nav class="toc-panel" aria-labelledby="toc-title">
+<h2 id="toc-title">On this page</h2>
+<ol>
+<li>
+<a href="#scope">Scope</a>
+</li>
+<li>
+<a href="#protocol">Protocol</a>
+</li>
+<li>
+<a href="#witnesses">Shortcut witnesses</a>
+</li>
+<li>
+<a href="#boundary">Boundary</a>
+</li>
+</ol>
+</nav>
+            <div class="source-panel" data-sidebar-open="true">
+<h2>Part 3 routes</h2>
+<ul>
+<li>
+<a href="../../">SFT overview</a>
+</li>
+<li>
+<a href="../">Part 3. Intervention</a>
+</li>
+<li>
+<a href="../governance/">3-1. Governance</a>
+</li>
+<li>
+<a href="../attractor-engineering/">3-2. Attractor Engineering</a>
+</li>
+<li>
+<a href="../stable-regions/">3-3. Stable Regions</a>
+</li>
+<li>
+<a href="./" aria-current="page">3-4. AI Governance</a>
+</li>
+<li>
+<a href="../lifecycle/">3-5. Lifecycle</a>
+</li>
+<li>
+<a href="../closed-loop/">3-6. Closed Loop</a>
+</li>
+</ul>
+</div>
           </aside>
           <div class="article-main">
-            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>How can AI-generated proposal support remain bounded, reviewable, and useful as field evidence?</p></aside>
+            <aside class="question-card" aria-label="Guiding question">
+<span class="question-card-label">Question</span>
+<p>How can AI-generated proposal support remain bounded, reviewable, and useful as field evidence?</p>
+</aside>
             <section id="scope" class="article-section">
               <h2>Scope</h2>
               <p>This page is about AI proposal governance, not general AI safety. The object is the proposal stream created by an AI agent inside a selected development field. SFT asks which operation families the proposal claims to support, which theorem or forecast boundaries it touches, and which review or CI feedback later updates the field.</p>
               <p>An AI proposal is not architecture lawfulness. It is a candidate field event. Its value depends on the prompt and policy boundary, source artifacts, allowed operation support, shortcut witnesses, theorem boundary, review mediation, observed outcome, and calibration linkage.</p>
+              <p>The reason AI matters for SFT is not only that a model can be wrong. It can change the field's apparent support. A local pattern that was once too tedious to repeat may become cheap. A shortcut that required a human to ignore a boundary can now appear as a plausible completion. Review load can move from writing code to classifying generated operation families.</p>
+              <p>That makes AI governance a field problem. The agent is not outside the development organization; it is another proposal generator, artifact interpreter, and local-pattern amplifier inside the field.</p>
             </section>
             <section id="protocol" class="article-section">
               <h2>Protocol</h2>
-              <figure class="code-panel"><figcaption>AI proposal governance</figcaption><pre><code>prompt / policy boundary
+              <figure class="code-panel">
+<figcaption>AI proposal governance</figcaption>
+<pre>
+<code>prompt / policy boundary
 -&gt; proposal source normalization
 -&gt; allowed operation support check
 -&gt; shortcut witness classification
 -&gt; review / CI mediation
 -&gt; posterior field update
--&gt; calibration / benchmark linkage</code></pre></figure>
+-&gt; calibration / benchmark linkage</code>
+</pre>
+</figure>
               <p>Allowed operation support is a bounded candidate set for reviewer evaluation. It distinguishes allowed candidates, conditionally allowed candidates, forbidden support, unknown support, and out-of-scope operations. Unknown support is not rounded into a safe path; it becomes review or issue-decomposition input.</p>
               <p>The theorem boundary keeps proved AAT claims separate from unmet preconditions. The forecast boundary keeps SFT reachability artifacts separate from prediction correctness. Review and CI mediation record how the proposal was accepted, redirected, blocked, or left inconclusive.</p>
+              <p>A useful AI policy is therefore not only a prompt. It is a proposal accounting rule. The field needs to know which artifacts the agent read, which operation family it selected, which boundary it crossed, which evidence was checked, and what later outcome should update the field estimate.</p>
+              <p>The goal is not to prevent every bad candidate from being generated. The goal is to keep generated support bounded, classifiable, and reviewable, so the stream improves observation instead of merely increasing noise.</p>
             </section>
             <section id="witnesses" class="article-section">
               <h2>Shortcut witnesses</h2>
               <p>AI agents can make a local pattern cheap even when the pattern crosses an architectural boundary. SFT records this as shortcut witness evidence: forbidden edges, missing invariants, hidden state, runtime boundary loss, theorem-boundary misuse, or review-load shifts.</p>
               <p>A shortcut witness is a review cue, not a proof that the model is unsafe or that the proposal must fail. Its purpose is to make low-cost risky paths visible so governance can redirect, instrument, split, or block them.</p>
+              <p>This is why the strongest AI governance surface is not a single approve-or-reject button. It is a path classifier: lawful extension, conditionally lawful extension, boundary-crossing shortcut, missing-invariant proposal, unknown-support proposal, or out-of-scope proposal. Each class leaves a different update in the field.</p>
             </section>
             <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p id="non-conclusion-3-4" class="statement"><a class="statement-anchor" href="#non-conclusion-3-4">Non-conclusion 3.4.</a> AI proposal governance does not evaluate model capability, prove autonomous coding safety, or promote policy compliance into architecture lawfulness. It records bounded proposal evidence for review, CI, field update, and later calibration.</p>
+              <p id="non-conclusion-3-4" class="statement">
+<a class="statement-anchor" href="#non-conclusion-3-4">Non-conclusion 3.4.</a> AI proposal governance does not evaluate model capability, prove autonomous coding safety, or promote policy compliance into architecture lawfulness. It records bounded proposal evidence for review, CI, field update, and later calibration.</p>
             </section>
-            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../stable-regions/"><span>Previous</span><strong>3-3. Stable Regions</strong></a><a class="page-nav-next" href="../lifecycle/"><span>Next</span><strong>3-5. Lifecycle Decisions</strong></a></nav>
+            <nav class="page-nav" aria-label="Reading sequence">
+<a class="page-nav-previous" href="../stable-regions/">
+<span>Previous</span>
+<strong>3-3. Stable Regions</strong>
+</a>
+<a class="page-nav-next" href="../lifecycle/">
+<span>Next</span>
+<strong>3-5. Lifecycle Decisions</strong>
+</a>
+</nav>
           </div>
         </div>
       </section>
     </main>
-    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+    <footer class="site-footer">
+<div class="site-shell footer-inner">
+<p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+<a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+</div>
+</footer>
   </body>
 </html>

--- a/website/sft/intervention/attractor-engineering/index.html
+++ b/website/sft/intervention/attractor-engineering/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 3-2: Attractor Engineering as support, policy, observation, and feedback shaping.">
+    <title>SFT 3-2: Attractor Engineering</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/intervention/attractor-engineering/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 3-2: Attractor Engineering">
+    <meta property="og:description" content="Designing fields where desirable futures become natural and shortcuts become costly, observable, and review-mediated.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/attractor-engineering/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 3-2: Attractor Engineering">
+    <meta name="twitter:description" content="A representative SFT application, not a synonym for the whole theory.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <main id="main">
+      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Attractor Engineering</span></nav><p class="eyebrow">SFT 3-2</p><h1>Attractor Engineering</h1><p class="lede">Attractor Engineering is a representative application of SFT: design the field so desirable architecture futures are natural, cheap, visible, and reviewable, while shortcut paths become high-cost and observable.</p></div></section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#application">Representative application</a></li><li><a href="#shaping">Shaping moves</a></li><li><a href="#terms">Attractor terms</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
+            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="./" aria-current="page">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+          </aside>
+          <div class="article-main">
+            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>How do we make the good path the path of least field resistance?</p></aside>
+            <section id="application" class="article-section">
+              <h2>Representative application</h2>
+              <p>Attractor Engineering is not the whole of SFT. SFT also defines the field, the computable slice, forecast cones, consequence envelopes, calibration boundaries, and lifecycle models. Attractor Engineering is the practical application people tend to notice first: it asks how to design the field so better futures become the natural next moves.</p>
+              <p>A field is not improved only by forbidding bad proposals. It improves when lawful operations are easy to discover, easy to imitate, cheap to review, and backed by visible evidence. Shortcuts should not merely be disallowed in prose; they should become expensive, instrumented, review-mediated, or decomposed into safer work.</p>
+            </section>
+            <section id="shaping" class="article-section">
+              <h2>Shaping moves</h2>
+              <figure class="code-panel"><figcaption>Attractor Engineering</figcaption><pre><code>target region R
++ support shaping
++ policy shaping
++ governance intervention
++ observation boundary
++ feedback update rule</code></pre></figure>
+              <p>Support shaping changes which operations the field makes possible or natural. Policy shaping changes which supported operations are selected. Observation shaping makes drift toward a bad basin visible as witness evidence. Feedback shaping stores review, CI, runtime, and incident outcomes in the posterior field.</p>
+              <p>The output is not a prediction that the target region must be reached. It is a field design in which selected operation families have better support, selected shortcuts have worse support, and future evidence can be compared against the design.</p>
+            </section>
+            <section id="terms" class="article-section">
+              <h2>Attractor terms</h2>
+              <p>The words attractor and basin are useful because they name recurrent practical experience: a codebase, team, and artifact set can keep pulling changes toward the same pattern. SFT preserves that intuition but decomposes the strong claim into safer objects: <code>StableRegion</code>, <code>ReachablePreimage</code>, <code>ForecastCone</code>, support safety, and proposal accounting.</p>
+              <p>Without explicit stability, recurrence, policy, probability, or calibration semantics, the attractor language remains a design metaphor grounded in bounded reachability. That keeps the application attractive without smuggling in a stronger theorem.</p>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-2" class="statement"><a class="statement-anchor" href="#non-conclusion-3-2">Non-conclusion 3.2.</a> Calling a region an attractor does not by itself prove convergence, stability, recurrence, or calibrated probability. Those stronger readings require additional semantics beyond the website exposition.</p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../governance/"><span>Previous</span><strong>3-1. Governance</strong></a><a class="page-nav-next" href="../stable-regions/"><span>Next</span><strong>3-3. Stable Regions</strong></a></nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+  </body>
+</html>

--- a/website/sft/intervention/attractor-engineering/index.html
+++ b/website/sft/intervention/attractor-engineering/index.html
@@ -24,51 +24,151 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../../assets/site.css">
-    <script defer src="../../../assets/site.js"></script>
+    <script defer src="../../../assets/site.js">
+</script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <header class="site-header" data-site-header>
+<div class="site-shell header-inner">
+<a class="brand" href="../../../" aria-label="AAT SFT home">
+<img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+<span class="brand-mark">AAT/SFT</span>
+<span class="brand-text">Research Notes</span>
+</a>
+<nav class="site-nav" aria-label="Primary navigation">
+<a href="../../../">Home</a>
+<a href="../../../aat/">AAT</a>
+<a class="is-active" href="../../">SFT</a>
+<a href="../../../archsig/">ArchSig</a>
+<a href="../../../outreach/">Outreach</a>
+</nav>
+</div>
+</header>
     <main id="main">
-      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Attractor Engineering</span></nav><p class="eyebrow">SFT 3-2</p><h1>Attractor Engineering</h1><p class="lede">Attractor Engineering is a representative application of SFT: design the field so desirable architecture futures are natural, cheap, visible, and reviewable, while shortcut paths become high-cost and observable.</p></div></section>
+      <section class="article-hero section-band">
+<div class="site-shell">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="../../../">Home</a>
+<a href="../../">SFT</a>
+<a href="../">Intervention</a>
+<span>Attractor Engineering</span>
+</nav>
+<p class="eyebrow">SFT 3-2</p>
+<h1>Attractor Engineering</h1>
+<p class="lede">Attractor Engineering is a representative application of SFT: design the field so desirable architecture futures are natural, cheap, visible, and reviewable, while shortcut paths become high-cost and observable.</p>
+</div>
+</section>
       <section class="section-band">
         <div class="site-shell article-layout">
           <aside class="article-sidebar" aria-label="Local navigation">
-            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#application">Representative application</a></li><li><a href="#shaping">Shaping moves</a></li><li><a href="#terms">Attractor terms</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
-            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="./" aria-current="page">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+            <nav class="toc-panel" aria-labelledby="toc-title">
+<h2 id="toc-title">On this page</h2>
+<ol>
+<li>
+<a href="#application">Representative application</a>
+</li>
+<li>
+<a href="#shaping">Shaping moves</a>
+</li>
+<li>
+<a href="#terms">Attractor terms</a>
+</li>
+<li>
+<a href="#boundary">Boundary</a>
+</li>
+</ol>
+</nav>
+            <div class="source-panel" data-sidebar-open="true">
+<h2>Part 3 routes</h2>
+<ul>
+<li>
+<a href="../../">SFT overview</a>
+</li>
+<li>
+<a href="../">Part 3. Intervention</a>
+</li>
+<li>
+<a href="../governance/">3-1. Governance</a>
+</li>
+<li>
+<a href="./" aria-current="page">3-2. Attractor Engineering</a>
+</li>
+<li>
+<a href="../stable-regions/">3-3. Stable Regions</a>
+</li>
+<li>
+<a href="../ai-governance/">3-4. AI Governance</a>
+</li>
+<li>
+<a href="../lifecycle/">3-5. Lifecycle</a>
+</li>
+<li>
+<a href="../closed-loop/">3-6. Closed Loop</a>
+</li>
+</ul>
+</div>
           </aside>
           <div class="article-main">
-            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>How do we make the good path the path of least field resistance?</p></aside>
+            <aside class="question-card" aria-label="Guiding question">
+<span class="question-card-label">Question</span>
+<p>How do we make the good path the path of least field resistance?</p>
+</aside>
             <section id="application" class="article-section">
               <h2>Representative application</h2>
               <p>Attractor Engineering is not the whole of SFT. SFT also defines the field, the computable slice, forecast cones, consequence envelopes, calibration boundaries, and lifecycle models. Attractor Engineering is the practical application people tend to notice first: it asks how to design the field so better futures become the natural next moves.</p>
               <p>A field is not improved only by forbidding bad proposals. It improves when lawful operations are easy to discover, easy to imitate, cheap to review, and backed by visible evidence. Shortcuts should not merely be disallowed in prose; they should become expensive, instrumented, review-mediated, or decomposed into safer work.</p>
+              <p>The attraction is not magic. It is the accumulated effect of examples, ownership, tests, module boundaries, templates, incidents, review habits, and agent prompts. A field pulls because the next plausible move has already been prepared by the surrounding system.</p>
+              <p>Attractor Engineering names the design discipline of preparing that surrounding system. Instead of telling developers to choose the right future, it changes the field so the right operation family is the one with examples, support, tests, names, and review affordances. The wrong family may still be reachable, but it becomes noisy, costly, and visible.</p>
             </section>
             <section id="shaping" class="article-section">
               <h2>Shaping moves</h2>
-              <figure class="code-panel"><figcaption>Attractor Engineering</figcaption><pre><code>target region R
+              <figure class="code-panel">
+<figcaption>Attractor Engineering</figcaption>
+<pre>
+<code>target region R
 + support shaping
 + policy shaping
 + governance intervention
 + observation boundary
-+ feedback update rule</code></pre></figure>
++ feedback update rule</code>
+</pre>
+</figure>
               <p>Support shaping changes which operations the field makes possible or natural. Policy shaping changes which supported operations are selected. Observation shaping makes drift toward a bad basin visible as witness evidence. Feedback shaping stores review, CI, runtime, and incident outcomes in the posterior field.</p>
               <p>The output is not a prediction that the target region must be reached. It is a field design in which selected operation families have better support, selected shortcuts have worse support, and future evidence can be compared against the design.</p>
+              <p>Support shaping can be mundane: create a lawful extension point, add examples, split an issue, remove a misleading helper, provide a tested adapter, or make the safe path shorter than the shortcut. Policy shaping decides which of the supported operations reviewers, CI, and agents are allowed to select without escalation.</p>
+              <p>Observation shaping is what keeps the idea honest. A bad basin that cannot be observed is only a story. SFT wants witness families, signature axes, runtime evidence, and review traces that can show whether the field is actually drifting toward the region the design intended to avoid.</p>
             </section>
             <section id="terms" class="article-section">
               <h2>Attractor terms</h2>
               <p>The words attractor and basin are useful because they name recurrent practical experience: a codebase, team, and artifact set can keep pulling changes toward the same pattern. SFT preserves that intuition but decomposes the strong claim into safer objects: <code>StableRegion</code>, <code>ReachablePreimage</code>, <code>ForecastCone</code>, support safety, and proposal accounting.</p>
               <p>Without explicit stability, recurrence, policy, probability, or calibration semantics, the attractor language remains a design metaphor grounded in bounded reachability. That keeps the application attractive without smuggling in a stronger theorem.</p>
+              <p>The payoff is that the metaphor becomes operational. A basin can be discussed as a reachable preimage. A stable attractor-like region can be discussed as a selected region preserved by accepted steps. A recurring shortcut can be discussed as a recurrent pattern under current support and policy. The vocabulary stays vivid, but the claim boundary stays visible.</p>
             </section>
             <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p id="non-conclusion-3-2" class="statement"><a class="statement-anchor" href="#non-conclusion-3-2">Non-conclusion 3.2.</a> Calling a region an attractor does not by itself prove convergence, stability, recurrence, or calibrated probability. Those stronger readings require additional semantics beyond the website exposition.</p>
+              <p id="non-conclusion-3-2" class="statement">
+<a class="statement-anchor" href="#non-conclusion-3-2">Non-conclusion 3.2.</a> Calling a region an attractor does not by itself prove convergence, stability, recurrence, or calibrated probability. Those stronger readings require additional semantics beyond the website exposition.</p>
             </section>
-            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../governance/"><span>Previous</span><strong>3-1. Governance</strong></a><a class="page-nav-next" href="../stable-regions/"><span>Next</span><strong>3-3. Stable Regions</strong></a></nav>
+            <nav class="page-nav" aria-label="Reading sequence">
+<a class="page-nav-previous" href="../governance/">
+<span>Previous</span>
+<strong>3-1. Governance</strong>
+</a>
+<a class="page-nav-next" href="../stable-regions/">
+<span>Next</span>
+<strong>3-3. Stable Regions</strong>
+</a>
+</nav>
           </div>
         </div>
       </section>
     </main>
-    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+    <footer class="site-footer">
+<div class="site-shell footer-inner">
+<p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+<a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+</div>
+</footer>
   </body>
 </html>

--- a/website/sft/intervention/closed-loop/index.html
+++ b/website/sft/intervention/closed-loop/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 3-6: closed-loop field updates from forecast, PR, review, CI, runtime feedback, incidents, calibration, and non-conclusions.">
+    <title>SFT 3-6: Closed-Loop Field Update</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/intervention/closed-loop/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 3-6: Closed-Loop Field Update">
+    <meta property="og:description" content="Updating field estimates with observed PRs, review and CI outcomes, runtime feedback, incident evidence, calibration, and non-conclusions.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/closed-loop/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 3-6: Closed-Loop Field Update">
+    <meta name="twitter:description" content="SFT is closed-loop only when forecast error and missing evidence are preserved.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <main id="main">
+      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Closed Loop</span></nav><p class="eyebrow">SFT 3-6</p><h1>Closed-Loop Field Update</h1><p class="lede">SFT becomes a learning field model only when forecast, proposal, review, CI, runtime, and incident outcomes are compared and preserved as bounded posterior evidence.</p></div></section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#loop">The loop</a></li><li><a href="#update">Posterior update</a></li><li><a href="#calibration">Calibration</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
+            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="./" aria-current="page">3-6. Closed Loop</a></li></ul></div>
+          </aside>
+          <div class="article-main">
+            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>What does the field learn when the observed future differs from the forecast cone?</p></aside>
+            <section id="loop" class="article-section">
+              <h2>The loop</h2>
+              <p>A closed loop begins with a prior field estimate and a bounded forecast artifact, then observes actual PR signatures, review decisions, CI outcomes, runtime feedback, incident traces, and follow-up issues. The purpose is not to claim automatic improvement. The purpose is to preserve the difference between expected support and observed behavior.</p>
+              <p>If a shortcut appeared that the model did not expose, the posterior field should remember the missing witness. If a lawful path was harder than expected, the update should record policy friction or capacity shortage. If evidence was unavailable, the non-conclusion should remain visible.</p>
+            </section>
+            <section id="update" class="article-section">
+              <h2>Posterior update</h2>
+              <figure class="code-panel"><figcaption>Field update</figcaption><pre><code>prior field
++ ForecastCone / ConsequenceEnvelope
++ observed PR signature delta
++ unexpected obstruction witnesses
++ review / CI outcome
++ runtime feedback
+-&gt; posterior field</code></pre></figure>
+              <p>The posterior field is a record-preserving update. It stores accepted lawful paths, redirected paths, blocked shortcuts, inconclusive evidence, unexpected witnesses, policy drift, and missing observation axes. That record is the material that later intervention design can use.</p>
+              <p>The same loop supports AI proposal governance and lifecycle decisions. The field can learn from accepted proposals, rejected proposal streams, migration outcomes, contraction effects, runtime incidents, and unsupported surfaces that should leave the lifecycle.</p>
+            </section>
+            <section id="calibration" class="article-section">
+              <h2>Calibration</h2>
+              <p>Calibration is the empirical step that compares forecast artifacts and witness reports against held-out or later observed outcomes. A report format does not provide calibration by itself. It only makes calibration possible by preserving forecast boundaries, non-conclusions, and outcome references.</p>
+              <p>Closed-loop SFT therefore treats calibration as a separate evidence process. The field update can store forecast error and missing evidence today without claiming that the next forecast is already calibrated.</p>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-6" class="statement"><a class="statement-anchor" href="#non-conclusion-3-6">Non-conclusion 3.6.</a> A posterior field update is not causal proof, automatic prediction improvement, or production calibration. It is a structured preservation of observed outcome evidence, forecast error, missing evidence, and non-conclusions.</p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../lifecycle/"><span>Previous</span><strong>3-5. Lifecycle Decisions</strong></a><a class="page-nav-next" href="../../"><span>Back to</span><strong>SFT overview</strong></a></nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+  </body>
+</html>

--- a/website/sft/intervention/closed-loop/index.html
+++ b/website/sft/intervention/closed-loop/index.html
@@ -24,52 +24,152 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../../assets/site.css">
-    <script defer src="../../../assets/site.js"></script>
+    <script defer src="../../../assets/site.js">
+</script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <header class="site-header" data-site-header>
+<div class="site-shell header-inner">
+<a class="brand" href="../../../" aria-label="AAT SFT home">
+<img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+<span class="brand-mark">AAT/SFT</span>
+<span class="brand-text">Research Notes</span>
+</a>
+<nav class="site-nav" aria-label="Primary navigation">
+<a href="../../../">Home</a>
+<a href="../../../aat/">AAT</a>
+<a class="is-active" href="../../">SFT</a>
+<a href="../../../archsig/">ArchSig</a>
+<a href="../../../outreach/">Outreach</a>
+</nav>
+</div>
+</header>
     <main id="main">
-      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Closed Loop</span></nav><p class="eyebrow">SFT 3-6</p><h1>Closed-Loop Field Update</h1><p class="lede">SFT becomes a learning field model only when forecast, proposal, review, CI, runtime, and incident outcomes are compared and preserved as bounded posterior evidence.</p></div></section>
+      <section class="article-hero section-band">
+<div class="site-shell">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="../../../">Home</a>
+<a href="../../">SFT</a>
+<a href="../">Intervention</a>
+<span>Closed Loop</span>
+</nav>
+<p class="eyebrow">SFT 3-6</p>
+<h1>Closed-Loop Field Update</h1>
+<p class="lede">SFT becomes a learning field model only when forecast, proposal, review, CI, runtime, and incident outcomes are compared and preserved as bounded posterior evidence.</p>
+</div>
+</section>
       <section class="section-band">
         <div class="site-shell article-layout">
           <aside class="article-sidebar" aria-label="Local navigation">
-            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#loop">The loop</a></li><li><a href="#update">Posterior update</a></li><li><a href="#calibration">Calibration</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
-            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="./" aria-current="page">3-6. Closed Loop</a></li></ul></div>
+            <nav class="toc-panel" aria-labelledby="toc-title">
+<h2 id="toc-title">On this page</h2>
+<ol>
+<li>
+<a href="#loop">The loop</a>
+</li>
+<li>
+<a href="#update">Posterior update</a>
+</li>
+<li>
+<a href="#calibration">Calibration</a>
+</li>
+<li>
+<a href="#boundary">Boundary</a>
+</li>
+</ol>
+</nav>
+            <div class="source-panel" data-sidebar-open="true">
+<h2>Part 3 routes</h2>
+<ul>
+<li>
+<a href="../../">SFT overview</a>
+</li>
+<li>
+<a href="../">Part 3. Intervention</a>
+</li>
+<li>
+<a href="../governance/">3-1. Governance</a>
+</li>
+<li>
+<a href="../attractor-engineering/">3-2. Attractor Engineering</a>
+</li>
+<li>
+<a href="../stable-regions/">3-3. Stable Regions</a>
+</li>
+<li>
+<a href="../ai-governance/">3-4. AI Governance</a>
+</li>
+<li>
+<a href="../lifecycle/">3-5. Lifecycle</a>
+</li>
+<li>
+<a href="./" aria-current="page">3-6. Closed Loop</a>
+</li>
+</ul>
+</div>
           </aside>
           <div class="article-main">
-            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>What does the field learn when the observed future differs from the forecast cone?</p></aside>
+            <aside class="question-card" aria-label="Guiding question">
+<span class="question-card-label">Question</span>
+<p>What does the field learn when the observed future differs from the forecast cone?</p>
+</aside>
             <section id="loop" class="article-section">
               <h2>The loop</h2>
               <p>A closed loop begins with a prior field estimate and a bounded forecast artifact, then observes actual PR signatures, review decisions, CI outcomes, runtime feedback, incident traces, and follow-up issues. The purpose is not to claim automatic improvement. The purpose is to preserve the difference between expected support and observed behavior.</p>
               <p>If a shortcut appeared that the model did not expose, the posterior field should remember the missing witness. If a lawful path was harder than expected, the update should record policy friction or capacity shortage. If evidence was unavailable, the non-conclusion should remain visible.</p>
+              <p>This is where SFT stops being a one-shot map. A forecast cone is useful, but a cone that never meets later evidence is only an elegant diagram. The closed loop asks what the field learned when the actual development path arrived.</p>
+              <p>The most valuable data is often the mismatch. A rejected PR can reveal unsupported policy. A passing CI run can reveal an observation gap. An incident can expose an invariant that no previous artifact named. A smooth migration can show that a path was cheaper than the model expected.</p>
             </section>
             <section id="update" class="article-section">
               <h2>Posterior update</h2>
-              <figure class="code-panel"><figcaption>Field update</figcaption><pre><code>prior field
+              <figure class="code-panel">
+<figcaption>Field update</figcaption>
+<pre>
+<code>prior field
 + ForecastCone / ConsequenceEnvelope
 + observed PR signature delta
 + unexpected obstruction witnesses
 + review / CI outcome
 + runtime feedback
--&gt; posterior field</code></pre></figure>
+-&gt; posterior field</code>
+</pre>
+</figure>
               <p>The posterior field is a record-preserving update. It stores accepted lawful paths, redirected paths, blocked shortcuts, inconclusive evidence, unexpected witnesses, policy drift, and missing observation axes. That record is the material that later intervention design can use.</p>
               <p>The same loop supports AI proposal governance and lifecycle decisions. The field can learn from accepted proposals, rejected proposal streams, migration outcomes, contraction effects, runtime incidents, and unsupported surfaces that should leave the lifecycle.</p>
+              <p>A posterior update should therefore preserve both success and disappointment. Success teaches which support actually worked. Disappointment teaches which boundary was missing. Inconclusive outcomes teach where the observation layer was too weak. All three are field memory.</p>
             </section>
             <section id="calibration" class="article-section">
               <h2>Calibration</h2>
               <p>Calibration is the empirical step that compares forecast artifacts and witness reports against held-out or later observed outcomes. A report format does not provide calibration by itself. It only makes calibration possible by preserving forecast boundaries, non-conclusions, and outcome references.</p>
               <p>Closed-loop SFT therefore treats calibration as a separate evidence process. The field update can store forecast error and missing evidence today without claiming that the next forecast is already calibrated.</p>
+              <p>The scientific promise is modest and important. SFT does not need to pretend that every forecast is already a validated predictor. It needs forecast artifacts precise enough to be wrong in inspectable ways, and field updates disciplined enough to turn those errors into better bounded models.</p>
+              <p>That is why non-conclusions remain first-class. A missing observation is not a failure to be hidden; it is part of the next modeling boundary. A field that records what it could not see is easier to improve than a field that silently converts absence of evidence into safety.</p>
             </section>
             <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p id="non-conclusion-3-6" class="statement"><a class="statement-anchor" href="#non-conclusion-3-6">Non-conclusion 3.6.</a> A posterior field update is not causal proof, automatic prediction improvement, or production calibration. It is a structured preservation of observed outcome evidence, forecast error, missing evidence, and non-conclusions.</p>
+              <p id="non-conclusion-3-6" class="statement">
+<a class="statement-anchor" href="#non-conclusion-3-6">Non-conclusion 3.6.</a> A posterior field update is not causal proof, automatic prediction improvement, or production calibration. It is a structured preservation of observed outcome evidence, forecast error, missing evidence, and non-conclusions.</p>
             </section>
-            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../lifecycle/"><span>Previous</span><strong>3-5. Lifecycle Decisions</strong></a><a class="page-nav-next" href="../../"><span>Back to</span><strong>SFT overview</strong></a></nav>
+            <nav class="page-nav" aria-label="Reading sequence">
+<a class="page-nav-previous" href="../lifecycle/">
+<span>Previous</span>
+<strong>3-5. Lifecycle Decisions</strong>
+</a>
+<a class="page-nav-next" href="../../">
+<span>Back to</span>
+<strong>SFT overview</strong>
+</a>
+</nav>
           </div>
         </div>
       </section>
     </main>
-    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+    <footer class="site-footer">
+<div class="site-shell footer-inner">
+<p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+<a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+</div>
+</footer>
   </body>
 </html>

--- a/website/sft/intervention/governance/index.html
+++ b/website/sft/intervention/governance/index.html
@@ -24,20 +24,36 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../../assets/site.css">
-    <script defer src="../../../assets/site.js"></script>
+    <script defer src="../../../assets/site.js">
+</script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
     <header class="site-header" data-site-header>
       <div class="site-shell header-inner">
-        <a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a>
-        <nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav>
+        <a class="brand" href="../../../" aria-label="AAT SFT home">
+<img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+<span class="brand-mark">AAT/SFT</span>
+<span class="brand-text">Research Notes</span>
+</a>
+        <nav class="site-nav" aria-label="Primary navigation">
+<a href="../../../">Home</a>
+<a href="../../../aat/">AAT</a>
+<a class="is-active" href="../../">SFT</a>
+<a href="../../../archsig/">ArchSig</a>
+<a href="../../../outreach/">Outreach</a>
+</nav>
       </div>
     </header>
     <main id="main">
       <section class="article-hero section-band">
         <div class="site-shell">
-          <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Governance</span></nav>
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="../../../">Home</a>
+<a href="../../">SFT</a>
+<a href="../">Intervention</a>
+<span>Governance</span>
+</nav>
           <p class="eyebrow">SFT 3-1</p>
           <h1>Governance as Field Shaping</h1>
           <p class="lede">Governance is not just a gate at the end of a change. In SFT, review, CI, type checking, runtime guards, ownership, and AI policy shape which future operations become cheap, selected, observable, or blocked.</p>
@@ -46,41 +62,113 @@
       <section class="section-band">
         <div class="site-shell article-layout">
           <aside class="article-sidebar" aria-label="Local navigation">
-            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#gate">Beyond the gate</a></li><li><a href="#interventions">Intervention types</a></li><li><a href="#memory">Field memory</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
-            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="./" aria-current="page">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+            <nav class="toc-panel" aria-labelledby="toc-title">
+<h2 id="toc-title">On this page</h2>
+<ol>
+<li>
+<a href="#gate">Beyond the gate</a>
+</li>
+<li>
+<a href="#interventions">Intervention types</a>
+</li>
+<li>
+<a href="#memory">Field memory</a>
+</li>
+<li>
+<a href="#boundary">Boundary</a>
+</li>
+</ol>
+</nav>
+            <div class="source-panel" data-sidebar-open="true">
+<h2>Part 3 routes</h2>
+<ul>
+<li>
+<a href="../../">SFT overview</a>
+</li>
+<li>
+<a href="../">Part 3. Intervention</a>
+</li>
+<li>
+<a href="./" aria-current="page">3-1. Governance</a>
+</li>
+<li>
+<a href="../attractor-engineering/">3-2. Attractor Engineering</a>
+</li>
+<li>
+<a href="../stable-regions/">3-3. Stable Regions</a>
+</li>
+<li>
+<a href="../ai-governance/">3-4. AI Governance</a>
+</li>
+<li>
+<a href="../lifecycle/">3-5. Lifecycle</a>
+</li>
+<li>
+<a href="../closed-loop/">3-6. Closed Loop</a>
+</li>
+</ul>
+</div>
           </aside>
           <div class="article-main">
-            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>What does governance change before the next diff is written?</p></aside>
+            <aside class="question-card" aria-label="Guiding question">
+<span class="question-card-label">Question</span>
+<p>What does governance change before the next diff is written?</p>
+</aside>
             <section id="gate" class="article-section">
               <h2>Beyond the gate</h2>
               <p>A narrow reading treats governance as a pass/fail gate: a review approves, CI passes, or a rule blocks the change. SFT keeps that function, but it is not the interesting part. Governance is a field mechanism because it changes future operation support and selection policy.</p>
               <p>A review norm can make invariant-preserving paths easier to propose. A type boundary can make illegal states expensive to express. A runtime guard can turn hidden failure into observable evidence. An AI policy can keep generated proposals inside a bounded candidate set. These are not only judgments about one change; they shape the field in which later changes are generated.</p>
+              <p>The question is therefore earlier than approval. Before a diff exists, governance has already influenced the vocabulary of the issue, the examples an agent will imitate, the tests a developer expects to fail, the reviewer who must be convinced, and the boundary that will be treated as expensive to cross.</p>
+              <p>A good governance system makes this pre-diff influence legible. It does not merely say no at the end; it changes the surface on which proposals are produced. That is why SFT treats review rules, CI, type systems, runtime guards, ownership, and policy as one intervention system rather than separate bureaucratic devices.</p>
             </section>
             <section id="interventions" class="article-section">
               <h2>Intervention types</h2>
-              <figure class="code-panel"><figcaption>Governance intervention</figcaption><pre><code>GovernanceIntervention
+              <figure class="code-panel">
+<figcaption>Governance intervention</figcaption>
+<pre>
+<code>GovernanceIntervention
   = support transformation
   + policy transformation
   + observation enrichment
   + feedback update
-  + escalation or deferral rule</code></pre></figure>
+  + escalation or deferral rule</code>
+</pre>
+</figure>
               <p>Restrictive interventions remove unsafe support. Redirective interventions raise shortcut cost and lower lawful path cost. Instrumenting interventions add tests, type checks, runtime checks, or measurement axes. Escalating interventions convert a proposal into review, design, or incident evidence. Learning interventions update field memory after an outcome.</p>
               <p>The useful question is therefore not only whether a rule blocks a bad PR. It is whether the governance system changes the support relation so that better next operations become easier to find and cheaper to justify.</p>
+              <p>For example, a reviewer can reject a shortcut, but the field has not improved much if the same shortcut will be proposed again next week. A stronger intervention names the missing invariant, adds a test or type boundary, records the review reason, and redirects future work toward an operation family that the team can repeat.</p>
+              <p>That is the control surface SFT cares about: support becomes easier or harder, policy selects differently, observation becomes sharper, and the field remembers enough to affect the next proposal.</p>
             </section>
             <section id="memory" class="article-section">
               <h2>Field memory</h2>
               <p>Good governance leaves residue. A rejected shortcut should leave a named missing invariant, a test boundary, an issue split, or a design note. A successful lawful path should leave an example later proposals can imitate. CI and runtime checks should preserve the observation boundary they improved.</p>
               <p>This is why SFT reads review, CI, type systems, architecture rules, runtime guards, and AI policy as one governance intervention system. The system is good when it protects selected regions and also makes the field learn.</p>
+              <p>Field memory is not only archive value. It is future operation support. A preserved design note can make a lawful path visible. A test can make an unsafe state harder to express. A postmortem can turn a hidden runtime assumption into a named constraint. A review template can make an AI-generated proposal expose its boundary rather than hide it.</p>
             </section>
             <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p id="non-conclusion-3-1" class="statement"><a class="statement-anchor" href="#non-conclusion-3-1">Non-conclusion 3.1.</a> Governance as field shaping is not an automatic proof of architecture lawfulness. A policy decision, passing CI run, or reviewer approval remains evidence inside a bounded field model, not a theorem about all future paths.</p>
+              <p id="non-conclusion-3-1" class="statement">
+<a class="statement-anchor" href="#non-conclusion-3-1">Non-conclusion 3.1.</a> Governance as field shaping is not an automatic proof of architecture lawfulness. A policy decision, passing CI run, or reviewer approval remains evidence inside a bounded field model, not a theorem about all future paths.</p>
             </section>
-            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../"><span>Previous</span><strong>Part 3. Intervention</strong></a><a class="page-nav-next" href="../attractor-engineering/"><span>Next</span><strong>3-2. Attractor Engineering</strong></a></nav>
+            <nav class="page-nav" aria-label="Reading sequence">
+<a class="page-nav-previous" href="../">
+<span>Previous</span>
+<strong>Part 3. Intervention</strong>
+</a>
+<a class="page-nav-next" href="../attractor-engineering/">
+<span>Next</span>
+<strong>3-2. Attractor Engineering</strong>
+</a>
+</nav>
           </div>
         </div>
       </section>
     </main>
-    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+    <footer class="site-footer">
+<div class="site-shell footer-inner">
+<p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+<a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+</div>
+</footer>
   </body>
 </html>

--- a/website/sft/intervention/governance/index.html
+++ b/website/sft/intervention/governance/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 3-1: governance as field shaping through review, CI, type checking, runtime guards, and feedback update.">
+    <title>SFT 3-1: Governance as Field Shaping</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/intervention/governance/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 3-1: Governance as Field Shaping">
+    <meta property="og:description" content="Review, CI, type checking, runtime guards, and AI policy as interventions that reshape future support and observation.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/governance/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 3-1: Governance as Field Shaping">
+    <meta name="twitter:description" content="Governance is a field intervention system, not only a quality gate.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a>
+        <nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav>
+      </div>
+    </header>
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Governance</span></nav>
+          <p class="eyebrow">SFT 3-1</p>
+          <h1>Governance as Field Shaping</h1>
+          <p class="lede">Governance is not just a gate at the end of a change. In SFT, review, CI, type checking, runtime guards, ownership, and AI policy shape which future operations become cheap, selected, observable, or blocked.</p>
+        </div>
+      </section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#gate">Beyond the gate</a></li><li><a href="#interventions">Intervention types</a></li><li><a href="#memory">Field memory</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
+            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="./" aria-current="page">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+          </aside>
+          <div class="article-main">
+            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>What does governance change before the next diff is written?</p></aside>
+            <section id="gate" class="article-section">
+              <h2>Beyond the gate</h2>
+              <p>A narrow reading treats governance as a pass/fail gate: a review approves, CI passes, or a rule blocks the change. SFT keeps that function, but it is not the interesting part. Governance is a field mechanism because it changes future operation support and selection policy.</p>
+              <p>A review norm can make invariant-preserving paths easier to propose. A type boundary can make illegal states expensive to express. A runtime guard can turn hidden failure into observable evidence. An AI policy can keep generated proposals inside a bounded candidate set. These are not only judgments about one change; they shape the field in which later changes are generated.</p>
+            </section>
+            <section id="interventions" class="article-section">
+              <h2>Intervention types</h2>
+              <figure class="code-panel"><figcaption>Governance intervention</figcaption><pre><code>GovernanceIntervention
+  = support transformation
+  + policy transformation
+  + observation enrichment
+  + feedback update
+  + escalation or deferral rule</code></pre></figure>
+              <p>Restrictive interventions remove unsafe support. Redirective interventions raise shortcut cost and lower lawful path cost. Instrumenting interventions add tests, type checks, runtime checks, or measurement axes. Escalating interventions convert a proposal into review, design, or incident evidence. Learning interventions update field memory after an outcome.</p>
+              <p>The useful question is therefore not only whether a rule blocks a bad PR. It is whether the governance system changes the support relation so that better next operations become easier to find and cheaper to justify.</p>
+            </section>
+            <section id="memory" class="article-section">
+              <h2>Field memory</h2>
+              <p>Good governance leaves residue. A rejected shortcut should leave a named missing invariant, a test boundary, an issue split, or a design note. A successful lawful path should leave an example later proposals can imitate. CI and runtime checks should preserve the observation boundary they improved.</p>
+              <p>This is why SFT reads review, CI, type systems, architecture rules, runtime guards, and AI policy as one governance intervention system. The system is good when it protects selected regions and also makes the field learn.</p>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-1" class="statement"><a class="statement-anchor" href="#non-conclusion-3-1">Non-conclusion 3.1.</a> Governance as field shaping is not an automatic proof of architecture lawfulness. A policy decision, passing CI run, or reviewer approval remains evidence inside a bounded field model, not a theorem about all future paths.</p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../"><span>Previous</span><strong>Part 3. Intervention</strong></a><a class="page-nav-next" href="../attractor-engineering/"><span>Next</span><strong>3-2. Attractor Engineering</strong></a></nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+  </body>
+</html>

--- a/website/sft/intervention/index.html
+++ b/website/sft/intervention/index.html
@@ -3,11 +3,32 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="SFT Part 3 index: field intervention and control.">
-    <title>SFT Part 3: Intervention</title>
+    <meta
+      name="description"
+      content="SFT Part 3: field intervention and control through governance, attractor engineering, stable regions, AI proposal governance, lifecycle decisions, and closed-loop updates."
+    >
+    <title>SFT Part 3: Field Intervention and Control</title>
     <link rel="canonical" href="https://iroha1203.dev/sft/intervention/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT Part 3: Field Intervention and Control">
+    <meta property="og:description" content="How governance and feedback reshape reachable architecture futures without turning SFT into prediction or general AI safety.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT Part 3: Field Intervention and Control">
+    <meta name="twitter:description" content="Governance, attractor engineering, stable regions, AI proposal governance, lifecycle decisions, and closed-loop field updates.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
     <link rel="stylesheet" href="../../assets/site.css">
     <script defer src="../../assets/site.js"></script>
   </head>
@@ -40,39 +61,128 @@
           <p class="eyebrow">SFT Part 3</p>
           <h1>Field Intervention and Control</h1>
           <p class="lede">
-            This part studies how governance, review, CI, runtime observation,
-            lifecycle decisions, and AI policy can reshape supported paths
-            without turning SFT into a forecast product or causal theorem.
+            Part 2 made reachable futures computable inside a bounded field
+            model. Part 3 asks how to change the field itself: support,
+            policy, observation, feedback, and lifecycle pressure can be shaped
+            so better architecture futures become easier to reach.
           </p>
         </div>
       </section>
       <section class="section-band">
         <div class="site-shell article-layout">
-          <aside class="article-sidebar" aria-label="SFT navigation">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#intervention">Intervention</a></li>
+                <li><a href="#control-surface">Control surface</a></li>
+                <li><a href="#chapter-index">Chapter index</a></li>
+                <li><a href="#boundary">Boundary</a></li>
+              </ol>
+            </nav>
             <div class="source-panel" data-sidebar-open="true">
-              <h2>SFT routes</h2>
+              <h2>Part 3 routes</h2>
               <ul>
-                <li><a href="../">Overview</a></li>
+                <li><a href="../">SFT overview</a></li>
                 <li><a href="../field/">Part 1. Field</a></li>
                 <li><a href="../computation/">Part 2. Computation</a></li>
                 <li><a href="./" aria-current="page">Part 3. Intervention</a></li>
+                <li><a href="governance/">3-1. Governance</a></li>
+                <li><a href="attractor-engineering/">3-2. Attractor Engineering</a></li>
+                <li><a href="stable-regions/">3-3. Stable Regions</a></li>
+                <li><a href="ai-governance/">3-4. AI Governance</a></li>
+                <li><a href="lifecycle/">3-5. Lifecycle Decisions</a></li>
+                <li><a href="closed-loop/">3-6. Closed-Loop Update</a></li>
               </ul>
             </div>
           </aside>
           <div class="article-main">
-            <section class="article-section">
+            <aside class="question-card" aria-label="Guiding question">
+              <span class="question-card-label">Question</span>
+              <p>Once reachable futures are visible, which field changes make the desired futures natural, observable, and reviewable?</p>
+            </aside>
+
+            <section id="intervention" class="article-section">
+              <h2>Intervention</h2>
+              <p>
+                SFT intervention is not only a mechanism for rejecting bad
+                changes. A restrictive gate can remove unsafe support, but the
+                deeper control problem is to reshape what the field makes
+                visible, cheap, selected, and remembered.
+              </p>
+              <p>
+                Review, CI, type checking, architecture rules, runtime guards,
+                AI policy, and lifecycle decisions all affect future operation
+                support. They can lower the cost of lawful paths, raise the
+                cost of shortcuts, add observation axes, redirect proposals
+                into design work, and preserve observed outcomes as field
+                memory.
+              </p>
+              <p id="definition-3-0" class="statement">
+                <a class="statement-anchor" href="#definition-3-0">Definition 3.0.</a>
+                A field intervention is a bounded change to support, policy,
+                observation, feedback update, or lifecycle capacity intended to
+                reshape the reachable architecture futures of a selected SFT
+                field model.
+              </p>
+              <p class="statement-status" aria-label="SFT status for Definition 3.0">
+                <span class="statement-status-label">SFT status</span>
+                <span class="status-badge status-badge-defined">conceptual definition</span>
+                <span>Website explanation of SFT intervention design; no Lean theorem is added by this page.</span>
+              </p>
+            </section>
+
+            <section id="control-surface" class="article-section">
+              <h2>Control surface</h2>
+              <figure class="code-panel">
+                <figcaption>Part 3 control surface</figcaption>
+                <pre><code>ForecastCone / ConsequenceEnvelope
+ selected target or safe region
+-&gt; support shaping
+-&gt; policy shaping
+-&gt; observation enrichment
+-&gt; review / CI / runtime intervention
+-&gt; posterior field update</code></pre>
+              </figure>
+              <p>
+                Attractor Engineering is the most vivid application of this
+                surface: design the field so desirable futures are natural,
+                cheap, visible, and repeatable, while shortcut paths become
+                costly, observable, and review-mediated. It is an application
+                of SFT, not a synonym for the whole theory.
+              </p>
+              <p>
+                The same surface also supports AI proposal governance,
+                lifecycle decisions, and closed-loop updates. The common habit
+                is to keep the intervention attached to a bounded field model
+                and to preserve non-conclusions when evidence is missing.
+              </p>
+            </section>
+
+            <section id="chapter-index" class="article-section">
               <h2>Chapter index</h2>
               <ul class="chapter-list">
-                <li><strong>Governance as Field Shaping</strong><span>Review, CI, type checking, runtime guards, and AI policy as support and observation interventions.</span></li>
-                <li><strong>Attractor Engineering</strong><span>Making desirable futures natural, cheap, visible, and reviewable while exposing shortcut paths.</span></li>
-                <li><strong>Stable Regions and Recurrent Paths</strong><span>Default paths, recurrent patterns, stable regions, and reachable preimages under bounded semantics.</span></li>
-                <li><strong>AI Proposal Governance</strong><span>Controlling AI-generated proposal support through theorem boundaries, review, and CI feedback.</span></li>
-                <li><strong>Lifecycle Decisions</strong><span>Repair, migration, contraction, deletion, and end-of-life as field-capacity choices.</span></li>
-                <li><strong>Closed-Loop Field Update</strong><span>Using PR, review, CI, runtime feedback, and incident outcomes to revise field estimates.</span></li>
+                <li><a href="governance/">3-1. Governance as Field Shaping</a><span>Review, CI, type checking, runtime guards, and AI policy as support and observation interventions.</span></li>
+                <li><a href="attractor-engineering/">3-2. Attractor Engineering</a><span>Making desirable futures natural, cheap, visible, and reviewable while exposing shortcut paths.</span></li>
+                <li><a href="stable-regions/">3-3. Stable Regions and Recurrent Paths</a><span>Default paths, recurrent patterns, stable regions, and reachable preimages under bounded semantics.</span></li>
+                <li><a href="ai-governance/">3-4. AI Proposal Governance</a><span>Controlling AI-generated proposal support through theorem boundaries, review, and CI feedback.</span></li>
+                <li><a href="lifecycle/">3-5. Lifecycle Decisions</a><span>Repair, migration, contraction, deletion, and end-of-life as field-capacity choices.</span></li>
+                <li><a href="closed-loop/">3-6. Closed-Loop Field Update</a><span>Using PR, review, CI, runtime feedback, and incident outcomes to revise field estimates.</span></li>
               </ul>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-0" class="statement">
+                <a class="statement-anchor" href="#non-conclusion-3-0">Non-conclusion 3.0.</a>
+                Field intervention does not prove deterministic control,
+                calibrated prediction, or general AI safety. It names bounded
+                ways to change support, policy, observation, feedback, and
+                capacity, then asks whether later evidence supports the update.
+              </p>
             </section>
             <nav class="page-nav" aria-label="Reading sequence">
               <a class="page-nav-previous" href="../computation/"><span>Previous</span><strong>Part 2. Computation</strong></a>
+              <a class="page-nav-next" href="governance/"><span>Next</span><strong>3-1. Governance as Field Shaping</strong></a>
             </nav>
           </div>
         </div>

--- a/website/sft/intervention/index.html
+++ b/website/sft/intervention/index.html
@@ -111,6 +111,15 @@
                 visible, cheap, selected, and remembered.
               </p>
               <p>
+                This is the turn from forecast to design. Part 2 asks which
+                futures are reachable under a selected model. Part 3 asks what
+                a team can change when that reachable shape is no longer
+                acceptable. The answer is rarely one lever. A review rule may
+                narrow a cone, but a missing invariant may require a type
+                boundary; a shortcut may require runtime observation; a
+                fragile surface may require migration or retirement.
+              </p>
+              <p>
                 Review, CI, type checking, architecture rules, runtime guards,
                 AI policy, and lifecycle decisions all affect future operation
                 support. They can lower the cost of lawful paths, raise the
@@ -150,6 +159,13 @@
                 cheap, visible, and repeatable, while shortcut paths become
                 costly, observable, and review-mediated. It is an application
                 of SFT, not a synonym for the whole theory.
+              </p>
+              <p>
+                The important shift is that governance stops being read as a
+                moral afterthought. In SFT, governance is part of the dynamical
+                object. It changes what developers and AI agents see as the
+                next plausible move, what CI can notice, what reviewers can
+                name, and what the organization remembers after the decision.
               </p>
               <p>
                 The same surface also supports AI proposal governance,

--- a/website/sft/intervention/lifecycle/index.html
+++ b/website/sft/intervention/lifecycle/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 3-5: lifecycle decisions as field capacity and architecture-future changes, not project management recommendations.">
+    <title>SFT 3-5: Lifecycle Decisions</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/intervention/lifecycle/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 3-5: Lifecycle Decisions">
+    <meta property="og:description" content="Repair, migration, contraction, deletion, and end-of-life as bounded field-capacity choices.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/lifecycle/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 3-5: Lifecycle Decisions">
+    <meta name="twitter:description" content="Lifecycle decisions compare architecture futures and field capacity under explicit boundaries.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <main id="main">
+      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Lifecycle</span></nav><p class="eyebrow">SFT 3-5</p><h1>Lifecycle Decisions</h1><p class="lede">Repair, migration, contraction, deletion, and end-of-life are field interventions. They change architecture futures by reallocating support, risk, ownership, observation, and capacity.</p></div></section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#trajectory">Lifecycle trajectory</a></li><li><a href="#decision-model">Decision model</a></li><li><a href="#interventions">Interventions</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
+            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="./" aria-current="page">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+          </aside>
+          <div class="article-main">
+            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>When does a field have capacity to repair, migrate, shrink, or retire a surface?</p></aside>
+            <section id="trajectory" class="article-section">
+              <h2>Lifecycle trajectory</h2>
+              <p>A software field includes birth, growth, stabilization, drift, repair, migration, contraction, and end-of-life. End-of-life is not a moral failure. It can be the correct field reconfiguration when the remaining operation support, ownership capacity, runtime guard, and migration path no longer justify preserving a surface.</p>
+              <p>SFT treats lifecycle decisions as changes to reachable architecture futures. The same codebase can have different futures depending on whether the field can still support repair, must migrate to a new support structure, should contract unsupported surface, or should remove a component from active lifecycle.</p>
+            </section>
+            <section id="decision-model" class="article-section">
+              <h2>Decision model</h2>
+              <figure class="code-panel"><figcaption>Lifecycle decision model</figcaption><pre><code>current lifecycle trajectory
++ ArchitectureSignature trajectory
++ ConsequenceEnvelope family
++ runtime / incident risk boundary
++ ownership / staffing boundary
++ selected intervention set
++ non-conclusions</code></pre></figure>
+              <p>The model compares architecture signature movement, affected regions, obstruction witnesses, missing boundaries, runtime risk, and ownership capacity. It does not output a managerial recommendation detached from the field. It asks how each intervention changes future support and unknown remainder.</p>
+            </section>
+            <section id="interventions" class="article-section">
+              <h2>Interventions</h2>
+              <p>Repair preserves the existing field while adding missing invariant or support. Migration transfers support and memory from an old field to a new one. Contraction reduces unsupported surface and reallocates capacity. Deletion removes a component or subsystem from the active lifecycle while recording dependent operation loss and retirement boundaries.</p>
+              <p>A ConsequenceEnvelope family makes these options comparable. A wide envelope is not automatically a reason to delete, and a local repair is not automatically safe. Each option has a different support, risk, capacity, and unknown-remainder profile.</p>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-5" class="statement"><a class="statement-anchor" href="#non-conclusion-3-5">Non-conclusion 3.5.</a> Lifecycle modeling is not project management advice. It is a bounded comparison of architecture futures and field capacity under selected evidence, selected interventions, and explicit non-conclusions.</p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../ai-governance/"><span>Previous</span><strong>3-4. AI Proposal Governance</strong></a><a class="page-nav-next" href="../closed-loop/"><span>Next</span><strong>3-6. Closed-Loop Field Update</strong></a></nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+  </body>
+</html>

--- a/website/sft/intervention/lifecycle/index.html
+++ b/website/sft/intervention/lifecycle/index.html
@@ -24,51 +24,150 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../../assets/site.css">
-    <script defer src="../../../assets/site.js"></script>
+    <script defer src="../../../assets/site.js">
+</script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <header class="site-header" data-site-header>
+<div class="site-shell header-inner">
+<a class="brand" href="../../../" aria-label="AAT SFT home">
+<img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+<span class="brand-mark">AAT/SFT</span>
+<span class="brand-text">Research Notes</span>
+</a>
+<nav class="site-nav" aria-label="Primary navigation">
+<a href="../../../">Home</a>
+<a href="../../../aat/">AAT</a>
+<a class="is-active" href="../../">SFT</a>
+<a href="../../../archsig/">ArchSig</a>
+<a href="../../../outreach/">Outreach</a>
+</nav>
+</div>
+</header>
     <main id="main">
-      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Lifecycle</span></nav><p class="eyebrow">SFT 3-5</p><h1>Lifecycle Decisions</h1><p class="lede">Repair, migration, contraction, deletion, and end-of-life are field interventions. They change architecture futures by reallocating support, risk, ownership, observation, and capacity.</p></div></section>
+      <section class="article-hero section-band">
+<div class="site-shell">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="../../../">Home</a>
+<a href="../../">SFT</a>
+<a href="../">Intervention</a>
+<span>Lifecycle</span>
+</nav>
+<p class="eyebrow">SFT 3-5</p>
+<h1>Lifecycle Decisions</h1>
+<p class="lede">Repair, migration, contraction, deletion, and end-of-life are field interventions. They change architecture futures by reallocating support, risk, ownership, observation, and capacity.</p>
+</div>
+</section>
       <section class="section-band">
         <div class="site-shell article-layout">
           <aside class="article-sidebar" aria-label="Local navigation">
-            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#trajectory">Lifecycle trajectory</a></li><li><a href="#decision-model">Decision model</a></li><li><a href="#interventions">Interventions</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
-            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="../stable-regions/">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="./" aria-current="page">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+            <nav class="toc-panel" aria-labelledby="toc-title">
+<h2 id="toc-title">On this page</h2>
+<ol>
+<li>
+<a href="#trajectory">Lifecycle trajectory</a>
+</li>
+<li>
+<a href="#decision-model">Decision model</a>
+</li>
+<li>
+<a href="#interventions">Interventions</a>
+</li>
+<li>
+<a href="#boundary">Boundary</a>
+</li>
+</ol>
+</nav>
+            <div class="source-panel" data-sidebar-open="true">
+<h2>Part 3 routes</h2>
+<ul>
+<li>
+<a href="../../">SFT overview</a>
+</li>
+<li>
+<a href="../">Part 3. Intervention</a>
+</li>
+<li>
+<a href="../governance/">3-1. Governance</a>
+</li>
+<li>
+<a href="../attractor-engineering/">3-2. Attractor Engineering</a>
+</li>
+<li>
+<a href="../stable-regions/">3-3. Stable Regions</a>
+</li>
+<li>
+<a href="../ai-governance/">3-4. AI Governance</a>
+</li>
+<li>
+<a href="./" aria-current="page">3-5. Lifecycle</a>
+</li>
+<li>
+<a href="../closed-loop/">3-6. Closed Loop</a>
+</li>
+</ul>
+</div>
           </aside>
           <div class="article-main">
-            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>When does a field have capacity to repair, migrate, shrink, or retire a surface?</p></aside>
+            <aside class="question-card" aria-label="Guiding question">
+<span class="question-card-label">Question</span>
+<p>When does a field have capacity to repair, migrate, shrink, or retire a surface?</p>
+</aside>
             <section id="trajectory" class="article-section">
               <h2>Lifecycle trajectory</h2>
               <p>A software field includes birth, growth, stabilization, drift, repair, migration, contraction, and end-of-life. End-of-life is not a moral failure. It can be the correct field reconfiguration when the remaining operation support, ownership capacity, runtime guard, and migration path no longer justify preserving a surface.</p>
               <p>SFT treats lifecycle decisions as changes to reachable architecture futures. The same codebase can have different futures depending on whether the field can still support repair, must migrate to a new support structure, should contract unsupported surface, or should remove a component from active lifecycle.</p>
+              <p>The lifecycle question is often hidden under project language. SFT reframes it as a field-capacity question. What operations can this organization still support? Which invariants can still be observed? Which runtime risks can still be governed? Which ownership boundaries still have people, knowledge, and review capacity behind them?</p>
+              <p>When those answers change, the future cone changes. A subsystem may remain syntactically present while its field support has already decayed. Another subsystem may look costly today but have a migration path that opens better futures. Lifecycle intervention is the discipline of comparing those futures without pretending that all surfaces deserve indefinite preservation.</p>
             </section>
             <section id="decision-model" class="article-section">
               <h2>Decision model</h2>
-              <figure class="code-panel"><figcaption>Lifecycle decision model</figcaption><pre><code>current lifecycle trajectory
+              <figure class="code-panel">
+<figcaption>Lifecycle decision model</figcaption>
+<pre>
+<code>current lifecycle trajectory
 + ArchitectureSignature trajectory
 + ConsequenceEnvelope family
 + runtime / incident risk boundary
 + ownership / staffing boundary
 + selected intervention set
-+ non-conclusions</code></pre></figure>
++ non-conclusions</code>
+</pre>
+</figure>
               <p>The model compares architecture signature movement, affected regions, obstruction witnesses, missing boundaries, runtime risk, and ownership capacity. It does not output a managerial recommendation detached from the field. It asks how each intervention changes future support and unknown remainder.</p>
+              <p>This makes lifecycle reasoning comparable rather than rhetorical. Repair may preserve compatibility but keep the same recurrent bad path. Migration may be expensive but move the field into a region with stronger support. Contraction may reduce surface and lower observation burden. Deletion may remove risk while creating dependent-operation loss that must be named.</p>
             </section>
             <section id="interventions" class="article-section">
               <h2>Interventions</h2>
               <p>Repair preserves the existing field while adding missing invariant or support. Migration transfers support and memory from an old field to a new one. Contraction reduces unsupported surface and reallocates capacity. Deletion removes a component or subsystem from the active lifecycle while recording dependent operation loss and retirement boundaries.</p>
               <p>A ConsequenceEnvelope family makes these options comparable. A wide envelope is not automatically a reason to delete, and a local repair is not automatically safe. Each option has a different support, risk, capacity, and unknown-remainder profile.</p>
+              <p>The useful output is therefore not a slogan such as modernize or keep stable. It is a bounded comparison: which paths remain reachable, which risks become observable, which operations lose support, which migration witnesses are missing, and what evidence would change the decision later.</p>
             </section>
             <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p id="non-conclusion-3-5" class="statement"><a class="statement-anchor" href="#non-conclusion-3-5">Non-conclusion 3.5.</a> Lifecycle modeling is not project management advice. It is a bounded comparison of architecture futures and field capacity under selected evidence, selected interventions, and explicit non-conclusions.</p>
+              <p id="non-conclusion-3-5" class="statement">
+<a class="statement-anchor" href="#non-conclusion-3-5">Non-conclusion 3.5.</a> Lifecycle modeling is not project management advice. It is a bounded comparison of architecture futures and field capacity under selected evidence, selected interventions, and explicit non-conclusions.</p>
             </section>
-            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../ai-governance/"><span>Previous</span><strong>3-4. AI Proposal Governance</strong></a><a class="page-nav-next" href="../closed-loop/"><span>Next</span><strong>3-6. Closed-Loop Field Update</strong></a></nav>
+            <nav class="page-nav" aria-label="Reading sequence">
+<a class="page-nav-previous" href="../ai-governance/">
+<span>Previous</span>
+<strong>3-4. AI Proposal Governance</strong>
+</a>
+<a class="page-nav-next" href="../closed-loop/">
+<span>Next</span>
+<strong>3-6. Closed-Loop Field Update</strong>
+</a>
+</nav>
           </div>
         </div>
       </section>
     </main>
-    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+    <footer class="site-footer">
+<div class="site-shell footer-inner">
+<p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+<a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+</div>
+</footer>
   </body>
 </html>

--- a/website/sft/intervention/stable-regions/index.html
+++ b/website/sft/intervention/stable-regions/index.html
@@ -24,49 +24,149 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../../assets/site.css">
-    <script defer src="../../../assets/site.js"></script>
+    <script defer src="../../../assets/site.js">
+</script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <header class="site-header" data-site-header>
+<div class="site-shell header-inner">
+<a class="brand" href="../../../" aria-label="AAT SFT home">
+<img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+<span class="brand-mark">AAT/SFT</span>
+<span class="brand-text">Research Notes</span>
+</a>
+<nav class="site-nav" aria-label="Primary navigation">
+<a href="../../../">Home</a>
+<a href="../../../aat/">AAT</a>
+<a class="is-active" href="../../">SFT</a>
+<a href="../../../archsig/">ArchSig</a>
+<a href="../../../outreach/">Outreach</a>
+</nav>
+</div>
+</header>
     <main id="main">
-      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Stable Regions</span></nav><p class="eyebrow">SFT 3-3</p><h1>Stable Regions and Recurrent Paths</h1><p class="lede">Stable-region language lets SFT talk about repeated development paths and safe areas of the field without pretending that every attractive pattern has convergence or probability semantics.</p></div></section>
+      <section class="article-hero section-band">
+<div class="site-shell">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="../../../">Home</a>
+<a href="../../">SFT</a>
+<a href="../">Intervention</a>
+<span>Stable Regions</span>
+</nav>
+<p class="eyebrow">SFT 3-3</p>
+<h1>Stable Regions and Recurrent Paths</h1>
+<p class="lede">Stable-region language lets SFT talk about repeated development paths and safe areas of the field without pretending that every attractive pattern has convergence or probability semantics.</p>
+</div>
+</section>
       <section class="section-band">
         <div class="site-shell article-layout">
           <aside class="article-sidebar" aria-label="Local navigation">
-            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#vocabulary">Vocabulary</a></li><li><a href="#reachability">Reachability</a></li><li><a href="#intervention">Intervention use</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
-            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="./" aria-current="page">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+            <nav class="toc-panel" aria-labelledby="toc-title">
+<h2 id="toc-title">On this page</h2>
+<ol>
+<li>
+<a href="#vocabulary">Vocabulary</a>
+</li>
+<li>
+<a href="#reachability">Reachability</a>
+</li>
+<li>
+<a href="#intervention">Intervention use</a>
+</li>
+<li>
+<a href="#boundary">Boundary</a>
+</li>
+</ol>
+</nav>
+            <div class="source-panel" data-sidebar-open="true">
+<h2>Part 3 routes</h2>
+<ul>
+<li>
+<a href="../../">SFT overview</a>
+</li>
+<li>
+<a href="../">Part 3. Intervention</a>
+</li>
+<li>
+<a href="../governance/">3-1. Governance</a>
+</li>
+<li>
+<a href="../attractor-engineering/">3-2. Attractor Engineering</a>
+</li>
+<li>
+<a href="./" aria-current="page">3-3. Stable Regions</a>
+</li>
+<li>
+<a href="../ai-governance/">3-4. AI Governance</a>
+</li>
+<li>
+<a href="../lifecycle/">3-5. Lifecycle</a>
+</li>
+<li>
+<a href="../closed-loop/">3-6. Closed Loop</a>
+</li>
+</ul>
+</div>
           </aside>
           <div class="article-main">
-            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>Which regions stay safe under selected operations, and which fields can reach them?</p></aside>
+            <aside class="question-card" aria-label="Guiding question">
+<span class="question-card-label">Question</span>
+<p>Which regions stay safe under selected operations, and which fields can reach them?</p>
+</aside>
             <section id="vocabulary" class="article-section">
               <h2>Vocabulary</h2>
               <p>SFT separates practical words that engineers use from the semantics needed to make them theorem-bearing. A <code>DefaultPath</code> is the operation sequence the field makes easy. A <code>RecurrentPattern</code> is a repeated path family observed or expected under the selected field model. A <code>StableRegion</code> is a region preserved by accepted steps.</p>
               <p>This separation matters because attractor and basin language can otherwise become too strong. In the set-valued core, the safer questions are may reachability, must reachability, stable-region preservation, and reachable preimage.</p>
+              <p>A default path is often more powerful than an explicit rule. It is the path a new developer copies, the path an AI agent completes from local context, the path a reviewer has seen before, and the path CI already understands. If that path points into a brittle region, the field will keep reproducing the same architecture tendency even when nobody intends to.</p>
+              <p>A stable region is the counter-question. Can the selected field keep operating inside a region whose invariants, ownership boundaries, and observation axes are still preserved? If not, the region may be attractive in prose but unstable under the actual support relation.</p>
             </section>
             <section id="reachability" class="article-section">
               <h2>Reachability</h2>
-              <figure class="code-panel"><figcaption>Stable-region core</figcaption><pre><code>MayReach_h(F, U, A)
+              <figure class="code-panel">
+<figcaption>Stable-region core</figcaption>
+<pre>
+<code>MayReach_h(F, U, A)
 MustReach_h(F, U, A)
 StableRegion(U, A)
-ReachablePreimage_h(U, A)</code></pre></figure>
-              <p><code>MayReach</code> asks whether some accepted path reaches a region within the horizon. <code>MustReach</code> asks whether all accepted paths reach it. <code>StableRegion</code> asks whether accepted steps from inside the region remain inside it. <code>ReachablePreimage</code> collects fields from which the region can be reached.</p>
+ReachablePreimage_h(U, A)</code>
+</pre>
+</figure>
+              <p>
+<code>MayReach</code> asks whether some accepted path reaches a region within the horizon. <code>MustReach</code> asks whether all accepted paths reach it. <code>StableRegion</code> asks whether accepted steps from inside the region remain inside it. <code>ReachablePreimage</code> collects fields from which the region can be reached.</p>
               <p>These objects are intentionally less dramatic than attractor language. Their advantage is that they say exactly what is being claimed under the selected operation support and horizon.</p>
+              <p>The difference between may and must matters for governance. A safe future that may be reached is an opportunity. A safe future that must be reached under accepted steps is a much stronger claim. A shortcut region that may be reached is a risk. A shortcut region whose preimage is wide under current support is a field design problem.</p>
             </section>
             <section id="intervention" class="article-section">
               <h2>Intervention use</h2>
               <p>Intervention design can now ask concrete questions. Does a review rule preserve the selected safe region? Does a policy change shrink the reachable preimage of a shortcut region? Does a new test move a default path away from a recurrent bad pattern? Does lifecycle contraction remove support for a region the field can no longer maintain?</p>
               <p>The answers remain relative to the model. That relativity is useful: it tells readers which operation support, horizon, and observation boundary make the stable-region claim meaningful.</p>
+              <p>This is where stable-region vocabulary becomes practical. It lets a team say, in bounded terms, that a planned intervention is not merely aesthetically cleaner. It changes which regions are reachable, which regions are preserved, and which default paths remain easy.</p>
             </section>
             <section id="boundary" class="article-section">
               <h2>Boundary</h2>
-              <p id="non-conclusion-3-3" class="statement"><a class="statement-anchor" href="#non-conclusion-3-3">Non-conclusion 3.3.</a> A stable region under a selected support relation is not a global safety proof. Recurrent or likely reachability needs stronger transition, policy, probability, or calibration semantics.</p>
+              <p id="non-conclusion-3-3" class="statement">
+<a class="statement-anchor" href="#non-conclusion-3-3">Non-conclusion 3.3.</a> A stable region under a selected support relation is not a global safety proof. Recurrent or likely reachability needs stronger transition, policy, probability, or calibration semantics.</p>
             </section>
-            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../attractor-engineering/"><span>Previous</span><strong>3-2. Attractor Engineering</strong></a><a class="page-nav-next" href="../ai-governance/"><span>Next</span><strong>3-4. AI Proposal Governance</strong></a></nav>
+            <nav class="page-nav" aria-label="Reading sequence">
+<a class="page-nav-previous" href="../attractor-engineering/">
+<span>Previous</span>
+<strong>3-2. Attractor Engineering</strong>
+</a>
+<a class="page-nav-next" href="../ai-governance/">
+<span>Next</span>
+<strong>3-4. AI Proposal Governance</strong>
+</a>
+</nav>
           </div>
         </div>
       </section>
     </main>
-    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+    <footer class="site-footer">
+<div class="site-shell footer-inner">
+<p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+<a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+</div>
+</footer>
   </body>
 </html>

--- a/website/sft/intervention/stable-regions/index.html
+++ b/website/sft/intervention/stable-regions/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="SFT 3-3: stable regions and recurrent development paths under bounded reachability semantics.">
+    <title>SFT 3-3: Stable Regions and Recurrent Paths</title>
+    <link rel="canonical" href="https://iroha1203.dev/sft/intervention/stable-regions/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="SFT 3-3: Stable Regions and Recurrent Paths">
+    <meta property="og:description" content="DefaultPath, RecurrentPattern, StableRegion, and ReachablePreimage without strengthening attractor vocabulary beyond its semantics.">
+    <meta property="og:url" content="https://iroha1203.dev/sft/intervention/stable-regions/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SFT 3-3: Stable Regions and Recurrent Paths">
+    <meta name="twitter:description" content="Bounded stable-region vocabulary for field intervention design.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../../assets/site.css">
+    <script defer src="../../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" data-site-header><div class="site-shell header-inner"><a class="brand" href="../../../" aria-label="AAT SFT home"><img class="brand-icon" src="../../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true"><span class="brand-mark">AAT/SFT</span><span class="brand-text">Research Notes</span></a><nav class="site-nav" aria-label="Primary navigation"><a href="../../../">Home</a><a href="../../../aat/">AAT</a><a class="is-active" href="../../">SFT</a><a href="../../../archsig/">ArchSig</a><a href="../../../outreach/">Outreach</a></nav></div></header>
+    <main id="main">
+      <section class="article-hero section-band"><div class="site-shell"><nav class="breadcrumb" aria-label="Breadcrumb"><a href="../../../">Home</a><a href="../../">SFT</a><a href="../">Intervention</a><span>Stable Regions</span></nav><p class="eyebrow">SFT 3-3</p><h1>Stable Regions and Recurrent Paths</h1><p class="lede">Stable-region language lets SFT talk about repeated development paths and safe areas of the field without pretending that every attractive pattern has convergence or probability semantics.</p></div></section>
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title"><h2 id="toc-title">On this page</h2><ol><li><a href="#vocabulary">Vocabulary</a></li><li><a href="#reachability">Reachability</a></li><li><a href="#intervention">Intervention use</a></li><li><a href="#boundary">Boundary</a></li></ol></nav>
+            <div class="source-panel" data-sidebar-open="true"><h2>Part 3 routes</h2><ul><li><a href="../../">SFT overview</a></li><li><a href="../">Part 3. Intervention</a></li><li><a href="../governance/">3-1. Governance</a></li><li><a href="../attractor-engineering/">3-2. Attractor Engineering</a></li><li><a href="./" aria-current="page">3-3. Stable Regions</a></li><li><a href="../ai-governance/">3-4. AI Governance</a></li><li><a href="../lifecycle/">3-5. Lifecycle</a></li><li><a href="../closed-loop/">3-6. Closed Loop</a></li></ul></div>
+          </aside>
+          <div class="article-main">
+            <aside class="question-card" aria-label="Guiding question"><span class="question-card-label">Question</span><p>Which regions stay safe under selected operations, and which fields can reach them?</p></aside>
+            <section id="vocabulary" class="article-section">
+              <h2>Vocabulary</h2>
+              <p>SFT separates practical words that engineers use from the semantics needed to make them theorem-bearing. A <code>DefaultPath</code> is the operation sequence the field makes easy. A <code>RecurrentPattern</code> is a repeated path family observed or expected under the selected field model. A <code>StableRegion</code> is a region preserved by accepted steps.</p>
+              <p>This separation matters because attractor and basin language can otherwise become too strong. In the set-valued core, the safer questions are may reachability, must reachability, stable-region preservation, and reachable preimage.</p>
+            </section>
+            <section id="reachability" class="article-section">
+              <h2>Reachability</h2>
+              <figure class="code-panel"><figcaption>Stable-region core</figcaption><pre><code>MayReach_h(F, U, A)
+MustReach_h(F, U, A)
+StableRegion(U, A)
+ReachablePreimage_h(U, A)</code></pre></figure>
+              <p><code>MayReach</code> asks whether some accepted path reaches a region within the horizon. <code>MustReach</code> asks whether all accepted paths reach it. <code>StableRegion</code> asks whether accepted steps from inside the region remain inside it. <code>ReachablePreimage</code> collects fields from which the region can be reached.</p>
+              <p>These objects are intentionally less dramatic than attractor language. Their advantage is that they say exactly what is being claimed under the selected operation support and horizon.</p>
+            </section>
+            <section id="intervention" class="article-section">
+              <h2>Intervention use</h2>
+              <p>Intervention design can now ask concrete questions. Does a review rule preserve the selected safe region? Does a policy change shrink the reachable preimage of a shortcut region? Does a new test move a default path away from a recurrent bad pattern? Does lifecycle contraction remove support for a region the field can no longer maintain?</p>
+              <p>The answers remain relative to the model. That relativity is useful: it tells readers which operation support, horizon, and observation boundary make the stable-region claim meaningful.</p>
+            </section>
+            <section id="boundary" class="article-section">
+              <h2>Boundary</h2>
+              <p id="non-conclusion-3-3" class="statement"><a class="statement-anchor" href="#non-conclusion-3-3">Non-conclusion 3.3.</a> A stable region under a selected support relation is not a global safety proof. Recurrent or likely reachability needs stronger transition, policy, probability, or calibration semantics.</p>
+            </section>
+            <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-previous" href="../attractor-engineering/"><span>Previous</span><strong>3-2. Attractor Engineering</strong></a><a class="page-nav-next" href="../ai-governance/"><span>Next</span><strong>3-4. AI Proposal Governance</strong></a></nav>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer"><div class="site-shell footer-inner"><p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a></div></footer>
+  </body>
+</html>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -135,4 +135,22 @@
   <url>
     <loc>https://iroha1203.dev/sft/intervention/</loc>
   </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/intervention/governance/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/intervention/attractor-engineering/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/intervention/stable-regions/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/intervention/ai-governance/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/intervention/lifecycle/</loc>
+  </url>
+  <url>
+    <loc>https://iroha1203.dev/sft/intervention/closed-loop/</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## 概要

Closes #959

- SFT 第3部 landing `/sft/intervention/` を、field intervention / control の入口として拡充しました。
- `3-1 Governance as Field Shaping` から `3-6 Closed-Loop Field Update` までの 6 route を追加しました。
- Attractor Engineering は SFT 全体ではなく代表的応用として位置付け、AI proposal governance / lifecycle / closed-loop update は bounded field model と non-conclusion の範囲で説明しています。
- `/sft/` overview と `website/sitemap.xml` に第3部導線を追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- `website/sft/index.html`
- `website/sft/intervention/index.html`
- `website/sft/intervention/governance/index.html`
- `website/sft/intervention/attractor-engineering/index.html`
- `website/sft/intervention/stable-regions/index.html`
- `website/sft/intervention/ai-governance/index.html`
- `website/sft/intervention/lifecycle/index.html`
- `website/sft/intervention/closed-loop/index.html`
- `website/sitemap.xml`

## 実施したテスト

- [x] 相対リンク静的チェック: 第3部 routes と `/sft/` overview の相対リンクが実ファイルへ解決できることを確認
- [x] Playwright desktop 表示確認: `/sft/intervention/` と 6 subroute が 200、title / h1 / local nav / 横スクロールなし
- [x] Playwright mobile 表示確認: 同 7 routes が 200、h1 表示、横スクロールなし
- [x] `git diff --check --cached`
- [x] hidden / bidirectional Unicode scan: `website/sft website/sitemap.xml` に該当なし
- [ ] `lake build`: Lean 変更なしのため未実施
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan: Lean 変更なしのため未実施

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を明確にした: website rewrite tracking / Lean theorem 追加なし
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている