### PR TITLE
outreachページに記事リンクを追加

### DIFF
--- a/website/outreach/index.html
+++ b/website/outreach/index.html
@@ -134,6 +134,15 @@
               </p>
               <ul class="chapter-list">
                 <li>
+                  <a href="https://blog.iroha1203.dev/forecast-cone-a-grand-theorem-for-computable-software-evolution" target="_blank" rel="noopener noreferrer">
+                    Forecast Cone: A Grand Theorem for Computable Software Evolution
+                  </a>
+                  <span>
+                    An English essay introducing ForecastCone as a computable
+                    theorem boundary for reasoning about software evolution.
+                  </span>
+                </li>
+                <li>
                   <a href="https://blog.iroha1203.dev/ai-agents-don-t-need-meetings-gotanda-style-for-stigmergic-software-maintenance" target="_blank" rel="noopener noreferrer">
                     AI Agents Don't Need Meetings: Gotanda Style for Stigmergic Software Maintenance
                   </a>
@@ -161,6 +170,15 @@
                 実務寄りの視点から紹介しています。
               </p>
               <ul class="chapter-list">
+                <li>
+                  <a href="https://zenn.dev/iroha1203/articles/039598ea7f0ec3" target="_blank" rel="noopener noreferrer">
+                    Software Architecture as a Field: ソフトウェアアーキテクチャの場の理論【日本語版】
+                  </a>
+                  <span>
+                    Software Architecture as a Field の日本語版として、
+                    ソフトウェアアーキテクチャを場として読む視点を紹介する Zenn 記事です。
+                  </span>
+                </li>
                 <li>
                   <a href="https://zenn.dev/iroha1203/articles/93ee3d4c5d5174" target="_blank" rel="noopener noreferrer">
                     五反田式: スティグマジーを応用した自律型マルチエージェントシステム【日本語訳】


### PR DESCRIPTION
## 概要

対応 Issue: なし（ユーザー依頼による outreach page のリンク追加）。

- Hashnode の Forecast Cone 記事を Blogs に追加
- Zenn の Software Architecture as a Field 日本語版を 日本語記事 に追加

## 証明した定理

- なし

## 編集したドキュメント

- website/outreach/index.html

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）
- [x] Playwright による website/outreach/index.html の静的表示確認
  - page title: Outreach
  - 追加した Hashnode リンク: 1件
  - 追加した Zenn リンク: 1件

## チェックリスト

- [ ] 対象 Issue を Closes #N 形式で本文に記載した（対応 Issue なし）
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした（Lean 変更なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている