### PR TITLE
Issue 1161 law-aware ArchSigレビュー基盤を実装

### DIFF
--- a/docs/tool/archmap_prd.md
+++ b/docs/tool/archmap_prd.md
@@ -129,6 +129,25 @@ evidence refs、coverage boundary、missing evidence、non-conclusions 付きで
 これは semantic preservation の自動証明ではない。ArchMap は、semantic theorem claim を直接作るのではなく、
 semantic evidence と semantic coverage gap を ArchSig の claim boundary に載せるための入口である。
 
+## Law-Aware Review Surface
+
+ArchSig / ArchMap の law-aware surface は、採用している設計原則を一つの判定器に押し込むのではなく、
+law ごとに evidence boundary を分ける。
+
+- `architecture-policy-v0` は project-local に adopted laws、layer selectors、allowed / forbidden
+  dependency、exception、SRP taxonomy を宣言する。
+- Layered Architecture は、selector が解決された component と measured import edge に対して
+  deterministic に forbidden dependency を検出できる。
+- SRP は file size や method count だけで violation としない。ArchMap map item は
+  `semanticRole`、`responsibilityRegions`、`reasonToChange`、`actorRefs`、`allowedRole`、
+  `lawRefs` を保持し、LLM Review Skill が evidence refs と policy refs を引用して
+  `probableViolation`、`risk`、`acceptableOrchestrator`、`unmeasured` を判断する。
+- `law-violation-report-v0` は deterministic Layered findings、allowed exceptions、unmeasured selector、
+  SRP review cue を分け、non-conclusions を review action / evidence gap として読む。
+
+この surface は architecture lawfulness proof ではない。policy pass は selected universe 上の
+tooling evidence であり、Lean status は empirical tooling / design tracking に留まる。
+
 ## Non-Goals
 
 この PRD は次を目標にしない。

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -15,7 +15,7 @@ ArchSig は単一の command ではなく、次の surface に分けて読む。
 | Surface | 現在使えるもの | Remaining gaps |
 | --- | --- | --- |
 | ArchSig Core | Lean / Python import graph scan、Sig0、validation、snapshot、signature diff。policy JSON と runtime edge evidence は明示入力として扱える。 | call graph、data dependency、dynamic import、plugin loading、framework convention は adapter boundary。extractor output は完全な `ComponentUniverse` ではない。 |
-| ArchSig Review | AIR、ArchMap supplied JSON validation、ArchMap-to-AIR projection、AIR validation、theorem precondition check、Feature Extension Report、policy decision、PR comment summary、baseline suppression、PR quality analysis。 | organization ごとの policy calibration、review practice との tuning、任意 invariant の自動判定。tool output は Lean theorem や merge approval ではない。 |
+| ArchSig Review | AIR、ArchMap supplied JSON validation、ArchMap-to-AIR projection、AIR validation、theorem precondition check、Feature Extension Report、architecture-policy、law violation report、policy decision、PR comment summary、baseline suppression、PR quality analysis。 | organization ごとの policy calibration、review practice との tuning、任意 invariant の自動判定。tool output は Lean theorem や merge approval ではない。 |
 | ArchSig SFT | Markdown PRD / Spec / Issue / AI proposal、GitHub Issue JSON、AI proposal JSON から `ArtifactDescriptor`、`OperationSupportEstimate`、`ForecastConeSkeleton`、`ConsequenceEnvelope`、validation report を生成する bounded pipeline。PRD v3 では `IntentMap`、`AlignmentMap`、`intent-forecast` を使って planning forecast を作る。 | real dataset calibration、framework semantics adapter は remaining gaps。`ForecastCone` は point prediction ではなく、`ConsequenceEnvelope` は report projection である。 |
 | ArchSig Operational | PR history dataset、feature extension dataset、outcome linkage、B10 daily ledger、calibration review、team threshold、ownership boundary、repair adoption、incident correlation、hypothesis refresh artifacts。 | 実 dataset での calibration、incident / rollback / MTTR との運用接続、confounder 管理、private data boundary の組織別設計が残る。correlation は因果 theorem ではない。 |
 
@@ -24,6 +24,7 @@ ArchSig は単一の command ではなく、次の surface に分けて読む。
 - Lean `import` / Python `import` graph から component と dependency edge を抽出する。
 - `hasCycle`, `sccMaxSize`, `maxDepth`, `fanoutRisk` などの構造 metric を計算する。
 - policy JSON がある場合、boundary / abstraction violation を測る。
+- architecture-policy JSON がある場合、Layered Architecture の deterministic violation と SRP review cue boundary を分ける。
 - runtime edge evidence JSON がある場合、runtime dependency projection を出す。
 - Sig0 output を validation し、revision snapshot と before / after diff を作る。
 - PR metadata、AIR、theorem precondition check、Feature Extension Report、policy decision、
@@ -139,6 +140,8 @@ archmap-v0
 | `signature-diff-report-v0` | before / after の悪化軸、改善軸、未評価軸、evidence diff、PR attribution candidate。 |
 | `feature-extension-report-v0` | split status、witness、coverage gap、theorem precondition checks。 |
 | `archmap-validation-report-v0` | supplied ArchMap の source refs、claim boundary、semantic coverage、conflict、formal promotion guardrail。 |
+| `architecture-policy-v0` | project-local adopted laws、layer selectors、exceptions、SRP taxonomy。 |
+| `law-violation-report-v0` | Layered deterministic violation、allowed exception、unmeasured selector、SRP review cue。 |
 | `policy-decision-report-v0` | organization policy に基づく pass / warn / fail / advisory decision。 |
 | `pr-comment-summary-v0` | GitHub Checks / PR comment 向け Markdown summary。 |
 | `pr-quality-analysis-report-v0` | ArchMap / AIR / theorem-check / feature-report / policy-decision 由来の PR review cue。merge 可否は自動判定しない。 |
@@ -177,6 +180,7 @@ AI agent や CI job は `signature` の値だけで判断せず、`metricStatus`
 - LLM / agent から `archmap-v0` を自動生成する。
 - metric と incident / rollback / MTTR の因果関係を証明する。
 - Lean theorem proof、extractor completeness、architecture lawfulness を tooling output だけで結論する。
+- SRP cue を deterministic tool violation として結論する。
 
 ## Test
 

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -40,6 +40,9 @@ non-conclusions を落とさない。
 | --- | --- | --- |
 | Organization policy validation report | `organization-policy-validation-report-v0` | warn / fail / advisory policy と formal claim promotion boundary を検査する。 |
 | Law policy template registry validation report | `law-policy-template-registry-validation-report-v0` | policy template registry の boundary refs と non-conclusions を検査する。 |
+| Architecture policy | `architecture-policy-v0` | project-local adopted laws、layer selectors、allowed / forbidden dependency、exception、SRP taxonomy を保持する。 |
+| Architecture policy validation report | `architecture-policy-validation-report-v0` | law-aware policy の selector / SRP evidence boundary / non-conclusions を検査する。 |
+| Law violation report | `law-violation-report-v0` | Layered Architecture の deterministic violation、allowed exception、unmeasured selector、SRP review cue を分ける。 |
 | Custom rule plugin registry validation report | `custom-rule-plugin-registry-validation-report-v0` | custom rule plugin registry の theorem refs と claim boundary を検査する。 |
 | Measurement unit registry validation report | `measurement-unit-registry-validation-report-v0` | measurement unit selection と evidence adapter boundary を検査する。 |
 | Repair rule registry validation report | `repair-rule-registry-validation-report-v0` | repair rule registry の selected obstruction boundary と advisory non-conclusions を検査する。 |
@@ -190,6 +193,8 @@ tooling evidence であり、Lean `ComponentUniverse` bridge precondition なし
 | fanout / 依存集中 | `fanoutRisk`, `maxFanout` | 依存辺総数や局所的な結合点候補が増えた。 | fanout 増加は常に悪ではない。 |
 | 到達 cone | `reachableConeSize` | 変更理解や影響確認の範囲が広がる候補。 | edge 方向は `source depends on target`。 |
 | boundary violation | `boundaryViolationCount`, `policyViolations[]` | 意図した layer / domain boundary が破られている候補。 | policy 未指定なら placeholder 0 でも違反なしとは読まない。 |
+| Layered law violation | `law-violation-report-v0.deterministicViolations[]`, `policyViolations[]` | resolved layer selector と measured import edge に対する deterministic forbidden dependency。 | selector 未解決、dynamic import、framework convention は unmeasured。policy pass は architecture lawfulness proof ではない。 |
+| SRP review cue | `archmap-v0.mapItems[].semanticRole`, `responsibilityRegions`, `reasonToChange`, `lawRefs`, `law-violation-report-v0.srpCues[]` | LLM Review Skill が probable violation / acceptable orchestrator / unmeasured を判断するための semantic evidence。 | tool 単独で SRP violation を断定しない。 |
 | abstraction violation | `abstractionViolationCount`, `policyViolations[]` | abstraction boundary の破れ候補。 | Lean の `ProjectionSound` witness そのものではない。 |
 | runtime exposure | `runtimePropagation`, `runtimeDependencyGraph`, `runtimeEdgeEvidence[]` | runtime evidence 上の exposure radius が大きい。 | runtime edge evidence を渡した場合だけ測定済み。 |
 | relation complexity | `relationComplexity`, `counts.*`, `excludedEvidence[]` | 状態遷移設計や運用リスクの review 対象候補。 | candidate evidence からの observation。 |
@@ -210,6 +215,7 @@ before / after の差分診断:
 - 任意 repository から完全な architecture model を抽出できる。
 - extractor output が Lean `ComponentUniverse` と同一である。
 - policy pass や schema compatibility pass が architecture lawfulness を示す。
+- SRP cue が tool-only violation を示す。
 - migration pass が semantic preservation を示す。
 - measured witness が Lean theorem proof である。
 - report warning が incident / rollback / MTTR を引き起こした。

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -14,7 +14,7 @@ directories for `--out` and `--out-dir` paths. Keep canonical fixtures and regre
 | Surface | Commands | 読み方 |
 | --- | --- | --- |
 | ArchSig Core | default scan、`validate`、`snapshot`、`signature-diff` | repository observation と revision diff。未評価軸は `metricStatus` と `metricDeltaStatus` で読む。 |
-| ArchSig Review | `air`、`archmap`、`archmap-generate`、`air-from-archmap`、`validate-air`、`theorem-check`、`feature-report`、`policy-decision`、`pr-comment`、`baseline-suppression`、`pr-quality-analysis` | PR / CI review 補助。tool output を formal theorem claim や merge approval に昇格しない。 |
+| ArchSig Review | `air`、`archmap`、`archmap-generate`、`air-from-archmap`、`validate-air`、`theorem-check`、`feature-report`、`architecture-policy`、`law-violation-report`、`policy-decision`、`pr-comment`、`baseline-suppression`、`pr-quality-analysis` | PR / CI review 補助。tool output を formal theorem claim や merge approval に昇格しない。 |
 | ArchSig SFT | `artifact-descriptor`、`intent-map`、`intent-archmap-alignment`、`archmap-sft-input`、`operation-support-estimate`、`intent-forecast`、`forecast-cone-skeleton`、`consequence-envelope`、`forecast-calibration-hook`、`intent-calibration-record`、`ai-proposal-governance`、`sft-forecast` | bounded forecast artifact と governance / report projection。point prediction、causal proof、global safety は non-conclusions。PRD v3 planning forecast は IntentMap x ArchMap alignment を入力にする。 |
 | ArchSig Operational | `dataset`、`pr-history-dataset`、`feature-extension-dataset`、`outcome-linkage-dataset`、B10 feedback commands | calibration、threshold、ownership、repair adoption、incident correlation、hypothesis refresh 用 artifact。correlation は因果 theorem ではない。 |
 
@@ -32,6 +32,11 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- \
 
 `--policy` と `--runtime-edges` は任意である。省略した metric は placeholder 0 を出す場合があるが、
 `metricStatus.<axis>.measured = false` として未評価を保持する。
+`--policy` には従来の `signature-policy-v0` または law-aware な `architecture-policy-v0` を渡せる。
+`architecture-policy-v0` の場合、Layered Architecture の forbidden dependency は
+resolved layer selector と measured import edge から deterministic に `policyViolations[]` へ入る。
+selector 未解決や layer 未分類がある場合、`boundaryViolationCount=0` でも
+`metricStatus.boundaryViolationCount.measured = false` として未評価を保持する。
 
 Python repository を scan する。
 
@@ -47,6 +52,36 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- \
 Python scan は `componentKind = "python-module"` を出し、標準 `ast` parser で
 `import` / `from ... import ...` を抽出する。dynamic import、plugin loading、
 framework convention は未評価 boundary として残す。
+Python scan でも `--policy architecture-policy.json` は使える。policy selector が Python module id に
+解決できた範囲では Layered law を deterministic に測定し、解決できない selector は unmeasured として残す。
+
+## Architecture Policy / Law Violation Report
+
+project-local な採用設計原則を検査する。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- architecture-policy \
+  --input tools/archsig/tests/fixtures/minimal/architecture_policy.json \
+  --out .archsig/policy/architecture-policy-validation.json
+```
+
+`architecture-policy-v0` は adopted laws、layer selectors、allowed / forbidden dependency、
+exception、SRP taxonomy を保持する。Layered Architecture は deterministic evaluator の対象だが、
+SRP は semantic role、responsibility region、reason-to-change、law refs を LLM Review Skill へ渡す
+cue であり、tool 単独の violation ではない。
+
+Sig0 と policy から law report を作る。
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- law-violation-report \
+  --sig0 .archsig/signature/sig0.json \
+  --policy tools/archsig/tests/fixtures/minimal/architecture_policy.json \
+  --out .archsig/policy/law-violation-report.json
+```
+
+`law-violation-report-v0` は `deterministicViolations[]`、`allowedExceptions[]`、
+`unmeasured[]`、`reviewActions[]` を分けて出す。`deterministicViolations[]` は Layered law の
+review action であり、Lean proof や global architecture lawfulness ではない。
 
 ## Validate
 

--- a/tools/archsig/skills/arch-pr-analyzer/SKILL.md
+++ b/tools/archsig/skills/arch-pr-analyzer/SKILL.md
@@ -15,6 +15,7 @@ Analyze PR / CI architecture evidence and produce review cues. This skill simpli
 - Sig0 and validation reports
 - `archmap-v0` and `archmap-validation-report-v0`
 - AIR, AIR validation, theorem-check, feature-report
+- `architecture-policy-v0` and `law-violation-report-v0`
 - policy-decision and PR comment summary
 - `pr-quality-analysis-report-v0`
 
@@ -67,6 +68,19 @@ ${ARCHSIG_BIN:-archsig} feature-report \
   --out .archsig/archmap/feature-report.json
 ```
 
+If a project-local law policy is supplied, validate it and evaluate Layered Architecture findings:
+
+```bash
+${ARCHSIG_BIN:-archsig} architecture-policy \
+  --input .archsig/policy/architecture-policy.json \
+  --out .archsig/policy/architecture-policy-validation.json
+
+${ARCHSIG_BIN:-archsig} law-violation-report \
+  --sig0 .archsig/signature/current/sig0.json \
+  --policy .archsig/policy/architecture-policy.json \
+  --out .archsig/policy/law-violation-report.json
+```
+
 Validate supplied PR quality report when present:
 
 ```bash
@@ -78,6 +92,9 @@ ${ARCHSIG_BIN:-archsig} pr-quality-analysis \
 3. Produce the review.
    - Separate measured zero from unmeasured.
    - Separate warning, failure, missing evidence, and negative evidence.
+   - Treat Layered Architecture `deterministicViolations[]` as deterministic over resolved selectors and measured edges.
+   - Treat SRP `semanticRole` / `responsibilityRegions` / `reasonToChange` / `lawRefs` as evidence for LLM judgment, not as tool-only violation.
+   - For SRP probable violation, cite both evidence refs and policy refs and distinguish `acceptableOrchestrator`, `allowedException`, and `unmeasured`.
    - Tie each finding to artifact ids or paths.
    - Keep recommendations bounded to PR review actions.
 

--- a/tools/archsig/skills/arch-pr-analyzer/references/artifact-reading-guide.md
+++ b/tools/archsig/skills/arch-pr-analyzer/references/artifact-reading-guide.md
@@ -9,7 +9,10 @@
 | AIR | normalized review representation | proof term |
 | theorem-check | formal precondition status | discharged theorem |
 | feature-report | split status, witnesses, coverage gaps | universal design judgment |
+| architecture-policy | adopted laws, layer selectors, SRP taxonomy, exceptions | architecture lawfulness |
+| law-violation-report | deterministic Layered violations, allowed exceptions, unmeasured selectors, SRP cues | SRP tool-only violation or Lean proof |
 | policy-decision | organization policy decision surface | global quality score |
 | pr-quality-analysis | review cues from artifact evidence | merge approval |
 
 Always read `metricStatus`, `metricDeltaStatus`, `unmeasuredAxes`, `missingEvidence`, and `nonConclusions` before summarizing.
+For SRP, cite `semanticRole`, `responsibilityRegions`, `reasonToChange`, evidence refs, and policy refs before saying `probableViolation`.

--- a/tools/archsig/src/architecture_policy.rs
+++ b/tools/archsig/src/architecture_policy.rs
@@ -1,0 +1,700 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
+use crate::{
+    ARCHITECTURE_POLICY_SCHEMA_VERSION, ARCHITECTURE_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+    ArchitectureAdoptedLawV0, ArchitecturePolicyDependencyRuleV0, ArchitecturePolicyExceptionV0,
+    ArchitecturePolicyV0, ArchitecturePolicyValidationInputV0,
+    ArchitecturePolicyValidationReportV0, ArchitecturePolicyValidationSummaryV0, Component, Edge,
+    LAW_VIOLATION_REPORT_SCHEMA_VERSION, LawViolationExceptionFindingV0, LawViolationFindingV0,
+    LawViolationPolicyRefV0, LawViolationReportV0, LawViolationSig0RefV0, LawViolationSummaryV0,
+    LawViolationUnmeasuredV0, MetricStatus, PolicyViolation, Sig0Document, SrpReviewCueV0,
+    ValidationCheck, measured_status, unmeasured_status,
+};
+
+const REQUIRED_NON_CONCLUSIONS: [&str; 5] = [
+    "architecture policy is review evidence, not a Lean theorem",
+    "LayeredArchitecture findings are deterministic over the measured selector universe only",
+    "SRP findings are evidence cues for LLM review, not tool-only violation judgments",
+    "unmeasured selector coverage is not measured zero",
+    "policy pass does not conclude architecture lawfulness",
+];
+
+const SRP_JUDGMENT_TAXONOMY: [&str; 6] = [
+    "violation",
+    "probableViolation",
+    "risk",
+    "acceptableOrchestrator",
+    "unmeasured",
+    "allowedException",
+];
+
+pub fn read_architecture_policy(path: &Path) -> Result<ArchitecturePolicyV0, Box<dyn Error>> {
+    let source = fs::read_to_string(path)?;
+    let policy: ArchitecturePolicyV0 = serde_json::from_str(&source)?;
+    Ok(policy)
+}
+
+pub fn validate_architecture_policy_report(
+    policy: &ArchitecturePolicyV0,
+    input_path: &str,
+) -> ArchitecturePolicyValidationReportV0 {
+    let checks = vec![
+        check_schema_version(policy),
+        check_identity(policy),
+        check_adopted_laws(policy),
+        check_layers(policy),
+        check_dependency_rules(policy),
+        check_srp_boundary(policy),
+        check_non_conclusions(policy),
+    ];
+    let summary = ArchitecturePolicyValidationSummaryV0 {
+        result: if checks.iter().any(|check| check.result == "fail") {
+            "fail".to_string()
+        } else if checks.iter().any(|check| check.result == "warn") {
+            "warn".to_string()
+        } else {
+            "pass".to_string()
+        },
+        adopted_law_count: policy.adopted_laws.len(),
+        layer_count: policy.layers.len(),
+        forbidden_dependency_count: policy.forbidden_dependencies.len(),
+        exception_count: policy.exceptions.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    ArchitecturePolicyValidationReportV0 {
+        schema_version: ARCHITECTURE_POLICY_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: ArchitecturePolicyValidationInputV0 {
+            schema_version: policy.schema_version.clone(),
+            path: input_path.to_string(),
+            policy_id: policy.policy_id.clone(),
+            policy_version: policy.policy_version.clone(),
+            component_id_kind: policy.component_id_kind.clone(),
+        },
+        policy: policy.clone(),
+        summary,
+        checks,
+    }
+}
+
+pub fn build_law_violation_report(
+    sig0: &Sig0Document,
+    sig0_path: Option<&str>,
+    policy: &ArchitecturePolicyV0,
+    policy_path: Option<&str>,
+) -> LawViolationReportV0 {
+    let layer_lookup = resolve_layers(policy, &sig0.components);
+    let deterministic_violations =
+        evaluate_layered_violations(policy, &sig0.components, &sig0.edges, &layer_lookup);
+    let allowed_exceptions =
+        evaluate_allowed_exceptions(policy, &sig0.components, &sig0.edges, &layer_lookup);
+    let unmeasured = unmeasured_layer_items(policy, &sig0.components, &layer_lookup);
+    let review_actions = report_review_actions(&deterministic_violations, &unmeasured);
+    let result = if !deterministic_violations.is_empty() {
+        "fail"
+    } else if !unmeasured.is_empty() {
+        "warn"
+    } else {
+        "pass"
+    };
+
+    LawViolationReportV0 {
+        schema_version: LAW_VIOLATION_REPORT_SCHEMA_VERSION.to_string(),
+        report_id: format!("law-violation-report:{}", policy.policy_id),
+        policy_ref: LawViolationPolicyRefV0 {
+            policy_id: policy.policy_id.clone(),
+            policy_version: policy.policy_version.clone(),
+            path: policy_path.map(str::to_string),
+        },
+        sig0_ref: LawViolationSig0RefV0 {
+            root: sig0.root.clone(),
+            component_kind: sig0.component_kind.clone(),
+            path: sig0_path.map(str::to_string),
+        },
+        summary: LawViolationSummaryV0 {
+            result: result.to_string(),
+            deterministic_violation_count: deterministic_violations.len(),
+            allowed_exception_count: allowed_exceptions.len(),
+            srp_cue_count: 0,
+            unmeasured_count: unmeasured.len(),
+        },
+        deterministic_violations,
+        allowed_exceptions,
+        srp_cues: Vec::new(),
+        unmeasured,
+        review_actions,
+        non_conclusions: REQUIRED_NON_CONCLUSIONS
+            .iter()
+            .map(|value| value.to_string())
+            .collect(),
+    }
+}
+
+pub fn apply_architecture_policy_to_sig0(
+    sig0: &mut Sig0Document,
+    policy: &ArchitecturePolicyV0,
+    policy_path: Option<&str>,
+) {
+    let report = build_law_violation_report(sig0, None, policy, policy_path);
+    sig0.policies.policy_id = Some(policy.policy_id.clone());
+    sig0.policies.schema_version = Some(policy.schema_version.clone());
+    sig0.policies.boundary_group_count = Some(policy.layers.len());
+    sig0.policies.boundary_allowed = policy
+        .allowed_dependencies
+        .iter()
+        .map(|rule| {
+            format!(
+                "{}:{}->{}",
+                rule.rule_id, rule.source_layer, rule.target_layer
+            )
+        })
+        .collect();
+    sig0.signature.boundary_violation_count = report.deterministic_violations.len();
+    sig0.policy_violations = report
+        .deterministic_violations
+        .iter()
+        .map(|finding| PolicyViolation {
+            axis: "boundaryViolationCount".to_string(),
+            source: finding.source.clone(),
+            target: finding.target.clone(),
+            evidence: finding.evidence.clone(),
+            source_group: Some(finding.source_layer.clone()),
+            target_group: Some(finding.target_layer.clone()),
+            relation_ids: Some(vec![finding.rule_id.clone()]),
+        })
+        .collect();
+    let status = if report.unmeasured.is_empty() {
+        measured_status(&format!("policy:{}", policy.policy_id))
+    } else {
+        unmeasured_status(
+            "architecture-policy selector coverage is incomplete; placeholder zero is not measured zero"
+                .to_string(),
+        )
+    };
+    sig0.metric_status
+        .insert("boundaryViolationCount".to_string(), status);
+    sig0.metric_status.insert(
+        "srpReviewCueCount".to_string(),
+        MetricStatus {
+            measured: false,
+            reason: Some(
+                "SRP review cues require ArchMap semantic evidence and LLM judgment".to_string(),
+            ),
+            source: policy_path.map(str::to_string),
+        },
+    );
+}
+
+pub fn srp_review_cue_from_archmap_item(
+    item_id: &str,
+    subject_ref: String,
+    semantic_role: Option<String>,
+    responsibility_regions: Vec<String>,
+    reason_to_change: Vec<String>,
+    actor_refs: Vec<String>,
+    allowed_role: Option<String>,
+    law_refs: Vec<String>,
+    evidence_refs: Vec<String>,
+    policy_refs: Vec<String>,
+    missing_evidence: Vec<String>,
+    non_conclusions: Vec<String>,
+) -> Option<SrpReviewCueV0> {
+    let has_srp_evidence = semantic_role.is_some()
+        || !responsibility_regions.is_empty()
+        || !reason_to_change.is_empty()
+        || !actor_refs.is_empty()
+        || allowed_role.is_some()
+        || law_refs.iter().any(|law| law.contains("SRP"));
+    has_srp_evidence.then(|| SrpReviewCueV0 {
+        cue_id: format!("srp-cue:{item_id}"),
+        subject_ref,
+        semantic_role,
+        responsibility_regions,
+        reason_to_change,
+        actor_refs,
+        allowed_role,
+        law_refs,
+        judgment_taxonomy: SRP_JUDGMENT_TAXONOMY
+            .iter()
+            .map(|value| value.to_string())
+            .collect(),
+        evidence_refs,
+        policy_refs,
+        missing_evidence,
+        review_level: "Level 3 LLM probable violation judgment".to_string(),
+        review_action:
+            "LLM Review Skill must cite evidence refs and policy refs before probableViolation"
+                .to_string(),
+        non_conclusions,
+    })
+}
+
+fn check_schema_version(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let mut check = validation_check(
+        "architecture-policy-schema-version-supported",
+        "architecture policy schema version is supported",
+        if policy.schema_version == ARCHITECTURE_POLICY_SCHEMA_VERSION {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!(
+            "unsupported architecture policy schemaVersion: {}",
+            policy.schema_version
+        ));
+    }
+    check
+}
+
+fn check_identity(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let mut invalid = Vec::new();
+    for (field, value) in [
+        ("policyId", &policy.policy_id),
+        ("policyVersion", &policy.policy_version),
+        ("componentIdKind", &policy.component_id_kind),
+        ("selectorSemantics", &policy.selector_semantics),
+    ] {
+        if value.trim().is_empty() {
+            invalid.push(generic_validation_example(
+                field,
+                value,
+                "field must be non-empty",
+            ));
+        }
+    }
+    if policy.selector_semantics != "exact-or-prefix-star" {
+        invalid.push(generic_validation_example(
+            "selectorSemantics",
+            &policy.selector_semantics,
+            "only exact-or-prefix-star selectors are supported in v0",
+        ));
+    }
+    check_examples(
+        "architecture-policy-identity-recorded",
+        "policy identity and selector semantics are recorded",
+        invalid,
+    )
+}
+
+fn check_adopted_laws(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let mut invalid = Vec::new();
+    if policy.adopted_laws.is_empty() {
+        invalid.push(generic_validation_example(
+            &policy.policy_id,
+            "adoptedLaws",
+            "at least one adopted law is required",
+        ));
+    }
+    for duplicate in duplicates(policy.adopted_laws.iter().map(|law| law.law_id.as_str())) {
+        invalid.push(generic_validation_example(
+            &duplicate,
+            "adoptedLaws",
+            "duplicate law id",
+        ));
+    }
+    for law in &policy.adopted_laws {
+        if law.law_id.trim().is_empty()
+            || law.law_kind.trim().is_empty()
+            || law.enforcement.trim().is_empty()
+            || law.review_level.trim().is_empty()
+        {
+            invalid.push(generic_validation_example(
+                &law.law_id,
+                &law.law_kind,
+                "adopted law fields must be non-empty",
+            ));
+        }
+    }
+    check_examples(
+        "architecture-policy-adopted-laws-recorded",
+        "adopted design laws are explicit",
+        invalid,
+    )
+}
+
+fn check_layers(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let mut invalid = Vec::new();
+    for duplicate in duplicates(policy.layers.iter().map(|layer| layer.layer_id.as_str())) {
+        invalid.push(generic_validation_example(
+            &duplicate,
+            "layers",
+            "duplicate layer id",
+        ));
+    }
+    for layer in &policy.layers {
+        if layer.layer_id.trim().is_empty()
+            || layer.selectors.is_empty()
+            || has_blank(&layer.selectors)
+        {
+            invalid.push(generic_validation_example(
+                &layer.layer_id,
+                "selectors",
+                "layer id and selectors must be non-empty",
+            ));
+        }
+    }
+    check_examples(
+        "architecture-policy-layer-selectors-recorded",
+        "layer selectors are explicit",
+        invalid,
+    )
+}
+
+fn check_dependency_rules(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let law_ids = policy
+        .adopted_laws
+        .iter()
+        .map(|law| law.law_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let layer_ids = policy
+        .layers
+        .iter()
+        .map(|layer| layer.layer_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut invalid = Vec::new();
+    for rule in policy
+        .allowed_dependencies
+        .iter()
+        .chain(policy.forbidden_dependencies.iter())
+    {
+        validate_dependency_rule(rule, &law_ids, &layer_ids, &mut invalid);
+    }
+    for exception in &policy.exceptions {
+        validate_exception(exception, &law_ids, &mut invalid);
+    }
+    check_examples(
+        "architecture-policy-dependency-rules-resolve",
+        "dependency rules and exceptions refer to known laws and layers",
+        invalid,
+    )
+}
+
+fn validate_dependency_rule(
+    rule: &ArchitecturePolicyDependencyRuleV0,
+    law_ids: &BTreeSet<&str>,
+    layer_ids: &BTreeSet<&str>,
+    invalid: &mut Vec<crate::ValidationExample>,
+) {
+    if rule.rule_id.trim().is_empty()
+        || !law_ids.contains(rule.law_ref.as_str())
+        || !layer_ids.contains(rule.source_layer.as_str())
+        || !layer_ids.contains(rule.target_layer.as_str())
+        || rule.severity.trim().is_empty()
+        || rule.review_action.trim().is_empty()
+    {
+        invalid.push(generic_validation_example(
+            &rule.rule_id,
+            &rule.law_ref,
+            "dependency rule must cite known law/layers and review action",
+        ));
+    }
+}
+
+fn validate_exception(
+    exception: &ArchitecturePolicyExceptionV0,
+    law_ids: &BTreeSet<&str>,
+    invalid: &mut Vec<crate::ValidationExample>,
+) {
+    if exception.exception_id.trim().is_empty()
+        || !law_ids.contains(exception.law_ref.as_str())
+        || exception.source_selector.trim().is_empty()
+        || exception.target_selector.trim().is_empty()
+        || exception.reason.trim().is_empty()
+    {
+        invalid.push(generic_validation_example(
+            &exception.exception_id,
+            &exception.law_ref,
+            "exception must cite known law and non-empty selectors/reason",
+        ));
+    }
+}
+
+fn check_srp_boundary(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let srp = &policy.srp;
+    let invalid = (srp.responsibility_taxonomy.is_empty()
+        || srp.reason_to_change_categories.is_empty()
+        || srp.allowed_orchestrator_roles.is_empty()
+        || srp.required_evidence_fields.is_empty()
+        || srp.judgment_boundary.trim().is_empty())
+    .then(|| {
+        generic_validation_example(
+            &policy.policy_id,
+            "srp",
+            "SRP taxonomy, reason categories, allowed roles, required evidence fields, and judgment boundary are required",
+        )
+    })
+    .into_iter()
+    .collect();
+    check_examples(
+        "architecture-policy-srp-evidence-boundary-recorded",
+        "SRP semantic evidence and LLM judgment boundary are explicit",
+        invalid,
+    )
+}
+
+fn check_non_conclusions(policy: &ArchitecturePolicyV0) -> ValidationCheck {
+    let conclusions = policy
+        .non_conclusions
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let invalid: Vec<_> = REQUIRED_NON_CONCLUSIONS
+        .iter()
+        .filter(|required| !conclusions.contains(**required))
+        .map(|required| generic_validation_example(&policy.policy_id, "nonConclusions", required))
+        .collect();
+    check_examples(
+        "architecture-policy-non-conclusion-boundary-recorded",
+        "non-conclusions are review guardrails",
+        invalid,
+    )
+}
+
+fn evaluate_layered_violations(
+    policy: &ArchitecturePolicyV0,
+    components: &[Component],
+    edges: &[Edge],
+    layer_lookup: &BTreeMap<String, LayerResolution>,
+) -> Vec<LawViolationFindingV0> {
+    let component_ids = components
+        .iter()
+        .map(|component| component.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut findings = Vec::new();
+    for edge in edges {
+        if !component_ids.contains(edge.source.as_str())
+            || !component_ids.contains(edge.target.as_str())
+            || edge_has_exception(policy, &edge.source, &edge.target)
+        {
+            continue;
+        }
+        let Some(source_layer) = single_layer(layer_lookup, &edge.source) else {
+            continue;
+        };
+        let Some(target_layer) = single_layer(layer_lookup, &edge.target) else {
+            continue;
+        };
+        let Some(rule) = policy.forbidden_dependencies.iter().find(|rule| {
+            rule.source_layer == source_layer.layer_id && rule.target_layer == target_layer.layer_id
+        }) else {
+            continue;
+        };
+        findings.push(LawViolationFindingV0 {
+            finding_id: format!("layered:{}->{}", edge.source, edge.target),
+            law_ref: rule.law_ref.clone(),
+            law_kind: "LayeredArchitecture".to_string(),
+            source: edge.source.clone(),
+            target: edge.target.clone(),
+            source_layer: source_layer.layer_id.to_string(),
+            target_layer: target_layer.layer_id.to_string(),
+            rule_id: rule.rule_id.clone(),
+            severity: rule.severity.clone(),
+            evidence: edge.evidence.clone(),
+            review_action: rule.review_action.clone(),
+            evidence_boundary:
+                "deterministic over resolved layer selectors and measured static import edges"
+                    .to_string(),
+            non_conclusions: REQUIRED_NON_CONCLUSIONS
+                .iter()
+                .map(|value| value.to_string())
+                .collect(),
+        });
+    }
+    findings
+}
+
+fn evaluate_allowed_exceptions(
+    policy: &ArchitecturePolicyV0,
+    components: &[Component],
+    edges: &[Edge],
+    _layer_lookup: &BTreeMap<String, LayerResolution>,
+) -> Vec<LawViolationExceptionFindingV0> {
+    let component_ids = components
+        .iter()
+        .map(|component| component.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut exceptions = Vec::new();
+    for edge in edges {
+        if !component_ids.contains(edge.source.as_str())
+            || !component_ids.contains(edge.target.as_str())
+        {
+            continue;
+        }
+        for exception in &policy.exceptions {
+            if selector_matches(&exception.source_selector, &edge.source)
+                && selector_matches(&exception.target_selector, &edge.target)
+            {
+                exceptions.push(LawViolationExceptionFindingV0 {
+                    exception_id: exception.exception_id.clone(),
+                    law_ref: exception.law_ref.clone(),
+                    source: edge.source.clone(),
+                    target: edge.target.clone(),
+                    reason: exception.reason.clone(),
+                    review_action: "confirm the exception remains intentional and scoped"
+                        .to_string(),
+                });
+            }
+        }
+    }
+    exceptions
+}
+
+fn unmeasured_layer_items(
+    policy: &ArchitecturePolicyV0,
+    components: &[Component],
+    layer_lookup: &BTreeMap<String, LayerResolution>,
+) -> Vec<LawViolationUnmeasuredV0> {
+    let mut items = Vec::new();
+    let component_ids = components
+        .iter()
+        .map(|component| component.id.clone())
+        .collect::<BTreeSet<_>>();
+    for layer in &policy.layers {
+        for selector in &layer.selectors {
+            if !component_ids
+                .iter()
+                .any(|component_id| selector_matches(selector, component_id))
+            {
+                items.push(LawViolationUnmeasuredV0 {
+                    item_id: format!("unresolved-selector:{}:{selector}", layer.layer_id),
+                    category: "unresolvedSelector".to_string(),
+                    subject_ref: selector.clone(),
+                    reason: "layer selector matched no measured component".to_string(),
+                    review_action: "fix selector or record this universe as unmeasured".to_string(),
+                });
+            }
+        }
+    }
+    for component in components {
+        match layer_lookup.get(&component.id) {
+            Some(resolution) if resolution.layer_ids.len() == 1 => {}
+            Some(resolution) if resolution.layer_ids.len() > 1 => {
+                items.push(LawViolationUnmeasuredV0 {
+                    item_id: format!("ambiguous-layer:{}", component.id),
+                    category: "ambiguousLayerSelector".to_string(),
+                    subject_ref: component.id.clone(),
+                    reason: format!(
+                        "component matched multiple layers: {}",
+                        resolution.layer_ids.join(",")
+                    ),
+                    review_action:
+                        "make layer selectors disjoint before reading policy zero as measured"
+                            .to_string(),
+                })
+            }
+            _ => items.push(LawViolationUnmeasuredV0 {
+                item_id: format!("unclassified-layer:{}", component.id),
+                category: "unclassifiedComponent".to_string(),
+                subject_ref: component.id.clone(),
+                reason: "component matched no architecture-policy layer".to_string(),
+                review_action: "add a layer selector or keep boundaryViolationCount unmeasured"
+                    .to_string(),
+            }),
+        }
+    }
+    items
+}
+
+#[derive(Debug, Clone)]
+struct LayerResolution {
+    layer_ids: Vec<String>,
+}
+
+fn resolve_layers(
+    policy: &ArchitecturePolicyV0,
+    components: &[Component],
+) -> BTreeMap<String, LayerResolution> {
+    components
+        .iter()
+        .map(|component| {
+            let layer_ids = policy
+                .layers
+                .iter()
+                .filter(|layer| {
+                    layer
+                        .selectors
+                        .iter()
+                        .any(|selector| selector_matches(selector, &component.id))
+                })
+                .map(|layer| layer.layer_id.clone())
+                .collect();
+            (component.id.clone(), LayerResolution { layer_ids })
+        })
+        .collect()
+}
+
+fn single_layer<'a>(
+    layer_lookup: &'a BTreeMap<String, LayerResolution>,
+    component_id: &str,
+) -> Option<ResolvedLayer<'a>> {
+    let resolution = layer_lookup.get(component_id)?;
+    (resolution.layer_ids.len() == 1).then(|| ResolvedLayer {
+        layer_id: &resolution.layer_ids[0],
+    })
+}
+
+struct ResolvedLayer<'a> {
+    layer_id: &'a str,
+}
+
+fn edge_has_exception(policy: &ArchitecturePolicyV0, source: &str, target: &str) -> bool {
+    policy.exceptions.iter().any(|exception| {
+        selector_matches(&exception.source_selector, source)
+            && selector_matches(&exception.target_selector, target)
+    })
+}
+
+fn selector_matches(selector: &str, component_id: &str) -> bool {
+    selector == component_id
+        || selector
+            .strip_suffix(".*")
+            .map(|prefix| component_id == prefix || component_id.starts_with(&format!("{prefix}.")))
+            .unwrap_or(false)
+}
+
+fn report_review_actions(
+    findings: &[LawViolationFindingV0],
+    unmeasured: &[LawViolationUnmeasuredV0],
+) -> Vec<String> {
+    let mut actions = findings
+        .iter()
+        .map(|finding| finding.review_action.clone())
+        .chain(unmeasured.iter().map(|item| item.review_action.clone()))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if actions.is_empty() {
+        actions.push(
+            "no deterministic LayeredArchitecture action over the measured selector universe"
+                .to_string(),
+        );
+    }
+    actions
+}
+
+fn check_examples(
+    id: &str,
+    title: &str,
+    examples: Vec<crate::ValidationExample>,
+) -> ValidationCheck {
+    let mut check = validation_check(id, title, if examples.is_empty() { "pass" } else { "fail" });
+    check.count = Some(examples.len());
+    check.examples = examples;
+    check
+}
+
+fn has_blank(values: &[String]) -> bool {
+    values.iter().any(|value| value.trim().is_empty())
+}
+
+#[allow(dead_code)]
+fn _law_kind(law: &ArchitectureAdoptedLawV0) -> &str {
+    &law.law_kind
+}

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -39,6 +39,7 @@ pub fn validate_archmap_report(
     let claim_boundary_checks = vec![
         check_measured_claim_evidence(document),
         check_missing_evidence_not_measured_zero(document),
+        check_srp_evidence_boundary(document),
     ];
     let semantic_coverage_checks = vec![check_semantic_coverage(document)];
     let conflict_checks = vec![check_conflicts(document, sig0)];
@@ -739,6 +740,42 @@ fn check_missing_evidence_not_measured_zero(document: &ArchMapDocumentV0) -> Val
         examples,
         "fail",
     )
+}
+
+fn check_srp_evidence_boundary(document: &ArchMapDocumentV0) -> ValidationCheck {
+    let examples: Vec<_> = document
+        .map_items
+        .iter()
+        .filter(|item| is_srp_item(item))
+        .filter(|item| {
+            item.semantic_role.is_none()
+                || item.responsibility_regions.is_empty()
+                || item.reason_to_change.is_empty()
+                || item.law_refs.is_empty()
+        })
+        .map(|item| {
+            generic_validation_example(
+                &item.map_item_id,
+                "SRP",
+                "SRP review cue must keep semanticRole, responsibilityRegions, reasonToChange, and lawRefs typed",
+            )
+        })
+        .collect();
+    check_from_examples(
+        "archmap-srp-evidence-boundary-typed",
+        "SRP review cues keep typed semantic evidence",
+        examples,
+        "warn",
+    )
+}
+
+fn is_srp_item(item: &ArchMapMapItem) -> bool {
+    item.law_refs.iter().any(|law| law.contains("SRP"))
+        || item
+            .preserves
+            .iter()
+            .any(|preserve| preserve.to_ascii_lowercase().contains("srp"))
+        || item.map_item_id.to_ascii_lowercase().contains("srp")
 }
 
 fn check_semantic_coverage(document: &ArchMapDocumentV0) -> ValidationCheck {
@@ -1539,6 +1576,12 @@ fn archmap_item_required_assumptions(item: &ArchMapMapItem) -> Vec<String> {
         "ArchMapPreservationPackage.{} candidate",
         archmap_item_lean_package_field(item)
     ));
+    if is_srp_item(item) {
+        required_assumptions.push(
+            "SRP probable violation requires LLM Review Skill judgment with evidence refs and policy refs"
+                .to_string(),
+        );
+    }
     required_assumptions.sort();
     required_assumptions.dedup();
     required_assumptions
@@ -1568,6 +1611,13 @@ fn archmap_item_non_conclusions(item: &ArchMapMapItem) -> Vec<String> {
     non_conclusions.push("ArchMap item does not prove semantic preservation".to_string());
     if item.claim_classification != "proved" {
         non_conclusions.push("LLM-authored mapping is not a Lean theorem".to_string());
+    }
+    if is_srp_item(item) {
+        non_conclusions.push("SRP cue is not a deterministic tool violation".to_string());
+        non_conclusions.push(
+            "SRP probableViolation requires review judgment with cited evidence and policy refs"
+                .to_string(),
+        );
     }
     non_conclusions.sort();
     non_conclusions.dedup();

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -3,6 +3,7 @@ mod air;
 mod air_validation;
 mod architecture_dynamics_metrics;
 mod architecture_field;
+mod architecture_policy;
 mod archmap;
 mod artifact_descriptor;
 mod artifact_retention;
@@ -61,6 +62,10 @@ pub use architecture_dynamics_metrics::{
 pub use architecture_field::{
     static_architecture_field_snapshot, static_operation_proposal_log,
     validate_architecture_field_snapshot, validate_operation_proposal_log,
+};
+pub use architecture_policy::{
+    apply_architecture_policy_to_sig0, build_law_violation_report, read_architecture_policy,
+    srp_review_cue_from_archmap_item, validate_architecture_policy_report,
 };
 pub use archmap::{
     ArchMapSourceInventoryInput, build_air_from_archmap,

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -9,7 +9,8 @@ use archsig::{
     AirDocumentV0, AirValidationReport, ArchMapDocumentV0, ArchMapSourceInventoryInput,
     ArchMapSourceInventoryV0, ArchMapValidationReportV0, ArchitectureDynamicsMetricsReportV0,
     ArchitectureDynamicsMetricsReportValidationReportV0, ArchitectureFieldSnapshotV0,
-    ArchitectureFieldSnapshotValidationReportV0, ArtifactDescriptorV0,
+    ArchitectureFieldSnapshotValidationReportV0, ArchitecturePolicyV0,
+    ArchitecturePolicyValidationReportV0, ArtifactDescriptorV0,
     ArtifactDescriptorValidationReportV0, CalibrationReviewRecordV0,
     ComponentUniverseValidationReport, ConsequenceEnvelopeReportV0,
     ConsequenceEnvelopeValidationReportV0, CustomRulePluginRegistryV0,
@@ -22,7 +23,7 @@ use archsig::{
     IncidentCorrelationMonitorV0, IntentArchMapAlignmentV0,
     IntentArchMapAlignmentValidationReportV0, IntentCalibrationRecordV0,
     IntentCalibrationValidationReportV0, IntentMapV0, IntentMapValidationReportV0,
-    LawPolicyTemplateRegistryV0, LawPolicyTemplateRegistryValidationReportV0,
+    LawPolicyTemplateRegistryV0, LawPolicyTemplateRegistryValidationReportV0, LawViolationReportV0,
     MeasurementUnitRegistryV0, MeasurementUnitRegistryValidationReportV0, NoSolutionCertificateV0,
     NoSolutionCertificateValidationReportV0, OperationProposalLogV0,
     OperationProposalLogValidationReportV0, OperationSupportEstimateV0,
@@ -36,14 +37,14 @@ use archsig::{
     SchemaVersionCatalogV0, Sig0Document, SignatureDiffReportV0, SignatureSnapshotStoreRecordV0,
     SignatureTrajectoryReportV0, SignatureTrajectoryReportValidationReportV0, SnapshotRecordInput,
     SnapshotRepositoryRef, SynthesisConstraintArtifactV0, SynthesisConstraintValidationReportV0,
-    TeamThresholdPolicyV0, TheoremPreconditionCheckReportV0, attach_framework_adapter_evidence,
-    build_ai_proposal_governance_from_descriptor, build_air_document, build_air_from_archmap,
-    build_artifact_descriptor_from_ai_proposal_json,
+    TeamThresholdPolicyV0, TheoremPreconditionCheckReportV0, apply_architecture_policy_to_sig0,
+    attach_framework_adapter_evidence, build_ai_proposal_governance_from_descriptor,
+    build_air_document, build_air_from_archmap, build_artifact_descriptor_from_ai_proposal_json,
     build_artifact_descriptor_from_github_issue_json, build_artifact_descriptor_from_markdown,
     build_baseline_suppression_report, build_consequence_envelope_from_forecast_cone,
     build_empirical_dataset, build_feature_extension_dataset_from_files,
     build_feature_extension_report, build_forecast_cone_skeleton_from_operation_support,
-    build_operation_support_estimate_from_archmap,
+    build_law_violation_report, build_operation_support_estimate_from_archmap,
     build_operation_support_estimate_from_descriptor,
     build_operation_support_estimate_from_intent_alignment,
     build_outcome_linkage_dataset_from_files, build_policy_decision_report,
@@ -52,7 +53,7 @@ use archsig::{
     build_signature_diff_report, build_signature_snapshot_record,
     build_theorem_precondition_check_report, extract_python_sig0,
     extract_relation_complexity_observation_from_file, extract_sig0_with_runtime,
-    render_pr_comment_markdown, static_ai_proposal_governance,
+    read_architecture_policy, render_pr_comment_markdown, static_ai_proposal_governance,
     static_architecture_dynamics_metrics_report, static_architecture_field_snapshot,
     static_artifact_descriptor, static_calibration_review_record,
     static_consequence_envelope_report, static_custom_rule_plugin_registry,
@@ -69,11 +70,12 @@ use archsig::{
     static_signature_trajectory_report, static_synthesis_constraint_artifact,
     static_team_threshold_policy, validate_ai_proposal_governance, validate_air_document_report,
     validate_architecture_dynamics_metrics_report, validate_architecture_field_snapshot,
-    validate_archmap_report, validate_artifact_descriptor_report,
-    validate_component_universe_report, validate_consequence_envelope_report,
-    validate_custom_rule_plugin_registry_report, validate_dynamics_measurement_contract_report,
-    validate_forecast_calibration_hook, validate_forecast_cone_skeleton,
-    validate_intent_archmap_alignment, validate_intent_calibration_record, validate_intent_map,
+    validate_architecture_policy_report, validate_archmap_report,
+    validate_artifact_descriptor_report, validate_component_universe_report,
+    validate_consequence_envelope_report, validate_custom_rule_plugin_registry_report,
+    validate_dynamics_measurement_contract_report, validate_forecast_calibration_hook,
+    validate_forecast_cone_skeleton, validate_intent_archmap_alignment,
+    validate_intent_calibration_record, validate_intent_map,
     validate_law_policy_template_registry_report, validate_measurement_unit_registry_report,
     validate_no_solution_certificate_report, validate_operation_proposal_log,
     validate_operation_support_estimate, validate_organization_policy_report,
@@ -636,6 +638,32 @@ enum Command {
         input: Option<PathBuf>,
 
         /// Output organization policy validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Validate a project-local architecture-policy v0 artifact.
+    ArchitecturePolicy {
+        /// Architecture policy JSON path.
+        #[arg(long)]
+        input: PathBuf,
+
+        /// Output architecture policy validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Evaluate architecture-policy laws against a Sig0 artifact.
+    LawViolationReport {
+        /// Sig0 JSON path.
+        #[arg(long)]
+        sig0: PathBuf,
+
+        /// Architecture policy JSON path.
+        #[arg(long)]
+        policy: PathBuf,
+
+        /// Output law violation report JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
     },
@@ -1679,6 +1707,31 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 ExitCode::SUCCESS
             })
         }
+        Some(Command::ArchitecturePolicy { input, out }) => {
+            let policy: ArchitecturePolicyV0 = read_json(&input)?;
+            let input_path = input.display().to_string();
+            let report: ArchitecturePolicyValidationReportV0 =
+                validate_architecture_policy_report(&policy, &input_path);
+            let failed = report.summary.result == "fail";
+            write_json(out, &report)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::LawViolationReport { sig0, policy, out }) => {
+            let sig0_document: Sig0Document = read_json(&sig0)?;
+            let policy_document: ArchitecturePolicyV0 = read_json(&policy)?;
+            let report: LawViolationReportV0 = build_law_violation_report(
+                &sig0_document,
+                Some(&sig0.display().to_string()),
+                &policy_document,
+                Some(&policy.display().to_string()),
+            );
+            write_json(out, &report)?;
+            Ok(ExitCode::SUCCESS)
+        }
         Some(Command::LawPolicyTemplates { input, out }) => {
             let registry: LawPolicyTemplateRegistryV0 = input
                 .as_ref()
@@ -2608,24 +2661,49 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
         }
         None => {
             let document = match args.language.as_str() {
-                "lean" => extract_sig0_with_runtime(
-                    &args.root,
-                    args.policy.as_deref(),
-                    args.runtime_edges.as_deref(),
-                )?,
-                "python" => {
-                    if args.policy.is_some() {
-                        return Err(
-                            "Python policy measurement is tracked by the Sig0 / AIR normalization work"
-                                .into(),
-                        );
+                "lean" => {
+                    if policy_schema_version(args.policy.as_deref())?.as_deref()
+                        == Some("architecture-policy-v0")
+                    {
+                        let mut document = extract_sig0_with_runtime(
+                            &args.root,
+                            None,
+                            args.runtime_edges.as_deref(),
+                        )?;
+                        if let Some(policy_path) = args.policy.as_deref() {
+                            let architecture_policy = read_architecture_policy(policy_path)?;
+                            apply_architecture_policy_to_sig0(
+                                &mut document,
+                                &architecture_policy,
+                                Some(&policy_path.display().to_string()),
+                            );
+                        }
+                        document
+                    } else {
+                        extract_sig0_with_runtime(
+                            &args.root,
+                            args.policy.as_deref(),
+                            args.runtime_edges.as_deref(),
+                        )?
                     }
+                }
+                "python" => {
                     if args.runtime_edges.is_some() {
                         return Err(
                             "runtime edge projection is not part of python-import-graph-v0".into(),
                         );
                     }
-                    extract_python_sig0(&args.root, &args.source_roots, &args.package_roots)?
+                    let mut document =
+                        extract_python_sig0(&args.root, &args.source_roots, &args.package_roots)?;
+                    if let Some(policy_path) = args.policy.as_deref() {
+                        let architecture_policy = read_architecture_policy(policy_path)?;
+                        apply_architecture_policy_to_sig0(
+                            &mut document,
+                            &architecture_policy,
+                            Some(&policy_path.display().to_string()),
+                        );
+                    }
+                    document
                 }
                 _ => unreachable!("clap restricts language values"),
             };
@@ -2633,6 +2711,18 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             Ok(ExitCode::SUCCESS)
         }
     }
+}
+
+fn policy_schema_version(path: Option<&Path>) -> Result<Option<String>, Box<dyn Error>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let source = std::fs::read_to_string(path)?;
+    let value: serde_json::Value = serde_json::from_str(&source)?;
+    Ok(value
+        .get("schemaVersion")
+        .and_then(|value| value.as_str())
+        .map(str::to_string))
 }
 
 fn write_json<T: serde::Serialize>(out: Option<PathBuf>, value: &T) -> Result<(), Box<dyn Error>> {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -41,6 +41,10 @@ pub const ORGANIZATION_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str =
 pub const LAW_POLICY_TEMPLATE_REGISTRY_SCHEMA_VERSION: &str = "law-policy-template-registry-v0";
 pub const LAW_POLICY_TEMPLATE_REGISTRY_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "law-policy-template-registry-validation-report-v0";
+pub const ARCHITECTURE_POLICY_SCHEMA_VERSION: &str = "architecture-policy-v0";
+pub const ARCHITECTURE_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str =
+    "architecture-policy-validation-report-v0";
+pub const LAW_VIOLATION_REPORT_SCHEMA_VERSION: &str = "law-violation-report-v0";
 pub const CUSTOM_RULE_PLUGIN_REGISTRY_SCHEMA_VERSION: &str = "custom-rule-plugin-registry-v0";
 pub const CUSTOM_RULE_PLUGIN_REGISTRY_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "custom-rule-plugin-registry-validation-report-v0";
@@ -2245,6 +2249,18 @@ pub struct ArchMapMapItem {
     pub non_conclusions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conflict_category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_role: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub responsibility_regions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reason_to_change: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub actor_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_role: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub law_refs: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -3202,6 +3218,209 @@ pub struct LawPolicyTemplateRegistryValidationSummary {
     pub template_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyV0 {
+    pub schema_version: String,
+    pub policy_id: String,
+    pub policy_version: String,
+    pub component_id_kind: String,
+    pub selector_semantics: String,
+    pub adopted_laws: Vec<ArchitectureAdoptedLawV0>,
+    pub layers: Vec<ArchitecturePolicyLayerV0>,
+    #[serde(default)]
+    pub allowed_dependencies: Vec<ArchitecturePolicyDependencyRuleV0>,
+    #[serde(default)]
+    pub forbidden_dependencies: Vec<ArchitecturePolicyDependencyRuleV0>,
+    #[serde(default)]
+    pub exceptions: Vec<ArchitecturePolicyExceptionV0>,
+    pub srp: ArchitecturePolicySrpV0,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitectureAdoptedLawV0 {
+    pub law_id: String,
+    pub law_kind: String,
+    pub enforcement: String,
+    pub review_level: String,
+    pub evidence_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyLayerV0 {
+    pub layer_id: String,
+    pub selectors: Vec<String>,
+    pub responsibility: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyDependencyRuleV0 {
+    pub rule_id: String,
+    pub law_ref: String,
+    pub source_layer: String,
+    pub target_layer: String,
+    pub severity: String,
+    pub review_action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyExceptionV0 {
+    pub exception_id: String,
+    pub law_ref: String,
+    pub source_selector: String,
+    pub target_selector: String,
+    pub reason: String,
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicySrpV0 {
+    pub responsibility_taxonomy: Vec<String>,
+    pub reason_to_change_categories: Vec<String>,
+    pub allowed_orchestrator_roles: Vec<String>,
+    pub required_evidence_fields: Vec<String>,
+    pub judgment_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyValidationReportV0 {
+    pub schema_version: String,
+    pub input: ArchitecturePolicyValidationInputV0,
+    pub policy: ArchitecturePolicyV0,
+    pub summary: ArchitecturePolicyValidationSummaryV0,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyValidationInputV0 {
+    pub schema_version: String,
+    pub path: String,
+    pub policy_id: String,
+    pub policy_version: String,
+    pub component_id_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitecturePolicyValidationSummaryV0 {
+    pub result: String,
+    pub adopted_law_count: usize,
+    pub layer_count: usize,
+    pub forbidden_dependency_count: usize,
+    pub exception_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationReportV0 {
+    pub schema_version: String,
+    pub report_id: String,
+    pub policy_ref: LawViolationPolicyRefV0,
+    pub sig0_ref: LawViolationSig0RefV0,
+    pub summary: LawViolationSummaryV0,
+    pub deterministic_violations: Vec<LawViolationFindingV0>,
+    pub allowed_exceptions: Vec<LawViolationExceptionFindingV0>,
+    pub srp_cues: Vec<SrpReviewCueV0>,
+    pub unmeasured: Vec<LawViolationUnmeasuredV0>,
+    pub review_actions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationPolicyRefV0 {
+    pub policy_id: String,
+    pub policy_version: String,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationSig0RefV0 {
+    pub root: String,
+    pub component_kind: String,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationSummaryV0 {
+    pub result: String,
+    pub deterministic_violation_count: usize,
+    pub allowed_exception_count: usize,
+    pub srp_cue_count: usize,
+    pub unmeasured_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationFindingV0 {
+    pub finding_id: String,
+    pub law_ref: String,
+    pub law_kind: String,
+    pub source: String,
+    pub target: String,
+    pub source_layer: String,
+    pub target_layer: String,
+    pub rule_id: String,
+    pub severity: String,
+    pub evidence: String,
+    pub review_action: String,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationExceptionFindingV0 {
+    pub exception_id: String,
+    pub law_ref: String,
+    pub source: String,
+    pub target: String,
+    pub reason: String,
+    pub review_action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SrpReviewCueV0 {
+    pub cue_id: String,
+    pub subject_ref: String,
+    pub semantic_role: Option<String>,
+    pub responsibility_regions: Vec<String>,
+    pub reason_to_change: Vec<String>,
+    pub actor_refs: Vec<String>,
+    pub allowed_role: Option<String>,
+    pub law_refs: Vec<String>,
+    pub judgment_taxonomy: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub policy_refs: Vec<String>,
+    pub missing_evidence: Vec<String>,
+    pub review_level: String,
+    pub review_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawViolationUnmeasuredV0 {
+    pub item_id: String,
+    pub category: String,
+    pub subject_ref: String,
+    pub reason: String,
+    pub review_action: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -1,19 +1,21 @@
 use crate::{
     AI_PROPOSAL_GOVERNANCE_SCHEMA_VERSION, AIR_SCHEMA_VERSION,
     ARCHITECTURE_DRIFT_LEDGER_SCHEMA_VERSION, ARCHITECTURE_DYNAMICS_METRICS_REPORT_SCHEMA_VERSION,
+    ARCHITECTURE_POLICY_SCHEMA_VERSION, ARCHITECTURE_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHMAP_SCHEMA_VERSION, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
     CALIBRATION_REVIEW_RECORD_SCHEMA_VERSION,
     DETECTABLE_VALUES_REPORTED_AXES_CATALOG_SCHEMA_VERSION,
     FEATURE_EXTENSION_REPORT_SCHEMA_VERSION, HYPOTHESIS_REFRESH_CYCLE_SCHEMA_VERSION,
     INCIDENT_CORRELATION_MONITOR_SCHEMA_VERSION, INTENT_ARCHMAP_ALIGNMENT_SCHEMA_VERSION,
     INTENT_CALIBRATION_RECORD_SCHEMA_VERSION, INTENTMAP_SCHEMA_VERSION,
-    OBSTRUCTION_WITNESS_SCHEMA_VERSION, OWNERSHIP_BOUNDARY_MONITOR_SCHEMA_VERSION,
-    PR_FORCE_REPORT_SCHEMA_VERSION, PR_QUALITY_ANALYSIS_REPORT_SCHEMA_VERSION,
-    REPAIR_ADOPTION_RECORD_SCHEMA_VERSION, REPORT_OUTCOME_DAILY_LEDGER_SCHEMA_VERSION,
-    SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION, SCHEMA_VERSION,
-    SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SIGNATURE_TRAJECTORY_REPORT_SCHEMA_VERSION,
-    SchemaCompatibilityBoundaryV0, SchemaCompatibilityDimensionV0, SchemaCompatibilityPolicyV0,
-    SchemaVersionCatalogEntryV0, SchemaVersionCatalogV0, TEAM_THRESHOLD_POLICY_SCHEMA_VERSION,
+    LAW_VIOLATION_REPORT_SCHEMA_VERSION, OBSTRUCTION_WITNESS_SCHEMA_VERSION,
+    OWNERSHIP_BOUNDARY_MONITOR_SCHEMA_VERSION, PR_FORCE_REPORT_SCHEMA_VERSION,
+    PR_QUALITY_ANALYSIS_REPORT_SCHEMA_VERSION, REPAIR_ADOPTION_RECORD_SCHEMA_VERSION,
+    REPORT_OUTCOME_DAILY_LEDGER_SCHEMA_VERSION, SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION,
+    SCHEMA_VERSION, SCHEMA_VERSION_CATALOG_SCHEMA_VERSION,
+    SIGNATURE_TRAJECTORY_REPORT_SCHEMA_VERSION, SchemaCompatibilityBoundaryV0,
+    SchemaCompatibilityDimensionV0, SchemaCompatibilityPolicyV0, SchemaVersionCatalogEntryV0,
+    SchemaVersionCatalogV0, TEAM_THRESHOLD_POLICY_SCHEMA_VERSION,
 };
 
 pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
@@ -108,6 +110,67 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                     ],
                     vec![
                         "Validation pass does not imply semantic correctness, completeness, or architecture lawfulness.",
+                    ],
+                ),
+            ),
+            artifact(
+                "architecture-policy",
+                "Architecture policy artifact",
+                ARCHITECTURE_POLICY_SCHEMA_VERSION,
+                "law-aware-review-policy",
+                "ArchMap law-aware review",
+                "implemented",
+                vec!["docs/tool/archmap_prd.md", "tools/archsig/docs/commands.md"],
+                vec!["#1162"],
+                compatibility_boundary(
+                    "Map adopted laws, layer selectors, dependency rules, exceptions, and SRP taxonomy explicitly; do not infer policy from repository shape.",
+                    vec![],
+                    vec![
+                        "New law families must declare deterministic versus LLM-review enforcement boundary.",
+                    ],
+                    vec![
+                        "Architecture policy is review evidence, not a Lean theorem or architecture lawfulness proof.",
+                    ],
+                ),
+            ),
+            artifact(
+                "architecture-policy-validation-report",
+                "Architecture policy validation report",
+                ARCHITECTURE_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+                "validation-output",
+                "ArchMap law-aware review",
+                "implemented",
+                vec!["tools/archsig/docs/commands.md"],
+                vec!["#1162"],
+                compatibility_boundary(
+                    "Keep identity, adopted law, layer selector, dependency rule, SRP evidence, and non-conclusion checks separate.",
+                    vec![],
+                    vec!["New checks must distinguish fail, warn, and unmeasured policy evidence."],
+                    vec![
+                        "Validation pass does not imply architecture lawfulness or SRP violation.",
+                    ],
+                ),
+            ),
+            artifact(
+                "law-violation-report",
+                "Law violation report",
+                LAW_VIOLATION_REPORT_SCHEMA_VERSION,
+                "review-output",
+                "ArchMap law-aware review",
+                "implemented",
+                vec![
+                    "tools/archsig/docs/commands.md",
+                    "tools/archsig/docs/artifacts-and-boundaries.md",
+                ],
+                vec!["#1164", "#1165"],
+                compatibility_boundary(
+                    "Map deterministic Layered findings, allowed exceptions, SRP cues, unmeasured selectors, review actions, and non-conclusions explicitly.",
+                    vec![],
+                    vec![
+                        "New law findings must preserve evidence refs and policy refs before review classification.",
+                    ],
+                    vec![
+                        "Layered findings are selected-universe tooling evidence and SRP cues are not tool-only violations.",
                     ],
                 ),
             ),

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -4215,6 +4215,115 @@ fn cli_extracts_policy_runtime_fixture_contract() {
 }
 
 #[test]
+fn cli_evaluates_architecture_policy_law_report_and_python_policy_status() {
+    let root = fixture_root();
+    let out_dir = temp_dir("architecture-policy");
+    let policy = root.join("architecture_policy.json");
+    let validation = out_dir.join("architecture-policy-validation.json");
+    let sig0 = out_dir.join("sig0.json");
+    let report = out_dir.join("law-violation-report.json");
+    let python_sig0 = out_dir.join("python-sig0.json");
+
+    run_sig0(&[
+        "architecture-policy",
+        "--input",
+        policy.to_str().expect("policy path is utf-8"),
+        "--out",
+        validation.to_str().expect("validation path is utf-8"),
+    ]);
+    let validation_json = read_json(&validation);
+    assert_eq!(
+        validation_json["schemaVersion"],
+        "architecture-policy-validation-report-v0"
+    );
+    assert_eq!(validation_json["summary"]["result"], "pass");
+    assert!(
+        validation_json["checks"]
+            .as_array()
+            .expect("checks are array")
+            .iter()
+            .any(|check| check["id"] == "architecture-policy-srp-evidence-boundary-recorded")
+    );
+
+    run_sig0(&[
+        "--root",
+        root.to_str().expect("fixture path is utf-8"),
+        "--policy",
+        policy.to_str().expect("policy path is utf-8"),
+        "--out",
+        sig0.to_str().expect("sig0 path is utf-8"),
+    ]);
+    let sig0_json = read_json(&sig0);
+    assert_eq!(
+        sig0_json["policies"]["schemaVersion"],
+        "architecture-policy-v0"
+    );
+    assert_eq!(
+        sig0_json["metricStatus"]["boundaryViolationCount"]["measured"],
+        true
+    );
+    assert_eq!(sig0_json["signature"]["boundaryViolationCount"], 1);
+    assert!(
+        sig0_json["policyViolations"]
+            .as_array()
+            .expect("policy violations are array")
+            .iter()
+            .any(|violation| {
+                violation["relationIds"]
+                    .as_array()
+                    .expect("relation ids are array")
+                    .iter()
+                    .any(|id| id == "forbid-domain-app")
+            })
+    );
+
+    run_sig0(&[
+        "law-violation-report",
+        "--sig0",
+        sig0.to_str().expect("sig0 path is utf-8"),
+        "--policy",
+        policy.to_str().expect("policy path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+    let report_json = read_json(&report);
+    assert_eq!(report_json["schemaVersion"], "law-violation-report-v0");
+    assert_eq!(report_json["summary"]["deterministicViolationCount"], 1);
+    assert!(
+        report_json["nonConclusions"]
+            .as_array()
+            .expect("nonConclusions are array")
+            .iter()
+            .any(|entry| entry == "SRP findings are evidence cues for LLM review, not tool-only violation judgments")
+    );
+
+    let python_root = python_fixture_root();
+    run_sig0(&[
+        "--language",
+        "python",
+        "--root",
+        python_root.to_str().expect("python fixture path is utf-8"),
+        "--source-root",
+        "src",
+        "--package-root",
+        "src",
+        "--policy",
+        policy.to_str().expect("policy path is utf-8"),
+        "--out",
+        python_sig0.to_str().expect("python sig0 path is utf-8"),
+    ]);
+    let python_json = read_json(&python_sig0);
+    assert_eq!(
+        python_json["policies"]["schemaVersion"],
+        "architecture-policy-v0"
+    );
+    assert_eq!(
+        python_json["metricStatus"]["boundaryViolationCount"]["measured"], false,
+        "selector mismatch must stay unmeasured instead of measured zero"
+    );
+}
+
+#[test]
 fn cli_dataset_fixture_keeps_unmeasured_deltas_null() {
     let root = fixture_root();
     let out_dir = temp_dir("dataset");

--- a/tools/archsig/tests/fixtures/expressiveness/archmap_expressiveness_suite_v0.json
+++ b/tools/archsig/tests/fixtures/expressiveness/archmap_expressiveness_suite_v0.json
@@ -78,6 +78,12 @@
       "claimClassification": "measured",
       "measurementBoundary": "measuredNonzero",
       "confidence": "medium",
+      "semanticRole": "service-orchestrator",
+      "responsibilityRegions": ["user orchestration", "user persistence"],
+      "reasonToChange": ["workflow policy change", "storage schema change"],
+      "actorRefs": ["actor:product", "actor:data"],
+      "allowedRole": "thin-orchestrator",
+      "lawRefs": ["SOLID.SRP"],
       "missingEvidence": [],
       "nonConclusions": ["SRP split cue is not a formal SOLID theorem"]
     },

--- a/tools/archsig/tests/fixtures/minimal/architecture_policy.json
+++ b/tools/archsig/tests/fixtures/minimal/architecture_policy.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": "architecture-policy-v0",
+  "policyId": "minimal-law-aware-review-policy",
+  "policyVersion": "2026-05-25",
+  "componentIdKind": "lean-module",
+  "selectorSemantics": "exact-or-prefix-star",
+  "adoptedLaws": [
+    {
+      "lawId": "LayeredArchitecture",
+      "lawKind": "layeredArchitecture",
+      "enforcement": "deterministic",
+      "reviewLevel": "Level 2 policy risk",
+      "evidenceBoundary": "resolved layer selectors over measured import edges"
+    },
+    {
+      "lawId": "SOLID.SRP",
+      "lawKind": "singleResponsibilityPrinciple",
+      "enforcement": "llmReview",
+      "reviewLevel": "Level 3 LLM probable violation",
+      "evidenceBoundary": "semantic role and reason-to-change evidence, not tool-only violation"
+    }
+  ],
+  "layers": [
+    {
+      "layerId": "app",
+      "selectors": ["Formal", "Formal.Arch.A"],
+      "responsibility": "entry and application-facing module"
+    },
+    {
+      "layerId": "domain",
+      "selectors": ["Formal.Arch.B"],
+      "responsibility": "domain support module"
+    }
+  ],
+  "allowedDependencies": [
+    {
+      "ruleId": "allow-app-domain",
+      "lawRef": "LayeredArchitecture",
+      "sourceLayer": "app",
+      "targetLayer": "domain",
+      "severity": "info",
+      "reviewAction": "dependency follows selected layer direction"
+    }
+  ],
+  "forbiddenDependencies": [
+    {
+      "ruleId": "forbid-domain-app",
+      "lawRef": "LayeredArchitecture",
+      "sourceLayer": "domain",
+      "targetLayer": "app",
+      "severity": "high",
+      "reviewAction": "move dependency behind an app-facing port or revise the layer policy"
+    }
+  ],
+  "exceptions": [],
+  "srp": {
+    "responsibilityTaxonomy": ["orchestration", "persistence", "policy", "adapter"],
+    "reasonToChangeCategories": ["workflow policy change", "storage schema change", "API contract change"],
+    "allowedOrchestratorRoles": ["thin-orchestrator", "transaction-script"],
+    "requiredEvidenceFields": ["semanticRole", "responsibilityRegions", "reasonToChange", "lawRefs"],
+    "judgmentBoundary": "LLM Review Skill may classify probableViolation only with evidence refs and policy refs"
+  },
+  "nonConclusions": [
+    "architecture policy is review evidence, not a Lean theorem",
+    "LayeredArchitecture findings are deterministic over the measured selector universe only",
+    "SRP findings are evidence cues for LLM review, not tool-only violation judgments",
+    "unmeasured selector coverage is not measured zero",
+    "policy pass does not conclude architecture lawfulness"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -127,6 +127,96 @@
       }
     },
     {
+      "artifactId": "architecture-policy",
+      "artifactName": "Architecture policy artifact",
+      "schemaVersionName": "architecture-policy-v0",
+      "artifactRole": "law-aware-review-policy",
+      "ownerPhase": "ArchMap law-aware review",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archmap_prd.md",
+        "tools/archsig/docs/commands.md"
+      ],
+      "downstreamIssues": [
+        "#1162"
+      ],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Map adopted laws, layer selectors, dependency rules, exceptions, and SRP taxonomy explicitly; do not infer policy from repository shape.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "New law families must declare deterministic versus LLM-review enforcement boundary."
+        ],
+        "coverageExactnessBoundary": [
+          "Architecture policy is review evidence, not a Lean theorem or architecture lawfulness proof."
+        ],
+        "nonConclusions": [
+          "field mapping does not prove semantic preservation",
+          "missing coverage is not measured zero",
+          "renamed fields do not discharge new required assumptions"
+        ]
+      }
+    },
+    {
+      "artifactId": "architecture-policy-validation-report",
+      "artifactName": "Architecture policy validation report",
+      "schemaVersionName": "architecture-policy-validation-report-v0",
+      "artifactRole": "validation-output",
+      "ownerPhase": "ArchMap law-aware review",
+      "status": "implemented",
+      "primaryDocs": [
+        "tools/archsig/docs/commands.md"
+      ],
+      "downstreamIssues": [
+        "#1162"
+      ],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Keep identity, adopted law, layer selector, dependency rule, SRP evidence, and non-conclusion checks separate.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "New checks must distinguish fail, warn, and unmeasured policy evidence."
+        ],
+        "coverageExactnessBoundary": [
+          "Validation pass does not imply architecture lawfulness or SRP violation."
+        ],
+        "nonConclusions": [
+          "field mapping does not prove semantic preservation",
+          "missing coverage is not measured zero",
+          "renamed fields do not discharge new required assumptions"
+        ]
+      }
+    },
+    {
+      "artifactId": "law-violation-report",
+      "artifactName": "Law violation report",
+      "schemaVersionName": "law-violation-report-v0",
+      "artifactRole": "review-output",
+      "ownerPhase": "ArchMap law-aware review",
+      "status": "implemented",
+      "primaryDocs": [
+        "tools/archsig/docs/commands.md",
+        "tools/archsig/docs/artifacts-and-boundaries.md"
+      ],
+      "downstreamIssues": [
+        "#1164",
+        "#1165"
+      ],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Map deterministic Layered findings, allowed exceptions, SRP cues, unmeasured selectors, review actions, and non-conclusions explicitly.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "New law findings must preserve evidence refs and policy refs before review classification."
+        ],
+        "coverageExactnessBoundary": [
+          "Layered findings are selected-universe tooling evidence and SRP cues are not tool-only violations."
+        ],
+        "nonConclusions": [
+          "field mapping does not prove semantic preservation",
+          "missing coverage is not measured zero",
+          "renamed fields do not discharge new required assumptions"
+        ]
+      }
+    },
+    {
       "artifactId": "archmap-generation-protocol",
       "artifactName": "ArchMap generation protocol",
       "schemaVersionName": "archmap-generation-protocol-v0",


### PR DESCRIPTION
## 概要

Closes #1161
Closes #1162
Closes #1163
Closes #1164
Closes #1165

ArchSig / ArchMap を law-aware review evidence pipeline として扱えるように、project-local な `architecture-policy-v0` と `law-violation-report-v0` を追加しました。Layered Architecture は resolved layer selector と measured import edge に対する deterministic violation として出し、SRP は `semanticRole` / `responsibilityRegions` / `reasonToChange` / `lawRefs` を持つ review cue として保持します。

主な実装:
- `architecture-policy` / `law-violation-report` CLI を追加
- Lean / Python Sig0 scan の `--policy architecture-policy-v0` 対応
- ArchMap map item に SRP evidence fields を追加し、validation / AIR claim boundary で保持
- schema catalog、fixtures、CLI regression test を更新
- arch-pr-analyzer skill と command / boundary docs を law-aware review 境界へ同期

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archmap_prd.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/skills/arch-pr-analyzer/SKILL.md`
- `tools/archsig/skills/arch-pr-analyzer/references/artifact-reading-guide.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（lib 50 件、CLI 84 件、doc-test 0 件、すべて pass）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan（`tools/archsig docs/tool`、該当なし）
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（変更範囲に Lean ソース追加なし。既存 docs / fixture の `unsafe` 文言のみ）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical tooling / design tracking` として扱う範囲に留めた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている