### PR TITLE
website外部リンクを別タブで開く

### DIFF
--- a/website/aat/architecture-signature/index.html
+++ b/website/aat/architecture-signature/index.html
@@ -494,7 +494,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/calculus-and-extensions/index.html
+++ b/website/aat/calculus-and-extensions/index.html
@@ -467,7 +467,7 @@ repair:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/canonical-examples-and-readings/index.html
+++ b/website/aat/canonical-examples-and-readings/index.html
@@ -592,7 +592,7 @@ retry appears on runtime surface
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/formal-anchors/index.html
+++ b/website/aat/formal-anchors/index.html
@@ -154,7 +154,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#selected-presentation--complete-extraction-boundary">Selected Presentation / Complete Extraction Boundary</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#selected-presentation--complete-extraction-boundary" target="_blank" rel="noopener noreferrer">Selected Presentation / Complete Extraction Boundary</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -202,7 +202,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">Architecture Core / Certified Architecture</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture" target="_blank" rel="noopener noreferrer">Architecture Core / Certified Architecture</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -254,7 +254,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">Finite Universe / Bridge Theorems</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems" target="_blank" rel="noopener noreferrer">Finite Universe / Bridge Theorems</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -296,7 +296,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/mathematical_theory.md#2-architecture-object">mathematical theory, Chapter 2</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/mathematical_theory.md#2-architecture-object" target="_blank" rel="noopener noreferrer">mathematical theory, Chapter 2</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -417,7 +417,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#signature-integrated-lawfulness">Signature-integrated lawfulness</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#signature-integrated-lawfulness" target="_blank" rel="noopener noreferrer">Signature-integrated lawfulness</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -463,7 +463,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/proof_obligations.md#L107">Current QED boundary</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/proof_obligations.md#L107" target="_blank" rel="noopener noreferrer">Current QED boundary</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -512,7 +512,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#chapter-11-analytic-axis-boundary-api">Chapter 11 analytic axis boundary API</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#chapter-11-analytic-axis-boundary-api" target="_blank" rel="noopener noreferrer">Chapter 11 analytic axis boundary API</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -563,7 +563,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture">Architecture Core / Certified Architecture</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/3bf99081cf64d10ca230ed89d13ec734cf15cae6/docs/aat/lean_theorem_index.md#architecture-core--certified-architecture" target="_blank" rel="noopener noreferrer">Architecture Core / Certified Architecture</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -627,7 +627,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#projection--dip">Projection / DIP</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#projection--dip" target="_blank" rel="noopener noreferrer">Projection / DIP</a></dd>
                     </div>
                     <div>
                       <dt>Non-conclusion</dt>
@@ -678,7 +678,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#observation--lsp">Observation / LSP</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#observation--lsp" target="_blank" rel="noopener noreferrer">Observation / LSP</a></dd>
                     </div>
                     <div>
                       <dt>Non-conclusion</dt>
@@ -725,7 +725,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#L871">Local contract design pattern</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#L871" target="_blank" rel="noopener noreferrer">Local contract design pattern</a></dd>
                     </div>
                     <div>
                       <dt>Non-conclusion</dt>
@@ -777,7 +777,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#flatness">Flatness</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#flatness" target="_blank" rel="noopener noreferrer">Flatness</a></dd>
                     </div>
                     <div>
                       <dt>Non-conclusion</dt>
@@ -827,7 +827,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#solid-counterexamples">SOLID Counterexamples</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b84cff4556746c2911de32d2bbf81814906564fc/docs/aat/lean_theorem_index.md#solid-counterexamples" target="_blank" rel="noopener noreferrer">SOLID Counterexamples</a></dd>
                     </div>
                     <div>
                       <dt>Non-conclusion</dt>
@@ -875,7 +875,7 @@
                     </div>
                     <div>
                       <dt>Index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L453">Architecture Operation</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L453" target="_blank" rel="noopener noreferrer">Architecture Operation</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -910,7 +910,7 @@
                     </div>
                     <div>
                       <dt>Index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L599">Architecture Calculus Laws</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L599" target="_blank" rel="noopener noreferrer">Architecture Calculus Laws</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -946,7 +946,7 @@
                     </div>
                     <div>
                       <dt>Index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L280">Feature Extension</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L280" target="_blank" rel="noopener noreferrer">Feature Extension</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -982,7 +982,7 @@
                     </div>
                     <div>
                       <dt>Index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L1161">Architecture Extension Formula</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/5a90d46853ae2ee6ad014438ea0ad242869bdb37/docs/aat/lean_theorem_index.md#L1161" target="_blank" rel="noopener noreferrer">Architecture Extension Formula</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -1021,7 +1021,7 @@
                   <dl class="formal-anchor-grid">
                     <div>
                       <dt>Lean index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#repair">Repair</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#repair-synthesis">Repair Synthesis</a>.</dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#repair" target="_blank" rel="noopener noreferrer">Repair</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#repair-synthesis" target="_blank" rel="noopener noreferrer">Repair Synthesis</a>.</dd>
                     </div>
                     <div>
                       <dt>Status</dt>
@@ -1053,7 +1053,7 @@
                   <dl class="formal-anchor-grid">
                     <div>
                       <dt>Lean index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#repair-transfer-counterexample">Repair Transfer Counterexample</a>.</dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#repair-transfer-counterexample" target="_blank" rel="noopener noreferrer">Repair Transfer Counterexample</a>.</dd>
                     </div>
                     <div>
                       <dt>Status</dt>
@@ -1087,7 +1087,7 @@
                   <dl class="formal-anchor-grid">
                     <div>
                       <dt>Lean index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#architecture-path">Architecture Path</a>, <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#signature-dynamics">Signature Dynamics</a>, and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#diagram-filler">Diagram Filler</a>.</dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#architecture-path" target="_blank" rel="noopener noreferrer">Architecture Path</a>, <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#signature-dynamics" target="_blank" rel="noopener noreferrer">Signature Dynamics</a>, and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/b697cff13ab629d5bcb173ac6db8bd8d124f873b/docs/aat/lean_theorem_index.md#diagram-filler" target="_blank" rel="noopener noreferrer">Diagram Filler</a>.</dd>
                     </div>
                     <div>
                       <dt>Status</dt>
@@ -1125,7 +1125,7 @@
                   <dl class="formal-anchor-grid">
                     <div>
                       <dt>Lean index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#matrix-bridge">Matrix Bridge</a>.</dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#matrix-bridge" target="_blank" rel="noopener noreferrer">Matrix Bridge</a>.</dd>
                     </div>
                     <div>
                       <dt>Status</dt>
@@ -1157,7 +1157,7 @@
                   <dl class="formal-anchor-grid">
                     <div>
                       <dt>Lean index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#analytic-representation">Analytic Representation</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#chapter-11-analytic-representation-entrypoint">Chapter 11 Analytic Representation Entrypoint</a>.</dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#analytic-representation" target="_blank" rel="noopener noreferrer">Analytic Representation</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#chapter-11-analytic-representation-entrypoint" target="_blank" rel="noopener noreferrer">Chapter 11 Analytic Representation Entrypoint</a>.</dd>
                     </div>
                     <div>
                       <dt>Status</dt>
@@ -1189,7 +1189,7 @@
                   <dl class="formal-anchor-grid">
                     <div>
                       <dt>Lean index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#state-transition--effect-boundary-laws">State Transition / Effect Boundary Laws</a>.</dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/d1431f766df424332617ed84cb88dd17a11e9c0c/docs/aat/lean_theorem_index.md#state-transition--effect-boundary-laws" target="_blank" rel="noopener noreferrer">State Transition / Effect Boundary Laws</a>.</dd>
                     </div>
                     <div>
                       <dt>Status</dt>
@@ -1241,7 +1241,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#feature-extension">Feature Extension theorem index</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#feature-extension" target="_blank" rel="noopener noreferrer">Feature Extension theorem index</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -1289,7 +1289,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#chapter-11-coupon-analytic-snapshot-api">Coupon analytic snapshot API</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#static--semantic-counterexample">Static / Semantic Counterexample</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#chapter-11-coupon-analytic-snapshot-api" target="_blank" rel="noopener noreferrer">Coupon analytic snapshot API</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#static--semantic-counterexample" target="_blank" rel="noopener noreferrer">Static / Semantic Counterexample</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -1336,7 +1336,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#repair-transfer-counterexample">Repair Transfer Counterexample</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#repair-transfer-counterexample" target="_blank" rel="noopener noreferrer">Repair Transfer Counterexample</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -1380,7 +1380,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#solid-counterexamples">SOLID Counterexamples</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/920c07d50500b06f98ef4bc6ab32f82760903323/docs/aat/lean_theorem_index.md#solid-counterexamples" target="_blank" rel="noopener noreferrer">SOLID Counterexamples</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -1478,7 +1478,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#signature-v0">Signature v0 / v1 index</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#signature-v0" target="_blank" rel="noopener noreferrer">Signature v0 / v1 index</a></dd>
                     </div>
                   </dl>
                 </article>
@@ -1510,7 +1510,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems">Finite Universe / Bridge Theorems</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#finite-universe--bridge-theorems" target="_blank" rel="noopener noreferrer">Finite Universe / Bridge Theorems</a></dd>
                     </div>
                   </dl>
                 </article>
@@ -1541,7 +1541,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor" target="_blank" rel="noopener noreferrer">Finite Static Structural Core Formal Anchor</a></dd>
                     </div>
                   </dl>
                 </article>
@@ -1573,7 +1573,7 @@
                     </div>
                     <div>
                       <dt>Primary index</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#analytic-representation">Analytic Representation</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/44d6266ec321ef19f0c00da53f60bde92ea7a18b/docs/aat/lean_theorem_index.md#analytic-representation" target="_blank" rel="noopener noreferrer">Analytic Representation</a></dd>
                     </div>
                   </dl>
                 </article>
@@ -1594,7 +1594,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/foundations/index.html
+++ b/website/aat/foundations/index.html
@@ -564,7 +564,7 @@ reserved for another presentation:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/index.html
+++ b/website/aat/index.html
@@ -258,7 +258,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/laws-and-witnesses/index.html
+++ b/website/aat/laws-and-witnesses/index.html
@@ -453,7 +453,7 @@ Then, within B:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/local-law-packages/index.html
+++ b/website/aat/local-law-packages/index.html
@@ -502,7 +502,7 @@ ProjectionExact + RepresentativeStable
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/quantifiable-axes/index.html
+++ b/website/aat/quantifiable-axes/index.html
@@ -400,7 +400,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/related-work/index.html
+++ b/website/aat/related-work/index.html
@@ -532,7 +532,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/repair-and-dynamics/index.html
+++ b/website/aat/repair-and-dynamics/index.html
@@ -484,7 +484,7 @@ Obs(D.lhs) != Obs(D.rhs)
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/representations-and-effects/index.html
+++ b/website/aat/representations-and-effects/index.html
@@ -542,7 +542,7 @@ migrate ; project_old = project_new ; migrateEvents</code></pre>
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/aat/status/index.html
+++ b/website/aat/status/index.html
@@ -176,7 +176,7 @@
                     </tr>
                     <tr>
                       <th>Repository snapshot</th>
-                      <td><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/6709857b5cf840218f3a88a3a776c184dbf825d4">6709857</a></td>
+                      <td><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/tree/6709857b5cf840218f3a88a3a776c184dbf825d4" target="_blank" rel="noopener noreferrer">6709857</a></td>
                     </tr>
                     <tr>
                       <th>Main Lean check</th>
@@ -204,11 +204,11 @@
                   <span><code>docs/aat/mathematical_theory.md</code> is the research text for definitions, theorem candidates, examples, and design boundaries.</span>
                 </li>
                 <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md">Lean theorem index</a></strong>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md" target="_blank" rel="noopener noreferrer">Lean theorem index</a></strong>
                   <span>Declaration names, file paths, current meanings, and status labels for the implemented Lean surface.</span>
                 </li>
                 <li>
-                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/proof_obligations.md">Proof obligations</a></strong>
+                  <strong><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/proof_obligations.md" target="_blank" rel="noopener noreferrer">Proof obligations</a></strong>
                   <span>Future theorem work, empirical hypotheses, and open boundaries that sit outside the current proved core.</span>
                 </li>
                 <li>
@@ -289,7 +289,7 @@ ArchitectureLawful X
                 </li>
                 <li>
                   <strong>Index entry</strong>
-                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor">Finite Static Structural Core Formal Anchor</a>.</span>
+                  <span><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/6709857b5cf840218f3a88a3a776c184dbf825d4/docs/aat/lean_theorem_index.md#finite-static-structural-core-formal-anchor" target="_blank" rel="noopener noreferrer">Finite Static Structural Core Formal Anchor</a>.</span>
                 </li>
               </ul>
             </section>
@@ -343,7 +343,7 @@ ArchitectureLawful X
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/archsig/air/index.html
+++ b/website/archsig/air/index.html
@@ -76,7 +76,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/anatomy/index.html
+++ b/website/archsig/anatomy/index.html
@@ -81,7 +81,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/archmap/index.html
+++ b/website/archsig/archmap/index.html
@@ -80,7 +80,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/artifacts/index.html
+++ b/website/archsig/artifacts/index.html
@@ -74,7 +74,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/boundaries/index.html
+++ b/website/archsig/boundaries/index.html
@@ -74,7 +74,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/ci/index.html
+++ b/website/archsig/ci/index.html
@@ -117,7 +117,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- pr-comment \
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/commands/index.html
+++ b/website/archsig/commands/index.html
@@ -114,7 +114,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- pr-comment \
   --from-markdown docs/prd/coupon.md \
   --artifact-kind prd \
   --out .lake/signature-current/artifact-descriptor.json</code></pre></figure></section>
-<section id="source-reference" class="article-section"><h2>Source reference</h2><p>The complete repository command guide remains the implementation-facing source for command examples and edge-case notes: <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2e1e0724e1e6576f13e0235b8f68a53c82c9c4bc/tools/archsig/docs/commands.md">tools/archsig/docs/commands.md</a>. This public page keeps the product-manual index: what each command consumes, what it emits, and when an engineer should choose it.</p></section>
+<section id="source-reference" class="article-section"><h2>Source reference</h2><p>The complete repository command guide remains the implementation-facing source for command examples and edge-case notes: <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2e1e0724e1e6576f13e0235b8f68a53c82c9c4bc/tools/archsig/docs/commands.md" target="_blank" rel="noopener noreferrer">tools/archsig/docs/commands.md</a>. This public page keeps the product-manual index: what each command consumes, what it emits, and when an engineer should choose it.</p></section>
 <section id="rule" class="article-section"><h2>Command reading rule</h2><div class="claim-strip"><p>A command produces an artifact. The artifact becomes trustworthy only when its schema, evidence, status fields, and non-conclusions are read together.</p></div></section>
             <nav class="page-nav" aria-label="Reading sequence"><a class="page-nav-prev" href="../semantic-air/"><span>Previous</span><strong>Semantic AIR</strong></a><a class="page-nav-next" href="../schemas/"><span>Next</span><strong>Schemas</strong></a></nav>
           </div>
@@ -124,7 +124,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- pr-comment \
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/examples/index.html
+++ b/website/archsig/examples/index.html
@@ -81,7 +81,7 @@ Review action:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/getting-started/index.html
+++ b/website/archsig/getting-started/index.html
@@ -88,7 +88,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/index.html
+++ b/website/archsig/index.html
@@ -86,7 +86,7 @@ Boundary:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/inputs/index.html
+++ b/website/archsig/inputs/index.html
@@ -82,7 +82,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/operational-feedback/index.html
+++ b/website/archsig/operational-feedback/index.html
@@ -73,7 +73,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/reading-output/index.html
+++ b/website/archsig/reading-output/index.html
@@ -75,7 +75,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/schemas/index.html
+++ b/website/archsig/schemas/index.html
@@ -73,7 +73,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/semantic-air/index.html
+++ b/website/archsig/semantic-air/index.html
@@ -88,7 +88,7 @@ Evidence boundary:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/why/index.html
+++ b/website/archsig/why/index.html
@@ -73,7 +73,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/archsig/workflows/index.html
+++ b/website/archsig/workflows/index.html
@@ -74,7 +74,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/index.html
+++ b/website/index.html
@@ -232,7 +232,7 @@
             <a
               class="featured-article"
               href="https://blog.iroha1203.dev/software-architecture-as-a-field"
-            >
+             target="_blank" rel="noopener noreferrer">
               <img
                 src="assets/software-architecture-as-a-field.jpg"
                 alt=""
@@ -308,7 +308,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/outreach/index.html
+++ b/website/outreach/index.html
@@ -95,7 +95,7 @@
               <a
                 class="featured-article"
                 href="https://blog.iroha1203.dev/software-architecture-as-a-field"
-              >
+               target="_blank" rel="noopener noreferrer">
                 <img
                   src="../assets/software-architecture-as-a-field.jpg"
                   alt=""
@@ -124,7 +124,7 @@
               </p>
               <ul class="chapter-list">
                 <li>
-                  <a href="https://blog.iroha1203.dev/ai-agents-don-t-need-meetings-gotanda-style-for-stigmergic-software-maintenance">
+                  <a href="https://blog.iroha1203.dev/ai-agents-don-t-need-meetings-gotanda-style-for-stigmergic-software-maintenance" target="_blank" rel="noopener noreferrer">
                     AI Agents Don't Need Meetings: Gotanda Style for Stigmergic Software Maintenance
                   </a>
                   <span>
@@ -133,7 +133,7 @@
                   </span>
                 </li>
                 <li>
-                  <a href="https://blog.iroha1203.dev/attractor-engineering-seeing-software-development-as-field-dynamics">
+                  <a href="https://blog.iroha1203.dev/attractor-engineering-seeing-software-development-as-field-dynamics" target="_blank" rel="noopener noreferrer">
                     Attractor Engineering: Seeing Software Development as Field Dynamics
                   </a>
                   <span>
@@ -152,7 +152,7 @@
               </p>
               <ul class="chapter-list">
                 <li>
-                  <a href="https://zenn.dev/iroha1203/articles/93ee3d4c5d5174">
+                  <a href="https://zenn.dev/iroha1203/articles/93ee3d4c5d5174" target="_blank" rel="noopener noreferrer">
                     五反田式: スティグマジーを応用した自律型マルチエージェントシステム【日本語訳】
                   </a>
                   <span>
@@ -160,7 +160,7 @@
                   </span>
                 </li>
                 <li>
-                  <a href="https://zenn.dev/iroha1203/articles/1452a2dcc2c38b">
+                  <a href="https://zenn.dev/iroha1203/articles/1452a2dcc2c38b" target="_blank" rel="noopener noreferrer">
                     アトラクターエンジニアリングという発見
                   </a>
                   <span>
@@ -179,7 +179,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">
           Repository
         </a>
       </div>

--- a/website/sft/computation/computational-core/index.html
+++ b/website/sft/computation/computational-core/index.html
@@ -366,7 +366,7 @@ PolicyAsSelection:
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/computation/forecast-cone/index.html
+++ b/website/sft/computation/forecast-cone/index.html
@@ -288,7 +288,7 @@ StateInSafeRegion(O, R, F)
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/computation/index.html
+++ b/website/sft/computation/index.html
@@ -158,7 +158,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/computation/interface/index.html
+++ b/website/sft/computation/interface/index.html
@@ -471,7 +471,7 @@ AAT non-conclusion
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/computation/workbench/index.html
+++ b/website/sft/computation/workbench/index.html
@@ -630,7 +630,7 @@ SelectedIntervention
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/field-and-force/field/index.html
+++ b/website/sft/field-and-force/field/index.html
@@ -311,7 +311,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/field-and-force/force/index.html
+++ b/website/sft/field-and-force/force/index.html
@@ -311,7 +311,7 @@ OperationPolicy(F)
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/field-and-force/governance/index.html
+++ b/website/sft/field-and-force/governance/index.html
@@ -386,7 +386,7 @@ UpdateSound(update)
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/field-and-force/index.html
+++ b/website/sft/field-and-force/index.html
@@ -164,7 +164,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/field-and-force/organization/index.html
+++ b/website/sft/field-and-force/organization/index.html
@@ -411,7 +411,7 @@ PolicyAsPreorder
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/index.html
+++ b/website/sft/index.html
@@ -512,7 +512,7 @@ SFT    -> software evolution as computable field dynamics</code></pre>
                 </p>
                 <a
                     href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2"
-                >
+                 target="_blank" rel="noopener noreferrer">
                     Repository
                 </a>
             </div>

--- a/website/sft/references/formal-anchors/index.html
+++ b/website/sft/references/formal-anchors/index.html
@@ -196,7 +196,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTField.lean">Formal/Arch/Evolution/SFTField.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTField.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/SFTField.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -249,7 +249,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTArtifactAction.lean">Formal/Arch/Evolution/SFTArtifactAction.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTArtifactAction.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/SFTArtifactAction.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -315,7 +315,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTForecastCone.lean">Formal/Arch/Evolution/SFTForecastCone.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTForecastCone.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/SFTForecastCone.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -368,7 +368,7 @@
                     </div>
                     <div>
                       <dt>Lean sources</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTConeProjection.lean">SFTConeProjection.lean</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTSupportSafety.lean">SFTSupportSafety.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTConeProjection.lean" target="_blank" rel="noopener noreferrer">SFTConeProjection.lean</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTSupportSafety.lean" target="_blank" rel="noopener noreferrer">SFTSupportSafety.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -419,7 +419,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTReachability.lean">Formal/Arch/Evolution/SFTReachability.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTReachability.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/SFTReachability.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -480,7 +480,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/AttractorEngineering.lean">Formal/Arch/Evolution/AttractorEngineering.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/AttractorEngineering.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/AttractorEngineering.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -542,7 +542,7 @@
                     </div>
                     <div>
                       <dt>Lean sources</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTEnvelope.lean">SFTEnvelope.lean</a>, <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTArchSigBoundary.lean">SFTArchSigBoundary.lean</a>, and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTInterfaceBoundary.lean">SFTInterfaceBoundary.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTEnvelope.lean" target="_blank" rel="noopener noreferrer">SFTEnvelope.lean</a>, <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTArchSigBoundary.lean" target="_blank" rel="noopener noreferrer">SFTArchSigBoundary.lean</a>, and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTInterfaceBoundary.lean" target="_blank" rel="noopener noreferrer">SFTInterfaceBoundary.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -595,7 +595,7 @@
                     </div>
                     <div>
                       <dt>Lean sources</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTPolicy.lean">SFTPolicy.lean</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTFieldUpdate.lean">SFTFieldUpdate.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTPolicy.lean" target="_blank" rel="noopener noreferrer">SFTPolicy.lean</a> and <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTFieldUpdate.lean" target="_blank" rel="noopener noreferrer">SFTFieldUpdate.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -656,7 +656,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTTheoremPackages.lean">Formal/Arch/Evolution/SFTTheoremPackages.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTTheoremPackages.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/SFTTheoremPackages.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -799,7 +799,7 @@
                     </div>
                     <div>
                       <dt>Lean source</dt>
-                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTCounterexamples.lean">Formal/Arch/Evolution/SFTCounterexamples.lean</a></dd>
+                      <dd><a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/blob/2cb4b5eeaa7307b7cdb8dd0577695fa06d8173a4/Formal/Arch/Evolution/SFTCounterexamples.lean" target="_blank" rel="noopener noreferrer">Formal/Arch/Evolution/SFTCounterexamples.lean</a></dd>
                     </div>
                   </dl>
                   <details class="formal-anchor-details">
@@ -832,7 +832,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/references/glossary/index.html
+++ b/website/sft/references/glossary/index.html
@@ -139,7 +139,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/references/index.html
+++ b/website/sft/references/index.html
@@ -150,7 +150,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/references/research-program/index.html
+++ b/website/sft/references/research-program/index.html
@@ -196,7 +196,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/software-evolution/ai-proposal-governance/index.html
+++ b/website/sft/software-evolution/ai-proposal-governance/index.html
@@ -484,7 +484,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/software-evolution/attractor-engineering/index.html
+++ b/website/sft/software-evolution/attractor-engineering/index.html
@@ -500,7 +500,7 @@ ReachablePreimage_h(U, A)</code></pre>
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/software-evolution/field-shaping/index.html
+++ b/website/sft/software-evolution/field-shaping/index.html
@@ -333,7 +333,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/software-evolution/index.html
+++ b/website/sft/software-evolution/index.html
@@ -160,7 +160,7 @@
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>

--- a/website/sft/software-evolution/lifecycle-closed-loop/index.html
+++ b/website/sft/software-evolution/lifecycle-closed-loop/index.html
@@ -424,7 +424,7 @@ prospective set
     <footer class="site-footer">
       <div class="site-shell footer-inner">
         <p>&copy; <span data-current-year>2026</span> Hiroyuki Nakahata.</p>
-        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2">Repository</a>
+        <a href="https://github.com/iroha1203/AlgebraicArchitectureTheoryV2" target="_blank" rel="noopener noreferrer">Repository</a>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
## 概要

Closes #1095

website 内の絶対外部リンク `http(s)://...` に `target="_blank"` を付け、`rel="noopener noreferrer"` も揃えました。公開読書面から外部サイトへ移動しても元ページを残し、`window.opener` 経由のリスクも避けます。

## 証明した定理

- なし

## 編集したドキュメント

- なし（website HTML の属性更新のみ）

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] 外部リンク属性チェック（`external anchors checked: 115, bad: 0`）
- [x] `node --check website/assets/site.js`
- [x] Playwright 代表ページ確認（Home / ArchSig / ArchMap / AAT formal anchors / SFT formal anchors / Outreach、bad external links=0）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean theorem 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている