### PR TITLE
ArchSig READMEにCodexスキルの説明を追加する

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -31,12 +31,29 @@ ArchSig は単一の command ではなく、次の surface に分けて読む。
 - supplied JSON の `archmap-v0` を validation report に変換し、AIR へ loss-aware に投影する。
 - 実証研究用 dataset、B10 operational feedback artifact、B12 SFT forecasting MVP の
   descriptor / support estimate / cone / envelope / calibration hook を JSON として出力する。
+- Codex skill として、ArchMap 作成、ArchSig 実行、artifact 診断の作業手順を AI agent に渡せる。
 
 詳細な command と artifact は次に分けている。
 
 - [Command Guide](docs/commands.md)
 - [Artifacts And Boundaries](docs/artifacts-and-boundaries.md)
 - [Operational Feedback](docs/operational-feedback.md)
+
+## Codex Skills
+
+`tools/archsig/skills/` には、ArchSig / ArchMap を Codex から扱うための skill bundle を置く。
+これらは ArchSig source repository に依存せず、built `archsig` binary と skill bundle だけで動ける
+ことを目標にしている。実行時は `archsig` が `PATH` にあるか、`ARCHSIG_BIN=/path/to/archsig`
+で明示されている前提で読む。
+
+| Skill | 用途 |
+| --- | --- |
+| [`archmap-creater`](skills/archmap-creater/SKILL.md) | repository evidence から bounded `archmap-v0` を作成し、source inventory、mapping guide、schema cheatsheet、examples に沿って validation まで進める。 |
+| [`archsig-executer`](skills/archsig-executer/SKILL.md) | `archsig` binary を使って scan、validation、ArchMap-to-AIR、ArchMap-to-SFT、ForecastCone、ConsequenceEnvelope などの artifact pipeline を実行する。 |
+| [`arch-doctor`](skills/arch-doctor/SKILL.md) | 生成済み artifact を読み、現在の architecture state、bounded evolution forecast、evidence gap、次の設計アクションを診断する。 |
+
+skill は AI native な操作面であり、tool output を Lean proof、forecast correctness、incident causality、
+global architecture truth として読まない。生成 artifact は標準では `.archsig/` 以下に置く。
 
 ## 最短手順
 


### PR DESCRIPTION
## 概要

`tools/archsig/README.md` に Codex Skills セクションを追加し、`archmap-creater` / `archsig-executer` / `arch-doctor` の用途と、built `archsig` binary + skill bundle で動作する前提を明記しました。

対応 Issue: なし（README 追記）

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`

## 実施したテスト

- [ ] `lake build`（未実施: README のみの変更）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（未実施: Lean ソース変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
