### PR TITLE
LLMネイティブgolden corpusを追加

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -21,6 +21,7 @@ Atom handoff checklist:
 - [Atom Handoff Checklist](atom_handoff.md)
 - [LawPolicy](law_policy.md)
 - [ArchSig Analysis Packet](archsig_analysis_packet.md)
+- [LLM-Native Golden Corpus](golden_corpus.md)
 
 Forward design PRDs:
 

--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -1,0 +1,46 @@
+# LLM-Native Golden Corpus
+
+The current ArchSig golden corpus is built around the LLM-native pipeline:
+
+```text
+ArchMap observation artifact
+  + LawPolicy
+  -> ArchSig analysis packet
+  -> LLM interpretation / human review
+```
+
+## Positive Fixtures
+
+- `tools/archsig/tests/fixtures/minimal/archmap.json`
+- `tools/archsig/tests/fixtures/minimal/law_policy.json`
+- `tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json`
+- `tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json`
+- `tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json`
+
+The layer-only LawPolicy fixture reuses the same ArchMap and produces a
+different ArchSig packet. This fixes the requirement that ArchMap remains
+law-independent and can be reanalyzed under multiple selected LawPolicy
+artifacts.
+
+## Negative Fixtures
+
+- `tools/archsig/tests/fixtures/minimal/archmap_invalid_concern_promoted.json`
+- `tools/archsig/tests/fixtures/minimal/archmap_invalid_gap_measured_zero.json`
+
+These fixtures lock the two main guardrails:
+
+- `concernHints` are not obstruction circuits.
+- `observationGaps` are not measured zero.
+
+## FieldSig Handoff Fixtures
+
+- `tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archmap.json`
+- `tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/law_policy.json`
+- `tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/law_policy_layer_only.json`
+- `tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json`
+- `tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet_layer_only.json`
+
+These files are handoff fixtures. FieldSig wiring is handled in the dedicated
+FieldSig issue; the fixtures exist here so the handoff target is stable. The
+FieldSig test suite reads these files as JSON contract fixtures and locks their
+schema versions, LawPolicy split, and concern/gap guardrails.

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -357,6 +357,96 @@ fn cli_archsig_analysis_step_outputs_packet_and_validation() {
 }
 
 #[test]
+fn cli_negative_archmap_fixtures_preserve_guardrails() {
+    let out_dir = temp_dir("negative-archmap-fixtures");
+    let root = fixture_root();
+
+    let concern_validation = out_dir.join("concern-validation.json");
+    let concern_output = run_sig0_output(&[
+        "archmap",
+        "--input",
+        root.join("archmap_invalid_concern_promoted.json")
+            .to_str()
+            .expect("invalid concern fixture path is utf-8"),
+        "--out",
+        concern_validation
+            .to_str()
+            .expect("concern validation path is utf-8"),
+    ]);
+    assert!(
+        !concern_output.status.success(),
+        "concern promotion fixture must fail validation"
+    );
+    let concern_json = read_json(&concern_validation);
+    assert!(
+        concern_json["atomicObservationChecks"]
+            .as_array()
+            .expect("atomic checks are array")
+            .iter()
+            .any(
+                |check| check["id"] == "archmap-concern-hints-are-not-obstruction-circuits"
+                    && check["result"] == "fail"
+            ),
+        "concernHints must not be accepted as obstruction circuits"
+    );
+
+    let gap_validation = out_dir.join("gap-validation.json");
+    let gap_output = run_sig0_output(&[
+        "archmap",
+        "--input",
+        root.join("archmap_invalid_gap_measured_zero.json")
+            .to_str()
+            .expect("invalid gap fixture path is utf-8"),
+        "--out",
+        gap_validation
+            .to_str()
+            .expect("gap validation path is utf-8"),
+    ]);
+    assert!(
+        !gap_output.status.success(),
+        "gap measured-zero fixture must fail validation"
+    );
+    let gap_json = read_json(&gap_validation);
+    assert!(
+        gap_json["atomicObservationChecks"]
+            .as_array()
+            .expect("atomic checks are array")
+            .iter()
+            .any(
+                |check| check["id"] == "archmap-observation-gaps-not-measured-zero"
+                    && check["result"] == "fail"
+            ),
+        "observation gaps must not be rounded to measured zero"
+    );
+}
+
+#[test]
+fn cli_regression_same_archmap_multiple_law_policies() {
+    let root = fixture_root();
+    let full_packet = read_json(&root.join("archsig_analysis_packet.json"));
+    let layer_only_packet = read_json(&root.join("archsig_analysis_packet_layer_only.json"));
+    assert_ne!(
+        full_packet["selectedLawPolicyRef"]["artifactId"],
+        layer_only_packet["selectedLawPolicyRef"]["artifactId"],
+        "golden corpus must include multiple LawPolicy analyses"
+    );
+    assert!(
+        full_packet["obstructionCircuits"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "full policy fixture should construct an obstruction"
+    );
+    assert_eq!(
+        layer_only_packet["obstructionCircuits"]
+            .as_array()
+            .expect("layer-only obstructions are array")
+            .len(),
+        0,
+        "layer-only policy should reanalyze the same ArchMap without semantic obstruction"
+    );
+}
+
+#[test]
 fn cli_locks_archmap_homomorphism_expressiveness_matrix() {
     let out_dir = temp_dir("archmap-homomorphism-expressiveness");
     let archmap = expressiveness_root().join("archmap_expressiveness_suite_v0.json");

--- a/tools/archsig/tests/fixtures/minimal/archmap_invalid_concern_promoted.json
+++ b/tools/archsig/tests/fixtures/minimal/archmap_invalid_concern_promoted.json
@@ -1,0 +1,427 @@
+{
+  "schemaVersion": "archmap-observation-map-v0",
+  "mapId": "invalid-archmap-concern-promoted",
+  "architectureId": "archmap-fixture-repo",
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "generator": {
+    "kind": "supplied-json",
+    "tool": "archsig",
+    "provider": "human-reviewed-fixture",
+    "modelId": "not-applicable"
+  },
+  "promptRefs": [
+    {
+      "artifactId": "prompt-archmap-schema",
+      "kind": "prompt",
+      "path": ".lake/archmap-prompt.md"
+    }
+  ],
+  "sourceInventoryRef": {
+    "artifactId": "source-inventory-fixture",
+    "kind": "source_inventory",
+    "path": "tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json",
+    "contentHash": "sha256-fixture-source-inventory"
+  },
+  "generationBoundary": {
+    "tokenBudget": "fixture",
+    "scope": [
+      "src/routes",
+      "src/services",
+      "docs/architecture.md"
+    ],
+    "excludedRefs": [
+      {
+        "kind": "file",
+        "path": "target/generated.rs"
+      }
+    ],
+    "privateRefs": [
+      {
+        "kind": "privateContext",
+        "path": "private/customer-rules.md"
+      }
+    ],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "nonConclusions": [
+      "source selection boundary does not imply extractor completeness",
+      "private context is not reconstructed by validation"
+    ]
+  },
+  "sourceUniverse": {
+    "root": ".",
+    "includedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      },
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      },
+      {
+        "artifactId": "doc-architecture",
+        "kind": "docSection",
+        "path": "docs/architecture.md",
+        "section": "Layer policy"
+      },
+      {
+        "artifactId": "test-user-contract",
+        "kind": "test",
+        "path": "tests/user_contract.test.ts",
+        "symbol": "createsUser"
+      }
+    ],
+    "excludedRefs": [
+      {
+        "kind": "file",
+        "path": "dist/generated.js"
+      }
+    ],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "privateRefs": [
+      {
+        "kind": "privateContext",
+        "path": "private/customer-rules.md"
+      }
+    ],
+    "hashes": [
+      {
+        "artifactId": "src-route-users",
+        "path": "src/routes/users.ts",
+        "contentHash": "sha256-fixture-route"
+      }
+    ],
+    "knownBlindSpots": [
+      "runtime traces not supplied",
+      "dynamic plugin loading not inspected"
+    ],
+    "selectionBoundary": "bounded ArchMap MVP fixture over route, service, policy doc, and contract test"
+  },
+  "provenance": {
+    "observer": "human-reviewed-fixture",
+    "observationMethod": "LLM-native source reading fixture",
+    "sourceRoot": ".",
+    "observationBoundary": "source-grounded observations only; no law-relative obstruction analysis",
+    "reviewedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      },
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      }
+    ],
+    "excludedReadings": [
+      "architecture lawfulness",
+      "obstruction circuit",
+      "zero curvature"
+    ],
+    "nonConclusions": [
+      "provenance records observation scope, not observation completeness"
+    ]
+  },
+  "atomObservations": [
+    {
+      "atomObservationId": "atom:component:route-users",
+      "atomFamily": "existence",
+      "predicate": "component route.users exists",
+      "subjectRef": "route.users",
+      "objectRefs": [
+        "route.users"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [],
+      "projectionRefs": [
+        "projection:aat:route-users"
+      ],
+      "nonConclusions": [
+        "component atom observation is not a certified universal atom"
+      ]
+    },
+    {
+      "atomObservationId": "atom:component:service-user",
+      "atomFamily": "existence",
+      "predicate": "component service.user exists",
+      "subjectRef": "service.user",
+      "objectRefs": [
+        "service.user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [],
+      "projectionRefs": [
+        "projection:aat:service-user"
+      ],
+      "nonConclusions": [
+        "service atom observation is not complete service discovery"
+      ]
+    },
+    {
+      "atomObservationId": "atom:relation:route-service",
+      "atomFamily": "relation",
+      "predicate": "route.users delegates user creation to service.user",
+      "subjectRef": "semantic.route.users->service.user",
+      "objectRefs": [
+        "route.users",
+        "service.user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        },
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": [
+        "runtime frequency not measured"
+      ],
+      "projectionRefs": [
+        "projection:aat:route-service"
+      ],
+      "nonConclusions": [
+        "relation atom observation does not prove runtime dependency"
+      ]
+    },
+    {
+      "atomObservationId": "atom:contract:create-user",
+      "atomFamily": "contractSpecification",
+      "predicate": "contract test observes create-user success",
+      "subjectRef": "contract.createsUser",
+      "objectRefs": [
+        "service.user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": [
+        "production traces not supplied"
+      ],
+      "projectionRefs": [
+        "projection:aat:create-user-contract"
+      ],
+      "nonConclusions": [
+        "contract atom observation is not global semantic completeness"
+      ]
+    }
+  ],
+  "moleculeObservations": [
+    {
+      "moleculeObservationId": "molecule:user-request-responsibility",
+      "moleculeFamily": "responsibility",
+      "roleName": "user request orchestration",
+      "atomObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "nonConclusions": [
+        "responsibility is a molecule over atoms, not a primitive atom"
+      ]
+    }
+  ],
+  "semanticObservations": [
+    {
+      "semanticObservationId": "semantic:create-user-flow",
+      "semanticFamily": "operationMeaning",
+      "subjectRef": "operation.createUser",
+      "predicate": "route, service, and contract jointly describe create-user behavior",
+      "atomObservationRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "moleculeObservationRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        },
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "nonConclusions": [
+        "semantic observation is not a proof of global semantic correctness"
+      ]
+    }
+  ],
+  "observationGaps": [
+    {
+      "gapId": "gap-runtime-user-db-trace",
+      "gapKind": "UnavailableRuntimeTrace",
+      "subjectRef": "runtime.service.user->db.users",
+      "evidenceStatus": "unavailable",
+      "reason": "runtime trace was requested but not supplied",
+      "expectedAtomFamilies": [
+        "runtimeInteraction",
+        "effect"
+      ],
+      "sourceRefs": [
+        {
+          "kind": "runtimeTrace",
+          "path": ".lake/runtime-trace.json"
+        }
+      ],
+      "nonConclusions": [
+        "unavailable runtime trace is not measured zero"
+      ]
+    }
+  ],
+  "projectionInfo": [
+    {
+      "projectionId": "projection:aat:route-users",
+      "projectionFamily": "object",
+      "sourceObservationRef": "atom:component:route-users",
+      "targetSurface": "aat:object:route.users",
+      "reading": "route.users is an observed component object",
+      "projectionBoundary": "derived from observed source atom; not primary ArchMap law claim",
+      "nonConclusions": [
+        "projection is not a Lean theorem"
+      ]
+    },
+    {
+      "projectionId": "projection:aat:route-service",
+      "projectionFamily": "relation",
+      "sourceObservationRef": "atom:relation:route-service",
+      "targetSurface": "aat:relation:route.users->service.user",
+      "reading": "route.users to service.user is an observed relation",
+      "projectionBoundary": "derived from observed source atom; runtime frequency unmeasured",
+      "nonConclusions": [
+        "projection is not a runtime dependency proof"
+      ]
+    },
+    {
+      "projectionId": "projection:sft:create-user",
+      "projectionFamily": "signatureAxis",
+      "sourceObservationRef": "semantic:create-user-flow",
+      "targetSurface": "sft:observation:create-user-flow",
+      "reading": "semantic observation can be handed off as bounded SFT evidence",
+      "projectionBoundary": "SFT consequence analysis is not owned by ArchMap",
+      "nonConclusions": [
+        "projection is not a forecast correctness claim"
+      ]
+    }
+  ],
+  "concernHints": [
+    {
+      "concernHintId": "concern:missing-compensation",
+      "concernFamily": "missingCompensation",
+      "subjectRef": "operation.createUser",
+      "atomObservationRefs": [
+        "atom:contract:create-user"
+      ],
+      "moleculeObservationRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "semanticObservationRefs": [
+        "semantic:create-user-flow"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "evidenceBoundary": "review cue from observed contract atom and semantic observation",
+      "analysisBoundary": "obstruction circuit candidate promoted inside ArchMap",
+      "nonConclusions": [
+        "concern hint does not prove a law violation",
+        "concern hint is not an obstruction circuit"
+      ]
+    }
+  ],
+  "nonConclusions": [
+    "ArchMap does not prove architecture lawfulness",
+    "ArchMap does not output obstruction circuits",
+    "ArchMap does not prove zero curvature",
+    "concernHints are review cues, not obstruction circuits",
+    "observation gaps are not measured zero",
+    "Atom observations are source-grounded observations, not universal atom truth"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/archmap_invalid_gap_measured_zero.json
+++ b/tools/archsig/tests/fixtures/minimal/archmap_invalid_gap_measured_zero.json
@@ -1,0 +1,427 @@
+{
+  "schemaVersion": "archmap-observation-map-v0",
+  "mapId": "invalid-archmap-gap-measured-zero",
+  "architectureId": "archmap-fixture-repo",
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "generator": {
+    "kind": "supplied-json",
+    "tool": "archsig",
+    "provider": "human-reviewed-fixture",
+    "modelId": "not-applicable"
+  },
+  "promptRefs": [
+    {
+      "artifactId": "prompt-archmap-schema",
+      "kind": "prompt",
+      "path": ".lake/archmap-prompt.md"
+    }
+  ],
+  "sourceInventoryRef": {
+    "artifactId": "source-inventory-fixture",
+    "kind": "source_inventory",
+    "path": "tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json",
+    "contentHash": "sha256-fixture-source-inventory"
+  },
+  "generationBoundary": {
+    "tokenBudget": "fixture",
+    "scope": [
+      "src/routes",
+      "src/services",
+      "docs/architecture.md"
+    ],
+    "excludedRefs": [
+      {
+        "kind": "file",
+        "path": "target/generated.rs"
+      }
+    ],
+    "privateRefs": [
+      {
+        "kind": "privateContext",
+        "path": "private/customer-rules.md"
+      }
+    ],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "nonConclusions": [
+      "source selection boundary does not imply extractor completeness",
+      "private context is not reconstructed by validation"
+    ]
+  },
+  "sourceUniverse": {
+    "root": ".",
+    "includedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      },
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      },
+      {
+        "artifactId": "doc-architecture",
+        "kind": "docSection",
+        "path": "docs/architecture.md",
+        "section": "Layer policy"
+      },
+      {
+        "artifactId": "test-user-contract",
+        "kind": "test",
+        "path": "tests/user_contract.test.ts",
+        "symbol": "createsUser"
+      }
+    ],
+    "excludedRefs": [
+      {
+        "kind": "file",
+        "path": "dist/generated.js"
+      }
+    ],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "privateRefs": [
+      {
+        "kind": "privateContext",
+        "path": "private/customer-rules.md"
+      }
+    ],
+    "hashes": [
+      {
+        "artifactId": "src-route-users",
+        "path": "src/routes/users.ts",
+        "contentHash": "sha256-fixture-route"
+      }
+    ],
+    "knownBlindSpots": [
+      "runtime traces not supplied",
+      "dynamic plugin loading not inspected"
+    ],
+    "selectionBoundary": "bounded ArchMap MVP fixture over route, service, policy doc, and contract test"
+  },
+  "provenance": {
+    "observer": "human-reviewed-fixture",
+    "observationMethod": "LLM-native source reading fixture",
+    "sourceRoot": ".",
+    "observationBoundary": "source-grounded observations only; no law-relative obstruction analysis",
+    "reviewedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      },
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      }
+    ],
+    "excludedReadings": [
+      "architecture lawfulness",
+      "obstruction circuit",
+      "zero curvature"
+    ],
+    "nonConclusions": [
+      "provenance records observation scope, not observation completeness"
+    ]
+  },
+  "atomObservations": [
+    {
+      "atomObservationId": "atom:component:route-users",
+      "atomFamily": "existence",
+      "predicate": "component route.users exists",
+      "subjectRef": "route.users",
+      "objectRefs": [
+        "route.users"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [],
+      "projectionRefs": [
+        "projection:aat:route-users"
+      ],
+      "nonConclusions": [
+        "component atom observation is not a certified universal atom"
+      ]
+    },
+    {
+      "atomObservationId": "atom:component:service-user",
+      "atomFamily": "existence",
+      "predicate": "component service.user exists",
+      "subjectRef": "service.user",
+      "objectRefs": [
+        "service.user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [],
+      "projectionRefs": [
+        "projection:aat:service-user"
+      ],
+      "nonConclusions": [
+        "service atom observation is not complete service discovery"
+      ]
+    },
+    {
+      "atomObservationId": "atom:relation:route-service",
+      "atomFamily": "relation",
+      "predicate": "route.users delegates user creation to service.user",
+      "subjectRef": "semantic.route.users->service.user",
+      "objectRefs": [
+        "route.users",
+        "service.user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        },
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": [
+        "runtime frequency not measured"
+      ],
+      "projectionRefs": [
+        "projection:aat:route-service"
+      ],
+      "nonConclusions": [
+        "relation atom observation does not prove runtime dependency"
+      ]
+    },
+    {
+      "atomObservationId": "atom:contract:create-user",
+      "atomFamily": "contractSpecification",
+      "predicate": "contract test observes create-user success",
+      "subjectRef": "contract.createsUser",
+      "objectRefs": [
+        "service.user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": [
+        "production traces not supplied"
+      ],
+      "projectionRefs": [
+        "projection:aat:create-user-contract"
+      ],
+      "nonConclusions": [
+        "contract atom observation is not global semantic completeness"
+      ]
+    }
+  ],
+  "moleculeObservations": [
+    {
+      "moleculeObservationId": "molecule:user-request-responsibility",
+      "moleculeFamily": "responsibility",
+      "roleName": "user request orchestration",
+      "atomObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "nonConclusions": [
+        "responsibility is a molecule over atoms, not a primitive atom"
+      ]
+    }
+  ],
+  "semanticObservations": [
+    {
+      "semanticObservationId": "semantic:create-user-flow",
+      "semanticFamily": "operationMeaning",
+      "subjectRef": "operation.createUser",
+      "predicate": "route, service, and contract jointly describe create-user behavior",
+      "atomObservationRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "moleculeObservationRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        },
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "nonConclusions": [
+        "semantic observation is not a proof of global semantic correctness"
+      ]
+    }
+  ],
+  "observationGaps": [
+    {
+      "gapId": "gap-runtime-user-db-trace",
+      "gapKind": "UnavailableRuntimeTrace",
+      "subjectRef": "runtime.service.user->db.users",
+      "evidenceStatus": "measuredZero",
+      "reason": "runtime trace was requested but not supplied",
+      "expectedAtomFamilies": [
+        "runtimeInteraction",
+        "effect"
+      ],
+      "sourceRefs": [
+        {
+          "kind": "runtimeTrace",
+          "path": ".lake/runtime-trace.json"
+        }
+      ],
+      "nonConclusions": [
+        "invalid fixture: gap incorrectly rounded to measured zero"
+      ]
+    }
+  ],
+  "projectionInfo": [
+    {
+      "projectionId": "projection:aat:route-users",
+      "projectionFamily": "object",
+      "sourceObservationRef": "atom:component:route-users",
+      "targetSurface": "aat:object:route.users",
+      "reading": "route.users is an observed component object",
+      "projectionBoundary": "derived from observed source atom; not primary ArchMap law claim",
+      "nonConclusions": [
+        "projection is not a Lean theorem"
+      ]
+    },
+    {
+      "projectionId": "projection:aat:route-service",
+      "projectionFamily": "relation",
+      "sourceObservationRef": "atom:relation:route-service",
+      "targetSurface": "aat:relation:route.users->service.user",
+      "reading": "route.users to service.user is an observed relation",
+      "projectionBoundary": "derived from observed source atom; runtime frequency unmeasured",
+      "nonConclusions": [
+        "projection is not a runtime dependency proof"
+      ]
+    },
+    {
+      "projectionId": "projection:sft:create-user",
+      "projectionFamily": "signatureAxis",
+      "sourceObservationRef": "semantic:create-user-flow",
+      "targetSurface": "sft:observation:create-user-flow",
+      "reading": "semantic observation can be handed off as bounded SFT evidence",
+      "projectionBoundary": "SFT consequence analysis is not owned by ArchMap",
+      "nonConclusions": [
+        "projection is not a forecast correctness claim"
+      ]
+    }
+  ],
+  "concernHints": [
+    {
+      "concernHintId": "concern:missing-compensation",
+      "concernFamily": "missingCompensation",
+      "subjectRef": "operation.createUser",
+      "atomObservationRefs": [
+        "atom:contract:create-user"
+      ],
+      "moleculeObservationRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "semanticObservationRefs": [
+        "semantic:create-user-flow"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "evidenceBoundary": "review cue from observed contract atom and semantic observation",
+      "analysisBoundary": "not an obstruction circuit; ArchSig must combine this ArchMap with LawPolicy before constructing obstruction witnesses",
+      "nonConclusions": [
+        "concern hint does not prove a law violation",
+        "concern hint is not an obstruction circuit"
+      ]
+    }
+  ],
+  "nonConclusions": [
+    "ArchMap does not prove architecture lawfulness",
+    "ArchMap does not output obstruction circuits",
+    "ArchMap does not prove zero curvature",
+    "concernHints are review cues, not obstruction circuits",
+    "observation gaps are not measured zero",
+    "Atom observations are source-grounded observations, not universal atom truth"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -1,0 +1,172 @@
+{
+  "schemaVersion": "archsig-analysis-packet-v0",
+  "analysisId": "archsig-analysis:fixture-archmap-atom-observation:layer-only-law-policy-fixture",
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "archMapRef": {
+    "artifactId": "fixture-archmap-atom-observation",
+    "artifactKind": "archmap",
+    "schemaVersion": "archmap-observation-map-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/archmap.json"
+  },
+  "selectedLawPolicyRef": {
+    "artifactId": "layer-only-law-policy-fixture",
+    "artifactKind": "law-policy",
+    "schemaVersion": "law-policy-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json"
+  },
+  "atomConfigurationSummary": {
+    "atomObservationCount": 4,
+    "moleculeObservationCount": 1,
+    "semanticObservationCount": 1,
+    "observationGapCount": 1,
+    "concernHintCount": 1,
+    "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
+    "coverageSummary": [
+      "4 atom observations",
+      "1 molecule observations",
+      "1 semantic observations",
+      "1 observation gaps preserved as gaps"
+    ],
+    "sourceRefs": [
+      "atom:component:route-users",
+      "atom:component:service-user",
+      "atom:contract:create-user",
+      "atom:relation:route-service",
+      "gap-runtime-user-db-trace"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "moleculeReadings": [
+    {
+      "moleculeReadingId": "molecule-reading:molecule-user-request-responsibility",
+      "moleculeObservationRef": "molecule:user-request-responsibility",
+      "lawRefs": [
+        "law:layer-respecting"
+      ],
+      "atomObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "reading": "molecule:user-request-responsibility is read as a responsibility molecule under selected LawPolicy",
+      "evidenceSummary": "molecule uses 4 atom observation refs and 1 source refs",
+      "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
+      "sourceRefs": [
+        "doc-architecture"
+      ],
+      "interpretationNotesForLLM": [
+        "Explain molecule readings as grouped observed atoms before discussing laws."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "obstructionCircuits": [],
+  "signatureAxes": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valueType": "nat",
+      "value": 0,
+      "zeroReading": "zero means no axis:layer-violation witness was constructed under declared coverage",
+      "coverageStatus": "coverage-gap-preserved",
+      "exactnessAssumptions": [
+        "the selected witness rules cover only policy-declared laws",
+        "zero readings are exact only for observed atoms and declared coverage requirements"
+      ],
+      "evidenceSummary": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+      "sourceRefs": [],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "flatnessReading": {
+    "readingId": "flatness:layer-only-law-policy-fixture",
+    "selectedLawPolicyRef": "layer-only-law-policy-fixture",
+    "status": "flatForConstructedWitnessesButCoverageGapBlocked",
+    "zeroSignatureAxisRefs": [
+      "sig-axis:layer-violation"
+    ],
+    "nonzeroSignatureAxisRefs": [],
+    "blockedByCoverageGaps": [
+      "gap-runtime-user-db-trace"
+    ],
+    "evidenceBoundary": "flatness is relative to selected signature axes, coverage gaps, and exactness assumptions",
+    "interpretationNotesForLLM": [
+      "Do not turn zero signature axes into global lawfulness claims."
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "staticRuntimeSemanticLayerSplit": {
+    "staticObservationRefs": [
+      "atom:component:route-users",
+      "atom:component:service-user",
+      "atom:relation:route-service"
+    ],
+    "runtimeObservationRefs": [
+      "gap-runtime-user-db-trace"
+    ],
+    "semanticObservationRefs": [
+      "atom:contract:create-user",
+      "semantic:create-user-flow"
+    ],
+    "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "repairOperationCandidates": [],
+  "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected LawPolicy layer-only-law-policy-fixture; concernHints are auxiliary cues only",
+  "interpretationNotesForLLM": [
+    "Lead with selected LawPolicy scope and evidence gaps.",
+    "Explain nonzero signature axes as law-relative ArchSig outputs.",
+    "Do not describe concernHints as obstruction circuits."
+  ],
+  "excludedReadings": [
+    "single architecture quality score",
+    "global architecture lawfulness",
+    "automatic repair safety",
+    "concern hint promoted without LawPolicy witness rule"
+  ],
+  "nonConclusions": [
+    "ArchSig analysis packet is not a Lean theorem proof",
+    "ArchSig analysis packet is not global architecture truth",
+    "ArchSig analysis packet does not prove source extraction completeness",
+    "signature axes are law-policy-relative, not universal quality scores",
+    "flatness reading is blocked by coverage gaps and exactness assumptions",
+    "repair operation candidates are not automatic safe refactorings"
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json
@@ -1,0 +1,215 @@
+{
+  "schemaVersion": "law-policy-v0",
+  "lawPolicyId": "layer-only-law-policy-fixture",
+  "policyVersion": "v0",
+  "scope": "Layer-only reanalysis fixture over the same ArchMap",
+  "archmapSchemaRef": "archmap-observation-map-v0",
+  "selectedLaws": [
+    {
+      "lawId": "law:layer-respecting",
+      "lawFamily": "dependency-direction",
+      "description": "Dependencies must respect the selected layer order.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredWitnessRefs": [
+        "witness:layer-violation"
+      ],
+      "requiredAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "requiredZeroAxes": [
+    {
+      "axisId": "axis:layer-violation",
+      "axisFamily": "dependency-direction",
+      "valueType": "nat",
+      "zeroReading": "zero means no required layer violation witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed relation atoms",
+        "observed boundary membership atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "optionalAxes": [
+    {
+      "axisId": "axis:observation-gap",
+      "axisFamily": "coverage",
+      "valueType": "nat",
+      "zeroReading": "zero means no policy-required observation gap was reported",
+      "measurementBoundary": "coverageBoundary",
+      "evidenceRequirements": [
+        "observation gap records"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "witnessRules": [
+    {
+      "witnessRuleId": "witness:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessKind": "forbidden-dependency-direction",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "moleculePatternRefs": [
+        "molecule:layered-component"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "moleculePatterns": [
+    {
+      "moleculePatternId": "molecule:layered-component",
+      "roleName": "layered component",
+      "requiredAtomFamilies": [
+        "existence",
+        "boundaryAuthority"
+      ],
+      "optionalAtomFamilies": [
+        "relation"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "moleculePatternId": "molecule:operation-contract",
+      "roleName": "operation contract",
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification"
+      ],
+      "optionalAtomFamilies": [
+        "semanticInterpretation",
+        "effect"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "obstructionCircuitDefinitions": [
+    {
+      "obstructionCircuitId": "obstruction:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessRuleRef": "witness:layer-violation",
+      "circuitKind": "BoundaryLeakCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "signatureAxisDefinitions": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valuationRule": "count constructed BoundaryLeakCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "exactnessAssumptions": [
+    "the selected witness rules cover only policy-declared laws",
+    "zero readings are exact only for observed atoms and declared coverage requirements"
+  ],
+  "coverageRequirements": [
+    {
+      "coverageRequirementId": "coverage:layer-atoms",
+      "appliesToLawRefs": [
+        "law:layer-respecting"
+      ],
+      "requiredAtomFamilies": [
+        "existence",
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "symbol"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "excludedReadings": [
+    "global architecture truth",
+    "Lean theorem discharge",
+    "SFT forecast correctness"
+  ],
+  "nonConclusions": [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+  ]
+}

--- a/tools/fieldsig/tests/cli.rs
+++ b/tools/fieldsig/tests/cli.rs
@@ -319,6 +319,66 @@ fn read_json(path: &Path) -> Value {
 }
 
 #[test]
+fn fieldsig_locks_llm_native_archsig_handoff_fixtures() {
+    let root = fixture_root().join("llm_native_handoff");
+    let archmap = read_json(&root.join("archmap.json"));
+    assert_eq!(archmap["schemaVersion"], "archmap-observation-map-v0");
+    assert!(
+        archmap["atomObservations"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "handoff ArchMap must retain source-derived atom observations"
+    );
+    assert!(
+        archmap["concernHints"][0]["analysisBoundary"]
+            .as_str()
+            .expect("concern hint has analysis boundary")
+            .contains("not an obstruction circuit"),
+        "concern hints must not be promoted to obstruction circuits in ArchMap"
+    );
+    assert_eq!(
+        archmap["observationGaps"][0]["evidenceStatus"], "unavailable",
+        "observation gaps remain unavailable evidence, not measured zero"
+    );
+
+    let law_policy = read_json(&root.join("law_policy.json"));
+    let layer_policy = read_json(&root.join("law_policy_layer_only.json"));
+    assert_eq!(law_policy["schemaVersion"], "law-policy-v0");
+    assert_eq!(layer_policy["schemaVersion"], "law-policy-v0");
+    assert_ne!(
+        law_policy["lawPolicyId"], layer_policy["lawPolicyId"],
+        "same ArchMap must be reanalyzable under distinct LawPolicy artifacts"
+    );
+
+    let full_packet = read_json(&root.join("archsig_analysis_packet.json"));
+    let layer_packet = read_json(&root.join("archsig_analysis_packet_layer_only.json"));
+    assert_eq!(full_packet["schemaVersion"], "archsig-analysis-packet-v0");
+    assert_eq!(layer_packet["schemaVersion"], "archsig-analysis-packet-v0");
+    assert_eq!(
+        full_packet["selectedLawPolicyRef"]["artifactId"],
+        law_policy["lawPolicyId"]
+    );
+    assert_eq!(
+        layer_packet["selectedLawPolicyRef"]["artifactId"],
+        layer_policy["lawPolicyId"]
+    );
+    assert!(
+        full_packet["obstructionCircuits"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "full LawPolicy fixture should produce obstruction circuit observations"
+    );
+    assert_eq!(
+        layer_packet["obstructionCircuits"]
+            .as_array()
+            .expect("obstruction circuits are an array")
+            .len(),
+        0,
+        "layer-only LawPolicy fixture should produce a distinct no-obstruction packet"
+    );
+}
+
+#[test]
 fn cli_validates_archmap_fixture_and_guardrails() {
     let out_dir = temp_dir("archmap-validation");
     let input = fixture_root().join("archmap.json");

--- a/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archmap.json
+++ b/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archmap.json
@@ -1,0 +1,383 @@
+{
+  "schemaVersion": "archmap-observation-map-v0",
+  "mapId": "fixture-archmap-atom-observation",
+  "architectureId": "archmap-fixture-repo",
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "generator": {
+    "kind": "supplied-json",
+    "tool": "archsig",
+    "provider": "human-reviewed-fixture",
+    "modelId": "not-applicable"
+  },
+  "promptRefs": [
+    {
+      "artifactId": "prompt-archmap-schema",
+      "kind": "prompt",
+      "path": ".lake/archmap-prompt.md"
+    }
+  ],
+  "sourceInventoryRef": {
+    "artifactId": "source-inventory-fixture",
+    "kind": "source_inventory",
+    "path": "tools/archsig/tests/fixtures/minimal/archmap_source_inventory.json",
+    "contentHash": "sha256-fixture-source-inventory"
+  },
+  "generationBoundary": {
+    "tokenBudget": "fixture",
+    "scope": ["src/routes", "src/services", "docs/architecture.md"],
+    "excludedRefs": [
+      {
+        "kind": "file",
+        "path": "target/generated.rs"
+      }
+    ],
+    "privateRefs": [
+      {
+        "kind": "privateContext",
+        "path": "private/customer-rules.md"
+      }
+    ],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "nonConclusions": [
+      "source selection boundary does not imply extractor completeness",
+      "private context is not reconstructed by validation"
+    ]
+  },
+  "sourceUniverse": {
+    "root": ".",
+    "includedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      },
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      },
+      {
+        "artifactId": "doc-architecture",
+        "kind": "docSection",
+        "path": "docs/architecture.md",
+        "section": "Layer policy"
+      },
+      {
+        "artifactId": "test-user-contract",
+        "kind": "test",
+        "path": "tests/user_contract.test.ts",
+        "symbol": "createsUser"
+      }
+    ],
+    "excludedRefs": [
+      {
+        "kind": "file",
+        "path": "dist/generated.js"
+      }
+    ],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "privateRefs": [
+      {
+        "kind": "privateContext",
+        "path": "private/customer-rules.md"
+      }
+    ],
+    "hashes": [
+      {
+        "artifactId": "src-route-users",
+        "path": "src/routes/users.ts",
+        "contentHash": "sha256-fixture-route"
+      }
+    ],
+    "knownBlindSpots": [
+      "runtime traces not supplied",
+      "dynamic plugin loading not inspected"
+    ],
+    "selectionBoundary": "bounded ArchMap MVP fixture over route, service, policy doc, and contract test"
+  },
+  "provenance": {
+    "observer": "human-reviewed-fixture",
+    "observationMethod": "LLM-native source reading fixture",
+    "sourceRoot": ".",
+    "observationBoundary": "source-grounded observations only; no law-relative obstruction analysis",
+    "reviewedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      },
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      }
+    ],
+    "excludedReadings": [
+      "architecture lawfulness",
+      "obstruction circuit",
+      "zero curvature"
+    ],
+    "nonConclusions": [
+      "provenance records observation scope, not observation completeness"
+    ]
+  },
+  "atomObservations": [
+    {
+      "atomObservationId": "atom:component:route-users",
+      "atomFamily": "existence",
+      "predicate": "component route.users exists",
+      "subjectRef": "route.users",
+      "objectRefs": ["route.users"],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [],
+      "projectionRefs": ["projection:aat:route-users"],
+      "nonConclusions": [
+        "component atom observation is not a certified universal atom"
+      ]
+    },
+    {
+      "atomObservationId": "atom:component:service-user",
+      "atomFamily": "existence",
+      "predicate": "component service.user exists",
+      "subjectRef": "service.user",
+      "objectRefs": ["service.user"],
+      "sourceRefs": [
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [],
+      "projectionRefs": ["projection:aat:service-user"],
+      "nonConclusions": [
+        "service atom observation is not complete service discovery"
+      ]
+    },
+    {
+      "atomObservationId": "atom:relation:route-service",
+      "atomFamily": "relation",
+      "predicate": "route.users delegates user creation to service.user",
+      "subjectRef": "semantic.route.users->service.user",
+      "objectRefs": ["route.users", "service.user"],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        },
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": ["runtime frequency not measured"],
+      "projectionRefs": ["projection:aat:route-service"],
+      "nonConclusions": [
+        "relation atom observation does not prove runtime dependency"
+      ]
+    },
+    {
+      "atomObservationId": "atom:contract:create-user",
+      "atomFamily": "contractSpecification",
+      "predicate": "contract test observes create-user success",
+      "subjectRef": "contract.createsUser",
+      "objectRefs": ["service.user"],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": ["production traces not supplied"],
+      "projectionRefs": ["projection:aat:create-user-contract"],
+      "nonConclusions": [
+        "contract atom observation is not global semantic completeness"
+      ]
+    }
+  ],
+  "moleculeObservations": [
+    {
+      "moleculeObservationId": "molecule:user-request-responsibility",
+      "moleculeFamily": "responsibility",
+      "roleName": "user request orchestration",
+      "atomObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "nonConclusions": [
+        "responsibility is a molecule over atoms, not a primitive atom"
+      ]
+    }
+  ],
+  "semanticObservations": [
+    {
+      "semanticObservationId": "semantic:create-user-flow",
+      "semanticFamily": "operationMeaning",
+      "subjectRef": "operation.createUser",
+      "predicate": "route, service, and contract jointly describe create-user behavior",
+      "atomObservationRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "moleculeObservationRefs": ["molecule:user-request-responsibility"],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        },
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "nonConclusions": [
+        "semantic observation is not a proof of global semantic correctness"
+      ]
+    }
+  ],
+  "observationGaps": [
+    {
+      "gapId": "gap-runtime-user-db-trace",
+      "gapKind": "UnavailableRuntimeTrace",
+      "subjectRef": "runtime.service.user->db.users",
+      "evidenceStatus": "unavailable",
+      "reason": "runtime trace was requested but not supplied",
+      "expectedAtomFamilies": ["runtimeInteraction", "effect"],
+      "sourceRefs": [
+        {
+          "kind": "runtimeTrace",
+          "path": ".lake/runtime-trace.json"
+        }
+      ],
+      "nonConclusions": ["unavailable runtime trace is not measured zero"]
+    }
+  ],
+  "projectionInfo": [
+    {
+      "projectionId": "projection:aat:route-users",
+      "projectionFamily": "object",
+      "sourceObservationRef": "atom:component:route-users",
+      "targetSurface": "aat:object:route.users",
+      "reading": "route.users is an observed component object",
+      "projectionBoundary": "derived from observed source atom; not primary ArchMap law claim",
+      "nonConclusions": ["projection is not a Lean theorem"]
+    },
+    {
+      "projectionId": "projection:aat:route-service",
+      "projectionFamily": "relation",
+      "sourceObservationRef": "atom:relation:route-service",
+      "targetSurface": "aat:relation:route.users->service.user",
+      "reading": "route.users to service.user is an observed relation",
+      "projectionBoundary": "derived from observed source atom; runtime frequency unmeasured",
+      "nonConclusions": ["projection is not a runtime dependency proof"]
+    },
+    {
+      "projectionId": "projection:sft:create-user",
+      "projectionFamily": "signatureAxis",
+      "sourceObservationRef": "semantic:create-user-flow",
+      "targetSurface": "sft:observation:create-user-flow",
+      "reading": "semantic observation can be handed off as bounded SFT evidence",
+      "projectionBoundary": "SFT consequence analysis is not owned by ArchMap",
+      "nonConclusions": ["projection is not a forecast correctness claim"]
+    }
+  ],
+  "concernHints": [
+    {
+      "concernHintId": "concern:missing-compensation",
+      "concernFamily": "missingCompensation",
+      "subjectRef": "operation.createUser",
+      "atomObservationRefs": ["atom:contract:create-user"],
+      "moleculeObservationRefs": ["molecule:user-request-responsibility"],
+      "semanticObservationRefs": ["semantic:create-user-flow"],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "evidenceBoundary": "review cue from observed contract atom and semantic observation",
+      "analysisBoundary": "not an obstruction circuit; ArchSig must combine this ArchMap with LawPolicy before constructing obstruction witnesses",
+      "nonConclusions": [
+        "concern hint does not prove a law violation",
+        "concern hint is not an obstruction circuit"
+      ]
+    }
+  ],
+  "nonConclusions": [
+    "ArchMap does not prove architecture lawfulness",
+    "ArchMap does not output obstruction circuits",
+    "ArchMap does not prove zero curvature",
+    "concernHints are review cues, not obstruction circuits",
+    "observation gaps are not measured zero",
+    "Atom observations are source-grounded observations, not universal atom truth"
+  ]
+}

--- a/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json
+++ b/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json
@@ -1,0 +1,243 @@
+{
+  "schemaVersion": "archsig-analysis-packet-v0",
+  "analysisId": "archsig-analysis-fixture",
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "archMapRef": {
+    "artifactId": "fixture-archmap-atom-observation",
+    "artifactKind": "archmap",
+    "schemaVersion": "archmap-observation-map-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/archmap.json"
+  },
+  "selectedLawPolicyRef": {
+    "artifactId": "llm-native-aat-law-policy-fixture",
+    "artifactKind": "law-policy",
+    "schemaVersion": "law-policy-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
+  },
+  "atomConfigurationSummary": {
+    "atomObservationCount": 4,
+    "moleculeObservationCount": 1,
+    "semanticObservationCount": 1,
+    "observationGapCount": 1,
+    "concernHintCount": 1,
+    "configurationBoundary": "counts are read from one bounded ArchMap fixture, not complete architecture enumeration",
+    "coverageSummary": [
+      "static source atoms observed",
+      "semantic contract observation observed",
+      "runtime trace remains unavailable"
+    ],
+    "sourceRefs": [
+      "atom:component:route-users",
+      "atom:component:service-user",
+      "atom:relation:route-service",
+      "atom:contract:create-user",
+      "gap-runtime-user-db-trace"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "moleculeReadings": [
+    {
+      "moleculeReadingId": "molecule-reading:user-request-responsibility",
+      "moleculeObservationRef": "molecule:user-request-responsibility",
+      "lawRefs": ["law:semantic-contract-alignment"],
+      "atomObservationRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "reading": "observed route/service/contract atoms form one operation-responsibility molecule",
+      "evidenceSummary": "molecule reading uses ArchMap atom observations and the selected semantic-contract law",
+      "evidenceBoundary": "law-relative reading over observed atoms; not a primitive atom and not theorem evidence",
+      "sourceRefs": ["doc-architecture", "test-user-contract"],
+      "interpretationNotesForLLM": [
+        "Explain this as a responsibility grouping over observed atoms."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "obstructionCircuits": [
+    {
+      "obstructionCircuitId": "obstruction:semantic-contract-mismatch:create-user",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessRuleRef": "witness:semantic-contract-mismatch",
+      "circuitKind": "SemanticMismatchCircuit",
+      "atomObservationRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "moleculeReadingRefs": ["molecule-reading:user-request-responsibility"],
+      "concernHintRefs": ["concern:missing-compensation"],
+      "signatureAxisRefs": ["sig-axis:semantic-inconsistency"],
+      "minimalityReading": "minimal within the selected operation molecule and semantic contract witness rule",
+      "evidenceSummary": "constructed from the concern hint, contract atom, relation atom, and semantic molecule reading",
+      "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; not an ArchMap observation",
+      "interpretationNotesForLLM": [
+        "Describe the obstruction as law-relative, not as a universal architecture defect."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "signatureAxes": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valueType": "nat",
+      "value": 0,
+      "zeroReading": "zero means no selected layer violation witness was constructed under declared coverage",
+      "coverageStatus": "covered-for-selected-static-atoms",
+      "exactnessAssumptions": [
+        "selected layer law observes only declared route/service relation atoms"
+      ],
+      "evidenceSummary": "no BoundaryLeakCircuit witness was constructed from the fixture atoms",
+      "sourceRefs": ["atom:relation:route-service"],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "signatureAxisId": "sig-axis:semantic-inconsistency",
+      "lawRef": "law:semantic-contract-alignment",
+      "axisRef": "axis:semantic-inconsistency",
+      "valueType": "nat",
+      "value": 1,
+      "zeroReading": "nonzero means one selected semantic mismatch witness was constructed",
+      "coverageStatus": "runtime-gap-blocked",
+      "exactnessAssumptions": [
+        "runtime trace gap blocks global zero reflection"
+      ],
+      "evidenceSummary": "one SemanticMismatchCircuit witness is present under the selected LawPolicy",
+      "sourceRefs": [
+        "atom:contract:create-user",
+        "concern:missing-compensation"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "flatnessReading": {
+    "readingId": "flatness:selected-law-policy",
+    "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture",
+    "status": "nonflatUnderSelectedPolicy",
+    "zeroSignatureAxisRefs": ["sig-axis:layer-violation"],
+    "nonzeroSignatureAxisRefs": ["sig-axis:semantic-inconsistency"],
+    "blockedByCoverageGaps": ["gap-runtime-user-db-trace"],
+    "evidenceBoundary": "flatness is read from selected signature axes; coverage gaps block global zero claims",
+    "interpretationNotesForLLM": [
+      "Report this as selected-policy non-flatness, not global architecture quality."
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "staticRuntimeSemanticLayerSplit": {
+    "staticObservationRefs": [
+      "atom:component:route-users",
+      "atom:component:service-user",
+      "atom:relation:route-service"
+    ],
+    "runtimeObservationRefs": ["gap-runtime-user-db-trace"],
+    "semanticObservationRefs": [
+      "atom:contract:create-user",
+      "semantic:create-user-flow"
+    ],
+    "splitBoundary": "runtime layer is gap-preserved and must not be rounded into measured zero",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "repairOperationCandidates": [
+    {
+      "repairOperationCandidateId": "repair:add-compensation-path",
+      "operationKind": "add-compensation-operation",
+      "targetObstructionRefs": [
+        "obstruction:semantic-contract-mismatch:create-user"
+      ],
+      "preservedInvariants": [
+        "preserve route/service dependency direction",
+        "preserve create-user contract visibility"
+      ],
+      "preconditions": [
+        "identify authoritative compensation owner",
+        "supply runtime trace evidence before claiming global zero"
+      ],
+      "expectedSignatureAxisEffects": [
+        "decrease sig-axis:semantic-inconsistency if compensation semantics are observed"
+      ],
+      "transferRisks": [
+        "may transfer complexity into runtime retry or idempotency layer"
+      ],
+      "evidenceBoundary": "repair candidate is an operation hypothesis over the selected packet, not an automatic patch",
+      "interpretationNotesForLLM": [
+        "Explain preserved invariants before proposing implementation work."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "evidenceBoundary": "packet is computed from one ArchMap fixture and one selected LawPolicy fixture",
+  "interpretationNotesForLLM": [
+    "Lead with selected LawPolicy scope and evidence gaps.",
+    "Explain each nonzero signature axis with source refs and non-conclusions."
+  ],
+  "excludedReadings": [
+    "single architecture quality score",
+    "global architecture lawfulness",
+    "automatic repair safety"
+  ],
+  "nonConclusions": [
+    "ArchSig analysis packet is not a Lean theorem proof",
+    "ArchSig analysis packet is not global architecture truth",
+    "ArchSig analysis packet does not prove source extraction completeness",
+    "signature axes are law-policy-relative, not universal quality scores",
+    "flatness reading is blocked by coverage gaps and exactness assumptions",
+    "repair operation candidates are not automatic safe refactorings"
+  ]
+}

--- a/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet_layer_only.json
+++ b/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet_layer_only.json
@@ -1,0 +1,172 @@
+{
+  "schemaVersion": "archsig-analysis-packet-v0",
+  "analysisId": "archsig-analysis:fixture-archmap-atom-observation:layer-only-law-policy-fixture",
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "archMapRef": {
+    "artifactId": "fixture-archmap-atom-observation",
+    "artifactKind": "archmap",
+    "schemaVersion": "archmap-observation-map-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/archmap.json"
+  },
+  "selectedLawPolicyRef": {
+    "artifactId": "layer-only-law-policy-fixture",
+    "artifactKind": "law-policy",
+    "schemaVersion": "law-policy-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json"
+  },
+  "atomConfigurationSummary": {
+    "atomObservationCount": 4,
+    "moleculeObservationCount": 1,
+    "semanticObservationCount": 1,
+    "observationGapCount": 1,
+    "concernHintCount": 1,
+    "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
+    "coverageSummary": [
+      "4 atom observations",
+      "1 molecule observations",
+      "1 semantic observations",
+      "1 observation gaps preserved as gaps"
+    ],
+    "sourceRefs": [
+      "atom:component:route-users",
+      "atom:component:service-user",
+      "atom:contract:create-user",
+      "atom:relation:route-service",
+      "gap-runtime-user-db-trace"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "moleculeReadings": [
+    {
+      "moleculeReadingId": "molecule-reading:molecule-user-request-responsibility",
+      "moleculeObservationRef": "molecule:user-request-responsibility",
+      "lawRefs": [
+        "law:layer-respecting"
+      ],
+      "atomObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "reading": "molecule:user-request-responsibility is read as a responsibility molecule under selected LawPolicy",
+      "evidenceSummary": "molecule uses 4 atom observation refs and 1 source refs",
+      "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
+      "sourceRefs": [
+        "doc-architecture"
+      ],
+      "interpretationNotesForLLM": [
+        "Explain molecule readings as grouped observed atoms before discussing laws."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "obstructionCircuits": [],
+  "signatureAxes": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valueType": "nat",
+      "value": 0,
+      "zeroReading": "zero means no axis:layer-violation witness was constructed under declared coverage",
+      "coverageStatus": "coverage-gap-preserved",
+      "exactnessAssumptions": [
+        "the selected witness rules cover only policy-declared laws",
+        "zero readings are exact only for observed atoms and declared coverage requirements"
+      ],
+      "evidenceSummary": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+      "sourceRefs": [],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "flatnessReading": {
+    "readingId": "flatness:layer-only-law-policy-fixture",
+    "selectedLawPolicyRef": "layer-only-law-policy-fixture",
+    "status": "flatForConstructedWitnessesButCoverageGapBlocked",
+    "zeroSignatureAxisRefs": [
+      "sig-axis:layer-violation"
+    ],
+    "nonzeroSignatureAxisRefs": [],
+    "blockedByCoverageGaps": [
+      "gap-runtime-user-db-trace"
+    ],
+    "evidenceBoundary": "flatness is relative to selected signature axes, coverage gaps, and exactness assumptions",
+    "interpretationNotesForLLM": [
+      "Do not turn zero signature axes into global lawfulness claims."
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "staticRuntimeSemanticLayerSplit": {
+    "staticObservationRefs": [
+      "atom:component:route-users",
+      "atom:component:service-user",
+      "atom:relation:route-service"
+    ],
+    "runtimeObservationRefs": [
+      "gap-runtime-user-db-trace"
+    ],
+    "semanticObservationRefs": [
+      "atom:contract:create-user",
+      "semantic:create-user-flow"
+    ],
+    "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "repairOperationCandidates": [],
+  "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected LawPolicy layer-only-law-policy-fixture; concernHints are auxiliary cues only",
+  "interpretationNotesForLLM": [
+    "Lead with selected LawPolicy scope and evidence gaps.",
+    "Explain nonzero signature axes as law-relative ArchSig outputs.",
+    "Do not describe concernHints as obstruction circuits."
+  ],
+  "excludedReadings": [
+    "single architecture quality score",
+    "global architecture lawfulness",
+    "automatic repair safety",
+    "concern hint promoted without LawPolicy witness rule"
+  ],
+  "nonConclusions": [
+    "ArchSig analysis packet is not a Lean theorem proof",
+    "ArchSig analysis packet is not global architecture truth",
+    "ArchSig analysis packet does not prove source extraction completeness",
+    "signature axes are law-policy-relative, not universal quality scores",
+    "flatness reading is blocked by coverage gaps and exactness assumptions",
+    "repair operation candidates are not automatic safe refactorings"
+  ]
+}

--- a/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/law_policy.json
+++ b/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/law_policy.json
@@ -1,0 +1,336 @@
+{
+  "schemaVersion": "law-policy-v0",
+  "lawPolicyId": "llm-native-aat-law-policy-fixture",
+  "policyVersion": "v0",
+  "scope": "LLM-native ArchMap observation analysis fixture",
+  "archmapSchemaRef": "archmap-observation-map-v0",
+  "selectedLaws": [
+    {
+      "lawId": "law:layer-respecting",
+      "lawFamily": "dependency-direction",
+      "description": "Dependencies must respect the selected layer order.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredWitnessRefs": [
+        "witness:layer-violation"
+      ],
+      "requiredAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "lawId": "law:semantic-contract-alignment",
+      "lawFamily": "semantic-contract",
+      "description": "Semantic observations and contract observations must agree on the selected operation meaning.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "requiredWitnessRefs": [
+        "witness:semantic-contract-mismatch"
+      ],
+      "requiredAxisRefs": [
+        "axis:semantic-inconsistency"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "requiredZeroAxes": [
+    {
+      "axisId": "axis:layer-violation",
+      "axisFamily": "dependency-direction",
+      "valueType": "nat",
+      "zeroReading": "zero means no required layer violation witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed relation atoms",
+        "observed boundary membership atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "axisId": "axis:semantic-inconsistency",
+      "axisFamily": "semantic-contract",
+      "valueType": "nat",
+      "zeroReading": "zero means no required semantic contract mismatch witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed semantic atoms",
+        "observed contract atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "optionalAxes": [
+    {
+      "axisId": "axis:observation-gap",
+      "axisFamily": "coverage",
+      "valueType": "nat",
+      "zeroReading": "zero means no policy-required observation gap was reported",
+      "measurementBoundary": "coverageBoundary",
+      "evidenceRequirements": [
+        "observation gap records"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "witnessRules": [
+    {
+      "witnessRuleId": "witness:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessKind": "forbidden-dependency-direction",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "moleculePatternRefs": [
+        "molecule:layered-component"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "witnessRuleId": "witness:semantic-contract-mismatch",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessKind": "semantic-contract-noncommutation",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "moleculePatternRefs": [
+        "molecule:operation-contract"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "moleculePatterns": [
+    {
+      "moleculePatternId": "molecule:layered-component",
+      "roleName": "layered component",
+      "requiredAtomFamilies": [
+        "existence",
+        "boundaryAuthority"
+      ],
+      "optionalAtomFamilies": [
+        "relation"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "moleculePatternId": "molecule:operation-contract",
+      "roleName": "operation contract",
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification"
+      ],
+      "optionalAtomFamilies": [
+        "semanticInterpretation",
+        "effect"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "obstructionCircuitDefinitions": [
+    {
+      "obstructionCircuitId": "obstruction:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessRuleRef": "witness:layer-violation",
+      "circuitKind": "BoundaryLeakCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "obstructionCircuitId": "obstruction:semantic-contract-mismatch",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessRuleRef": "witness:semantic-contract-mismatch",
+      "circuitKind": "SemanticMismatchCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:semantic-inconsistency"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "signatureAxisDefinitions": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valuationRule": "count constructed BoundaryLeakCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "signatureAxisId": "sig-axis:semantic-inconsistency",
+      "lawRef": "law:semantic-contract-alignment",
+      "axisRef": "axis:semantic-inconsistency",
+      "valuationRule": "count constructed SemanticMismatchCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "exactnessAssumptions": [
+    "the selected witness rules cover only policy-declared laws",
+    "zero readings are exact only for observed atoms and declared coverage requirements"
+  ],
+  "coverageRequirements": [
+    {
+      "coverageRequirementId": "coverage:layer-atoms",
+      "appliesToLawRefs": [
+        "law:layer-respecting"
+      ],
+      "requiredAtomFamilies": [
+        "existence",
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "symbol"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "coverageRequirementId": "coverage:semantic-contract-atoms",
+      "appliesToLawRefs": [
+        "law:semantic-contract-alignment"
+      ],
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "doc-section",
+        "test"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "excludedReadings": [
+    "global architecture truth",
+    "Lean theorem discharge",
+    "SFT forecast correctness"
+  ],
+  "nonConclusions": [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+  ]
+}

--- a/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/law_policy_layer_only.json
+++ b/tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/law_policy_layer_only.json
@@ -1,0 +1,215 @@
+{
+  "schemaVersion": "law-policy-v0",
+  "lawPolicyId": "layer-only-law-policy-fixture",
+  "policyVersion": "v0",
+  "scope": "Layer-only reanalysis fixture over the same ArchMap",
+  "archmapSchemaRef": "archmap-observation-map-v0",
+  "selectedLaws": [
+    {
+      "lawId": "law:layer-respecting",
+      "lawFamily": "dependency-direction",
+      "description": "Dependencies must respect the selected layer order.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredWitnessRefs": [
+        "witness:layer-violation"
+      ],
+      "requiredAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "requiredZeroAxes": [
+    {
+      "axisId": "axis:layer-violation",
+      "axisFamily": "dependency-direction",
+      "valueType": "nat",
+      "zeroReading": "zero means no required layer violation witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed relation atoms",
+        "observed boundary membership atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "optionalAxes": [
+    {
+      "axisId": "axis:observation-gap",
+      "axisFamily": "coverage",
+      "valueType": "nat",
+      "zeroReading": "zero means no policy-required observation gap was reported",
+      "measurementBoundary": "coverageBoundary",
+      "evidenceRequirements": [
+        "observation gap records"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "witnessRules": [
+    {
+      "witnessRuleId": "witness:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessKind": "forbidden-dependency-direction",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "moleculePatternRefs": [
+        "molecule:layered-component"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "moleculePatterns": [
+    {
+      "moleculePatternId": "molecule:layered-component",
+      "roleName": "layered component",
+      "requiredAtomFamilies": [
+        "existence",
+        "boundaryAuthority"
+      ],
+      "optionalAtomFamilies": [
+        "relation"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "moleculePatternId": "molecule:operation-contract",
+      "roleName": "operation contract",
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification"
+      ],
+      "optionalAtomFamilies": [
+        "semanticInterpretation",
+        "effect"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "obstructionCircuitDefinitions": [
+    {
+      "obstructionCircuitId": "obstruction:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessRuleRef": "witness:layer-violation",
+      "circuitKind": "BoundaryLeakCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "signatureAxisDefinitions": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valuationRule": "count constructed BoundaryLeakCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "exactnessAssumptions": [
+    "the selected witness rules cover only policy-declared laws",
+    "zero readings are exact only for observed atoms and declared coverage requirements"
+  ],
+  "coverageRequirements": [
+    {
+      "coverageRequirementId": "coverage:layer-atoms",
+      "appliesToLawRefs": [
+        "law:layer-respecting"
+      ],
+      "requiredAtomFamilies": [
+        "existence",
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "symbol"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "excludedReadings": [
+    "global architecture truth",
+    "Lean theorem discharge",
+    "SFT forecast correctness"
+  ],
+  "nonConclusions": [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1334

LLM-native ArchMap/ArchSig の golden corpus を、PRD の主要 field と guardrail を検証できる形で追加しました。

- same ArchMap を複数 LawPolicy で再分析する fixture を追加
- `concernHints` を obstruction circuit として扱わない negative fixture を追加
- `observationGaps` を measured zero に丸めない negative fixture を追加
- FieldSig handoff 用の JSON fixture set を追加し、schema / LawPolicy split / guardrail をテストで固定
- golden corpus の読み方を `docs/tool/golden_corpus.md` に追加

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/golden_corpus.md`
- `docs/tool/README.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical tooling / design tracking` として扱っている
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
