### PR TITLE
ArchMap source inventory fixture と validation を固定

### DIFF
--- a/docs/tool/archmap_prd.md
+++ b/docs/tool/archmap_prd.md
@@ -211,13 +211,17 @@ manifest である。
 | `includedRefs[]` | LLM に渡した file、symbol、doc section、test、trace、PR metadata。 |
 | `excludedRefs[]` | scope 外、large file、generated file、binary、private data など。 |
 | `unavailableRefs[]` | 参照は必要だが取得できない artifact。 |
-| `selectionReason` | scope を選んだ理由。 |
+| `selectionBoundary` | scope を選んだ境界と理由。 |
 | `hashes[]` | 可能な範囲での content hash / revision ref。 |
 | `knownBlindSpots[]` | dynamic import、reflection、framework convention、runtime trace 不足など。 |
 
 `sourceRefs[]` はこの inventory の中の item を参照する。inventory にない source ref を
 LLM が出した場合、validator は dangling source ref として扱う。private / unavailable
 context は safe や measured zero へ丸めず、coverage gap として保持する。
+canonical fixture では `sourceInventoryRef.path` が
+`tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json` を指し、validator は
+この独立 artifact の欠落や `sourceUniverse` との不整合を `sourceInventoryChecks` に boundary
+finding として記録する。
 
 ### R4. Semantic structure を第一級 mapping kind にする
 

--- a/docs/tool/examples.md
+++ b/docs/tool/examples.md
@@ -134,6 +134,13 @@ fixture は次を同時に表す。
 - Semantic structure: selected semantic diagram、semantic commutation claim、nonfillability witness。
 - Boundary: measured semantic evidence、unmeasured runtime evidence、assumed policy boundary、private / unavailable context、conflict review cue。
 
+`archmap.json` の `sourceInventoryRef` は、独立 fixture
+`tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json` を指す。この source inventory
+artifact は LLM に渡した bounded review universe を再現するためのもので、included / excluded /
+unavailable / private refs、hash、known blind spots、selection boundary を保持する。`archmap`
+validation は、この artifact の欠落や `sourceUniverse` との不整合を architecture ground truth
+判定ではなく `sourceInventoryChecks` の boundary finding として報告する。
+
 `archmap` validation は、LLM-authored measured claim と formal/proved claim を混同しない。
 `air-from-archmap` projection は、semantic measured zero と semantic unmeasured、missing evidence と
 measured zero、conflict と resolved claim を混同しない。

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -117,6 +117,11 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- archmap \
 
 `archmap` は `archmap-validation-report-v0` を出す。source inventory / source refs、
 claim boundary、semantic coverage、conflict category、formal promotion guardrail を検査する。
+canonical fixture では `sourceInventoryRef.path` が
+`tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json` を指し、validation は
+その独立 artifact の存在、included / excluded / unavailable / private boundary、hash、
+selection boundary が `archmap.json` 内の `sourceUniverse` と整合するかを
+`sourceInventoryChecks` に記録する。
 warning は conflict や dangling boundary を review cue として残すために使い、semantic correctness や
 architecture lawfulness は結論しない。
 

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -2,22 +2,31 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
 use crate::{
-    AIR_SCHEMA_VERSION, ARCHMAP_SCHEMA_VERSION, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
-    AirArchitecturePath, AirArtifact, AirClaim, AirComponent, AirCoverage, AirCoverageLayer,
-    AirDocumentV0, AirEvidence, AirExtension, AirFeature, AirIdPolicies, AirNonfillabilityWitness,
-    AirOperationTrace, AirPolicies, AirRelation, AirRevision, AirSemanticDiagram, AirSignature,
-    ArchMapConflict, ArchMapDocumentV0, ArchMapMapItem, ArchMapSourceRef,
-    ArchMapValidationReportV0, ArchMapValidationSummary, Sig0Document, ValidationCheck,
+    AIR_SCHEMA_VERSION, ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION,
+    ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, AirArchitecturePath, AirArtifact, AirClaim,
+    AirComponent, AirCoverage, AirCoverageLayer, AirDocumentV0, AirEvidence, AirExtension,
+    AirFeature, AirIdPolicies, AirNonfillabilityWitness, AirOperationTrace, AirPolicies,
+    AirRelation, AirRevision, AirSemanticDiagram, AirSignature, ArchMapConflict, ArchMapDocumentV0,
+    ArchMapMapItem, ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapValidationReportV0,
+    ArchMapValidationSummary, Sig0Document, ValidationCheck,
 };
+
+pub struct ArchMapSourceInventoryInput<'a> {
+    pub path: &'a str,
+    pub document: Option<&'a ArchMapSourceInventoryV0>,
+    pub read_error: Option<String>,
+}
 
 pub fn validate_archmap_report(
     document: &ArchMapDocumentV0,
     input_path: &str,
     sig0: Option<&Sig0Document>,
+    source_inventory: Option<ArchMapSourceInventoryInput<'_>>,
 ) -> ArchMapValidationReportV0 {
     let source_inventory_checks = vec![
         check_archmap_schema_version(&document.schema_version),
         check_source_inventory_boundary(document),
+        check_source_inventory_artifact(document, source_inventory.as_ref()),
     ];
     let mut source_ref_checks = vec![check_archmap_unique_map_item_ids(document)];
     source_ref_checks.push(check_source_refs(document));
@@ -106,6 +115,18 @@ pub fn build_air_from_archmap(
         rule_id: Some(document.schema_version.clone()),
         confidence: Some("medium".to_string()),
     }];
+    if let Some(source_inventory_ref) = &document.source_inventory_ref {
+        evidence.push(AirEvidence {
+            evidence_id: "evidence-archmap-source-inventory".to_string(),
+            kind: "manual_annotation".to_string(),
+            artifact_ref: Some(source_inventory_ref.artifact_id.clone()),
+            path: source_inventory_ref.path.clone(),
+            symbol: None,
+            line: None,
+            rule_id: Some(document.schema_version.clone()),
+            confidence: Some("medium".to_string()),
+        });
+    }
     let mut source_evidence_ids = BTreeMap::new();
     for source_ref in all_source_refs(document) {
         let key = source_ref_key(source_ref);
@@ -405,6 +426,142 @@ fn check_source_inventory_boundary(document: &ArchMapDocumentV0) -> ValidationCh
     )
 }
 
+fn check_source_inventory_artifact(
+    document: &ArchMapDocumentV0,
+    source_inventory: Option<&ArchMapSourceInventoryInput<'_>>,
+) -> ValidationCheck {
+    let Some(source_inventory_ref) = &document.source_inventory_ref else {
+        return warning_check_from_examples(
+            "archmap-source-inventory-artifact",
+            "Source inventory artifact ref is present and matches sourceUniverse",
+            vec![generic_validation_example(
+                "sourceInventoryRef",
+                "missing",
+                "source inventory artifact ref is absent; input boundary remains embedded only",
+            )],
+        );
+    };
+
+    let mut examples = Vec::new();
+    let expected_path = source_inventory_ref.path.as_deref().unwrap_or_default();
+    if expected_path.trim().is_empty() {
+        examples.push(generic_validation_example(
+            "sourceInventoryRef.path",
+            "empty",
+            "source inventory artifact path must be explicit",
+        ));
+    }
+
+    let Some(source_inventory) = source_inventory else {
+        examples.push(generic_validation_example(
+            "sourceInventoryRef.path",
+            expected_path,
+            "source inventory artifact was not supplied to validation",
+        ));
+        return warning_check_from_examples(
+            "archmap-source-inventory-artifact",
+            "Source inventory artifact ref is present and matches sourceUniverse",
+            examples,
+        );
+    };
+
+    if source_inventory.path != expected_path {
+        examples.push(generic_validation_example(
+            "sourceInventoryRef.path",
+            source_inventory.path,
+            "loaded source inventory path differs from ArchMap sourceInventoryRef.path",
+        ));
+    }
+    if let Some(read_error) = &source_inventory.read_error {
+        examples.push(generic_validation_example(
+            "sourceInventoryRef.path",
+            expected_path,
+            read_error,
+        ));
+    }
+
+    let Some(inventory) = source_inventory.document else {
+        return warning_check_from_examples(
+            "archmap-source-inventory-artifact",
+            "Source inventory artifact ref is present and matches sourceUniverse",
+            examples,
+        );
+    };
+
+    if inventory.schema_version != ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION {
+        examples.push(generic_validation_example(
+            "sourceInventory.schemaVersion",
+            &inventory.schema_version,
+            "source inventory schema version is unsupported",
+        ));
+    }
+    if inventory.root != document.source_universe.root {
+        examples.push(generic_validation_example(
+            "sourceInventory.root",
+            &inventory.root,
+            "source inventory root differs from ArchMap sourceUniverse.root",
+        ));
+    }
+    if inventory.selection_boundary != document.source_universe.selection_boundary {
+        examples.push(generic_validation_example(
+            "sourceInventory.selectionBoundary",
+            &inventory.selection_boundary,
+            "source inventory selection boundary differs from ArchMap sourceUniverse",
+        ));
+    }
+
+    compare_source_ref_sets(
+        &mut examples,
+        "includedRefs",
+        &inventory.included_refs,
+        &document.source_universe.included_refs,
+    );
+    compare_source_ref_sets(
+        &mut examples,
+        "excludedRefs",
+        &inventory.excluded_refs,
+        &document.source_universe.excluded_refs,
+    );
+    compare_source_ref_sets(
+        &mut examples,
+        "unavailableRefs",
+        &inventory.unavailable_refs,
+        &document.source_universe.unavailable_refs,
+    );
+    compare_source_ref_sets(
+        &mut examples,
+        "privateRefs",
+        &inventory.private_refs,
+        &document.source_universe.private_refs,
+    );
+
+    compare_artifact_ref_sets(
+        &mut examples,
+        "hashes",
+        &inventory.hashes,
+        &document.source_universe.hashes,
+    );
+
+    let mut check = warning_check_from_examples(
+        "archmap-source-inventory-artifact",
+        "Source inventory artifact ref is present and matches sourceUniverse",
+        examples,
+    );
+    if check.result == "pass" {
+        check.count = Some(
+            inventory.included_refs.len()
+                + inventory.excluded_refs.len()
+                + inventory.unavailable_refs.len()
+                + inventory.private_refs.len(),
+        );
+        check.reason = Some(
+            "source inventory preserves included, excluded, unavailable, private, hash, and selection boundary categories"
+                .to_string(),
+        );
+    }
+    check
+}
+
 fn check_archmap_unique_map_item_ids(document: &ArchMapDocumentV0) -> ValidationCheck {
     let duplicate_ids = duplicates(
         document
@@ -595,6 +752,62 @@ fn check_from_examples(
         check.examples = examples;
     }
     check
+}
+
+fn warning_check_from_examples(
+    id: &str,
+    title: &str,
+    examples: Vec<crate::ValidationExample>,
+) -> ValidationCheck {
+    check_from_examples(id, title, examples, "warn")
+}
+
+fn compare_source_ref_sets(
+    examples: &mut Vec<crate::ValidationExample>,
+    field: &str,
+    inventory_refs: &[ArchMapSourceRef],
+    embedded_refs: &[ArchMapSourceRef],
+) {
+    let inventory_keys: BTreeSet<_> = inventory_refs.iter().map(source_ref_key).collect();
+    let embedded_keys: BTreeSet<_> = embedded_refs.iter().map(source_ref_key).collect();
+    for key in inventory_keys.difference(&embedded_keys) {
+        examples.push(generic_validation_example(
+            &format!("sourceInventory.{field}"),
+            key,
+            "source inventory ref is absent from embedded ArchMap sourceUniverse",
+        ));
+    }
+    for key in embedded_keys.difference(&inventory_keys) {
+        examples.push(generic_validation_example(
+            &format!("sourceUniverse.{field}"),
+            key,
+            "embedded ArchMap sourceUniverse ref is absent from source inventory artifact",
+        ));
+    }
+}
+
+fn compare_artifact_ref_sets(
+    examples: &mut Vec<crate::ValidationExample>,
+    field: &str,
+    inventory_refs: &[crate::ArchMapArtifactRef],
+    embedded_refs: &[crate::ArchMapArtifactRef],
+) {
+    let inventory_keys: BTreeSet<_> = inventory_refs.iter().map(artifact_ref_key).collect();
+    let embedded_keys: BTreeSet<_> = embedded_refs.iter().map(artifact_ref_key).collect();
+    for key in inventory_keys.difference(&embedded_keys) {
+        examples.push(generic_validation_example(
+            &format!("sourceInventory.{field}"),
+            key,
+            "source inventory artifact hash is absent from embedded ArchMap sourceUniverse",
+        ));
+    }
+    for key in embedded_keys.difference(&inventory_keys) {
+        examples.push(generic_validation_example(
+            &format!("sourceUniverse.{field}"),
+            key,
+            "embedded ArchMap sourceUniverse hash is absent from source inventory artifact",
+        ));
+    }
 }
 
 fn explicit_and_derived_conflicts(
@@ -954,6 +1167,21 @@ fn source_ref_key(source_ref: &ArchMapSourceRef) -> String {
             .unwrap_or_default(),
         source_ref.section.as_deref().unwrap_or("")
     )
+}
+
+fn artifact_ref_key(artifact_ref: &crate::ArchMapArtifactRef) -> String {
+    let mut parts = Vec::new();
+    parts.push(format!("artifactId={}", artifact_ref.artifact_id));
+    if let Some(kind) = &artifact_ref.kind {
+        parts.push(format!("kind={kind}"));
+    }
+    if let Some(path) = &artifact_ref.path {
+        parts.push(format!("path={path}"));
+    }
+    if let Some(content_hash) = &artifact_ref.content_hash {
+        parts.push(format!("contentHash={content_hash}"));
+    }
+    parts.join("|")
 }
 
 fn stable_id(value: &str) -> String {

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -61,7 +61,7 @@ pub use architecture_field::{
     static_architecture_field_snapshot, static_operation_proposal_log,
     validate_architecture_field_snapshot, validate_operation_proposal_log,
 };
-pub use archmap::{build_air_from_archmap, validate_archmap_report};
+pub use archmap::{ArchMapSourceInventoryInput, build_air_from_archmap, validate_archmap_report};
 pub use artifact_descriptor::{
     build_artifact_descriptor_from_ai_proposal_json,
     build_artifact_descriptor_from_github_issue_json, build_artifact_descriptor_from_markdown,

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -1,14 +1,15 @@
 use std::error::Error;
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use archsig::{
     AiProposalGovernanceV0, AiProposalGovernanceValidationReportV0, AirDocumentInput,
-    AirDocumentV0, AirValidationReport, ArchMapDocumentV0, ArchMapValidationReportV0,
-    ArchitectureDynamicsMetricsReportV0, ArchitectureDynamicsMetricsReportValidationReportV0,
-    ArchitectureFieldSnapshotV0, ArchitectureFieldSnapshotValidationReportV0, ArtifactDescriptorV0,
+    AirDocumentV0, AirValidationReport, ArchMapDocumentV0, ArchMapSourceInventoryInput,
+    ArchMapSourceInventoryV0, ArchMapValidationReportV0, ArchitectureDynamicsMetricsReportV0,
+    ArchitectureDynamicsMetricsReportValidationReportV0, ArchitectureFieldSnapshotV0,
+    ArchitectureFieldSnapshotValidationReportV0, ArtifactDescriptorV0,
     ArtifactDescriptorValidationReportV0, CalibrationReviewRecordV0,
     ComponentUniverseValidationReport, ConsequenceEnvelopeReportV0,
     ConsequenceEnvelopeValidationReportV0, CustomRulePluginRegistryV0,
@@ -1303,10 +1304,38 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
         Some(Command::Archmap { input, sig0, out }) => {
             let document: ArchMapDocumentV0 = read_json(&input)?;
             let sig0_document: Option<Sig0Document> = sig0.as_ref().map(read_json).transpose()?;
+            let source_inventory_path = document
+                .source_inventory_ref
+                .as_ref()
+                .and_then(|source_inventory_ref| source_inventory_ref.path.as_deref());
+            let mut source_inventory_document: Option<ArchMapSourceInventoryV0> = None;
+            let mut source_inventory_error: Option<String> = None;
+            if let Some(path) = source_inventory_path {
+                match resolve_archmap_sidecar_path(&input, path) {
+                    Some(resolved_path) => match read_json(&resolved_path) {
+                        Ok(source_inventory) => source_inventory_document = Some(source_inventory),
+                        Err(error) => {
+                            source_inventory_error = Some(format!(
+                                "source inventory artifact could not be read: {error}"
+                            ));
+                        }
+                    },
+                    None => {
+                        source_inventory_error =
+                            Some("source inventory artifact path does not exist".to_string());
+                    }
+                }
+            }
+            let source_inventory = source_inventory_path.map(|path| ArchMapSourceInventoryInput {
+                path,
+                document: source_inventory_document.as_ref(),
+                read_error: source_inventory_error.clone(),
+            });
             let report: ArchMapValidationReportV0 = validate_archmap_report(
                 &document,
                 &input.display().to_string(),
                 sig0_document.as_ref(),
+                source_inventory,
             );
             let failed = report.summary.result == "fail";
             write_json(out, &report)?;
@@ -2237,6 +2266,33 @@ fn write_text(out: Option<PathBuf>, value: &str) -> Result<(), Box<dyn Error>> {
 
 fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T, Box<dyn Error>> {
     Ok(serde_json::from_reader(File::open(path)?)?)
+}
+
+fn resolve_archmap_sidecar_path(archmap_path: &Path, sidecar_path: &str) -> Option<PathBuf> {
+    let raw_path = PathBuf::from(sidecar_path);
+    if raw_path.is_absolute() {
+        return raw_path.exists().then_some(raw_path);
+    }
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        let candidate = current_dir.join(&raw_path);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    let archmap_parent = archmap_path.parent()?;
+    let local_candidate = archmap_parent.join(&raw_path);
+    if local_candidate.exists() {
+        return Some(local_candidate);
+    }
+    for ancestor in archmap_parent.ancestors() {
+        let candidate = ancestor.join(&raw_path);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn read_risk_dispositions(paths: &[PathBuf]) -> Result<Vec<RiskDispositionV0>, Box<dyn Error>> {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -13,6 +13,7 @@ pub const SIGNATURE_DIFF_REPORT_SCHEMA_VERSION: &str = "signature-diff-report-v0
 pub const AIR_SCHEMA_VERSION: &str = "aat-air-v0";
 pub const AIR_VALIDATION_REPORT_SCHEMA_VERSION: &str = "aat-air-validation-report-v0";
 pub const ARCHMAP_SCHEMA_VERSION: &str = "archmap-v0";
+pub const ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION: &str = "archmap-source-inventory-v0";
 pub const ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION: &str = "archmap-validation-report-v0";
 pub const FEATURE_EXTENSION_REPORT_SCHEMA_VERSION: &str = "feature-extension-report-v0";
 pub const OBSTRUCTION_WITNESS_SCHEMA_VERSION: &str = "obstruction-witness-v0";
@@ -2156,6 +2157,29 @@ pub struct ArchMapSourceUniverse {
     #[serde(default)]
     pub known_blind_spots: Vec<String>,
     pub selection_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapSourceInventoryV0 {
+    pub schema_version: String,
+    pub inventory_id: String,
+    pub root: String,
+    #[serde(default)]
+    pub included_refs: Vec<ArchMapSourceRef>,
+    #[serde(default)]
+    pub excluded_refs: Vec<ArchMapSourceRef>,
+    #[serde(default)]
+    pub unavailable_refs: Vec<ArchMapSourceRef>,
+    #[serde(default)]
+    pub private_refs: Vec<ArchMapSourceRef>,
+    #[serde(default)]
+    pub hashes: Vec<ArchMapArtifactRef>,
+    #[serde(default)]
+    pub known_blind_spots: Vec<String>,
+    pub selection_boundary: String,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -74,6 +74,20 @@ fn cli_validates_archmap_fixture_and_guardrails() {
     let json = read_json(&report);
     assert_eq!(json["schemaVersion"], "archmap-validation-report-v0");
     assert_eq!(json["summary"]["result"], "warn");
+    let source_inventory_checks = json["sourceInventoryChecks"]
+        .as_array()
+        .expect("source inventory checks are an array");
+    assert!(
+        source_inventory_checks.iter().any(|check| {
+            check["id"] == "archmap-source-inventory-artifact"
+                && check["result"] == "pass"
+                && check["reason"]
+                    .as_str()
+                    .expect("source inventory pass has a reason")
+                    .contains("included, excluded, unavailable, private")
+        }),
+        "source inventory artifact boundary should be present and consistent"
+    );
     assert!(
         json["conflictChecks"][0]["examples"]
             .as_array()
@@ -120,6 +134,109 @@ fn cli_validates_archmap_fixture_and_guardrails() {
     assert_eq!(
         invalid_report_json["formalPromotionGuardrailChecks"][0]["id"],
         "archmap-formal-promotion-guardrail"
+    );
+
+    let missing_inventory = out_dir.join("archmap-missing-source-inventory.json");
+    let missing_inventory_report = out_dir.join("archmap-missing-source-inventory-report.json");
+    let mut missing_inventory_json = read_json(&input);
+    missing_inventory_json["sourceInventoryRef"]["path"] =
+        serde_json::json!("tools/archsig/tests/fixtures/minimal/missing_source_inventory.json");
+    fs::write(
+        &missing_inventory,
+        serde_json::to_string_pretty(&missing_inventory_json)
+            .expect("missing inventory ArchMap serializes"),
+    )
+    .expect("missing inventory ArchMap is written");
+
+    run_sig0(&[
+        "archmap",
+        "--input",
+        missing_inventory
+            .to_str()
+            .expect("missing inventory path is utf-8"),
+        "--out",
+        missing_inventory_report
+            .to_str()
+            .expect("output path is utf-8"),
+    ]);
+    let missing_inventory_report_json = read_json(&missing_inventory_report);
+    assert_eq!(missing_inventory_report_json["summary"]["result"], "warn");
+    assert!(
+        missing_inventory_report_json["sourceInventoryChecks"]
+            .as_array()
+            .expect("source inventory checks are an array")
+            .iter()
+            .any(|check| {
+                check["id"] == "archmap-source-inventory-artifact"
+                    && check["result"] == "warn"
+                    && check["examples"]
+                        .as_array()
+                        .expect("warning examples are an array")
+                        .iter()
+                        .any(|example| {
+                            example["evidence"] == "source inventory artifact path does not exist"
+                        })
+            })
+    );
+
+    let mismatched_inventory = out_dir.join("archmap-source-inventory-mismatched.json");
+    let mismatched_archmap = out_dir.join("archmap-mismatched-source-inventory.json");
+    let mismatched_inventory_report =
+        out_dir.join("archmap-mismatched-source-inventory-report.json");
+    let mut inventory_json = read_json(&fixture_root().join("archmap_source_inventory.json"));
+    inventory_json["includedRefs"] = serde_json::json!([]);
+    fs::write(
+        &mismatched_inventory,
+        serde_json::to_string_pretty(&inventory_json).expect("mismatched inventory serializes"),
+    )
+    .expect("mismatched inventory is written");
+    let mut mismatched_archmap_json = read_json(&input);
+    mismatched_archmap_json["sourceInventoryRef"]["path"] = serde_json::json!(
+        mismatched_inventory
+            .to_str()
+            .expect("mismatched inventory path is utf-8")
+    );
+    fs::write(
+        &mismatched_archmap,
+        serde_json::to_string_pretty(&mismatched_archmap_json)
+            .expect("mismatched ArchMap serializes"),
+    )
+    .expect("mismatched ArchMap is written");
+
+    run_sig0(&[
+        "archmap",
+        "--input",
+        mismatched_archmap
+            .to_str()
+            .expect("mismatched ArchMap path is utf-8"),
+        "--out",
+        mismatched_inventory_report
+            .to_str()
+            .expect("output path is utf-8"),
+    ]);
+    let mismatched_inventory_report_json = read_json(&mismatched_inventory_report);
+    assert_eq!(
+        mismatched_inventory_report_json["summary"]["result"],
+        "warn"
+    );
+    assert!(
+        mismatched_inventory_report_json["sourceInventoryChecks"]
+            .as_array()
+            .expect("source inventory checks are an array")
+            .iter()
+            .any(|check| {
+                check["id"] == "archmap-source-inventory-artifact"
+                    && check["result"] == "warn"
+                    && check["examples"]
+                        .as_array()
+                        .expect("warning examples are an array")
+                        .iter()
+                        .any(|example| {
+                            example["source"] == "sourceUniverse.includedRefs"
+                                && example["evidence"]
+                                    == "embedded ArchMap sourceUniverse ref is absent from source inventory artifact"
+                        })
+            })
     );
 }
 
@@ -173,6 +290,28 @@ fn cli_projects_archmap_to_air_and_existing_reports() {
 
     let air_json = read_json(&air);
     assert_eq!(air_json["schemaVersion"], "aat-air-v0");
+    assert!(
+        air_json["artifacts"]
+            .as_array()
+            .expect("AIR artifacts are an array")
+            .iter()
+            .any(|artifact| {
+                artifact["artifactId"] == "source-inventory-fixture"
+                    && artifact["kind"] == "source_inventory"
+                    && artifact["path"]
+                        == "tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json"
+            })
+    );
+    assert!(
+        air_json["evidence"]
+            .as_array()
+            .expect("AIR evidence is an array")
+            .iter()
+            .any(|evidence| {
+                evidence["evidenceId"] == "evidence-archmap-source-inventory"
+                    && evidence["artifactRef"] == "source-inventory-fixture"
+            })
+    );
     assert!(
         air_json["semanticDiagrams"]
             .as_array()

--- a/tools/archsig/tests/fixtures/minimal/archmap.json
+++ b/tools/archsig/tests/fixtures/minimal/archmap.json
@@ -19,7 +19,8 @@
   "sourceInventoryRef": {
     "artifactId": "source-inventory-fixture",
     "kind": "source_inventory",
-    "path": "tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json"
+    "path": "tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json",
+    "contentHash": "sha256-fixture-source-inventory"
   },
   "generationBoundary": {
     "tokenBudget": "fixture",

--- a/tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json
+++ b/tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": "archmap-source-inventory-v0",
+  "inventoryId": "source-inventory-fixture",
+  "root": ".",
+  "includedRefs": [
+    {
+      "artifactId": "src-route-users",
+      "kind": "file",
+      "path": "src/routes/users.ts",
+      "symbol": "createUserRoute",
+      "line": 42
+    },
+    {
+      "artifactId": "src-service-user",
+      "kind": "file",
+      "path": "src/services/user.ts",
+      "symbol": "UserService",
+      "line": 12
+    },
+    {
+      "artifactId": "doc-architecture",
+      "kind": "docSection",
+      "path": "docs/architecture.md",
+      "section": "Layer policy"
+    },
+    {
+      "artifactId": "test-user-contract",
+      "kind": "test",
+      "path": "tests/user_contract.test.ts",
+      "symbol": "createsUser"
+    }
+  ],
+  "excludedRefs": [
+    {
+      "kind": "file",
+      "path": "dist/generated.js"
+    }
+  ],
+  "unavailableRefs": [
+    {
+      "kind": "runtimeTrace",
+      "path": ".lake/runtime-trace.json"
+    }
+  ],
+  "privateRefs": [
+    {
+      "kind": "privateContext",
+      "path": "private/customer-rules.md"
+    }
+  ],
+  "hashes": [
+    {
+      "artifactId": "src-route-users",
+      "path": "src/routes/users.ts",
+      "contentHash": "sha256-fixture-route"
+    }
+  ],
+  "knownBlindSpots": [
+    "runtime traces not supplied",
+    "dynamic plugin loading not inspected"
+  ],
+  "selectionBoundary": "bounded ArchMap MVP fixture over route, service, policy doc, and contract test",
+  "nonConclusions": [
+    "source inventory is a bounded review universe, not a complete repository mirror",
+    "private refs are named only as boundary markers and are not reconstructed"
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1080

- `tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json` を追加し、canonical `archmap.json` の `sourceInventoryRef` と整合させました。
- `archmap` validation が source inventory artifact の存在、schema、included / excluded / unavailable / private refs、hash、selection boundary と `sourceUniverse` の整合を `sourceInventoryChecks` に報告するようにしました。
- 欠落・不整合は architecture ground truth 判定ではなく warning の boundary finding として扱い、AIR projection では source inventory を artifact と evidence boundary の両方に保持します。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archmap_prd.md`
- `docs/tool/examples.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml archmap`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `LC_ALL=C rg -n "[\\x{200B}\\x{200C}\\x{200D}\\x{200E}\\x{200F}\\x{202A}\\x{202B}\\x{202C}\\x{202D}\\x{202E}\\x{2066}\\x{2067}\\x{2068}\\x{2069}\\x{FEFF}]" tools/archsig docs/tool`
- [x] production Rust 差分の `unwrap` / `expect` / `panic!` scan: `git diff -U0 -- tools/archsig/src/archmap.rs tools/archsig/src/main.rs | rg -n "^\\+.*(unwrap\\(|expect\\(|panic!|TODO|placeholder)"`
- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #1080` 形式で本文に記載した
- [x] Lean status は Issue 記載どおり empirical hypothesis / tooling design の範囲で、Lean theorem の追加なし
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている