### PR TITLE
LawPolicy schemaとvalidationを追加

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -19,6 +19,7 @@ Current source-of-truth boundaries:
 Atom handoff checklist:
 
 - [Atom Handoff Checklist](atom_handoff.md)
+- [LawPolicy](law_policy.md)
 
 Forward design PRDs:
 

--- a/docs/tool/law_policy.md
+++ b/docs/tool/law_policy.md
@@ -1,0 +1,61 @@
+# LawPolicy
+
+`law-policy-v0` is the selected LawUniverse artifact used by the
+LLM-native ArchMap / ArchSig pipeline.
+
+It is intentionally separate from ArchMap.
+
+```text
+ArchMap
+  records law-independent Atom observations.
+
+LawPolicy
+  selects laws, witness rules, molecule patterns, obstruction definitions,
+  signature axes, coverage requirements, and exactness assumptions.
+
+ArchSig
+  reads ArchMap + LawPolicy and computes law-relative analysis.
+```
+
+## Responsibility
+
+LawPolicy owns the selected analysis policy for a specific review context.
+It does not define AAT and does not prove architecture lawfulness.
+
+The implemented schema records:
+
+- `lawPolicyId`
+- `selectedLaws`
+- `requiredZeroAxes`
+- `optionalAxes`
+- `witnessRules`
+- `moleculePatterns`
+- `obstructionCircuitDefinitions`
+- `signatureAxisDefinitions`
+- `exactnessAssumptions`
+- `coverageRequirements`
+- `excludedReadings`
+- `nonConclusions`
+
+## Validation Boundary
+
+LawPolicy validation checks schema support, identity, uniqueness, cross-reference
+integrity, witness / obstruction boundaries, coverage requirements, exactness
+assumptions, and required non-conclusions.
+
+Validation does not imply:
+
+- architecture lawfulness
+- certified Atom truth
+- zero curvature
+- Lean theorem discharge
+- extractor completeness
+
+Missing coverage remains a coverage gap. It is not measured zero.
+
+## Current Fixture
+
+- `tools/archsig/tests/fixtures/minimal/law_policy.json`
+
+The fixture is locked against the static Rust builder and the schema catalog
+records both `law-policy-v0` and `law-policy-validation-report-v0`.

--- a/tools/archsig/src/law_policy.rs
+++ b/tools/archsig/src/law_policy.rs
@@ -1,0 +1,834 @@
+use std::collections::BTreeSet;
+
+use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
+use crate::{
+    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+    LawPolicyAxisDefinitionV0, LawPolicyCoverageRequirementV0, LawPolicyDocumentV0,
+    LawPolicyMoleculePatternV0, LawPolicyObstructionCircuitDefinitionV0, LawPolicySelectedLawV0,
+    LawPolicySignatureAxisDefinitionV0, LawPolicyValidationInputV0, LawPolicyValidationReportV0,
+    LawPolicyValidationSummaryV0, LawPolicyWitnessRuleV0, ValidationCheck, ValidationExample,
+};
+
+const REQUIRED_NON_CONCLUSIONS: [&str; 5] = [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions",
+];
+
+pub fn static_law_policy() -> LawPolicyDocumentV0 {
+    LawPolicyDocumentV0 {
+        schema_version: LAW_POLICY_SCHEMA_VERSION.to_string(),
+        law_policy_id: "llm-native-aat-law-policy-fixture".to_string(),
+        policy_version: "v0".to_string(),
+        scope: "LLM-native ArchMap observation analysis fixture".to_string(),
+        archmap_schema_ref: "archmap-observation-map-v0".to_string(),
+        selected_laws: vec![
+            selected_law(
+                "law:layer-respecting",
+                "dependency-direction",
+                "Dependencies must respect the selected layer order.",
+                &["relation", "boundaryAuthority"],
+                &["witness:layer-violation"],
+                &["axis:layer-violation"],
+            ),
+            selected_law(
+                "law:semantic-contract-alignment",
+                "semantic-contract",
+                "Semantic observations and contract observations must agree on the selected operation meaning.",
+                &["contractSpecification", "semanticInterpretation"],
+                &["witness:semantic-contract-mismatch"],
+                &["axis:semantic-inconsistency"],
+            ),
+        ],
+        required_zero_axes: vec![
+            axis(
+                "axis:layer-violation",
+                "dependency-direction",
+                "nat",
+                "zero means no required layer violation witness was constructed under this policy",
+                "computedFromObservedAtoms",
+                &[
+                    "observed relation atoms",
+                    "observed boundary membership atoms",
+                ],
+            ),
+            axis(
+                "axis:semantic-inconsistency",
+                "semantic-contract",
+                "nat",
+                "zero means no required semantic contract mismatch witness was constructed under this policy",
+                "computedFromObservedAtoms",
+                &["observed semantic atoms", "observed contract atoms"],
+            ),
+        ],
+        optional_axes: vec![axis(
+            "axis:observation-gap",
+            "coverage",
+            "nat",
+            "zero means no policy-required observation gap was reported",
+            "coverageBoundary",
+            &["observation gap records"],
+        )],
+        witness_rules: vec![
+            witness_rule(
+                "witness:layer-violation",
+                "law:layer-respecting",
+                "forbidden-dependency-direction",
+                &["relation", "boundaryAuthority"],
+                &["molecule:layered-component"],
+            ),
+            witness_rule(
+                "witness:semantic-contract-mismatch",
+                "law:semantic-contract-alignment",
+                "semantic-contract-noncommutation",
+                &["contractSpecification", "semanticInterpretation"],
+                &["molecule:operation-contract"],
+            ),
+        ],
+        molecule_patterns: vec![
+            molecule_pattern(
+                "molecule:layered-component",
+                "layered component",
+                &["existence", "boundaryAuthority"],
+                &["relation"],
+            ),
+            molecule_pattern(
+                "molecule:operation-contract",
+                "operation contract",
+                &["capability", "contractSpecification"],
+                &["semanticInterpretation", "effect"],
+            ),
+        ],
+        obstruction_circuit_definitions: vec![
+            obstruction_definition(
+                "obstruction:layer-violation",
+                "law:layer-respecting",
+                "witness:layer-violation",
+                "BoundaryLeakCircuit",
+                &["axis:layer-violation"],
+            ),
+            obstruction_definition(
+                "obstruction:semantic-contract-mismatch",
+                "law:semantic-contract-alignment",
+                "witness:semantic-contract-mismatch",
+                "SemanticMismatchCircuit",
+                &["axis:semantic-inconsistency"],
+            ),
+        ],
+        signature_axis_definitions: vec![
+            signature_axis(
+                "sig-axis:layer-violation",
+                "law:layer-respecting",
+                "axis:layer-violation",
+                "count constructed BoundaryLeakCircuit witnesses",
+            ),
+            signature_axis(
+                "sig-axis:semantic-inconsistency",
+                "law:semantic-contract-alignment",
+                "axis:semantic-inconsistency",
+                "count constructed SemanticMismatchCircuit witnesses",
+            ),
+        ],
+        exactness_assumptions: vec![
+            "the selected witness rules cover only policy-declared laws".to_string(),
+            "zero readings are exact only for observed atoms and declared coverage requirements"
+                .to_string(),
+        ],
+        coverage_requirements: vec![
+            coverage_requirement(
+                "coverage:layer-atoms",
+                &["law:layer-respecting"],
+                &["existence", "relation", "boundaryAuthority"],
+                &["file", "symbol"],
+            ),
+            coverage_requirement(
+                "coverage:semantic-contract-atoms",
+                &["law:semantic-contract-alignment"],
+                &[
+                    "capability",
+                    "contractSpecification",
+                    "semanticInterpretation",
+                ],
+                &["file", "doc-section", "test"],
+            ),
+        ],
+        excluded_readings: vec![
+            "global architecture truth".to_string(),
+            "Lean theorem discharge".to_string(),
+            "SFT forecast correctness".to_string(),
+        ],
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+pub fn validate_law_policy_report(
+    policy: &LawPolicyDocumentV0,
+    input_path: &str,
+) -> LawPolicyValidationReportV0 {
+    let checks = vec![
+        check_schema_version(policy),
+        check_identity(policy),
+        check_ids_unique(policy),
+        check_law_refs(policy),
+        check_axis_refs(policy),
+        check_witness_and_obstruction_boundaries(policy),
+        check_coverage_and_exactness(policy),
+        check_non_conclusions(policy),
+    ];
+    let summary = LawPolicyValidationSummaryV0 {
+        result: if checks.iter().any(|check| check.result == "fail") {
+            "fail".to_string()
+        } else if checks.iter().any(|check| check.result == "warn") {
+            "warn".to_string()
+        } else {
+            "pass".to_string()
+        },
+        selected_law_count: policy.selected_laws.len(),
+        required_zero_axis_count: policy.required_zero_axes.len(),
+        witness_rule_count: policy.witness_rules.len(),
+        obstruction_circuit_definition_count: policy.obstruction_circuit_definitions.len(),
+        signature_axis_definition_count: policy.signature_axis_definitions.len(),
+        coverage_requirement_count: policy.coverage_requirements.len(),
+        failed_check_count: count_checks(&checks, "fail"),
+        warning_check_count: count_checks(&checks, "warn"),
+    };
+
+    LawPolicyValidationReportV0 {
+        schema_version: LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION.to_string(),
+        input: LawPolicyValidationInputV0 {
+            schema_version: policy.schema_version.clone(),
+            path: input_path.to_string(),
+            law_policy_id: policy.law_policy_id.clone(),
+            policy_version: policy.policy_version.clone(),
+            archmap_schema_ref: policy.archmap_schema_ref.clone(),
+        },
+        policy: policy.clone(),
+        summary,
+        checks,
+    }
+}
+
+fn check_schema_version(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let mut check = validation_check(
+        "law-policy-schema-version-supported",
+        "law policy schema version is supported",
+        if policy.schema_version == LAW_POLICY_SCHEMA_VERSION {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!(
+            "unsupported law policy schemaVersion: {}",
+            policy.schema_version
+        ));
+    }
+    check
+}
+
+fn check_identity(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let mut examples = Vec::new();
+    push_blank(&mut examples, "lawPolicyId", &policy.law_policy_id);
+    push_blank(&mut examples, "policyVersion", &policy.policy_version);
+    push_blank(&mut examples, "scope", &policy.scope);
+    push_blank(
+        &mut examples,
+        "archMapSchemaRef",
+        &policy.archmap_schema_ref,
+    );
+    check_from_examples(
+        "law-policy-identity-recorded",
+        "law policy identity, scope, and target ArchMap schema are recorded",
+        examples,
+        "fail",
+    )
+}
+
+fn check_ids_unique(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let mut examples = Vec::new();
+    examples.extend(duplicate_examples(
+        "selectedLaws[].lawId",
+        duplicates(policy.selected_laws.iter().map(|law| law.law_id.as_str())),
+    ));
+    examples.extend(duplicate_examples(
+        "requiredZeroAxes[].axisId",
+        duplicates(
+            policy
+                .required_zero_axes
+                .iter()
+                .map(|axis| axis.axis_id.as_str()),
+        ),
+    ));
+    examples.extend(duplicate_examples(
+        "optionalAxes[].axisId",
+        duplicates(
+            policy
+                .optional_axes
+                .iter()
+                .map(|axis| axis.axis_id.as_str()),
+        ),
+    ));
+    examples.extend(duplicate_examples(
+        "witnessRules[].witnessRuleId",
+        duplicates(
+            policy
+                .witness_rules
+                .iter()
+                .map(|rule| rule.witness_rule_id.as_str()),
+        ),
+    ));
+    examples.extend(duplicate_examples(
+        "moleculePatterns[].moleculePatternId",
+        duplicates(
+            policy
+                .molecule_patterns
+                .iter()
+                .map(|pattern| pattern.molecule_pattern_id.as_str()),
+        ),
+    ));
+    examples.extend(duplicate_examples(
+        "obstructionCircuitDefinitions[].obstructionCircuitId",
+        duplicates(
+            policy
+                .obstruction_circuit_definitions
+                .iter()
+                .map(|definition| definition.obstruction_circuit_id.as_str()),
+        ),
+    ));
+    examples.extend(duplicate_examples(
+        "signatureAxisDefinitions[].signatureAxisId",
+        duplicates(
+            policy
+                .signature_axis_definitions
+                .iter()
+                .map(|definition| definition.signature_axis_id.as_str()),
+        ),
+    ));
+    examples.extend(duplicate_examples(
+        "coverageRequirements[].coverageRequirementId",
+        duplicates(
+            policy
+                .coverage_requirements
+                .iter()
+                .map(|requirement| requirement.coverage_requirement_id.as_str()),
+        ),
+    ));
+    check_from_examples(
+        "law-policy-ids-unique",
+        "law policy ids are unique within each definition family",
+        examples,
+        "fail",
+    )
+}
+
+fn check_law_refs(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let law_ids = set(policy.selected_laws.iter().map(|law| law.law_id.as_str()));
+    let axis_ids = policy
+        .required_zero_axes
+        .iter()
+        .chain(policy.optional_axes.iter())
+        .map(|axis| axis.axis_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let witness_ids = set(policy
+        .witness_rules
+        .iter()
+        .map(|rule| rule.witness_rule_id.as_str()));
+    let mut examples = Vec::new();
+
+    for law in &policy.selected_laws {
+        if law.required_witness_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &law.law_id,
+                "requiredWitnessRefs",
+                "selected law must declare witness rules",
+            ));
+        }
+        if law.required_axis_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &law.law_id,
+                "requiredAxisRefs",
+                "selected law must declare required signature axes",
+            ));
+        }
+        for witness_ref in &law.required_witness_refs {
+            if !witness_ids.contains(witness_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &law.law_id,
+                    witness_ref,
+                    "selected law references an unknown witness rule",
+                ));
+            }
+        }
+        for axis_ref in &law.required_axis_refs {
+            if !axis_ids.contains(axis_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &law.law_id,
+                    axis_ref,
+                    "selected law references an unknown required or optional axis",
+                ));
+            }
+        }
+    }
+
+    for rule in &policy.witness_rules {
+        if !law_ids.contains(rule.law_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &rule.witness_rule_id,
+                &rule.law_ref,
+                "witness rule references an unknown selected law",
+            ));
+        }
+    }
+    for definition in &policy.obstruction_circuit_definitions {
+        if !law_ids.contains(definition.law_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &definition.obstruction_circuit_id,
+                &definition.law_ref,
+                "obstruction circuit definition references an unknown selected law",
+            ));
+        }
+    }
+    for axis in &policy.signature_axis_definitions {
+        if !law_ids.contains(axis.law_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &axis.signature_axis_id,
+                &axis.law_ref,
+                "signature axis definition references an unknown selected law",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "law-policy-law-refs-resolve",
+        "selected laws, witness rules, obstruction definitions, and signature axes cross-reference each other",
+        examples,
+        "fail",
+    )
+}
+
+fn check_axis_refs(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let axis_ids = policy
+        .required_zero_axes
+        .iter()
+        .chain(policy.optional_axes.iter())
+        .map(|axis| axis.axis_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = Vec::new();
+
+    for definition in &policy.signature_axis_definitions {
+        if !axis_ids.contains(definition.axis_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &definition.signature_axis_id,
+                &definition.axis_ref,
+                "signature axis definition references an unknown axis",
+            ));
+        }
+    }
+    for definition in &policy.obstruction_circuit_definitions {
+        if definition.signature_axis_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &definition.obstruction_circuit_id,
+                "signatureAxisRefs",
+                "obstruction circuit definition should declare affected signature axes",
+            ));
+        }
+        for axis_ref in &definition.signature_axis_refs {
+            if !axis_ids.contains(axis_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &definition.obstruction_circuit_id,
+                    axis_ref,
+                    "obstruction circuit definition references an unknown axis",
+                ));
+            }
+        }
+    }
+    check_from_examples(
+        "law-policy-axis-refs-resolve",
+        "required and optional axes are referenced explicitly by signature and obstruction definitions",
+        examples,
+        "fail",
+    )
+}
+
+fn check_witness_and_obstruction_boundaries(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let witness_ids = set(policy
+        .witness_rules
+        .iter()
+        .map(|rule| rule.witness_rule_id.as_str()));
+    let molecule_pattern_ids = set(policy
+        .molecule_patterns
+        .iter()
+        .map(|pattern| pattern.molecule_pattern_id.as_str()));
+    let mut examples = Vec::new();
+
+    for rule in &policy.witness_rules {
+        if rule.evidence_boundary.trim().is_empty() {
+            examples.push(generic_validation_example(
+                &rule.witness_rule_id,
+                "evidenceBoundary",
+                "witness rule must declare evidence boundary",
+            ));
+        }
+        if rule.required_atom_families.is_empty() && rule.molecule_pattern_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &rule.witness_rule_id,
+                "requiredAtomFamilies",
+                "witness rule must declare atom families or molecule pattern refs",
+            ));
+        }
+        for pattern_ref in &rule.molecule_pattern_refs {
+            if !molecule_pattern_ids.contains(pattern_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &rule.witness_rule_id,
+                    pattern_ref,
+                    "witness rule references an unknown molecule pattern",
+                ));
+            }
+        }
+    }
+
+    for definition in &policy.obstruction_circuit_definitions {
+        if !witness_ids.contains(definition.witness_rule_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &definition.obstruction_circuit_id,
+                &definition.witness_rule_ref,
+                "obstruction circuit definition references an unknown witness rule",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} minimalityReading", definition.obstruction_circuit_id),
+            &definition.minimality_reading,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} evidenceBoundary", definition.obstruction_circuit_id),
+            &definition.evidence_boundary,
+        );
+    }
+
+    check_from_examples(
+        "law-policy-witness-and-obstruction-boundaries",
+        "witness and obstruction definitions declare evidence, minimality, and molecule boundaries",
+        examples,
+        "fail",
+    )
+}
+
+fn check_coverage_and_exactness(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let law_ids = set(policy.selected_laws.iter().map(|law| law.law_id.as_str()));
+    let mut examples = Vec::new();
+    if policy.exactness_assumptions.is_empty() || has_blank(&policy.exactness_assumptions) {
+        examples.push(generic_validation_example(
+            &policy.law_policy_id,
+            "exactnessAssumptions",
+            "law policy must declare exactness assumptions",
+        ));
+    }
+    if policy.coverage_requirements.is_empty() {
+        examples.push(generic_validation_example(
+            &policy.law_policy_id,
+            "coverageRequirements",
+            "law policy must declare coverage requirements",
+        ));
+    }
+    for requirement in &policy.coverage_requirements {
+        if requirement.applies_to_law_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &requirement.coverage_requirement_id,
+                "appliesToLawRefs",
+                "coverage requirement must declare selected laws",
+            ));
+        }
+        for law_ref in &requirement.applies_to_law_refs {
+            if !law_ids.contains(law_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &requirement.coverage_requirement_id,
+                    law_ref,
+                    "coverage requirement references an unknown selected law",
+                ));
+            }
+        }
+        if requirement.required_atom_families.is_empty() {
+            examples.push(generic_validation_example(
+                &requirement.coverage_requirement_id,
+                "requiredAtomFamilies",
+                "coverage requirement must declare atom families",
+            ));
+        }
+        if requirement.missing_coverage_behavior.trim().is_empty() {
+            examples.push(generic_validation_example(
+                &requirement.coverage_requirement_id,
+                "missingCoverageBehavior",
+                "coverage requirement must state missing coverage behavior",
+            ));
+        }
+    }
+    check_from_examples(
+        "law-policy-coverage-and-exactness-declared",
+        "coverage requirements and exactness assumptions are declared",
+        examples,
+        "fail",
+    )
+}
+
+fn check_non_conclusions(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let present = policy
+        .non_conclusions
+        .iter()
+        .map(|value| value.as_str())
+        .collect::<BTreeSet<_>>();
+    let examples = REQUIRED_NON_CONCLUSIONS
+        .iter()
+        .filter(|required| !present.contains(**required))
+        .map(|required| {
+            generic_validation_example(
+                &policy.law_policy_id,
+                required,
+                "missing required law policy non-conclusion",
+            )
+        })
+        .collect();
+    check_from_examples(
+        "law-policy-non-conclusion-boundary",
+        "law policy keeps theory, lawfulness, atom truth, coverage, and signature-zero boundaries explicit",
+        examples,
+        "fail",
+    )
+}
+
+fn selected_law(
+    law_id: &str,
+    law_family: &str,
+    description: &str,
+    applies_to_atom_families: &[&str],
+    required_witness_refs: &[&str],
+    required_axis_refs: &[&str],
+) -> LawPolicySelectedLawV0 {
+    LawPolicySelectedLawV0 {
+        law_id: law_id.to_string(),
+        law_family: law_family.to_string(),
+        description: description.to_string(),
+        enforcement_boundary: "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness".to_string(),
+        applies_to_atom_families: strings(applies_to_atom_families),
+        required_witness_refs: strings(required_witness_refs),
+        required_axis_refs: strings(required_axis_refs),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn axis(
+    axis_id: &str,
+    axis_family: &str,
+    value_type: &str,
+    zero_reading: &str,
+    measurement_boundary: &str,
+    evidence_requirements: &[&str],
+) -> LawPolicyAxisDefinitionV0 {
+    LawPolicyAxisDefinitionV0 {
+        axis_id: axis_id.to_string(),
+        axis_family: axis_family.to_string(),
+        value_type: value_type.to_string(),
+        zero_reading: zero_reading.to_string(),
+        measurement_boundary: measurement_boundary.to_string(),
+        evidence_requirements: strings(evidence_requirements),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn witness_rule(
+    witness_rule_id: &str,
+    law_ref: &str,
+    witness_kind: &str,
+    required_atom_families: &[&str],
+    molecule_pattern_refs: &[&str],
+) -> LawPolicyWitnessRuleV0 {
+    LawPolicyWitnessRuleV0 {
+        witness_rule_id: witness_rule_id.to_string(),
+        law_ref: law_ref.to_string(),
+        witness_kind: witness_kind.to_string(),
+        atom_observation_refs: Vec::new(),
+        required_atom_families: strings(required_atom_families),
+        molecule_pattern_refs: strings(molecule_pattern_refs),
+        evidence_boundary: "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits".to_string(),
+        missing_evidence_behavior: "report observation gap; do not infer measured zero".to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn molecule_pattern(
+    molecule_pattern_id: &str,
+    role_name: &str,
+    required_atom_families: &[&str],
+    optional_atom_families: &[&str],
+) -> LawPolicyMoleculePatternV0 {
+    LawPolicyMoleculePatternV0 {
+        molecule_pattern_id: molecule_pattern_id.to_string(),
+        role_name: role_name.to_string(),
+        required_atom_families: strings(required_atom_families),
+        optional_atom_families: strings(optional_atom_families),
+        interpretation_boundary:
+            "molecule pattern is role interpretation over atoms, not a primitive atom".to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn obstruction_definition(
+    obstruction_circuit_id: &str,
+    law_ref: &str,
+    witness_rule_ref: &str,
+    circuit_kind: &str,
+    signature_axis_refs: &[&str],
+) -> LawPolicyObstructionCircuitDefinitionV0 {
+    LawPolicyObstructionCircuitDefinitionV0 {
+        obstruction_circuit_id: obstruction_circuit_id.to_string(),
+        law_ref: law_ref.to_string(),
+        witness_rule_ref: witness_rule_ref.to_string(),
+        circuit_kind: circuit_kind.to_string(),
+        minimality_reading: "minimality is evaluated within the selected observed Atom configuration and witness rule".to_string(),
+        evidence_boundary: "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge".to_string(),
+        signature_axis_refs: strings(signature_axis_refs),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn signature_axis(
+    signature_axis_id: &str,
+    law_ref: &str,
+    axis_ref: &str,
+    valuation_rule: &str,
+) -> LawPolicySignatureAxisDefinitionV0 {
+    LawPolicySignatureAxisDefinitionV0 {
+        signature_axis_id: signature_axis_id.to_string(),
+        law_ref: law_ref.to_string(),
+        axis_ref: axis_ref.to_string(),
+        valuation_rule: valuation_rule.to_string(),
+        value_type: "nat".to_string(),
+        zero_reading: "zero means no matching required witness was constructed under declared coverage and exactness assumptions".to_string(),
+        coverage_boundary: "coverage gaps remain observation gaps, not measured zero".to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn coverage_requirement(
+    coverage_requirement_id: &str,
+    applies_to_law_refs: &[&str],
+    required_atom_families: &[&str],
+    required_source_ref_kinds: &[&str],
+) -> LawPolicyCoverageRequirementV0 {
+    LawPolicyCoverageRequirementV0 {
+        coverage_requirement_id: coverage_requirement_id.to_string(),
+        applies_to_law_refs: strings(applies_to_law_refs),
+        required_atom_families: strings(required_atom_families),
+        required_source_ref_kinds: strings(required_source_ref_kinds),
+        missing_coverage_behavior: "report observation gap and block signature-zero reflection"
+            .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn check_from_examples(
+    id: &str,
+    title: &str,
+    examples: Vec<ValidationExample>,
+    failure_result: &str,
+) -> ValidationCheck {
+    let mut check = validation_check(
+        id,
+        title,
+        if examples.is_empty() {
+            "pass"
+        } else {
+            failure_result
+        },
+    );
+    check.count = Some(examples.len());
+    check.examples = examples;
+    check
+}
+
+fn duplicate_examples(field: &str, duplicates: Vec<String>) -> Vec<ValidationExample> {
+    duplicates
+        .into_iter()
+        .map(|id| generic_validation_example(field, &id, "duplicate id"))
+        .collect()
+}
+
+fn push_blank(examples: &mut Vec<ValidationExample>, field: &str, value: &str) {
+    if value.trim().is_empty() {
+        examples.push(generic_validation_example(
+            field,
+            value,
+            "field must be non-empty",
+        ));
+    }
+}
+
+fn has_blank(values: &[String]) -> bool {
+    values.iter().any(|value| value.trim().is_empty())
+}
+
+fn set<'a>(values: impl Iterator<Item = &'a str>) -> BTreeSet<&'a str> {
+    values.collect()
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_law_policy_validates() {
+        let policy = static_law_policy();
+        let report = validate_law_policy_report(&policy, "static-law-policy.json");
+        assert_eq!(
+            report.schema_version,
+            LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION
+        );
+        assert_eq!(report.summary.result, "pass");
+        assert_eq!(report.summary.selected_law_count, 2);
+        assert!(report.checks.iter().any(|check| {
+            check.id == "law-policy-non-conclusion-boundary" && check.result == "pass"
+        }));
+    }
+
+    #[test]
+    fn missing_law_policy_non_conclusion_fails() {
+        let mut policy = static_law_policy();
+        policy.non_conclusions.clear();
+        let report = validate_law_policy_report(&policy, "bad-law-policy.json");
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "law-policy-non-conclusion-boundary" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn unknown_witness_ref_fails() {
+        let mut policy = static_law_policy();
+        policy.selected_laws[0]
+            .required_witness_refs
+            .push("witness:missing".to_string());
+        let report = validate_law_policy_report(&policy, "bad-law-policy.json");
+        assert_eq!(report.summary.result, "fail");
+        assert!(
+            report.checks.iter().any(|check| {
+                check.id == "law-policy-law-refs-resolve" && check.result == "fail"
+            })
+        );
+    }
+
+    #[test]
+    fn canonical_fixture_matches_static_law_policy() {
+        let fixture: LawPolicyDocumentV0 =
+            serde_json::from_str(include_str!("../tests/fixtures/minimal/law_policy.json"))
+                .expect("law policy fixture parses");
+        assert_eq!(fixture, static_law_policy());
+    }
+}

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -12,6 +12,7 @@ mod extractor;
 mod feature_report;
 mod framework_adapter;
 mod graph;
+mod law_policy;
 mod law_policy_template;
 mod measurement_unit;
 mod no_solution_certificate;
@@ -59,6 +60,7 @@ pub use feature_report::{
     build_feature_extension_report, build_feature_extension_report_with_archmap_diagnostics,
 };
 pub use framework_adapter::attach_framework_adapter_evidence;
+pub use law_policy::{static_law_policy, validate_law_policy_report};
 pub use law_policy_template::{
     static_law_policy_template_registry, validate_law_policy_template_registry_report,
 };

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -38,6 +38,8 @@ pub const NO_SOLUTION_CERTIFICATE_VALIDATION_REPORT_SCHEMA_VERSION: &str =
 pub const ORGANIZATION_POLICY_SCHEMA_VERSION: &str = "organization-policy-v0";
 pub const ORGANIZATION_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "organization-policy-validation-report-v0";
+pub const LAW_POLICY_SCHEMA_VERSION: &str = "law-policy-v0";
+pub const LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str = "law-policy-validation-report-v0";
 pub const LAW_POLICY_TEMPLATE_REGISTRY_SCHEMA_VERSION: &str = "law-policy-template-registry-v0";
 pub const LAW_POLICY_TEMPLATE_REGISTRY_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "law-policy-template-registry-validation-report-v0";
@@ -2513,6 +2515,172 @@ pub struct LawPolicyTemplateRegistryValidationInput {
 pub struct LawPolicyTemplateRegistryValidationSummary {
     pub result: String,
     pub template_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyDocumentV0 {
+    pub schema_version: String,
+    pub law_policy_id: String,
+    pub policy_version: String,
+    pub scope: String,
+    pub archmap_schema_ref: String,
+    pub selected_laws: Vec<LawPolicySelectedLawV0>,
+    pub required_zero_axes: Vec<LawPolicyAxisDefinitionV0>,
+    #[serde(default)]
+    pub optional_axes: Vec<LawPolicyAxisDefinitionV0>,
+    pub witness_rules: Vec<LawPolicyWitnessRuleV0>,
+    #[serde(default)]
+    pub molecule_patterns: Vec<LawPolicyMoleculePatternV0>,
+    pub obstruction_circuit_definitions: Vec<LawPolicyObstructionCircuitDefinitionV0>,
+    pub signature_axis_definitions: Vec<LawPolicySignatureAxisDefinitionV0>,
+    pub exactness_assumptions: Vec<String>,
+    pub coverage_requirements: Vec<LawPolicyCoverageRequirementV0>,
+    #[serde(default)]
+    pub excluded_readings: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicySelectedLawV0 {
+    pub law_id: String,
+    pub law_family: String,
+    pub description: String,
+    pub enforcement_boundary: String,
+    #[serde(default)]
+    pub applies_to_atom_families: Vec<String>,
+    #[serde(default)]
+    pub required_witness_refs: Vec<String>,
+    #[serde(default)]
+    pub required_axis_refs: Vec<String>,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyAxisDefinitionV0 {
+    pub axis_id: String,
+    pub axis_family: String,
+    pub value_type: String,
+    pub zero_reading: String,
+    pub measurement_boundary: String,
+    #[serde(default)]
+    pub evidence_requirements: Vec<String>,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyWitnessRuleV0 {
+    pub witness_rule_id: String,
+    pub law_ref: String,
+    pub witness_kind: String,
+    #[serde(default)]
+    pub atom_observation_refs: Vec<String>,
+    #[serde(default)]
+    pub required_atom_families: Vec<String>,
+    #[serde(default)]
+    pub molecule_pattern_refs: Vec<String>,
+    pub evidence_boundary: String,
+    #[serde(default)]
+    pub missing_evidence_behavior: String,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyMoleculePatternV0 {
+    pub molecule_pattern_id: String,
+    pub role_name: String,
+    #[serde(default)]
+    pub required_atom_families: Vec<String>,
+    #[serde(default)]
+    pub optional_atom_families: Vec<String>,
+    pub interpretation_boundary: String,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyObstructionCircuitDefinitionV0 {
+    pub obstruction_circuit_id: String,
+    pub law_ref: String,
+    pub witness_rule_ref: String,
+    pub circuit_kind: String,
+    pub minimality_reading: String,
+    pub evidence_boundary: String,
+    #[serde(default)]
+    pub signature_axis_refs: Vec<String>,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicySignatureAxisDefinitionV0 {
+    pub signature_axis_id: String,
+    pub law_ref: String,
+    pub axis_ref: String,
+    pub valuation_rule: String,
+    pub value_type: String,
+    pub zero_reading: String,
+    pub coverage_boundary: String,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyCoverageRequirementV0 {
+    pub coverage_requirement_id: String,
+    #[serde(default)]
+    pub applies_to_law_refs: Vec<String>,
+    #[serde(default)]
+    pub required_atom_families: Vec<String>,
+    #[serde(default)]
+    pub required_source_ref_kinds: Vec<String>,
+    pub missing_coverage_behavior: String,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyValidationReportV0 {
+    pub schema_version: String,
+    pub input: LawPolicyValidationInputV0,
+    pub policy: LawPolicyDocumentV0,
+    pub summary: LawPolicyValidationSummaryV0,
+    pub checks: Vec<ValidationCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyValidationInputV0 {
+    pub schema_version: String,
+    pub path: String,
+    pub law_policy_id: String,
+    pub policy_version: String,
+    pub archmap_schema_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyValidationSummaryV0 {
+    pub result: String,
+    pub selected_law_count: usize,
+    pub required_zero_axis_count: usize,
+    pub witness_rule_count: usize,
+    pub obstruction_circuit_definition_count: usize,
+    pub signature_axis_definition_count: usize,
+    pub coverage_requirement_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
 }

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -4,7 +4,8 @@ use crate::{
     ARCHITECTURE_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, ARCHMAP_SCHEMA_VERSION,
     ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
     DETECTABLE_VALUES_REPORTED_AXES_CATALOG_SCHEMA_VERSION,
-    FEATURE_EXTENSION_REPORT_SCHEMA_VERSION, LAW_VIOLATION_REPORT_SCHEMA_VERSION,
+    FEATURE_EXTENSION_REPORT_SCHEMA_VERSION, LAW_POLICY_SCHEMA_VERSION,
+    LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, LAW_VIOLATION_REPORT_SCHEMA_VERSION,
     OBSTRUCTION_WITNESS_SCHEMA_VERSION, PR_QUALITY_ANALYSIS_REPORT_SCHEMA_VERSION,
     SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION, SCHEMA_VERSION,
     SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaCompatibilityBoundaryV0,
@@ -114,6 +115,50 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                     ],
                     vec![
                         "Validation pass does not imply semantic correctness, completeness, architecture lawfulness, certified atom truth, zero curvature, or SFT forecast correctness.",
+                    ],
+                ),
+            ),
+            artifact(
+                "law-policy",
+                "LLM-native selected LawPolicy artifact",
+                LAW_POLICY_SCHEMA_VERSION,
+                "selected-law-universe-policy",
+                "LLM-native ArchMap / ArchSig",
+                "implemented",
+                vec![
+                    "docs/tool/llm_native_archmap_archsig_prd.md",
+                    "docs/tool/README.md",
+                ],
+                vec!["#1330"],
+                compatibility_boundary(
+                    "LawPolicy owns selected laws, witness rules, molecule patterns, obstruction definitions, signature axis definitions, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations.",
+                    vec![],
+                    vec![
+                        "New law families must declare witness rules, required zero axes, coverage requirements, and exactness assumptions.",
+                        "New signature axes must keep missing coverage distinct from measured zero.",
+                    ],
+                    vec![
+                        "LawPolicy is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
+                    ],
+                ),
+            ),
+            artifact(
+                "law-policy-validation-report",
+                "LLM-native LawPolicy validation report",
+                LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+                "validation-output",
+                "LLM-native ArchMap / ArchSig",
+                "implemented",
+                vec!["docs/tool/llm_native_archmap_archsig_prd.md"],
+                vec!["#1330"],
+                compatibility_boundary(
+                    "Validation reports schema support, identity, id uniqueness, law/witness/axis references, coverage, exactness, and non-conclusion guardrails without proving lawfulness.",
+                    vec![],
+                    vec![
+                        "New checks must fail or warn without promoting policy validation to theorem evidence.",
+                    ],
+                    vec![
+                        "Validation pass does not imply architecture lawfulness, certified atom truth, zero curvature, or Lean theorem discharge.",
                     ],
                 ),
             ),
@@ -509,6 +554,8 @@ mod tests {
         for expected in [
             SCHEMA_VERSION,
             AIR_SCHEMA_VERSION,
+            LAW_POLICY_SCHEMA_VERSION,
+            LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
             FEATURE_EXTENSION_REPORT_SCHEMA_VERSION,
             OBSTRUCTION_WITNESS_SCHEMA_VERSION,
             ARCHITECTURE_DRIFT_LEDGER_SCHEMA_VERSION,

--- a/tools/archsig/tests/fixtures/minimal/law_policy.json
+++ b/tools/archsig/tests/fixtures/minimal/law_policy.json
@@ -1,0 +1,336 @@
+{
+  "schemaVersion": "law-policy-v0",
+  "lawPolicyId": "llm-native-aat-law-policy-fixture",
+  "policyVersion": "v0",
+  "scope": "LLM-native ArchMap observation analysis fixture",
+  "archmapSchemaRef": "archmap-observation-map-v0",
+  "selectedLaws": [
+    {
+      "lawId": "law:layer-respecting",
+      "lawFamily": "dependency-direction",
+      "description": "Dependencies must respect the selected layer order.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredWitnessRefs": [
+        "witness:layer-violation"
+      ],
+      "requiredAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "lawId": "law:semantic-contract-alignment",
+      "lawFamily": "semantic-contract",
+      "description": "Semantic observations and contract observations must agree on the selected operation meaning.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "requiredWitnessRefs": [
+        "witness:semantic-contract-mismatch"
+      ],
+      "requiredAxisRefs": [
+        "axis:semantic-inconsistency"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "requiredZeroAxes": [
+    {
+      "axisId": "axis:layer-violation",
+      "axisFamily": "dependency-direction",
+      "valueType": "nat",
+      "zeroReading": "zero means no required layer violation witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed relation atoms",
+        "observed boundary membership atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "axisId": "axis:semantic-inconsistency",
+      "axisFamily": "semantic-contract",
+      "valueType": "nat",
+      "zeroReading": "zero means no required semantic contract mismatch witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed semantic atoms",
+        "observed contract atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "optionalAxes": [
+    {
+      "axisId": "axis:observation-gap",
+      "axisFamily": "coverage",
+      "valueType": "nat",
+      "zeroReading": "zero means no policy-required observation gap was reported",
+      "measurementBoundary": "coverageBoundary",
+      "evidenceRequirements": [
+        "observation gap records"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "witnessRules": [
+    {
+      "witnessRuleId": "witness:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessKind": "forbidden-dependency-direction",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "moleculePatternRefs": [
+        "molecule:layered-component"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "witnessRuleId": "witness:semantic-contract-mismatch",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessKind": "semantic-contract-noncommutation",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "moleculePatternRefs": [
+        "molecule:operation-contract"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "moleculePatterns": [
+    {
+      "moleculePatternId": "molecule:layered-component",
+      "roleName": "layered component",
+      "requiredAtomFamilies": [
+        "existence",
+        "boundaryAuthority"
+      ],
+      "optionalAtomFamilies": [
+        "relation"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "moleculePatternId": "molecule:operation-contract",
+      "roleName": "operation contract",
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification"
+      ],
+      "optionalAtomFamilies": [
+        "semanticInterpretation",
+        "effect"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "obstructionCircuitDefinitions": [
+    {
+      "obstructionCircuitId": "obstruction:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessRuleRef": "witness:layer-violation",
+      "circuitKind": "BoundaryLeakCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "obstructionCircuitId": "obstruction:semantic-contract-mismatch",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessRuleRef": "witness:semantic-contract-mismatch",
+      "circuitKind": "SemanticMismatchCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:semantic-inconsistency"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "signatureAxisDefinitions": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valuationRule": "count constructed BoundaryLeakCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "signatureAxisId": "sig-axis:semantic-inconsistency",
+      "lawRef": "law:semantic-contract-alignment",
+      "axisRef": "axis:semantic-inconsistency",
+      "valuationRule": "count constructed SemanticMismatchCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "exactnessAssumptions": [
+    "the selected witness rules cover only policy-declared laws",
+    "zero readings are exact only for observed atoms and declared coverage requirements"
+  ],
+  "coverageRequirements": [
+    {
+      "coverageRequirementId": "coverage:layer-atoms",
+      "appliesToLawRefs": [
+        "law:layer-respecting"
+      ],
+      "requiredAtomFamilies": [
+        "existence",
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "symbol"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "coverageRequirementId": "coverage:semantic-contract-atoms",
+      "appliesToLawRefs": [
+        "law:semantic-contract-alignment"
+      ],
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "doc-section",
+        "test"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "excludedReadings": [
+    "global architecture truth",
+    "Lean theorem discharge",
+    "SFT forecast correctness"
+  ],
+  "nonConclusions": [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -136,6 +136,66 @@
       }
     },
     {
+      "artifactId": "law-policy",
+      "artifactName": "LLM-native selected LawPolicy artifact",
+      "schemaVersionName": "law-policy-v0",
+      "artifactRole": "selected-law-universe-policy",
+      "ownerPhase": "LLM-native ArchMap / ArchSig",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/llm_native_archmap_archsig_prd.md",
+        "docs/tool/README.md"
+      ],
+      "downstreamIssues": [
+        "#1330"
+      ],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "LawPolicy owns selected laws, witness rules, molecule patterns, obstruction definitions, signature axis definitions, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "New law families must declare witness rules, required zero axes, coverage requirements, and exactness assumptions.",
+          "New signature axes must keep missing coverage distinct from measured zero."
+        ],
+        "coverageExactnessBoundary": [
+          "LawPolicy is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge."
+        ],
+        "nonConclusions": [
+          "field mapping does not prove semantic preservation",
+          "missing coverage is not measured zero",
+          "renamed fields do not discharge new required assumptions"
+        ]
+      }
+    },
+    {
+      "artifactId": "law-policy-validation-report",
+      "artifactName": "LLM-native LawPolicy validation report",
+      "schemaVersionName": "law-policy-validation-report-v0",
+      "artifactRole": "validation-output",
+      "ownerPhase": "LLM-native ArchMap / ArchSig",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/llm_native_archmap_archsig_prd.md"
+      ],
+      "downstreamIssues": [
+        "#1330"
+      ],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Validation reports schema support, identity, id uniqueness, law/witness/axis references, coverage, exactness, and non-conclusion guardrails without proving lawfulness.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "New checks must fail or warn without promoting policy validation to theorem evidence."
+        ],
+        "coverageExactnessBoundary": [
+          "Validation pass does not imply architecture lawfulness, certified atom truth, zero curvature, or Lean theorem discharge."
+        ],
+        "nonConclusions": [
+          "field mapping does not prove semantic preservation",
+          "missing coverage is not measured zero",
+          "renamed fields do not discharge new required assumptions"
+        ]
+      }
+    },
+    {
       "artifactId": "architecture-policy",
       "artifactName": "Architecture policy artifact",
       "schemaVersionName": "architecture-policy-v0",


### PR DESCRIPTION
## 概要

Closes #1330

LLM-native ArchMap / ArchSig 再設計の LawPolicy 面として、`law-policy-v0` と `law-policy-validation-report-v0` を追加しました。LawPolicy は ArchMap から独立した selected LawUniverse / witness rule / signature axis / coverage / exactness / non-conclusion の artifact として扱い、同じ ArchMap を複数の LawPolicy で再分析できる前提を schema 上で表現します。

今回の PR は #1330 に範囲を絞り、ArchSig analysis engine、CLI workflow 全体、ArchMap 本体の破壊的再設計は後続 Issue に残します。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/law_policy.md`
- `docs/tool/README.md`

## 実施したテスト

- [ ] `lake build`（Lean source 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean source 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: empirical tooling / design tracking.
