### PR TITLE
ArchMapをAAT準同型写像として第一級化

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -1,6 +1,6 @@
 # Tool Docs
 
-`docs/tool/` is being rebuilt around the ArchMap-primary ArchSig workflow tracked by Issue #1203 and Issue #1204.
+`docs/tool/` is being rebuilt around the ArchMap-homomorphism-primary ArchSig workflow tracked by Issue #1206 and its child Issues.
 
 The previous mixed ArchSig / ArchMap / AIR / theorem-precondition / FieldSig-transition documents are archived under:
 
@@ -8,9 +8,10 @@ The previous mixed ArchSig / ArchMap / AIR / theorem-precondition / FieldSig-tra
 
 Current source-of-truth boundaries:
 
-- ArchSig starts from supplied `archmap-v0` evidence and projects it through AIR, theorem precondition checks, Feature Extension Report, and AAT Observable Bundle review artifacts.
+- ArchSig starts from supplied `archmap-v0` evidence read as a bounded AAT homomorphism. It diagnoses domain / codomain, object map, relation map, law map, obstruction map, signature-axis map, preservation claims, forgetful boundaries, unmeasured boundaries, unsupported boundaries, and non-conclusions.
+- ArchSig projects that homomorphism through AIR, theorem precondition checks, Feature Extension Report, and AAT Observable Bundle review artifacts.
 - Lean / Python import-graph output is optional bounded adapter evidence, emitted explicitly by `archsig adapter-scan`; adapter artifacts retain `coverageBoundary`, `unsupportedConstructs`, `missingEvidence`, and `nonConclusions`.
 - ArchSig validation does not prove extractor completeness, semantic correctness, architecture lawfulness, global safety, or Lean theorem discharge.
 - FieldSig / SFT forecast and governance surfaces are not owned by ArchSig.
 
-New ArchMap-first specification documents should be added here only when they match the implementation and keep those boundaries explicit.
+New ArchMap-homomorphism-first specification documents should be added here only when they match the implementation and keep those boundaries explicit.

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -1,6 +1,6 @@
 # ArchSig
 
-`archsig` is an AAT structural review CLI. Its primary surface is an ArchMap-first workflow: supplied `archmap-v0` evidence is validated, projected to AIR, checked against theorem-precondition boundaries, summarized as a Feature Extension Report, and bundled as AAT observable review evidence.
+`archsig` is an AAT structural review CLI. Its primary surface is an ArchMap-homomorphism workflow: supplied `archmap-v0` evidence is read as a bounded map from selected source architecture evidence into the AAT object / relation / law / obstruction / signature-axis world. ArchSig diagnoses what that map preserves, what it forgets, which parts are unmeasured or unsupported, and which obstruction witnesses or next evidence should be reviewed.
 
 ArchSig is not a Lean prover, extractor-completeness claim, architecture-lawfulness oracle, merge approval system, or SFT forecast engine. FieldSig owns SFT forecast, IntentMap, workflow evidence, operational feedback, dynamics, governance, and calibration under `tools/fieldsig`.
 
@@ -8,14 +8,14 @@ ArchSig is not a Lean prover, extractor-completeness claim, architecture-lawfuln
 
 | Surface | Current role | Boundary |
 | --- | --- | --- |
-| ArchMap primary workflow | `archmap-workflow`, `archmap`, `air-from-archmap`, `validate-air`, `theorem-check`, `feature-report`, `aat-observable-bundle` | Supplied evidence and validation reports are review artifacts, not semantic truth or Lean theorem discharge. The workflow bundle is built from the input ArchMap and generated reports, not from the static fixture. |
+| ArchMap homomorphism workflow | `archmap-workflow`, `archmap`, `air-from-archmap`, `validate-air`, `theorem-check`, `feature-report`, `aat-observable-bundle` | ArchMap is the canonical bounded AAT homomorphism input. Diagnostics report homomorphic / partial / lossy / non-homomorphic status, preservation failures, forgetful boundaries, unmeasured boundaries, unsupported boundaries, AAT signature axes, and obstruction refs. |
 | Bounded adapters | `adapter-scan` for Lean / Python import-graph Sig0 evidence, optional framework adapter evidence | Adapter output is an evidence supplier for conflict checks or legacy diff workflows; it retains `coverageBoundary`, `unsupportedConstructs`, `missingEvidence`, and `nonConclusions`, but it is not the ArchSig primary surface and does not produce a complete `ComponentUniverse`. |
 | Revision comparison | `validate`, `snapshot`, `signature-diff` over explicit Sig0 adapter artifacts | Diff values must be read with measured / unmeasured boundaries and non-conclusions. |
 | Review support | policy, law violation, policy decision, PR comment, PR quality analysis, schema compatibility | Tool output supports review; humans remain responsible for risk acceptance and product decisions. |
 
 ## Quick Start
 
-Run the primary ArchMap workflow:
+Run the primary ArchMap homomorphism workflow:
 
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \
@@ -32,6 +32,8 @@ This writes:
 - `.archsig/archmap-primary/feature-report.json`
 - `.archsig/archmap-primary/aat-observable-bundle.json`
 - `.archsig/archmap-primary/aat-observable-bundle-validation.json`
+
+The validation report contains `homomorphismDiagnostics`; the Feature Extension Report contains `homomorphismSummary`. These are user-facing AAT diagnostics, not proof objects.
 
 When language import-graph evidence is needed, run it explicitly as an adapter:
 

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -1,17 +1,17 @@
 # ArchSig Artifacts And Boundaries
 
-ArchSig owns AAT structural review artifacts. Its primary artifact path is ArchMap -> AIR -> theorem-precondition check -> Feature Extension Report -> AAT Observable Bundle.
+ArchSig owns AAT structural review artifacts. Its primary artifact path is ArchMap homomorphism -> AIR -> theorem-precondition check -> Feature Extension Report -> AAT Observable Bundle.
 
 ## Primary Artifacts
 
 | artifact | schemaVersion | role |
 | --- | --- | --- |
-| ArchMap | `archmap-v0` | Supplied structural map from selected sources to architecture objects, relations, semantic diagrams, missing evidence, coverage boundaries, and non-conclusions. |
-| ArchMap validation report | `archmap-validation-report-v0` | Source inventory, source refs, semantic coverage, conflict, projection separation, and formal-promotion guardrail checks. |
+| ArchMap | `archmap-v0` | Bounded homomorphism candidate from selected source architecture evidence to AAT object / relation / law / obstruction / signature-axis space. It records domain, codomain, object map, relation map, law map, obstruction map, signature-axis map, preservation claims, forgetful boundary, unmeasured boundary, unsupported boundary, and non-conclusions. |
+| ArchMap validation report | `archmap-validation-report-v0` | Source inventory, source refs, semantic coverage, conflict, projection separation, formal-promotion guardrail checks, and user-facing `homomorphismDiagnostics`. |
 | AIR | `aat-air-v0` | Architecture Interpretation Record connecting ArchMap evidence to review claims, coverage, semantic paths, and theorem-boundary data. |
 | AIR validation report | `aat-air-validation-report-v0` | Reference, claim, coverage, and theorem-promotion guardrail checks. |
 | Theorem precondition check | `theorem-precondition-check-report-v0` | Boundary report for formal theorem-shaped claims. |
-| Feature Extension Report | `feature-extension-report-v0` | Reviewer-facing structural movement report with coverage gaps and theorem-precondition results. |
+| Feature Extension Report | `feature-extension-report-v0` | Reviewer-facing structural movement report with coverage gaps, homomorphism summary, obstruction refs, and theorem-precondition results. |
 | AAT Observable Bundle | `aat-observable-bundle-v0` | AAT concept / witness / selected universe review bundle with deterministic, LLM, human, and formal-proof responsibility boundaries. |
 | PR quality analysis | `pr-quality-analysis-report-v0` | Review cue projection from ArchMap / AIR / theorem-check / feature-report / policy refs. |
 
@@ -32,4 +32,4 @@ Adapter output must preserve coverage boundary, unsupported constructs, missing 
 
 FieldSig consumes ArchSig outputs through JSON artifact refs. ArchSig does not expose SFT / workflow commands or compatibility aliases. In particular, `operation-support-estimate-v0`, `forecast-cone-skeleton-v0`, `consequence-envelope-report-v0`, `software-field-measurement-v0`, `fieldsig-run-manifest-v0`, operational feedback, dynamics, governance, and calibration artifacts belong to FieldSig.
 
-Validation pass for either tool is not a Lean proof, forecast correctness proof, probability claim, causal theorem, global safety guarantee, semantic correctness proof, extractor-completeness proof, or replacement for CI / tests / human review.
+Validation pass for either tool is not a Lean proof, forecast correctness proof, probability claim, causal theorem, global safety guarantee, semantic correctness proof, extractor-completeness proof, or replacement for CI / tests / human review. A `homomorphic` classification is bounded to the selected ArchMap domain and codomain; it is not a claim that the repository or deployed system is globally complete.

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -1,10 +1,10 @@
 # ArchSig Commands
 
-`archsig` is ArchMap-primary. The normal review path starts from supplied `archmap-v0` evidence. Lean / Python import-graph scanning is available only through the explicit `adapter-scan` command as bounded evidence.
+`archsig` is ArchMap-homomorphism-primary. The normal review path starts from supplied `archmap-v0` evidence and reads it as a bounded AAT homomorphism from selected source architecture evidence into AAT object / relation / law / obstruction / signature-axis space. Lean / Python import-graph scanning is available only through the explicit `adapter-scan` command as bounded evidence.
 
 FieldSig owns SFT forecast, IntentMap, workflow evidence, operational feedback, dynamics, governance, and calibration commands under `tools/fieldsig`.
 
-## ArchMap Primary Workflow
+## ArchMap Homomorphism Workflow
 
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \
@@ -12,7 +12,9 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \
   --out-dir .archsig/archmap-primary
 ```
 
-The command emits ArchMap validation, AIR, AIR validation, theorem precondition check, Feature Extension Report, AAT Observable Bundle, and bundle validation artifacts. The bundle is assembled from the input ArchMap and generated workflow reports, so static fixture architecture ids, source refs, witnesses, and selected universes are not carried into workflow output. Optional Sig0 adapter evidence can be supplied for static / semantic conflict checks:
+The command emits ArchMap validation, AIR, AIR validation, theorem precondition check, Feature Extension Report, AAT Observable Bundle, and bundle validation artifacts. The ArchMap validation report includes `homomorphismDiagnostics`; the Feature Extension Report includes `homomorphismSummary`. These surfaces answer the user-facing AAT questions: what structure the ArchMap preserves, what it forgets, where it is partial or non-homomorphic, which axes are unmeasured, and which obstruction witnesses or next evidence should be reviewed.
+
+The bundle is assembled from the input ArchMap and generated workflow reports, so static fixture architecture ids, source refs, witnesses, and selected universes are not carried into workflow output. Optional Sig0 adapter evidence can be supplied for static / semantic conflict checks:
 
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -7,9 +7,12 @@ use crate::{
     AirComponent, AirCoverage, AirCoverageLayer, AirDocumentV0, AirEvidence, AirExtension,
     AirFeature, AirIdPolicies, AirNonfillabilityWitness, AirOperationTrace, AirPolicies,
     AirRelation, AirRevision, AirSemanticDiagram, AirSignature, ArchMapConflict, ArchMapDocumentV0,
-    ArchMapLeanPreservationChecklistEntry, ArchMapLeanPreservationVocabularyEntry, ArchMapMapItem,
-    ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapValidationReportV0,
-    ArchMapValidationSummary, Sig0Document, ValidationCheck,
+    ArchMapHomomorphismDiagnosticsV0, ArchMapHomomorphismFamilySummaryV0,
+    ArchMapHomomorphismMapEntryV0, ArchMapHomomorphismPreservationClaimV0,
+    ArchMapHomomorphismUniverseV0, ArchMapHomomorphismV0, ArchMapLeanPreservationChecklistEntry,
+    ArchMapLeanPreservationVocabularyEntry, ArchMapMapItem, ArchMapSourceInventoryV0,
+    ArchMapSourceRef, ArchMapValidationReportV0, ArchMapValidationSummary, Sig0Document,
+    ValidationCheck,
 };
 
 pub struct ArchMapSourceInventoryInput<'a> {
@@ -42,6 +45,9 @@ pub fn validate_archmap_report(
         check_formal_promotion_guardrail(document),
         check_projection_separation(document),
     ];
+    let homomorphism = archmap_homomorphism(document);
+    let homomorphism_diagnostics = archmap_homomorphism_diagnostics(document, &homomorphism, sig0);
+    let homomorphism_checks = vec![check_homomorphism_diagnostics(&homomorphism_diagnostics)];
 
     let mut all_checks = Vec::new();
     all_checks.append(&mut source_inventory_checks.clone());
@@ -50,6 +56,7 @@ pub fn validate_archmap_report(
     all_checks.extend(semantic_coverage_checks.clone());
     all_checks.extend(conflict_checks.clone());
     all_checks.extend(formal_promotion_guardrail_checks.clone());
+    all_checks.extend(homomorphism_checks);
 
     let failed_check_count = count_checks(&all_checks, "fail");
     let warning_check_count = count_checks(&all_checks, "warn");
@@ -72,15 +79,262 @@ pub fn validate_archmap_report(
         semantic_coverage_checks,
         conflict_checks,
         formal_promotion_guardrail_checks,
+        homomorphism_diagnostics: homomorphism_diagnostics.clone(),
         summary: ArchMapValidationSummary {
             result: result.to_string(),
             map_item_count: document.map_items.len(),
+            homomorphism_classification: homomorphism_diagnostics.classification,
             conflict_count: explicit_and_derived_conflicts(document, sig0).len(),
             failed_check_count,
             warning_check_count,
         },
         non_conclusions: archmap_non_conclusions(document),
     }
+}
+
+pub fn archmap_homomorphism(document: &ArchMapDocumentV0) -> ArchMapHomomorphismV0 {
+    if !document.homomorphism.object_map.is_empty()
+        || !document.homomorphism.relation_map.is_empty()
+        || !document.homomorphism.law_map.is_empty()
+        || !document.homomorphism.obstruction_map.is_empty()
+        || !document.homomorphism.signature_axis_map.is_empty()
+    {
+        return document.homomorphism.clone();
+    }
+
+    let domain_refs = document
+        .source_universe
+        .included_refs
+        .iter()
+        .map(archmap_source_ref_label)
+        .collect();
+    let codomain_refs = document
+        .target_universe
+        .selected_layers
+        .iter()
+        .map(|layer| format!("aat-layer:{layer}"))
+        .collect();
+    let mut hom = ArchMapHomomorphismV0 {
+        reading: "bounded AAT homomorphism derived from legacy mapItems".to_string(),
+        domain: ArchMapHomomorphismUniverseV0 {
+            universe_id: format!("source:{}", document.architecture_id),
+            description: "selected source architecture evidence".to_string(),
+            refs: domain_refs,
+            boundary: document.source_universe.selection_boundary.clone(),
+        },
+        codomain: ArchMapHomomorphismUniverseV0 {
+            universe_id: format!("aat:{}", document.architecture_id),
+            description: document.target_universe.representation.clone(),
+            refs: codomain_refs,
+            boundary: "selected AAT observable universe".to_string(),
+        },
+        object_map: Vec::new(),
+        relation_map: Vec::new(),
+        law_map: Vec::new(),
+        obstruction_map: Vec::new(),
+        signature_axis_map: Vec::new(),
+        preservation_claims: Vec::new(),
+        forgetful_boundary: Vec::new(),
+        unmeasured_boundary: document.coverage.unmeasured_layers.clone(),
+        unsupported_boundary: document.coverage.unsupported_constructs.clone(),
+        non_conclusions: archmap_non_conclusions(document),
+    };
+
+    for item in &document.map_items {
+        let entry = ArchMapHomomorphismMapEntryV0 {
+            map_entry_id: item.map_item_id.clone(),
+            map_family: archmap_item_map_family(item).to_string(),
+            source_ref: item
+                .source_refs
+                .first()
+                .map(archmap_source_ref_label)
+                .unwrap_or_else(|| "source:unspecified".to_string()),
+            target_ref: archmap_target_ref_label(item),
+            preserves: item.preserves.clone(),
+            forgets: item.forgets.clone(),
+            measurement_boundary: item.measurement_boundary.clone(),
+            claim_classification: item.claim_classification.clone(),
+            evidence_refs: item.evidence_refs.clone(),
+            non_conclusions: archmap_item_non_conclusions(item),
+        };
+        for forgets in &item.forgets {
+            hom.forgetful_boundary
+                .push(format!("{} forgets {forgets}", item.map_item_id));
+        }
+        if item.measurement_boundary == "unmeasured" || item.claim_classification == "unmeasured" {
+            hom.unmeasured_boundary.push(item.map_item_id.clone());
+        }
+        hom.preservation_claims
+            .extend(
+                item.preserves
+                    .iter()
+                    .enumerate()
+                    .map(
+                        |(index, preserved_structure)| ArchMapHomomorphismPreservationClaimV0 {
+                            claim_id: format!("preservation-{}-{}", item.map_item_id, index + 1),
+                            map_entry_ref: item.map_item_id.clone(),
+                            preserved_structure: preserved_structure.clone(),
+                            status: archmap_item_homomorphism_status(document, item).to_string(),
+                            boundary: item.measurement_boundary.clone(),
+                            missing_evidence: item.missing_evidence.clone(),
+                            non_conclusions: archmap_item_non_conclusions(item),
+                        },
+                    ),
+            );
+
+        match entry.map_family.as_str() {
+            "object" => hom.object_map.push(entry),
+            "relation" => hom.relation_map.push(entry),
+            "law" => hom.law_map.push(entry),
+            "obstruction" => hom.obstruction_map.push(entry),
+            "signatureAxis" => hom.signature_axis_map.push(entry),
+            _ => hom.signature_axis_map.push(entry),
+        }
+    }
+
+    hom.forgetful_boundary.sort();
+    hom.forgetful_boundary.dedup();
+    hom.unmeasured_boundary.sort();
+    hom.unmeasured_boundary.dedup();
+    hom.unsupported_boundary.sort();
+    hom.unsupported_boundary.dedup();
+    hom
+}
+
+fn archmap_homomorphism_diagnostics(
+    document: &ArchMapDocumentV0,
+    hom: &ArchMapHomomorphismV0,
+    sig0: Option<&Sig0Document>,
+) -> ArchMapHomomorphismDiagnosticsV0 {
+    let families = [
+        ("object", hom.object_map.as_slice()),
+        ("relation", hom.relation_map.as_slice()),
+        ("law", hom.law_map.as_slice()),
+        ("obstruction", hom.obstruction_map.as_slice()),
+        ("signatureAxis", hom.signature_axis_map.as_slice()),
+    ];
+    let map_family_summaries = families
+        .iter()
+        .map(|(family, entries)| homomorphism_family_summary(family, entries))
+        .collect::<Vec<_>>();
+    let mut preservation_failures = hom
+        .preservation_claims
+        .iter()
+        .filter(|claim| claim.status == "nonHomomorphic" || claim.status == "blocked")
+        .map(|claim| {
+            format!(
+                "{} does not preserve {}",
+                claim.map_entry_ref, claim.preserved_structure
+            )
+        })
+        .collect::<Vec<_>>();
+    preservation_failures.extend(
+        explicit_and_derived_conflicts(document, sig0)
+            .into_iter()
+            .map(|conflict| format!("{}: {}", conflict.category, conflict.subject_ref)),
+    );
+    preservation_failures.sort();
+    preservation_failures.dedup();
+
+    let mut next_evidence = Vec::new();
+    if !hom.unmeasured_boundary.is_empty() {
+        next_evidence.push("supply evidence for unmeasured homomorphism map families".to_string());
+    }
+    if !hom.unsupported_boundary.is_empty() {
+        next_evidence
+            .push("declare adapter or manual evidence for unsupported constructs".to_string());
+    }
+    if !preservation_failures.is_empty() {
+        next_evidence.push("review non-homomorphic preservation failures".to_string());
+    }
+
+    let classification = if !preservation_failures.is_empty() {
+        "nonHomomorphic"
+    } else if !hom.unmeasured_boundary.is_empty() || !hom.unsupported_boundary.is_empty() {
+        "partial"
+    } else if !hom.forgetful_boundary.is_empty() {
+        "lossy"
+    } else {
+        "homomorphic"
+    };
+
+    ArchMapHomomorphismDiagnosticsV0 {
+        classification: classification.to_string(),
+        reading: if hom.reading.is_empty() {
+            "bounded AAT homomorphism".to_string()
+        } else {
+            hom.reading.clone()
+        },
+        domain_ref: hom.domain.universe_id.clone(),
+        codomain_ref: hom.codomain.universe_id.clone(),
+        map_family_summaries,
+        preservation_failures,
+        forgetful_boundaries: hom.forgetful_boundary.clone(),
+        unmeasured_boundaries: hom.unmeasured_boundary.clone(),
+        unsupported_boundaries: hom.unsupported_boundary.clone(),
+        obstruction_refs: hom
+            .obstruction_map
+            .iter()
+            .map(|entry| entry.target_ref.clone())
+            .collect(),
+        signature_axis_refs: hom
+            .signature_axis_map
+            .iter()
+            .map(|entry| entry.target_ref.clone())
+            .collect(),
+        next_evidence,
+        non_conclusions: hom.non_conclusions.clone(),
+    }
+}
+
+fn homomorphism_family_summary(
+    family: &str,
+    entries: &[ArchMapHomomorphismMapEntryV0],
+) -> ArchMapHomomorphismFamilySummaryV0 {
+    ArchMapHomomorphismFamilySummaryV0 {
+        map_family: family.to_string(),
+        entry_count: entries.len(),
+        measured_count: entries
+            .iter()
+            .filter(|entry| entry.claim_classification == "measured")
+            .count(),
+        unmeasured_count: entries
+            .iter()
+            .filter(|entry| {
+                entry.claim_classification == "unmeasured"
+                    || entry.measurement_boundary == "unmeasured"
+            })
+            .count(),
+        assumed_count: entries
+            .iter()
+            .filter(|entry| entry.claim_classification == "assumed")
+            .count(),
+        lossy_count: entries
+            .iter()
+            .filter(|entry| !entry.forgets.is_empty())
+            .count(),
+    }
+}
+
+fn check_homomorphism_diagnostics(
+    diagnostics: &ArchMapHomomorphismDiagnosticsV0,
+) -> ValidationCheck {
+    let result = if diagnostics.classification == "nonHomomorphic" {
+        "warn"
+    } else {
+        "pass"
+    };
+    let mut check = validation_check(
+        "archmap-homomorphism-diagnostics",
+        "ArchMap is read as a bounded AAT homomorphism with explicit loss and boundary diagnostics",
+        result,
+    );
+    if diagnostics.classification == "nonHomomorphic" {
+        check.reason = Some(
+            "non-homomorphic preservation failures are retained as review evidence".to_string(),
+        );
+    }
+    check
 }
 
 pub fn build_air_from_archmap(
@@ -1548,12 +1802,71 @@ fn archmap_item_non_conclusions(item: &ArchMapMapItem) -> Vec<String> {
 
 fn archmap_non_conclusions(document: &ArchMapDocumentV0) -> Vec<String> {
     let mut non_conclusions = document.non_conclusions.clone();
+    non_conclusions.extend(document.homomorphism.non_conclusions.clone());
     non_conclusions.extend(document.generation_boundary.non_conclusions.clone());
+    non_conclusions.push(
+        "ArchMap is a bounded AAT homomorphism candidate, not architecture ground truth"
+            .to_string(),
+    );
     non_conclusions.push("ArchMap validation does not prove architecture lawfulness".to_string());
     non_conclusions.push("ArchMap validation does not prove semantic completeness".to_string());
     non_conclusions.sort();
     non_conclusions.dedup();
     non_conclusions
+}
+
+fn archmap_item_map_family(item: &ArchMapMapItem) -> &'static str {
+    let lean_field = archmap_item_lean_package_field(item);
+    match lean_field {
+        "ObjectPreservation" => "object",
+        "RelationPreservation" | "SemanticDiagramPreservation" => "relation",
+        "LawPolicyPreservation" => "law",
+        "NonfillabilityWitnessPreservation" => "obstruction",
+        "FlatnessPreconditionPreservation" | "CoverageExactnessBoundary" => "signatureAxis",
+        _ => "signatureAxis",
+    }
+}
+
+fn archmap_item_homomorphism_status(
+    document: &ArchMapDocumentV0,
+    item: &ArchMapMapItem,
+) -> &'static str {
+    if item.conflict_category.is_some() {
+        "nonHomomorphic"
+    } else if !item.missing_evidence.is_empty()
+        || archmap_item_has_unmeasured_coverage(document, item)
+    {
+        "blocked"
+    } else if item.claim_classification == "assumed" {
+        "assumed"
+    } else {
+        "preserved"
+    }
+}
+
+fn archmap_source_ref_label(source_ref: &ArchMapSourceRef) -> String {
+    if let Some(artifact_id) = &source_ref.artifact_id {
+        return artifact_id.clone();
+    }
+    if let Some(path) = &source_ref.path {
+        return path.clone();
+    }
+    source_ref.kind.clone()
+}
+
+fn archmap_target_ref_label(item: &ArchMapMapItem) -> String {
+    item.target_ref
+        .subject_ref
+        .clone()
+        .or_else(|| item.target_ref.id.clone())
+        .or_else(|| {
+            item.target_ref
+                .from
+                .as_ref()
+                .zip(item.target_ref.to.as_ref())
+                .map(|(from, to)| format!("{from}->{to}"))
+        })
+        .unwrap_or_else(|| item.map_item_id.clone())
 }
 
 fn is_aat_facing_item(item: &ArchMapMapItem) -> bool {

--- a/tools/archsig/src/feature_report.rs
+++ b/tools/archsig/src/feature_report.rs
@@ -8,11 +8,11 @@ use crate::{
     FeatureExtensionReportV0, FeatureReportArchitectureSummary, FeatureReportCoverageGap,
     FeatureReportEdgeRef, FeatureReportEvidenceRef, FeatureReportGeneratedPatchOperation,
     FeatureReportGeneratedPatchReviewWarning, FeatureReportGeneratedPatchSummary,
-    FeatureReportInput, FeatureReportInterpretedExtension, FeatureReportInvariant,
-    FeatureReportObstructionWitness, FeatureReportRepairSuggestion, FeatureReportReviewSummary,
-    FeatureReportRuntimeSummary, FeatureReportSemanticDiagramSummary,
-    FeatureReportSemanticNonfillabilityWitnessSummary, FeatureReportSemanticPathSummary,
-    RepairRuleV0, TheoremPreconditionCheck,
+    FeatureReportHomomorphismFamily, FeatureReportHomomorphismSummary, FeatureReportInput,
+    FeatureReportInterpretedExtension, FeatureReportInvariant, FeatureReportObstructionWitness,
+    FeatureReportRepairSuggestion, FeatureReportReviewSummary, FeatureReportRuntimeSummary,
+    FeatureReportSemanticDiagramSummary, FeatureReportSemanticNonfillabilityWitnessSummary,
+    FeatureReportSemanticPathSummary, RepairRuleV0, TheoremPreconditionCheck,
 };
 
 pub fn build_feature_extension_report(
@@ -119,6 +119,11 @@ pub fn build_feature_extension_report(
             measured_axes,
             unmeasured_axes,
         },
+        homomorphism_summary: feature_report_homomorphism_summary(
+            document,
+            &coverage_gaps,
+            &introduced_obstruction_witnesses,
+        ),
         runtime_summary,
         interpreted_extension: FeatureReportInterpretedExtension {
             embedding_claim_ref: document.extension.embedding_claim_ref.clone(),
@@ -166,6 +171,115 @@ pub fn build_feature_extension_report(
             "Runtime formal claims require coverage, projection, exactness, and theorem preconditions".to_string(),
         ],
         non_conclusions,
+    }
+}
+
+fn feature_report_homomorphism_summary(
+    document: &AirDocumentV0,
+    coverage_gaps: &[FeatureReportCoverageGap],
+    obstruction_witnesses: &[FeatureReportObstructionWitness],
+) -> FeatureReportHomomorphismSummary {
+    let relation_entries = document
+        .relations
+        .iter()
+        .filter(|relation| relation.extraction_rule.as_deref() == Some("archmap-v0-projection"))
+        .count();
+    let object_entries = document
+        .components
+        .iter()
+        .filter(|component| component.kind == "archmap-component")
+        .count();
+    let unmeasured_boundaries = coverage_gaps
+        .iter()
+        .filter(|gap| gap.measurement_boundary == "unmeasured")
+        .map(|gap| gap.layer.clone())
+        .chain(
+            document
+                .coverage
+                .layers
+                .iter()
+                .filter(|layer| layer.measurement_boundary == "unmeasured")
+                .map(|layer| layer.layer.clone()),
+        )
+        .collect::<Vec<_>>();
+    let unsupported_boundaries = coverage_gaps
+        .iter()
+        .flat_map(|gap| gap.unsupported_constructs.clone())
+        .chain(
+            document
+                .coverage
+                .layers
+                .iter()
+                .flat_map(|layer| layer.unsupported_constructs.clone()),
+        )
+        .collect::<Vec<_>>();
+    let forgetful_boundaries = document
+        .claims
+        .iter()
+        .flat_map(|claim| claim.exactness_assumptions.clone())
+        .filter(|assumption| !assumption.trim().is_empty())
+        .collect::<Vec<_>>();
+    let obstruction_refs = obstruction_witnesses
+        .iter()
+        .map(|witness| witness.witness_id.clone())
+        .collect::<Vec<_>>();
+    let classification = if !obstruction_refs.is_empty() {
+        "nonHomomorphic"
+    } else if !unmeasured_boundaries.is_empty() || !unsupported_boundaries.is_empty() {
+        "partial"
+    } else if !forgetful_boundaries.is_empty() {
+        "lossy"
+    } else {
+        "homomorphic"
+    };
+    let next_evidence = if classification == "homomorphic" {
+        Vec::new()
+    } else {
+        vec!["supply ArchMap evidence for unmeasured or lossy map families".to_string()]
+    };
+
+    FeatureReportHomomorphismSummary {
+        classification: classification.to_string(),
+        domain: "ArchMap selected source universe".to_string(),
+        codomain: document.feature.description.clone().unwrap_or_else(|| {
+            "AAT observable signature / obstruction / boundary universe".to_string()
+        }),
+        map_families: vec![
+            FeatureReportHomomorphismFamily {
+                map_family: "object".to_string(),
+                entry_count: object_entries,
+                measured_count: object_entries,
+                unmeasured_count: 0,
+                lossy_count: 0,
+            },
+            FeatureReportHomomorphismFamily {
+                map_family: "relation".to_string(),
+                entry_count: relation_entries,
+                measured_count: relation_entries,
+                unmeasured_count: 0,
+                lossy_count: document
+                    .claims
+                    .iter()
+                    .filter(|claim| !claim.exactness_assumptions.is_empty())
+                    .count(),
+            },
+        ],
+        preserved_structure_refs: document
+            .claims
+            .iter()
+            .flat_map(|claim| claim.coverage_assumptions.clone())
+            .collect(),
+        obstruction_refs,
+        forgetful_boundaries,
+        unmeasured_boundaries,
+        unsupported_boundaries,
+        next_evidence,
+        non_conclusions: vec![
+            "ArchMap homomorphism summary is review evidence, not architecture ground truth"
+                .to_string(),
+            "homomorphic classification is bounded to the selected source and AAT codomain"
+                .to_string(),
+        ],
     }
 }
 

--- a/tools/archsig/src/reported_axes_catalog.rs
+++ b/tools/archsig/src/reported_axes_catalog.rs
@@ -84,6 +84,26 @@ pub fn static_detectable_values_reported_axes_catalog() -> DetectableValuesRepor
                 "AAT-facing projection is a bounded preservation checklist, not JSON proof parsing",
             ],
         ),
+        axis(
+            "archMapHomomorphismClassification",
+            "archmap",
+            "homomorphic | partial | lossy | nonHomomorphic | unmeasured",
+            vec![
+                "ArchMap Validation Report",
+                "Feature Extension Report",
+                "AAT Observable Bundle",
+            ],
+            "unmeasured",
+            vec![
+                "ArchMap declares or derives domain, codomain, object map, relation map, law map, obstruction map, and signature-axis map",
+                "forgetful, unmeasured, unsupported, and non-conclusion boundaries remain explicit",
+            ],
+            vec!["ArchMapModel.AATHomomorphicRelation"],
+            vec![
+                "homomorphic is bounded to the selected ArchMap domain and codomain",
+                "partial and lossy are review states, not failure to parse JSON",
+            ],
+        ),
     ];
 
     DetectableValuesReportedAxesCatalogV0 {
@@ -150,6 +170,20 @@ fn frozen_fixtures() -> Vec<BenchmarkSuiteFixtureV0> {
             vec![
                 "aiSessionTraceability:unmeasured",
                 "boundaryViolationCount:unmeasured",
+            ],
+        ),
+        fixture(
+            "archmap-homomorphism-expressiveness",
+            "tools/archsig/tests/fixtures/expressiveness/archmap_expressiveness_suite_v0.json",
+            "ArchMap",
+            vec![
+                "AAT concept coverage matrix",
+                "homomorphism boundary preservation",
+            ],
+            vec![
+                "archMapHomomorphismClassification:partial",
+                "runtime:unmeasured",
+                "dynamic:unsupported",
             ],
         ),
     ]

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -1162,11 +1162,90 @@ pub struct ArchMapDocumentV0 {
     pub source_universe: ArchMapSourceUniverse,
     pub target_universe: ArchMapTargetUniverse,
     #[serde(default)]
+    pub homomorphism: ArchMapHomomorphismV0,
+    #[serde(default)]
     pub map_items: Vec<ArchMapMapItem>,
     #[serde(default)]
     pub coverage: ArchMapCoverage,
     #[serde(default)]
     pub conflicts: Vec<ArchMapConflict>,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapHomomorphismV0 {
+    #[serde(default)]
+    pub reading: String,
+    #[serde(default)]
+    pub domain: ArchMapHomomorphismUniverseV0,
+    #[serde(default)]
+    pub codomain: ArchMapHomomorphismUniverseV0,
+    #[serde(default)]
+    pub object_map: Vec<ArchMapHomomorphismMapEntryV0>,
+    #[serde(default)]
+    pub relation_map: Vec<ArchMapHomomorphismMapEntryV0>,
+    #[serde(default)]
+    pub law_map: Vec<ArchMapHomomorphismMapEntryV0>,
+    #[serde(default)]
+    pub obstruction_map: Vec<ArchMapHomomorphismMapEntryV0>,
+    #[serde(default)]
+    pub signature_axis_map: Vec<ArchMapHomomorphismMapEntryV0>,
+    #[serde(default)]
+    pub preservation_claims: Vec<ArchMapHomomorphismPreservationClaimV0>,
+    #[serde(default)]
+    pub forgetful_boundary: Vec<String>,
+    #[serde(default)]
+    pub unmeasured_boundary: Vec<String>,
+    #[serde(default)]
+    pub unsupported_boundary: Vec<String>,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapHomomorphismUniverseV0 {
+    #[serde(default)]
+    pub universe_id: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub refs: Vec<String>,
+    #[serde(default)]
+    pub boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapHomomorphismMapEntryV0 {
+    pub map_entry_id: String,
+    pub map_family: String,
+    pub source_ref: String,
+    pub target_ref: String,
+    #[serde(default)]
+    pub preserves: Vec<String>,
+    #[serde(default)]
+    pub forgets: Vec<String>,
+    pub measurement_boundary: String,
+    pub claim_classification: String,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapHomomorphismPreservationClaimV0 {
+    pub claim_id: String,
+    pub map_entry_ref: String,
+    pub preserved_structure: String,
+    pub status: String,
+    pub boundary: String,
+    #[serde(default)]
+    pub missing_evidence: Vec<String>,
     #[serde(default)]
     pub non_conclusions: Vec<String>,
 }
@@ -1383,8 +1462,38 @@ pub struct ArchMapValidationReportV0 {
     pub semantic_coverage_checks: Vec<ValidationCheck>,
     pub conflict_checks: Vec<ValidationCheck>,
     pub formal_promotion_guardrail_checks: Vec<ValidationCheck>,
+    pub homomorphism_diagnostics: ArchMapHomomorphismDiagnosticsV0,
     pub summary: ArchMapValidationSummary,
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapHomomorphismDiagnosticsV0 {
+    pub classification: String,
+    pub reading: String,
+    pub domain_ref: String,
+    pub codomain_ref: String,
+    pub map_family_summaries: Vec<ArchMapHomomorphismFamilySummaryV0>,
+    pub preservation_failures: Vec<String>,
+    pub forgetful_boundaries: Vec<String>,
+    pub unmeasured_boundaries: Vec<String>,
+    pub unsupported_boundaries: Vec<String>,
+    pub obstruction_refs: Vec<String>,
+    pub signature_axis_refs: Vec<String>,
+    pub next_evidence: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapHomomorphismFamilySummaryV0 {
+    pub map_family: String,
+    pub entry_count: usize,
+    pub measured_count: usize,
+    pub unmeasured_count: usize,
+    pub assumed_count: usize,
+    pub lossy_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1392,6 +1501,7 @@ pub struct ArchMapValidationReportV0 {
 pub struct ArchMapValidationSummary {
     pub result: String,
     pub map_item_count: usize,
+    pub homomorphism_classification: String,
     pub conflict_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
@@ -1484,6 +1594,7 @@ pub struct FeatureExtensionReportV0 {
     pub feature: AirFeature,
     pub review_summary: FeatureReportReviewSummary,
     pub architecture_summary: FeatureReportArchitectureSummary,
+    pub homomorphism_summary: FeatureReportHomomorphismSummary,
     #[serde(default)]
     pub runtime_summary: FeatureReportRuntimeSummary,
     pub interpreted_extension: FeatureReportInterpretedExtension,
@@ -1505,6 +1616,32 @@ pub struct FeatureExtensionReportV0 {
     pub repair_suggestions: Vec<FeatureReportRepairSuggestion>,
     pub empirical_annotations: Vec<String>,
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureReportHomomorphismSummary {
+    pub classification: String,
+    pub domain: String,
+    pub codomain: String,
+    pub map_families: Vec<FeatureReportHomomorphismFamily>,
+    pub preserved_structure_refs: Vec<String>,
+    pub obstruction_refs: Vec<String>,
+    pub forgetful_boundaries: Vec<String>,
+    pub unmeasured_boundaries: Vec<String>,
+    pub unsupported_boundaries: Vec<String>,
+    pub next_evidence: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureReportHomomorphismFamily {
+    pub map_family: String,
+    pub entry_count: usize,
+    pub measured_count: usize,
+    pub unmeasured_count: usize,
+    pub lossy_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -9,6 +9,10 @@ fn fixture_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal")
 }
 
+fn expressiveness_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/expressiveness")
+}
+
 #[test]
 fn cli_help_excludes_fieldsig_owned_commands() {
     let output = run_sig0_output(&["--help"]);
@@ -125,6 +129,31 @@ fn cli_runs_archmap_primary_workflow() {
         validation_json["schemaVersion"],
         "archmap-validation-report-v0"
     );
+    assert_eq!(
+        validation_json["homomorphismDiagnostics"]["reading"].as_str(),
+        Some(
+            "bounded AAT homomorphism from selected source architecture evidence to AAT observable signature, obstruction, and boundary space"
+        )
+    );
+    assert!(
+        matches!(
+            validation_json["homomorphismDiagnostics"]["classification"].as_str(),
+            Some("partial" | "nonHomomorphic")
+        ),
+        "ArchMap validation must classify the bounded homomorphism with explicit boundary state"
+    );
+    let family_names = validation_json["homomorphismDiagnostics"]["mapFamilySummaries"]
+        .as_array()
+        .expect("homomorphism family summaries are present")
+        .iter()
+        .map(|entry| entry["mapFamily"].as_str().expect("map family"))
+        .collect::<Vec<_>>();
+    for family in ["object", "relation", "law", "obstruction", "signatureAxis"] {
+        assert!(
+            family_names.contains(&family),
+            "homomorphism diagnostics must retain {family} map family"
+        );
+    }
     assert!(
         matches!(
             validation_json["summary"]["result"].as_str(),
@@ -142,6 +171,19 @@ fn cli_runs_archmap_primary_workflow() {
     );
     let feature_json = read_json(&out_dir.join("feature-report.json"));
     assert_eq!(feature_json["schemaVersion"], "feature-extension-report-v0");
+    assert!(
+        matches!(
+            feature_json["homomorphismSummary"]["classification"].as_str(),
+            Some("partial" | "nonHomomorphic" | "lossy")
+        ),
+        "Feature report must summarize the ArchMap homomorphism boundary"
+    );
+    assert!(
+        feature_json["homomorphismSummary"]["unmeasuredBoundaries"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "homomorphism summary must keep unmeasured boundaries"
+    );
     let bundle_json = read_json(&out_dir.join("aat-observable-bundle.json"));
     assert_eq!(bundle_json["schemaVersion"], "aat-observable-bundle-v0");
     assert_eq!(
@@ -170,6 +212,51 @@ fn cli_runs_archmap_primary_workflow() {
     assert!(source_ref_ids.contains(&"source:archmap:primary"));
     assert!(source_ref_ids.contains(&"source:air:primary"));
     assert!(source_ref_ids.contains(&"source:theorem-check:primary"));
+}
+
+#[test]
+fn cli_locks_archmap_homomorphism_expressiveness_matrix() {
+    let out_dir = temp_dir("archmap-homomorphism-expressiveness");
+    let archmap = expressiveness_root().join("archmap_expressiveness_suite_v0.json");
+    let validation = out_dir.join("archmap-validation.json");
+
+    run_sig0(&[
+        "archmap",
+        "--input",
+        archmap.to_str().expect("archmap path is utf-8"),
+        "--out",
+        validation.to_str().expect("validation path is utf-8"),
+    ]);
+
+    let json = read_json(&validation);
+    assert_eq!(
+        json["homomorphismDiagnostics"]["reading"].as_str(),
+        Some("AAT concept coverage matrix for ArchMap bounded homomorphism expressiveness")
+    );
+    let family_names = json["homomorphismDiagnostics"]["mapFamilySummaries"]
+        .as_array()
+        .expect("homomorphism family summaries are array")
+        .iter()
+        .map(|entry| entry["mapFamily"].as_str().expect("map family"))
+        .collect::<Vec<_>>();
+    for family in ["object", "relation", "law", "obstruction", "signatureAxis"] {
+        assert!(
+            family_names.contains(&family),
+            "expressiveness matrix must retain AAT {family} map family"
+        );
+    }
+    assert!(
+        json["homomorphismDiagnostics"]["unsupportedBoundaries"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "unsupported AAT concept coverage must remain explicit"
+    );
+    assert!(
+        json["homomorphismDiagnostics"]["unmeasuredBoundaries"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "unmeasured AAT concept coverage must remain explicit"
+    );
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/expressiveness/archmap_expressiveness_suite_v0.json
+++ b/tools/archsig/tests/fixtures/expressiveness/archmap_expressiveness_suite_v0.json
@@ -52,6 +52,143 @@
     "representation": "aat-air-v0",
     "selectedLayers": ["static", "semantic", "policy", "runtime", "framework", "dynamic"]
   },
+  "homomorphism": {
+    "reading": "AAT concept coverage matrix for ArchMap bounded homomorphism expressiveness",
+    "domain": {
+      "universeId": "source:archmap-expressiveness-fixture-repo",
+      "description": "selected source refs covering policy, service, contract, event, saga, framework, runtime, dynamic, and static evidence",
+      "refs": [
+        "src-layer-policy",
+        "src-user-service",
+        "src-user-contract",
+        "src-rounding-test",
+        "src-event-store",
+        "src-saga",
+        "src-framework-route",
+        "src-plugin-loader",
+        "src-runtime-trace",
+        "src-static-edge"
+      ],
+      "boundary": "archmap-expressiveness-suite-v0 bounded source inventory"
+    },
+    "codomain": {
+      "universeId": "aat:archmap-expressiveness-fixture-repo",
+      "description": "AAT coverage matrix over object, relation, boundary, layer, policy, contract, runtime edge, state effect, semantic diagram, obstruction, operation, repair, and signature axis",
+      "refs": [
+        "object",
+        "relation",
+        "boundary",
+        "layer",
+        "policy",
+        "contract",
+        "runtime-edge",
+        "state-effect",
+        "semantic-diagram",
+        "obstruction",
+        "operation",
+        "repair",
+        "signature-axis"
+      ],
+      "boundary": "selected AAT concept coverage matrix; not repository completeness"
+    },
+    "objectMap": [
+      {
+        "mapEntryId": "srp_responsibility_split",
+        "mapFamily": "object",
+        "sourceRef": "src-user-service",
+        "targetRef": "component.user_service.responsibility",
+        "preserves": ["SRP responsibility region", "reason-to-change candidate"],
+        "forgets": ["file size heuristic"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["src-user-service"],
+        "nonConclusions": ["object/responsibility coverage is selected-source relative"]
+      }
+    ],
+    "relationMap": [
+      {
+        "mapEntryId": "contract_preservation",
+        "mapFamily": "relation",
+        "sourceRef": "src-user-contract",
+        "targetRef": "semantic.contract.create_user",
+        "preserves": ["contract preservation", "contract-test observation"],
+        "forgets": ["all production traces"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["src-user-contract"],
+        "nonConclusions": ["contract relation coverage is not global semantic completeness"]
+      }
+    ],
+    "lawMap": [
+      {
+        "mapEntryId": "layered_policy_violation",
+        "mapFamily": "law",
+        "sourceRef": "src-layer-policy",
+        "targetRef": "policy.layered.route_to_db",
+        "preserves": ["Layered Architecture dependency direction"],
+        "forgets": ["framework adapter internals"],
+        "measurementBoundary": "unmeasured",
+        "claimClassification": "assumed",
+        "evidenceRefs": ["src-layer-policy"],
+        "nonConclusions": ["policy map is not global architecture lawfulness"]
+      }
+    ],
+    "obstructionMap": [
+      {
+        "mapEntryId": "semantic_non_commutation",
+        "mapFamily": "obstruction",
+        "sourceRef": "src-rounding-test",
+        "targetRef": "witness-rounding-non-commutation",
+        "preserves": ["semantic non-commutation", "nonfillability witness"],
+        "forgets": ["all price paths"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["src-rounding-test"],
+        "nonConclusions": ["obstruction witness is selected-observation relative"]
+      }
+    ],
+    "signatureAxisMap": [
+      {
+        "mapEntryId": "runtime_unmeasured",
+        "mapFamily": "signatureAxis",
+        "sourceRef": "src-runtime-trace",
+        "targetRef": "signature.runtimePropagation",
+        "preserves": ["runtime edge boundary"],
+        "forgets": ["runtime frequency"],
+        "measurementBoundary": "unmeasured",
+        "claimClassification": "unmeasured",
+        "evidenceRefs": ["src-runtime-trace"],
+        "nonConclusions": ["runtime signature axis is not measured zero"]
+      }
+    ],
+    "preservationClaims": [
+      {
+        "claimId": "coverage-matrix-object",
+        "mapEntryRef": "srp_responsibility_split",
+        "preservedStructure": "object / responsibility",
+        "status": "preserved",
+        "boundary": "selected service source",
+        "missingEvidence": [],
+        "nonConclusions": ["coverage matrix is not completeness proof"]
+      },
+      {
+        "claimId": "coverage-matrix-runtime",
+        "mapEntryRef": "runtime_unmeasured",
+        "preservedStructure": "runtime edge boundary",
+        "status": "blocked",
+        "boundary": "runtime trace unavailable",
+        "missingEvidence": ["runtime trace unavailable"],
+        "nonConclusions": ["runtime gap remains unmeasured"]
+      }
+    ],
+    "forgetfulBoundary": ["framework adapter internals", "all production traces", "all price paths"],
+    "unmeasuredBoundary": ["runtime", "dynamic"],
+    "unsupportedBoundary": ["dynamic plugin registry", "private framework convention"],
+    "nonConclusions": [
+      "coverage matrix pass does not prove AAT completeness",
+      "unsupported concept coverage remains explicit"
+    ]
+  },
   "mapItems": [
     {
       "mapItemId": "layered_policy_violation",

--- a/tools/archsig/tests/fixtures/minimal/archmap.json
+++ b/tools/archsig/tests/fixtures/minimal/archmap.json
@@ -113,6 +113,168 @@
     "representation": "aat-air-v0",
     "selectedLayers": ["static", "semantic", "policy", "runtime"]
   },
+  "homomorphism": {
+    "reading": "bounded AAT homomorphism from selected source architecture evidence to AAT observable signature, obstruction, and boundary space",
+    "domain": {
+      "universeId": "source:archmap-fixture-repo",
+      "description": "route, service, policy document, and contract-test source evidence",
+      "refs": ["src-route-users", "src-service-user", "doc-architecture", "test-user-contract"],
+      "boundary": "bounded ArchMap MVP fixture over route, service, policy doc, and contract test"
+    },
+    "codomain": {
+      "universeId": "aat:archmap-fixture-repo",
+      "description": "AAT object / relation / law / obstruction / signature-axis review universe",
+      "refs": ["aat-object", "aat-relation", "aat-law", "aat-obstruction", "aat-signature-axis"],
+      "boundary": "selected AAT observable universe; not global architecture truth"
+    },
+    "objectMap": [
+      {
+        "mapEntryId": "object-route-users",
+        "mapFamily": "object",
+        "sourceRef": "src-route-users",
+        "targetRef": "route.users",
+        "preserves": ["component identity"],
+        "forgets": ["method count"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["src-route-users"],
+        "nonConclusions": ["object map is bounded to the selected source universe"]
+      },
+      {
+        "mapEntryId": "object-service-user",
+        "mapFamily": "object",
+        "sourceRef": "src-service-user",
+        "targetRef": "service.user",
+        "preserves": ["component identity"],
+        "forgets": ["constructor details"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["src-service-user"],
+        "nonConclusions": ["object map is not complete service discovery"]
+      }
+    ],
+    "relationMap": [
+      {
+        "mapEntryId": "relation-route-service",
+        "mapFamily": "relation",
+        "sourceRef": "src-route-users",
+        "targetRef": "semantic.route.users->service.user",
+        "preserves": ["request-to-service semantic dependency"],
+        "forgets": ["call count", "runtime frequency"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["src-route-users", "src-service-user"],
+        "nonConclusions": ["semantic relation map does not prove runtime relation"]
+      },
+      {
+        "mapEntryId": "semantic-create-user-diagram",
+        "mapFamily": "relation",
+        "sourceRef": "test-user-contract",
+        "targetRef": "semantic.diagram.create_user",
+        "preserves": ["contract-test observation"],
+        "forgets": ["all production traces"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["test-user-contract"],
+        "nonConclusions": ["diagram map is not global semantic completeness"]
+      }
+    ],
+    "lawMap": [
+      {
+        "mapEntryId": "policy-layered-route-service",
+        "mapFamily": "law",
+        "sourceRef": "doc-architecture",
+        "targetRef": "policy.layered.route_to_service",
+        "preserves": ["Layered Architecture dependency direction", "SOLID DIP local policy boundary"],
+        "forgets": ["framework adapter implementation"],
+        "measurementBoundary": "unmeasured",
+        "claimClassification": "assumed",
+        "evidenceRefs": ["doc-architecture"],
+        "nonConclusions": ["policy assumption is not measured compliance"]
+      }
+    ],
+    "obstructionMap": [
+      {
+        "mapEntryId": "nonfillability-user-saga",
+        "mapFamily": "obstruction",
+        "sourceRef": "test-user-contract",
+        "targetRef": "witness-user-saga-missing-compensation",
+        "preserves": ["obstruction witness"],
+        "forgets": ["root-cause analysis"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["test-user-contract"],
+        "nonConclusions": ["obstruction map is not incident causality"]
+      }
+    ],
+    "signatureAxisMap": [
+      {
+        "mapEntryId": "aat-flatness-precondition",
+        "mapFamily": "signatureAxis",
+        "sourceRef": "test-user-contract",
+        "targetRef": "signature.semantic.flatnessPrecondition",
+        "preserves": ["AAT signature axis", "flatness precondition boundary"],
+        "forgets": ["global semantic completeness"],
+        "measurementBoundary": "measuredNonzero",
+        "claimClassification": "measured",
+        "evidenceRefs": ["test-user-contract"],
+        "nonConclusions": ["signature axis map does not discharge zero-curvature preconditions"]
+      },
+      {
+        "mapEntryId": "runtime-unmeasured-boundary",
+        "mapFamily": "signatureAxis",
+        "sourceRef": "src-service-user",
+        "targetRef": "runtime.service.user->db.users",
+        "preserves": ["runtime dependency boundary"],
+        "forgets": ["runtime frequency"],
+        "measurementBoundary": "unmeasured",
+        "claimClassification": "unmeasured",
+        "evidenceRefs": ["src-service-user"],
+        "nonConclusions": ["runtime boundary is not measured zero"]
+      }
+    ],
+    "preservationClaims": [
+      {
+        "claimId": "preservation-object-route-users",
+        "mapEntryRef": "object-route-users",
+        "preservedStructure": "component identity",
+        "status": "preserved",
+        "boundary": "selected source component",
+        "missingEvidence": [],
+        "nonConclusions": ["component identity preservation is bounded"]
+      },
+      {
+        "claimId": "preservation-policy-layered-route-service",
+        "mapEntryRef": "policy-layered-route-service",
+        "preservedStructure": "Layered Architecture dependency direction",
+        "status": "assumed",
+        "boundary": "policy document evidence",
+        "missingEvidence": [],
+        "nonConclusions": ["policy preservation is not measured compliance"]
+      },
+      {
+        "claimId": "preservation-runtime-boundary",
+        "mapEntryRef": "runtime-unmeasured-boundary",
+        "preservedStructure": "runtime dependency boundary",
+        "status": "blocked",
+        "boundary": "runtime trace unavailable",
+        "missingEvidence": ["runtime trace not supplied"],
+        "nonConclusions": ["unmeasured runtime map is not measured zero"]
+      }
+    ],
+    "forgetfulBoundary": [
+      "method count",
+      "constructor details",
+      "runtime frequency",
+      "global semantic completeness"
+    ],
+    "unmeasuredBoundary": ["runtime", "policy-layered-route-service", "runtime-unmeasured-boundary"],
+    "unsupportedBoundary": ["dynamic plugin loading"],
+    "nonConclusions": [
+      "ArchMap homomorphism is bounded to selected source evidence",
+      "homomorphism diagnostics do not prove architecture lawfulness"
+    ]
+  },
   "mapItems": [
     {
       "mapItemId": "object-route-users",

--- a/tools/archsig/tests/fixtures/minimal/detectable_values_reported_axes_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/detectable_values_reported_axes_catalog.json
@@ -108,6 +108,26 @@
         "axis-removal-requires-migration-note",
         "measurement-boundary-change-requires-review"
       ]
+    },
+    {
+      "fixtureId": "archmap-homomorphism-expressiveness",
+      "path": "tools/archsig/tests/fixtures/expressiveness/archmap_expressiveness_suite_v0.json",
+      "artifactKind": "ArchMap",
+      "frozenFor": [
+        "AAT concept coverage matrix",
+        "homomorphism boundary preservation"
+      ],
+      "expectedBoundaries": [
+        "archMapHomomorphismClassification:partial",
+        "runtime:unmeasured",
+        "dynamic:unsupported"
+      ],
+      "updateRuleRefs": [
+        "axis-addition-requires-version-review",
+        "axis-rename-requires-explicit-field-mapping",
+        "axis-removal-requires-migration-note",
+        "measurement-boundary-change-requires-review"
+      ]
     }
   ],
   "updateRules": [
@@ -343,6 +363,43 @@
         "unmeasured axis evidence is not measured-zero evidence",
         "reported axis evidence does not promote a Lean theorem claim"
       ]
+    },
+    {
+      "axisId": "archMapHomomorphismClassification",
+      "layer": "archmap",
+      "valueType": "homomorphic | partial | lossy | nonHomomorphic | unmeasured",
+      "reportedIn": [
+        "ArchMap Validation Report",
+        "Feature Extension Report",
+        "AAT Observable Bundle"
+      ],
+      "allowedMeasurementBoundaries": [
+        "measuredZero",
+        "measuredNonzero",
+        "assumed",
+        "unmeasured",
+        "unavailable",
+        "private",
+        "notComparable",
+        "outOfScope"
+      ],
+      "defaultMeasurementBoundary": "unmeasured",
+      "evidenceRequirements": [
+        "ArchMap declares or derives domain, codomain, object map, relation map, law map, obstruction map, and signature-axis map",
+        "forgetful, unmeasured, unsupported, and non-conclusion boundaries remain explicit"
+      ],
+      "theoremRefs": [
+        "ArchMapModel.AATHomomorphicRelation"
+      ],
+      "compatibilityNotes": [
+        "homomorphic is bounded to the selected ArchMap domain and codomain",
+        "partial and lossy are review states, not failure to parse JSON"
+      ],
+      "nonConclusions": [
+        "axis value compatibility does not prove semantic preservation",
+        "unmeasured axis evidence is not measured-zero evidence",
+        "reported axis evidence does not promote a Lean theorem claim"
+      ]
     }
   ],
   "schemaCompatibility": {
@@ -456,6 +513,18 @@
         ],
         "exactnessAssumptions": [
           "AAT-facing projection is a bounded preservation checklist, not JSON proof parsing"
+        ]
+      },
+      {
+        "axisOrLayer": "archMapHomomorphismClassification",
+        "measurementBoundary": "unmeasured",
+        "coverageAssumptions": [
+          "ArchMap declares or derives domain, codomain, object map, relation map, law map, obstruction map, and signature-axis map",
+          "forgetful, unmeasured, unsupported, and non-conclusion boundaries remain explicit"
+        ],
+        "exactnessAssumptions": [
+          "homomorphic is bounded to the selected ArchMap domain and codomain",
+          "partial and lossy are review states, not failure to parse JSON"
         ]
       }
     ],


### PR DESCRIPTION
## 概要

Closes #1206
Closes #1208
Closes #1209
Closes #1207
Closes #1211
Closes #1210

ArchMap を supplied JSON projection ではなく、source architecture から AAT object / relation / law / obstruction / signature-axis world への bounded homomorphism として第一級化しました。

- `archmap-v0` schema に `homomorphism` を追加し、未指定時は既存 `mapItems` から互換的に導出
- `archmap-validation-report-v0` に `homomorphismDiagnostics` と summary classification を追加
- `feature-extension-report-v0` に `homomorphismSummary` を追加
- expressiveness fixture を AAT concept coverage matrix として固定
- README / command guide / artifact docs を homomorphism-first に改稿

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`
- `docs/tool/README.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling definition / bridge tracking。Lean theorem 追加ではなく、既存 `ArchMapModel` / `AATHomomorphicRelation` の user-facing tooling 化。
