### PR TITLE
analysis packet起点に旧ArchMap面を再配線

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -74,3 +74,19 @@ The builder:
 - preserves observation gaps as flatness blockers, not measured zero
 - emits repair operation candidates with preserved invariants, preconditions,
   transfer risks, evidence boundaries, and non-conclusions
+
+## Downstream Review Artifacts
+
+`llm-native-workflow` treats the analysis packet as the source artifact for
+downstream review surfaces:
+
+- AIR projection
+- AIR validation
+- theorem precondition check
+- Feature Extension Report
+- AAT Observable Bundle
+
+These projections carry the `ArchMap + LawPolicy -> ArchSig analysis` boundary.
+They do not make the legacy ArchMap projection rule the source of truth, and
+they do not promote analysis-packet validation into theorem proof, global
+architecture lawfulness, extractor completeness, or automatic repair safety.

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -1,6 +1,12 @@
 # ArchSig
 
-`archsig` is an AAT structural review CLI. Its primary surface is an ArchMap-homomorphism workflow: supplied `archmap-v0` evidence is read as a bounded map from selected source architecture evidence into the AAT object / relation / law / obstruction / signature-axis world. ArchSig diagnoses what that map preserves, what it forgets, which parts are unmeasured or unsupported, and which obstruction witnesses or next evidence should be reviewed.
+`archsig` is an AAT structural review CLI. Its primary surface is the
+LLM-native ArchMap / LawPolicy / ArchSig workflow: supplied
+`archmap-observation-map-v0` evidence records source-grounded Atom
+observations, a selected `law-policy-v0` defines the law universe and witness
+rules, and ArchSig emits an `archsig-analysis-packet-v0` for LLM and human
+review. Downstream AIR, theorem-check, Feature Report, and AAT Observable
+Bundle artifacts are projected from that analysis packet.
 
 ArchSig is not a Lean prover, extractor-completeness claim, architecture-lawfulness oracle, merge approval system, or SFT forecast engine. FieldSig owns SFT forecast, IntentMap, workflow evidence, operational feedback, dynamics, governance, and calibration under `tools/fieldsig`.
 
@@ -8,32 +14,41 @@ ArchSig is not a Lean prover, extractor-completeness claim, architecture-lawfuln
 
 | Surface | Current role | Boundary |
 | --- | --- | --- |
-| ArchMap homomorphism workflow | `archmap-workflow`, `archmap`, `air-from-archmap`, `validate-air`, `theorem-check`, `feature-report`, `aat-observable-bundle` | ArchMap is the canonical bounded AAT homomorphism input. Diagnostics report homomorphic / partial / lossy / non-homomorphic status, preservation failures, forgetful boundaries, unmeasured boundaries, unsupported boundaries, AAT signature axes, and obstruction refs. |
+| LLM-native analysis workflow | `llm-native-workflow`, `archmap`, `law-policy`, `archsig-analysis`, `validate-air`, `theorem-check`, `feature-report`, `aat-observable-bundle` | ArchMap is law-independent Atom observation evidence. LawPolicy selects the law universe. ArchSig owns law-relative molecule readings, obstruction circuits, signature axes, flatness readings, repair operation candidates, and LLM interpretation notes. |
+| Legacy ArchMap projection workflow | `archmap-workflow`, `air-from-archmap` | Kept as a bounded compatibility review surface for older AIR/report consumers. It is not the current source of truth for LLM-native ArchSig analysis. |
 | Bounded adapters | `adapter-scan` for Lean / Python import-graph Sig0 evidence, optional framework adapter evidence | Adapter output is an evidence supplier for conflict checks or legacy diff workflows; it retains `coverageBoundary`, `unsupportedConstructs`, `missingEvidence`, and `nonConclusions`, but it is not the ArchSig primary surface and does not produce a complete `ComponentUniverse`. |
 | Revision comparison | `validate`, `snapshot`, `signature-diff` over explicit Sig0 adapter artifacts | Diff values must be read with measured / unmeasured boundaries and non-conclusions. |
 | Review support | policy, law violation, policy decision, PR comment, PR quality analysis, schema compatibility | Tool output supports review; humans remain responsible for risk acceptance and product decisions. |
 
 ## Quick Start
 
-Run the primary ArchMap homomorphism workflow:
+Run the primary LLM-native analysis workflow:
 
 ```bash
-cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-workflow \
+cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
-  --out-dir .archsig/archmap-primary
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .archsig/llm-native
 ```
 
 This writes:
 
-- `.archsig/archmap-primary/archmap-validation.json`
-- `.archsig/archmap-primary/air.json`
-- `.archsig/archmap-primary/air-validation.json`
-- `.archsig/archmap-primary/theorem-precondition-check.json`
-- `.archsig/archmap-primary/feature-report.json`
-- `.archsig/archmap-primary/aat-observable-bundle.json`
-- `.archsig/archmap-primary/aat-observable-bundle-validation.json`
+- `.archsig/llm-native/archmap-validation.json`
+- `.archsig/llm-native/law-policy-validation.json`
+- `.archsig/llm-native/archsig-analysis-packet.json`
+- `.archsig/llm-native/archsig-analysis-validation.json`
+- `.archsig/llm-native/llm-interpretation-packet.json`
+- `.archsig/llm-native/air.json`
+- `.archsig/llm-native/air-validation.json`
+- `.archsig/llm-native/theorem-precondition-check.json`
+- `.archsig/llm-native/feature-report.json`
+- `.archsig/llm-native/aat-observable-bundle.json`
+- `.archsig/llm-native/aat-observable-bundle-validation.json`
 
-The validation report contains `homomorphismDiagnostics`; the Feature Extension Report carries the same ArchMap homomorphism family surface forward in `homomorphismSummary`, including object, relation, law, obstruction, and signature-axis families. The AAT Observable Bundle derives concept mapping review status from the ArchMap validation checklist, theorem precondition report, and Feature Extension Report. These are user-facing AAT diagnostics, not proof objects.
+The analysis packet is the source of truth for downstream review artifacts.
+`llm-interpretation-packet.json` is the same structured packet written for LLM
+reading. It is not natural-language judgment, not a Lean proof, and not an
+automatic repair instruction.
 
 When language import-graph evidence is needed, run it explicitly as an adapter:
 
@@ -64,7 +79,9 @@ Calling `archsig` without a subcommand intentionally fails. The old implicit sca
 - [Artifacts And Boundaries](docs/artifacts-and-boundaries.md)
 - [Operational Feedback](docs/operational-feedback.md)
 
-`docs/tool/` is being rebuilt around this ArchMap-primary boundary. Older mixed tool documents are archived under `docs/archive/2026-05-26-tool-docs-pre-archmap-primary/`.
+`docs/tool/` is being rebuilt around the LLM-native ArchMap / LawPolicy /
+ArchSig responsibility split. Older mixed tool documents are archived under
+`docs/archive/2026-05-26-tool-docs-pre-archmap-primary/`.
 
 ## Codex Skills
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -20,10 +20,21 @@ The command emits:
 - `archsig-analysis-packet.json`
 - `archsig-analysis-validation.json`
 - `llm-interpretation-packet.json`
+- `air.json`
+- `air-validation.json`
+- `theorem-precondition-check.json`
+- `feature-report.json`
+- `aat-observable-bundle.json`
+- `aat-observable-bundle-validation.json`
 
 `llm-interpretation-packet.json` is the same structured packet written for LLM
 reading. It is not a natural-language judgement, not a Lean proof, and not an
 automatic repair instruction.
+
+The downstream AIR, theorem-check, Feature Report, and AAT Observable Bundle
+are projected from `archsig-analysis-packet-v0`. They retain the
+`ArchMap + LawPolicy -> ArchSig analysis` boundary and do not use the legacy
+legacy ArchMap projection rule as their source of truth.
 
 Equivalent step-by-step commands:
 

--- a/tools/archsig/src/aat_observable.rs
+++ b/tools/archsig/src/aat_observable.rs
@@ -31,17 +31,17 @@ pub fn static_aat_observable_bundle() -> AatObservableBundleV0 {
     AatObservableBundleV0 {
         schema_version: AAT_OBSERVABLE_BUNDLE_SCHEMA_VERSION.to_string(),
         bundle_id: "fixture-aat-observable-bundle-v0".to_string(),
-        architecture_id: "coupon-service".to_string(),
+        architecture_id: "llm-native-archsig-fixture".to_string(),
         source_refs: vec![
             source_ref(
-                "source:air:coupon",
+                "source:air:analysis-packet",
                 "air",
                 AIR_SCHEMA_VERSION,
                 "tools/archsig/tests/fixtures/air/good_extension.json",
                 &["components", "relations", "claims", "coverage", "semanticDiagrams"],
             ),
             source_ref(
-                "source:archmap:coupon",
+                "source:archsig-analysis-packet:fixture",
                 "archmap",
                 ARCHMAP_SCHEMA_VERSION,
                 "tools/archsig/tests/fixtures/minimal/archmap.json",
@@ -56,7 +56,7 @@ pub fn static_aat_observable_bundle() -> AatObservableBundleV0 {
                 ],
             ),
             source_ref(
-                "source:feature-report:coupon",
+                "source:feature-report:analysis-packet",
                 "feature-extension-report",
                 FEATURE_EXTENSION_REPORT_SCHEMA_VERSION,
                 "tools/archsig/tests/fixtures/minimal/feature_extension_report.json",
@@ -68,8 +68,8 @@ pub fn static_aat_observable_bundle() -> AatObservableBundleV0 {
             ),
         ],
         selected_universe: AatSelectedUniverseV0 {
-            universe_id: "universe:coupon-selected".to_string(),
-            included_refs: vec!["component:checkout".to_string(), "component:coupon".to_string()],
+            universe_id: "universe:llm-native-selected".to_string(),
+            included_refs: vec!["component:archmap-observation".to_string(), "component:archsig-analysis".to_string()],
             excluded_refs: vec!["component:billing-private".to_string()],
             private_refs: vec!["repo:private-observability".to_string()],
             unavailable_refs: vec!["runtime:production-traces".to_string()],
@@ -101,8 +101,8 @@ pub fn static_aat_observable_bundle() -> AatObservableBundleV0 {
         llm_review_surface: AatLlmReviewSurfaceV0 {
             skill_ref: "tools/archsig/skills/aat-reviewer/SKILL.md".to_string(),
             input_artifact_refs: vec![
-                "source:air:coupon".to_string(),
-                "source:feature-report:coupon".to_string(),
+                "source:air:analysis-packet".to_string(),
+                "source:feature-report:analysis-packet".to_string(),
                 "bundle:fixture-aat-observable-bundle-v0".to_string(),
             ],
             review_questions: vec![
@@ -205,7 +205,10 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:architecture-object",
             "ArchitectureObject / ComponentUniverse",
-            &["source:archmap:coupon", "source:air:coupon"],
+            &[
+                "source:archsig-analysis-packet:fixture",
+                "source:air:analysis-packet",
+            ],
             &["coverage-boundary:dynamic-dispatch"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -218,7 +221,7 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:obstruction-witness",
             "ObstructionWitness",
-            &["source:feature-report:coupon"],
+            &["source:feature-report:analysis-packet"],
             &["witness:projection-mismatch", "witness:nonfillability"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -257,7 +260,7 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:projection-observation",
             "Projection / Observation / LSP / DIP",
-            &["source:air:coupon"],
+            &["source:air:analysis-packet"],
             &["evidence:projection-abstraction"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -270,7 +273,7 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:feature-extension",
             "FeatureExtension / ExtensionObstruction",
-            &["source:feature-report:coupon"],
+            &["source:feature-report:analysis-packet"],
             &["feature-evidence:coupon-extension"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -283,7 +286,7 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:semantic-diagram",
             "Path / Homotopy / DiagramFiller / NonFillability",
-            &["source:air:coupon"],
+            &["source:air:analysis-packet"],
             &["semantic:evidence:coupon-noncommutation"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -296,7 +299,7 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:state-effect",
             "StateTransition / EffectBoundary",
-            &["source:air:coupon"],
+            &["source:air:analysis-packet"],
             &["state-effect:evidence:coupon-replay"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -309,7 +312,7 @@ fn concept_mappings() -> Vec<AatConceptMappingV0> {
         concept(
             "concept:repair-synthesis",
             "Repair / Synthesis / ComplexityTransfer",
-            &["source:feature-report:coupon"],
+            &["source:feature-report:analysis-packet"],
             &["repair:evidence:coupon-boundary"],
             &["tools/archsig/skills/aat-reviewer/SKILL.md"],
             "representable",
@@ -353,7 +356,7 @@ fn observed_axes() -> Vec<AatObservedAxisV0> {
         AatObservedAxisV0 {
             axis_id: "axis:projectionSoundnessViolation".to_string(),
             concept_refs: vec!["concept:projection-observation".to_string()],
-            artifact_refs: vec!["source:air:coupon".to_string()],
+            artifact_refs: vec!["source:air:analysis-packet".to_string()],
             measurement_status: "measuredNonzero".to_string(),
             value: Some(1),
             boundary: "selected AIR claim and witness universe".to_string(),
@@ -404,7 +407,7 @@ fn witness_catalog() -> Vec<AatWitnessCatalogEntryV0> {
             "witness:projection-mismatch",
             "projectionFailure",
             &["law:lsp-observation-preservation"],
-            &["source:air:coupon"],
+            &["source:air:analysis-packet"],
             "measuredNonzero",
             "high",
             "review:inspect-projection-mismatch",
@@ -414,7 +417,7 @@ fn witness_catalog() -> Vec<AatWitnessCatalogEntryV0> {
             "witness:nonfillability",
             "nonFillabilityWitness",
             &["law:semantic-commutation"],
-            &["source:air:coupon"],
+            &["source:air:analysis-packet"],
             "measuredNonzero",
             "medium",
             "review:inspect-semantic-diagram",
@@ -424,7 +427,7 @@ fn witness_catalog() -> Vec<AatWitnessCatalogEntryV0> {
             "witness:effect-leakage",
             "effectLeakage",
             &["law:effect-boundary"],
-            &["source:air:coupon"],
+            &["source:air:analysis-packet"],
             "partiallyMeasured",
             "medium",
             "review:request-effect-evidence",
@@ -434,7 +437,7 @@ fn witness_catalog() -> Vec<AatWitnessCatalogEntryV0> {
             "witness:complexity-transfer",
             "complexityTransfer",
             &["law:repair-selected-axis"],
-            &["source:feature-report:coupon"],
+            &["source:feature-report:analysis-packet"],
             "reviewNeeded",
             "medium",
             "review:inspect-repair-transfer",
@@ -468,7 +471,7 @@ fn projection_observation_evidence() -> Vec<AatProjectionObservationEvidenceV0> 
     vec![AatProjectionObservationEvidenceV0 {
         evidence_ref: "evidence:projection-abstraction".to_string(),
         evidence_kind: "projectionMismatch".to_string(),
-        source_ref: "component:coupon-adapter".to_string(),
+        source_ref: "component:archsig-analysis-adapter".to_string(),
         target_ref: "interface:discount-policy".to_string(),
         local_contract_boundary: "LSP cue over selected interface methods".to_string(),
         global_layering_boundary: "does not conclude global Clean Architecture compliance"
@@ -488,7 +491,7 @@ fn feature_extension_evidence() -> Vec<AatFeatureExtensionEvidenceV0> {
             "interactionObstruction".to_string(),
             "residualCoverageGap".to_string(),
         ],
-        source_refs: vec!["source:feature-report:coupon".to_string()],
+        source_refs: vec!["source:feature-report:analysis-packet".to_string()],
         witness_refs: vec!["witness:projection-mismatch".to_string()],
         missing_evidence_refs: vec!["runtime:production-traces".to_string()],
         static_boundary: "static component/relation delta is retained".to_string(),

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -853,7 +853,7 @@ pub fn build_air_from_archmap(
                     kind: "archmap-relation".to_string(),
                     lifecycle: "after".to_string(),
                     protected_by: None,
-                    extraction_rule: Some("archmap-v0-projection".to_string()),
+                    extraction_rule: Some("archmap-observation-map-to-air-v0".to_string()),
                     evidence_refs: evidence_refs.clone(),
                 });
             }
@@ -966,7 +966,9 @@ pub fn build_air_from_archmap(
         feature: AirFeature {
             feature_id: Some(document.map_id.clone()),
             title: Some("ArchMap supplied JSON projection".to_string()),
-            description: Some("AIR generated from supplied archmap-v0 artifact".to_string()),
+            description: Some(
+                "AIR generated from supplied ArchMap observation artifact".to_string(),
+            ),
             source: "manual".to_string(),
             ai_session: None,
         },
@@ -1698,7 +1700,7 @@ fn archmap_air_coverage(
             projection_rule: if layer == "runtime" && !measured {
                 None
             } else {
-                Some("archmap-v0-to-air-v0".to_string())
+                Some("archmap-observation-map-to-air-v0".to_string())
             },
             extraction_scope: vec![document.source_universe.selection_boundary.clone()],
             exactness_assumptions: vec![
@@ -1746,7 +1748,7 @@ fn archmap_signature_axes(document: &ArchMapDocumentV0) -> Vec<crate::AirSignatu
                 } else {
                     "unmeasured".to_string()
                 },
-                source: Some("archmap-v0".to_string()),
+                source: Some("archmap-observation-map-v0".to_string()),
                 reason: (!measured).then(|| format!("{layer} layer is not measured by ArchMap")),
             }
         })
@@ -1756,8 +1758,8 @@ fn archmap_signature_axes(document: &ArchMapDocumentV0) -> Vec<crate::AirSignatu
         value: None,
         measured: false,
         measurement_boundary: "unmeasured".to_string(),
-        source: Some("archmap-v0".to_string()),
-        reason: Some("runtime traces are not supplied by ArchMap MVP fixture".to_string()),
+        source: Some("archmap-observation-map-v0".to_string()),
+        reason: Some("runtime traces are retained as ArchMap observation gaps".to_string()),
     });
     axes
 }
@@ -1989,7 +1991,9 @@ fn archmap_formal_promotion_guardrail_checklist_entry() -> ArchMapLeanPreservati
             "validation and projection do not discharge ArchMapPreservationPackage fields"
                 .to_string(),
         ],
-        missing_evidence: vec!["Lean theorem witness not supplied by archmap-v0".to_string()],
+        missing_evidence: vec![
+            "Lean theorem witness not supplied by ArchMap observation artifact".to_string(),
+        ],
         coverage_boundary:
             "formal promotion requires explicit Lean theorem refs and discharged preconditions"
                 .to_string(),

--- a/tools/archsig/src/feature_report.rs
+++ b/tools/archsig/src/feature_report.rs
@@ -241,7 +241,12 @@ fn feature_report_homomorphism_summary(
     let relation_entries = document
         .relations
         .iter()
-        .filter(|relation| relation.extraction_rule.as_deref() == Some("archmap-v0-projection"))
+        .filter(|relation| {
+            matches!(
+                relation.extraction_rule.as_deref(),
+                Some("archmap-observation-map-to-air-v0") | Some("archmap-v0-projection")
+            )
+        })
         .count();
     let object_entries = document
         .components

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -6,22 +6,25 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use archsig::{
-    AAT_OBSERVABLE_BUNDLE_SCHEMA_VERSION, ARCHMAP_SCHEMA_VERSION, AatAnalyticAxisV0,
-    AatConceptMappingV0, AatCoverageBoundaryV0, AatFeatureExtensionEvidenceV0,
+    AAT_OBSERVABLE_BUNDLE_SCHEMA_VERSION, AIR_SCHEMA_VERSION, ARCHMAP_SCHEMA_VERSION,
+    AatAnalyticAxisV0, AatConceptMappingV0, AatCoverageBoundaryV0, AatFeatureExtensionEvidenceV0,
     AatLlmReviewSurfaceV0, AatObservableBundleV0, AatObservableBundleValidationReportV0,
     AatObservableSourceRefV0, AatObservedAxisV0, AatOperationCandidateV0,
     AatProjectionObservationEvidenceV0, AatRepairSynthesisEvidenceV0, AatResponsibilityBoundaryV0,
     AatReviewActionV0, AatSelectedUniverseV0, AatSemanticDiagramEvidenceV0,
-    AatStateEffectLawEvidenceV0, AatTheoremBoundaryV0, AatWitnessCatalogEntryV0, AirDocumentInput,
-    AirDocumentV0, AirValidationReport, ArchMapDocumentV0, ArchMapSourceInventoryInput,
-    ArchMapSourceInventoryV0, ArchMapValidationReportV0, ArchitecturePolicyV0,
+    AatStateEffectLawEvidenceV0, AatTheoremBoundaryV0, AatWitnessCatalogEntryV0, AirArtifact,
+    AirClaim, AirComponent, AirCoverage, AirCoverageLayer, AirDocumentInput, AirDocumentV0,
+    AirEvidence, AirExtension, AirFeature, AirIdPolicies, AirOperationTrace, AirPolicies,
+    AirRelation, AirRevision, AirSignature, AirSignatureAxis, AirValidationReport,
+    ArchMapDocumentV0, ArchMapSourceInventoryInput, ArchMapSourceInventoryV0,
+    ArchMapValidationReportV0, ArchSigAnalysisPacketV0, ArchitecturePolicyV0,
     ArchitecturePolicyValidationReportV0, ComponentUniverseValidationReport,
     CustomRulePluginRegistryV0, CustomRulePluginRegistryValidationReportV0, DEFAULT_UNIVERSE_MODE,
     DetectableValuesReportedAxesCatalogV0, EmpiricalDatasetInput, FeatureExtensionReportV0,
-    FrameworkAdapterEvidenceV0, LawPolicyDocumentV0, LawPolicyTemplateRegistryV0,
-    LawPolicyTemplateRegistryValidationReportV0, LawViolationReportV0, MeasurementUnitRegistryV0,
-    MeasurementUnitRegistryValidationReportV0, NoSolutionCertificateV0,
-    NoSolutionCertificateValidationReportV0, OrganizationPolicyV0,
+    FeatureReportHomomorphismFamily, FeatureReportHomomorphismSummary, FrameworkAdapterEvidenceV0,
+    LawPolicyDocumentV0, LawPolicyTemplateRegistryV0, LawPolicyTemplateRegistryValidationReportV0,
+    LawViolationReportV0, MeasurementUnitRegistryV0, MeasurementUnitRegistryValidationReportV0,
+    NoSolutionCertificateV0, NoSolutionCertificateValidationReportV0, OrganizationPolicyV0,
     OrganizationPolicyValidationReportV0, PolicyDecisionReportV0, PrQualityAnalysisReportV0,
     PrQualityAnalysisValidationReportV0, RepairRuleRegistryV0,
     RepairRuleRegistryValidationReportV0, ReportArtifactRetentionManifestV0,
@@ -273,7 +276,7 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Validate a supplied ArchMap v0 JSON artifact.
+    /// Validate a supplied ArchMap observation JSON artifact.
     Archmap {
         /// Input ArchMap JSON path.
         #[arg(long)]
@@ -349,7 +352,7 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Project a supplied ArchMap v0 JSON artifact into AIR v0.
+    /// Project a supplied ArchMap observation JSON artifact into AIR v0.
     AirFromArchmap {
         /// Input ArchMap JSON path.
         #[arg(long)]
@@ -538,7 +541,7 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Build the ArchMap-primary review workflow artifacts.
+    /// Build the legacy ArchMap projection review workflow artifacts.
     ArchmapWorkflow {
         /// Input ArchMap JSON path.
         #[arg(long)]
@@ -1417,6 +1420,12 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             let analysis_packet_path = out_dir.join("archsig-analysis-packet.json");
             let analysis_validation_path = out_dir.join("archsig-analysis-validation.json");
             let llm_interpretation_path = out_dir.join("llm-interpretation-packet.json");
+            let air_path = out_dir.join("air.json");
+            let air_validation_path = out_dir.join("air-validation.json");
+            let theorem_check_path = out_dir.join("theorem-precondition-check.json");
+            let feature_report_path = out_dir.join("feature-report.json");
+            let observable_bundle_path = out_dir.join("aat-observable-bundle.json");
+            let observable_validation_path = out_dir.join("aat-observable-bundle-validation.json");
 
             let archmap_document: ArchMapDocumentV0 = read_json(&archmap)?;
             let source_inventory_path = archmap_document
@@ -1474,9 +1483,53 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 &analysis_packet_path.display().to_string(),
             );
             let analysis_failed = analysis_validation.summary.result == "fail";
-            write_json(Some(analysis_validation_path), &analysis_validation)?;
+            write_json(Some(analysis_validation_path.clone()), &analysis_validation)?;
 
-            Ok(if archmap_failed || law_policy_failed || analysis_failed {
+            let air = build_air_from_archsig_analysis_packet(
+                &analysis_packet,
+                &analysis_packet_path.display().to_string(),
+            );
+            write_json(Some(air_path.clone()), &air)?;
+            let air_validation =
+                validate_air_document_report(&air, &air_path.display().to_string(), false);
+            let air_failed = air_validation.summary.result == "fail";
+            write_json(Some(air_validation_path.clone()), &air_validation)?;
+
+            let theorem_check =
+                build_theorem_precondition_check_report(&air, &air_path.display().to_string());
+            write_json(Some(theorem_check_path.clone()), &theorem_check)?;
+
+            let mut feature_report =
+                build_feature_extension_report(&air, &air_path.display().to_string());
+            apply_archsig_analysis_packet_to_feature_report(&mut feature_report, &analysis_packet);
+            write_json(Some(feature_report_path.clone()), &feature_report)?;
+
+            let observable_bundle = observable_bundle_from_archsig_analysis_workflow(
+                &analysis_packet,
+                &air,
+                &theorem_check,
+                &feature_report,
+                &analysis_packet_path,
+                &analysis_validation_path,
+                &air_path,
+                &air_validation_path,
+                &theorem_check_path,
+                &feature_report_path,
+            );
+            write_json(Some(observable_bundle_path.clone()), &observable_bundle)?;
+            let observable_validation = validate_aat_observable_bundle(
+                &observable_bundle,
+                &observable_bundle_path.display().to_string(),
+            );
+            let observable_failed = observable_validation.summary.result == "fail";
+            write_json(Some(observable_validation_path), &observable_validation)?;
+
+            Ok(if archmap_failed
+                || law_policy_failed
+                || analysis_failed
+                || air_failed
+                || observable_failed
+            {
                 ExitCode::from(1)
             } else {
                 ExitCode::SUCCESS
@@ -1638,7 +1691,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             })
         }
         None => {
-            Err("ArchSig is ArchMap-primary; use `archsig archmap-workflow` for review artifacts or `archsig adapter-scan` for bounded Lean/Python evidence.".into())
+            Err("ArchSig is LLM-native ArchMap/LawPolicy/analysis-packet primary; use `archsig llm-native-workflow` for review artifacts or `archsig adapter-scan` for bounded Lean/Python evidence.".into())
         }
     }
 }
@@ -1686,6 +1739,979 @@ fn build_adapter_sig0(
         _ => unreachable!("clap restricts language values"),
     };
     Ok(document)
+}
+
+fn build_air_from_archsig_analysis_packet(
+    packet: &ArchSigAnalysisPacketV0,
+    packet_path: &str,
+) -> AirDocumentV0 {
+    let analysis_artifact_id = "artifact-archsig-analysis-packet".to_string();
+    let artifacts = vec![
+        AirArtifact {
+            artifact_id: analysis_artifact_id.clone(),
+            kind: "archsig_analysis_packet".to_string(),
+            schema_version: Some(packet.schema_version.clone()),
+            path: Some(packet_path.to_string()),
+            content_hash: None,
+            produced_by: Some("archsig".to_string()),
+        },
+        AirArtifact {
+            artifact_id: "artifact-archmap-observation".to_string(),
+            kind: packet.arch_map_ref.artifact_kind.clone(),
+            schema_version: Some(packet.arch_map_ref.schema_version.clone()),
+            path: packet.arch_map_ref.path.clone(),
+            content_hash: packet.arch_map_ref.content_hash.clone(),
+            produced_by: Some("external-agent".to_string()),
+        },
+        AirArtifact {
+            artifact_id: "artifact-law-policy".to_string(),
+            kind: packet.selected_law_policy_ref.artifact_kind.clone(),
+            schema_version: Some(packet.selected_law_policy_ref.schema_version.clone()),
+            path: packet.selected_law_policy_ref.path.clone(),
+            content_hash: packet.selected_law_policy_ref.content_hash.clone(),
+            produced_by: Some("human-selected-policy".to_string()),
+        },
+    ];
+    let mut evidence: Vec<AirEvidence> = artifacts
+        .iter()
+        .map(|artifact| AirEvidence {
+            evidence_id: format!("evidence-{}", artifact.artifact_id.replace("artifact-", "")),
+            kind: "manual_annotation".to_string(),
+            artifact_ref: Some(artifact.artifact_id.clone()),
+            path: artifact.path.clone(),
+            symbol: None,
+            line: None,
+            rule_id: artifact.schema_version.clone(),
+            confidence: Some("high".to_string()),
+        })
+        .collect();
+
+    let mut components = Vec::new();
+    let mut component_ids = BTreeSet::new();
+    for source_ref in &packet.atom_configuration_summary.source_refs {
+        let id = format!("observation-{}", stable_fragment(source_ref));
+        if component_ids.insert(id.clone()) {
+            components.push(AirComponent {
+                id,
+                kind: "archsig-observation-ref".to_string(),
+                lifecycle: "after".to_string(),
+                owner: None,
+                evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+            });
+        }
+    }
+    for obstruction in &packet.obstruction_circuits {
+        if component_ids.insert(obstruction.obstruction_circuit_id.clone()) {
+            components.push(AirComponent {
+                id: obstruction.obstruction_circuit_id.clone(),
+                kind: "archsig-obstruction-circuit".to_string(),
+                lifecycle: "after".to_string(),
+                owner: None,
+                evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+            });
+        }
+    }
+    for molecule in &packet.molecule_readings {
+        let id = format!(
+            "observation-{}",
+            stable_fragment(&molecule.molecule_observation_ref)
+        );
+        if component_ids.insert(id.clone()) {
+            components.push(AirComponent {
+                id,
+                kind: "archsig-molecule-reading".to_string(),
+                lifecycle: "after".to_string(),
+                owner: None,
+                evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+            });
+        }
+    }
+
+    let mut relations = Vec::new();
+    for (index, molecule) in packet.molecule_readings.iter().enumerate() {
+        let from = molecule
+            .atom_observation_refs
+            .first()
+            .map(|value| format!("observation-{}", stable_fragment(value)));
+        let to = Some(format!(
+            "observation-{}",
+            stable_fragment(&molecule.molecule_observation_ref)
+        ));
+        relations.push(AirRelation {
+            id: format!("relation-archsig-molecule-{:04}", index + 1),
+            layer: "semantic".to_string(),
+            from_component: from,
+            to_component: to,
+            kind: "archsig-molecule-reading".to_string(),
+            lifecycle: "after".to_string(),
+            protected_by: None,
+            extraction_rule: Some("archsig-analysis-packet-to-air-v0".to_string()),
+            evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+        });
+    }
+    for (index, obstruction) in packet.obstruction_circuits.iter().enumerate() {
+        let from = obstruction
+            .atom_observation_refs
+            .first()
+            .map(|value| format!("observation-{}", stable_fragment(value)));
+        relations.push(AirRelation {
+            id: format!("relation-archsig-obstruction-{:04}", index + 1),
+            layer: "policy".to_string(),
+            from_component: from,
+            to_component: Some(obstruction.obstruction_circuit_id.clone()),
+            kind: obstruction.circuit_kind.clone(),
+            lifecycle: "after".to_string(),
+            protected_by: Some(obstruction.law_ref.clone()),
+            extraction_rule: Some("archsig-analysis-packet-to-air-v0".to_string()),
+            evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+        });
+    }
+
+    for axis in &packet.signature_axes {
+        evidence.push(AirEvidence {
+            evidence_id: format!("evidence-axis-{}", stable_fragment(&axis.signature_axis_id)),
+            kind: "manual_annotation".to_string(),
+            artifact_ref: Some(analysis_artifact_id.clone()),
+            path: Some(packet_path.to_string()),
+            symbol: Some(axis.signature_axis_id.clone()),
+            line: None,
+            rule_id: Some(axis.law_ref.clone()),
+            confidence: Some("high".to_string()),
+        });
+    }
+
+    let mut claims = Vec::new();
+    for obstruction in &packet.obstruction_circuits {
+        claims.push(AirClaim {
+            claim_id: format!(
+                "claim-archsig-obstruction-{}",
+                stable_fragment(&obstruction.obstruction_circuit_id)
+            ),
+            subject_ref: obstruction.obstruction_circuit_id.clone(),
+            predicate: format!("selected LawPolicy constructs {}", obstruction.circuit_kind),
+            claim_level: "tooling-analysis".to_string(),
+            claim_classification: "measured".to_string(),
+            measurement_boundary: "measuredNonzero".to_string(),
+            theorem_refs: vec![
+                obstruction.law_ref.clone(),
+                obstruction.witness_rule_ref.clone(),
+            ],
+            evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+            required_assumptions: vec![obstruction.minimality_reading.clone()],
+            coverage_assumptions: obstruction.atom_observation_refs.clone(),
+            exactness_assumptions: vec![obstruction.evidence_boundary.clone()],
+            missing_preconditions: Vec::new(),
+            non_conclusions: obstruction.non_conclusions.clone(),
+        });
+    }
+    for axis in &packet.signature_axes {
+        claims.push(AirClaim {
+            claim_id: format!(
+                "claim-archsig-axis-{}",
+                stable_fragment(&axis.signature_axis_id)
+            ),
+            subject_ref: axis.signature_axis_id.clone(),
+            predicate: format!(
+                "selected LawPolicy axis {} has value {}",
+                axis.axis_ref, axis.value
+            ),
+            claim_level: "tooling-analysis".to_string(),
+            claim_classification: "measured".to_string(),
+            measurement_boundary: axis_measurement_boundary(axis.value),
+            theorem_refs: vec![axis.law_ref.clone()],
+            evidence_refs: vec![format!(
+                "evidence-axis-{}",
+                stable_fragment(&axis.signature_axis_id)
+            )],
+            required_assumptions: axis.exactness_assumptions.clone(),
+            coverage_assumptions: axis.source_refs.clone(),
+            exactness_assumptions: axis.exactness_assumptions.clone(),
+            missing_preconditions: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+            non_conclusions: axis.non_conclusions.clone(),
+        });
+    }
+    claims.push(AirClaim {
+        claim_id: "claim-archsig-flatness-reading".to_string(),
+        subject_ref: packet.flatness_reading.reading_id.clone(),
+        predicate: format!(
+            "selected LawPolicy flatness status is {}",
+            packet.flatness_reading.status
+        ),
+        claim_level: "tooling-analysis".to_string(),
+        claim_classification: "empirical".to_string(),
+        measurement_boundary: if packet
+            .flatness_reading
+            .nonzero_signature_axis_refs
+            .is_empty()
+        {
+            "measuredZero".to_string()
+        } else {
+            "measuredNonzero".to_string()
+        },
+        theorem_refs: vec![packet.flatness_reading.selected_law_policy_ref.clone()],
+        evidence_refs: vec!["evidence-archsig-analysis-packet".to_string()],
+        required_assumptions: packet.flatness_reading.interpretation_notes_for_llm.clone(),
+        coverage_assumptions: packet.flatness_reading.zero_signature_axis_refs.clone(),
+        exactness_assumptions: vec![packet.flatness_reading.evidence_boundary.clone()],
+        missing_preconditions: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+        non_conclusions: packet.flatness_reading.non_conclusions.clone(),
+    });
+
+    let signature_axes = packet
+        .signature_axes
+        .iter()
+        .map(|axis| AirSignatureAxis {
+            axis: axis.signature_axis_id.clone(),
+            value: Some(axis.value),
+            measured: true,
+            measurement_boundary: axis_measurement_boundary(axis.value),
+            source: Some("archsig-analysis-packet-v0".to_string()),
+            reason: Some(axis.evidence_summary.clone()),
+        })
+        .chain([AirSignatureAxis {
+            axis: "runtimePropagation".to_string(),
+            value: None,
+            measured: false,
+            measurement_boundary: "unmeasured".to_string(),
+            source: Some("archsig-analysis-packet-v0".to_string()),
+            reason: Some(
+                "runtime observations are retained as gaps in the analysis packet".to_string(),
+            ),
+        }])
+        .collect();
+    let coverage = AirCoverage {
+        layers: archsig_analysis_air_coverage_layers(packet),
+    };
+
+    AirDocumentV0 {
+        schema_version: AIR_SCHEMA_VERSION.to_string(),
+        schema_compatibility: None,
+        architecture_id: packet.arch_map_ref.artifact_id.clone(),
+        ids: AirIdPolicies {
+            component_id_policy: "ArchSig packet observation and obstruction ids".to_string(),
+            relation_id_policy: "ArchSig packet stable ordinal".to_string(),
+            evidence_id_policy: "ArchSig packet artifact and axis ids".to_string(),
+            claim_id_policy: "ArchSig packet obstruction, axis, and flatness ids".to_string(),
+        },
+        revision: AirRevision {
+            before: None,
+            after: packet.generated_at.clone(),
+        },
+        feature: AirFeature {
+            feature_id: Some(packet.analysis_id.clone()),
+            title: Some("ArchSig analysis packet downstream projection".to_string()),
+            description: Some(
+                "AIR generated from archsig-analysis-packet-v0, not direct ArchMap homomorphism"
+                    .to_string(),
+            ),
+            source: "manual".to_string(),
+            ai_session: None,
+        },
+        artifacts,
+        evidence,
+        components,
+        relations,
+        policies: AirPolicies {
+            laws: stable_strings(
+                packet
+                    .signature_axes
+                    .iter()
+                    .map(|axis| axis.law_ref.clone())
+                    .chain(
+                        packet
+                            .molecule_readings
+                            .iter()
+                            .flat_map(|reading| reading.law_refs.clone()),
+                    )
+                    .collect(),
+            ),
+            boundaries: vec![packet.evidence_boundary.clone()],
+            allowed_edges: Vec::new(),
+            forbidden_edges: packet
+                .obstruction_circuits
+                .iter()
+                .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+                .collect(),
+            abstraction_rules: packet.excluded_readings.clone(),
+            protection_rules: packet.interpretation_notes_for_llm.clone(),
+        },
+        semantic_diagrams: Vec::new(),
+        architecture_paths: Vec::new(),
+        homotopy_generators: Vec::new(),
+        nonfillability_witnesses: Vec::new(),
+        signature: AirSignature {
+            axes: signature_axes,
+        },
+        coverage,
+        claims,
+        operation_trace: AirOperationTrace {
+            operations: packet
+                .repair_operation_candidates
+                .iter()
+                .map(|candidate| candidate.repair_operation_candidate_id.clone())
+                .collect(),
+        },
+        extension: AirExtension {
+            embedding_claim_ref: Some("claim-archsig-flatness-reading".to_string()),
+            feature_view_claim_ref: None,
+            interaction_claim_refs: packet
+                .obstruction_circuits
+                .iter()
+                .map(|obstruction| {
+                    format!(
+                        "claim-archsig-obstruction-{}",
+                        stable_fragment(&obstruction.obstruction_circuit_id)
+                    )
+                })
+                .collect(),
+            split_claim_ref: Some("claim-archsig-flatness-reading".to_string()),
+            split_status: packet.flatness_reading.status.clone(),
+        },
+    }
+}
+
+fn archsig_analysis_air_coverage_layers(packet: &ArchSigAnalysisPacketV0) -> Vec<AirCoverageLayer> {
+    [
+        (
+            "static",
+            &packet
+                .static_runtime_semantic_layer_split
+                .static_observation_refs,
+        ),
+        (
+            "runtime",
+            &packet
+                .static_runtime_semantic_layer_split
+                .runtime_observation_refs,
+        ),
+        (
+            "semantic",
+            &packet
+                .static_runtime_semantic_layer_split
+                .semantic_observation_refs,
+        ),
+    ]
+    .into_iter()
+    .map(|(layer, refs)| {
+        let has_refs = !refs.is_empty();
+        let is_runtime_gap = layer == "runtime"
+            && refs
+                .iter()
+                .any(|reference| reference.starts_with("gap") || reference.contains("gap"));
+        let measured_layer = layer == "static" && has_refs && !is_runtime_gap;
+        AirCoverageLayer {
+            layer: layer.to_string(),
+            measurement_boundary: if measured_layer {
+                "measuredNonzero".to_string()
+            } else {
+                "unmeasured".to_string()
+            },
+            universe_refs: vec!["artifact-archsig-analysis-packet".to_string()],
+            measured_axes: if measured_layer {
+                vec![format!("{layer}ArchSigAnalysisCoverage")]
+            } else {
+                Vec::new()
+            },
+            unmeasured_axes: if !measured_layer {
+                if layer == "runtime" {
+                    vec![
+                        format!("{layer}ArchSigAnalysisCoverage"),
+                        "runtimePropagation".to_string(),
+                    ]
+                } else {
+                    vec![format!("{layer}ArchSigAnalysisCoverage")]
+                }
+            } else {
+                Vec::new()
+            },
+            projection_rule: measured_layer
+                .then(|| "archsig-analysis-packet-to-air-v0".to_string()),
+            extraction_scope: packet.atom_configuration_summary.coverage_summary.clone(),
+            exactness_assumptions: packet
+                .signature_axes
+                .iter()
+                .flat_map(|axis| axis.exactness_assumptions.clone())
+                .collect(),
+            unsupported_constructs: if is_runtime_gap {
+                refs.clone()
+            } else {
+                Vec::new()
+            },
+        }
+    })
+    .collect()
+}
+
+fn apply_archsig_analysis_packet_to_feature_report(
+    report: &mut FeatureExtensionReportV0,
+    packet: &ArchSigAnalysisPacketV0,
+) {
+    report.homomorphism_summary = FeatureReportHomomorphismSummary {
+        classification: packet.flatness_reading.status.clone(),
+        domain: packet.arch_map_ref.schema_version.clone(),
+        codomain: packet.schema_version.clone(),
+        map_families: vec![
+            FeatureReportHomomorphismFamily {
+                map_family: "atomObservation".to_string(),
+                entry_count: packet.atom_configuration_summary.atom_observation_count,
+                measured_count: packet.atom_configuration_summary.atom_observation_count,
+                unmeasured_count: packet.atom_configuration_summary.observation_gap_count,
+                lossy_count: packet.atom_configuration_summary.concern_hint_count,
+            },
+            FeatureReportHomomorphismFamily {
+                map_family: "moleculeReading".to_string(),
+                entry_count: packet.molecule_readings.len(),
+                measured_count: packet.molecule_readings.len(),
+                unmeasured_count: 0,
+                lossy_count: 0,
+            },
+            FeatureReportHomomorphismFamily {
+                map_family: "obstructionCircuit".to_string(),
+                entry_count: packet.obstruction_circuits.len(),
+                measured_count: packet.obstruction_circuits.len(),
+                unmeasured_count: 0,
+                lossy_count: 0,
+            },
+            FeatureReportHomomorphismFamily {
+                map_family: "signatureAxis".to_string(),
+                entry_count: packet.signature_axes.len(),
+                measured_count: packet.signature_axes.len(),
+                unmeasured_count: packet.flatness_reading.blocked_by_coverage_gaps.len(),
+                lossy_count: 0,
+            },
+        ],
+        preserved_structure_refs: packet
+            .signature_axes
+            .iter()
+            .flat_map(|axis| axis.source_refs.clone())
+            .collect(),
+        obstruction_refs: packet
+            .obstruction_circuits
+            .iter()
+            .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+            .collect(),
+        forgetful_boundaries: packet.excluded_readings.clone(),
+        unmeasured_boundaries: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+        unsupported_boundaries: packet
+            .static_runtime_semantic_layer_split
+            .runtime_observation_refs
+            .clone(),
+        next_evidence: packet
+            .repair_operation_candidates
+            .iter()
+            .flat_map(|candidate| candidate.preconditions.clone())
+            .collect(),
+        non_conclusions: stable_strings(
+            packet
+                .non_conclusions
+                .iter()
+                .cloned()
+                .chain([
+                    "Feature Report is derived from ArchSig analysis packet state".to_string(),
+                    "ArchMap concern hints are interpreted only after LawPolicy selection"
+                        .to_string(),
+                ])
+                .collect(),
+        ),
+    };
+    report.review_summary.top_witnesses = packet
+        .obstruction_circuits
+        .iter()
+        .map(|obstruction| obstruction.circuit_kind.clone())
+        .collect();
+    report.review_summary.required_action = if packet.obstruction_circuits.is_empty() {
+        "inspect-selected-policy-boundaries".to_string()
+    } else {
+        "review-selected-policy-obstruction-circuits".to_string()
+    };
+    report.non_conclusions = stable_strings(
+        report
+            .non_conclusions
+            .iter()
+            .cloned()
+            .chain(packet.non_conclusions.clone())
+            .collect(),
+    );
+}
+
+fn observable_bundle_from_archsig_analysis_workflow(
+    packet: &ArchSigAnalysisPacketV0,
+    _air: &AirDocumentV0,
+    theorem_check: &TheoremPreconditionCheckReportV0,
+    feature_report: &FeatureExtensionReportV0,
+    analysis_packet_path: &Path,
+    analysis_validation_path: &Path,
+    air_path: &Path,
+    air_validation_path: &Path,
+    theorem_check_path: &Path,
+    feature_report_path: &Path,
+) -> AatObservableBundleV0 {
+    let source_refs = vec![
+        AatObservableSourceRefV0 {
+            source_ref_id: "source:archsig-analysis-packet:primary".to_string(),
+            artifact_kind: "archsig-analysis-packet".to_string(),
+            schema_version: packet.schema_version.clone(),
+            path: analysis_packet_path.display().to_string(),
+            retained_fields: vec![
+                "archMapRef".to_string(),
+                "selectedLawPolicyRef".to_string(),
+                "obstructionCircuits".to_string(),
+                "signatureAxes".to_string(),
+                "flatnessReading".to_string(),
+                "repairOperationCandidates".to_string(),
+                "nonConclusions".to_string(),
+            ],
+            non_conclusions: packet.non_conclusions.clone(),
+        },
+        AatObservableSourceRefV0 {
+            source_ref_id: "source:archsig-analysis-validation:primary".to_string(),
+            artifact_kind: "archsig-analysis-validation-report".to_string(),
+            schema_version: "archsig-analysis-packet-validation-report-v0".to_string(),
+            path: analysis_validation_path.display().to_string(),
+            retained_fields: vec!["checks".to_string(), "summary".to_string()],
+            non_conclusions: vec![
+                "analysis validation does not prove architecture lawfulness".to_string(),
+            ],
+        },
+        AatObservableSourceRefV0 {
+            source_ref_id: "source:air:analysis-packet".to_string(),
+            artifact_kind: "air".to_string(),
+            schema_version: AIR_SCHEMA_VERSION.to_string(),
+            path: air_path.display().to_string(),
+            retained_fields: vec![
+                "artifacts".to_string(),
+                "claims".to_string(),
+                "coverage".to_string(),
+            ],
+            non_conclusions: vec![
+                "AIR projection records analysis packet claims, not Lean theorem discharge"
+                    .to_string(),
+            ],
+        },
+        AatObservableSourceRefV0 {
+            source_ref_id: "source:air-validation:analysis-packet".to_string(),
+            artifact_kind: "air-validation-report".to_string(),
+            schema_version: "aat-air-validation-report-v0".to_string(),
+            path: air_validation_path.display().to_string(),
+            retained_fields: vec!["checks".to_string(), "summary".to_string()],
+            non_conclusions: vec!["AIR validation does not approve merge".to_string()],
+        },
+        AatObservableSourceRefV0 {
+            source_ref_id: "source:theorem-check:analysis-packet".to_string(),
+            artifact_kind: "theorem-precondition-check-report".to_string(),
+            schema_version: "theorem-precondition-check-report-v0".to_string(),
+            path: theorem_check_path.display().to_string(),
+            retained_fields: vec!["checks".to_string(), "summary".to_string()],
+            non_conclusions: vec!["theorem precondition check is not a Lean proof".to_string()],
+        },
+        AatObservableSourceRefV0 {
+            source_ref_id: "source:feature-report:analysis-packet".to_string(),
+            artifact_kind: "feature-extension-report".to_string(),
+            schema_version: "feature-extension-report-v0".to_string(),
+            path: feature_report_path.display().to_string(),
+            retained_fields: vec![
+                "homomorphismSummary".to_string(),
+                "reviewSummary".to_string(),
+                "nonConclusions".to_string(),
+            ],
+            non_conclusions: vec![
+                "feature report is analysis-packet-derived review evidence".to_string(),
+            ],
+        },
+    ];
+    let source_ref_ids: Vec<String> = source_refs
+        .iter()
+        .map(|source_ref| source_ref.source_ref_id.clone())
+        .collect();
+    let witness_refs: Vec<String> = packet
+        .obstruction_circuits
+        .iter()
+        .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+        .collect();
+    let theorem_claim_ref = theorem_check
+        .checks
+        .first()
+        .map(|check| check.claim_id.clone())
+        .unwrap_or_else(|| "claim-archsig-flatness-reading".to_string());
+
+    AatObservableBundleV0 {
+        schema_version: AAT_OBSERVABLE_BUNDLE_SCHEMA_VERSION.to_string(),
+        bundle_id: format!("llm-native-archsig-analysis:{}", packet.analysis_id),
+        architecture_id: packet.arch_map_ref.artifact_id.clone(),
+        source_refs,
+        selected_universe: AatSelectedUniverseV0 {
+            universe_id: format!("universe:{}", packet.arch_map_ref.artifact_id),
+            included_refs: packet.atom_configuration_summary.source_refs.clone(),
+            excluded_refs: packet.excluded_readings.clone(),
+            private_refs: Vec::new(),
+            unavailable_refs: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+            unsupported_refs: packet
+                .static_runtime_semantic_layer_split
+                .runtime_observation_refs
+                .clone(),
+            dynamic_boundary_refs: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+            exactness_assumptions: packet
+                .signature_axes
+                .iter()
+                .flat_map(|axis| axis.exactness_assumptions.clone())
+                .collect(),
+            measurement_status: "partiallyMeasured".to_string(),
+            non_conclusions: packet.non_conclusions.clone(),
+        },
+        concept_mappings: archsig_analysis_concept_mappings(packet, feature_report),
+        observed_axes: packet
+            .signature_axes
+            .iter()
+            .map(|axis| AatObservedAxisV0 {
+                axis_id: axis.signature_axis_id.clone(),
+                concept_refs: vec!["concept:archsig-signature-axis".to_string()],
+                artifact_refs: vec!["source:archsig-analysis-packet:primary".to_string()],
+                measurement_status: axis.coverage_status.clone(),
+                value: Some(axis.value),
+                boundary: axis.evidence_summary.clone(),
+                non_conclusions: axis.non_conclusions.clone(),
+            })
+            .collect(),
+        coverage_boundaries: vec![
+            AatCoverageBoundaryV0 {
+                boundary_id: "coverage:archsig-analysis-packet".to_string(),
+                boundary_kind: "analysis-packet-boundary".to_string(),
+                affected_refs: source_ref_ids.clone(),
+                measurement_status: "partiallyMeasured".to_string(),
+                review_action_ref: Some("review:inspect-analysis-packet-boundaries".to_string()),
+                non_conclusions: packet.non_conclusions.clone(),
+            },
+            AatCoverageBoundaryV0 {
+                boundary_id: "coverage:archsig-runtime-gaps".to_string(),
+                boundary_kind: "unmeasured".to_string(),
+                affected_refs: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+                measurement_status: "unmeasured".to_string(),
+                review_action_ref: Some("review:inspect-analysis-packet-boundaries".to_string()),
+                non_conclusions: vec!["observation gaps are not measured zero".to_string()],
+            },
+            AatCoverageBoundaryV0 {
+                boundary_id: "coverage:archsig-excluded-readings".to_string(),
+                boundary_kind: "out-of-scope".to_string(),
+                affected_refs: packet.excluded_readings.clone(),
+                measurement_status: "outOfScope".to_string(),
+                review_action_ref: Some("review:inspect-analysis-packet-boundaries".to_string()),
+                non_conclusions: vec![
+                    "excluded readings are retained as boundary data".to_string(),
+                ],
+            },
+        ],
+        witness_catalog: if witness_refs.is_empty() {
+            Vec::new()
+        } else {
+            vec![AatWitnessCatalogEntryV0 {
+                witness_ref: witness_refs[0].clone(),
+                witness_kind: packet.obstruction_circuits[0].circuit_kind.clone(),
+                law_refs: vec![packet.obstruction_circuits[0].law_ref.clone()],
+                source_refs: source_ref_ids.clone(),
+                measurement_status: "measuredNonzero".to_string(),
+                severity: feature_report.review_summary.required_action.clone(),
+                review_action_ref: "review:inspect-analysis-packet-boundaries".to_string(),
+                non_conclusions: packet.obstruction_circuits[0].non_conclusions.clone(),
+            }]
+        },
+        operation_candidates: packet
+            .repair_operation_candidates
+            .iter()
+            .map(|candidate| AatOperationCandidateV0 {
+                operation_ref: candidate.repair_operation_candidate_id.clone(),
+                operation_kind: candidate.operation_kind.clone(),
+                role: "repair-operation-candidate".to_string(),
+                confidence: "medium".to_string(),
+                deterministic_cues: candidate.expected_signature_axis_effects.clone(),
+                llm_judgment_needed: candidate.preconditions.clone(),
+                evidence_refs: source_ref_ids.clone(),
+                preserved_invariant_refs: candidate.preserved_invariants.clone(),
+                possible_transferred_obstruction_refs: candidate.transfer_risks.clone(),
+                non_conclusions: candidate.non_conclusions.clone(),
+            })
+            .collect(),
+        projection_observation_evidence: vec![AatProjectionObservationEvidenceV0 {
+            evidence_ref: "evidence:analysis-packet-to-air".to_string(),
+            evidence_kind: "analysis-packet-projection".to_string(),
+            source_ref: "source:archsig-analysis-packet:primary".to_string(),
+            target_ref: "source:air:analysis-packet".to_string(),
+            local_contract_boundary: packet.evidence_boundary.clone(),
+            global_layering_boundary: "global layering is not concluded from packet projection"
+                .to_string(),
+            witness_refs: witness_refs.clone(),
+            non_conclusions: vec![
+                "projection evidence does not prove semantic preservation".to_string(),
+            ],
+        }],
+        feature_extension_evidence: vec![AatFeatureExtensionEvidenceV0 {
+            evidence_ref: "evidence:feature-report:analysis-packet".to_string(),
+            feature_ref: packet.analysis_id.clone(),
+            operation_ref: "operation:llm-native-archsig-review".to_string(),
+            obstruction_classifications: feature_report.review_summary.top_witnesses.clone(),
+            source_refs: source_ref_ids.clone(),
+            witness_refs: witness_refs.clone(),
+            missing_evidence_refs: feature_report.undischarged_assumptions.clone(),
+            static_boundary: "static observations are read from the analysis packet".to_string(),
+            runtime_boundary: packet
+                .static_runtime_semantic_layer_split
+                .split_boundary
+                .clone(),
+            semantic_boundary: packet.evidence_boundary.clone(),
+            coverage_boundary: packet.flatness_reading.evidence_boundary.clone(),
+            non_conclusions: feature_report.non_conclusions.clone(),
+        }],
+        semantic_diagram_evidence: Vec::new(),
+        state_effect_law_evidence: vec![AatStateEffectLawEvidenceV0 {
+            evidence_ref: "evidence:selected-law-policy:analysis-packet".to_string(),
+            law_kind: packet.selected_law_policy_ref.artifact_id.clone(),
+            law_case_refs: packet
+                .signature_axes
+                .iter()
+                .map(|axis| axis.law_ref.clone())
+                .collect(),
+            measurement_status: "partiallyMeasured".to_string(),
+            witness_refs: witness_refs.clone(),
+            unmeasured_law_families: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+            non_conclusions: packet.non_conclusions.clone(),
+        }],
+        repair_synthesis_evidence: vec![AatRepairSynthesisEvidenceV0 {
+            evidence_ref: "evidence:repair-candidates:analysis-packet".to_string(),
+            repair_step_refs: packet
+                .repair_operation_candidates
+                .iter()
+                .map(|candidate| candidate.repair_operation_candidate_id.clone())
+                .collect(),
+            synthesis_candidate_refs: Vec::new(),
+            no_solution_certificate_refs: Vec::new(),
+            selected_obstruction_decrease_refs: packet
+                .repair_operation_candidates
+                .iter()
+                .flat_map(|candidate| candidate.target_obstruction_refs.clone())
+                .collect(),
+            transferred_risk_refs: packet
+                .repair_operation_candidates
+                .iter()
+                .flat_map(|candidate| candidate.transfer_risks.clone())
+                .collect(),
+            solver_status: "not-run".to_string(),
+            non_conclusions: vec![
+                "repair candidates are review hypotheses, not guaranteed improvements".to_string(),
+            ],
+        }],
+        analytic_axes: vec![AatAnalyticAxisV0 {
+            axis_id: "analytic:archsig-analysis-packet".to_string(),
+            metric_ref: "archsigAnalysis.signatureAxes".to_string(),
+            representation_strength: vec!["law-policy-relative".to_string()],
+            selected_witness_universe: witness_refs.clone(),
+            aggregate_zero_reflection:
+                "zero selected axes still requires explicit coverage and exactness assumptions"
+                    .to_string(),
+            coverage_assumptions: packet.atom_configuration_summary.coverage_summary.clone(),
+            non_conclusions: packet.non_conclusions.clone(),
+        }],
+        theorem_boundaries: vec![AatTheoremBoundaryV0 {
+            boundary_ref: "boundary:archsig-analysis-theorem-preconditions".to_string(),
+            claim_ref: theorem_claim_ref,
+            claim_level: "tooling-analysis".to_string(),
+            claim_classification: "review".to_string(),
+            missing_preconditions: theorem_check
+                .checks
+                .iter()
+                .flat_map(|check| check.missing_preconditions.clone())
+                .collect(),
+            measured_violation_refs: witness_refs,
+            review_action_ref: "review:inspect-analysis-packet-boundaries".to_string(),
+            non_conclusions: vec!["theorem precondition check is not a Lean proof".to_string()],
+        }],
+        review_actions: vec![AatReviewActionV0 {
+            review_action_id: "review:inspect-analysis-packet-boundaries".to_string(),
+            category: "human-review".to_string(),
+            source_refs: source_ref_ids.clone(),
+            action:
+                "inspect ArchSig analysis packet boundaries before interpreting repair candidates"
+                    .to_string(),
+            next_evidence: packet.flatness_reading.blocked_by_coverage_gaps.clone(),
+            owner: "human-reviewer".to_string(),
+            non_conclusions: packet.non_conclusions.clone(),
+        }],
+        llm_review_surface: AatLlmReviewSurfaceV0 {
+            skill_ref: "tools/archsig/skills/aat-reviewer/SKILL.md".to_string(),
+            input_artifact_refs: source_ref_ids,
+            review_questions: vec![
+                "Which selected LawPolicy generated the obstruction circuit?".to_string(),
+                "Which observation gaps block flatness or global zero readings?".to_string(),
+                "Which repair candidates preserve declared invariants?".to_string(),
+            ],
+            output_categories: vec![
+                "selectedPolicyObstruction".to_string(),
+                "coverageGap".to_string(),
+                "repairCandidate".to_string(),
+                "nonConclusion".to_string(),
+            ],
+            deterministic_inputs: vec![
+                "ArchSig analysis packet".to_string(),
+                "AIR projection from analysis packet".to_string(),
+                "theorem precondition checks".to_string(),
+                "feature report analysis summary".to_string(),
+            ],
+            llm_judgment_boundaries: vec![
+                "interpret repair candidate tradeoffs".to_string(),
+                "translate evidence gaps into next review questions".to_string(),
+            ],
+            human_review_boundaries: vec![
+                "risk acceptance".to_string(),
+                "merge approval".to_string(),
+            ],
+            non_conclusions: packet.non_conclusions.clone(),
+        },
+        responsibility_boundary: AatResponsibilityBoundaryV0 {
+            deterministic_tool: vec![
+                "validate analysis packet schema and refs".to_string(),
+                "project packet claims into AIR and review artifacts".to_string(),
+            ],
+            llm_review: vec![
+                "interpret packet notes and repair candidates".to_string(),
+                "prioritize next evidence from gaps".to_string(),
+            ],
+            human_review: vec![
+                "accept residual risk".to_string(),
+                "decide implementation changes".to_string(),
+            ],
+            formal_proof: vec![
+                "Lean theorem packages remain separate from ArchSig validation".to_string(),
+            ],
+            non_conclusions: packet.non_conclusions.clone(),
+        },
+        non_conclusions: stable_strings(
+            packet
+                .non_conclusions
+                .iter()
+                .cloned()
+                .chain([
+                    "AAT observable bundle is generated from ArchSig analysis packet state"
+                        .to_string(),
+                    "AAT observable bundle is tooling evidence, not a Lean theorem proof"
+                        .to_string(),
+                    "unmeasured is not measured zero".to_string(),
+                    "validation pass does not prove extractor completeness".to_string(),
+                    "LLM review output is judgment support, not automatic merge approval"
+                        .to_string(),
+                ])
+                .collect(),
+        ),
+    }
+}
+
+fn archsig_analysis_concept_mappings(
+    packet: &ArchSigAnalysisPacketV0,
+    feature_report: &FeatureExtensionReportV0,
+) -> Vec<AatConceptMappingV0> {
+    vec![
+        archmap_concept_mapping(
+            "concept:architecture-object",
+            "ArchitectureObject / ComponentUniverse",
+            "partiallyMeasured",
+            "reviewable",
+            &["atom observations are source-grounded, not universal atom truth"],
+        ),
+        archmap_concept_mapping(
+            "concept:obstruction-witness",
+            "ObstructionWitness",
+            if packet.obstruction_circuits.is_empty() {
+                "measuredZeroUnderSelectedPolicy"
+            } else {
+                "measuredNonzero"
+            },
+            "reviewable",
+            &["obstruction circuits are computed by ArchSig from ArchMap plus LawPolicy"],
+        ),
+        archmap_concept_mapping(
+            "concept:signature-axis",
+            "AnalyticRepresentation / ObstructionValuation",
+            "partiallyMeasured",
+            &feature_report.review_summary.required_action,
+            &["signature axes are law-policy-relative, not universal quality scores"],
+        ),
+        archmap_concept_mapping(
+            "concept:theorem-boundary",
+            "TheoremBoundary / NonConclusion",
+            "unmeasured",
+            "reviewable",
+            &["theorem boundary status records blocked preconditions and guardrails"],
+        ),
+        archmap_concept_mapping(
+            "concept:operation",
+            "ArchitectureOperation",
+            "partiallyMeasured",
+            "reviewable",
+            &["repair operation candidates are not automatic safe refactorings"],
+        ),
+        archmap_concept_mapping(
+            "concept:projection-observation",
+            "Projection / Observation / LSP / DIP",
+            "partiallyMeasured",
+            "reviewable",
+            &["analysis packet projection is review evidence, not semantic preservation proof"],
+        ),
+        archmap_concept_mapping(
+            "concept:feature-extension",
+            "FeatureExtension / ExtensionObstruction",
+            if packet.obstruction_circuits.is_empty() {
+                "unmeasured"
+            } else {
+                "partiallyMeasured"
+            },
+            "reviewable",
+            &["feature report is derived from selected analysis packet state"],
+        ),
+        archmap_concept_mapping(
+            "concept:semantic-diagram",
+            "Path / Homotopy / DiagramFiller / NonFillability",
+            "unmeasured",
+            "reviewable",
+            &["semantic diagram evidence is not reconstructed from the packet adapter"],
+        ),
+        archmap_concept_mapping(
+            "concept:state-effect",
+            "StateTransition / EffectBoundary",
+            "partiallyMeasured",
+            "reviewable",
+            &["state/effect law evidence is selected-law-policy-relative"],
+        ),
+        archmap_concept_mapping(
+            "concept:repair-synthesis",
+            "Repair / Synthesis / ComplexityTransfer",
+            "outOfScope",
+            "reviewable",
+            &["repair synthesis is not run by the analysis packet adapter"],
+        ),
+    ]
+}
+
+fn axis_measurement_boundary(value: i64) -> String {
+    if value == 0 {
+        "measuredZero".to_string()
+    } else {
+        "measuredNonzero".to_string()
+    }
+}
+
+fn stable_fragment(value: &str) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn stable_strings(mut values: Vec<String>) -> Vec<String> {
+    values.sort();
+    values.dedup();
+    values
 }
 
 fn observable_bundle_from_archmap_workflow(

--- a/tools/archsig/src/pr_quality.rs
+++ b/tools/archsig/src/pr_quality.rs
@@ -1,6 +1,6 @@
 use crate::validation::{count_checks, validation_check};
 use crate::{
-    PR_QUALITY_ANALYSIS_REPORT_SCHEMA_VERSION,
+    ARCHMAP_SCHEMA_VERSION, PR_QUALITY_ANALYSIS_REPORT_SCHEMA_VERSION,
     PR_QUALITY_ANALYSIS_VALIDATION_REPORT_SCHEMA_VERSION, PrQualityAnalysisReportV0,
     PrQualityAnalysisValidationInput, PrQualityAnalysisValidationReportV0,
     PrQualityAnalysisValidationSummary, PrQualityArchMapArtifactRefV0, PrQualityArtifactRefV0,
@@ -22,7 +22,7 @@ pub fn static_pr_quality_analysis_report() -> PrQualityAnalysisReportV0 {
         archmap_ref: PrQualityArchMapArtifactRefV0 {
             artifact_id: "artifact:archmap".to_string(),
             artifact_kind: "archmap".to_string(),
-            schema_version: Some("archmap-v0".to_string()),
+            schema_version: Some(ARCHMAP_SCHEMA_VERSION.to_string()),
             path: "archmap.json".to_string(),
             selected_map_item_ids: vec!["object-route-users".to_string()],
             non_conclusions: strings(&PR_QUALITY_NON_CONCLUSIONS),

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -21,7 +21,7 @@ fn cli_help_excludes_fieldsig_owned_commands() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("archmap-workflow"),
-        "ArchSig help must expose the ArchMap-primary workflow\n{stdout}"
+        "ArchSig help must expose the bounded ArchMap projection workflow\n{stdout}"
     );
     assert!(
         stdout.contains("adapter-scan"),
@@ -53,8 +53,8 @@ fn cli_rejects_implicit_scan_default() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("ArchSig is ArchMap-primary"),
-        "implicit scan should be rejected with an ArchMap-primary boundary\n{stderr}"
+        stderr.contains("ArchSig is LLM-native"),
+        "implicit scan should be rejected with an LLM-native boundary\n{stderr}"
     );
 }
 
@@ -320,6 +320,65 @@ fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
     );
     let llm_packet = read_json(&out_dir.join("llm-interpretation-packet.json"));
     assert_eq!(llm_packet, analysis_packet);
+
+    let air_json = read_json(&out_dir.join("air.json"));
+    assert_eq!(air_json["schemaVersion"], "aat-air-v0");
+    assert_eq!(
+        air_json["feature"]["source"].as_str(),
+        Some("manual"),
+        "analysis-packet AIR remains a bounded manual review projection"
+    );
+    assert!(
+        air_json["artifacts"]
+            .as_array()
+            .expect("AIR artifacts are array")
+            .iter()
+            .any(|artifact| artifact["kind"] == "archsig_analysis_packet"),
+        "AIR must be projected from the ArchSig analysis packet"
+    );
+    assert!(
+        !serde_json::to_string(&air_json)
+            .expect("AIR serializes")
+            .contains("archmap-v0-projection"),
+        "LLM-native downstream AIR must not use the legacy ArchMap projection rule"
+    );
+    let air_validation = read_json(&out_dir.join("air-validation.json"));
+    assert_eq!(air_validation["summary"]["result"].as_str(), Some("pass"));
+    let theorem_check = read_json(&out_dir.join("theorem-precondition-check.json"));
+    assert_eq!(
+        theorem_check["schemaVersion"],
+        "theorem-precondition-check-report-v0"
+    );
+    let feature_report = read_json(&out_dir.join("feature-report.json"));
+    assert_eq!(
+        feature_report["schemaVersion"],
+        "feature-extension-report-v0"
+    );
+    assert_eq!(
+        feature_report["homomorphismSummary"]["domain"].as_str(),
+        Some("archmap-observation-map-v0"),
+        "Feature Report must read the new ArchMap observation boundary"
+    );
+    assert_eq!(
+        feature_report["homomorphismSummary"]["codomain"].as_str(),
+        Some("archsig-analysis-packet-v0"),
+        "Feature Report must carry ArchSig analysis packet state forward"
+    );
+    let bundle = read_json(&out_dir.join("aat-observable-bundle.json"));
+    assert_eq!(bundle["schemaVersion"], "aat-observable-bundle-v0");
+    let source_ref_ids = bundle["sourceRefs"]
+        .as_array()
+        .expect("source refs are array")
+        .iter()
+        .map(|entry| entry["sourceRefId"].as_str().expect("source ref id"))
+        .collect::<Vec<_>>();
+    assert!(source_ref_ids.contains(&"source:archsig-analysis-packet:primary"));
+    assert!(source_ref_ids.contains(&"source:air:analysis-packet"));
+    let bundle_validation = read_json(&out_dir.join("aat-observable-bundle-validation.json"));
+    assert_eq!(
+        bundle_validation["summary"]["result"].as_str(),
+        Some("pass")
+    );
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/minimal/aat_observable_bundle.json
+++ b/tools/archsig/tests/fixtures/minimal/aat_observable_bundle.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": "aat-observable-bundle-v0",
   "bundleId": "fixture-aat-observable-bundle-v0",
-  "architectureId": "coupon-service",
+  "architectureId": "llm-native-archsig-fixture",
   "sourceRefs": [
     {
-      "sourceRefId": "source:air:coupon",
+      "sourceRefId": "source:air:analysis-packet",
       "artifactKind": "air",
       "schemaVersion": "aat-air-v0",
       "path": "tools/archsig/tests/fixtures/air/good_extension.json",
@@ -20,22 +20,25 @@
       ]
     },
     {
-      "sourceRefId": "source:archmap:coupon",
+      "sourceRefId": "source:archsig-analysis-packet:fixture",
       "artifactKind": "archmap",
-      "schemaVersion": "archmap-v0",
+      "schemaVersion": "archmap-observation-map-v0",
       "path": "tools/archsig/tests/fixtures/minimal/archmap.json",
       "retainedFields": [
         "sourceUniverse",
-        "mapItems",
-        "coverage",
-        "conflicts"
+        "atomObservations",
+        "moleculeObservations",
+        "semanticObservations",
+        "observationGaps",
+        "projectionInfo",
+        "concernHints"
       ],
       "nonConclusions": [
         "source ref does not prove artifact completeness"
       ]
     },
     {
-      "sourceRefId": "source:feature-report:coupon",
+      "sourceRefId": "source:feature-report:analysis-packet",
       "artifactKind": "feature-extension-report",
       "schemaVersion": "feature-extension-report-v0",
       "path": "tools/archsig/tests/fixtures/minimal/feature_extension_report.json",
@@ -50,10 +53,10 @@
     }
   ],
   "selectedUniverse": {
-    "universeId": "universe:coupon-selected",
+    "universeId": "universe:llm-native-selected",
     "includedRefs": [
-      "component:checkout",
-      "component:coupon"
+      "component:archmap-observation",
+      "component:archsig-analysis"
     ],
     "excludedRefs": [
       "component:billing-private"
@@ -85,8 +88,8 @@
       "conceptId": "concept:architecture-object",
       "aatConcept": "ArchitectureObject / ComponentUniverse",
       "artifactRefs": [
-        "source:archmap:coupon",
-        "source:air:coupon"
+        "source:archsig-analysis-packet:fixture",
+        "source:air:analysis-packet"
       ],
       "reportRefs": [
         "coverage-boundary:dynamic-dispatch"
@@ -107,7 +110,7 @@
       "conceptId": "concept:obstruction-witness",
       "aatConcept": "ObstructionWitness",
       "artifactRefs": [
-        "source:feature-report:coupon"
+        "source:feature-report:analysis-packet"
       ],
       "reportRefs": [
         "witness:projection-mismatch",
@@ -172,7 +175,7 @@
       "conceptId": "concept:projection-observation",
       "aatConcept": "Projection / Observation / LSP / DIP",
       "artifactRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "reportRefs": [
         "evidence:projection-abstraction"
@@ -193,7 +196,7 @@
       "conceptId": "concept:feature-extension",
       "aatConcept": "FeatureExtension / ExtensionObstruction",
       "artifactRefs": [
-        "source:feature-report:coupon"
+        "source:feature-report:analysis-packet"
       ],
       "reportRefs": [
         "feature-evidence:coupon-extension"
@@ -214,7 +217,7 @@
       "conceptId": "concept:semantic-diagram",
       "aatConcept": "Path / Homotopy / DiagramFiller / NonFillability",
       "artifactRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "reportRefs": [
         "semantic:evidence:coupon-noncommutation"
@@ -235,7 +238,7 @@
       "conceptId": "concept:state-effect",
       "aatConcept": "StateTransition / EffectBoundary",
       "artifactRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "reportRefs": [
         "state-effect:evidence:coupon-replay"
@@ -256,7 +259,7 @@
       "conceptId": "concept:repair-synthesis",
       "aatConcept": "Repair / Synthesis / ComplexityTransfer",
       "artifactRefs": [
-        "source:feature-report:coupon"
+        "source:feature-report:analysis-packet"
       ],
       "reportRefs": [
         "repair:evidence:coupon-boundary"
@@ -319,7 +322,7 @@
         "concept:projection-observation"
       ],
       "artifactRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "measurementStatus": "measuredNonzero",
       "value": 1,
@@ -378,7 +381,7 @@
         "law:lsp-observation-preservation"
       ],
       "sourceRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "measurementStatus": "measuredNonzero",
       "severity": "high",
@@ -394,7 +397,7 @@
         "law:semantic-commutation"
       ],
       "sourceRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "measurementStatus": "measuredNonzero",
       "severity": "medium",
@@ -410,7 +413,7 @@
         "law:effect-boundary"
       ],
       "sourceRefs": [
-        "source:air:coupon"
+        "source:air:analysis-packet"
       ],
       "measurementStatus": "partiallyMeasured",
       "severity": "medium",
@@ -426,7 +429,7 @@
         "law:repair-selected-axis"
       ],
       "sourceRefs": [
-        "source:feature-report:coupon"
+        "source:feature-report:analysis-packet"
       ],
       "measurementStatus": "reviewNeeded",
       "severity": "medium",
@@ -468,7 +471,7 @@
     {
       "evidenceRef": "evidence:projection-abstraction",
       "evidenceKind": "projectionMismatch",
-      "sourceRef": "component:coupon-adapter",
+      "sourceRef": "component:archsig-analysis-adapter",
       "targetRef": "interface:discount-policy",
       "localContractBoundary": "LSP cue over selected interface methods",
       "globalLayeringBoundary": "does not conclude global Clean Architecture compliance",
@@ -491,7 +494,7 @@
         "residualCoverageGap"
       ],
       "sourceRefs": [
-        "source:feature-report:coupon"
+        "source:feature-report:analysis-packet"
       ],
       "witnessRefs": [
         "witness:projection-mismatch"
@@ -718,13 +721,13 @@
   "llmReviewSurface": {
     "skillRef": "tools/archsig/skills/aat-reviewer/SKILL.md",
     "inputArtifactRefs": [
-      "source:air:coupon",
-      "source:feature-report:coupon",
+      "source:air:analysis-packet",
+      "source:feature-report:analysis-packet",
       "bundle:fixture-aat-observable-bundle-v0"
     ],
     "reviewQuestions": [
       "Which invariant is preserved, broken, unmeasured, or out of scope?",
-      "Which obstruction witnesses are measured, and which witness families remain unmeasured?",
+      "Which obstruction witnesses are typed as obstruction circuits, and which circuit families remain unmeasured?",
       "Which operation family is plausible, and what must stay a human judgment?",
       "Which theorem boundary blocks a formal claim?",
       "What next evidence would change the review decision?"

--- a/tools/archsig/tests/fixtures/minimal/pr_quality_analysis_report.json
+++ b/tools/archsig/tests/fixtures/minimal/pr_quality_analysis_report.json
@@ -5,7 +5,7 @@
     "artifactId": "artifact:archmap",
     "artifactKind": "archmap",
     "path": "archmap.json",
-    "schemaVersion": "archmap-v0",
+    "schemaVersion": "archmap-observation-map-v0",
     "selectedMapItemIds": [
       "object-route-users"
     ],


### PR DESCRIPTION
## 概要

Closes #1335

旧 ArchMap projection 面を current workflow の source of truth から外し、`llm-native-workflow` の downstream review artifacts を `archsig-analysis-packet-v0` 起点に再配線しました。

- `llm-native-workflow` が AIR / AIR validation / theorem check / Feature Report / AAT Observable Bundle まで生成
- downstream AIR projection に `archsig-analysis-packet-to-air-v0` 境界を追加
- Feature Report の analysis summary を ArchMap observation schema -> ArchSig analysis packet として上書き
- AAT Observable Bundle を analysis packet 起点で生成し、static fixture residue を更新
- README / command docs / docs/tool の説明を LLM-native pipeline に同期

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical tooling / design tracking` として扱っている
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
