### PR TITLE
AAT website本文を磨く

### DIFF
--- a/website/aat/architecture-signature/index.html
+++ b/website/aat/architecture-signature/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT Architecture Signature, theorem boundaries, measurement status, and non-conclusions."
+      content="AAT Architecture Signature: a multi-axis coordinate system for obstruction evidence, proof support, and comparable readings."
     >
     <title>AAT Architecture Signature</title>
     <link rel="canonical" href="https://iroha1203.dev/aat/architecture-signature/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AAT Architecture Signature">
-    <meta property="og:description" content="AAT Architecture Signature, theorem boundaries, measurement status, and non-conclusions.">
+    <meta property="og:description" content="AAT Architecture Signature: a multi-axis coordinate system for obstruction evidence, proof support, and comparable readings.">
     <meta property="og:url" content="https://iroha1203.dev/aat/architecture-signature/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AAT Architecture Signature">
-    <meta name="twitter:description" content="AAT Architecture Signature, theorem boundaries, measurement status, and non-conclusions.">
+    <meta name="twitter:description" content="AAT Architecture Signature: a multi-axis coordinate system for obstruction evidence, proof support, and comparable readings.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -63,9 +63,9 @@
           <p class="eyebrow">AAT Part III</p>
           <h1>Architecture Signature</h1>
           <p class="lede">
-            Architecture Signature turns obstruction evidence into a multi-axis
-            diagnostic. Theorem boundaries package the universe, evidence,
-            assumptions, and conclusion that make each coordinate readable.
+            This chapter gives AAT a coordinate system for architectural
+            evidence. Obstructions, measurements, theorem support, and
+            comparison rules become typed axes that can be read together.
           </p>
         </div>
       </section>
@@ -156,15 +156,15 @@
             <section id="signature" class="article-section">
               <p class="research-question">
                 Can architectural quality be read as a multi-axis signature
-                under theorem boundaries?
+                with explicit proof support?
               </p>
               <h2>Architecture Signature</h2>
               <p>
-                <code>ArchitectureSignature</code> records coordinates of
-                obstruction families. Static, boundary, abstraction,
-                projection or LSP, runtime, semantic, operation, extension, and
-                analytic axes may all appear as separate coordinates in a
-                multi-axis diagnostic.
+                The signature records coordinates of obstruction families.
+                Static structure, boundary policy, abstraction, projection,
+                LSP, runtime behavior, semantic observation, operation,
+                extension, and analytic readings can each become a typed axis
+                in the diagnostic.
               </p>
               <figure class="code-panel">
                 <figcaption>Signature reading</figcaption>
@@ -176,7 +176,7 @@
                 An <code>ArchitectureSignature</code> is a family of typed
                 coordinates indexed by obstruction axes. A coordinate is read
                 together with its measurement status, evidence universe, claim
-                level, and non-conclusions.
+                level, proof support, and recorded non-conclusions.
               </p>
               <p id="proposition-5-2" class="statement">
                 <a class="statement-anchor" href="#proposition-5-2">Proposition 5.2.</a>
@@ -207,8 +207,10 @@
                 Every axis carries a status. <code>measured_zero</code>,
                 <code>measured_nonzero(value)</code>, <code>unmeasured</code>,
                 <code>out_of_scope</code>, <code>private_unavailable</code>,
-                and <code>not_applicable</code> are different claim states.
-                <code>unmeasured</code> is a boundary on what can be compared.
+                and <code>not_applicable</code> are different claim states. The
+                status is part of the coordinate: it tells a reader how the
+                evidence can participate in theorem use, reports, and
+                comparison.
               </p>
               <figure class="code-panel">
                 <figcaption>Status vocabulary</figcaption>
@@ -228,7 +230,7 @@
               </p>
               <p id="proposition-5-4" class="statement">
                 <a class="statement-anchor" href="#proposition-5-4">Proposition 5.4.</a>
-                An unmeasured boundary is not measured-zero evidence. In
+                An unmeasured status is not measured-zero evidence. In
                 particular, an optional signature axis with value
                 <code>none</code> may satisfy a weak no-nonzero predicate, but
                 it does not discharge an available-and-zero theorem
@@ -243,7 +245,7 @@
                 an available <code>some 0</code> value, and
                 <code>not_axisAvailableAndZero_of_axisValue_none</code> proves
                 that <code>none</code> does not satisfy it. The report-facing
-                claim boundary mirrors this separation through
+                report-facing claim support mirrors this separation through
                 <code>MeasurementBoundary.unmeasured_not_measuredZero</code>
                 and <code>ArchitectureClaim.unmeasured_not_measuredZero</code>.
               </p>
@@ -262,7 +264,7 @@
                 </li>
                 <li>
                   <strong>Empirical readings</strong>
-                  <span>Cost and product outcomes are not required zero axes inside AAT.</span>
+                  <span>Cost and product outcomes live as empirical coordinates with their own evidence basis.</span>
                 </li>
               </ul>
             </section>
@@ -271,9 +273,9 @@
               <h2>Signature record</h2>
               <p>
                 A signature coordinate is a typed claim. The coordinate
-                records the axis, the measured or unmeasured status, the claim
-                level, the universe in which it was produced, the evidence that
-                supports it, and the conclusion attached to it.
+                records the axis, measurement status, claim level, universe,
+                evidence references, proof support, and conclusion. This
+                turns a report value into a reusable mathematical object.
               </p>
               <figure class="code-panel">
                 <figcaption>Coordinate shape</figcaption>
@@ -282,32 +284,34 @@
   + measurement status
   + value when measured
   + claim level
-  + universe / coverage boundary
+  + universe / coverage support
   + evidence references
+  + theorem support / claim support
   + non-conclusions</code></pre>
               </figure>
               <p id="definition-5-5" class="statement">
                 <a class="statement-anchor" href="#definition-5-5">Definition 5.5.</a>
                 A signature coordinate is the tuple consisting of an axis, a
                 measurement status, a value when measured, a claim level, a
-                universe or coverage boundary, evidence references, and
-                recorded non-conclusions.
+                universe or coverage support, evidence references, theorem
+                support or claim support, and recorded non-conclusions.
               </p>
               <p>
                 Report comparison reads the coordinate together with its
-                boundary and axis-specific order; the value alone is only one
-                part of the coordinate.
+                support and axis-specific order. The coordinate supplies the
+                value together with the assumptions that make comparison
+                meaningful.
               </p>
             </section>
 
             <section id="theorem-boundary" class="article-section">
               <h2>Theorem boundary</h2>
               <p>
-                A theorem boundary packages selected universe, required laws,
+                A <code>TheoremBoundary</code> packages selected universe, required laws,
                 invariant family, witness universe, coverage assumptions,
                 exactness assumptions, operation preconditions, conclusion, and
-                non-conclusions. It states the inference licensed by a formal
-                or report-side result.
+                non-conclusions. It is the proof-carrying envelope around a
+                formal or report-side result.
               </p>
               <figure class="code-panel">
                 <figcaption>Boundary record</figcaption>
@@ -334,7 +338,7 @@
                 <a class="statement-anchor" href="#proposition-6-2">Proposition 6.2.</a>
                 A theorem-boundary-backed claim carries its conclusion and its
                 non-conclusions together. The non-conclusion field is part of
-                the package, not commentary after the fact.
+                the package and travels with the conclusion.
               </p>
               <p id="proof-6-2" class="statement-proof">
                 <a class="statement-anchor" href="#proof-6-2">Proof idea.</a>
@@ -342,8 +346,8 @@
                 and prove accessor theorems showing that the predicate read by
                 clients is exactly that field. Tooling metadata also proves
                 that a measured witness is not a formal proved claim and that
-                missing preconditions block formal proved status. The boundary
-                therefore travels with the claim object.
+                missing preconditions block formal proved status. The proof
+                support therefore travels with the claim object.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -351,9 +355,9 @@
               </p>
               <div class="claim-strip">
                 <p>
-                  The theorem boundary makes the inference levels explicit:
+                  The theorem package makes the inference levels explicit:
                   static split, runtime flatness, semantic flatness, selected
-                  witness absence, and global absence are distinct claims.
+                  witness zero, and global ambient claims are distinct claims.
                 </p>
               </div>
             </section>
@@ -362,8 +366,8 @@
               <h2>Claim levels</h2>
               <p>
                 A signature coordinate is more than a number. It also carries a
-                claim level and a measurement boundary. A formal coordinate is
-                backed by a theorem boundary; a tooling coordinate is produced
+                claim level and measurement status. A formal coordinate is
+                backed by theorem support; a tooling coordinate is produced
                 by an extractor or validator; an empirical coordinate belongs
                 to a dataset or calibration protocol; a hypothesis is a future
                 research claim.
@@ -377,15 +381,15 @@
               <ul class="term-list">
                 <li>
                   <strong>formal</strong>
-                  <span>A Lean-backed or theorem-boundary-backed statement under explicit assumptions.</span>
+                  <span>A Lean-backed statement under explicit assumptions.</span>
                 </li>
                 <li>
                   <strong>tooling</strong>
-                  <span>An artifact produced by a scanner, validator, report, or workflow with its own evidence boundary.</span>
+                  <span>An artifact produced by a scanner, validator, report, or workflow with its own evidence basis.</span>
                 </li>
                 <li>
                   <strong>empirical / hypothesis</strong>
-                  <span>A repository, operation, or outcome claim that is not promoted to theorem status.</span>
+                  <span>A repository, operation, or outcome claim read through a dataset, calibration protocol, or future research program.</span>
                 </li>
               </ul>
             </section>
@@ -396,16 +400,16 @@
                 Signature comparison is axis-local. Two reports are comparable
                 where the same axis is present on both sides, measured under
                 compatible assumptions, and equipped with a meaningful order.
-                Missing evidence, private evidence, or a changed measurement
-                universe breaks that comparison rather than contributing a
-                numeric zero.
+                Unmeasured evidence, private evidence, and changed measurement
+                universes are recorded as coordinate status, so comparison
+                stays attached to the selected axes.
               </p>
               <figure class="code-panel">
                 <figcaption>Comparable-axis guard</figcaption>
                 <pre><code>ComparableAxes(S1, S2)
   + MeasuredOnBoth(axis)
   + AxisOrder(axis)
-  + compatible boundary
+  + compatible support
   -&gt; compare selected measured axes</code></pre>
               </figure>
               <p id="proposition-6-4" class="statement">
@@ -417,7 +421,7 @@
               </p>
               <p id="proof-6-4" class="statement-proof">
                 <a class="statement-anchor" href="#proof-6-4">Proof idea.</a>
-                The rule follows from the boundary vocabulary rather than from
+                The rule follows from the coordinate vocabulary rather than from
                 a global ordering theorem. Because <code>unmeasured</code> is
                 not <code>measured_zero</code>, and because each coordinate is
                 read relative to a selected universe and axis order, a full
@@ -435,16 +439,15 @@
               <p>
                 <code>ArchitectureSignature</code> gives AAT a multi-axis way
                 to read architecture quality. Each coordinate carries its
-                measurement status, evidence boundary, theorem boundary, and
-                comparison rule, so a report can combine static, runtime,
-                semantic, empirical, and product readings without collapsing
-                them into a single score.
+                measurement status, evidence basis, proof support, and
+                comparison rule. A report can place static, runtime, semantic,
+                empirical, and product readings in one structured diagnostic.
               </p>
               <p>
                 The chapter's main contribution is a disciplined reading of
                 architectural evidence. A signature records what is measured,
                 how a coordinate can be compared, and which theorem or
-                empirical boundary supports the reading; later chapters use
+                empirical support carries the reading. Later chapters use
                 that record to track repairs, examples, and representations.
               </p>
               <h3>Terms</h3>

--- a/website/aat/architecture-signature/index.html
+++ b/website/aat/architecture-signature/index.html
@@ -129,8 +129,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -132,8 +132,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT calculus and extensions as theorem-boundary-backed operation packages, feature-extension evidence, and structural obstruction classifications."
+      content="AAT calculus and extensions as composable architecture operations, feature-extension evidence, and structural obstruction classifications."
     >
     <title>AAT Calculus and Extensions</title>
     <link rel="canonical" href="https://iroha1203.dev/aat/calculus-and-extensions/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AAT Calculus and Extensions">
-    <meta property="og:description" content="AAT calculus and extensions as theorem-boundary-backed operation packages, feature-extension evidence, and structural obstruction classifications.">
+    <meta property="og:description" content="AAT calculus and extensions as composable architecture operations, feature-extension evidence, and structural obstruction classifications.">
     <meta property="og:url" content="https://iroha1203.dev/aat/calculus-and-extensions/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AAT Calculus and Extensions">
-    <meta name="twitter:description" content="AAT calculus and extensions as theorem-boundary-backed operation packages, feature-extension evidence, and structural obstruction classifications.">
+    <meta name="twitter:description" content="AAT calculus and extensions as composable architecture operations, feature-extension evidence, and structural obstruction classifications.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -63,10 +63,11 @@
           <p class="eyebrow">AAT Part V</p>
           <h1>Calculus and Extensions</h1>
           <p class="lede">
-            Architecture moves become partial operations with explicit proof
-            boundaries. Feature extension supplies a compact calculus for
-            embedding a core, lifting feature behavior, recording coverage, and
-            classifying extension obstructions.
+            Architecture moves become composable operations. Feature extension
+            is AAT's local model of software evolution: a compact calculus for
+            embedding a core, lifting feature behavior through declared
+            interfaces, gathering coverage, and classifying extension
+            obstructions.
           </p>
         </div>
       </section>
@@ -161,6 +162,13 @@
                 operations?
               </p>
               <h2>Architecture operation</h2>
+              <p>
+                AAT treats architectural change as algebraic action. An
+                operation has a source, a target, a precondition, a transition,
+                an invariant family, and a map that carries witnesses across
+                the move. This turns change language into objects that can be
+                composed, compared, audited, and repaired.
+              </p>
               <figure class="code-panel">
                 <figcaption>Operation carrier</figcaption>
                 <pre><code>ArchitectureOperation X Y
@@ -175,11 +183,11 @@
               </figure>
               <p id="definition-9-1" class="statement">
                 <a class="statement-anchor" href="#definition-9-1">Definition 9.1.</a>
-                An architecture operation is a boundary-indexed partial
+                An architecture operation is an evidence-indexed partial
                 morphism between selected architecture states. It becomes a
                 theorem package when its preconditions, witness mapping,
-                invariant family, conclusion, and non-conclusions have been
-                supplied.
+                invariant family, conclusion, and recorded non-conclusions have
+                been supplied.
               </p>
               <p id="proposition-9-2" class="statement">
                 <a class="statement-anchor" href="#proposition-9-2">Proposition 9.2.</a>
@@ -191,8 +199,7 @@
                 <a class="statement-anchor" href="#proof-9-2">Proof idea.</a>
                 The schema stores the generated obligation and witness mapping
                 as fields. The accessor theorems recover those fields and the
-                existential witness bridge without adding any new preservation
-                claim.
+                existential witness bridge as reusable proof data.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -208,15 +215,17 @@
                 <code>abstract</code>, <code>split</code>, <code>merge</code>,
                 <code>isolate</code>, <code>protect</code>, <code>migrate</code>,
                 <code>reverse</code>, <code>contract</code>, <code>repair</code>,
-                and <code>synthesize</code>. A name makes the operation
-                auditable; it does not discharge the law.
+                and <code>synthesize</code>. The name gives the operation a
+                stable algebraic handle; the law package supplies the
+                assumptions, conclusion, and proof data.
               </p>
               <p>
                 Law packages state exactly which observation, interface,
                 coverage, exactness, finite universe, obstruction universe, or
                 certificate makes a law readable as proved. The same surface
-                phrase can therefore have different proof boundaries in graph,
-                runtime, migration, repair, and synthesis settings.
+                phrase can then become graph law, runtime law, migration law,
+                repair law, or synthesis law according to the evidence it
+                carries.
               </p>
               <p id="proposition-9-3" class="statement">
                 <a class="statement-anchor" href="#proposition-9-3">Proposition 9.3.</a>
@@ -240,16 +249,25 @@
                 <pre><code>T subset Ops(S)  &lt;-&gt;  S subset Inv(T)</code></pre>
               </figure>
               <p>
-                This correspondence is useful because it makes design
-                principles compare as operation/invariant packages instead of
-                slogans. It is a weak Galois-style reading: classifying all
-                operations, proving a lattice isomorphism, and promoting local
-                contracts into global decomposability remain separate claims.
+                This correspondence gives design principles an algebraic form:
+                they can be compared as operation/invariant packages. It is a
+                weak Galois-style reading: stronger invariant families select
+                a smaller operation space, while richer operation families
+                reveal the invariants they preserve.
               </p>
             </section>
 
             <section id="feature-extension" class="article-section">
               <h2>Feature extension</h2>
+              <p>
+                Feature extension is one of AAT's original moves: software
+                evolution read as a local operation. A system grows by
+                embedding an existing core into a larger architecture, adding a
+                feature view, and carrying evidence for the interface route,
+                runtime behavior, semantic preservation, and coverage. This
+                gives SFT one of the AAT-side algebraic handles it later uses
+                to compute with software evolution.
+              </p>
               <figure class="code-panel">
                 <figcaption>Extension schema</figcaption>
                 <pre><code>FeatureExtension
@@ -266,15 +284,14 @@
                 A feature extension is a local operation from a selected core
                 into a selected extended architecture. Static split evidence,
                 declared interface factorization, lifting evidence, runtime
-                preservation, semantic preservation, and coverage are separate
-                packages that may or may not accompany the base extension.
+                preservation, semantic preservation, and coverage travel as
+                focused packages around the base extension.
               </p>
               <p>
-                The base extension and the evidence packages are intentionally
-                separated so a page, proof, or report can name the layer where
-                the obstruction appears. Static hidden dependencies, semantic
-                filling failures, and runtime axes each carry their own
-                evidence.
+                This layered presentation lets a page, proof, or report name
+                the layer that carries the relevant witness. Static hidden
+                dependencies, semantic filling obstructions, and runtime axes
+                each carry their own evidence.
               </p>
             </section>
 
@@ -289,7 +306,7 @@
               <ul class="status-list">
                 <li>
                   <strong>Static split</strong>
-                  <span><code>StaticSplitFeatureExtension</code> records core edge preservation, declared interface factorization, absence of forbidden static edges, and embedding policy preservation.</span>
+                  <span><code>StaticSplitFeatureExtension</code> records core edge preservation, declared interface factorization, static edge discipline, and embedding policy preservation.</span>
                 </li>
                 <li>
                   <strong>Feature view</strong>
@@ -314,9 +331,9 @@
               <p id="proof-10-2" class="statement-proof">
                 <a class="statement-anchor" href="#proof-10-2">Proof idea.</a>
                 The theorem reads the supplied split package as coverage-aware
-                flatness evidence. Static, runtime, and semantic axes are
-                separate inputs, so <code>ArchitectureFlatWithin</code> and
-                global <code>ArchitectureFlat</code> remain distinct claims.
+                flatness evidence. Static, runtime, and semantic axes assemble
+                <code>ArchitectureFlatWithin</code> and prepare any stronger
+                global flatness reading.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -362,8 +379,8 @@
               <h2>Example and counterexample</h2>
               <p>
                 A feature extension adds a feature component to a selected core
-                and chooses how the feature crosses the core boundary. The
-                structured case routes the interaction through a declared port;
+                and chooses how the feature reaches the core. The structured
+                case routes the interaction through a declared port;
                 the obstruction case introduces a direct dependency from the
                 feature component to an internal implementation component.
                 Repair restores the declared interface route.
@@ -394,31 +411,31 @@ repair:
             <section id="operation-summary" class="article-section">
               <h2>Chapter summary</h2>
               <p>
-                The calculus page treats architecture change as a
-                boundary-indexed operation. Each move records its source,
-                target, support, preconditions, transition, invariant family,
-                witness map, conclusion, and evidence boundary.
+                The calculus treats architecture change as a selected
+                operation. Each move records its source, target, support,
+                preconditions, transition, invariant family, witness map,
+                conclusion, and evidence record.
               </p>
               <p>
-                Feature extension becomes a first-class operation rather than
-                an informal growth story. AAT can describe structured
-                extensions, classify selected obstruction witnesses, and read
-                repairs as operations that restore the intended interface
-                route under explicit assumptions.
+                Feature extension is the chapter's software-evolution move.
+                AAT can describe structured extensions, classify selected
+                obstruction witnesses, and read repairs as operations that
+                restore the intended interface route under explicit
+                assumptions.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">
                 <div>
-                  <dt>operation boundary</dt>
+                  <dt>operation package</dt>
                   <dd>The source, target, support, precondition, transition, invariant family, witness map, conclusion, and non-conclusion record for an architecture move.</dd>
                 </div>
                 <div>
                   <dt>law package</dt>
-                  <dd>A theorem wrapper that carries an operation kind, a law kind, explicit assumptions, and a conclusion. The law tag alone is only metadata.</dd>
+                  <dd>A theorem wrapper that carries an operation kind, a law kind, explicit assumptions, a conclusion, and reusable proof data.</dd>
                 </div>
                 <div>
                   <dt>feature extension</dt>
-                  <dd>A first-class addition schema with core and feature embeddings plus a selected feature view. Static split, lifting, runtime, and semantic evidence are separate.</dd>
+                  <dd>A first-class addition schema with core and feature embeddings plus a selected feature view, together with static split, lifting, runtime, and semantic evidence packages.</dd>
                 </div>
                 <div>
                   <dt>extension obstruction</dt>

--- a/website/aat/canonical-examples-and-readings/index.html
+++ b/website/aat/canonical-examples-and-readings/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT examples and boundaries: finite feature-extension skeletons, signature readings, semantic obstruction, repair transfer, and SOLID counterexamples."
+      content="AAT canonical examples and readings: finite feature-extension skeletons, signature readings, semantic obstruction, repair transfer, and SOLID counterexamples."
     >
-    <title>AAT Examples and Boundaries</title>
-    <link rel="canonical" href="https://iroha1203.dev/aat/examples-and-boundaries/">
+    <title>AAT Canonical Examples and Readings</title>
+    <link rel="canonical" href="https://iroha1203.dev/aat/canonical-examples-and-readings/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
-    <meta property="og:title" content="AAT Examples and Boundaries">
-    <meta property="og:description" content="AAT examples and boundaries: finite feature-extension skeletons, signature readings, semantic obstruction, repair transfer, and SOLID counterexamples.">
-    <meta property="og:url" content="https://iroha1203.dev/aat/examples-and-boundaries/">
+    <meta property="og:title" content="AAT Canonical Examples and Readings">
+    <meta property="og:description" content="AAT canonical examples and readings: finite feature-extension skeletons, signature readings, semantic obstruction, repair transfer, and SOLID counterexamples.">
+    <meta property="og:url" content="https://iroha1203.dev/aat/canonical-examples-and-readings/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AAT Examples and Boundaries">
-    <meta name="twitter:description" content="AAT examples and boundaries: finite feature-extension skeletons, signature readings, semantic obstruction, repair transfer, and SOLID counterexamples.">
+    <meta name="twitter:title" content="AAT Canonical Examples and Readings">
+    <meta name="twitter:description" content="AAT canonical examples and readings: finite feature-extension skeletons, signature readings, semantic obstruction, repair transfer, and SOLID counterexamples.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -58,15 +58,15 @@
           <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="../../">Home</a>
             <a href="../">AAT</a>
-            <span>Examples and Boundaries</span>
+            <span>Canonical Examples and Readings</span>
           </nav>
           <p class="eyebrow">AAT Part VIII</p>
-          <h1>Examples and Boundaries</h1>
+          <h1>Canonical Examples and Readings</h1>
           <p class="lede">
-            Examples instantiate AAT through finite skeletons, witnesses,
-            signature readings, and claim levels. Counterexamples become
-            constructive tests that separate local contracts, static split,
-            repair, and measured-zero readings.
+            Canonical examples turn AAT's algebra into something that can be
+            followed line by line: finite skeletons carry witnesses, signatures
+            record axis-local readings, and theorem packages display the
+            evidence behind each architectural judgement.
           </p>
         </div>
       </section>
@@ -81,11 +81,11 @@
                 <li><a href="#example-template">Example template</a></li>
                 <li><a href="#coupon-case-study">Finite extension skeleton</a></li>
                 <li><a href="#coupon-signature">Signature reading</a></li>
-                <li><a href="#coupon-claim-boundary">Claim levels</a></li>
+                <li><a href="#evidence-levels">Evidence levels</a></li>
                 <li><a href="#counterexamples">Counterexamples</a></li>
-                <li><a href="#aat-boundary">AAT boundary</a></li>
+                <li><a href="#aat-readings">AAT readings</a></li>
                 <li><a href="#coupon-reading">Layered reading</a></li>
-                <li><a href="#solid-boundary">SOLID boundary</a></li>
+                <li><a href="#solid-readings">SOLID readings</a></li>
                 <li><a href="#example-summary">Chapter summary</a></li>
               </ol>
             </nav>
@@ -133,8 +133,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/" aria-current="page">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/" aria-current="page">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>
@@ -159,23 +159,23 @@
           <div class="article-main">
             <section id="canonical-examples" class="article-section">
               <p class="research-question">
-                Can finite skeletons make theorem boundaries and
+                How do finite skeletons make theorem packages and
                 counterexamples readable?
               </p>
               <h2>Canonical examples</h2>
               <p>
                 A canonical AAT example is a finite architecture presentation
-                that exposes one operation, one selected evidence boundary,
-                and the witnesses read through that boundary. The concrete
-                names are small; the object being displayed is the proof
-                shape.
+                that exposes one operation, one selected evidence package, and
+                the witnesses read through that package. The component names
+                are intentionally small, so the proof shape can become the
+                main object of attention.
               </p>
               <p id="definition-15-0" class="statement">
                 <a class="statement-anchor" href="#definition-15-0">Definition 15.0.</a>
                 A canonical AAT example is a finite presentation consisting of
                 an architecture object, an operation or extension, an invariant
                 family under test, a witness universe, measured signature axes,
-                a theorem boundary, and recorded counterexamples or
+                a theorem package, and recorded counterexamples or
                 non-conclusions.
               </p>
               <ul class="term-list">
@@ -193,10 +193,10 @@
             <section id="example-template" class="article-section">
               <h2>Example template</h2>
               <p>
-                Each canonical example should expose the same proof-relevant
-                structure: an architecture object, an operation, a witness
-                universe, a signature reading, and the conclusions attached to
-                that reading.
+                Each canonical example follows the same proof-relevant shape:
+                an architecture object, an operation, a witness universe, a
+                signature reading, and the conclusions attached to that
+                reading.
               </p>
               <figure class="code-panel">
                 <figcaption>Paper-style example record</figcaption>
@@ -206,7 +206,7 @@
   + invariant family under test
   + witness universe
   + measured signature axes
-  + theorem boundary
+  + theorem package
   + counterexample or non-conclusion</code></pre>
               </figure>
               <p>
@@ -220,8 +220,9 @@
               <p>
                 The running finite skeleton uses a feature component, a
                 declared interface, a core service, and an internal adapter
-                endpoint. It displays the claim discipline without making the
-                domain vocabulary carry the argument.
+                endpoint. The example is small enough to inspect, and rich
+                enough to display static, semantic, runtime, and signature
+                readings side by side.
               </p>
               <p id="example-15-1" class="statement">
                 <a class="statement-anchor" href="#example-15-1">Example 15.1.</a>
@@ -237,10 +238,9 @@
                 The finite skeleton names the core components, the feature
                 component, the declared port, and the internal endpoint. Lean
                 exhibits the hidden edge as a selected witness for the
-                obstructed extension and proves that this witness refutes the
-                selected static split predicate. The repaired extension removes
-                that selected direct edge and supplies the static split package
-                again.
+                obstructed extension and proves the selected static split
+                obstruction. The repaired extension removes that selected
+                direct edge and supplies the static split package again.
               </p>
               <figure class="code-panel">
                 <figcaption>Finite extension universe</figcaption>
@@ -270,7 +270,7 @@ obstructing static edge:
                 </li>
                 <li>
                   <strong>Static obstruction</strong>
-                  <span>A direct dependency from the feature component into an internal adapter endpoint violates the selected static split or boundary policy.</span>
+                  <span>A direct dependency from the feature component into an internal adapter endpoint records the selected static split obstruction.</span>
                 </li>
                 <li>
                   <strong>Semantic obstruction</strong>
@@ -278,7 +278,7 @@ obstructing static edge:
                 </li>
                 <li>
                   <strong>Runtime obstruction</strong>
-                  <span>A retry, callback, invalidation, or protection failure crosses a selected runtime boundary.</span>
+                  <span>A retry, callback, invalidation, or protection witness appears on the selected runtime surface.</span>
                 </li>
                 <li>
                   <strong>Scope</strong>
@@ -300,65 +300,46 @@ semantic_curvature:
   status: measured_nonzero(delta) when selected diagram is measured
 
 runtime_exposure:
-  witness: retry / cache / callback crosses selected runtime boundary
+  witness: retry / cache / callback appears on selected runtime surface
   status: unmeasured in the static-only report
 
 global repository completeness:
   status: out_of_scope</code></pre>
               </figure>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Example field</th>
-                      <th>Finite instantiation</th>
-                      <th>Claim level</th>
-                      <th>Scope</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>`ComponentUniverse`</td>
-                      <td>`CheckoutService`, `CouponService`, `PaymentPort`, selected payment core / adapter components, and selected static / runtime relations.</td>
-                      <td>Tooling / formal when backed by proof-carrying finite universe data.</td>
-                      <td>Selected finite universe and selected relations.</td>
-                    </tr>
-                    <tr>
-                      <td>Declared static route</td>
-                      <td>`CheckoutService -> CouponService`, `CouponService -> PaymentPort`, `PaymentPort -> PaymentAdapter` under declared interface policy.</td>
-                      <td>Formal or tooling depending on evidence source.</td>
-                      <td>Selected static relations are covered.</td>
-                    </tr>
-                    <tr>
-                      <td>Obstructing static witness set</td>
-                      <td>Direct `CouponService -> PaymentAdapter` or `CouponService -> PaymentCache` edge bypassing the declared boundary.</td>
-                      <td>`proved` when the finite witness list and obstruction predicate are connected by the theorem package.</td>
-                      <td>Selected witness universe.</td>
-                    </tr>
-                    <tr>
-                      <td>Semantic observation mismatch</td>
-                      <td>Different total, rounding trace, error result, or discount ordering under selected checkout contexts.</td>
-                      <td>Defined / proved for selected observation bridges; otherwise tooling or empirical evidence.</td>
-                      <td>Selected semantic diagram.</td>
-                    </tr>
-                    <tr>
-                      <td>Runtime exposure witness</td>
-                      <td>Retry, callback, cache invalidation, or protection failure crossing a runtime boundary.</td>
-                      <td>Defined / proved for selected runtime bridge packages; empirical for real incidents.</td>
-                      <td>Runtime flatness is separate from static flatness.</td>
-                    </tr>
-                    <tr>
-                      <td>Signature coordinates</td>
-                      <td>Static obstruction count, semantic witness status, runtime exposure status, residual coverage gap.</td>
-                      <td>Multi-axis diagnostic.</td>
-                      <td>Axis-local readings.</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
+              <p>
+                Read as an AAT object, the skeleton has six visible parts.
+                Each part contributes one piece of evidence and names the
+                surface on which that evidence is read.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong><code>ComponentUniverse</code></strong>
+                  <span><code>CheckoutService</code>, <code>CouponService</code>, <code>PaymentPort</code>, selected payment core / adapter components, and selected static / runtime relations form the finite universe.</span>
+                </li>
+                <li>
+                  <strong>Declared static route</strong>
+                  <span><code>CheckoutService -&gt; CouponService</code>, <code>CouponService -&gt; PaymentPort</code>, and <code>PaymentPort -&gt; PaymentAdapter</code> give the interface path under the declared policy.</span>
+                </li>
+                <li>
+                  <strong>Static witness set</strong>
+                  <span>A direct <code>CouponService -&gt; PaymentAdapter</code> or <code>CouponService -&gt; PaymentCache</code> edge supplies the selected witness when it bypasses the interface route.</span>
+                </li>
+                <li>
+                  <strong>Semantic observation</strong>
+                  <span>Total, rounding trace, error result, or discount ordering can be read under selected checkout contexts and observation bridges.</span>
+                </li>
+                <li>
+                  <strong>Runtime surface</strong>
+                  <span>Retry, callback, cache invalidation, or protection evidence lives on the runtime surface and is read through its own package.</span>
+                </li>
+                <li>
+                  <strong>Signature coordinates</strong>
+                  <span>Static obstruction count, semantic witness status, runtime exposure status, and residual coverage gap become axis-local readings.</span>
+                </li>
+              </ul>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
-                <a href="../formal-anchors/#examples-and-boundaries">Formal Anchors Audit</a>
+                <a href="../formal-anchors/#canonical-examples-and-readings">Formal Anchors Audit</a>
               </p>
             </section>
 
@@ -366,9 +347,9 @@ global repository completeness:
               <h2>Signature reading</h2>
               <p>
                 The finite skeleton is read as a multi-axis diagnostic. The
-                static axis can be measured zero or measured nonzero inside the
-                finite witness universe, while semantic and runtime axes carry
-                their own measurement status.
+                static axis is measured inside the finite witness universe,
+                while semantic and runtime axes carry their own evidence and
+                measurement status.
               </p>
               <p id="signature-reading-15-2" class="statement">
                 <a class="statement-anchor" href="#signature-reading-15-2">Signature reading 15.2.</a>
@@ -377,129 +358,89 @@ global repository completeness:
                 <code>none</code> axes. A repaired selected static axis can be
                 available-and-zero while a semantic rounding-order axis is
                 unmeasured or measured nonzero, and while runtime exposure
-                remains outside the static-only report.
+                belongs to a runtime evidence package.
               </p>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Axis</th>
-                      <th>Obstructed extension</th>
-                      <th>Repaired extension</th>
-                      <th>How to read it</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>`static_hidden_interaction`</td>
-                      <td>`measured_nonzero(1)` for the selected direct cache edge.</td>
-                      <td>`measured_zero` for the selected static witness universe.</td>
-                      <td>Lean-backed when the finite witness list and theorem package are the cited source.</td>
-                    </tr>
-                    <tr>
-                      <td>`semantic_curvature`</td>
-                      <td>`unmeasured` unless a selected semantic diagram is supplied.</td>
-                      <td>`measured_nonzero(delta)` when the selected rounding-order diagram is measured.</td>
-                      <td>Semantic evidence supplies this axis.</td>
-                    </tr>
-                    <tr>
-                      <td>`runtime_exposure`</td>
-                      <td>`unmeasured` in a static-only report.</td>
-                      <td>`unmeasured` unless runtime retries, callbacks, cache behavior, or protection evidence is supplied.</td>
-                      <td>Runtime flatness is a different observation context.</td>
-                    </tr>
-                    <tr>
-                      <td>Repository completeness</td>
-                      <td>`out_of_scope`</td>
-                      <td>`out_of_scope`</td>
-                      <td>Repository extraction is a separate evidence problem.</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
+              <ul class="status-list">
+                <li>
+                  <strong><code>static_hidden_interaction</code></strong>
+                  <span>The obstructed extension reads as <code>measured_nonzero(1)</code> for the selected direct cache edge. After repair, the selected static witness universe reads as <code>measured_zero</code>. This is Lean-backed when the finite witness list and theorem package are cited.</span>
+                </li>
+                <li>
+                  <strong><code>semantic_curvature</code></strong>
+                  <span>The static-only report leaves this axis <code>unmeasured</code>. A selected semantic diagram can supply <code>measured_nonzero(delta)</code>, including the rounding-order diagram in the repaired extension.</span>
+                </li>
+                <li>
+                  <strong><code>runtime_exposure</code></strong>
+                  <span>The static-only report leaves runtime exposure <code>unmeasured</code>. Runtime evidence can then supply retry, callback, cache behavior, or protection readings on its own surface.</span>
+                </li>
+                <li>
+                  <strong>Repository completeness</strong>
+                  <span>Repository extraction is recorded as <code>out_of_scope</code> for both snapshots and belongs to a separate evidence problem.</span>
+                </li>
+              </ul>
             </section>
 
-            <section id="coupon-claim-boundary" class="article-section">
-              <h2>Claim levels</h2>
+            <section id="evidence-levels" class="article-section">
+              <h2>Evidence levels</h2>
               <p>
-                The same finite skeleton supports formal claims, tooling
-                claims, empirical readings, and exposition. AAT keeps those
-                claim levels visible.
+                The same finite skeleton supports formal theorems, tooling
+                readings, empirical readings, and exposition. AAT makes those
+                evidence levels part of the example's visible structure.
               </p>
-              <div class="article-table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Claim</th>
-                      <th>Lean / evidence reference</th>
-                      <th>Claim level</th>
-                      <th>Scope</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>The obstructed extension has the selected static hidden dependency witness.</td>
-                      <td>`CouponStaticDependencyExample.hiddenDependencyWitnessExists` and `bad_not_selectedStaticSplitFeatureExtension`.</td>
-                      <td>`proved` for the selected finite static skeleton.</td>
-                      <td>Selected static witness universe.</td>
-                    </tr>
-                    <tr>
-                      <td>The repaired extension restores selected static split.</td>
-                      <td>`CouponStaticDependencyExample.repaired_selectedStaticSplitFeatureExtension` and `Chapter11AnalyticRepresentation.CouponAnalyticSnapshot.repaired_staticHiddenInteraction_bridge`.</td>
-                      <td>`proved` / report-facing bridge for selected static axis.</td>
-                      <td>Selected static axis.</td>
-                    </tr>
-                    <tr>
-                      <td>Coupon / discount ordering can have measured semantic residual.</td>
-                      <td>`CouponDiscountExample.roundingOrderValuation_positive` and `StaticSemanticCounterexample.canonical_not_semanticFlatWithin`.</td>
-                      <td>`proved` for selected diagram and counterexample packages.</td>
-                      <td>Selected semantic diagram.</td>
-                    </tr>
-                    <tr>
-                      <td>Runtime retries, callbacks, or caches may expose a boundary crossing.</td>
-                      <td>Runtime report, telemetry, or incident evidence.</td>
-                      <td>Tooling / empirical unless a specific runtime theorem package is supplied.</td>
-                      <td>Selected runtime evidence.</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
+              <dl class="term-list definition-list">
+                <div>
+                  <dt>Static hidden dependency</dt>
+                  <dd><code>CouponStaticDependencyExample.hiddenDependencyWitnessExists</code> and <code>bad_not_selectedStaticSplitFeatureExtension</code> prove the selected witness reading for the finite static skeleton.</dd>
+                </div>
+                <div>
+                  <dt>Repaired static split</dt>
+                  <dd><code>CouponStaticDependencyExample.repaired_selectedStaticSplitFeatureExtension</code> and <code>Chapter11AnalyticRepresentation.CouponAnalyticSnapshot.repaired_staticHiddenInteraction_bridge</code> supply the proved / report-facing bridge for the selected static axis.</dd>
+                </div>
+                <div>
+                  <dt>Semantic residual</dt>
+                  <dd><code>CouponDiscountExample.roundingOrderValuation_positive</code> and <code>StaticSemanticCounterexample.canonical_not_semanticFlatWithin</code> give the selected diagram and counterexample package for coupon / discount ordering.</dd>
+                </div>
+                <div>
+                  <dt>Runtime-surface witness</dt>
+                  <dd>Runtime reports, telemetry, and incident evidence supply tooling or empirical readings for retries, callbacks, caches, and protection behavior.</dd>
+                </div>
+              </dl>
             </section>
 
             <section id="counterexamples" class="article-section">
               <h2>Counterexamples</h2>
               <p>
                 Static repair can satisfy selected static split while a
-                semantic diagram still fails to commute. A repair can reduce a
-                selected static obstruction while transferring risk to runtime
-                or semantic axes. SOLID-style local contracts can hold without
-                implying global decomposability or acyclicity.
+                semantic diagram carries a non-commutation witness. A repair
+                can reduce a selected static obstruction while transferring
+                risk to runtime or semantic axes. SOLID-style local contracts
+                can sit beside distinct structural witnesses on the global graph.
               </p>
               <figure class="code-panel">
-                <figcaption>Non-implications</figcaption>
+                <figcaption>Separation tests</figcaption>
                 <pre><code>StaticFlatWithin X U
-  does not imply
+  separates from
 SemanticFlatWithin X
 
 selected obstruction decreases
-  does not imply
-all axes are non-increasing</code></pre>
+  records transfer axis separately</code></pre>
               </figure>
               <p id="counterexample-15-3" class="statement">
                 <a class="statement-anchor" href="#counterexample-15-3">Counterexample 15.3.</a>
                 There is a selected repaired static skeleton that satisfies
                 selected static flatness while the selected semantic diagram
-                still does not commute. Static flatness therefore does not imply
-                semantic flatness or global architecture flatness.
+                carries a non-commutation witness. The example separates
+                static flatness from semantic flatness and global architecture
+                flatness.
               </p>
               <p id="proof-15-3" class="statement-proof">
                 <a class="statement-anchor" href="#proof-15-3">Proof idea.</a>
                 Lean reuses the repaired finite static skeleton for the static
                 side and supplies a selected semantic diagram whose two paths
                 differ under the chosen observation. The static package and
-                the semantic obstruction coexist, so the implication from
-                selected static flatness to semantic flatness is refuted under
-                the selected diagram universe.
+                the semantic obstruction coexist, displaying the separation
+                between selected static flatness and selected semantic
+                flatness.
               </p>
               <p id="counterexample-15-4" class="statement">
                 <a class="statement-anchor" href="#counterexample-15-4">Counterexample 15.4.</a>
@@ -510,20 +451,21 @@ all axes are non-increasing</code></pre>
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
-                <a href="../formal-anchors/#examples-and-boundaries">Formal Anchors Audit</a>
+                <a href="../formal-anchors/#canonical-examples-and-readings">Formal Anchors Audit</a>
               </p>
             </section>
 
-            <section id="aat-boundary" class="article-section">
-              <h2>AAT boundary</h2>
+            <section id="aat-readings" class="article-section">
+              <h2>AAT readings</h2>
               <p>
                 AAT is an algebraic framework for software architecture. The
                 examples on this page show static, semantic, repair, and
-                signature readings under explicit evidence boundaries.
+                signature readings as explicit evidence packages that can be
+                inspected, cited, and recombined.
               </p>
               <p id="non-conclusion-16-1" class="statement">
                 <a class="statement-anchor" href="#non-conclusion-16-1">Non-conclusion 16.1.</a>
-                The examples on this page prove or illustrate boundary-aware
+                The examples on this page prove or illustrate package-aware
                 readings under selected evidence: finite static witnesses,
                 semantic diagrams, runtime observations, repair transfers, and
                 multi-axis signature readings.
@@ -533,12 +475,12 @@ all axes are non-increasing</code></pre>
             <section id="coupon-reading" class="article-section">
               <h2>Layered reading</h2>
               <p>
-                The finite skeleton exposes the theorem boundary. A static
+                The finite skeleton exposes the theorem package. A static
                 report measures whether a feature bypasses a declared
                 interface. A semantic report measures whether selected
                 observations commute. A runtime report measures retry, cache,
-                or callback exposure. These are connected readings over
-                separate axes.
+                or callback exposure. Together they form connected readings
+                over separate axes.
               </p>
               <figure class="code-panel">
                 <figcaption>Layered example reading</figcaption>
@@ -548,19 +490,19 @@ all axes are non-increasing</code></pre>
 different rounding trace
   -&gt; semantic obstruction witness
 
-retry leaks across boundary
+retry appears on runtime surface
   -&gt; runtime obstruction witness</code></pre>
               </figure>
             </section>
 
-            <section id="solid-boundary" class="article-section">
-              <h2>SOLID boundary</h2>
+            <section id="solid-readings" class="article-section">
+              <h2>SOLID readings</h2>
               <p>
                 SOLID-style contracts are local law packages. A component can
                 satisfy selected substitution tests and interface separation
                 checks while the abstract dependency layer is cyclic.
                 Conversely, a layered graph can be acyclic while selected LSP
-                observations still fail.
+                observations carry their own witness.
               </p>
               <p id="counterexample-15-5" class="statement">
                 <a class="statement-anchor" href="#counterexample-15-5">Counterexample 15.5.</a>
@@ -576,17 +518,17 @@ retry leaks across boundary
                   <span>A selected client context or interface contract satisfies its observation law.</span>
                 </li>
                 <li>
-                  <strong>Global failure</strong>
-                  <span>Layering, decomposition, acyclicity, or boundary preservation fails outside the local contract.</span>
+                  <strong>Global structure</strong>
+                  <span>Layering, decomposition, or acyclicity can carry a distinct structural witness beyond the local contract.</span>
                 </li>
                 <li>
-                  <strong>Cross-layer caution</strong>
-                  <span>A theorem boundary connects one law family to another when such a bridge is available.</span>
+                  <strong>Cross-layer bridge</strong>
+                  <span>A theorem package connects one law family to another when such a bridge is available.</span>
                 </li>
               </ul>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
-                <a href="../formal-anchors/#examples-and-boundaries">Formal Anchors Audit</a>
+                <a href="../formal-anchors/#canonical-examples-and-readings">Formal Anchors Audit</a>
               </p>
             </section>
 
@@ -602,15 +544,15 @@ retry leaks across boundary
               <p>
                 This is the practical role of examples in the theory. They
                 demonstrate how selected evidence becomes a theorem-facing
-                object, how counterexamples separate local and global claims,
+                object, how counterexamples separate local and global readings,
                 and how architecture quality can be read across several axes
-                without flattening them.
+                while preserving the structure of those axes.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">
                 <div>
                   <dt>finite skeleton</dt>
-                  <dd>A small selected architecture object used to expose the claim boundary, witness family, or counterexample shape.</dd>
+                  <dd>A small selected architecture object used to expose the theorem package, witness family, or counterexample shape.</dd>
                 </div>
                 <div>
                   <dt>layered reading</dt>
@@ -622,7 +564,7 @@ retry leaks across boundary
                 </div>
                 <div>
                   <dt>global structure</dt>
-                  <dd>The selected dependency, layering, decomposition, or boundary-preservation reading of the architecture object.</dd>
+                  <dd>The selected dependency, layering, decomposition, or structural reading of the architecture object.</dd>
                 </div>
               </dl>
             </section>

--- a/website/aat/formal-anchors/index.html
+++ b/website/aat/formal-anchors/index.html
@@ -84,7 +84,7 @@
                 <li><a href="#calculus-and-extensions">Calculus and Extensions</a></li>
                 <li><a href="#repair-and-dynamics">Repair and Dynamics</a></li>
                 <li><a href="#representations-and-effects">Representations and Effects</a></li>
-                <li><a href="#examples-and-boundaries">Examples and Boundaries</a></li>
+                <li><a href="#canonical-examples-and-readings">Canonical Examples and Readings</a></li>
                 <li><a href="#related-work">Related Work and Novelty</a></li>
               </ol>
             </nav>
@@ -99,7 +99,7 @@
                 <li><a href="../calculus-and-extensions/">Calculus and Extensions</a></li>
                 <li><a href="../repair-and-dynamics/">Repair and Dynamics</a></li>
                 <li><a href="../representations-and-effects/">Representations and Effects</a></li>
-                <li><a href="../examples-and-boundaries/">Examples and Boundaries</a></li>
+                <li><a href="../canonical-examples-and-readings/">Canonical Examples and Readings</a></li>
                 <li><a href="../related-work/">Related Work and Novelty</a></li>
                 <li><a href="../status/">Status</a></li>
                 <li><a href="./" aria-current="page">Formal Anchors Audit</a></li>
@@ -1208,9 +1208,9 @@
             </section>
 
 
-            <section id="examples-and-boundaries" class="article-section">
-              <h2>Examples and Boundaries</h2>
-              <div class="formal-anchor-cards" aria-label="Examples and Boundaries formal-anchor audit trail">
+            <section id="canonical-examples-and-readings" class="article-section">
+              <h2>Canonical Examples and Readings</h2>
+              <div class="formal-anchor-cards" aria-label="Canonical Examples and Readings formal-anchor audit trail">
                 <article class="formal-anchor-card">
                   <header class="formal-anchor-card-header">
                     <div>
@@ -1220,9 +1220,9 @@
                     <span class="status-badge status-badge-proved">defined / proved</span>
                   </header>
                   <p class="formal-anchor-audits">
-                    Audits <a href="../examples-and-boundaries/#example-15-1">Example 15.1</a>,
-                    <a href="../examples-and-boundaries/#proof-15-1">Proof idea 15.1</a>, and
-                    the static part of <a href="../examples-and-boundaries/#signature-reading-15-2">Signature
+                    Audits <a href="../canonical-examples-and-readings/#example-15-1">Example 15.1</a>,
+                    <a href="../canonical-examples-and-readings/#proof-15-1">Proof idea 15.1</a>, and
+                    the static part of <a href="../canonical-examples-and-readings/#signature-reading-15-2">Signature
                     reading 15.2</a>.
                   </p>
                   <dl class="formal-anchor-grid">
@@ -1269,9 +1269,9 @@
                     <span class="status-badge status-badge-proved">defined / proved</span>
                   </header>
                   <p class="formal-anchor-audits">
-                    Audits <a href="../examples-and-boundaries/#signature-reading-15-2">Signature reading
-                      15.2</a> and <a href="../examples-and-boundaries/#counterexample-15-3">Counterexample
-                      15.3</a> / <a href="../examples-and-boundaries/#proof-15-3">Proof idea</a>.
+                    Audits <a href="../canonical-examples-and-readings/#signature-reading-15-2">Signature reading
+                      15.2</a> and <a href="../canonical-examples-and-readings/#counterexample-15-3">Counterexample
+                      15.3</a> / <a href="../canonical-examples-and-readings/#proof-15-3">Proof idea</a>.
                   </p>
                   <dl class="formal-anchor-grid">
                     <div>
@@ -1317,7 +1317,7 @@
                     <span class="status-badge status-badge-proved">proved</span>
                   </header>
                   <p class="formal-anchor-audits">
-                    Audits <a href="../examples-and-boundaries/#counterexample-15-4">Counterexample
+                    Audits <a href="../canonical-examples-and-readings/#counterexample-15-4">Counterexample
                       15.4</a>.
                   </p>
                   <dl class="formal-anchor-grid">
@@ -1355,13 +1355,13 @@
                 <article class="formal-anchor-card">
                   <header class="formal-anchor-card-header">
                     <div>
-                      <span class="formal-anchor-card-label">SOLID boundary</span>
+                      <span class="formal-anchor-card-label">SOLID reading</span>
                       <h3>Local contract compatibility does not imply global decomposability</h3>
                     </div>
                     <span class="status-badge status-badge-proved">proved</span>
                   </header>
                   <p class="formal-anchor-audits">
-                    Audits <a href="../examples-and-boundaries/#counterexample-15-5">Counterexample
+                    Audits <a href="../canonical-examples-and-readings/#counterexample-15-5">Counterexample
                       15.5</a>.
                   </p>
                   <dl class="formal-anchor-grid">

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT foundations: selected presentation, judgement form, ArchitectureObject, ArchitectureCore, and ComponentUniverse."
+      content="AAT foundations: architecture becomes a selected presentation where lawfulness, obstruction, and zero acquire mathematical force."
     >
     <title>AAT Foundations</title>
     <link rel="canonical" href="https://iroha1203.dev/aat/foundations/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AAT Foundations">
-    <meta property="og:description" content="AAT foundations: selected presentation, judgement form, ArchitectureObject, ArchitectureCore, and ComponentUniverse.">
+    <meta property="og:description" content="AAT foundations: architecture becomes a selected presentation where lawfulness, obstruction, and zero acquire mathematical force.">
     <meta property="og:url" content="https://iroha1203.dev/aat/foundations/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AAT Foundations">
-    <meta name="twitter:description" content="AAT foundations: selected presentation, judgement form, ArchitectureObject, ArchitectureCore, and ComponentUniverse.">
+    <meta name="twitter:description" content="AAT foundations: architecture becomes a selected presentation where lawfulness, obstruction, and zero acquire mathematical force.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -63,11 +63,10 @@
           <p class="eyebrow">AAT Part I</p>
           <h1>Foundations</h1>
           <p class="lede">
-            Foundations gives AAT its first act of construction: a software
-            architecture becomes a selected mathematical presentation, equipped
-            with carriers, policies, observations, witnesses, and theorem
-            boundaries. In that presentation, words such as "zero,"
-            "lawful," and "obstructed" acquire precise mathematical force.
+            Foundations is where architecture first becomes an object of
+            algebraic study. Code, policy, and observation are gathered into a
+            selected presentation, so claims about lawfulness, obstruction, and
+            zero acquire mathematical force.
           </p>
         </div>
       </section>
@@ -161,12 +160,21 @@
               <h2>Central decomposition</h2>
               <p>
                 AAT reads software architecture as an algebraic object of
-                change. A selected architecture carries operations, invariant
-                families, obstruction witnesses, signatures, and theorem
-                boundaries. This turns design language into a calculus: an
-                operation acts, an invariant is preserved or exposed, a witness
-                records the obstruction, and a signature gathers the result
-                across several axes.
+                change. Across the theory, selected architectures carry
+                operations, invariant families, obstruction witnesses,
+                signatures, and theorem boundaries. This turns design language
+                into a calculus: operations act, invariants are preserved or
+                tested, witnesses record obstructions, and signatures gather
+                the result across several axes.
+              </p>
+              <p>
+                Foundations supplies the base layer of that calculus: selected
+                presentations. A carrier, policy, and observation context
+                assemble an architecture object; restriction maps ambient
+                structure into a measured universe; judgement forms make
+                claims live over that selected presentation. Later chapters
+                enrich this base with operations, invariants, witnesses,
+                signatures, and repair.
               </p>
               <figure class="code-panel">
                 <figcaption>AAT decomposition</figcaption>
@@ -183,12 +191,11 @@
             <section id="object-definition" class="article-section">
               <h2>Object definition</h2>
               <p>
-                The foundational record is deliberately small and expressive.
-                It selects components and relations, gives policies for reading
-                them, and adds an observation context that turns evidence into
-                mathematical input. Together these parts form the
-                presentation in which an architectural claim receives its
-                meaning.
+                The foundational record is compact and expressive. It selects
+                components and relations, gives policies for reading them, and
+                adds an observation context that turns evidence into
+                mathematical input. Together these parts form the presentation
+                in which an architectural claim receives its meaning.
               </p>
               <figure class="code-panel">
                 <figcaption>Architecture object schema</figcaption>
@@ -215,7 +222,7 @@ ArchitectureObject
                 This schema is AAT's first source of structure. The carrier
                 presents the architectural material, the policy gives its
                 reading, and the observation context supplies the evidence
-                channel. A theorem or report carries these three pieces with
+                channel. A theorem or report carries this presentation with
                 the claim.
               </p>
               <figure class="code-panel">
@@ -271,7 +278,7 @@ P |-AAT phi
               <p>
                 <code>ArchitectureCore</code> is the proof-carrying
                 presentation of an architecture object. It bundles the evidence
-                AAT needs for bounded reasoning: static and runtime relations,
+                AAT uses for bounded reasoning: static and runtime relations,
                 boundary and abstraction policy, selected semantic diagrams,
                 decidability assumptions, and a finite
                 <code>ComponentUniverse</code>. This bundle supports selected
@@ -354,7 +361,7 @@ P |-AAT phi
                 by finite bridge theorems. It records which components and
                 relations were measured, plus the coverage and exactness
                 assumptions that make those measurements meaningful. This is
-                where AAT earns its precision: zero, absence, flatness, split,
+                where AAT gains its precision: zero, absence, flatness, split,
                 and lawfulness are all read inside a declared universe.
               </p>
               <p id="definition-3-1" class="statement">
@@ -492,10 +499,10 @@ reserved for another presentation:
               <p>
                 The foundational move is constructive. AAT gives software
                 architecture a disciplined way to say what has been measured,
-                what has been proved in the selected presentation, and what
-                belongs to the theorem boundary. Later chapters build on this
-                record to define laws, signatures, operations, repairs, and
-                representations.
+                what has been proved in the selected presentation, and which
+                theorem boundary carries the conclusion. Later chapters build
+                on this record to define laws, signatures, operations, repairs,
+                and representations.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -63,10 +63,11 @@
           <p class="eyebrow">AAT Part I</p>
           <h1>Foundations</h1>
           <p class="lede">
-            Foundations builds the object language of AAT: architecture
-            objects, observation models, evidence boundaries, and the universes
-            in which they are read. These carriers make zero, lawfulness, and
-            obstruction claims precise enough to reason about.
+            Foundations gives AAT its first act of construction: a software
+            architecture becomes a selected mathematical presentation, equipped
+            with carriers, policies, observations, witnesses, and theorem
+            boundaries. In that presentation, words such as "zero,"
+            "lawful," and "obstructed" acquire precise mathematical force.
           </p>
         </div>
       </section>
@@ -159,12 +160,13 @@
               </p>
               <h2>Central decomposition</h2>
               <p>
-                AAT formalizes software architecture as an algebraic language of
-                objects, operations, invariant families, obstruction witnesses,
-                signatures, and theorem boundaries. Its review question asks
-                which invariant is being required, through which observation
-                context, and which witness or theorem package supports the
-                claim.
+                AAT reads software architecture as an algebraic object of
+                change. A selected architecture carries operations, invariant
+                families, obstruction witnesses, signatures, and theorem
+                boundaries. This turns design language into a calculus: an
+                operation acts, an invariant is preserved or exposed, a witness
+                records the obstruction, and a signature gathers the result
+                across several axes.
               </p>
               <figure class="code-panel">
                 <figcaption>AAT decomposition</figcaption>
@@ -181,10 +183,12 @@
             <section id="object-definition" class="article-section">
               <h2>Object definition</h2>
               <p>
-                The foundational record is deliberately small. AAT begins
-                with the selected carrier, the policies used to read that
-                carrier, and the observation context that states what evidence
-                is in scope.
+                The foundational record is deliberately small and expressive.
+                It selects components and relations, gives policies for reading
+                them, and adds an observation context that turns evidence into
+                mathematical input. Together these parts form the
+                presentation in which an architectural claim receives its
+                meaning.
               </p>
               <figure class="code-panel">
                 <figcaption>Architecture object schema</figcaption>
@@ -208,9 +212,11 @@ ArchitectureObject
   + ArchitectureObservationContext</code></pre>
               </figure>
               <p>
-                This schema is the first scope discipline. A claim about the
-                object is evaluated together with the carrier, policy, and
-                observation context that present it.
+                This schema is AAT's first source of structure. The carrier
+                presents the architectural material, the policy gives its
+                reading, and the observation context supplies the evidence
+                channel. A theorem or report carries these three pieces with
+                the claim.
               </p>
               <figure class="code-panel">
                 <figcaption>Judgement form</figcaption>
@@ -225,9 +231,9 @@ P |-AAT phi
                 <a class="statement-anchor" href="#definition-1-1">Definition 1.1.</a>
                 An <code>ArchitectureObject</code> is the mathematical object
                 presented by a carrier, a policy, and an observation context.
-                It can be assembled from code, specifications, review evidence,
-                or operational observations, and its claims are read through
-                that presentation.
+                It may be assembled from code, specifications, review evidence,
+                or operational observations; the selected presentation gives
+                each claim its reading.
               </p>
               <p id="proposition-1-2" class="statement">
                 <a class="statement-anchor" href="#proposition-1-2">Proposition 1.2.</a>
@@ -252,11 +258,11 @@ P |-AAT phi
               </p>
               <p id="remark-1-3" class="statement">
                 <a class="statement-anchor" href="#remark-1-3">Remark 1.3.</a>
-                If the observation context is erased, a static import graph
-                and a runtime call graph can be read as the same object even
-                when they support different claims. The theorem boundary then
-                has no way to say whether "no edge" means measured absence or
-                simply unobserved evidence.
+                The observation context carries mathematical content. It keeps
+                a static import graph, a runtime call graph, semantic workflow
+                evidence, and review evidence in their proper readings. The
+                theorem boundary can then state which kind of evidence supports
+                the reading.
               </p>
             </section>
 
@@ -264,10 +270,13 @@ P |-AAT phi
               <h2>Core proposition</h2>
               <p>
                 <code>ArchitectureCore</code> is the proof-carrying
-                presentation of an architecture object. It bundles static and
-                runtime evidence, boundary and abstraction policy, selected
-                semantic diagrams, decidability assumptions, and a finite
-                <code>ComponentUniverse</code>.
+                presentation of an architecture object. It bundles the evidence
+                AAT needs for bounded reasoning: static and runtime relations,
+                boundary and abstraction policy, selected semantic diagrams,
+                decidability assumptions, and a finite
+                <code>ComponentUniverse</code>. This bundle supports selected
+                theorem packages and keeps the complete-extraction premise
+                visible as a separate mathematical condition.
               </p>
               <figure class="code-panel">
                 <figcaption>Core presentation schema</figcaption>
@@ -283,16 +292,18 @@ P |-AAT phi
                 A selected presentation is complete for an ambient relation
                 when every ambient edge in that relation has selected
                 endpoints mapping to it. In Lean this boundary is named
-                <code>CompleteForRelation</code>; it is an explicit premise,
-                not a field automatically supplied by <code>ArchitectureCore</code>.
+                <code>CompleteForRelation</code>; Lean records it as an
+                explicit premise alongside the fields supplied by
+                <code>ArchitectureCore</code>.
               </p>
               <p id="proposition-2-1" class="statement">
                 <a class="statement-anchor" href="#proposition-2-1">Proposition 2.1.</a>
-                Core presentations do not imply
-                complete extraction. A core can expose the evidence needed by
-                a theorem package while still omitting relations outside its
-                declared coverage boundary. Presentation equivalence is
-                therefore relative to the selected observation model.
+                Core presentations license selected evidence. A core exposes
+                the evidence used by a theorem package, and ambient complete
+                extraction enters through the explicit
+                <code>CompleteForRelation</code> premise. Presentation
+                equivalence is therefore relative to the selected observation
+                model.
               </p>
               <p id="proof-2-1" class="statement-proof">
                 <a class="statement-anchor" href="#proof-2-1">Proof.</a>
@@ -325,10 +336,10 @@ P |-AAT phi
                 <a class="statement-anchor" href="#non-conclusion-2-3">Non-conclusion 2.3.</a>
                 This distinction is essential. Reading
                 <code>ArchitectureCore</code> as complete extraction would
-                promote every omitted runtime edge into evidence of absence.
-                The record is intentionally weaker: it proves facts about the
-                supplied universe, not about every edge a production system
-                could emit.
+                turn every omitted runtime edge into evidence of absence.
+                The record is calibrated to the supplied universe: it proves
+                facts carried by that universe and exposes the premise needed
+                to speak about ambient extraction.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -340,10 +351,11 @@ P |-AAT phi
               <h2>Universe proposition</h2>
               <p>
                 <code>ComponentUniverse</code> is the measurement scope used
-                by finite bridge theorems. It records selected components,
-                selected relations, coverage conditions, and exactness
-                conditions. Zero, absence, flatness, split, and lawfulness are
-                read through that universe.
+                by finite bridge theorems. It records which components and
+                relations were measured, plus the coverage and exactness
+                assumptions that make those measurements meaningful. This is
+                where AAT earns its precision: zero, absence, flatness, split,
+                and lawfulness are all read inside a declared universe.
               </p>
               <p id="definition-3-1" class="statement">
                 <a class="statement-anchor" href="#definition-3-1">Definition 3.1.</a>
@@ -354,22 +366,21 @@ P |-AAT phi
               <p id="proposition-3-2" class="statement">
                 <a class="statement-anchor" href="#proposition-3-2">Proposition 3.2.</a>
                 Finite bridges are
-                coverage-relative. Executable or graph-level facts become
-                proposition-level facts only under their supplied universe and
-                closure assumptions.
+                coverage-relative. An executable check or graph-level fact
+                becomes a proposition-level fact when paired with the supplied
+                universe, coverage assumptions, and closure assumptions.
               </p>
               <p id="proof-3-2" class="statement-proof">
                 <a class="statement-anchor" href="#proof-3-2">Proof idea.</a>
-                A finite universe supplies a measured
-                list of components together with the assertion that the
-                relevant graph evidence is covered by that list. Closure says
-                that an in-scope edge does not leave the measured list. Under
-                these two assumptions, a finite computation over the measured
-                list can be read as a statement about the selected graph,
-                because every component and every selected edge needed by the
-                claim has already been accounted for. Reachability is likewise
-                finite: inside the supplied universe, a reachability assertion
-                is witnessed by a finite path in the selected graph.
+                A finite universe supplies a measured list of components and
+                the assertion that the relevant graph evidence is covered by
+                that list. Closure says that an in-scope edge does not leave
+                the measured list. Under these assumptions, a finite
+                computation can be read as a statement about the selected
+                graph, because every component and selected edge needed by the
+                claim has already been accounted for. Reachability is handled
+                the same way: inside the supplied universe, it is witnessed by
+                a finite path in the selected graph.
               </p>
               <p id="counterexample-3-3" class="statement">
                 <a class="statement-anchor" href="#counterexample-3-3">Counterexample 3.3.</a>
@@ -384,8 +395,8 @@ P |-AAT phi
                 <code>ComponentCategory</code>: it remembers whether
                 reachability exists and intentionally forgets path count and
                 walk length. Path counts, adjacency powers, finite metrics, and
-                future free-category constructions live outside that
-                thin-category claim. Likewise, current
+                future free-category constructions belong to richer
+                representations. Likewise, current
                 <code>Decomposable</code> means <code>StrictLayered</code>;
                 acyclicity, finite propagation, nilpotence, and spectral
                 conditions remain separate theorems or representations.
@@ -403,9 +414,9 @@ P |-AAT phi
                 Let a selected presentation <code>P</code> choose one
                 component <code>A</code> from an ambient system that also
                 contains an unselected component <code>C</code>. Two ambient
-                relations may look identical through <code>P</code> even when
-                one of them contains an edge whose source is <code>C</code>.
-                The selected restriction is the object being judged.
+                relations can then look identical through <code>P</code>, even
+                if one contains an edge whose source is <code>C</code>. The
+                selected restriction is the object being judged.
               </p>
               <figure class="code-panel">
                 <figcaption>Minimal selected universe</figcaption>
@@ -425,9 +436,9 @@ same selected reading:
   EdgeRestriction P R0 = EdgeRestriction P R1
 
 selected claim:
-  P licenses only the selected-restriction statement
+  P licenses the selected-restriction statement
 
-not selected:
+reserved for another presentation:
   C as a selected endpoint
   the ambient edge C -&gt; A
   runtime telemetry
@@ -436,24 +447,24 @@ not selected:
               <ul class="term-list">
                 <li>
                   <strong>Measured zero</strong>
-                  <span>No selected violating relation was found inside the chosen universe and exactness boundary.</span>
+                  <span>The chosen universe and exactness boundary support the selected zero reading.</span>
                 </li>
                 <li>
                   <strong>Unmeasured outside</strong>
-                  <span>No claim is made about components, relations, effects, or observations outside that boundary.</span>
+                  <span>The boundary records components, relations, effects, or observations reserved for another presentation.</span>
                 </li>
                 <li>
                   <strong>Presentation equivalence</strong>
-                  <span>Different carriers can present the same object only relative to the selected observation model.</span>
+                  <span>Different carriers can present the same object through the selected observation model.</span>
                 </li>
               </ul>
               <p id="bounded-reading-4-2" class="statement">
                 <a class="statement-anchor" href="#bounded-reading-4-2">Selected reading 4.2.</a>
                 In this presentation, <code>R0</code> and <code>R1</code>
-                have the same selected restriction. A theorem or report may
+                have the same selected restriction. A theorem or report can
                 therefore license a statement about the selected edge relation
-                under <code>P</code>. It does not automatically license a
-                statement about every edge in the ambient system.
+                under <code>P</code>. A broader ambient reading is obtained by
+                selecting the larger presentation and its evidence.
               </p>
               <p id="non-conclusion-4-3" class="statement">
                 <a class="statement-anchor" href="#non-conclusion-4-3">Non-conclusion 4.3.</a>
@@ -471,19 +482,20 @@ not selected:
             <section id="basic-summary" class="article-section">
               <h2>Chapter summary</h2>
               <p>
-                AAT begins by selecting the universe, observation model,
-                coverage assumptions, and exactness assumptions under which an
-                architecture claim is read. This turns architecture discussion
-                into an algebraic record: claims quantify over selected
-                carriers, witnesses, and relations, and every conclusion stays
-                attached to the presentation that supports it.
+                AAT begins by constructing the stage on which architecture
+                claims live: a selected universe, an observation model,
+                coverage assumptions, and exactness assumptions. That stage
+                turns architecture discussion into an algebraic record. Claims
+                quantify over selected carriers, witnesses, and relations, and
+                each conclusion travels with the presentation that supports it.
               </p>
               <p>
                 The foundational move is constructive. AAT gives software
-                architecture a way to say what has been measured, what has been
-                proved in the selected presentation, and how later pages can
-                compose those readings into laws, signatures, operations,
-                repairs, and representations.
+                architecture a disciplined way to say what has been measured,
+                what has been proved in the selected presentation, and what
+                belongs to the theorem boundary. Later chapters build on this
+                record to define laws, signatures, operations, repairs, and
+                representations.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">
@@ -505,15 +517,15 @@ not selected:
                 </div>
                 <div>
                   <dt>evidence boundary</dt>
-                  <dd>The line between measured evidence and facts that remain outside the theorem package or report.</dd>
+                  <dd>The declared edge of the theorem package or report, separating measured evidence from future presentations.</dd>
                 </div>
                 <div>
                   <dt>measured zero</dt>
-                  <dd>The selected evidence was measured and no in-scope violating relation or witness was found.</dd>
+                  <dd>The selected evidence was measured and every in-scope relation or witness satisfied the zero reading.</dd>
                 </div>
                 <div>
                   <dt>unmeasured outside</dt>
-                  <dd>The relation, effect, component, or observation was not selected, so absence is not asserted.</dd>
+                  <dd>A relation, effect, component, or observation reserved for another selected presentation.</dd>
                 </div>
                 <div>
                   <dt>non-conclusion</dt>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -129,8 +129,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>
@@ -481,7 +481,7 @@ reserved for another presentation:
                 change the judgement being evaluated. Each reading has its own
                 observation context and theorem boundary. Worked domain
                 examples belong on the
-                <a href="../examples-and-boundaries/">examples and boundaries
+                <a href="../canonical-examples-and-readings/">canonical examples and readings
                   page</a>.
               </p>
             </section>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -136,8 +136,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>
@@ -217,8 +217,8 @@
                   <span>Graph, matrix, analytic representation, state-transition algebra, and effect boundary.</span>
                 </li>
                 <li>
-                  <a href="examples-and-boundaries/">Examples and Boundaries</a>
-                  <span>Finite skeletons, signature readings, counterexamples, and claim levels.</span>
+                  <a href="canonical-examples-and-readings/">Canonical Examples and Readings</a>
+                  <span>Finite skeletons, signature readings, counterexamples, and evidence levels.</span>
                 </li>
                 <li>
                   <a href="related-work/">Related Work and Novelty</a>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -166,37 +166,6 @@
                 reflect, improve, localize, translate, or transfer those
                 invariants.
               </p>
-              <p>
-                SOLID is the familiar entry point. AAT reads it as a local
-                contract algebra.
-              </p>
-              <ul class="term-list">
-                <li>
-                  <strong>SRP</strong>
-                  <span>Localizes reasons for change as selected responsibility boundaries.</span>
-                </li>
-                <li>
-                  <strong>OCP</strong>
-                  <span>Reads extension as contract-preserving growth over a selected object.</span>
-                </li>
-                <li>
-                  <strong>LSP</strong>
-                  <span>Compares client observations under replacement in the selected context.</span>
-                </li>
-                <li>
-                  <strong>ISP</strong>
-                  <span>Splits interfaces into selected projections and observation boundaries.</span>
-                </li>
-                <li>
-                  <strong>DIP</strong>
-                  <span>Moves dependencies through abstraction boundaries and projection laws.</span>
-                </li>
-              </ul>
-              <p>
-                The same reading extends beyond SOLID: each architecture
-                tradition contributes an invariant family and witness shape
-                natural to its layer.
-              </p>
               <ul class="term-list">
                 <li>
                   <strong>Local contract layer</strong>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -129,8 +129,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT laws and witnesses: invariant families, LawUniverse, obstruction witnesses, and zero-curvature reading."
+      content="AAT laws and witnesses: design principles become invariant families, obstruction witnesses, and theorem-bearing zero readings."
     >
     <title>AAT Laws and Witnesses</title>
     <link rel="canonical" href="https://iroha1203.dev/aat/laws-and-witnesses/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AAT Laws and Witnesses">
-    <meta property="og:description" content="AAT laws and witnesses: invariant families, LawUniverse, obstruction witnesses, and zero-curvature reading.">
+    <meta property="og:description" content="AAT laws and witnesses: design principles become invariant families, obstruction witnesses, and theorem-bearing zero readings.">
     <meta property="og:url" content="https://iroha1203.dev/aat/laws-and-witnesses/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AAT Laws and Witnesses">
-    <meta name="twitter:description" content="AAT laws and witnesses: invariant families, LawUniverse, obstruction witnesses, and zero-curvature reading.">
+    <meta name="twitter:description" content="AAT laws and witnesses: design principles become invariant families, obstruction witnesses, and theorem-bearing zero readings.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -63,10 +63,9 @@
           <p class="eyebrow">AAT Part II</p>
           <h1>Laws and Witnesses</h1>
           <p class="lede">
-            Design principles become invariant families, and architecture
-            failures become inspectable through obstruction witnesses. This
-            chapter turns lawfulness into a theorem-bearing relation between
-            required invariants, witness families, and measured evidence.
+            Design principles become algebraic material here: invariants to
+            preserve, obstruction witnesses to inspect, and theorem bridges
+            that make zero readings carry lawfulness.
           </p>
         </div>
       </section>
@@ -81,7 +80,7 @@
                 <li><a href="#law-universe">Law universe</a></li>
                 <li><a href="#obstruction-witnesses">Obstruction witnesses</a></li>
                 <li><a href="#lemma-sequence">Lemma sequence</a></li>
-                <li><a href="#main-theorem">Required theorem schema</a></li>
+                <li><a href="#main-theorem">Architecture zero-curvature theorem</a></li>
                 <li><a href="#examples">Examples</a></li>
                 <li><a href="#law-summary">Chapter summary</a></li>
               </ol>
@@ -161,15 +160,47 @@
               </p>
               <h2>Invariant families</h2>
               <p>
-                An `Invariant` is a property an architecture object or operation
-                is expected to preserve. Design principles induce families of
-                operations that preserve, reflect, improve, localize, translate,
-                or transfer invariants.
+                An <code>Invariant</code> is a property carried by an
+                architecture object, operation, or law package. Design
+                principles become families of transformations that preserve,
+                reflect, improve, localize, translate, or transfer those
+                invariants.
+              </p>
+              <p>
+                SOLID is the familiar entry point. AAT reads it as a local
+                contract algebra.
+              </p>
+              <ul class="term-list">
+                <li>
+                  <strong>SRP</strong>
+                  <span>Localizes reasons for change as selected responsibility boundaries.</span>
+                </li>
+                <li>
+                  <strong>OCP</strong>
+                  <span>Reads extension as contract-preserving growth over a selected object.</span>
+                </li>
+                <li>
+                  <strong>LSP</strong>
+                  <span>Compares client observations under replacement in the selected context.</span>
+                </li>
+                <li>
+                  <strong>ISP</strong>
+                  <span>Splits interfaces into selected projections and observation boundaries.</span>
+                </li>
+                <li>
+                  <strong>DIP</strong>
+                  <span>Moves dependencies through abstraction boundaries and projection laws.</span>
+                </li>
+              </ul>
+              <p>
+                The same reading extends beyond SOLID: each architecture
+                tradition contributes an invariant family and witness shape
+                natural to its layer.
               </p>
               <ul class="term-list">
                 <li>
                   <strong>Local contract layer</strong>
-                  <span>SRP, OCP, LSP, ISP, and DIP organize contracts, abstraction, substitutability, and interface separation.</span>
+                  <span>SOLID-style laws organize local contracts, abstraction, substitutability, interface projections, and dependency inversion.</span>
                 </li>
                 <li>
                   <strong>Global structure layer</strong>
@@ -186,37 +217,36 @@
               <h2>Law universe</h2>
               <p>
                 A <code>LawUniverse</code> is the setting in which a principle
-                can be checked. It collects required laws, optional laws,
-                derived laws, the witness family used to observe breakage, and
-                the observation context under which those witnesses are
-                meaningful.
+                becomes readable. It collects required laws, optional laws,
+                derived laws, the witness family used to observe obstructions,
+                and the observation context that gives those witnesses their
+                meaning.
               </p>
               <figure class="code-panel">
-                <figcaption>Lawfulness is not defined as witness absence</figcaption>
+                <figcaption>Lawfulness, witnesses, and axes</figcaption>
                 <pre><code>SemanticLawful X L
   = X satisfies the selected law universe L
 
 NoRequiredWitness X W
-  = no required bad witness appears in W
+  = required obstruction predicate is zero over W
 
 RequiredSignatureAxesZero X S
   = selected required signature axes are available and zero</code></pre>
               </figure>
               <p>
                 The first line is the semantic predicate. The second and third
-                lines are measured presentations of the same claim when a
-                theorem boundary supplies coverage, exactness, and observation
-                assumptions. The law universe stays close to the claim it
-                organizes.
+                lines are measured readings of that predicate. Coverage,
+                exactness, and observation assumptions provide the bridge, so
+                the law universe remains attached to the claim it organizes.
               </p>
               <ul class="status-list">
                 <li>
                   <strong>Required laws</strong>
-                  <span>The laws whose absence or violation is allowed to affect the theorem conclusion.</span>
+                  <span>The law family that carries the theorem conclusion.</span>
                 </li>
                 <li>
                   <strong>Optional and derived laws</strong>
-                  <span>Useful diagnostics or corollaries that are not silently promoted to required axes.</span>
+                  <span>Diagnostics and corollaries that enrich the selected reading.</span>
                 </li>
                 <li>
                   <strong>Observation boundary</strong>
@@ -228,12 +258,12 @@ RequiredSignatureAxesZero X S
             <section id="obstruction-witnesses" class="article-section">
               <h2>Obstruction witnesses</h2>
               <p>
-                An `ObstructionWitness` structurally explains why a desired law
-                does not hold. A forbidden static edge, hidden interaction,
-                boundary policy violation, projection failure, LSP mismatch,
+                An <code>ObstructionWitness</code> records the concrete place
+                where a law bends. A forbidden static edge, hidden interaction,
+                boundary policy violation, projection obstruction, LSP mismatch,
                 non-commuting semantic diagram, runtime exposure, lifting
-                failure, or residual coverage gap can all be witnesses when
-                they belong to the relevant universe.
+                obstruction, or residual coverage gap can all become witnesses
+                when they belong to the relevant universe.
               </p>
               <figure class="code-panel">
                 <figcaption>Finite witness kernel</figcaption>
@@ -241,27 +271,27 @@ RequiredSignatureAxesZero X S
   = xs filtered by bad
 
 violationCount bad xs = 0
-  &lt;-&gt; every measured witness is not bad</code></pre>
+  &lt;-&gt; violatingWitnesses bad xs is empty</code></pre>
               </figure>
               <p>
-                In Lean, the generic law-family layer separates measured
-                witness absence from required witness absence. The bridge from
-                measured zero to required absence uses witness coverage, and the
-                bridge from required absence to semantic lawfulness uses
-                complete coverage for the selected law family.
+                In Lean, the generic law-family layer gives each reading its
+                own type. A measured zero lives over the finite list; required
+                zero lives over the selected witness predicate; semantic
+                lawfulness lives over the law family. Coverage theorems connect
+                those readings.
               </p>
               <ul class="status-list">
                 <li>
                   <strong><code>NoMeasuredObstruction</code></strong>
-                  <span>There is no bad witness in the measured finite list. This is a finite report claim.</span>
+                  <span>The finite measured list supports a zero obstruction reading.</span>
                 </li>
                 <li>
                   <strong><code>NoRequiredObstruction</code></strong>
-                  <span>There is no bad witness among the required witness predicate. This needs coverage to follow from the measured list.</span>
+                  <span>The selected required witness predicate supports the same zero reading.</span>
                 </li>
                 <li>
                   <strong><code>Lawful</code></strong>
-                  <span>The independent lawfulness predicate supplied by the law family. It is connected to witness absence by bridge theorems, not by definition.</span>
+                  <span>The semantic lawfulness predicate supplied by the selected law family and connected by bridge theorems.</span>
                 </li>
               </ul>
             </section>
@@ -270,9 +300,9 @@ violationCount bad xs = 0
               <h2>Lemma sequence</h2>
               <p>
                 The center of the chapter is a sequence of small bridges. Each
-                step changes the type of claim, so the assumptions are shown
-                before the conclusion rather than being hidden in the word
-                "zero."
+                step changes the type of claim, and each bridge displays the
+                assumptions that let a zero reading move from measurement to
+                required witnesses to semantic lawfulness.
               </p>
               <figure class="code-panel">
                 <figcaption>Witness-to-lawfulness bridge</figcaption>
@@ -290,7 +320,8 @@ CompleteWitnessCoverage
                 Axis exactness adds the signature side of the statement. A
                 required axis must be available and zero, and the axis must
                 exactly represent the corresponding required witness subfamily.
-                Missing axis values remain measurement gaps, not theorem claims.
+                Available exact axes become theorem-bearing coordinates of the
+                selected law reading.
               </p>
               <figure class="code-panel">
                 <figcaption>Axis exactness bridge</figcaption>
@@ -311,13 +342,15 @@ CompleteWitnessCoverage + RequiredAxisExact
             </section>
 
             <section id="main-theorem" class="article-section">
-              <h2>Required theorem schema</h2>
+              <h2>Architecture zero-curvature theorem</h2>
               <p>
                 The zero-curvature theorem is the lawfulness bridge read at the
                 theorem boundary. It is stated as a schema because the law
                 universe, witness family, signature axes, and observation model
                 vary across structural, projection, semantic, runtime, and
-                extension readings.
+                extension readings. In the mathematical theory this is the
+                required obstruction vanishing theorem; in AAT language it is
+                the architecture zero-curvature theorem.
               </p>
               <figure class="code-panel">
                 <figcaption>Required obstruction vanishing theorem</figcaption>
@@ -339,23 +372,23 @@ Then, within B:
     &lt;-&gt; RequiredSignatureAxesZero X S</code></pre>
               </figure>
               <p>
-                This theorem shape is also the readability guardrail. A
-                dashboard zero, a passing local contract, or a missing witness
-                list becomes a lawfulness statement through the stated
-                completeness and exactness assumptions.
+                This theorem shape is the translation rule. A dashboard zero,
+                a passing local contract, or a witness list becomes a
+                lawfulness statement through the stated completeness and
+                exactness assumptions.
               </p>
               <ul class="status-list">
                 <li>
                   <strong>Semantic predicate</strong>
-                  <span>`SemanticLawful X L` says the selected law universe is satisfied under the selected observation.</span>
+                  <span><code>SemanticLawful X L</code> says the selected law universe is satisfied under the selected observation.</span>
                 </li>
                 <li>
                   <strong>Witness predicate</strong>
-                  <span>`NoRequiredWitness X W` says no required bad witness appears in the selected finite witness family.</span>
+                  <span><code>NoRequiredWitness X W</code> states the required zero reading over the selected finite witness family.</span>
                 </li>
                 <li>
                   <strong>Signature predicate</strong>
-                  <span>`RequiredSignatureAxesZero X S` says the required measured axes are zero, not that every possible axis is safe.</span>
+                  <span><code>RequiredSignatureAxesZero X S</code> states the required zero reading over the selected measured axes.</span>
                 </li>
               </ul>
               <p class="formal-audit-link">
@@ -367,12 +400,12 @@ Then, within B:
             <section id="examples" class="article-section">
               <h2>Examples</h2>
               <p>
-                An LSP contract can be lawful for selected client contexts
-                while the overall dependency graph remains cyclic. A layered
-                ranking can be lawful for static dependencies while a runtime
-                callback still crosses a protected boundary. A Saga law can hold
-                for a compensation relation while distributed convergence is
-                handled by a separate law family.
+                An LSP contract can be lawful for selected client contexts;
+                global cyclicity is read by a global structure family. A
+                layered ranking can govern static dependencies; runtime
+                callbacks are read by a runtime observation layer. A Saga law
+                can hold for a compensation relation; distributed convergence
+                is handled by its own law family.
               </p>
               <ul class="term-list">
                 <li>
@@ -385,7 +418,7 @@ Then, within B:
                 </li>
                 <li>
                   <strong>Runtime witness</strong>
-                  <span>A propagation, exposure, retry, or protection failure in a separate runtime observation layer.</span>
+                  <span>A propagation, exposure, retry, or protection obstruction in a separate runtime observation layer.</span>
                 </li>
               </ul>
             </section>
@@ -395,17 +428,17 @@ Then, within B:
               <p>
                 Laws and witnesses turn design principles into families of
                 invariants, observations, and obstruction predicates. A
-                principle becomes mathematically useful when it supplies the
-                selected law universe, the evidence that can witness failure,
-                and the bridge theorem that connects witness absence to
-                lawfulness under the stated assumptions.
+                principle becomes a reusable theorem package when it supplies
+                the selected law universe, the witness family, and the bridge
+                theorem that carries zero readings into lawfulness under the
+                stated assumptions.
               </p>
               <p>
                 This chapter gives AAT its working grammar for architecture
                 principles. Local contracts, global structure, state
                 transitions, runtime protection, and distributed convergence
-                can all be read as invariant families, while their failures
-                become explicit witnesses instead of loose review language.
+                can all be read as invariant families, and their obstructions
+                become reusable mathematical data.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">
@@ -419,7 +452,7 @@ Then, within B:
                 </div>
                 <div>
                   <dt>obstruction witness</dt>
-                  <dd>A finite selected value that records where an invariant, law, or observation condition fails.</dd>
+                  <dd>A finite selected value that records an obstruction site for an invariant, law, or observation condition.</dd>
                 </div>
                 <div>
                   <dt>semantic lawfulness</dt>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -131,8 +131,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT local law packages as theorem-boundary-backed statements for projection, observation, LSP, DIP, and three-layer flatness."
+      content="AAT local law packages: projection, observation, LSP, DIP, and flatness as composable proof-carrying laws."
     >
     <title>AAT Local Law Packages</title>
     <link rel="canonical" href="https://iroha1203.dev/aat/local-law-packages/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AAT Local Law Packages">
-    <meta property="og:description" content="AAT local law packages as theorem-boundary-backed statements for projection, observation, LSP, DIP, and three-layer flatness.">
+    <meta property="og:description" content="AAT local law packages: projection, observation, LSP, DIP, and flatness as composable proof-carrying laws.">
     <meta property="og:url" content="https://iroha1203.dev/aat/local-law-packages/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AAT Local Law Packages">
-    <meta name="twitter:description" content="AAT local law packages as theorem-boundary-backed statements for projection, observation, LSP, DIP, and three-layer flatness.">
+    <meta name="twitter:description" content="AAT local law packages: projection, observation, LSP, DIP, and flatness as composable proof-carrying laws.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -63,10 +63,11 @@
           <p class="eyebrow">AAT Part IV</p>
           <h1>Local Law Packages</h1>
           <p class="lede">
-            Projection, observation, substitutability, abstraction, and
-            flatness become local theorem packages with explicit assumptions.
-            AAT uses them to express local contract soundness and to compose
-            projection, LSP, DIP, runtime, and semantic evidence.
+            Local Law Packages turn familiar design principles into
+            proof-carrying algebra. Projection, observation, substitutability,
+            abstraction, runtime behavior, and semantic evidence travel as
+            selected laws that can be assembled into larger architecture
+            readings.
           </p>
         </div>
       </section>
@@ -158,11 +159,43 @@
               <p class="research-question">
                 Can local design principles become composable theorem packages?
               </p>
+              <p>
+                SOLID is the familiar acronym for Single Responsibility, Open
+                / Closed, Liskov Substitution, Interface Segregation, and
+                Dependency Inversion. In this page, <code>DIP</code> means the
+                Dependency Inversion Principle, and AAT reads each SOLID
+                principle as a local law package with selected projections,
+                observations, invariants, and witnesses.
+              </p>
+              <ul class="term-list intro-term-list">
+                <li>
+                  <strong>SRP</strong>
+                  <span>Single Responsibility selects the responsibility axis carried by the local package.</span>
+                </li>
+                <li>
+                  <strong>OCP</strong>
+                  <span>Open / Closed reads extension as growth that preserves selected observations.</span>
+                </li>
+                <li>
+                  <strong>LSP</strong>
+                  <span>Liskov Substitution compares selected client observations under replacement.</span>
+                </li>
+                <li>
+                  <strong>ISP</strong>
+                  <span>Interface Segregation refines the projection visible to a client context.</span>
+                </li>
+                <li>
+                  <strong>DIP</strong>
+                  <span>Dependency Inversion records how concrete dependency evidence travels through abstraction.</span>
+                </li>
+              </ul>
               <h2>Projection and observation</h2>
               <p>
-                Local law packages name the projection, observation, equality,
-                and context universe used by a claim. The schematic kernel
-                inclusion below is read relative to that chosen boundary.
+                A local law package gives a design statement its projection,
+                observation, equality, and context universe. The kernel
+                inclusion below is the algebraic shape: sameness through an
+                abstraction map carries sameness through the observation that
+                the package selects.
               </p>
               <figure class="code-panel">
                 <figcaption>Projection / observation kernel</figcaption>
@@ -175,11 +208,11 @@ ker(F) &lt;= ker(Obs)</code></pre>
               </figure>
               <p id="definition-7-1" class="statement">
                 <a class="statement-anchor" href="#definition-7-1">Definition 7.1.</a>
-                A local projection-observation boundary consists of an
+                A local projection-observation package consists of an
                 <code>InterfaceProjection</code>, an <code>Observation</code>,
                 an observation equivalence relation, and a selected universe of
-                concrete objects or client contexts to which the claim is
-                allowed to apply.
+                concrete objects or client contexts over which the statement is
+                interpreted.
               </p>
               <p id="proposition-7-2" class="statement">
                 <a class="statement-anchor" href="#proposition-7-2">Proposition 7.2.</a>
@@ -209,10 +242,13 @@ ker(F) &lt;= ker(Obs)</code></pre>
               <figure class="code-panel">
                 <figcaption>Strength ladder</figcaption>
                 <pre><code>ProjectionSound
-  does not imply
+  carries concrete evidence into the abstract graph
+
 ProjectionComplete
-  does not imply
-ProjectionExact + RepresentativeStable</code></pre>
+  supplies concrete representatives for abstract edges
+
+ProjectionExact + RepresentativeStable
+  supports quotient-style DIP readings</code></pre>
               </figure>
               <p id="definition-7-3" class="statement">
                 <a class="statement-anchor" href="#definition-7-3">Definition 7.3.</a>
@@ -246,11 +282,11 @@ ProjectionExact + RepresentativeStable</code></pre>
             <section id="observation-lsp" class="article-section">
               <h2>Observation and LSP</h2>
               <p>
-                AAT reads LSP-style claims through observation. Two concrete
-                implementations may be substitutable for checkout totals,
-                rounding traces, and selected errors while timing properties,
-                hidden effects, and other client contexts remain separate
-                observations.
+                AAT reads LSP-style statements through selected observation
+                equivalence. Two concrete implementations can be substitutable
+                for checkout totals, rounding traces, and selected errors, and
+                the same framework can name timing properties, effects, and
+                client contexts as additional observation packages.
               </p>
               <figure class="code-panel">
                 <figcaption>Selected client contexts</figcaption>
@@ -268,9 +304,9 @@ ProjectionExact + RepresentativeStable</code></pre>
               <p id="proposition-7-6" class="statement">
                 <a class="statement-anchor" href="#proposition-7-6">Proposition 7.6.</a>
                 In the current finite theorem package, LSP compatibility is
-                equivalent to absence of selected LSP obstruction witnesses;
-                when the finite measurement universe closes the relevant
-                same-abstraction pairs, zero violation count yields
+                equivalent to a selected universe with zero LSP obstruction
+                witnesses. When that finite measurement universe closes the
+                relevant same-abstraction pairs, zero violation count yields
                 <code>LSPCompatible</code>.
               </p>
               <p class="formal-audit-link">
@@ -282,21 +318,34 @@ ProjectionExact + RepresentativeStable</code></pre>
             <section id="local-contract-packages" class="article-section">
               <h2>Local contract packages</h2>
               <p>
-                AAT reads SOLID as a local-contract layer: selected projection
-                soundness, LSP compatibility, and DIP compatibility travel with
-                the local replacement package. Layered and Clean Architecture
-                are global structural layers; state-transition patterns are
-                algebraic layers; runtime protection and distributed
-                convergence use their own evidence models.
+                The SOLID names now become a local-contract layer in AAT.
+                Projection soundness, selected observation equivalence, and
+                dependency-inversion evidence travel together as proof data
+                attached to the replacement package.
               </p>
+              <ul class="term-list">
+                <li>
+                  <strong>Local contract</strong>
+                  <span>Projection soundness, LSP compatibility, and DIP compatibility travel with the replacement package.</span>
+                </li>
+                <li>
+                  <strong>Structural layer</strong>
+                  <span>Layered and Clean Architecture contribute global shape readings through their own invariants.</span>
+                </li>
+                <li>
+                  <strong>State and runtime layers</strong>
+                  <span>State-transition patterns, protection, and distributed convergence receive dedicated law packages and evidence models.</span>
+                </li>
+              </ul>
               <p id="proposition-7-7" class="statement">
                 <a class="statement-anchor" href="#proposition-7-7">Proposition 7.7.</a>
                 A proof-carrying <code>LocalReplacementContract</code> gives
                 the target state projection soundness, LSP compatibility, and
                 DIP compatibility selected by the local contract invariant
                 family. As a <code>DesignPattern</code>, the local contract
-                package records that unconditional <code>Decomposable</code>
-                or <code>StrictLayered</code> does not follow.
+                package records local contract evidence separately from
+                unconditional <code>Decomposable</code> or
+                <code>StrictLayered</code> evidence.
               </p>
               <p id="proof-7-7" class="statement-proof">
                 <a class="statement-anchor" href="#proof-7-7">Proof idea.</a>
@@ -305,7 +354,7 @@ ProjectionExact + RepresentativeStable</code></pre>
                 from that evidence, then places the operation family and
                 invariant family into the general <code>DesignPattern</code>
                 closure schema. The non-conclusion is a field of the pattern,
-                so the global layering boundary travels with the package.
+                so the global layering clause travels with the package.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -321,15 +370,15 @@ ProjectionExact + RepresentativeStable</code></pre>
   = StaticFlatWithin
   + RuntimeFlatWithin
   + SemanticFlatWithin
-  + no unmeasured required axis
-  + coverage / exactness boundary</code></pre>
+  + required-axis coverage
+  + coverage / exactness support</code></pre>
               </figure>
               <p id="definition-8-1" class="statement">
                 <a class="statement-anchor" href="#definition-8-1">Definition 8.1.</a>
                 <code>ArchitectureFlatWithin</code> is the coverage-aware
                 flatness predicate that bundles selected static, runtime, and
                 semantic flatness with required-axis coverage and exactness
-                boundaries.
+                support.
               </p>
               <p id="proposition-8-2" class="statement">
                 <a class="statement-anchor" href="#proposition-8-2">Proposition 8.2.</a>
@@ -366,8 +415,8 @@ ProjectionExact + RepresentativeStable</code></pre>
                 A package can satisfy strong DIP-style projection conditions
                 and selected LSP compatibility while the abstract graph remains
                 cyclic and therefore not <code>Decomposable</code>. This is
-                the precise failure mode separating local contract
-                compatibility from global structural decomposition.
+                the precise witness separating local contract compatibility
+                from global structural decomposition.
               </p>
               <div class="article-table">
                 <table>
@@ -375,14 +424,14 @@ ProjectionExact + RepresentativeStable</code></pre>
                     <tr>
                       <th>Scenario</th>
                       <th>What is proved or measured</th>
-                      <th>What remains outside</th>
+                      <th>Next package reading</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
                       <td>Selected replacement</td>
                       <td>Selected client observations can remain equivalent under the named context universe.</td>
-                      <td>Background jobs, caches, callbacks, hidden runtime dependencies, and unmeasured semantic diagrams.</td>
+                      <td>Runtime packages for background jobs, caches, callbacks, dependency exposure, and semantic diagrams.</td>
                     </tr>
                     <tr>
                       <td>Strong abstract cycle</td>
@@ -397,17 +446,17 @@ ProjectionExact + RepresentativeStable</code></pre>
             <section id="local-summary" class="article-section">
               <h2>Chapter summary</h2>
               <p>
-                Local law packages make principle-level claims composable.
+                Local law packages make principle-level statements composable.
                 Projection, DIP compatibility, LSP compatibility, and
                 observation equivalence can be bundled into theorem packages
                 that preserve selected local invariants.
               </p>
               <p>
-                The key reading is layered rather than slogan-based. SOLID
-                contributes local contract structure; layered and clean
-                architectures contribute global structural readings; state,
-                runtime, and distributed properties require their own law
-                packages and bridges.
+                The key reading is layered and algebraic. SOLID contributes
+                local contract structure; layered and clean architectures
+                contribute global structural readings; state, runtime, and
+                distributed properties receive their own law packages and
+                bridges.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">
@@ -425,7 +474,7 @@ ProjectionExact + RepresentativeStable</code></pre>
                 </div>
                 <div>
                   <dt>non-conclusion</dt>
-                  <dd>The global property that remains outside the theorem, even when the local package is proved.</dd>
+                  <dd>A recorded theorem-package clause naming global properties reserved for another law package.</dd>
                 </div>
               </dl>
             </section>

--- a/website/aat/related-work/index.html
+++ b/website/aat/related-work/index.html
@@ -133,8 +133,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>
@@ -510,9 +510,9 @@
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a href="../examples-and-boundaries/">
+              <a href="../canonical-examples-and-readings/">
                 <span>Previous</span>
-                <strong>Examples and Boundaries</strong>
+                <strong>Canonical Examples and Readings</strong>
               </a>
               <a href="../status/">
                 <span>Next</span>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -63,10 +63,10 @@
           <p class="eyebrow">AAT Part VI</p>
           <h1>Repair and Dynamics</h1>
           <p class="lede">
-            Repair transforms obstruction evidence through admissible
-            operations. Dynamics tracks how repair, synthesis, paths,
-            homotopies, and diagram fillers move across theorem packages and
-            measured signature trajectories.
+            Repair turns obstruction evidence into controlled architectural
+            movement. Dynamics then follows repair plans, synthesis
+            certificates, paths, homotopies, diagram fillers, and signature
+            trajectories as first-class architecture data.
           </p>
         </div>
       </section>
@@ -161,6 +161,12 @@
                 and signature trajectories?
               </p>
               <h2>Repair step</h2>
+              <p>
+                A repair step is an operation that acts on a selected witness
+                universe. It carries a source, a target, a repair rule, and an
+                admissible decrease package, so improvement can be read as a
+                theorem-bearing movement through obstruction evidence.
+              </p>
               <figure class="code-panel">
                 <figcaption>Repair schema</figcaption>
                 <pre><code>RepairStep
@@ -175,8 +181,8 @@
                 <a class="statement-anchor" href="#definition-11-1">Definition 11.1.</a>
                 A repair step is a source-to-target architecture operation read
                 against a selected obstruction universe. The base step records
-                the operation skeleton; selected-measure decrease is a separate
-                theorem boundary supplied by an admissible repair rule.
+                the operation skeleton; selected-measure decrease is carried by
+                an admissible repair rule.
               </p>
               <p id="proposition-11-2" class="statement">
                 <a class="statement-anchor" href="#proposition-11-2">Proposition 11.2.</a>
@@ -189,8 +195,7 @@
                 <a class="statement-anchor" href="#proof-11-2">Proof idea.</a>
                 The admissible rule carries exactly the decrease theorem needed
                 by the selected step. The conclusion is a measure comparison in
-                the selected universe, so no unselected axis is folded into the
-                theorem.
+                the selected universe.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -207,24 +212,24 @@
                 selected conclusion travel with the plan.
               </p>
               <p>
-                Synthesis has a different obligation. A produced candidate
-                needs satisfaction evidence for the selected constraints; a
-                no-solution claim uses a valid certificate.
+                Synthesis turns constraints into architecture candidates. A
+                produced candidate carries satisfaction evidence for the
+                selected constraints; a no-solution reading uses a valid
+                certificate for the finite search universe.
               </p>
               <p id="proposition-11-3" class="statement">
                 <a class="statement-anchor" href="#proposition-11-3">Proposition 11.3.</a>
                 A finite repair package exposes selected-obstruction clearing,
                 a synthesis soundness package exposes candidate satisfaction,
-                and a valid no-solution certificate exposes absence of a
-                selected satisfying architecture. Solver completeness outside
-                the recorded universe is a separate claim.
+                and a valid no-solution certificate exposes selected
+                no-solution soundness for the finite search universe.
               </p>
               <p id="proof-11-3" class="statement-proof">
                 <a class="statement-anchor" href="#proof-11-3">Proof idea.</a>
-                Each package stores its own soundness field and boundary
-                assumptions. The accessor theorem returns that stored
-                conclusion; completeness for an unrecorded search space or an
-                unsupported constraint language requires a separate package.
+                Each package stores its own soundness field and assumptions.
+                The accessor theorem returns that stored conclusion; a larger
+                search space or a richer constraint language receives its own
+                certificate package.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -235,10 +240,10 @@
             <section id="complexity-transfer" class="article-section">
               <h2>Complexity transfer</h2>
               <p>
-                A repair can reduce a selected static witness while making a
-                different measured axis worse. AAT treats this as a first-class
-                boundary because "removed here" and "improved everywhere" are
-                different claims.
+                A repair can reduce a selected static witness while moving
+                complexity into another measured axis. AAT treats that transfer
+                as first-class evidence, so repair histories can show where
+                complexity moved as well as where an obstruction decreased.
               </p>
               <figure class="code-panel">
                 <figcaption>Transfer-aware reading</figcaption>
@@ -247,14 +252,14 @@ runtime diagnostic axis: 0 -&gt; 1
 
 therefore:
   selected repair decrease proved
-  all-axis nonincrease refuted</code></pre>
+  complexity transfer recorded</code></pre>
               </figure>
               <p id="counterexample-11-4" class="statement">
                 <a class="statement-anchor" href="#counterexample-11-4">Counterexample 11.4.</a>
                 There is a finite repair skeleton in which the selected static
                 obstruction measure decreases, while a runtime-axis witness
-                appears after repair. Therefore selected repair decrease does
-                not imply all-axis nonincrease.
+                appears after repair. This records complexity transfer from
+                the selected static axis to a runtime diagnostic axis.
               </p>
               <p id="proof-11-4" class="statement-proof">
                 <a class="statement-anchor" href="#proof-11-4">Proof idea.</a>
@@ -271,7 +276,8 @@ therefore:
                 <a class="statement-anchor" href="#non-conclusion-11-5">Non-conclusion 11.5.</a>
                 A repair report, repair suggestion, and adoption record each
                 live in a selected evidence context. Correctness, empirical
-                cost, and side-effect claims are recorded as separate readings.
+                cost, and side-effect readings travel as distinct evidence
+                packages.
               </p>
             </section>
 
@@ -280,8 +286,8 @@ therefore:
               <p>
                 Dynamics reads a repair or migration path as a sequence of
                 selected observations. Endpoint equality, endpoint delta zero,
-                or a safer final state can miss excursions and transfer events
-                that occur along the path.
+                and a stronger final state become trajectory data together
+                with excursions and transfer events along the path.
               </p>
               <figure class="code-panel">
                 <figcaption>Observed trajectory</figcaption>
@@ -289,9 +295,9 @@ therefore:
   + selected SignatureObservation
   -&gt; SignatureTrajectory [sig(X0), ..., sig(Xn)]
 
-safe endpoints
-  do not imply
-safe trajectory</code></pre>
+endpoint reading
+  + trajectory reading
+  + transfer events</code></pre>
               </figure>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -341,16 +347,15 @@ safe trajectory</code></pre>
                 A semantic diagram compares two endpoint-matched operation
                 paths. A filler says the paths are homotopic under the selected
                 finite path calculus. A non-fillability witness says that, for
-                the selected observation and witness value, no such filler can
-                exist.
+                the selected observation and witness value, the diagram carries
+                a certified obstruction to filling.
               </p>
               <figure class="code-panel">
-                <figcaption>Filling boundary</figcaption>
+                <figcaption>Filling package</figcaption>
                 <pre><code>DiagramFiller D
   -&gt; Obs(D.lhs) = Obs(D.rhs)
 
 Obs(D.lhs) != Obs(D.rhs)
-  -&gt; no selected DiagramFiller D
   -&gt; NonFillabilityWitnessFor D w</code></pre>
               </figure>
               <p id="proposition-12-3" class="statement">
@@ -399,7 +404,7 @@ Obs(D.lhs) != Obs(D.rhs)
                 The finite diagram records a semantic obstruction for the
                 selected observation.
                 Static repair, runtime exposure, repository extraction, and
-                empirical frequency are separate evidence packages.
+                empirical frequency travel as their own evidence packages.
               </p>
             </section>
 
@@ -409,21 +414,21 @@ Obs(D.lhs) != Obs(D.rhs)
                 Repair and dynamics read architecture evolution as movement
                 through obstruction evidence. A repair step becomes
                 theorem-bearing when an admissible package states which witness
-                family is cleared, decreased, transferred, or left for another
-                axis.
+                family is cleared, decreased, transferred, or carried into
+                another axis.
               </p>
               <p>
                 This gives AAT a finite language for improvement. Repair plans,
                 no-solution certificates, complexity transfer, signature
                 trajectories, and finite semantic diagrams all become evidence
                 records that can be compared and composed while preserving their
-                theorem boundaries.
+                theorem packages.
               </p>
               <h3>Terms</h3>
               <dl class="term-list definition-list">
                 <div>
                   <dt>selected obstruction universe</dt>
-                  <dd>The witness family and measure that a repair theorem is allowed to decrease or clear.</dd>
+                  <dd>The witness family and measure that a repair theorem decreases or clears.</dd>
                 </div>
                 <div>
                   <dt>repair step</dt>
@@ -431,7 +436,7 @@ Obs(D.lhs) != Obs(D.rhs)
                 </div>
                 <div>
                   <dt>finite repair package</dt>
-                  <dd>A finite plan, target clearing claim, coverage assumptions, and non-conclusions for selected witnesses.</dd>
+                  <dd>A finite plan, target clearing statement, coverage assumptions, and non-conclusions for selected witnesses.</dd>
                 </div>
                 <div>
                   <dt>no-solution certificate</dt>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -131,8 +131,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="AAT representations and effects: graph, matrix, analytic representation, state transition algebra, and effect boundary."
+      content="AAT representations and effects: graph, matrix, analytic representation, state-transition algebra, and effect law surfaces."
     >
     <title>AAT Representations and Effects</title>
     <link rel="canonical" href="https://iroha1203.dev/aat/representations-and-effects/">
     <meta property="og:site_name" content="AAT / SFT Research Notes">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AAT Representations and Effects">
-    <meta property="og:description" content="AAT representations and effects: graph, matrix, analytic representation, state transition algebra, and effect boundary.">
+    <meta property="og:description" content="AAT representations and effects: graph, matrix, analytic representation, state-transition algebra, and effect law surfaces.">
     <meta property="og:url" content="https://iroha1203.dev/aat/representations-and-effects/">
     <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AAT Representations and Effects">
-    <meta name="twitter:description" content="AAT representations and effects: graph, matrix, analytic representation, state transition algebra, and effect boundary.">
+    <meta name="twitter:description" content="AAT representations and effects: graph, matrix, analytic representation, state-transition algebra, and effect law surfaces.">
     <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
     <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
@@ -63,10 +63,10 @@
           <p class="eyebrow">AAT Part VII</p>
           <h1>Representations and Effects</h1>
           <p class="lede">
-            Graph, matrix, analytic, and state-transition views are different
-            representations of architecture structure. AAT uses them to
-            transport zeros, obstructions, valuations, and effect laws across
-            explicit preserving and reflecting assumptions.
+            Graphs, matrices, analytic values, state transitions, and effects
+            are representation surfaces for the same architecture object. AAT
+            uses them to transport zeros, obstructions, valuations, and effect
+            laws through preserving and reflecting packages.
           </p>
         </div>
       </section>
@@ -80,7 +80,7 @@
                 <li><a href="#graph-matrix">Graph and matrix</a></li>
                 <li><a href="#analytic-representation">Analytic representation</a></li>
                 <li><a href="#representation-pattern">Representation pattern</a></li>
-                <li><a href="#valuation-boundary">Valuation boundary</a></li>
+                <li><a href="#valuation-surface">Valuation surface</a></li>
                 <li><a href="#state-effects">State transitions and effects</a></li>
                 <li><a href="#effect-examples">Effect examples</a></li>
                 <li><a href="#representation-summary">Chapter summary</a></li>
@@ -161,11 +161,10 @@
               </p>
               <h2>Graph and matrix</h2>
               <p>
-                On a finite unweighted universe, acyclicity, absence of closed
-                walks, and nilpotence of the adjacency matrix can express the
-                same static structure. Finite propagation is not baked into
-                that structural theorem; it depends on a walk universe and a
-                propagation model.
+                On a finite unweighted universe, acyclicity, closed-walk zero,
+                and nilpotence of the adjacency matrix can express the same
+                static structure. Finite propagation becomes a further reading
+                once a walk universe and propagation model are selected.
               </p>
               <figure class="code-panel">
                 <figcaption>Finite structural bridge</figcaption>
@@ -174,7 +173,7 @@
   &lt;-&gt; nilpotent adjacency matrix</code></pre>
               </figure>
               <figure class="code-panel">
-                <figcaption>Claim boundary</figcaption>
+                <figcaption>Representation package</figcaption>
                 <pre><code>finite selected static universe
   + coverage assumptions
   -&gt;
@@ -183,42 +182,40 @@
     &lt;-&gt; adjacency nilpotence
 
 runtime propagation
-  requires runtime graph / propagation model
-  and is not built into Decomposable</code></pre>
+  = runtime graph + propagation model
+  + selected reachability reading</code></pre>
               </figure>
               <p id="definition-13-1" class="statement">
                 <a class="statement-anchor" href="#definition-13-1">Definition 13.1.</a>
                 The graph / matrix bridge is the selected finite structural
                 reading that compares an unweighted dependency graph, its
                 finite walk evidence, and its adjacency matrix. Its input is a
-                proof-carrying finite component universe, not an ambient
-                repository.
+                proof-carrying finite component universe.
               </p>
               <p id="proposition-13-2" class="statement">
                 <a class="statement-anchor" href="#proposition-13-2">Proposition 13.2.</a>
                 For a finite selected unweighted structural universe, the
                 graph and matrix readings are theorem-connected: acyclicity,
-                absence of nonempty closed walks, and adjacency nilpotence are
-                the same structural zero package, with the spectral-radius
+                closed-walk zero, and adjacency nilpotence are the same
+                structural zero package, with the spectral-radius
                 reading living on the corresponding finite complex matrix.
               </p>
               <p id="proof-13-2" class="statement-proof">
                 <a class="statement-anchor" href="#proof-13-2">Proof idea.</a>
                 Powers of the finite adjacency matrix enumerate selected
                 finite walks. If the graph is acyclic, sufficiently long
-                selected walks cannot exist, so a positive matrix power is
-                zero. Conversely, a nonempty closed walk can be repeated past
-                any nilpotence cutoff and refutes matrix nilpotence. The
-                spectral statement is then read through the finite complex
-                adjacency matrix; it does not attach cost or runtime meaning
-                to the radius.
+                selected walks have zero count, so a positive matrix power is
+                zero. Conversely, a nonempty closed walk repeats past any
+                nilpotence cutoff and refutes matrix nilpotence. The spectral
+                statement is then read through the finite complex adjacency
+                matrix.
               </p>
               <p id="non-conclusion-13-3" class="statement">
                 <a class="statement-anchor" href="#non-conclusion-13-3">Non-conclusion 13.3.</a>
                 <code>Decomposable</code> remains <code>StrictLayered</code>.
                 Acyclicity, finite propagation, nilpotence, and spectral
-                conditions are separate structural or analytic readings rather
-                than part of that base definition.
+                conditions appear as structural or analytic representation
+                readings connected to that base definition by theorem packages.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -233,13 +230,13 @@ runtime propagation
                 architecture object into an analytic domain. The representation
                 can be zero-preserving, zero-reflecting,
                 obstruction-preserving, or obstruction-reflecting. These are
-                different strengths; reflecting directions carry stronger
-                evidence obligations.
+                different strengths; reflecting directions carry richer
+                evidence packages.
               </p>
               <p id="definition-13-4" class="statement">
                 <a class="statement-anchor" href="#definition-13-4">Definition 13.4.</a>
                 An <code>AnalyticRepresentation</code> consists of a
-                representation map together with separate predicates for
+                representation map together with focused predicates for
                 preserving and reflecting selected zeros and obstructions. The
                 reflecting predicates carry coverage, witness completeness,
                 semantic contract coverage, and non-conclusion fields.
@@ -302,21 +299,22 @@ analytic zero
 structural zero</code></pre>
               </figure>
               <p>
-                This pattern also explains why dashboards and numerical
-                summaries are useful but insufficient: an aggregate can guide
-                attention without by itself proving structural flatness.
+                This pattern gives dashboards and numerical summaries their
+                theorem shape: an aggregate can guide attention, and a
+                reflecting package turns the represented value into structural
+                evidence.
               </p>
               <p id="proposition-13-5" class="statement">
                 <a class="statement-anchor" href="#proposition-13-5">Proposition 13.5.</a>
-                Preserving and reflecting are independent theorem boundaries.
+                Preserving and reflecting are independent theorem packages.
                 A preserving representation can transport a structural zero
-                into an analytic zero; a reflecting claim additionally needs
-                the recorded assumptions that authorize reading the analytic
-                result back as a selected structural claim.
+                into an analytic zero; a reflecting package additionally
+                carries the recorded assumptions that authorize reading the
+                analytic result back as a selected structural statement.
               </p>
               <p id="proof-13-5" class="statement-proof">
                 <a class="statement-anchor" href="#proof-13-5">Proof idea.</a>
-                The Lean API keeps the four predicates separate. The preserving
+                The Lean API keeps the four predicates distinct. The preserving
                 theorems use the corresponding preserving field; the reflecting
                 theorems use the reflecting field and its assumptions. A report
                 with a represented value still needs the reflecting package to
@@ -328,8 +326,8 @@ structural zero</code></pre>
               </p>
             </section>
 
-            <section id="valuation-boundary" class="article-section">
-              <h2>Valuation boundary</h2>
+            <section id="valuation-surface" class="article-section">
+              <h2>Valuation surface</h2>
               <p>
                 <code>ObstructionValuation</code> maps selected witnesses to
                 numeric or ordered values. Aggregates can be useful for
@@ -347,17 +345,17 @@ aggregate = 0
   -&gt; selected witnesses are zero</code></pre>
               </figure>
               <p>
-                This is the same boundary discipline as matrix and analytic
-                representations: preserving zero is weaker than reflecting
-                zero, and reflecting an obstruction requires coverage and
-                semantic contract assumptions.
+                This is the same representation discipline as matrix and
+                analytic readings: preserving zero transports evidence
+                forward, while reflecting zero carries coverage and semantic
+                contract assumptions back into the structural world.
               </p>
               <p id="proposition-13-6" class="statement">
                 <a class="statement-anchor" href="#proposition-13-6">Proposition 13.6.</a>
-                A zero valuation discharges selected witness absence when its
-                zero-reflecting premise is available. An optional missing value,
-                an unavailable axis, or an unmeasured report field is a
-                different kind of zero.
+                A zero valuation discharges selected witness zero when its
+                zero-reflecting premise is available. Optional omitted values,
+                unavailable axes, and unmeasured report fields have their own
+                measurement status.
               </p>
               <figure class="code-panel">
                 <figcaption>Measured zero versus unmeasured</figcaption>
@@ -380,9 +378,9 @@ none
                 naturality are projections of this algebra.
               </p>
               <p>
-                The effect boundary captures obstruction that a dependency
-                graph alone may miss: cross-boundary effects, implicit
-                authority, missing handlers, and non-commuting effect pairs.
+                The effect law surface captures obstruction visible through
+                behavior: cross-surface effects, implicit authority, handler
+                gaps, and non-commuting effect pairs.
               </p>
               <figure class="code-panel">
                 <figcaption>Example relations</figcaption>
@@ -394,32 +392,32 @@ migrate ; project_old = project_new ; migrateEvents</code></pre>
               </figure>
               <p id="definition-14-1" class="statement">
                 <a class="statement-anchor" href="#definition-14-1">Definition 14.1.</a>
-                A state-transition or effect-boundary law package is a selected
+                A state-transition or effect law package is a selected
                 finite family of replay, roundtrip, compensation, projection,
                 migration, or effect relations read against a carrier and
-                observation semantics. Lawfulness is a package claim over those
-                selected relations.
+                observation semantics. Lawfulness is a package statement over
+                those selected relations.
               </p>
               <ul class="term-list">
                 <li>
                   <strong>Event Sourcing</strong>
-                  <span>Replay and projection laws are selected finite law cases; complete real-code event logs require separate evidence.</span>
+                  <span>Replay and projection laws are selected finite law cases that read event histories through observation.</span>
                 </li>
                 <li>
                   <strong>Saga</strong>
-                  <span>Compensation and weak recovery are selected law packages; general inverses for failure modes require separate assumptions.</span>
+                  <span>Compensation and weak recovery are selected law packages with explicit recovery relations.</span>
                 </li>
                 <li>
                   <strong>CRUD</strong>
-                  <span>Overwrite behavior is read against the selected state and observation relation, separate from broad claims about CRUD.</span>
+                  <span>Overwrite behavior is read against the selected state and observation relation.</span>
                 </li>
                 <li>
                   <strong>Circuit Breaker</strong>
-                  <span>Runtime protection is relative to selected localization and failure-model assumptions.</span>
+                  <span>Runtime protection is read through selected localization and fault-model assumptions.</span>
                 </li>
                 <li>
                   <strong>Replicated Log</strong>
-                  <span>Convergence is conditional on selected quorum, ordering, failure model, and entries.</span>
+                  <span>Convergence travels with selected quorum, ordering, fault model, and entries.</span>
                 </li>
               </ul>
             </section>
@@ -427,12 +425,11 @@ migrate ; project_old = project_new ; migrateEvents</code></pre>
             <section id="effect-examples" class="article-section">
               <h2>Effect examples</h2>
               <p>
-                A dependency graph may show that checkout depends only on a
-                payment interface, while the effect layer reveals a hidden
-                authority boundary: a retry command is not idempotent, a
-                compensation does not undo the action, a snapshot omits a
-                required event, or a migration fails to commute with the old
-                projection.
+                A dependency graph may show checkout through a payment
+                interface, while the effect layer reveals a hidden authority
+                surface: a non-idempotent retry command, a compensation gap, a
+                snapshot with an omitted required event, or a non-commuting
+                migration against the old projection.
               </p>
               <ul class="term-list">
                 <li>
@@ -449,23 +446,23 @@ migrate ; project_old = project_new ; migrateEvents</code></pre>
                 </li>
                 <li>
                   <strong>Effect obstruction</strong>
-                  <span>Missing handlers, implicit authority, or non-commuting effect pairs can be selected obstruction witnesses.</span>
+                  <span>Handler gaps, implicit authority, or non-commuting effect pairs can be selected obstruction witnesses.</span>
                 </li>
               </ul>
               <p id="proposition-14-2" class="statement">
                 <a class="statement-anchor" href="#proposition-14-2">Proposition 14.2.</a>
-                State-transition and effect-boundary lawfulness can be
-                connected to selected obstruction absence for the law family and
-                observation semantics supplied to the package.
+                State-transition and effect lawfulness can be connected to
+                selected obstruction zero for the law family and observation
+                semantics supplied to the package.
               </p>
               <p id="proof-14-2" class="statement-proof">
                 <a class="statement-anchor" href="#proof-14-2">Proof idea.</a>
                 The law family packages expose the selected laws and their
                 obstruction predicates in the same universe. The bridge theorem
-                states that selected family lawfulness is equivalent to absence
-                of the selected family obstruction. Runtime traces, hidden
-                effects, and real-code extractor completeness require their own
-                evidence packages.
+                states that selected family lawfulness is equivalent to zero
+                selected family obstruction. Runtime traces, hidden effects,
+                and real-code extraction travel through their own evidence
+                packages.
               </p>
               <p class="formal-audit-link">
                 <span>Audit trail</span>
@@ -509,15 +506,15 @@ migrate ; project_old = project_new ; migrateEvents</code></pre>
                 </div>
                 <div>
                   <dt>unmeasured axis</dt>
-                  <dd>The axis is not available in the selected evidence; it is not a zero.</dd>
+                  <dd>The axis has its own measurement status and is distinct from measured zero.</dd>
                 </div>
                 <div>
                   <dt>state-transition algebra</dt>
                   <dd>The command, event, replay, compensation, projection, and migration laws read as selected finite law cases.</dd>
                 </div>
                 <div>
-                  <dt>effect boundary</dt>
-                  <dd>The selected law surface for effects that a static dependency graph may not see.</dd>
+                  <dt>effect law surface</dt>
+                  <dd>The selected law surface for effects that enrich the static dependency graph.</dd>
                 </div>
               </dl>
             </section>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -130,8 +130,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>
@@ -524,9 +524,9 @@ migrate ; project_old = project_new ; migrateEvents</code></pre>
                 <span>Previous</span>
                 <strong>Repair and Dynamics</strong>
               </a>
-              <a href="../examples-and-boundaries/">
+              <a href="../canonical-examples-and-readings/">
                 <span>Next</span>
-                <strong>Examples and Boundaries</strong>
+                <strong>Canonical Examples and Readings</strong>
               </a>
             </nav>
           </div>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -127,8 +127,8 @@
                   </a>
                 </li>
                 <li>
-                  <a href="../examples-and-boundaries/">
-                    Examples and Boundaries
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
                   </a>
                 </li>
                 <li>
@@ -314,7 +314,7 @@ ArchitectureLawful X
                   <span>Operation schemas, feature extension evidence, split packages, and obstruction classification.</span>
                 </li>
                 <li>
-                  <strong><a href="../formal-anchors/#examples-and-boundaries">Example anchors</a></strong>
+                  <strong><a href="../formal-anchors/#canonical-examples-and-readings">Example anchors</a></strong>
                   <span>Coupon static evidence, semantic counterexample, repair transfer, and worked example boundaries.</span>
                 </li>
               </ul>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1263,7 +1263,8 @@ p {
 }
 
 .article-main p code,
-.article-main li code {
+.article-main li code,
+.article-main dd code {
   overflow-wrap: anywhere;
 }
 

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1231,6 +1231,10 @@ p {
   padding: 18px 0;
 }
 
+.article-section .intro-term-list + h2 {
+  margin-top: 36px;
+}
+
 .chapter-list a,
 .term-list strong,
 .status-list strong {

--- a/website/index.html
+++ b/website/index.html
@@ -126,7 +126,7 @@
               <a href="aat/calculus-and-extensions/">Calculus and Extensions</a>
               <a href="aat/repair-and-dynamics/">Repair and Dynamics</a>
               <a href="aat/representations-and-effects/">Representations and Effects</a>
-              <a href="aat/examples-and-boundaries/">Examples and Boundaries</a>
+              <a href="aat/canonical-examples-and-readings/">Canonical Examples and Readings</a>
               <a href="aat/related-work/">Related Work and Novelty</a>
               <a href="aat/status/">Status</a>
               <a href="aat/formal-anchors/">Formal Anchors Audit</a>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -10,7 +10,7 @@
     <loc>https://iroha1203.dev/aat/calculus-and-extensions/</loc>
   </url>
   <url>
-    <loc>https://iroha1203.dev/aat/examples-and-boundaries/</loc>
+    <loc>https://iroha1203.dev/aat/canonical-examples-and-readings/</loc>
   </url>
   <url>
     <loc>https://iroha1203.dev/aat/foundations/</loc>


### PR DESCRIPTION
## 概要

AAT website の各章本文を、数学的な厳密さを保ちながら公開読書面として読みやすく磨きました。防衛的・否定的な表現を抑え、AAT が何を読めるようにする理論なのかを前面に出しています。

主な変更:
- Foundations から Canonical Examples and Readings までの本文コピーを調整
- `Examples and Boundaries` を `Canonical Examples and Readings` に改題し、URL も `canonical-examples-and-readings` に変更
- Canonical Examples and Readings のテーブル表現をリスト/定義リストへ変更
- AAT ナビゲーション、前後リンク、sitemap、formal anchor 参照を更新
- 長い Lean 識別子がモバイルで崩れないよう CSS を調整

対象 Issue: なし（ユーザー依頼による website copy polish）

## 証明した定理

- なし

## 編集したドキュメント

- `website/index.html`
- `website/aat/**/index.html`
- `website/assets/site.css`
- `website/sitemap.xml`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] Playwright による website 静的ページ確認（desktop / mobile、canonical、内部アンカー、横スクロール）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
