### PR TITLE
AAT定量軸ページを追加

### DIFF
--- a/website/aat/architecture-signature/index.html
+++ b/website/aat/architecture-signature/index.html
@@ -139,6 +139,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -142,6 +142,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/canonical-examples-and-readings/index.html
+++ b/website/aat/canonical-examples-and-readings/index.html
@@ -143,6 +143,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/formal-anchors/index.html
+++ b/website/aat/formal-anchors/index.html
@@ -101,6 +101,7 @@
                 <li><a href="../representations-and-effects/">Representations and Effects</a></li>
                 <li><a href="../canonical-examples-and-readings/">Canonical Examples and Readings</a></li>
                 <li><a href="../related-work/">Related Work and Novelty</a></li>
+                <li><a href="../quantifiable-axes/">Quantifiable Axes</a></li>
                 <li><a href="../status/">Status</a></li>
                 <li><a href="./" aria-current="page">Formal Anchors Audit</a></li>
               </ul>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -139,6 +139,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -146,6 +146,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="status/">
                     Status
                   </a>
@@ -223,6 +228,10 @@
                 <li>
                   <a href="related-work/">Related Work and Novelty</a>
                   <span>Adjacent methods and the algebraic claim grammar AAT adds.</span>
+                </li>
+                <li>
+                  <a href="quantifiable-axes/">Quantifiable Axes</a>
+                  <span>Structural, boundary, semantic, runtime, operational, analytic, and theorem-boundary coordinates.</span>
                 </li>
                 <li>
                   <a href="status/">Status</a>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -139,6 +139,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -141,6 +141,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/quantifiable-axes/index.html
