### PR TITLE
ArchSig の empirical dataset 責務を snapshot attribution へ整理する

### DIFF
--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -56,6 +56,13 @@ Adapter output must preserve coverage boundary, unsupported constructs, missing
 evidence, and non-conclusions. Missing, private, unavailable, unsupported,
 dynamic, or framework-specific evidence is not measured zero.
 
+ArchSig keeps the shared signature-shape and delta helpers only for snapshot,
+diff, AIR, and bounded review attribution. PR metadata accepted by `air` and
+`signature-diff` is read as `archsig-snapshot-attribution-input-v0`, not as an
+empirical outcome dataset. ArchSig does not emit empirical PR-history datasets
+or own historical outcome modeling; those surfaces belong to FieldSig or to an
+explicit external data pipeline.
+
 ## FieldSig Handoff
 
 FieldSig consumes the serialized `archsig-analysis-packet-v0` through

--- a/tools/archsig/src/air.rs
+++ b/tools/archsig/src/air.rs
@@ -7,16 +7,16 @@ use crate::{
     AirDocumentInput, AirDocumentV0, AirEvidence, AirExtension, AirFeature, AirIdPolicies,
     AirOperationTrace, AirPolicies, AirRelation, AirRevision, AirSignature, AirSignatureAxis,
     ArchitectureSignatureV1DatasetShape, COMPONENT_KIND, ComponentUniverseValidationReport,
-    EMPIRICAL_DATASET_SCHEMA_VERSION, EXTRACTOR_NAME, Edge, EmpiricalDatasetInput, MetricStatus,
-    PYTHON_COMPONENT_KIND, PYTHON_IMPORT_RULE_VERSION, RUNTIME_PROJECTION_RULE_VERSION,
-    Sig0Document, SignatureDiffReportV0, unmeasured_status,
+    EXTRACTOR_NAME, Edge, MetricStatus, PYTHON_COMPONENT_KIND, PYTHON_IMPORT_RULE_VERSION,
+    RUNTIME_PROJECTION_RULE_VERSION, SNAPSHOT_ATTRIBUTION_INPUT_SCHEMA_VERSION, Sig0Document,
+    SignatureDiffReportV0, SnapshotAttributionInput, unmeasured_status,
 };
 
 pub fn build_air_document(
     sig0: &Sig0Document,
     validation: Option<&ComponentUniverseValidationReport>,
     diff: Option<&SignatureDiffReportV0>,
-    pr_metadata: Option<&EmpiricalDatasetInput>,
+    pr_metadata: Option<&SnapshotAttributionInput>,
     input: AirDocumentInput,
 ) -> AirDocumentV0 {
     let signature = dataset_signature_shape(sig0);
@@ -58,7 +58,7 @@ pub fn build_air_document(
         artifacts.push(AirArtifact {
             artifact_id: "artifact-pr-metadata".to_string(),
             kind: "pr_metadata".to_string(),
-            schema_version: Some(EMPIRICAL_DATASET_SCHEMA_VERSION.to_string()),
+            schema_version: Some(SNAPSHOT_ATTRIBUTION_INPUT_SCHEMA_VERSION.to_string()),
             path: input.pr_metadata_path,
             content_hash: None,
             produced_by: Some(EXTRACTOR_NAME.to_string()),
@@ -411,7 +411,7 @@ fn air_component_lifecycle(diff: Option<&SignatureDiffReportV0>) -> BTreeMap<Str
 
 fn air_revision(
     diff: Option<&SignatureDiffReportV0>,
-    pr_metadata: Option<&EmpiricalDatasetInput>,
+    pr_metadata: Option<&SnapshotAttributionInput>,
 ) -> AirRevision {
     if let Some(diff) = diff {
         return AirRevision {
@@ -431,7 +431,7 @@ fn air_revision(
     }
 }
 
-fn air_feature(pr_metadata: Option<&EmpiricalDatasetInput>) -> AirFeature {
+fn air_feature(pr_metadata: Option<&SnapshotAttributionInput>) -> AirFeature {
     if let Some(pr_metadata) = pr_metadata {
         AirFeature {
             feature_id: Some(format!("#{}", pr_metadata.pull_request.number)),

--- a/tools/archsig/src/dataset.rs
+++ b/tools/archsig/src/dataset.rs
@@ -1,12 +1,10 @@
 use std::collections::BTreeMap;
-use std::error::Error;
 
 use crate::graph::Graph;
 use crate::{
-    ArchitectureSignatureV1DatasetShape, EMPIRICAL_DATASET_SCHEMA_VERSION, EXTRACTOR_NAME,
-    EXTRACTOR_VERSION, EmpiricalDatasetInput, EmpiricalSignatureDatasetV0, ExtractorRef,
-    GitCommitRef, MetricDeltaStatus, MetricStatus, NullableSignatureIntVector, RULE_SET_VERSION,
-    Sig0Document, SignatureSnapshot, measured_status, unmeasured_status,
+    ArchitectureSignatureV1DatasetShape, MetricDeltaStatus, MetricStatus,
+    NullableSignatureIntVector, Sig0Document, SignatureSnapshot, measured_status,
+    unmeasured_status,
 };
 
 pub(crate) const DATASET_SIGNATURE_AXES: [&str; 16] = [
@@ -45,76 +43,6 @@ pub(crate) const DATASET_DELTA_AXES: [&str; 15] = [
     "runtimePropagation",
     "relationComplexity",
 ];
-
-pub fn build_empirical_dataset(
-    before: &Sig0Document,
-    after: &Sig0Document,
-    mut input: EmpiricalDatasetInput,
-    after_commit_role: &str,
-) -> Result<EmpiricalSignatureDatasetV0, Box<dyn Error>> {
-    if !matches!(after_commit_role, "head" | "merge") {
-        return Err(format!("unsupported after commit role: {after_commit_role}").into());
-    }
-
-    let before_snapshot = signature_snapshot(
-        before,
-        GitCommitRef {
-            sha: input.pull_request.base_commit.clone(),
-            role: "base".to_string(),
-        },
-    );
-    let after_sha = match after_commit_role {
-        "head" => input.pull_request.head_commit.clone(),
-        "merge" => input
-            .pull_request
-            .merge_commit
-            .clone()
-            .ok_or("after commit role merge requires pullRequest.mergeCommit")?,
-        _ => unreachable!("after commit role is checked above"),
-    };
-    let after_snapshot = signature_snapshot(
-        after,
-        GitCommitRef {
-            sha: after_sha,
-            role: after_commit_role.to_string(),
-        },
-    );
-    let delta_signature_signed = delta_signature_signed(&before_snapshot, &after_snapshot);
-    let metric_delta_status = metric_delta_status(&before_snapshot, &after_snapshot);
-
-    input.analysis_metadata.signature_after_commit_role = after_commit_role.to_string();
-
-    Ok(EmpiricalSignatureDatasetV0 {
-        schema_version: EMPIRICAL_DATASET_SCHEMA_VERSION.to_string(),
-        repository: input.repository,
-        pull_request: input.pull_request,
-        signature_before: before_snapshot,
-        signature_after: after_snapshot,
-        delta_signature_signed,
-        metric_delta_status,
-        pr_metrics: input.pr_metrics,
-        issue_incident_links: input.issue_incident_links,
-        analysis_metadata: input.analysis_metadata,
-    })
-}
-
-pub(crate) fn signature_snapshot(
-    document: &Sig0Document,
-    commit: GitCommitRef,
-) -> SignatureSnapshot {
-    let signature = dataset_signature_shape(document);
-    SignatureSnapshot {
-        commit,
-        extractor: ExtractorRef {
-            name: EXTRACTOR_NAME.to_string(),
-            version: EXTRACTOR_VERSION.to_string(),
-            rule_set_version: RULE_SET_VERSION.to_string(),
-            policy_version: document.policies.policy_id.clone(),
-        },
-        metric_status: dataset_metric_status(document),
-        signature,
-    }
-}
 
 pub(crate) fn dataset_signature_shape(
     document: &Sig0Document,
@@ -340,101 +268,4 @@ fn metric_status_reason(axis: &str, metric_status: &BTreeMap<String, MetricStatu
         .get(axis)
         .and_then(|status| status.reason.clone())
         .unwrap_or_else(|| "metricStatus entry is missing".to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::EMPIRICAL_DATASET_SCHEMA_VERSION;
-    use crate::test_support::{dataset_input, sig0_document_for_edges};
-
-    use super::build_empirical_dataset;
-
-    #[test]
-    fn builds_empirical_dataset_with_comparable_and_unmeasured_deltas() {
-        let before = sig0_document_for_edges(
-            vec![
-                ("A", "A.lean"),
-                ("B", "B.lean"),
-                ("C", "C.lean"),
-                ("D", "D.lean"),
-            ],
-            vec![("A", "B")],
-        );
-        let after = sig0_document_for_edges(
-            vec![
-                ("A", "A.lean"),
-                ("B", "B.lean"),
-                ("C", "C.lean"),
-                ("D", "D.lean"),
-            ],
-            vec![("A", "B"), ("A", "C"), ("C", "D")],
-        );
-
-        let dataset = build_empirical_dataset(&before, &after, dataset_input(), "head")
-            .expect("dataset builds");
-
-        assert_eq!(dataset.schema_version, EMPIRICAL_DATASET_SCHEMA_VERSION);
-        assert_eq!(dataset.signature_before.commit.sha, "base-sha");
-        assert_eq!(dataset.signature_after.commit.role, "head");
-        assert_eq!(dataset.delta_signature_signed.fanout_risk, Some(2));
-        assert_eq!(dataset.delta_signature_signed.max_fanout, Some(1));
-        assert_eq!(dataset.delta_signature_signed.reachable_cone_size, Some(2));
-        assert_eq!(
-            dataset.delta_signature_signed.boundary_violation_count,
-            None
-        );
-        assert_eq!(dataset.signature_after.signature.weighted_scc_risk, None);
-        assert!(
-            !dataset
-                .signature_after
-                .metric_status
-                .get("weightedSccRisk")
-                .expect("weighted status")
-                .measured
-        );
-        assert_eq!(dataset.signature_after.signature.runtime_propagation, None);
-        assert!(
-            !dataset
-                .signature_after
-                .metric_status
-                .get("runtimePropagation")
-                .expect("runtime status")
-                .measured
-        );
-
-        let fanout_status = dataset
-            .metric_delta_status
-            .get("fanoutRisk")
-            .expect("fanout delta status");
-        assert!(fanout_status.comparable);
-        assert!(fanout_status.before_measured);
-        assert!(fanout_status.after_measured);
-
-        let boundary_status = dataset
-            .metric_delta_status
-            .get("boundaryViolationCount")
-            .expect("boundary delta status");
-        assert!(!boundary_status.comparable);
-        assert!(!boundary_status.before_measured);
-        assert!(!boundary_status.after_measured);
-        assert!(
-            boundary_status
-                .reason
-                .contains("policy file not provided before")
-                || boundary_status.reason.contains("policy file not provided")
-        );
-    }
-
-    #[test]
-    fn dataset_merge_role_uses_merge_commit() {
-        let document = sig0_document_for_edges(vec![("A", "A.lean")], Vec::new());
-        let dataset = build_empirical_dataset(&document, &document, dataset_input(), "merge")
-            .expect("dataset builds");
-
-        assert_eq!(dataset.signature_after.commit.sha, "merge-sha");
-        assert_eq!(
-            dataset.analysis_metadata.signature_after_commit_role,
-            "merge"
-        );
-    }
 }

--- a/tools/archsig/src/extractor.rs
+++ b/tools/archsig/src/extractor.rs
@@ -326,8 +326,8 @@ fn dedup_edges(import_edges: Vec<ImportEdge>) -> Vec<Edge> {
 
 #[cfg(test)]
 mod tests {
-    use crate::dataset::build_empirical_dataset;
-    use crate::test_support::{dataset_input, fixture_root};
+    use crate::dataset::dataset_signature_shape;
+    use crate::test_support::fixture_root;
     use crate::{
         COMPONENT_KIND, RUNTIME_PROJECTION_RULE_VERSION, SCHEMA_VERSION, extractor::ParsedImport,
     };
@@ -512,19 +512,15 @@ import Should.Not.Appear
                 .measured
         );
 
-        let dataset = build_empirical_dataset(&document, &document, dataset_input(), "head")
-            .expect("dataset builds");
         assert_eq!(
-            dataset.signature_after.signature.runtime_propagation,
+            dataset_signature_shape(&document).runtime_propagation,
             Some(2)
         );
-        assert_eq!(dataset.delta_signature_signed.runtime_propagation, Some(0));
         assert!(
-            dataset
-                .signature_after
+            document
                 .metric_status
                 .get("runtimePropagation")
-                .expect("runtime dataset status")
+                .expect("runtime status")
                 .measured
         );
     }

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -20,7 +20,7 @@ use archsig::{
     ArchMapValidationReportV0, ArchSigAnalysisPacketV0, ArchitecturePolicyV0,
     ArchitecturePolicyValidationReportV0, ComponentUniverseValidationReport,
     CustomRulePluginRegistryV0, CustomRulePluginRegistryValidationReportV0, DEFAULT_UNIVERSE_MODE,
-    DetectableValuesReportedAxesCatalogV0, EmpiricalDatasetInput, FeatureExtensionReportV0,
+    DetectableValuesReportedAxesCatalogV0, FeatureExtensionReportV0,
     FeatureReportHomomorphismFamily, FeatureReportHomomorphismSummary, FrameworkAdapterEvidenceV0,
     LawPolicyDocumentV0, LawPolicyTemplateRegistryV0, LawPolicyTemplateRegistryValidationReportV0,
     LawViolationReportV0, MeasurementUnitRegistryV0, MeasurementUnitRegistryValidationReportV0,
@@ -30,11 +30,11 @@ use archsig::{
     RepairRuleRegistryValidationReportV0, ReportArtifactRetentionManifestV0,
     ReportArtifactRetentionValidationReportV0, RepositoryRevisionRef, RiskDispositionV0,
     ScanMetadata, SchemaCompatibilityCheckReportV0, SchemaVersionCatalogV0, Sig0Document,
-    SignatureDiffReportV0, SignatureSnapshotStoreRecordV0, SnapshotRecordInput,
-    SnapshotRepositoryRef, SynthesisConstraintArtifactV0, SynthesisConstraintValidationReportV0,
-    TheoremPreconditionCheckReportV0, apply_architecture_policy_to_sig0,
-    attach_framework_adapter_evidence, build_air_document, build_air_from_archmap,
-    build_archsig_analysis_packet, build_baseline_suppression_report,
+    SignatureDiffReportV0, SignatureSnapshotStoreRecordV0, SnapshotAttributionInput,
+    SnapshotRecordInput, SnapshotRepositoryRef, SynthesisConstraintArtifactV0,
+    SynthesisConstraintValidationReportV0, TheoremPreconditionCheckReportV0,
+    apply_architecture_policy_to_sig0, attach_framework_adapter_evidence, build_air_document,
+    build_air_from_archmap, build_archsig_analysis_packet, build_baseline_suppression_report,
     build_feature_extension_report, build_feature_extension_report_with_archmap_diagnostics,
     build_law_violation_report, build_policy_decision_report,
     build_schema_compatibility_check_report, build_signature_diff_report,
@@ -830,7 +830,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             let pr_metadata = pr_metadata
                 .iter()
                 .map(read_json)
-                .collect::<Result<Vec<EmpiricalDatasetInput>, Box<dyn Error>>>()?;
+                .collect::<Result<Vec<SnapshotAttributionInput>, Box<dyn Error>>>()?;
             let report = build_signature_diff_report(
                 &before,
                 &after,
@@ -855,7 +855,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 validation.as_ref().map(read_json).transpose()?;
             let diff_report: Option<SignatureDiffReportV0> =
                 diff.as_ref().map(read_json).transpose()?;
-            let pr_metadata_document: Option<EmpiricalDatasetInput> =
+            let pr_metadata_document: Option<SnapshotAttributionInput> =
                 pr_metadata.as_ref().map(read_json).transpose()?;
             let mut air = build_air_document(
                 &document,

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -7,7 +7,7 @@ pub const COMPONENT_KIND: &str = "lean-module";
 pub const PYTHON_COMPONENT_KIND: &str = "python-module";
 pub const PYTHON_IMPORT_RULE_VERSION: &str = "python-import-graph-v0";
 pub const VALIDATION_REPORT_SCHEMA_VERSION: &str = "component-universe-validation-report-v0";
-pub const EMPIRICAL_DATASET_SCHEMA_VERSION: &str = "empirical-signature-dataset-v0";
+pub const SNAPSHOT_ATTRIBUTION_INPUT_SCHEMA_VERSION: &str = "archsig-snapshot-attribution-input-v0";
 pub const SIGNATURE_SNAPSHOT_STORE_SCHEMA_VERSION: &str = "signature-snapshot-store-v0";
 pub const SIGNATURE_DIFF_REPORT_SCHEMA_VERSION: &str = "signature-diff-report-v0";
 pub const AIR_SCHEMA_VERSION: &str = "aat-air-v0";
@@ -533,28 +533,13 @@ pub struct ValidationExample {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct EmpiricalDatasetInput {
+pub struct SnapshotAttributionInput {
     pub repository: RepositoryRef,
     pub pull_request: PullRequestRef,
     pub pr_metrics: PullRequestMetrics,
     #[serde(default)]
     pub issue_incident_links: Vec<IssueIncidentLink>,
     #[serde(default)]
-    pub analysis_metadata: AnalysisMetadata,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EmpiricalSignatureDatasetV0 {
-    pub schema_version: String,
-    pub repository: RepositoryRef,
-    pub pull_request: PullRequestRef,
-    pub signature_before: SignatureSnapshot,
-    pub signature_after: SignatureSnapshot,
-    pub delta_signature_signed: NullableSignatureIntVector,
-    pub metric_delta_status: BTreeMap<String, MetricDeltaStatus>,
-    pub pr_metrics: PullRequestMetrics,
-    pub issue_incident_links: Vec<IssueIncidentLink>,
     pub analysis_metadata: AnalysisMetadata,
 }
 

--- a/tools/archsig/src/snapshot.rs
+++ b/tools/archsig/src/snapshot.rs
@@ -6,13 +6,14 @@ use crate::dataset::{
 };
 use crate::{
     AttributionCandidate, ComponentSetDelta, ComponentUniverseValidationReport, EXTRACTOR_NAME,
-    EXTRACTOR_VERSION, Edge, EdgeSetDelta, EmpiricalDatasetInput, ExtractorRef, GitCommitRef,
-    MetricDeltaStatus, PolicyViolation, PolicyViolationSetDelta, RULE_SET_VERSION,
+    EXTRACTOR_VERSION, Edge, EdgeSetDelta, ExtractorRef, GitCommitRef, MetricDeltaStatus,
+    PolicyViolation, PolicyViolationSetDelta, RULE_SET_VERSION,
     SIGNATURE_DIFF_REPORT_SCHEMA_VERSION, SIGNATURE_SNAPSHOT_STORE_SCHEMA_VERSION, Sig0Document,
     SignatureAxisChange, SignatureDiffReportV0, SignatureSnapshot, SignatureSnapshotStoreRecordV0,
-    SnapshotAnalysisMetadata, SnapshotArtifacts, SnapshotComparisonStatus, SnapshotDiffAttribution,
-    SnapshotDiffEndpoint, SnapshotEvidenceDiff, SnapshotExtractorMetadata, SnapshotPolicyMetadata,
-    SnapshotRecordInput, SnapshotValidationSummary, UnmeasuredAxisDelta,
+    SnapshotAnalysisMetadata, SnapshotArtifacts, SnapshotAttributionInput,
+    SnapshotComparisonStatus, SnapshotDiffAttribution, SnapshotDiffEndpoint, SnapshotEvidenceDiff,
+    SnapshotExtractorMetadata, SnapshotPolicyMetadata, SnapshotRecordInput,
+    SnapshotValidationSummary, UnmeasuredAxisDelta,
 };
 
 pub fn build_signature_snapshot_record(
@@ -69,7 +70,7 @@ pub fn build_signature_diff_report(
     after: &SignatureSnapshotStoreRecordV0,
     before_document: Option<&Sig0Document>,
     after_document: Option<&Sig0Document>,
-    pr_metadata: &[EmpiricalDatasetInput],
+    pr_metadata: &[SnapshotAttributionInput],
 ) -> SignatureDiffReportV0 {
     let before_snapshot = store_record_signature_snapshot(before, "before");
     let after_snapshot = store_record_signature_snapshot(after, "after");
@@ -323,7 +324,7 @@ fn snapshot_diff_attribution(
     after: &SignatureSnapshotStoreRecordV0,
     evidence_diff: &SnapshotEvidenceDiff,
     worsened_axes: &[SignatureAxisChange],
-    pr_metadata: &[EmpiricalDatasetInput],
+    pr_metadata: &[SnapshotAttributionInput],
 ) -> SnapshotDiffAttribution {
     let touched_components = touched_components_from_evidence_diff(evidence_diff);
     let worsened_axis_names = worsened_axes
@@ -404,7 +405,7 @@ fn attribution_candidate(
     evidence_diff: &SnapshotEvidenceDiff,
     touched_components: &BTreeSet<String>,
     worsened_axes: &[String],
-    metadata: &EmpiricalDatasetInput,
+    metadata: &SnapshotAttributionInput,
 ) -> AttributionCandidate {
     let changed_components = metadata.pr_metrics.changed_components.clone();
     let changed_set = changed_components.iter().cloned().collect::<BTreeSet<_>>();

--- a/tools/archsig/src/test_support.rs
+++ b/tools/archsig/src/test_support.rs
@@ -1,12 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use crate::graph::compute_signature;
-use crate::{
-    AirDocumentV0, AnalysisMetadata, COMPONENT_KIND, Component, Edge, EmpiricalDatasetInput,
-    MetricStatus, Policies, PullRequestMetrics, PullRequestRef, RepositoryRef, SCHEMA_VERSION,
-    Sig0Document, measured_status, unmeasured_status,
-};
+use crate::{AirDocumentV0, MetricStatus, unmeasured_status};
 
 pub(crate) fn fixture_root() -> PathBuf {
     manifest_root().join("tests/fixtures/minimal")
@@ -18,64 +13,6 @@ pub(crate) fn air_fixture_document(fixture: &str) -> AirDocumentV0 {
     serde_json::from_str(&contents).expect("AIR fixture parses")
 }
 
-pub(crate) fn sig0_document_for_edges(
-    components: Vec<(&str, &str)>,
-    edge_pairs: Vec<(&str, &str)>,
-) -> Sig0Document {
-    let components: Vec<Component> = components
-        .into_iter()
-        .map(|(id, path)| Component {
-            id: id.to_string(),
-            path: path.to_string(),
-        })
-        .collect();
-    let edges: Vec<Edge> = edge_pairs
-        .into_iter()
-        .map(|(source, target)| Edge {
-            source: source.to_string(),
-            target: target.to_string(),
-            kind: "import".to_string(),
-            evidence: format!("import {target}"),
-        })
-        .collect();
-    let signature = compute_signature(&components, &edges);
-    let mut metric_status = BTreeMap::new();
-    for axis in ["hasCycle", "sccMaxSize", "maxDepth", "fanoutRisk"] {
-        metric_status.insert(axis.to_string(), measured_status("archsig:import-graph"));
-    }
-    insert_unmeasured_policy_status(&mut metric_status);
-
-    Sig0Document {
-        schema_version: SCHEMA_VERSION.to_string(),
-        root: ".".to_string(),
-        component_kind: COMPONENT_KIND.to_string(),
-        components,
-        edges,
-        policies: Policies {
-            boundary_allowed: Vec::new(),
-            abstraction_allowed: Vec::new(),
-            policy_id: None,
-            schema_version: None,
-            boundary_group_count: None,
-            abstraction_relation_count: None,
-        },
-        signature,
-        metric_status,
-        policy_violations: Vec::new(),
-        runtime_edge_evidence: Vec::new(),
-        runtime_dependency_graph: None,
-        coverage_boundary: "test support selected universe".to_string(),
-        unsupported_constructs: Vec::new(),
-        missing_evidence: vec![
-            "test support does not model complete repository evidence".to_string(),
-        ],
-        non_conclusions: vec![
-            "test support Sig0 is not architecture ground truth".to_string(),
-            "missing evidence is not measured zero".to_string(),
-        ],
-    }
-}
-
 pub(crate) fn insert_unmeasured_policy_status(metric_status: &mut BTreeMap<String, MetricStatus>) {
     metric_status.insert(
         "boundaryViolationCount".to_string(),
@@ -85,41 +22,6 @@ pub(crate) fn insert_unmeasured_policy_status(metric_status: &mut BTreeMap<Strin
         "abstractionViolationCount".to_string(),
         unmeasured_status("policy file not provided".to_string()),
     );
-}
-
-pub(crate) fn dataset_input() -> EmpiricalDatasetInput {
-    EmpiricalDatasetInput {
-        repository: RepositoryRef {
-            owner: "example".to_string(),
-            name: "service".to_string(),
-            default_branch: "main".to_string(),
-        },
-        pull_request: PullRequestRef {
-            number: 42,
-            author: "alice".to_string(),
-            created_at: "2026-04-01T00:00:00Z".to_string(),
-            merged_at: Some("2026-04-02T00:00:00Z".to_string()),
-            base_commit: "base-sha".to_string(),
-            head_commit: "head-sha".to_string(),
-            merge_commit: Some("merge-sha".to_string()),
-            labels: vec!["feature".to_string()],
-            is_bot_generated: false,
-        },
-        pr_metrics: PullRequestMetrics {
-            changed_files: 2,
-            changed_lines_added: 20,
-            changed_lines_deleted: 5,
-            changed_components: vec!["A".to_string(), "C".to_string()],
-            review_comment_count: 1,
-            review_thread_count: 1,
-            review_round_count: 1,
-            first_review_latency_hours: Some(2.0),
-            approval_latency_hours: Some(6.0),
-            merge_latency_hours: Some(12.0),
-        },
-        issue_incident_links: Vec::new(),
-        analysis_metadata: AnalysisMetadata::default(),
-    }
 }
 
 fn manifest_root() -> &'static Path {


### PR DESCRIPTION
## 概要

Closes #1362

- ArchSig 側の未使用 `build_empirical_dataset` / `signature_snapshot` と専用テスト helper を削除しました。
- PR metadata 入力を `SnapshotAttributionInput` / `archsig-snapshot-attribution-input-v0` として扱い、ArchSig が empirical PR-history dataset を emit / own しない境界を明確化しました。
- snapshot / diff / AIR で使う bounded signature shape / delta helper は維持し、runtimePropagation の回帰確認は dataset output ではなく signature shape 側へ移しました。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/docs/artifacts-and-boundaries.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（49 unit + 10 cli + doc-tests、warning なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `cargo fmt --manifest-path tools/archsig/Cargo.toml --check`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean theorem status 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
