### PR TITLE
AAT原子化レイヤーの設計ノートを追加

### DIFF
--- a/docs/aat/note_20260526.md
+++ b/docs/aat/note_20260526.md
@@ -1,0 +1,885 @@
+## 提案：AAT に「Atomization Layer」を追加する
+
+AATの現在の核は、実コードそのものではなく、選択された universe / observation / coverage / exactness に相対化された bounded な `ArchitectureObject` を扱い、その上で invariant、obstruction witness、signature axis、theorem boundary を読む、という設計になっています。したがって「原子」も、絶対的なクラス・モジュール単位ではなく、**ある theorem boundary の下で、それ以上分解すると同じ law / witness / role を保てない最小有限 subobject** として定義するのが自然です。
+
+結論から言うと、AATの原子は次の形にするのがよいです。
+
+```text
+ArchitectureAtom_B(X)
+  = selected boundary B の下で
+    ArchitectureObject X の中に埋め込まれた
+    finite / typed / evidence-aware / minimal subobject
+```
+
+ここで `B` は atomization boundary です。
+
+```text
+AtomizationBoundary B :=
+  selected component universe
+  + selected relation universe
+  + selected observation universe
+  + law universe
+  + witness universe
+  + decomposition mode
+  + coverage / exactness assumptions
+  + classification priority
+```
+
+重要なのは、**原子は partition ではなく cover / incidence hypergraph である**、という点です。1つのクラスが `PureRuleAtom` と `CoordinatorAtom` と `EffectAtom` を同時に含むことがあるし、1つの witness が boundary violation と abstraction leakage の両方に分類されることもあります。これは、AAT本文で feature extension obstruction が互いに素な分解を無条件には主張しない、という立場とも整合します。
+
+---
+
+## 1. 原子の正式定義
+
+### 1.1 最小支持原子
+
+まず、`X` を architecture object、`S ≤ X` を有限 subobject とします。`S` は component だけでなく、edge、runtime relation、projection、semantic diagram、effect observation などを含められる「支持」です。
+
+```text
+Support S :=
+  selected components
+  + selected static edges
+  + selected runtime edges
+  + selected projection edges
+  + selected observations
+  + selected semantic diagrams
+  + selected effect labels
+```
+
+ある atom kind `κ` に対して、原子は次で定義します。
+
+```text
+Atom_B,κ(S, X) :=
+  Emb(S, X)
+  ∧ Finite(S)
+  ∧ NonEmpty(S)
+  ∧ Shape_B,κ(S)
+  ∧ Minimal_B,κ(S)
+```
+
+最小性は次です。
+
+```text
+Minimal_B,κ(S) :=
+  for all T ⊂ S,
+    not Shape_B,κ(T)
+```
+
+つまり、`S` は `κ` 型の構造または違反を示す最小支持です。
+
+例：
+
+```text
+ForbiddenEdgeAtom(e)
+  = 1本の dependency edge e が
+    selected boundary/ranking policy を破る最小 witness
+
+SimpleCycleAtom(c)
+  = c が simple directed cycle であり、
+    どの proper sub-support も cycle ではない
+
+LSPMismatchAtom(x, y, C)
+  = F(x) = F(y) だが
+    Obs(C[x]) ≁ Obs(C[y]) となる最小 client-context witness
+```
+
+AAT本文では、obstruction witness は単なるエラーではなく、修復・分類・不能性・後続操作の制約を説明する構造的対象として扱われています。このため、原子は「良い構成要素」だけでなく、**最小 obstruction witness** も含むべきです。
+
+---
+
+### 1.2 prime atom と witness atom を分ける
+
+AATでは、少なくとも2種類の「原子」を分けるべきです。
+
+```text
+ConstructiveAtom
+  = 正常な構成の最小生成元
+
+ObstructionAtom
+  = law / invariant を破る最小 witness
+
+CoverageAtom
+  = unmeasured / residual / private_unavailable などの測定境界 atom
+```
+
+数学的には次の対応です。
+
+```text
+ConstructiveAtom:
+  presentation generator / role generator
+
+ObstructionAtom:
+  minimal bad witness
+
+CoverageAtom:
+  claim boundary / evidence boundary witness
+```
+
+この区別を入れないと、「良い原子の組み合わせ」と「悪い原子の局所 witness」が混ざります。AATの signature は単一スコアではなく多軸診断であり、未測定や対象外も measurement status として分ける設計になっているため、原子側にも `measured_zero` / `measured_nonzero` / `unmeasured` / `out_of_scope` などの状態を持たせるべきです。
+
+---
+
+## 2. 原子の基本分類
+
+AAT Atom は、次の4層に分けるのがよいです。
+
+```text
+Layer 0: Carrier atoms
+Layer 1: Role atoms
+Layer 2: Law / obstruction atoms
+Layer 3: Operation / repair atoms
+```
+
+### Layer 0: Carrier atoms
+
+これは、実コードや抽出器がまず作る最小事実です。
+
+| Atom                 | 意味                                                 | 典型的な evidence                 |
+| -------------------- | -------------------------------------------------- | ----------------------------- |
+| `ComponentAtom`      | class / module / package / function / endpoint など  | AST node、file path            |
+| `StaticEdgeAtom`     | import / call / instantiate / inherit / implements | import graph、call graph       |
+| `RuntimeEdgeAtom`    | runtime call / message / event / RPC               | trace、config、observability    |
+| `EffectEdgeAtom`     | DB、FS、network、clock、random、外部APIなど                 | effect annotation、call target |
+| `BoundaryLabelAtom`  | layer、bounded context、team ownership、visibility    | directory rule、annotation     |
+| `ProjectionEdgeAtom` | concrete → abstract、implementation → port          | interface implementation      |
+| `ObservationAtom`    | test、contract、semantic observation                 | test case、spec、trace          |
+
+この層は「正しい設計」をまだ言いません。単に architecture object の有限 presentation を作るための carrier です。
+
+---
+
+### Layer 1: Role atoms
+
+これは、SOLIDやLayered/Clean Architectureを「原子の組み合わせ」に落とすための正の原子です。
+
+| Atom                 | 役割                                              | 保存したい invariant                        |
+| -------------------- | ----------------------------------------------- | -------------------------------------- |
+| `PureRuleAtom`       | domain rule / pure calculation                  | local contract、observation equivalence |
+| `PortAtom`           | abstract capability / interface                 | abstraction policy、DIP                 |
+| `AdapterAtom`        | external system との変換境界                          | boundary policy、effect isolation       |
+| `CoordinatorAtom`    | 複数 capability の orchestration                   | dependency direction、local composition |
+| `StateAtom`          | repository / cache / projection / mutable state | replay law、projection law              |
+| `GuardAtom`          | circuit breaker / retry / timeout / authz       | runtime protection                     |
+| `TranslatorAtom`     | DTO ↔ domain、encode/decode                      | semantic preservation                  |
+| `EventAtom`          | command / event / handler / projection          | state transition algebra               |
+| `PolicyBoundaryAtom` | layer / clean boundary の局所単位                    | ranking、boundary preservation          |
+
+例えば Clean Architecture は、`PureRuleAtom` が内側、`PortAtom` が境界、`AdapterAtom` が外側、依存は内向き、という incidence 制約として表現できます。AAT本文でも、SOLID、Layered、Clean、Event Sourcing、Circuit Breaker などはそれぞれ異なる invariant family に属すると整理されているため、原子分類も同じく invariant family ごとに分けるのがよいです。
+
+---
+
+### Layer 2: Obstruction atoms
+
+これは、AATの「分類」を強くする中心です。
+
+| Atom                      | 最小 witness                                          | 対応する改善                                       |
+| ------------------------- | --------------------------------------------------- | -------------------------------------------- |
+| `ForbiddenStaticEdgeAtom` | forbidden dependency edge                           | move、invert、introduce port                   |
+| `BoundaryLeakAtom`        | boundary を越える未許可 edge                               | adapter / facade / ACL                       |
+| `AbstractionLeakAtom`     | concrete へ直接依存                                      | port 抽出、projection 修正                        |
+| `SimpleCycleAtom(n)`      | simple directed cycle                               | split SCC、introduce interface、event化         |
+| `HiddenInteractionAtom`   | declared interface 外の interaction                   | declared interface 追加、runtime isolation      |
+| `ProjectionFailureAtom`   | concrete relation が abstract relation に sound に写らない | abstraction redesign                         |
+| `LSPMismatchAtom`         | `F(x)=F(y)` だが observation が異なる                     | contract 分割、subtype 解消、interface narrow      |
+| `FatInterfaceAtom`        | client が不要 capability に依存                           | interface segregation                        |
+| `NonCommutingSquareAtom`  | 2経路の observation が一致しない                             | canonical order、compensation、semantic law 追加 |
+| `RuntimeExposureAtom`     | runtime edge が guard なしで外部障害に露出                     | guard / timeout / circuit breaker            |
+| `EffectLeakAtom`          | 暗黙 authority / effect boundary 越え                   | effect interface 明示                          |
+| `ReplayViolationAtom`     | replay / projection law の破れ                         | event schema / projection 修正                 |
+| `ComplexityTransferAtom`  | repair 後に別軸 obstruction が増える                        | side-effect boundary 明示                      |
+| `CoverageGapAtom`         | 未測定・対象外・private evidence                            | claim boundary 明示                            |
+
+AAT本文では、finite witness universe 上で `violationCount = 0` と「測定された bad witness が存在しない」ことが接続され、さらに witness completeness / axis exactness 等の仮定の下で lawfulness や signature zero と接続されます。Atom layer はこの witness universe をさらに「最小支持」に分解するものです。
+
+---
+
+### Layer 3: Operation / repair atoms
+
+修復操作も原子化します。
+
+| Repair atom             | 入力 obstruction                             | 主張できること                        |
+| ----------------------- | ------------------------------------------ | ------------------------------ |
+| `IntroducePortAtom`     | abstraction leak / forbidden concrete edge | selected abstraction axis を改善  |
+| `InvertDependencyAtom`  | wrong direction edge                       | ranking violation を除去          |
+| `SplitComponentAtom`    | SRP / fat component / cycle                | selected local obstruction を分離 |
+| `ExtractAdapterAtom`    | effect leak / boundary leak                | effect boundary を局所化           |
+| `ProtectRuntimeAtom`    | runtime exposure                           | runtime protection axis を改善    |
+| `SeparateInterfaceAtom` | fat interface                              | ISP-style obstruction を減少      |
+| `InsertTranslatorAtom`  | semantic mismatch                          | encode/decode law を追加          |
+| `AddCompensationAtom`   | saga failure                               | compensation law を追加           |
+| `CanonicalizeOrderAtom` | non-commuting diagram                      | semantic diagram の commute を回復 |
+
+ただし、repair は総合的改善を意味しません。AAT本文でも、repair は selected obstruction を減らすが別軸へ complexity transfer が起きうるため、repair theorem は「減らす witness universe」「保存する invariant」「増加を主張しない軸」を明示すべきだとされています。
+
+---
+
+## 3. 分解フロー
+
+実コードからの流れは次です。ここでの主役は deterministic extractor ではなく、
+LLM / human がコードを読んで作る semantic architecture reading です。
+静的解析器や実行時 trace は補助 evidence であり、ArchMap の本質は
+静的解析では拾えない意味論を AAT の atom / law / witness 語彙へ写すことにあります。
+
+```text
+source code
+  -> semantic architecture reading
+  -> finite typed architecture reading / hypergraph
+  -> atom candidate proposal
+  -> atomization certificate
+  -> Lean-checked certificate soundness
+  -> AtomSignature
+  -> repair suggestions
+```
+
+### 3.1 semantic reading が保持するもの
+
+```text
+ArchitectureReadingCore :=
+  components
+  + static relations
+  + runtime relations
+  + effect relations
+  + projection relations
+  + boundary labels
+  + observation links
+  + evidence references
+  + coverage / exactness metadata
+```
+
+ここで重要なのは、semantic reading は proof ではなく、selected evidence に相対化された
+AAT interpretation candidate だという点です。AAT本文は、実コードから完全な
+`ComponentUniverse` を抽出できるとは主張しないし、`ArchitectureCore -> ArchitectureObject`
+が完全・単射であるとも言わない、という境界を置いています。原子化も同じ境界に置くべきです。
+LLM が読む範囲、読めなかった範囲、private / unavailable な evidence、判断不能なものは、
+atomization boundary または coverage atom として保持します。
+
+### 3.2 atom candidate generation
+
+候補は次のように生成します。
+
+```text
+1. unary candidates:
+   component, boundary label, observation
+
+2. binary candidates:
+   static edge, runtime edge, effect edge, projection edge
+
+3. small diagram candidates:
+   triangle, square, lifting square, projection square
+
+4. path / cycle candidates:
+   simple path, simple cycle, rank-violating path
+
+5. semantic candidates:
+   lhs/rhs operation path with observation comparison
+
+6. coverage candidates:
+   unmeasured required axis, private evidence, out_of_scope relation
+```
+
+特に cycle は無限 family になりえますが、実コードから切り出した selected finite universe では有限です。`SimpleCycleAtom(n)` のように、schema は有限個、instance は有限 universe に相対化して列挙、という扱いにします。
+
+### 3.3 atomization result
+
+出力は partition ではなく、次のような incidence hypergraph です。
+
+```text
+AtomizationResult :=
+  atoms : Finset ArchitectureAtom
+  incidence : Atom -> Support
+  evidence : Atom -> EvidenceRefs
+  status : Atom -> MeasurementStatus
+  signature : Axis -> MeasurementStatus × Count
+  repairCandidates : ObstructionAtom -> Finset RepairAtom
+```
+
+例：
+
+```json
+{
+  "atomId": "A-137",
+  "kind": "BoundaryLeakAtom",
+  "axis": "boundary",
+  "polarity": "obstruction",
+  "support": {
+    "components": ["CouponService", "PaymentAdapter"],
+    "edges": ["CouponService -> PaymentAdapter"]
+  },
+  "evidence": [
+    {"file": "coupon/CouponService.ts", "range": "L41-L52"}
+  ],
+  "repairCandidates": [
+    "IntroducePortAtom",
+    "ExtractAdapterAtom"
+  ],
+  "claimBoundary": {
+    "coverage": "static_only",
+    "exactness": "ast_exact_runtime_unmeasured"
+  }
+}
+```
+
+---
+
+## 4. SOLID / Layered / Clean を atom の制約に落とす
+
+### SRP
+
+SRP は「クラスは1つの責務だけ」という自然言語ではなく、AATでは次のようにします。
+
+```text
+SRP_B(c) :=
+  component c に支持される RoleAtom 群が
+  selected change axis / law family 上で
+  mutually coherent である
+```
+
+違反 atom：
+
+```text
+MultiReasonChangeAtom(c, r1, r2)
+  where r1 and r2 are independent role/law supports
+```
+
+改善：
+
+```text
+SplitComponentAtom
+IntroduceCoordinatorAtom
+ExtractPureRuleAtom
+ExtractAdapterAtom
+```
+
+### OCP
+
+OCP は「既存 core を変更せず extension できる」ではなく、feature extension の atom 制約です。
+
+```text
+OCP_B(extension) :=
+  new FeatureAtom が
+  declared PortAtom / ExtensionPointAtom を通じて core に接続し、
+  inherited core obstruction を増やさない
+```
+
+違反 atom：
+
+```text
+CoreMutationAtom
+BypassExtensionPointAtom
+FeatureToCoreForbiddenEdgeAtom
+```
+
+AAT本文の extension obstruction formula では、extension の破れを inherited core obstruction、feature-local obstruction、interaction obstruction、lifting failure、filling failure、complexity transfer、residual coverage gap に分類しています。Atom layer ではそれぞれを最小 witness に分解します。
+
+### LSP
+
+AAT本文の LSP 読みはかなり明確で、`F(x)=F(y)` なら selected client context universe で `Obs(C[x]) ~= Obs(C[y])` である、つまり `ker(F) <= ker(Obs)` と読めます。
+
+原子化すると：
+
+```text
+LSPPairAtom(x, y, C)
+  = same abstraction under F
+    + selected client context C
+    + observation pair
+
+LSPMismatchAtom(x, y, C)
+  = F(x) = F(y)
+    ∧ Obs(C[x]) ≁ Obs(C[y])
+```
+
+改善：
+
+```text
+SplitAbstractionAtom
+NarrowInterfaceAtom
+RemoveInvalidSubtypeAtom
+StrengthenObservationContractAtom
+```
+
+### ISP
+
+ISP は interface を細かくすること自体ではなく、client が不要 capability に依存しているかを見る atom です。
+
+```text
+FatInterfaceAtom(client, interface, capability)
+  = client depends on interface
+    ∧ capability ∈ interface
+    ∧ capability not used by client under selected observation
+```
+
+改善：
+
+```text
+SeparateInterfaceAtom
+ClientSpecificPortAtom
+```
+
+### DIP
+
+DIP は concrete dependency を abstract dependency に sound に写す projection の atom 制約です。AAT本文でも、DIP / Clean Architecture 的な抽象化は `ProjectionSound`、`ProjectionComplete`、`ProjectionExact`、`RepresentativeStable` を分けるべきだとされています。
+
+違反 atom：
+
+```text
+ConcreteBypassAtom
+ProjectionFailureAtom
+UnstableRepresentativeAtom
+AbstractCycleAtom
+```
+
+注意すべき点は、DIP が満たされても大域的な acyclicity や decomposability は従わないことです。AAT本文にも、SOLID-style local contracts は `Decomposable(G)` を含意しないという反例が置かれています。
+
+### Layered Architecture
+
+Layered は ranking function に対する edge atom の制約です。
+
+```text
+Layered_B(X) :=
+  exists rank : Component -> Nat,
+    for every selected static edge u -> v,
+      AllowedDirection(rank u, rank v)
+```
+
+違反 atom：
+
+```text
+ForbiddenRankEdgeAtom(u, v)
+SimpleCycleAtom(n)
+CrossLayerBypassAtom(u, v)
+```
+
+finite unweighted universe では、acyclicity、closed walk absence、adjacency nilpotence が同じ構造の異なる表示として読める、というAAT本文の整理と接続できます。
+
+---
+
+## 5. Lean で証明すべき核
+
+Lean側では、LLM が出した原子分類をそのまま「信じる」のではなく、
+**atomization certificate の soundness と、selected universe に対する coverage theorem**
+を証明します。最初から executable classifier を Lean 内に実装する必要はありません。
+まずは「分類候補と Shape / boundary witness が与えられたとき、それが valid atom である」
+ことを証明する certificate-first な設計にします。Lean 4 は定理証明支援系かつ
+プログラミング言語であり、inductive type や structure / record を使ってこうした証明対象を表現できます。
+([Lean Language][1]) ([Theorem Proving in Lean 4][2])
+
+Mathlib 側では `Finset` や finite type 周辺の道具を使えるため、selected finite universe 上の
+列挙・個数・最小性・zero-count kernel を形式化しやすいです。([Mathlib Finset][3])
+([Mathlib Fintype Sets][4])
+
+### 5.1 Lean skeleton
+
+```lean
+namespace Formal.Arch
+
+inductive Axis
+  | static
+  | boundary
+  | abstraction
+  | lsp
+  | runtime
+  | semantic
+  | state
+  | coverage
+  deriving DecidableEq, Repr
+
+inductive Polarity
+  | constructive
+  | obstruction
+  | coverage
+  deriving DecidableEq, Repr
+
+inductive AtomKind
+  | component
+  | staticEdge
+  | runtimeEdge
+  | effectEdge
+  | port
+  | adapter
+  | pureRule
+  | coordinator
+  | stateCell
+  | guard
+  | forbiddenStaticEdge
+  | boundaryLeak
+  | abstractionLeak
+  | simpleCycle : Nat -> AtomKind
+  | projectionFailure
+  | lspMismatch
+  | fatInterface
+  | nonCommutingSquare
+  | runtimeExposure
+  | replayViolation
+  | complexityTransfer
+  | coverageGap
+  deriving DecidableEq, Repr
+
+structure Edge (C : Type) where
+  src : C
+  dst : C
+  axis : Axis
+  deriving Repr
+
+structure Support (C E D : Type) where
+  comps : Finset C
+  edges : Finset E
+  diagrams : Finset D
+
+structure AtomizationBoundary where
+  requiredAxes : Finset Axis
+  -- law universe, witness universe, exactness, coverage, etc.
+
+structure ArchitectureAtom (C E D : Type) where
+  kind : AtomKind
+  axis : Axis
+  polarity : Polarity
+  support : Support C E D
+  measured : Bool
+```
+
+### 5.2 形 predicate
+
+各 atom kind には `Shape` を与えます。
+
+```lean
+def Shape
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (k : AtomKind)
+  (S : Support C E D) : Prop :=
+  match k with
+  | AtomKind.forbiddenStaticEdge =>
+      -- S contains exactly one static edge and it violates policy
+      ForbiddenStaticEdgeShape B X S
+  | AtomKind.boundaryLeak =>
+      BoundaryLeakShape B X S
+  | AtomKind.simpleCycle n =>
+      SimpleCycleShape B X n S
+  | AtomKind.lspMismatch =>
+      LSPMismatchShape B X S
+  | _ =>
+      ConstructiveShape B X k S
+```
+
+### 5.3 原子性 predicate
+
+```lean
+def ProperSubsupport (T S : Support C E D) : Prop :=
+  T.comps ⊂ S.comps
+  ∨ T.edges ⊂ S.edges
+  ∨ T.diagrams ⊂ S.diagrams
+
+def MinimalShape
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (k : AtomKind)
+  (S : Support C E D) : Prop :=
+  Shape B X k S ∧
+  ∀ T, ProperSubsupport T S -> ¬ Shape B X k T
+
+def ValidAtom
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (a : ArchitectureAtom C E D) : Prop :=
+  MinimalShape B X a.kind a.support
+```
+
+### 5.4 certificate soundness
+
+```lean
+structure AtomizationCertificate
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs) where
+  atoms : Finset (ArchitectureAtom C E D)
+  valid : ∀ a, a ∈ atoms -> ValidAtom B X a
+  selectedEvidenceCoveredOrBoundary : Prop
+  nonConclusions : Prop
+
+theorem atomization_certificate_sound
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (cert : AtomizationCertificate B X)
+  (a : ArchitectureAtom C E D) :
+  a ∈ cert.atoms ->
+  ValidAtom B X a :=
+  cert.valid a
+```
+
+これは最初に証明すべき theorem です。executable な `classify` / `atomize` は、
+certificate 方式が固まった後で、特定の finite grammar に対して追加すればよいです。
+
+### 5.5 atomization soundness
+
+```lean
+theorem atomize_sound
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (cert : AtomizationCertificate B X)
+  (a : ArchitectureAtom C E D) :
+  a ∈ cert.atoms ->
+  ValidAtom B X a := by
+  exact atomization_certificate_sound B X cert a
+```
+
+### 5.6 obstruction atom と zero signature の接続
+
+```lean
+def BadAtom
+  (a : ArchitectureAtom C E D) : Prop :=
+  a.polarity = Polarity.obstruction
+
+def HasBadAtomOn
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (cert : AtomizationCertificate B X)
+  (ax : Axis) : Prop :=
+  ∃ a, a ∈ cert.atoms ∧ a.axis = ax ∧ BadAtom a
+
+theorem zero_axis_iff_no_bad_atom
+  (B : AtomizationBoundary)
+  (X : ArchitectureObject C A StaticObs SemanticExpr SemanticObs)
+  (cert : AtomizationCertificate B X)
+  (ax : Axis)
+  (hComplete : WitnessComplete B X)
+  (hExact : AxisExact B X ax) :
+  SignatureZero B X ax ↔ ¬ HasBadAtomOn B X cert ax := by
+  -- future proof obligation; proof body is intentionally omitted in this design note
+```
+
+これが AAT の required obstruction vanishing theorem の atom 版です。AAT本文では、finite law universe、theorem boundary、complete witness coverage、required axis exactness の下で lawfulness、no required obstruction witness、required signature axes zero が接続されるため、atom theorem はその witness を最小支持に分解した refinement になります。
+
+---
+
+## 6. AAT Atomization の主要定理パッケージ
+
+最初に作るべき theorem package は次です。
+
+### Theorem 1: Atom Soundness
+
+```text
+a ∈ cert.atoms
+  -> ValidAtom_B(X, a)
+```
+
+atomization certificate が保持する atom は、定義上の原子である。
+
+### Theorem 2: Witness Localization
+
+```text
+bad witness w exists
+  -> exists atom a,
+       a is obstruction atom
+       ∧ support(a) ⊆ support(w)
+```
+
+任意の selected bad witness は、少なくとも1つの obstruction atom に局所化できる。
+
+### Theorem 3: Atom Vanishing
+
+```text
+WitnessComplete(B)
++ AxisExact(B)
++ AtomCoverComplete(B)
+->
+RequiredAxisZero(X, ax)
+  <-> no obstruction atom on ax
+```
+
+zero-count kernel の atom 版。
+
+### Theorem 4: Disjoint Sum Formula
+
+```text
+NoCrossInteraction(X, Y)
+->
+Atoms_B(X ⊕ Y)
+  = Atoms_B(X) ⊎ Atoms_B(Y)
+```
+
+cross edge / cross diagram がない場合、原子は直和で足し合わされる。
+
+### Theorem 5: Extension Atom Formula
+
+```text
+Atoms_B(X')
+  =
+  inherited core atoms
+  + feature-local atoms
+  + interaction atoms
+  + lifting/filling atoms
+  + complexity-transfer atoms
+  + residual coverage atoms
+```
+
+これは Architecture Extension Formula の atom refinement です。互いに素な分解は無条件には主張せず、分類関数または incidence relation として扱います。
+
+### Theorem 6: Repair Monotonicity, bounded version
+
+```text
+RepairStep r targets axis ax
++ preconditions(r)
++ sideEffectBoundary(r)
+->
+count(obstruction atoms on ax, r(X))
+  < count(obstruction atoms on ax, X)
+```
+
+ただし、
+
+```text
+does not imply:
+  all axes non-increasing
+```
+
+これは AAT の repair transfer 反例と整合します。
+
+---
+
+## 7. 最小実装ロードマップ
+
+### v0: Static atomizer
+
+まずは static graph だけでよいです。
+
+対象：
+
+```text
+components
+static dependency edges
+boundary labels
+projection edges
+ranking / layer policy
+```
+
+atom：
+
+```text
+ComponentAtom
+StaticEdgeAtom
+ForbiddenStaticEdgeAtom
+BoundaryLeakAtom
+AbstractionLeakAtom
+SimpleCycleAtom(n)
+ConcreteBypassAtom
+CoverageGapAtom
+```
+
+証明：
+
+```text
+atomization_certificate_sound
+atomize_sound
+forbidden_edge_zero_iff_no_forbidden_edge_atom
+acyclic_iff_no_simple_cycle_atom
+layered_iff_no_rank_violation_atom + acyclic condition
+```
+
+### v1: SOLID / Clean atomizer
+
+追加：
+
+```text
+PortAtom
+AdapterAtom
+PureRuleAtom
+CoordinatorAtom
+FatInterfaceAtom
+LSPMismatchAtom
+ProjectionFailureAtom
+```
+
+証明：
+
+```text
+ProjectionSound atom theorem
+LSPMismatch atom theorem
+DIP local soundness theorem
+SOLID does not imply global decomposability theorem
+```
+
+### v2: Semantic / runtime atomizer
+
+追加：
+
+```text
+RuntimeEdgeAtom
+GuardAtom
+RuntimeExposureAtom
+NonCommutingSquareAtom
+EffectLeakAtom
+ReplayViolationAtom
+CompensationGapAtom
+```
+
+証明：
+
+```text
+static_zero_not_imply_semantic_zero counterexample
+runtime protection local theorem
+non_commuting_square witness theorem
+```
+
+AAT本文でも static flatness、runtime flatness、semantic flatness は分かれており、static flatness だけから runtime / semantic flatness は従わないため、v0 と v2 は意図的に分離すべきです。
+
+---
+
+## 8. 最終的な設計判断
+
+AATに入れるべき定義は、おそらく次の5つです。
+
+```text
+ArchitectureAtom
+AtomizationBoundary
+AtomizationCertificate
+AtomDecomposition
+AtomSignature
+```
+
+中心定義はこれです。
+
+```text
+ArchitectureAtom_B(X)
+  := minimal finite support in X
+     classified by a selected atom schema
+     under boundary B
+```
+
+そして AAT の分類体系は、次のように拡張されます。
+
+```text
+ArchitectureObject
+  -> ArchitectureAtomization
+  -> AtomSignature
+  -> ObstructionSignature
+  -> RepairCandidate
+  -> ArchitectureOperation
+```
+
+これにより、ユーザーが望んでいる流れ：
+
+```text
+実コード
+  -> LLM semantic architecture reading
+  -> 原子分解
+  -> AAT theorem による分析・分類
+  -> repair operation 提案
+  -> 改善後 signature 比較
+```
+
+が、AAT本文の theorem boundary / non-conclusion 方針を崩さずに実現できます。
+
+最も重要な設計原則は、**原子を「小さいコード片」と定義しないこと**です。原子はあくまで、
+
+```text
+selected law universe に対して
+意味を持つ最小有限支持
+```
+
+です。
+
+そのため、同じクラスでも、static universe では `StaticEdgeAtom` の集合として、SOLID universe では `RoleAtom` と `FatInterfaceAtom` として、semantic universe では `NonCommutingSquareAtom` として見えることがあります。この相対性を明示することで、AATの分類能力はかなり強くなります。
+
+[1]: https://lean-lang.org/ "Lean Programming Language"
+[2]: https://leanprover.github.io/theorem_proving_in_lean4/ "Theorem Proving in Lean 4"
+[3]: https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Finset/Basic.html "Mathlib.Data.Finset.Basic"
+[4]: https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Fintype/Sets.html "Mathlib.Data.Fintype.Sets"


### PR DESCRIPTION
## 概要

`docs/aat/note_20260526.md` を追加し、AAT に Atomization Layer を導入するための設計ノートを整理しました。

Refs #1220
Refs #1226

主な内容:
- `ArchitectureAtom_B(X)` を selected boundary 下の finite / typed / evidence-aware / minimal subobject として整理
- ConstructiveAtom / ObstructionAtom / CoverageAtom の区別
- semantic architecture reading から atomization certificate へ進む流れ
- certificate-first な Lean skeleton と future proof obligations
- ArchMap / ArchSig / Lean proof の責務分離

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat/note_20260526.md`

## 実施したテスト

- [ ] `lake build`（docs-only のため未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 実装変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（tracking note のため close せず `Refs` に留める）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
