### PR TITLE
MITライセンスを追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hiroyuki Nakahata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.jp.md
+++ b/README.jp.md
@@ -200,3 +200,7 @@ Algebraic Architecture Theory V2
 Issue は研究の依存構造に沿って milestone と
 `type:*`, `area:*`, `priority:*`, `status:*` label で整理します。
 README には Issue 一覧を重複して持たせません。
+
+## ライセンス
+
+このリポジトリは MIT License で公開します。詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -208,3 +208,7 @@ Open work is tracked in GitHub Issues. Issues are organized according to the
 research dependency structure with milestones and `type:*`, `area:*`,
 `priority:*`, and `status:*` labels. The README does not duplicate the issue
 list.
+
+## License
+
+This repository is licensed under the MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
## 概要

MIT License の LICENSE ファイルを追加し、英語・日本語 README にライセンス表記を追加しました。

Issue 起点ではない軽微なリポジトリ設定変更のため、Closes #N は記載していません。

## 証明した定理

- なし

## 編集したドキュメント

- LICENSE
- README.md
- README.jp.md

## 実施したテスト

- [ ] lake build（Lean ソース変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [x] axiom / admit / sorry / unsafe scan

## チェックリスト

- [ ] 対象 Issue を Closes #N 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした（Lean status 変更なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている