### PR TITLE
[website] サイドバーを sticky scroll と mobile accordion に改善する

### DIFF
--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -1037,6 +1037,11 @@ p {
   top: 92px;
   display: grid;
   gap: 18px;
+  max-height: calc(100vh - 112px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+  scrollbar-gutter: stable;
   min-width: 0;
 }
 
@@ -2221,6 +2226,24 @@ p {
 
   .article-sidebar {
     position: static;
+    gap: 10px;
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
+    scrollbar-gutter: auto;
+  }
+
+  .article-sidebar > .toc-panel,
+  .article-sidebar > .source-panel,
+  .article-sidebar > .version-panel,
+  .article-sidebar > .boundary-note {
+    padding-top: 11px;
+  }
+
+  .article-sidebar .sidebar-panel-content {
+    max-height: min(58vh, 420px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   .theorem-card-grid {

--- a/website/assets/site.js
+++ b/website/assets/site.js
@@ -58,6 +58,8 @@ navLinks
 document.querySelector("[data-current-year]").textContent =
   new Date().getFullYear();
 
+const compactSidebarQuery = window.matchMedia("(max-width: 880px)");
+
 document
   .querySelectorAll(
     ".article-sidebar > .toc-panel, .article-sidebar > .source-panel, .article-sidebar > .version-panel, .article-sidebar > .boundary-note"
@@ -88,8 +90,9 @@ document
     button.textContent = heading.textContent;
     heading.replaceChildren(button);
 
-    const expanded =
+    const desktopExpanded =
       panel.classList.contains("toc-panel") || panel.dataset.sidebarOpen === "true";
+    const expanded = compactSidebarQuery.matches ? false : desktopExpanded;
     button.setAttribute("aria-expanded", String(expanded));
     panel.classList.toggle("is-open", expanded);
     content.hidden = !expanded;


### PR DESCRIPTION
## 概要

Closes #1084

- desktop の `.article-sidebar` に viewport 内スクロール制約を追加し、項目が多いページでも下部が見切れないようにしました。
- mobile 幅では sidebar panel の初期状態を全て閉じ、本文前のナビゲーションを compact な accordion として扱うようにしました。
- HTML 構造と site-wide navigation の情報設計は変更していません。

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [x] `playwright --version`
- [x] Playwright / Chromium で `website/aat/index.html`, `website/sft/index.html`, `website/archsig/index.html` を desktop viewport で確認
- [x] Playwright / Chromium で同3ページを mobile viewport で確認
- [x] mobile accordion の `aria-controls`, `aria-expanded`, current page 表示を確認
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `website/assets/site.css`, `website/assets/site.js`
- [ ] `lake build` は未実施。Lean 変更なし
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan は未実施。Lean 変更なし

## チェックリスト

- [x] 対象 Issue を `Closes #1084` 形式で本文に記載した
- [x] Lean status: website UX implementation。Lean theorem / proof obligation ではない
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている