### PR TITLE
トップページのSFTリンクを拡充する

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -590,6 +590,56 @@ p {
   color: var(--accent-warm);
 }
 
+.sft-chapter-map {
+  display: grid;
+  gap: 18px;
+  border-top: 1px solid rgba(152, 169, 161, 0.64);
+  padding-top: 18px;
+}
+
+.sft-chapter-group {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.38fr) minmax(0, 1fr);
+  gap: 16px 24px;
+  border-bottom: 1px solid rgba(152, 169, 161, 0.44);
+  padding-bottom: 18px;
+}
+
+.sft-chapter-group:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.sft-part-link {
+  color: #21302d;
+  font-family: var(--font-sans);
+  font-size: 0.92rem;
+  font-weight: 750;
+  line-height: 1.35;
+  text-decoration: none;
+}
+
+.sft-subchapter-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 18px;
+}
+
+.sft-subchapter-links a {
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 650;
+  line-height: 1.35;
+  text-decoration: none;
+  text-decoration-color: rgba(49, 95, 131, 0.28);
+}
+
+.sft-part-link:hover,
+.sft-subchapter-links a:hover {
+  color: var(--accent-warm);
+}
+
 .document-table {
   border-top: 1px solid var(--rule-strong);
 }
@@ -2232,6 +2282,11 @@ p {
   .home-page .chapter-link-list {
     grid-template-columns: 1fr;
     gap: 0;
+  }
+
+  .sft-chapter-group,
+  .sft-subchapter-links {
+    grid-template-columns: 1fr;
   }
 
   .home-page .featured-article {

--- a/website/index.html
+++ b/website/index.html
@@ -149,10 +149,34 @@
           </div>
           <div class="research-detail">
             <a class="research-primary-link" href="sft/">Read SFT overview</a>
-            <nav class="chapter-link-list" aria-label="SFT chapters">
-              <a href="sft/field-and-force/">Part 1. Field and Force</a>
-              <a href="sft/computation/">Part 2. Computation</a>
-              <a href="sft/software-evolution/">Part 3. Software Evolution</a>
+            <nav class="sft-chapter-map" aria-label="SFT chapters">
+              <div class="sft-chapter-group">
+                <a class="sft-part-link" href="sft/field-and-force/">Part 1. Field and Force</a>
+                <div class="sft-subchapter-links">
+                  <a href="sft/field-and-force/field/">1-1. Field</a>
+                  <a href="sft/field-and-force/force/">1-2. Force</a>
+                  <a href="sft/field-and-force/organization/">1-3. Organization</a>
+                  <a href="sft/field-and-force/governance/">1-4. Governance</a>
+                </div>
+              </div>
+              <div class="sft-chapter-group">
+                <a class="sft-part-link" href="sft/computation/">Part 2. Computation</a>
+                <div class="sft-subchapter-links">
+                  <a href="sft/computation/interface/">2-1. Interface</a>
+                  <a href="sft/computation/computational-core/">2-2. Computational Core</a>
+                  <a href="sft/computation/forecast-cone/">2-3. ForecastCone</a>
+                  <a href="sft/computation/workbench/">2-4. Workbench</a>
+                </div>
+              </div>
+              <div class="sft-chapter-group">
+                <a class="sft-part-link" href="sft/software-evolution/">Part 3. Software Evolution</a>
+                <div class="sft-subchapter-links">
+                  <a href="sft/software-evolution/field-shaping/">3-1. Field Shaping</a>
+                  <a href="sft/software-evolution/attractor-engineering/">3-2. Attractor Engineering</a>
+                  <a href="sft/software-evolution/ai-proposal-governance/">3-3. AI Proposal Governance</a>
+                  <a href="sft/software-evolution/lifecycle-closed-loop/">3-4. Lifecycle and Closed Loop</a>
+                </div>
+              </div>
             </nav>
           </div>
         </div>


### PR DESCRIPTION
## 概要

トップページの SFT セクションに、Part 1/2/3 の親リンクだけでなく各下層ページへのリンクを追加しました。

- Part ごとに下層ページをグルーピング
- SFT セクション専用のリンクレイアウトを追加
- desktop / mobile でリンクがはみ出さず、Software Evolution が 1 行で表示されることを確認

対象 Issue: なし（トップページの小規模 website 改善）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] Playwright による `website/index.html` の desktop / mobile 表示確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [ ] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean / docs 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている