### PR TITLE
LLM-native ArchMap/ArchSig E2EをCIに固定

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -39,3 +39,72 @@ jobs:
 
       - name: Test FieldSig
         run: cargo test --manifest-path tools/fieldsig/Cargo.toml
+
+  llm-native-e2e:
+    name: llm-native ArchMap/ArchSig e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run LLM-native ArchMap to FieldSig handoff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          out_dir=".lake/llm-native-e2e"
+          archsig_dir="$out_dir/archsig"
+          fieldsig_dir="$out_dir/fieldsig"
+          mkdir -p "$archsig_dir" "$fieldsig_dir"
+
+          cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
+            --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+            --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+            --out-dir "$archsig_dir"
+
+          test -s "$archsig_dir/archmap-validation.json"
+          test -s "$archsig_dir/law-policy-validation.json"
+          test -s "$archsig_dir/archsig-analysis-packet.json"
+          test -s "$archsig_dir/archsig-analysis-validation.json"
+          test -s "$archsig_dir/llm-interpretation-packet.json"
+
+          cmp "$archsig_dir/archsig-analysis-packet.json" "$archsig_dir/llm-interpretation-packet.json"
+
+          jq -e '
+            .schemaVersion == "archsig-analysis-packet-v0"
+            and .archMapRef.schemaVersion == "archmap-observation-map-v0"
+            and .selectedLawPolicyRef.schemaVersion == "law-policy-v0"
+            and ((.obstructionCircuits | length) > 0)
+            and ((.signatureAxes | length) > 0)
+            and ([.nonConclusions[] | contains("not a Lean theorem proof")] | any)
+          ' "$archsig_dir/archsig-analysis-packet.json"
+
+          jq -e '
+            .summary.result == "pass"
+            and ([.checks[]?.id] | index("archsig-analysis-packet-non-conclusion-boundary") != null)
+          ' "$archsig_dir/archsig-analysis-validation.json"
+
+          cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
+            --analysis-packet "$archsig_dir/archsig-analysis-packet.json" \
+            --out "$fieldsig_dir/operation-support-estimate.json"
+
+          jq -e '
+            .schemaVersion == "operation-support-estimate-v0"
+            and .descriptorRef.artifactKind == "archsig-analysis-packet"
+            and ([.candidateOperationFamilies[]?.supportKind] | index("archsig-analysis-repair-candidate") != null)
+            and ([.knownForbiddenSupport[]?.operationFamily] | index("raw-archmap-truth-promotion") != null)
+            and ([.unknownRemainder[]?.treatment] | map(contains("not round to absence, measured zero, or forecast truth")) | any)
+          ' "$fieldsig_dir/operation-support-estimate.json"
+
+          if cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
+            --analysis-packet tools/archsig/tests/fixtures/minimal/archmap.json \
+            --out "$fieldsig_dir/raw-archmap-rejected.json"; then
+            echo "FieldSig accepted raw ArchMap as ArchSig analysis packet" >&2
+            exit 1
+          fi
+
+      - name: Upload LLM-native e2e artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-native-e2e-${{ github.run_id }}
+          path: .lake/llm-native-e2e

--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -22,6 +22,7 @@ Atom handoff checklist:
 - [LawPolicy](law_policy.md)
 - [ArchSig Analysis Packet](archsig_analysis_packet.md)
 - [LLM-Native Golden Corpus](golden_corpus.md)
+- [LLM-native E2E Workflow](llm_native_e2e_workflow.md)
 
 Forward design PRDs:
 

--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -1,0 +1,91 @@
+# LLM-native ArchMap / ArchSig E2E Workflow
+
+This document fixes the end-to-end workflow required by the LLM-native
+ArchMap / LawPolicy / ArchSig redesign. It is an implementation transcript,
+not a new theory document.
+
+## Flow
+
+```text
+source artifacts
+  -> supplied archmap-observation-map-v0
+  -> selected law-policy-v0
+  -> archsig-analysis-packet-v0
+  -> llm-interpretation-packet.json
+  -> operation-support-estimate-v0
+```
+
+The first three artifacts are ArchSig-owned. The final
+`operation-support-estimate-v0` is FieldSig-owned and reads the ArchSig
+analysis packet as bounded local AAT state.
+
+## Command Transcript
+
+Run the ArchSig workflow:
+
+```bash
+mkdir -p .lake/llm-native-e2e/archsig .lake/llm-native-e2e/fieldsig
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .lake/llm-native-e2e/archsig
+```
+
+Expected ArchSig outputs:
+
+```text
+.lake/llm-native-e2e/archsig/archmap-validation.json
+.lake/llm-native-e2e/archsig/law-policy-validation.json
+.lake/llm-native-e2e/archsig/archsig-analysis-packet.json
+.lake/llm-native-e2e/archsig/archsig-analysis-validation.json
+.lake/llm-native-e2e/archsig/llm-interpretation-packet.json
+.lake/llm-native-e2e/archsig/air.json
+.lake/llm-native-e2e/archsig/air-validation.json
+.lake/llm-native-e2e/archsig/theorem-precondition-check.json
+.lake/llm-native-e2e/archsig/feature-report.json
+.lake/llm-native-e2e/archsig/aat-observable-bundle.json
+.lake/llm-native-e2e/archsig/aat-observable-bundle-validation.json
+```
+
+The LLM interpretation packet is byte-for-byte the same structured analysis
+packet:
+
+```bash
+cmp \
+  .lake/llm-native-e2e/archsig/archsig-analysis-packet.json \
+  .lake/llm-native-e2e/archsig/llm-interpretation-packet.json
+```
+
+Project the ArchSig analysis packet into FieldSig:
+
+```bash
+cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
+  --analysis-packet .lake/llm-native-e2e/archsig/archsig-analysis-packet.json \
+  --out .lake/llm-native-e2e/fieldsig/operation-support-estimate.json
+```
+
+The output must be `operation-support-estimate-v0` with
+`descriptorRef.artifactKind = "archsig-analysis-packet"`.
+
+## Regression Guardrails
+
+The E2E flow must preserve these boundaries:
+
+- ArchMap remains law-independent source-grounded Atom observation evidence.
+- LawPolicy is the selected law universe and witness-rule artifact.
+- ArchSig computes law-relative obstruction circuits, signature axes, flatness
+  readings, repair candidates, coverage gaps, and non-conclusions.
+- `llm-interpretation-packet.json` is structured analysis input for an LLM, not
+  a natural-language judgement, proof, or automatic repair instruction.
+- FieldSig accepts `archsig-analysis-packet-v0` and rejects raw ArchMap JSON as
+  the current handoff input.
+- Coverage gaps are carried as unknown remainder; they are not rounded to
+  absence, measured zero, or forecast truth.
+
+## CI
+
+`.github/workflows/lean.yml` contains the `llm-native ArchMap/ArchSig e2e` job.
+The job runs the transcript above, validates key schema and boundary fields with
+`jq`, rejects raw ArchMap handoff to FieldSig, and uploads
+`.lake/llm-native-e2e` as an artifact.

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -36,6 +36,13 @@ are projected from `archsig-analysis-packet-v0`. They retain the
 `ArchMap + LawPolicy -> ArchSig analysis` boundary and do not use the older
 ArchMap projection rule as their source of truth.
 
+The complete ArchSig-to-FieldSig transcript is fixed in
+[`docs/tool/llm_native_e2e_workflow.md`](../../../docs/tool/llm_native_e2e_workflow.md)
+and in the `llm-native ArchMap/ArchSig e2e` CI job. That E2E path verifies that
+the generated LLM interpretation packet is the same structured analysis packet
+and that FieldSig consumes only `archsig-analysis-packet-v0`, not raw ArchMap
+JSON.
+
 Equivalent step-by-step commands:
 
 ```bash

--- a/tools/fieldsig/docs/commands.md
+++ b/tools/fieldsig/docs/commands.md
@@ -22,6 +22,11 @@ cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-inpu
 This command rejects raw ArchMap JSON when it is supplied as the analysis-packet
 input. The accepted boundary is `archsig-analysis-packet-v0`.
 
+The end-to-end command transcript is fixed in
+[`docs/tool/llm_native_e2e_workflow.md`](../../../docs/tool/llm_native_e2e_workflow.md).
+CI runs the same flow from ArchMap and LawPolicy through ArchSig analysis,
+LLM interpretation packet emission, and FieldSig handoff.
+
 ## Operational and Governance
 
 Use `dataset`, `pr-metadata`, `pr-history-dataset`, `feature-extension-dataset`, `outcome-linkage-dataset`, `report-outcome-daily-ledger`, `calibration-review-record`, `team-threshold-policy`, `ownership-boundary-monitor`, `repair-adoption-record`, `incident-correlation-monitor`, `hypothesis-refresh-cycle`, `pr-force-report`, `signature-trajectory-report`, `architecture-field-snapshot`, `operation-proposal-log`, `architecture-dynamics-metrics`, `dynamics-measurements`, and `ai-proposal-governance` for workflow evidence, feedback, field dynamics, and AI proposal governance.


### PR DESCRIPTION
## 概要

Closes #1340

LLM-native ArchMap / LawPolicy / ArchSig analysis packet / LLM interpretation packet / FieldSig handoff を一続きで固定する E2E job と transcript docs を追加しました。CI では schema / boundary field を `jq` で確認し、raw ArchMap が FieldSig handoff として受理されないことも regression として固定します。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/llm_native_e2e_workflow.md`
- `docs/tool/README.md`
- `tools/archsig/docs/commands.md`
- `tools/fieldsig/docs/commands.md`
- `.github/workflows/lean.yml`

## 実施したテスト

- [x] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] LLM-native E2E command chain:
  `archsig llm-native-workflow` -> `cmp` analysis / LLM packet -> `fieldsig archsig-analysis-sft-input` -> raw ArchMap rejection
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lean.yml")'`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] Lean-source forbidden-token scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
