### PR TITLE
LLMネイティブCLI workflowを追加

### DIFF
--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -1,10 +1,52 @@
 # ArchSig Commands
 
-`archsig` is ArchMap-homomorphism-primary with an atomic observation surface. The normal review path starts from supplied `archmap-v0` evidence and reads it as a bounded AAT homomorphism from selected source architecture evidence into AAT object / relation / law / obstruction / signature-axis space, while also preserving atom candidates, molecule candidates, obstruction circuit candidates, and observation gaps. Lean / Python import-graph scanning is available only through the explicit `adapter-scan` command as bounded evidence.
+`archsig` is the LLM-native ArchMap / LawPolicy / ArchSig tool surface. The normal review path starts from supplied `archmap-observation-map-v0` evidence, validates a selected `law-policy-v0`, and builds an `archsig-analysis-packet-v0` containing law-relative molecule readings, obstruction circuits, signature axes, flatness reading, repair operation candidates, evidence boundaries, LLM interpretation notes, and non-conclusions. Lean / Python import-graph scanning is available only through the explicit `adapter-scan` command as bounded evidence.
 
 FieldSig owns SFT forecast, IntentMap, workflow evidence, operational feedback, dynamics, governance, and calibration commands under `tools/fieldsig`.
 
-## ArchMap Homomorphism Workflow
+## LLM-Native Workflow
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .archsig/llm-native
+```
+
+The command emits:
+
+- `archmap-validation.json`
+- `law-policy-validation.json`
+- `archsig-analysis-packet.json`
+- `archsig-analysis-validation.json`
+- `llm-interpretation-packet.json`
+
+`llm-interpretation-packet.json` is the same structured packet written for LLM
+reading. It is not a natural-language judgement, not a Lean proof, and not an
+automatic repair instruction.
+
+Equivalent step-by-step commands:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- archmap \
+  --input tools/archsig/tests/fixtures/minimal/archmap.json \
+  --out .archsig/llm-native/archmap-validation.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy \
+  --input tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out .archsig/llm-native/law-policy-validation.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- archsig-analysis \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out .archsig/llm-native/archsig-analysis-packet.json \
+  --validation-out .archsig/llm-native/archsig-analysis-validation.json \
+  --llm-interpretation-out .archsig/llm-native/llm-interpretation-packet.json
+```
+
+`law-policy --fixture` emits the canonical minimal `law-policy-v0` fixture.
+
+## Legacy ArchMap Projection Workflow
 
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \
@@ -12,7 +54,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \
   --out-dir .archsig/archmap-primary
 ```
 
-The command emits ArchMap validation, AIR, AIR validation, theorem precondition check, Feature Extension Report, AAT Observable Bundle, and bundle validation artifacts. The ArchMap validation report includes `homomorphismDiagnostics`, `atomicObservationChecks`, and `atomicObservationSummary`; `atomicObservationSummary` also records the Lean-facing AtomPresentation promotion boundary, promotable atom candidate count, rejected / uncertain candidate count, and presentation candidate count. The Feature Extension Report carries the homomorphism family surface forward in `homomorphismSummary`, including object, relation, law, obstruction, and signature-axis families. The AAT Observable Bundle derives concept mapping and theorem-boundary review status from the validation checklist, theorem precondition report, and Feature Extension Report. These surfaces answer the user-facing AAT questions: what structure the ArchMap preserves, what it forgets, where it is partial or non-homomorphic, which atom candidates were observed, which responsibility-like molecules are only composed roles, which obstruction circuits are present, which observation gaps remain, which axes are unmeasured, which formal-promotion guardrails remain blocked, and which next evidence should be reviewed.
+The legacy command still emits ArchMap validation, AIR, AIR validation, theorem precondition check, Feature Extension Report, AAT Observable Bundle, and bundle validation artifacts for older review surfaces. New LLM-native work should prefer `llm-native-workflow` and `archsig-analysis`.
 
 The bundle is assembled from the input ArchMap and generated workflow reports, so static fixture architecture ids, source refs, witnesses, and selected universes are not carried into workflow output. Optional Sig0 adapter evidence can be supplied for static / semantic conflict checks:
 

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -18,7 +18,7 @@ use archsig::{
     ArchitecturePolicyValidationReportV0, ComponentUniverseValidationReport,
     CustomRulePluginRegistryV0, CustomRulePluginRegistryValidationReportV0, DEFAULT_UNIVERSE_MODE,
     DetectableValuesReportedAxesCatalogV0, EmpiricalDatasetInput, FeatureExtensionReportV0,
-    FrameworkAdapterEvidenceV0, LawPolicyTemplateRegistryV0,
+    FrameworkAdapterEvidenceV0, LawPolicyDocumentV0, LawPolicyTemplateRegistryV0,
     LawPolicyTemplateRegistryValidationReportV0, LawViolationReportV0, MeasurementUnitRegistryV0,
     MeasurementUnitRegistryValidationReportV0, NoSolutionCertificateV0,
     NoSolutionCertificateValidationReportV0, OrganizationPolicyV0,
@@ -31,21 +31,22 @@ use archsig::{
     SnapshotRepositoryRef, SynthesisConstraintArtifactV0, SynthesisConstraintValidationReportV0,
     TheoremPreconditionCheckReportV0, apply_architecture_policy_to_sig0,
     attach_framework_adapter_evidence, build_air_document, build_air_from_archmap,
-    build_baseline_suppression_report, build_feature_extension_report,
-    build_feature_extension_report_with_archmap_diagnostics, build_law_violation_report,
-    build_policy_decision_report, build_schema_compatibility_check_report,
-    build_signature_diff_report, build_signature_snapshot_record,
-    build_theorem_precondition_check_report, extract_python_sig0,
+    build_archsig_analysis_packet, build_baseline_suppression_report,
+    build_feature_extension_report, build_feature_extension_report_with_archmap_diagnostics,
+    build_law_violation_report, build_policy_decision_report,
+    build_schema_compatibility_check_report, build_signature_diff_report,
+    build_signature_snapshot_record, build_theorem_precondition_check_report, extract_python_sig0,
     extract_relation_complexity_observation_from_file, extract_sig0_with_runtime,
     read_architecture_policy, render_pr_comment_markdown, static_aat_observable_bundle,
     static_custom_rule_plugin_registry, static_detectable_values_reported_axes_catalog,
-    static_law_policy_template_registry, static_measurement_unit_registry,
+    static_law_policy, static_law_policy_template_registry, static_measurement_unit_registry,
     static_no_solution_certificate, static_organization_policy, static_pr_quality_analysis_report,
     static_repair_rule_registry, static_report_artifact_retention_manifest,
     static_schema_version_catalog, static_synthesis_constraint_artifact,
     validate_aat_observable_bundle, validate_air_document_report,
     validate_architecture_policy_report, validate_archmap_report,
-    validate_component_universe_report, validate_custom_rule_plugin_registry_report,
+    validate_archsig_analysis_packet_report, validate_component_universe_report,
+    validate_custom_rule_plugin_registry_report, validate_law_policy_report,
     validate_law_policy_template_registry_report, validate_measurement_unit_registry_report,
     validate_no_solution_certificate_report, validate_organization_policy_report,
     validate_pr_quality_analysis_report, validate_repair_rule_registry_report,
@@ -56,7 +57,7 @@ use clap::{Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(
     version,
-    about = "Validate ArchMap-first ArchSig review artifacts and bounded adapter evidence"
+    about = "Validate LLM-native ArchMap, LawPolicy, and ArchSig analysis artifacts"
 )]
 struct Args {
     #[command(subcommand)]
@@ -285,6 +286,44 @@ enum Command {
         /// Output ArchMap validation report JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
+    },
+
+    /// Validate or emit a LawPolicy artifact for LLM-native ArchSig analysis.
+    LawPolicy {
+        /// Optional LawPolicy JSON path. If omitted, the static fixture policy is validated.
+        #[arg(long)]
+        input: Option<PathBuf>,
+
+        /// Emit the canonical law-policy-v0 fixture instead of a validation report.
+        #[arg(long)]
+        fixture: bool,
+
+        /// Output LawPolicy fixture or validation report JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Build an ArchSig analysis packet from ArchMap + LawPolicy.
+    ArchsigAnalysis {
+        /// Input ArchMap observation artifact path.
+        #[arg(long)]
+        archmap: PathBuf,
+
+        /// Input LawPolicy artifact path.
+        #[arg(long = "law-policy")]
+        law_policy: PathBuf,
+
+        /// Output archsig-analysis-packet-v0 JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+
+        /// Optional output validation report path.
+        #[arg(long = "validation-out")]
+        validation_out: Option<PathBuf>,
+
+        /// Optional LLM interpretation packet output path. This writes the same structured packet for LLM reading.
+        #[arg(long = "llm-interpretation-out")]
+        llm_interpretation_out: Option<PathBuf>,
     },
 
     /// Emit a bounded external-agent protocol for generating ArchMap JSON.
@@ -516,6 +555,21 @@ enum Command {
         /// Treat measured AIR claims without evidence refs as validation failures.
         #[arg(long)]
         strict_measured_evidence: bool,
+    },
+
+    /// Run the LLM-native ArchMap -> LawPolicy -> ArchSig analysis workflow.
+    LlmNativeWorkflow {
+        /// Input ArchMap observation artifact path.
+        #[arg(long)]
+        archmap: PathBuf,
+
+        /// Input LawPolicy artifact path.
+        #[arg(long = "law-policy")]
+        law_policy: PathBuf,
+
+        /// Output directory for LLM-native workflow artifacts.
+        #[arg(long = "out-dir")]
+        out_dir: PathBuf,
     },
 
     /// Emit the B9 detectable values / reported axes catalog.
@@ -863,6 +917,65 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             );
             let failed = report.summary.result == "fail";
             write_json(out, &report)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::LawPolicy {
+            input,
+            fixture,
+            out,
+        }) => {
+            if fixture {
+                let policy = static_law_policy();
+                write_json(out, &policy)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            let policy: LawPolicyDocumentV0 = input
+                .as_ref()
+                .map(read_json)
+                .transpose()?
+                .unwrap_or_else(static_law_policy);
+            let input_path = input
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "static-law-policy".to_string());
+            let report = validate_law_policy_report(&policy, &input_path);
+            let failed = report.summary.result == "fail";
+            write_json(out, &report)?;
+            Ok(if failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::ArchsigAnalysis {
+            archmap,
+            law_policy,
+            out,
+            validation_out,
+            llm_interpretation_out,
+        }) => {
+            let archmap_document: ArchMapDocumentV0 = read_json(&archmap)?;
+            let law_policy_document: LawPolicyDocumentV0 = read_json(&law_policy)?;
+            let packet = build_archsig_analysis_packet(
+                &archmap_document,
+                &law_policy_document,
+                Some(&archmap.display().to_string()),
+                Some(&law_policy.display().to_string()),
+            );
+            let validation =
+                validate_archsig_analysis_packet_report(&packet, "archsig-analysis-packet");
+            let failed = validation.summary.result == "fail";
+            if let Some(path) = validation_out {
+                write_json(Some(path), &validation)?;
+            }
+            if let Some(path) = llm_interpretation_out {
+                write_json(Some(path), &packet)?;
+            }
+            write_json(out, &packet)?;
             Ok(if failed {
                 ExitCode::from(1)
             } else {
@@ -1289,6 +1402,81 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             write_json(Some(observable_validation_path), &observable_validation)?;
 
             Ok(if archmap_failed || air_failed || observable_failed {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Some(Command::LlmNativeWorkflow {
+            archmap,
+            law_policy,
+            out_dir,
+        }) => {
+            let archmap_validation_path = out_dir.join("archmap-validation.json");
+            let law_policy_validation_path = out_dir.join("law-policy-validation.json");
+            let analysis_packet_path = out_dir.join("archsig-analysis-packet.json");
+            let analysis_validation_path = out_dir.join("archsig-analysis-validation.json");
+            let llm_interpretation_path = out_dir.join("llm-interpretation-packet.json");
+
+            let archmap_document: ArchMapDocumentV0 = read_json(&archmap)?;
+            let source_inventory_path = archmap_document
+                .source_inventory_ref
+                .as_ref()
+                .and_then(|source_inventory_ref| source_inventory_ref.path.as_deref());
+            let mut source_inventory_document: Option<ArchMapSourceInventoryV0> = None;
+            let mut source_inventory_error: Option<String> = None;
+            if let Some(path) = source_inventory_path {
+                match resolve_archmap_sidecar_path(&archmap, path) {
+                    Some(resolved_path) => match read_json(&resolved_path) {
+                        Ok(source_inventory) => source_inventory_document = Some(source_inventory),
+                        Err(error) => {
+                            source_inventory_error = Some(format!(
+                                "source inventory artifact could not be read: {error}"
+                            ));
+                        }
+                    },
+                    None => {
+                        source_inventory_error =
+                            Some("source inventory artifact path does not exist".to_string());
+                    }
+                }
+            }
+            let source_inventory = source_inventory_path.map(|path| ArchMapSourceInventoryInput {
+                path,
+                document: source_inventory_document.as_ref(),
+                read_error: source_inventory_error.clone(),
+            });
+            let archmap_validation = validate_archmap_report(
+                &archmap_document,
+                &archmap.display().to_string(),
+                None,
+                source_inventory,
+            );
+            let archmap_failed = archmap_validation.summary.result == "fail";
+            write_json(Some(archmap_validation_path), &archmap_validation)?;
+
+            let law_policy_document: LawPolicyDocumentV0 = read_json(&law_policy)?;
+            let law_policy_validation =
+                validate_law_policy_report(&law_policy_document, &law_policy.display().to_string());
+            let law_policy_failed = law_policy_validation.summary.result == "fail";
+            write_json(Some(law_policy_validation_path), &law_policy_validation)?;
+
+            let analysis_packet = build_archsig_analysis_packet(
+                &archmap_document,
+                &law_policy_document,
+                Some(&archmap.display().to_string()),
+                Some(&law_policy.display().to_string()),
+            );
+            write_json(Some(analysis_packet_path.clone()), &analysis_packet)?;
+            write_json(Some(llm_interpretation_path), &analysis_packet)?;
+            let analysis_validation = validate_archsig_analysis_packet_report(
+                &analysis_packet,
+                &analysis_packet_path.display().to_string(),
+            );
+            let analysis_failed = analysis_validation.summary.result == "fail";
+            write_json(Some(analysis_validation_path), &analysis_validation)?;
+
+            Ok(if archmap_failed || law_policy_failed || analysis_failed {
                 ExitCode::from(1)
             } else {
                 ExitCode::SUCCESS

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -265,6 +265,98 @@ fn cli_runs_archmap_primary_workflow() {
 }
 
 #[test]
+fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
+    let out_dir = temp_dir("llm-native-workflow");
+    let root = fixture_root();
+    let archmap = root.join("archmap.json");
+    let law_policy = root.join("law_policy.json");
+
+    run_sig0(&[
+        "llm-native-workflow",
+        "--archmap",
+        archmap.to_str().expect("archmap path is utf-8"),
+        "--law-policy",
+        law_policy.to_str().expect("law policy path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("output directory path is utf-8"),
+    ]);
+
+    let archmap_validation = read_json(&out_dir.join("archmap-validation.json"));
+    assert_eq!(
+        archmap_validation["schemaVersion"],
+        "archmap-validation-report-v0"
+    );
+    let law_policy_validation = read_json(&out_dir.join("law-policy-validation.json"));
+    assert_eq!(
+        law_policy_validation["schemaVersion"],
+        "law-policy-validation-report-v0"
+    );
+    let analysis_packet = read_json(&out_dir.join("archsig-analysis-packet.json"));
+    assert_eq!(
+        analysis_packet["schemaVersion"],
+        "archsig-analysis-packet-v0"
+    );
+    assert!(
+        analysis_packet["obstructionCircuits"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "analysis packet must construct obstruction circuits"
+    );
+    assert!(
+        analysis_packet["signatureAxes"]
+            .as_array()
+            .expect("signature axes are array")
+            .iter()
+            .any(
+                |axis| axis["signatureAxisId"] == "sig-axis:semantic-inconsistency"
+                    && axis["value"] == 1
+            ),
+        "analysis packet must value required signature axes"
+    );
+    let analysis_validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
+    assert_eq!(
+        analysis_validation["summary"]["result"].as_str(),
+        Some("pass")
+    );
+    let llm_packet = read_json(&out_dir.join("llm-interpretation-packet.json"));
+    assert_eq!(llm_packet, analysis_packet);
+}
+
+#[test]
+fn cli_archsig_analysis_step_outputs_packet_and_validation() {
+    let out_dir = temp_dir("archsig-analysis-step");
+    let root = fixture_root();
+    let packet = out_dir.join("packet.json");
+    let validation = out_dir.join("validation.json");
+    let llm_packet = out_dir.join("llm-packet.json");
+    run_sig0(&[
+        "archsig-analysis",
+        "--archmap",
+        root.join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("law policy path is utf-8"),
+        "--out",
+        packet.to_str().expect("packet path is utf-8"),
+        "--validation-out",
+        validation.to_str().expect("validation path is utf-8"),
+        "--llm-interpretation-out",
+        llm_packet.to_str().expect("llm packet path is utf-8"),
+    ]);
+    let packet_json = read_json(&packet);
+    let validation_json = read_json(&validation);
+    assert_eq!(packet_json["schemaVersion"], "archsig-analysis-packet-v0");
+    assert_eq!(
+        validation_json["schemaVersion"],
+        "archsig-analysis-packet-validation-report-v0"
+    );
+    assert_eq!(read_json(&llm_packet), packet_json);
+}
+
+#[test]
 fn cli_locks_archmap_homomorphism_expressiveness_matrix() {
     let out_dir = temp_dir("archmap-homomorphism-expressiveness");
     let archmap = expressiveness_root().join("archmap_expressiveness_suite_v0.json");


### PR DESCRIPTION
## 概要

Closes #1333

LLM-native ArchMap / LawPolicy / ArchSig pipeline 用の CLI surface を追加しました。

- `law-policy`: `law-policy-v0` fixture emit / validation
- `archsig-analysis`: ArchMap + LawPolicy から `archsig-analysis-packet-v0` を生成し、validation / LLM interpretation packet を任意出力
- `llm-native-workflow`: `ArchMap -> LawPolicy -> ArchSig analysis -> LLM interpretation packet` の E2E artifact 出力

command docs と CLI tests も新 workflow に合わせて更新しています。旧 `archmap-workflow` は後続 cleanup Issue で削除・再配線する前提で legacy projection workflow として残しています。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/docs/commands.md`

## 実施したテスト

- [ ] `lake build`（Lean source 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean source 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: empirical tooling / design tracking.
