### PR TITLE
website トップページのコピーを更新

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1929,7 +1929,6 @@ p {
 
 .site-footer {
   background: var(--ink);
-  box-shadow: 0 100vh 0 100vh var(--ink);
   color: #d9e3df;
   font-family: var(--font-sans);
   font-size: 0.86rem;

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1929,6 +1929,7 @@ p {
 
 .site-footer {
   background: var(--ink);
+  box-shadow: 0 100vh 0 100vh var(--ink);
   color: #d9e3df;
   font-family: var(--font-sans);
   font-size: 0.86rem;

--- a/website/index.html
+++ b/website/index.html
@@ -7,16 +7,16 @@
       name="description"
       content="Research notes on software architecture, formal methods, Lean, Algebraic Architecture Theory, Software Field Theory, and architecture signatures."
     >
-    <title>Algebraic Architecture Theory / Software Field Theory</title>
+    <title>AAT / SFT Research Notes</title>
     <link rel="canonical" href="https://iroha1203.dev/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Algebraic Architecture Theory / Software Field Theory">
+    <meta property="og:title" content="AAT / SFT Research Notes">
     <meta property="og:description" content="Research notes on software architecture, formal methods, Lean, Algebraic Architecture Theory, Software Field Theory, and architecture signatures.">
     <meta property="og:url" content="https://iroha1203.dev/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Algebraic Architecture Theory / Software Field Theory">
+    <meta name="twitter:title" content="AAT / SFT Research Notes">
     <meta name="twitter:description" content="Research notes on software architecture, formal methods, Lean, Algebraic Architecture Theory, Software Field Theory, and architecture signatures.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="assets/favicon-32.png" sizes="32x32" type="image/png">
@@ -86,12 +86,12 @@
         <div class="site-shell hero-grid">
           <div class="hero-copy">
             <p class="eyebrow">Algebraic Architecture Theory / Software Field Theory</p>
-            <h1>Software architecture as a formal object of change.</h1>
+            <h1>Software evolution, made computable.</h1>
             <p class="lede">
               This site is the public home for AAT, SFT, and ArchSig: a research
-              program for reasoning about architecture operations, invariant
-              preservation, obstruction witnesses, signature trajectories, and
-              bounded software evolution.
+              program for making software evolution computable through
+              architecture operations, invariant preservation, obstruction
+              witnesses, and signature trajectories.
             </p>
           </div>
           <aside class="hero-aside author-card" aria-labelledby="author-title">
@@ -110,9 +110,10 @@
             <p class="eyebrow">AAT</p>
             <h2>Algebraic Architecture Theory</h2>
             <p>
-              Algebraic Architecture Theory reads a selected architecture
-              object through operations, invariant families, obstruction
-              witnesses, signature axes, and theorem boundaries.
+              Algebraic Architecture Theory gives architecture review a
+              calculus for change: design principles become invariants,
+              failures become witnesses, and repairs become visible movement
+              across a signature.
             </p>
           </div>
           <div class="research-detail">
@@ -120,14 +121,15 @@
             <nav class="chapter-link-list" aria-label="AAT chapters">
               <a href="aat/foundations/">Foundations</a>
               <a href="aat/laws-and-witnesses/">Laws and Witnesses</a>
-              <a href="aat/signature-and-boundary/">Signature and Boundary</a>
+              <a href="aat/signature-and-boundary/">Signature and Theorem Boundary</a>
               <a href="aat/local-law-packages/">Local Law Packages</a>
               <a href="aat/calculus-and-extensions/">Calculus and Extensions</a>
               <a href="aat/repair-and-dynamics/">Repair and Dynamics</a>
               <a href="aat/representations-and-effects/">Representations and Effects</a>
               <a href="aat/examples-and-boundaries/">Examples and Boundaries</a>
-              <a href="aat/related-work/">Related Work</a>
+              <a href="aat/related-work/">Related Work and Novelty</a>
               <a href="aat/status/">Status</a>
+              <a href="aat/formal-anchors/">Formal Anchors Audit</a>
             </nav>
           </div>
         </div>
@@ -137,7 +139,7 @@
         <div class="site-shell section-grid">
           <div class="section-heading">
             <p class="eyebrow">SFT</p>
-            <h2>Software Field Theory</h2>
+            <h2>Software<br>Field<br>Theory</h2>
             <p>
               Software Field Theory models selected slices of software
               evolution through field state, operation support, policy,
@@ -190,7 +192,7 @@
             <h2>Research Essays</h2>
             <p>
               Articles and essays on AAT, SFT, ArchSig, and the design
-              questions behind bounded software evolution.
+              questions that make software evolution observable and computable.
             </p>
           </div>
           <div class="outreach-stack">
@@ -229,8 +231,9 @@
             <p class="eyebrow">Profile</p>
             <h2>Originator of the research program.</h2>
             <p>
-              AAT, SFT, and ArchSig are developed as a research program across
-              theory notes, Lean source, tooling, and public essays.
+              This is an independent, personal research practice: a place to
+              follow the mathematics of software architecture beyond day-to-day
+              engineering work.
             </p>
           </div>
           <div class="home-profile-card">
@@ -245,8 +248,8 @@
               <p class="home-profile-name">Hiroyuki Nakahata</p>
               <p class="home-profile-handle">@iroha1203</p>
               <p>
-                Software engineer in Tokyo, working on Algebraic Architecture
-                Theory, Software Field Theory, and ArchSig.
+                Software engineer in Tokyo. Away from work and research, I
+                enjoy horse racing.
               </p>
               <dl class="home-profile-meta">
                 <div>


### PR DESCRIPTION
## 概要

website トップページのコピーをブラッシュアップしました。

- title / OGP / Twitter title を `AAT / SFT Research Notes` に統一
- ヒーローコピーを `Software evolution, made computable.` に更新
- AAT セクションのリードを、設計原則・失敗・修復・signature の対応が伝わる文言へ更新
- AAT chapter links に `Formal Anchors Audit` を追加し、一部ラベルを AAT overview と統一
- SFT 見出しを 3 行表示に調整
- Outreach / Profile / author bio の文言を外向きかつ個人研究の由来が伝わる表現へ更新

対応 Issue はありません。ユーザーからの直接依頼による website copy refresh です。

## 証明した定理

- なし

## 編集したドキュメント

- `website/index.html`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check main...HEAD`
- [x] hidden / bidirectional Unicode scan: `website/index.html`
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan: `website/index.html` に該当なし
- [x] Playwright static page check: `website/index.html` を file URL で開き、title / H1 / SFT 見出し / Formal Anchors link / image loading を確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
