### PR TITLE
SFT大定理の日本語名を追記

### DIFF
--- a/docs/sft/sft_theorem_roadmap_and_research_vision.md
+++ b/docs/sft/sft_theorem_roadmap_and_research_vision.md
@@ -691,6 +691,8 @@ This would give a deeper semantics of refactoring, migration, and architecture-p
 
 ## 6. Grand Theorem: Fundamental Modularity Theorem of Software Evolution
 
+日本語名: **ソフトウェア進化の基本定理**
+
 The above theorems suggest a larger unifying theorem.
 
 ### Statement Sketch


### PR DESCRIPTION
## 概要

SFT の Grand Theorem `Fundamental Modularity Theorem of Software Evolution` に、日本語名として **ソフトウェア進化の基本定理** を追記しました。

対象 Issue: なし（docs の表記追加のみ）

## 証明した定理

- なし

## 編集したドキュメント

- `docs/sft/sft_theorem_roadmap_and_research_vision.md`

## 実施したテスト

- [ ] `lake build`（未実施: docs の日本語名追記のみ）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（未実施: Lean ソース変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（該当なし: docs の表記追加のみ）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている