### PR TITLE
FieldSigをArchSig analysis handoffへ再配線

### DIFF
--- a/docs/sft/aat_interface.md
+++ b/docs/sft/aat_interface.md
@@ -73,8 +73,12 @@ Lean 側では `Formal/Arch/Evolution/SFTInterfaceBoundary.lean` の
 `Formal/Arch/Observation/AtomPresentation.lean` と
 `Formal/Arch/Observation/ArchMap.lean` の observation layer に分離する。
 SFT が読むのは raw ArchMap candidate ではなく、AATCore transition に接続された
-selected observation / delta boundary である。旧 compatibility surface は #1307 で
-archive せず削除し、Lean source of truth は `AtomAxiomSystem` / `AATCore` /
+selected observation / delta boundary である。tooling handoff では、FieldSig は raw
+ArchMap observation ではなく `archsig-analysis-packet-v0` を局所 AAT algebra state
+として読む。obstruction circuit、signature axis、repair candidate、coverage gap は
+SFT の forecast truth ではなく、`operation-support-estimate-v0` へ渡される bounded
+coordinate / unknown remainder である。旧 compatibility surface は #1307 で archive
+せず削除し、Lean source of truth は `AtomAxiomSystem` / `AATCore` /
 `AATCoreTransition` に一本化する。
 
 ## 3. SFT 側で導入するもの

--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -44,3 +44,14 @@ These files are handoff fixtures. FieldSig wiring is handled in the dedicated
 FieldSig issue; the fixtures exist here so the handoff target is stable. The
 FieldSig test suite reads these files as JSON contract fixtures and locks their
 schema versions, LawPolicy split, and concern/gap guardrails.
+
+FieldSig's current handoff command reads the ArchSig analysis packet, not raw
+ArchMap observations:
+
+```text
+archsig-analysis-packet-v0 -> operation-support-estimate-v0
+```
+
+The projection keeps obstruction circuits, signature axes, repair candidates,
+and coverage gaps as bounded local AAT state. It does not promote raw ArchMap
+observations to forecast truth.

--- a/tools/fieldsig/docs/commands.md
+++ b/tools/fieldsig/docs/commands.md
@@ -1,6 +1,6 @@
 # FieldSig Commands
 
-FieldSig owns SFT software evolution measurement and workflow-evidence artifacts. ArchSig artifacts enter FieldSig through JSON refs such as `archmap-v0`, `archsig-sig0-v0`, AIR, validation, and review-cue artifact paths. `archmap-sft-input` preserves ArchMap atom / circuit / observation gap refs as observation refs and unknown remainder refs; it does not consume them as certified atoms, zero-curvature proof, or forecast correctness. FieldSig does not share Rust types with ArchSig as a contract; the stable boundary is the serialized artifact ref.
+FieldSig owns SFT software evolution measurement and workflow-evidence artifacts. The current ArchSig handoff is the serialized `archsig-analysis-packet-v0`: FieldSig reads it as local AAT algebra state, not as forecast truth, causal correctness, or global safety. `archsig-analysis-sft-input` projects that packet into `operation-support-estimate-v0` while preserving obstruction circuits, signature axes, repair candidates, and coverage gaps as bounded refs. `archmap-sft-input` remains a legacy bounded projection and must not promote raw ArchMap observations to forecast truth. FieldSig does not share Rust types with ArchSig as a contract; the stable boundary is the serialized artifact ref.
 
 ## Measurement
 
@@ -10,6 +10,17 @@ FieldSig owns SFT software evolution measurement and workflow-evidence artifacts
 ## Forecast and Intent
 
 Use `artifact-descriptor`, `intent-map`, `intent-archmap-alignment`, `intent-forecast`, `operation-support-estimate`, `forecast-cone-skeleton`, `consequence-envelope`, `sft-review-summary`, `forecast-calibration-hook`, `intent-calibration-record`, and `sft-forecast` for bounded SFT forecast artifacts. These commands preserve missing evidence and unknown remainder; they do not create probability or causal-correctness claims.
+
+ArchSig analysis packet handoff:
+
+```bash
+cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
+  --analysis-packet tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json \
+  --out .fieldsig/operation-support-estimate.json
+```
+
+This command rejects raw ArchMap JSON when it is supplied as the analysis-packet
+input. The accepted boundary is `archsig-analysis-packet-v0`.
 
 ## Operational and Governance
 

--- a/tools/fieldsig/src/archmap.rs
+++ b/tools/fieldsig/src/archmap.rs
@@ -163,6 +163,96 @@ pub fn build_operation_support_estimate_from_archmap(
     }
 }
 
+pub fn build_operation_support_estimate_from_archsig_analysis_packet(
+    packet: &serde_json::Value,
+    input_path: &str,
+) -> Result<OperationSupportEstimateV0, Box<dyn std::error::Error>> {
+    let schema_version = packet
+        .get("schemaVersion")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if schema_version != "archsig-analysis-packet-v0" {
+        return Err(format!(
+            "FieldSig ArchSig handoff requires archsig-analysis-packet-v0, got {schema_version}"
+        )
+        .into());
+    }
+    let analysis_id = packet
+        .get("analysisId")
+        .and_then(|value| value.as_str())
+        .unwrap_or("archsig-analysis-packet");
+    let source_ref_ids = archsig_packet_sft_source_refs(packet, input_path);
+    let action_class_candidate_ids = archsig_packet_action_candidate_ids(packet);
+    let candidate_operation_families =
+        archsig_packet_candidate_families(packet, &source_ref_ids, &action_class_candidate_ids);
+    let family_ids = candidate_operation_families
+        .iter()
+        .map(|family| family.family_id.clone())
+        .collect::<Vec<_>>();
+    let non_conclusions = archsig_packet_sft_non_conclusions(packet);
+
+    Ok(OperationSupportEstimateV0 {
+        schema_version: OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION.to_string(),
+        estimate_id: format!("estimate:archsig-analysis:{}", stable_id(analysis_id)),
+        descriptor_ref: OperationSupportDescriptorRefV0 {
+            descriptor_schema_version: ARTIFACT_DESCRIPTOR_SCHEMA_VERSION.to_string(),
+            descriptor_id: format!("descriptor:archsig-analysis:{analysis_id}"),
+            artifact_kind: "archsig-analysis-packet".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            action_class_candidate_ids: action_class_candidate_ids.clone(),
+            non_conclusions: non_conclusions.clone(),
+        },
+        candidate_operation_families,
+        policy_constraints: vec![OperationSupportPolicyConstraintV0 {
+            constraint_id: "constraint:archsig-analysis:no-forecast-truth-promotion".to_string(),
+            constraint_kind: "claim-boundary".to_string(),
+            applies_to_family_ids: family_ids.clone(),
+            source_ref_ids: source_ref_ids.clone(),
+            rule: "ArchSig analysis packet is local AAT algebra state for SFT input, not forecast truth".to_string(),
+            safety_claim_boundary:
+                "SFT consumes selected obstruction, axis, repair, and gap refs as bounded coordinates only"
+                    .to_string(),
+            policy_refs: vec!["policy:archsig-analysis-sft-boundary".to_string()],
+            support_disposition: "conditionallyAllowed".to_string(),
+            governance_action_refs: vec!["governance:review-archsig-analysis-handoff".to_string()],
+            non_conclusions: non_conclusions.clone(),
+        }],
+        known_forbidden_support: vec![KnownForbiddenOperationSupportV0 {
+            forbidden_id: "forbidden:raw-archmap-forecast-truth".to_string(),
+            operation_family: "raw-archmap-truth-promotion".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            constraint_refs: vec![
+                "constraint:archsig-analysis:no-forecast-truth-promotion".to_string(),
+            ],
+            reason: "raw ArchMap observations and ArchSig analysis packets do not assert SFT forecast correctness".to_string(),
+            boundary: "FieldSig must keep ArchSig packet refs as bounded local AAT state, not ground truth".to_string(),
+            non_conclusions: non_conclusions.clone(),
+        }],
+        unknown_remainder: archsig_packet_unknown_remainders(packet, &family_ids, &source_ref_ids),
+        evidence_boundary: OperationSupportEvidenceBoundaryV0 {
+            boundary_id: format!("boundary:archsig-analysis:{}:sft-input", stable_id(analysis_id)),
+            source_ref_ids,
+            measurement_boundary_refs: archsig_packet_measurement_boundary_refs(packet),
+            confidence_boundary:
+                "ArchSig analysis packet confidence is structural review evidence, not probability"
+                    .to_string(),
+            evidence_kinds: vec![
+                "archsig-analysis-packet".to_string(),
+                "selected-law-policy".to_string(),
+                "archmap-observation-map".to_string(),
+            ],
+            unsupported_constructs: json_string_array(packet, &["excludedReadings"]),
+            assumptions: vec![
+                "FieldSig reads ArchSig analysis packet refs as local AAT algebra state".to_string(),
+                "obstruction circuits are law-policy-relative coordinates, not causal proof".to_string(),
+                "observation gaps remain unknown remainder, not measured zero".to_string(),
+            ],
+            non_conclusions,
+        },
+        non_conclusions: archsig_packet_sft_non_conclusions(packet),
+    })
+}
+
 pub fn build_air_from_archmap(
     document: &ArchMapDocumentV0,
     input_path: &str,
@@ -457,6 +547,187 @@ pub fn build_air_from_archmap(
             split_status: "unmeasured".to_string(),
         },
     }
+}
+
+fn archsig_packet_sft_source_refs(packet: &serde_json::Value, input_path: &str) -> Vec<String> {
+    let mut refs = vec![format!("source:archsig-analysis-packet:{input_path}")];
+    refs.extend(json_string_array(
+        packet,
+        &["atomConfigurationSummary", "sourceRefs"],
+    ));
+    refs.extend(
+        packet
+            .get("obstructionCircuits")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|obstruction| obstruction.get("obstructionCircuitId")?.as_str())
+            .map(|id| format!("archsigObstructionCircuit:{id}")),
+    );
+    refs.extend(
+        packet
+            .get("signatureAxes")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|axis| axis.get("signatureAxisId")?.as_str())
+            .map(|id| format!("archsigSignatureAxis:{id}")),
+    );
+    unique_strings(refs)
+}
+
+fn archsig_packet_action_candidate_ids(packet: &serde_json::Value) -> Vec<String> {
+    let mut ids = json_object_string_array(
+        packet,
+        &["repairOperationCandidates"],
+        "repairOperationCandidateId",
+    );
+    ids.extend(json_object_string_array(
+        packet,
+        &["obstructionCircuits"],
+        "obstructionCircuitId",
+    ));
+    unique_strings(ids)
+}
+
+fn archsig_packet_candidate_families(
+    packet: &serde_json::Value,
+    source_ref_ids: &[String],
+    action_class_candidate_ids: &[String],
+) -> Vec<CandidateOperationFamilyV0> {
+    let non_conclusions = archsig_packet_sft_non_conclusions(packet);
+    let mut families = Vec::new();
+    for candidate in packet
+        .get("repairOperationCandidates")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+    {
+        let id = candidate
+            .get("repairOperationCandidateId")
+            .and_then(|value| value.as_str())
+            .unwrap_or("repair-operation-candidate");
+        let operation_family = candidate
+            .get("operationKind")
+            .and_then(|value| value.as_str())
+            .unwrap_or("archsig-repair-operation-candidate");
+        families.push(CandidateOperationFamilyV0 {
+            family_id: format!("family:archsig-repair:{}", stable_id(id)),
+            operation_family: operation_family.to_string(),
+            support_kind: "archsig-analysis-repair-candidate".to_string(),
+            action_class_candidate_ids: vec![id.to_string()],
+            source_ref_ids: source_ref_ids.to_vec(),
+            confidence: "medium".to_string(),
+            rationale: "repair candidate is read from ArchSig analysis packet as local AAT state"
+                .to_string(),
+            assumptions: json_string_array_value(candidate, "preconditions"),
+            non_conclusions: non_conclusions.clone(),
+        });
+    }
+    if families.is_empty() {
+        families.push(CandidateOperationFamilyV0 {
+            family_id: "family:archsig-review-only".to_string(),
+            operation_family: "review-selected-archsig-analysis".to_string(),
+            support_kind: "review-boundary".to_string(),
+            action_class_candidate_ids: action_class_candidate_ids.to_vec(),
+            source_ref_ids: source_ref_ids.to_vec(),
+            confidence: "low".to_string(),
+            rationale: "no repair candidate is present; FieldSig keeps the packet as review input"
+                .to_string(),
+            assumptions: vec!["selected LawPolicy may not cover all future SFT axes".to_string()],
+            non_conclusions,
+        });
+    }
+    families
+}
+
+fn archsig_packet_unknown_remainders(
+    packet: &serde_json::Value,
+    family_ids: &[String],
+    source_ref_ids: &[String],
+) -> Vec<OperationSupportUnknownRemainderV0> {
+    json_string_array(packet, &["flatnessReading", "blockedByCoverageGaps"])
+        .into_iter()
+        .map(|gap| OperationSupportUnknownRemainderV0 {
+            remainder_id: format!("unknown:archsig-analysis:{}", stable_id(&gap)),
+            affected_family_ids: family_ids.to_vec(),
+            source_ref_ids: source_ref_ids.to_vec(),
+            unknown_axes: vec![gap.clone()],
+            reason: "ArchSig flatness reading is blocked by a coverage gap".to_string(),
+            treatment: "carry as unknown remainder; do not round to absence, measured zero, or forecast truth".to_string(),
+            non_conclusions: archsig_packet_sft_non_conclusions(packet),
+        })
+        .collect()
+}
+
+fn archsig_packet_measurement_boundary_refs(packet: &serde_json::Value) -> Vec<String> {
+    let mut refs = json_string_array(packet, &["flatnessReading", "blockedByCoverageGaps"])
+        .into_iter()
+        .map(|gap| format!("archsigCoverageGap:{gap}"))
+        .collect::<Vec<_>>();
+    refs.extend(
+        packet
+            .get("signatureAxes")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|axis| axis.get("coverageStatus")?.as_str())
+            .map(|status| format!("archsigAxisCoverage:{status}")),
+    );
+    unique_strings(refs)
+}
+
+fn archsig_packet_sft_non_conclusions(packet: &serde_json::Value) -> Vec<String> {
+    let mut values = json_string_array(packet, &["nonConclusions"]);
+    values.extend([
+        "ArchSig analysis packet is FieldSig input state, not forecast correctness".to_string(),
+        "raw ArchMap observations are not promoted to SFT ground truth".to_string(),
+        "observation gaps are unknown remainder, not measured zero".to_string(),
+        "FieldSig handoff does not prove causal correctness or global safety".to_string(),
+    ]);
+    unique_strings(values)
+}
+
+fn json_string_array(packet: &serde_json::Value, path: &[&str]) -> Vec<String> {
+    let mut current = packet;
+    for key in path {
+        let Some(next) = current.get(*key) else {
+            return Vec::new();
+        };
+        current = next;
+    }
+    current
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn json_object_string_array(packet: &serde_json::Value, path: &[&str], key: &str) -> Vec<String> {
+    let mut current = packet;
+    for segment in path {
+        let Some(next) = current.get(*segment) else {
+            return Vec::new();
+        };
+        current = next;
+    }
+    current
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.get(key)?.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn json_string_array_value(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+        .collect()
 }
 
 fn check_archmap_schema_version(schema_version: &str) -> ValidationCheck {

--- a/tools/fieldsig/src/lib.rs
+++ b/tools/fieldsig/src/lib.rs
@@ -72,7 +72,8 @@ pub use architecture_policy::{
 };
 pub use archmap::{
     ArchMapSourceInventoryInput, build_air_from_archmap,
-    build_operation_support_estimate_from_archmap, validate_archmap_report,
+    build_operation_support_estimate_from_archmap,
+    build_operation_support_estimate_from_archsig_analysis_packet, validate_archmap_report,
 };
 pub use artifact_descriptor::{
     build_artifact_descriptor_from_ai_proposal_json,

--- a/tools/fieldsig/src/main.rs
+++ b/tools/fieldsig/src/main.rs
@@ -50,6 +50,7 @@ use fieldsig::{
     build_empirical_dataset, build_feature_extension_dataset_from_files,
     build_feature_extension_report, build_forecast_cone_skeleton_from_operation_support,
     build_law_violation_report, build_operation_support_estimate_from_archmap,
+    build_operation_support_estimate_from_archsig_analysis_packet,
     build_operation_support_estimate_from_descriptor,
     build_operation_support_estimate_from_intent_alignment,
     build_outcome_linkage_dataset_from_files, build_policy_decision_report,
@@ -547,6 +548,17 @@ enum Command {
         /// Input ArchMap JSON path.
         #[arg(long)]
         archmap: PathBuf,
+
+        /// Output operation-support-estimate-v0 JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Project an ArchSig analysis packet into SFT operation-support input.
+    ArchsigAnalysisSftInput {
+        /// Input archsig-analysis-packet-v0 JSON path.
+        #[arg(long = "analysis-packet")]
+        analysis_packet: PathBuf,
 
         /// Output operation-support-estimate-v0 JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
@@ -1648,6 +1660,18 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                     &document,
                     &archmap.display().to_string(),
                 );
+            write_json(out, &estimate)?;
+            Ok(ExitCode::SUCCESS)
+        }
+        Some(Command::ArchsigAnalysisSftInput {
+            analysis_packet,
+            out,
+        }) => {
+            let packet: serde_json::Value = read_json(&analysis_packet)?;
+            let estimate = build_operation_support_estimate_from_archsig_analysis_packet(
+                &packet,
+                &analysis_packet.display().to_string(),
+            )?;
             write_json(out, &estimate)?;
             Ok(ExitCode::SUCCESS)
         }

--- a/tools/fieldsig/src/signature_trajectory_report.rs
+++ b/tools/fieldsig/src/signature_trajectory_report.rs
@@ -64,6 +64,12 @@ pub fn static_signature_trajectory_report() -> SignatureTrajectoryReportV0 {
         Some(PR_FORCE_REPORT_SCHEMA_VERSION),
         Some("fixture-pr-force-report-v0"),
     );
+    let archsig_analysis_ref = artifact_ref(
+        "archsig-analysis-packet",
+        "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+        Some("archsig-analysis-packet-v0"),
+        Some("archsig-analysis-fixture"),
+    );
     let drift_ref = artifact_ref(
         "architecture-drift-ledger",
         "tools/archsig/tests/fixtures/minimal/architecture_drift_ledger.json",
@@ -101,11 +107,11 @@ pub fn static_signature_trajectory_report() -> SignatureTrajectoryReportV0 {
                         Some(json!(3)),
                         "measured",
                         None,
-                        vec![before_ref.clone()],
+                        vec![before_ref.clone(), archsig_analysis_ref.clone()],
                         boundary(
                             "signature",
                             &["boundaryViolationCount"],
-                            vec![before_ref.clone()],
+                            vec![before_ref.clone(), archsig_analysis_ref.clone()],
                             Some(window.clone()),
                             &["selected Signature snapshot is retained for the trajectory point"],
                             &["path safety outside the selected window"],
@@ -141,11 +147,19 @@ pub fn static_signature_trajectory_report() -> SignatureTrajectoryReportV0 {
                     Some(json!(5)),
                     "measured",
                     None,
-                    vec![middle_ref.clone(), force_ref.clone()],
+                    vec![
+                        middle_ref.clone(),
+                        force_ref.clone(),
+                        archsig_analysis_ref.clone(),
+                    ],
                     boundary(
                         "signature",
                         &["boundaryViolationCount"],
-                        vec![middle_ref.clone(), force_ref.clone()],
+                        vec![
+                            middle_ref.clone(),
+                            force_ref.clone(),
+                            archsig_analysis_ref.clone(),
+                        ],
                         Some(window.clone()),
                         &[
                             "trajectory point records an internal excursion before the selected endpoint",
@@ -169,11 +183,19 @@ pub fn static_signature_trajectory_report() -> SignatureTrajectoryReportV0 {
                     Some(json!(1)),
                     "measured",
                     None,
-                    vec![after_ref.clone(), force_ref.clone()],
+                    vec![
+                        after_ref.clone(),
+                        force_ref.clone(),
+                        archsig_analysis_ref.clone(),
+                    ],
                     boundary(
                         "signature",
                         &["boundaryViolationCount"],
-                        vec![after_ref.clone(), force_ref.clone()],
+                        vec![
+                            after_ref.clone(),
+                            force_ref.clone(),
+                            archsig_analysis_ref.clone(),
+                        ],
                         Some(window.clone()),
                         &["selected endpoint Signature snapshot is retained"],
                         &["global attractor inference"],

--- a/tools/fieldsig/tests/cli.rs
+++ b/tools/fieldsig/tests/cli.rs
@@ -379,6 +379,103 @@ fn fieldsig_locks_llm_native_archsig_handoff_fixtures() {
 }
 
 #[test]
+fn cli_projects_archsig_analysis_packet_to_sft_input_boundary() {
+    let out_dir = temp_dir("archsig-analysis-sft-input");
+    let root = fixture_root().join("llm_native_handoff");
+    let packet = root.join("archsig_analysis_packet.json");
+    let estimate = out_dir.join("operation-support-estimate.json");
+    let cone = out_dir.join("forecast-cone.json");
+
+    run_sig0(&[
+        "archsig-analysis-sft-input",
+        "--analysis-packet",
+        packet.to_str().expect("analysis packet path is utf-8"),
+        "--out",
+        estimate.to_str().expect("estimate path is utf-8"),
+    ]);
+    run_sig0(&[
+        "forecast-cone-skeleton",
+        "--operation-support",
+        estimate.to_str().expect("estimate path is utf-8"),
+        "--out",
+        cone.to_str().expect("cone path is utf-8"),
+    ]);
+
+    let estimate_json = read_json(&estimate);
+    assert_eq!(
+        estimate_json["schemaVersion"],
+        "operation-support-estimate-v0"
+    );
+    assert_eq!(
+        estimate_json["descriptorRef"]["artifactKind"],
+        "archsig-analysis-packet"
+    );
+    assert!(
+        estimate_json["candidateOperationFamilies"]
+            .as_array()
+            .expect("candidate families are array")
+            .iter()
+            .any(|family| family["supportKind"] == "archsig-analysis-repair-candidate"),
+        "FieldSig must read repair candidates from ArchSig analysis state"
+    );
+    assert!(
+        estimate_json["knownForbiddenSupport"]
+            .as_array()
+            .expect("forbidden support entries are array")
+            .iter()
+            .any(|entry| entry["operationFamily"] == "raw-archmap-truth-promotion"),
+        "raw ArchMap observation must not be promoted to forecast truth"
+    );
+    assert!(
+        estimate_json["unknownRemainder"]
+            .as_array()
+            .expect("unknown remainder is array")
+            .iter()
+            .any(|entry| {
+                entry["treatment"]
+                    .as_str()
+                    .expect("treatment is string")
+                    .contains("not round to absence, measured zero, or forecast truth")
+            }),
+        "coverage gaps must remain unknown remainder"
+    );
+
+    let cone_json = read_json(&cone);
+    assert!(
+        cone_json["operationSupportRef"]["sourceRefIds"]
+            .as_array()
+            .expect("source refs are array")
+            .iter()
+            .any(|source| {
+                source
+                    .as_str()
+                    .expect("source ref is string")
+                    .starts_with("source:archsig-analysis-packet:")
+            }),
+        "forecast cone must carry the ArchSig analysis packet boundary forward"
+    );
+
+    let rejected = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--analysis-packet",
+        fixture_root()
+            .join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+        "--out",
+        out_dir
+            .join("rejected.json")
+            .to_str()
+            .expect("rejected path is utf-8"),
+    ]);
+    assert!(!rejected.status.success());
+    assert!(
+        String::from_utf8_lossy(&rejected.stderr).contains("requires archsig-analysis-packet-v0"),
+        "raw ArchMap input must be rejected by the ArchSig analysis handoff command"
+    );
+}
+
+#[test]
 fn cli_validates_archmap_fixture_and_guardrails() {
     let out_dir = temp_dir("archmap-validation");
     let input = fixture_root().join("archmap.json");

--- a/tools/fieldsig/tests/fixtures/minimal/signature_trajectory_report.json
+++ b/tools/fieldsig/tests/fixtures/minimal/signature_trajectory_report.json
@@ -40,6 +40,12 @@
               "path": "tools/archsig/tests/fixtures/minimal/signature_snapshot_before.json",
               "schemaVersion": "signature-snapshot-store-v0",
               "artifactId": "fixture-trajectory-before-signature"
+            },
+            {
+              "kind": "archsig-analysis-packet",
+              "path": "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+              "schemaVersion": "archsig-analysis-packet-v0",
+              "artifactId": "archsig-analysis-fixture"
             }
           ],
           "measurementBoundary": {
@@ -53,6 +59,12 @@
                 "path": "tools/archsig/tests/fixtures/minimal/signature_snapshot_before.json",
                 "schemaVersion": "signature-snapshot-store-v0",
                 "artifactId": "fixture-trajectory-before-signature"
+              },
+              {
+                "kind": "archsig-analysis-packet",
+                "path": "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+                "schemaVersion": "archsig-analysis-packet-v0",
+                "artifactId": "archsig-analysis-fixture"
               }
             ],
             "extractorVersion": "0.1.0",
@@ -197,6 +209,12 @@
               "path": "tools/archsig/tests/fixtures/minimal/pr_force_report.json",
               "schemaVersion": "pr-force-report-v0",
               "artifactId": "fixture-pr-force-report-v0"
+            },
+            {
+              "kind": "archsig-analysis-packet",
+              "path": "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+              "schemaVersion": "archsig-analysis-packet-v0",
+              "artifactId": "archsig-analysis-fixture"
             }
           ],
           "measurementBoundary": {
@@ -216,6 +234,12 @@
                 "path": "tools/archsig/tests/fixtures/minimal/pr_force_report.json",
                 "schemaVersion": "pr-force-report-v0",
                 "artifactId": "fixture-pr-force-report-v0"
+              },
+              {
+                "kind": "archsig-analysis-packet",
+                "path": "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+                "schemaVersion": "archsig-analysis-packet-v0",
+                "artifactId": "archsig-analysis-fixture"
               }
             ],
             "extractorVersion": "0.1.0",
@@ -339,6 +363,12 @@
               "path": "tools/archsig/tests/fixtures/minimal/pr_force_report.json",
               "schemaVersion": "pr-force-report-v0",
               "artifactId": "fixture-pr-force-report-v0"
+            },
+            {
+              "kind": "archsig-analysis-packet",
+              "path": "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+              "schemaVersion": "archsig-analysis-packet-v0",
+              "artifactId": "archsig-analysis-fixture"
             }
           ],
           "measurementBoundary": {
@@ -358,6 +388,12 @@
                 "path": "tools/archsig/tests/fixtures/minimal/pr_force_report.json",
                 "schemaVersion": "pr-force-report-v0",
                 "artifactId": "fixture-pr-force-report-v0"
+              },
+              {
+                "kind": "archsig-analysis-packet",
+                "path": "tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json",
+                "schemaVersion": "archsig-analysis-packet-v0",
+                "artifactId": "archsig-analysis-fixture"
               }
             ],
             "extractorVersion": "0.1.0",


### PR DESCRIPTION
## 概要

Closes #1336

FieldSig が `archsig-analysis-packet-v0` を SFT の局所 AAT algebra state として読めるように再配線しました。

- `archsig-analysis-sft-input` コマンドを追加
- ArchSig analysis packet から `operation-support-estimate-v0` を生成
- raw ArchMap JSON を analysis packet 入力として渡した場合に拒否
- signature trajectory fixture に ArchSig analysis packet ref を追加
- FieldSig docs / SFT AAT interface / golden corpus docs に handoff 境界を反映

## 証明した定理

- なし

## 編集したドキュメント

- `docs/sft/aat_interface.md`
- `docs/tool/golden_corpus.md`
- `tools/fieldsig/docs/commands.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical tooling / design tracking` として扱っている
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