+++ b/website/aat/quantifiable-axes/index.html
@@ -1,0 +1,409 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="AAT quantifiable axes: the structural, boundary, semantic, runtime, operational, analytic, and theorem-boundary coordinates that Architecture Signature can measure."
+    >
+    <title>AAT Quantifiable Axes</title>
+    <link rel="canonical" href="https://iroha1203.dev/aat/quantifiable-axes/">
+    <meta property="og:site_name" content="AAT / SFT Research Notes">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="AAT Quantifiable Axes">
+    <meta property="og:description" content="AAT quantifiable axes: the structural, boundary, semantic, runtime, operational, analytic, and theorem-boundary coordinates that Architecture Signature can measure.">
+    <meta property="og:url" content="https://iroha1203.dev/aat/quantifiable-axes/">
+    <meta property="og:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="AAT Quantifiable Axes">
+    <meta name="twitter:description" content="AAT quantifiable axes: the structural, boundary, semantic, runtime, operational, analytic, and theorem-boundary coordinates that Architecture Signature can measure.">
+    <meta name="twitter:image" content="https://iroha1203.dev/assets/ogp-aat-sft.png">
+    <link rel="icon" href="../../assets/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="../../assets/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="alternate" hreflang="en" href="./">
+    <link rel="alternate" hreflang="x-default" href="./">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Inter:wght@400;500;600;700&amp;family=Source+Serif+4:opsz,wght@8..60,400..700&amp;display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="../../assets/site.css">
+    <script defer src="../../assets/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" data-site-header>
+      <div class="site-shell header-inner">
+        <a class="brand" href="../../" aria-label="AAT SFT home">
+          <img class="brand-icon" src="../../assets/favicon-512.png" alt="" width="512" height="512" aria-hidden="true">
+          <span class="brand-mark">AAT/SFT</span>
+          <span class="brand-text">Research Notes</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="../../">Home</a>
+          <a class="is-active" href="../">AAT</a>
+          <a href="../../sft/">SFT</a>
+          <a href="../../archsig/">ArchSig</a>
+          <a href="../../outreach/">Outreach</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="article-hero section-band">
+        <div class="site-shell">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../">Home</a>
+            <a href="../">AAT</a>
+            <span>Quantifiable Axes</span>
+          </nav>
+          <p class="eyebrow">Appendix</p>
+          <h1>Quantifiable Axes</h1>
+          <p class="lede">
+            AAT turns architecture review into a coordinate reading. It makes
+            structural shape, boundary pressure, semantic agreement, runtime
+            exposure, operational change, analytic representation, and theorem
+            readiness visible as comparable signature axes.
+          </p>
+        </div>
+      </section>
+
+      <section class="section-band">
+        <div class="site-shell article-layout">
+          <aside class="article-sidebar" aria-label="Local navigation">
+            <nav class="toc-panel" aria-labelledby="toc-title">
+              <h2 id="toc-title">On this page</h2>
+              <ol>
+                <li><a href="#reading-contract">Reading contract</a></li>
+                <li><a href="#axis-catalog">Axis catalog</a></li>
+                <li><a href="#tool-surface">Tool surface</a></li>
+                <li><a href="#comparison">Comparison</a></li>
+                <li><a href="#precision">Precision</a></li>
+              </ol>
+            </nav>
+            <div class="source-panel" data-sidebar-open="true">
+              <h2>AAT chapters</h2>
+              <ul>
+                <li>
+                  <a href="../">
+                    AAT overview
+                  </a>
+                </li>
+                <li>
+                  <a href="../foundations/">
+                    Foundations
+                  </a>
+                </li>
+                <li>
+                  <a href="../laws-and-witnesses/">
+                    Laws and Witnesses
+                  </a>
+                </li>
+                <li>
+                  <a href="../architecture-signature/">
+                    Architecture Signature
+                  </a>
+                </li>
+                <li>
+                  <a href="../local-law-packages/">
+                    Local Law Packages
+                  </a>
+                </li>
+                <li>
+                  <a href="../calculus-and-extensions/">
+                    Calculus and Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="../repair-and-dynamics/">
+                    Repair and Dynamics
+                  </a>
+                </li>
+                <li>
+                  <a href="../representations-and-effects/">
+                    Representations and Effects
+                  </a>
+                </li>
+                <li>
+                  <a href="../canonical-examples-and-readings/">
+                    Canonical Examples and Readings
+                  </a>
+                </li>
+                <li>
+                  <a href="../related-work/">
+                    Related Work and Novelty
+                  </a>
+                </li>
+                <li>
+                  <a href="../quantifiable-axes/" aria-current="page">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
+                  <a href="../status/">
+                    Status
+                  </a>
+                </li>
+                <li>
+                  <a href="../formal-anchors/">
+                    Formal Anchors Audit
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </aside>
+
+          <div class="article-main">
+            <section id="reading-contract" class="article-section">
+              <p class="research-question">
+                Can software architecture be observed quantitatively as a
+                multi-axis signature?
+              </p>
+              <h2>Reading contract</h2>
+              <p>
+                AAT quantifies selected coordinates of an
+                <code>ArchitectureSignature</code>. Each coordinate tells a
+                reader what was observed, which architectural law it touches,
+                how strongly it is supported, and how it can be compared with
+                another revision. The result is a vocabulary for asking where
+                architecture improves, where pressure accumulates, and which
+                repair direction has measurable support.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Quantified signature coordinate</figcaption>
+                <pre><code>axis reading
+  = selected axis
+  + measured value
+  + evidence universe
+  + coverage / exactness boundary
+  + theorem or report support
+  + comparison rule</code></pre>
+              </figure>
+              <p id="quantifiable-axis-a-1" class="statement">
+                <a class="statement-anchor" href="#quantifiable-axis-a-1">Axis A.1.</a>
+                AAT quantifies obstruction, preservation, coverage, and
+                comparison coordinates by pairing each axis with its selected
+                universe, measurement status, and axis-local order.
+              </p>
+            </section>
+
+            <section id="axis-catalog" class="article-section">
+              <h2>Axis catalog</h2>
+              <p>
+                The table below is a public reading catalog. It shows the
+                architectural quantities AAT can make visible across the
+                mathematical theory, signature artifacts, reports,
+                theorem-precondition checks, and architecture evolution
+                readings.
+              </p>
+              <div class="article-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Axis family</th>
+                      <th>What is quantified</th>
+                      <th>Typical coordinate</th>
+                      <th>What it enables</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Static structure</td>
+                      <td>Finite dependency shape and forbidden structural evidence.</td>
+                      <td>component count, relation count, cycle flag, SCC size, max depth, forbidden edge count.</td>
+                      <td>Layering, decomposition, cycle pressure, and forbidden-edge review become measurable.</td>
+                    </tr>
+                    <tr>
+                      <td>Propagation and concentration</td>
+                      <td>How dependency pressure spreads from a component and where it concentrates.</td>
+                      <td>fanout risk, max fanout, reachable cone size, SCC excess, weighted SCC risk.</td>
+                      <td>Hotspots, propagation cones, and weighted structural pressure become visible as separate coordinates.</td>
+                    </tr>
+                    <tr>
+                      <td>Boundary policy</td>
+                      <td>Edges or accesses that cross a declared architectural boundary.</td>
+                      <td>boundary violation count, direction policy, policy evidence status.</td>
+                      <td>Architectural boundaries become reviewable policy coordinates instead of informal diagrams.</td>
+                    </tr>
+                    <tr>
+                      <td>Abstraction and interface</td>
+                      <td>Dependency on abstraction, concrete leakage, projection loss, and substitution evidence.</td>
+                      <td>DIP violation, LSP counterexample, projection mismatch, contract coverage level.</td>
+                      <td>Local contract pressure becomes visible at projection, substitution, and dependency seams.</td>
+                    </tr>
+                    <tr>
+                      <td>Feature extension</td>
+                      <td>How an operation changes the architecture and where extension obstruction appears.</td>
+                      <td>added component count, changed relation count, split status, hidden interaction witness.</td>
+                      <td>Feature work can be read as inherited, local, and interaction change instead of one undifferentiated diff.</td>
+                    </tr>
+                    <tr>
+                      <td>Repair and transfer</td>
+                      <td>Selected obstruction decrease and possible movement into another axis.</td>
+                      <td>eliminated witness count, residual witness count, transfer candidate, repair adoption status.</td>
+                      <td>Repair gains and transferred pressure can be tracked as separate architectural movements.</td>
+                    </tr>
+                    <tr>
+                      <td>Architecture evolution</td>
+                      <td>Bounded sequences of feature, drift, repair, migration, policy, runtime, and semantic steps.</td>
+                      <td>path length, transition kind count, lawful-step status, target-flat status, reported drift witness.</td>
+                      <td>An architecture change becomes a typed path whose steps, endpoints, and witnesses can be inspected.</td>
+                    </tr>
+                    <tr>
+                      <td>Signature dynamics</td>
+                      <td>How observed signatures move across an architecture evolution path.</td>
+                      <td>signature trajectory, per-step delta sequence, endpoint delta, recurrent region witness.</td>
+                      <td>Architectural movement can be read as a trajectory through signature space.</td>
+                    </tr>
+                    <tr>
+                      <td>Runtime dependency</td>
+                      <td>Runtime edges, protected paths, unprotected paths, and exposure witnesses.</td>
+                      <td>runtime edge count, protected path count, unprotected path count, exposure witness.</td>
+                      <td>Runtime exposure becomes a signature coordinate alongside static structure.</td>
+                    </tr>
+                    <tr>
+                      <td>Semantic and homotopy</td>
+                      <td>Whether paths, diagrams, and observations agree under the selected semantic reading.</td>
+                      <td>semantic diagram count, filler claim, nonfillability witness, observation mismatch.</td>
+                      <td>Equivalent-looking paths can be compared by the semantic diagrams they preserve or fail to fill.</td>
+                    </tr>
+                    <tr>
+                      <td>State and effect</td>
+                      <td>Command, event, retry, compensation, snapshot, migration, and effect-law obstruction.</td>
+                      <td>effect-pair order, handler coverage, authority crossing, migration alignment.</td>
+                      <td>State-transition and effect design become algebraic law surfaces with measurable witnesses.</td>
+                    </tr>
+                    <tr>
+                      <td>Graph and matrix</td>
+                      <td>Finite graph readings transported into walk, matrix, nilpotence, or spectral coordinates.</td>
+                      <td>closed-walk absence, adjacency nilpotence, walk count, propagation bound.</td>
+                      <td>Structural facts can move between graph, walk, matrix, and analytic representations.</td>
+                    </tr>
+                    <tr>
+                      <td>Analytic valuation</td>
+                      <td>Numeric or ordered values assigned to selected witnesses or representations.</td>
+                      <td>obstruction valuation, aggregate drift, zero-preserving or zero-reflecting value.</td>
+                      <td>Witness families can be summarized by ordered values while retaining their architectural meaning.</td>
+                    </tr>
+                    <tr>
+                      <td>Coverage and exactness</td>
+                      <td>Which observations are available and which assumptions are ready for discharge.</td>
+                      <td>measured axes, measurement backlog, construct coverage, exactness assumption list.</td>
+                      <td>Reviewers can distinguish available evidence, future measurement work, and assumption discharge.</td>
+                    </tr>
+                    <tr>
+                      <td>Theorem boundary</td>
+                      <td>Whether a measured report can discharge a theorem package precondition.</td>
+                      <td>discharged assumption, precondition work item, formal readiness status.</td>
+                      <td>Measured artifacts can be organized into the precondition checklist for formal theorem use.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section id="tool-surface" class="article-section">
+              <h2>Tool surface</h2>
+              <p>
+                ArchSig gives the catalog an executable surface. It reads Lean
+                and Python import graphs, validates Sig0 artifacts, compares
+                signature snapshots, builds AIR records, checks theorem
+                preconditions, summarizes feature extensions, and records
+                policy decisions. These reports let architecture review move
+                from prose judgement to axis-level evidence.
+              </p>
+              <ul class="status-list">
+                <li>
+                  <strong>Sig0</strong>
+                  <span>Records components, edges, policies, signature values, metric status, runtime evidence, supported constructs, and runtime dependency graph entries.</span>
+                </li>
+                <li>
+                  <strong>Feature Extension Report</strong>
+                  <span>Reads split status, preserved and changed invariants, introduced and eliminated witnesses, complexity transfer candidates, theorem checks, and repair suggestions.</span>
+                </li>
+                <li>
+                  <strong>Theorem precondition check</strong>
+                  <span>Organizes discharged assumptions, precondition work, coverage evidence, exactness evidence, and formal-claim readiness.</span>
+                </li>
+              </ul>
+            </section>
+
+            <section id="comparison" class="article-section">
+              <h2>Comparison</h2>
+              <p>
+                Signature comparison is axis-local. A before/after report can
+                show which coordinates improved, worsened, or stayed stable
+                when both revisions measure the same axis under a compatible
+                schema, unit, projection, coverage, and order. This makes
+                architectural movement readable as a vector of local changes.
+              </p>
+              <figure class="code-panel">
+                <figcaption>Comparable signature delta</figcaption>
+                <pre><code>SignatureDelta(before, after)
+  requires:
+    same selected axis
+    + measured on both sides
+    + compatible unit / projection / coverage
+    + axis-local order
+
+  yields:
+    improved | worsened | unchanged | notComparable</code></pre>
+              </figure>
+            </section>
+
+            <section id="precision" class="article-section">
+              <h2>Precision</h2>
+              <p>
+                AAT's precision comes from keeping each coordinate attached to
+                its observation universe, evidence source, measurement status,
+                and theorem package. The same page can therefore show a
+                measured zero, a measured obstruction, a comparable delta, and
+                a theorem-ready precondition as different useful pieces of
+                architectural knowledge.
+              </p>
+              <p>
+                This is the point of the axis catalog. A structural count, a
+                propagation cone, a signature trajectory, a runtime exposure,
+                a semantic mismatch, an effect-law witness, and a
+                theorem-precondition status can sit in one signature as
+                distinct coordinates. The reader sees the shape of
+                architectural evidence directly.
+              </p>
+              <p id="axis-precision-a-2" class="statement">
+                <a class="statement-anchor" href="#axis-precision-a-2">Axis A.2.</a>
+                The catalog turns architecture evidence into named coordinates:
+                it lets a reviewer measure where a law is preserved, where an
+                obstruction appears, how a repair moves the signature, and
+                which observations are ready to support a stronger theorem
+                package.
+              </p>
+            </section>
+
+            <nav class="page-nav" aria-label="Reading sequence">
+              <a class="page-nav-previous" href="../related-work/">
+                <span>Previous</span>
+                <strong>Related Work and Novelty</strong>
+              </a>
+              <a class="page-nav-next" href="../status/">
+                <span>Next</span>
+                <strong>Status</strong>
+              </a>
+            </nav>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-shell footer-inner">
+        <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+          Repository
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/aat/related-work/index.html
+++ b/website/aat/related-work/index.html
@@ -143,6 +143,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>
@@ -514,9 +519,9 @@
                 <span>Previous</span>
                 <strong>Canonical Examples and Readings</strong>
               </a>
-              <a href="../status/">
+              <a href="../quantifiable-axes/">
                 <span>Next</span>
-                <strong>AAT Status</strong>
+                <strong>Quantifiable Axes</strong>
               </a>
             </nav>
           </div>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -141,6 +141,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -140,6 +140,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/">
                     Status
                   </a>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -137,6 +137,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="../quantifiable-axes/">
+                    Quantifiable Axes
+                  </a>
+                </li>
+                <li>
                   <a href="../status/" aria-current="page">
                     Status
                   </a>
@@ -321,9 +326,9 @@ ArchitectureLawful X
             </section>
 
             <nav class="page-nav" aria-label="Reading sequence">
-              <a class="page-nav-previous" href="../related-work/">
+              <a class="page-nav-previous" href="../quantifiable-axes/">
                 <span>Previous</span>
-                <strong>Related Work and Novelty</strong>
+                <strong>Quantifiable Axes</strong>
               </a>
               <a class="page-nav-next" href="../formal-anchors/">
                 <span>Next</span>

--- a/website/index.html
+++ b/website/index.html
@@ -128,6 +128,7 @@
               <a href="aat/representations-and-effects/">Representations and Effects</a>
               <a href="aat/canonical-examples-and-readings/">Canonical Examples and Readings</a>
               <a href="aat/related-work/">Related Work and Novelty</a>
+              <a href="aat/quantifiable-axes/">Quantifiable Axes</a>
               <a href="aat/status/">Status</a>
               <a href="aat/formal-anchors/">Formal Anchors Audit</a>
             </nav>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -41,6 +41,7 @@ a proof system.
 
 - Home: https://iroha1203.dev/
 - AAT overview: https://iroha1203.dev/aat/
+- AAT Quantifiable Axes: https://iroha1203.dev/aat/quantifiable-axes/
 - SFT overview: https://iroha1203.dev/sft/
 - SFT Part 1, Field and Force: https://iroha1203.dev/sft/field-and-force/
 - SFT 1-1, Field: https://iroha1203.dev/sft/field-and-force/field/

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -25,6 +25,9 @@
     <loc>https://iroha1203.dev/aat/related-work/</loc>
   </url>
   <url>
+    <loc>https://iroha1203.dev/aat/quantifiable-axes/</loc>
+  </url>
+  <url>
     <loc>https://iroha1203.dev/aat/repair-and-dynamics/</loc>
   </url>
   <url>


### PR DESCRIPTION
## 概要

AAT website に新章 `Quantifiable Axes` を追加しました。

この章では、AAT によってソフトウェアアーキテクチャを定量的に観測できる軸を、読み物として完結する形で整理しています。Status と Related Work の間に配置し、全 AAT 章のサイドバー、トップページ、`sitemap.xml`、`llms.txt` の導線を更新しました。

対象 Issue: なし（ユーザー直接依頼）

## 証明した定理

- なし

## 編集したドキュメント

- `website/aat/quantifiable-axes/index.html`
- `website/aat/index.html`
- `website/aat/*/index.html` の AAT 章サイドバー
- `website/index.html`
- `website/llms.txt`
- `website/sitemap.xml`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] ローカルリンク存在チェック
- [x] Playwright による `website/aat/quantifiable-axes/index.html` の mobile / desktop 表示確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
