### PR TITLE
ArchMap atom 抽出ガイドを明文化する

### DIFF
--- a/docs/tool/llm_native_archmap_archsig_prd.md
+++ b/docs/tool/llm_native_archmap_archsig_prd.md
@@ -104,6 +104,17 @@ atomObservation
 `confidence` は truth probability ではない。review priority、観測の粗さ、追加確認の必要性を
 読むための epistemic metadata である。
 
+Atom observation authoring では、atomFamily ごとに観測対象と禁止対象を skill / prompt
+pack / mapping guide で明示する。LLM は AST、symbol index、route list、framework convention
+を探索補助として使ってよいが、それらを Atom observation の根拠そのものとして扱わない。
+`sourceRefs` は実際に読んだ source evidence を指し、`evidenceBoundary` は source observed、
+assumed、unmeasured、private、unavailable、out-of-scope の違いを保持する。
+
+大きな workflow、責務、policy reading、review cue は coarse Atom として記録しない。
+primitive fact を `atomObservations` に置き、責務は `moleculeObservations`、意味・workflow
+reading は `semanticObservations`、不足 evidence は `observationGaps`、review cue は
+`concernHints` に分離する。
+
 ### R2. ArchMap は law-independent に保つ
 
 ArchMap は Atom、Molecule、Semantic observation、Observation gap を記録する。

--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -44,28 +44,41 @@ Use these rules before writing any observation.
 
 - An Atom is a primitive architectural fact: a small typed fact such as component existence, relation, capability, state, effect, authority, trust, contract, semantic fact, or runtime interaction.
 - An Atom observation is the LLM's bounded observation of such a fact from selected sources. It is not the certified canonical Atom itself.
+- An Atom observation has no coarse/fine scale. If the reading needs to be split into smaller architectural facts, it is not yet an atom observation.
 - A Molecule observation composes Atom observations into a higher role such as responsibility. Do not model responsibility as a primitive atom.
 - A Semantic observation records a source-supported meaning, contract reading, workflow reading, or commutation cue. It is not global semantic correctness.
 - A Concern hint records a review cue over observations. It is not an obstruction circuit or law violation.
 - A Projection info entry is a downstream handoff hint, especially toward AAT or SFT surfaces. It is not proof or forecast output.
 - An Observation gap records unavailable, private, unmeasured, or out-of-scope evidence. Never rewrite missing evidence as measured absence.
+- Static structure, ASTs, symbol indexes, route lists, and framework conventions may guide navigation, but they do not by themselves create an atom. The source text still has to support the architectural fact being recorded.
+
+Before writing an atom observation, ask:
+
+1. What exact architectural fact is observed?
+2. Which selected source refs directly support it?
+3. Is it primitive, or is it a responsibility, workflow, policy reading, concern, or gap?
+4. What evidence boundary prevents overclaiming?
+
+If any answer is unclear, do not write an atom yet. Read more source evidence, lower the confidence, or record an observation gap.
 
 Common Atom families:
 
-```text
-existence              component, module, service, class, package, process, table, queue
-relation               imports, calls, reads, writes, publishes, subscribes, owns, implements
-capability             port, command, query, handler, storage access, serialization
-state                  field, table column, cache entry, config value, event projection
-effect                 database write, message send, email, payment, event publish, remote call
-authority              permission, owner, visibility, access path, policy scope
-trust                  trusted source, delegated authority, integration trust boundary
-contractSpecification  precondition, postcondition, return shape, error behavior, invariant
-semantic               domain meaning, identity meaning, ownership meaning, workflow meaning
-runtimeInteraction     trace/log evidence for runtime call, edge, message, or effect
-```
+| atomFamily | Record when the selected source directly shows | Do not record when |
+| --- | --- | --- |
+| `existence` | component, module, service, class, package, process, table, queue, or public surface exists | the only evidence is a guessed layer or inferred runtime instance |
+| `relation` | import, call, read, write, publish, subscribe, ownership, implementation, or explicit dependency edge | the edge is only a naming similarity, directory proximity, or framework convention not inspected |
+| `capability` | command, query, handler, port, interface, storage access, serializer, processor, or tool surface | the statement is really an end-to-end workflow or responsibility |
+| `state` | field, table column, cache entry, config value, event projection, lifecycle status, durable job marker | the fact is a transient runtime value with no supplied source or trace |
+| `effect` | database write, message send, email, payment, event publish, remote call, file/object storage mutation, provider call | the effect is only possible from a library name and no effecting code was read |
+| `authority` | permission check, owner scope, role gate, visibility boundary, access path, policy scope, admin bypass | the source only names a user or role without an observed guard or authority state |
+| `trust` | trusted source, delegated authority, token verification, webhook boundary, integration trust, provider output boundary | the source merely calls an external library without a trust decision or boundary |
+| `contractSpecification` | precondition, postcondition, return shape, error behavior, invariant, validation rule, retry or idempotency contract | a test or doc is being generalized to all executions |
+| `semantic` | source-supported domain meaning, identity meaning, ownership meaning, unit meaning, workflow term meaning | the statement is a large workflow reading better represented as `semanticObservations[]` |
+| `runtimeInteraction` | trace/log-supported runtime call, edge, message, or effect | runtime evidence was unavailable or only expected |
 
 If a source can support both a primitive fact and a larger interpretation, write the primitive fact in `atomObservations[]` first. Put the larger interpretation in `moleculeObservations[]`, `semanticObservations[]`, `projectionInfo[]`, or `concernHints[]`.
+
+See `references/mapping-guide.md` for atomFamily-specific yes/no examples and `references/schema-cheatsheet.md` for required evidence metadata.
 
 ## Workflow
 
@@ -117,6 +130,8 @@ If this skill bundle is copied outside the ArchSig repository, use the local pat
 
 4. Draft `.archsig/archmap/archmap.json`.
    - Use `atomObservations[]` for source-grounded primitive observations.
+   - For every observed atom, make `sourceRefs[].artifactId` resolve to `sourceUniverse.includedRefs[]` and keep `evidenceBoundary` consistent with what was actually inspected.
+   - Put inferred, private, unavailable, framework-expanded, or runtime-only evidence into `observationGaps[]` unless it was directly supplied and read.
    - Use `moleculeObservations[]` for composed roles such as responsibility over atom observation refs.
    - Use `semanticObservations[]` for selected behavioral, contract, workflow, or diagram readings supported by sources.
    - Use `observationGaps[]` for unknown/private/unavailable/out-of-scope evidence; never round gaps to absence.

--- a/tools/archsig/skills/archmap-creater/references/examples.md
+++ b/tools/archsig/skills/archmap-creater/references/examples.md
@@ -46,6 +46,311 @@ Bad:
 
 Why bad: obstruction and law violation are law-relative ArchSig readings, not ArchMap atom observations. It also has no source refs and claims certification.
 
+## From Code Fragment To Atoms
+
+Source fragment:
+
+```ts
+import { CustomerRepository } from "../repositories/customer";
+import { EventBus } from "../events/bus";
+
+export class CustomerService {
+  private cache: CustomerCache;
+
+  constructor(
+    private readonly customers: CustomerRepository,
+    private readonly events: EventBus
+  ) {}
+
+  async updateEmail(actor: Actor, customerId: string, email: string): Promise<CustomerDto> {
+    requireWorkspaceRole(actor, "workspace-admin");
+    const customer = await this.customers.findById(customerId);
+    customer.email = normalizeEmail(email);
+    await this.customers.save(customer);
+    await this.events.publish("customer.email.updated", { customerId });
+    return toCustomerDto(customer);
+  }
+}
+```
+
+The source fragment can support several primitive atom observations. Do not compress them into
+one atom such as "CustomerService handles customer email updates correctly".
+
+Good atom set:
+
+```json
+[
+  {
+    "atomObservationId": "atom:existence:customer-service",
+    "atomFamily": "existence",
+    "predicate": "CustomerService is a service component",
+    "subjectRef": "service.customer",
+    "objectRefs": ["CustomerService"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "CustomerService"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": [],
+    "projectionRefs": [],
+    "nonConclusions": ["component existence does not prove service responsibility boundaries"]
+  },
+  {
+    "atomObservationId": "atom:relation:customer-service-repository-import",
+    "atomFamily": "relation",
+    "predicate": "CustomerService source imports CustomerRepository",
+    "subjectRef": "service.customer",
+    "objectRefs": ["repository.customer"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "CustomerRepository"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": ["static import does not measure runtime call frequency"],
+    "projectionRefs": [],
+    "nonConclusions": ["relation atom is not a complete dependency graph"]
+  },
+  {
+    "atomObservationId": "atom:state:customer-service-cache",
+    "atomFamily": "state",
+    "predicate": "CustomerService declares a CustomerCache state field",
+    "subjectRef": "service.customer",
+    "objectRefs": ["state.customerCache"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "cache"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": ["cache lifecycle and invalidation policy are not shown in this fragment"],
+    "projectionRefs": [],
+    "nonConclusions": ["state atom does not prove cache consistency"]
+  },
+  {
+    "atomObservationId": "atom:authority:update-email-admin-role",
+    "atomFamily": "authority",
+    "predicate": "updateEmail requires workspace-admin role before mutation",
+    "subjectRef": "operation.customer.updateEmail",
+    "objectRefs": ["role.workspace-admin", "resource.customer"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "requireWorkspaceRole"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": ["the implementation of requireWorkspaceRole is not inspected by this fragment"],
+    "projectionRefs": [],
+    "nonConclusions": ["authority atom does not prove complete authorization coverage"]
+  },
+  {
+    "atomObservationId": "atom:contract:update-email-return-shape",
+    "atomFamily": "contractSpecification",
+    "predicate": "updateEmail accepts actor, customer id, and email, and returns Promise<CustomerDto>",
+    "subjectRef": "operation.customer.updateEmail",
+    "objectRefs": ["Actor", "CustomerDto"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "updateEmail"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": ["type annotation does not prove runtime validation of email"],
+    "projectionRefs": [],
+    "nonConclusions": ["contract atom does not prove all executions satisfy the return type"]
+  },
+  {
+    "atomObservationId": "atom:effect:customer-save",
+    "atomFamily": "effect",
+    "predicate": "updateEmail persists the mutated customer through CustomerRepository.save",
+    "subjectRef": "operation.customer.updateEmail",
+    "objectRefs": ["repository.customer.save"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "customers.save"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": ["repository transaction behavior is not shown in this fragment"],
+    "projectionRefs": [],
+    "nonConclusions": ["effect atom does not prove commit success"]
+  },
+  {
+    "atomObservationId": "atom:effect:customer-email-event",
+    "atomFamily": "effect",
+    "predicate": "updateEmail publishes customer.email.updated after saving the customer",
+    "subjectRef": "operation.customer.updateEmail",
+    "objectRefs": ["event.customer.email.updated"],
+    "sourceRefs": [
+      {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts", "symbol": "events.publish"}
+    ],
+    "observationStatus": "observed",
+    "evidenceBoundary": "sourceObserved",
+    "confidence": "high",
+    "uncertainty": ["event bus delivery and subscriber behavior are not shown in this fragment"],
+    "projectionRefs": [],
+    "nonConclusions": ["effect atom does not prove event delivery"]
+  }
+]
+```
+
+Bad coarse atom:
+
+```json
+{
+  "atomObservationId": "atom:customer-service:update-email-workflow",
+  "atomFamily": "semantic",
+  "predicate": "CustomerService correctly updates customer email with authorization, persistence, and event publication",
+  "subjectRef": "service.customer",
+  "objectRefs": [],
+  "sourceRefs": [
+    {"artifactId": "src-customer-service", "kind": "file", "path": "src/services/customer.ts"}
+  ],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": [],
+  "projectionRefs": [],
+  "nonConclusions": []
+}
+```
+
+Why bad: it hides existence, relation, state, authority, contract, and effect facts inside one broad statement and adds correctness. The workflow reading can be a `semanticObservations[]` entry after primitive atoms exist, but it is not a primitive atom.
+
+## Atom Family Choice
+
+Good authority atom:
+
+```json
+{
+  "atomObservationId": "atom:authority:workspace-role-gate",
+  "atomFamily": "authority",
+  "predicate": "workspace route checks member role before invoking workspace operation",
+  "subjectRef": "route.workspace.membership",
+  "objectRefs": ["role.workspaceMember", "operation.workspace"],
+  "sourceRefs": [
+    {"artifactId": "src-workspace-route", "kind": "file", "path": "src/routes/workspace.ts", "symbol": "requireWorkspaceMember"},
+    {"artifactId": "src-permissions", "kind": "file", "path": "src/auth/permissions.ts", "symbol": "requireWorkspaceMember"}
+  ],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": ["route-by-route coverage outside the cited route is not claimed"],
+  "projectionRefs": [],
+  "nonConclusions": ["authority atom does not prove complete permission coverage"]
+}
+```
+
+Bad authority atom:
+
+```json
+{
+  "atomObservationId": "atom:authority:all-workspace-access",
+  "atomFamily": "authority",
+  "predicate": "all workspace access is correctly permissioned",
+  "subjectRef": "workspace",
+  "objectRefs": [],
+  "sourceRefs": [
+    {"artifactId": "src-user-model", "kind": "file", "path": "src/models/user.ts"}
+  ],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": [],
+  "projectionRefs": [],
+  "nonConclusions": []
+}
+```
+
+Why bad: a user model or role field alone does not show full route permission coverage. This should become smaller authority atoms for observed guards plus an observation gap for unaudited routes.
+
+Good effect atom:
+
+```json
+{
+  "atomObservationId": "atom:effect:invoice-email-send",
+  "atomFamily": "effect",
+  "predicate": "invoice service delegates invoice email delivery to an email provider",
+  "subjectRef": "service.invoice",
+  "objectRefs": ["provider.email"],
+  "sourceRefs": [
+    {"artifactId": "src-invoice-service", "kind": "file", "path": "src/services/invoice.ts", "symbol": "sendInvoiceEmail"}
+  ],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": ["provider runtime delivery outcome was not inspected"],
+  "projectionRefs": [],
+  "nonConclusions": ["effect atom does not prove email delivery success"]
+}
+```
+
+Bad effect atom:
+
+```json
+{
+  "atomObservationId": "atom:effect:email-success",
+  "atomFamily": "effect",
+  "predicate": "invoice emails are delivered successfully",
+  "subjectRef": "provider.email",
+  "objectRefs": [],
+  "sourceRefs": [],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": [],
+  "projectionRefs": [],
+  "nonConclusions": []
+}
+```
+
+Why bad: delivery success is runtime/provider evidence. Without supplied provider traces it belongs in an observation gap or non-conclusion, not an observed effect atom.
+
+Good contract atom:
+
+```json
+{
+  "atomObservationId": "atom:contract:refresh-token-rotation",
+  "atomFamily": "contractSpecification",
+  "predicate": "refresh token rotation accepts the previous token only within a bounded grace rule",
+  "subjectRef": "auth.refreshTokenRotation",
+  "objectRefs": ["state.refreshToken", "contract.rotationGrace"],
+  "sourceRefs": [
+    {"artifactId": "src-refresh-service", "kind": "file", "path": "src/auth/refresh-token.ts", "symbol": "rotateRefreshToken"}
+  ],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": ["concurrent production behavior was not traced"],
+  "projectionRefs": [],
+  "nonConclusions": ["contract atom does not prove all concurrent executions are correct"]
+}
+```
+
+Bad contract atom:
+
+```json
+{
+  "atomObservationId": "atom:contract:auth-correct",
+  "atomFamily": "contractSpecification",
+  "predicate": "authentication is correct",
+  "subjectRef": "auth",
+  "objectRefs": [],
+  "sourceRefs": [
+    {"artifactId": "test-auth", "kind": "test", "path": "tests/auth.test.ts"}
+  ],
+  "observationStatus": "observed",
+  "evidenceBoundary": "sourceObserved",
+  "confidence": "high",
+  "uncertainty": [],
+  "projectionRefs": [],
+  "nonConclusions": []
+}
+```
+
+Why bad: a selected test may support a bounded contract observation, not global authentication correctness.
+
 ## Molecule Observation
 
 Good:

--- a/tools/archsig/skills/archmap-creater/references/mapping-guide.md
+++ b/tools/archsig/skills/archmap-creater/references/mapping-guide.md
@@ -23,6 +23,34 @@ ArchMap authoring is source-grounded observation, not architecture invention and
 | Domain event, state update, migration, lifecycle transition | Event / state transition observation | `atomObservations[]`, `semanticObservations[]`, `projectionInfo[]` | Preserve source refs and missing preconditions. |
 | Test oracle, acceptance criterion, invariant check | Test oracle observation | `semanticObservations[]`, `projectionInfo[]` | Use as evidence for later operation support, not correctness proof. |
 
+## Atom Family Extraction Guide
+
+Use this section when deciding whether a source-backed reading belongs in `atomObservations[]`.
+Each atom should record one primitive architectural fact. If the candidate combines multiple
+facts, split it before writing the atom. If the candidate is still meaningful only as a workflow,
+responsibility, policy interpretation, concern, or missing evidence note, use the corresponding
+non-atom surface.
+
+| atomFamily | Good atom cue | Not an atom cue | Usually move to |
+| --- | --- | --- | --- |
+| `existence` | A selected file defines `BillingService`, a route module, a queue name, a DB model, or a command object. | A directory name suggests there is a service, but no file or symbol was read. | `observationGaps[]` if the component is expected but uninspected. |
+| `relation` | Source shows `OrderRoute` calling `OrderService.create`, a repository reading a table, or a task publishing to a queue. | Two files share a domain word, or an AST import exists without architectural boundary relevance. | `semanticObservations[]` for larger dependency readings; `observationGaps[]` for unexpanded framework edges. |
+| `capability` | A service exposes a command/query, a handler processes a message, a processor supports a MIME type, or an adapter exposes storage access. | The candidate describes the whole end-to-end request workflow. | `moleculeObservations[]` for composed responsibility; `semanticObservations[]` for workflow meaning. |
+| `state` | A model field, table column, cache key, enum status, job lifecycle marker, or persisted projection is defined or mutated. | A runtime value is guessed from domain knowledge or not present in selected evidence. | `observationGaps[]` for unavailable runtime state. |
+| `effect` | Code commits DB writes, sends email, invokes a provider, publishes an event, mutates object storage, or enqueues work. | A dependency name implies possible I/O but no effecting code path was read. | `observationGaps[]` or `concernHints[]` if review should check effect ordering. |
+| `authority` | Code checks workspace role, admin level, owner scope, RLS/session context, signed token, allowlist, or route dependency. | A schema has `user_id` but no access rule, ownership check, or authority boundary was inspected. | `semanticObservations[]` for authority architecture reading; `observationGaps[]` for route audit gaps. |
+| `trust` | Source verifies webhook signatures, JWT/JWKS, provider identity, delegated credentials, or treats LLM/provider output as untrusted until validation. | Any external API call is treated as trust evidence without an observed trust decision. | `concernHints[]` for provider trust review cues; `observationGaps[]` for missing provider logs. |
+| `contractSpecification` | DTO validation, precondition, postcondition, error mapping, idempotency key, retry rule, invariant, or bounded return shape is visible. | A passing test is generalized into universal correctness. | `semanticObservations[]` for behavior reading; `projectionInfo[]` for downstream handoff. |
+| `semantic` | Source names a domain identity, ownership meaning, unit, status meaning, or bounded business term. | A long process narrative combines many atoms and roles. | `semanticObservations[]` for larger meaning/workflow readings. |
+| `runtimeInteraction` | Supplied trace or log directly shows runtime call, edge, message, or effect. | Runtime behavior is expected from source code but no trace/log was supplied. | `observationGaps[]`; never measured-zero. |
+
+Anti-patterns:
+
+- Do not create a coarse atom such as "the authentication system owns all tenant access". Split observed role gates, token verification, session/RLS state, and admin bypass facts into atoms, then compose the larger reading as a molecule or semantic observation.
+- Do not create an atom only because AST, import graph, or route discovery found a symbol. Use that index to navigate to source evidence, then record the architectural fact supported by the source.
+- Do not use atom families such as `responsibility`, `workflow`, `policy`, `obstruction`, `lawViolation`, `forecast`, `qualityScore`, or `incidentCausality`.
+- Do not turn an unavailable trace, private secret, unexpanded framework convention, or unreviewed generated file into an observed atom.
+
 ## AAT-Facing Vs SFT-Facing
 
 AAT-facing observations preserve architecture structure:
@@ -59,6 +87,19 @@ Use conservative status and boundary text:
 | LLM inference without specific source refs | avoid the observation | `unmeasured` if retained as a gap | `low` |
 
 Never use measured absence for unavailable evidence. Use measured absence only when the selected measurement actually observed absence.
+
+## Source Reference And Boundary Requirements
+
+For every `atomObservations[]` entry:
+
+- `sourceRefs[]` must name the source artifacts that were actually read.
+- For `observationStatus: "observed"`, each supporting `sourceRefs[].artifactId` should resolve to `sourceUniverse.includedRefs[]`.
+- `evidenceBoundary` should say how the evidence was observed, usually `sourceObserved`, `assumedSource`, `unmeasured`, `unavailable`, `private`, or `outOfScope`.
+- `confidence` is qualitative review priority, not probability. Use `high` only for direct, local source evidence; use `medium` when the fact spans files or depends on supplied policy; use `low` when retained only as weak evidence.
+- `uncertainty[]` should preserve local caveats, such as missing runtime confirmation, framework expansion, sampled coverage, or partial route audit.
+- `nonConclusions[]` should prevent promotion to architecture truth, global correctness, lawfulness, or proof discharge.
+
+Move the candidate to `observationGaps[]` when the relevant evidence exists only as a private credential, provider log, runtime trace, generated file, framework expansion, production database row, or unreviewed test suite.
 
 ## Concern Hints
 

--- a/tools/archsig/skills/archmap-creater/references/prompt-pack.md
+++ b/tools/archsig/skills/archmap-creater/references/prompt-pack.md
@@ -19,6 +19,9 @@ Create an `archmap-observation-map-v0` JSON artifact from the supplied bounded s
 ## Atom Reading
 
 Write `atomObservations[]` only for primitive architectural facts grounded in selected source refs.
+An atom has no coarse/fine scale. If a candidate summarizes a subsystem, responsibility, workflow, policy reading, or concern, split the primitive facts into atom observations and move the larger reading to `moleculeObservations[]`, `semanticObservations[]`, `observationGaps[]`, or `concernHints[]`.
+
+ASTs, symbol indexes, import graphs, route lists, and framework conventions may guide source navigation. They are not sufficient evidence by themselves. Cite the selected source refs that were actually read and that directly support the architectural fact.
 
 Common primitive fact families:
 
@@ -34,6 +37,14 @@ Common primitive fact families:
 - `runtimeInteraction`: trace/log-supported runtime edge, message, call, or effect
 
 Do not use `atomObservations[]` for responsibility, law violation, obstruction, forecast, quality, incident causality, or global correctness.
+
+Before emitting an observed atom:
+
+- Confirm the fact belongs to exactly one atomFamily.
+- Confirm the fact is primitive enough that it cannot be usefully split into smaller architectural observations.
+- Confirm `sourceRefs[].artifactId` resolves to `sourceUniverse.includedRefs[]`.
+- Preserve local uncertainty in `uncertainty[]` and `nonConclusions[]`.
+- Move unavailable runtime, private, generated, or unexpanded framework evidence to `observationGaps[]`.
 
 ## Observation Surfaces
 

--- a/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
+++ b/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
@@ -61,6 +61,7 @@ Use `excludedReadings` for things intentionally not read, such as lawfulness, ob
 ## Atom Observations
 
 An atom observation records a bounded observation of a primitive architectural fact. It does not certify the canonical Atom itself.
+An atom observation should not have coarse/fine scale. If a candidate observation summarizes a workflow, role, subsystem, or policy reading, split it into primitive atoms and move the larger reading to `moleculeObservations[]` or `semanticObservations[]`.
 
 Each `atomObservations[]` entry should include:
 
@@ -78,6 +79,28 @@ Each `atomObservations[]` entry should include:
 - `nonConclusions`
 
 Do not use atom families such as `responsibility`, `obstruction`, `lawViolation`, `forecast`, `qualityScore`, or `incidentCausality`. Responsibility is a molecule. Obstruction is law-relative ArchSig analysis, not an ArchMap atom observation.
+
+Atom family intent:
+
+| atomFamily | Intended primitive fact | Required evidence cue |
+| --- | --- | --- |
+| `existence` | component, module, service, class, package, process, table, queue, route, command object | selected source defines or declares the subject |
+| `relation` | import, call, read, write, publish, subscribe, owner edge, implementation edge, dependency edge | selected source shows the edge or explicit dependency |
+| `capability` | command, query, handler, port, adapter, processor, serializer, storage access | selected source exposes or dispatches the capability |
+| `state` | field, table column, cache entry, config value, status, lifecycle marker, projection | selected source defines, stores, or mutates the state |
+| `effect` | DB write, message send, email, payment, event publish, remote call, object storage mutation, queue enqueue | selected source executes or schedules the effect |
+| `authority` | permission, owner scope, role gate, visibility boundary, access path, policy scope, admin bypass | selected source checks or establishes authority |
+| `trust` | trusted source, token verification, delegated authority, provider/webhook/LLM trust boundary | selected source accepts, verifies, delegates, or constrains trust |
+| `contractSpecification` | precondition, postcondition, return shape, error behavior, invariant, idempotency, retry rule | selected source defines validation, behavior, or failure contract |
+| `semantic` | bounded domain meaning, identity meaning, ownership meaning, unit meaning, status meaning | selected source names or constrains the meaning |
+| `runtimeInteraction` | runtime call, edge, message, effect, or trace/log event | supplied runtime trace or log directly supports it |
+
+Boundary rule:
+
+- `observed` + `sourceObserved` requires inspected source refs.
+- `assumed` + `assumedSource` is for supplied policy/doc assumptions, not independent measurement.
+- `unmeasured`, `unavailable`, `private`, or `outOfScope` normally belongs in `observationGaps[]`, unless the schema field itself is recording a boundary note.
+- Missing runtime evidence, private provider behavior, unexpanded framework convention, or generated code not read is not an observed atom.
 
 ## Molecule Observations
 


### PR DESCRIPTION
## 概要

Closes #1389

- `archmap-creater` の `SKILL.md` に atomFamily ごとの観測対象・禁止対象と、atom 作成前の確認事項を追加しました。
- mapping guide / schema cheatsheet / examples / prompt pack に、sourceRefs、evidenceBoundary、confidence、uncertainty、observationGaps へ回す判断基準を同期しました。
- LLM-native ArchMap PRD に、AST や symbol index は探索補助であり Atom observation の根拠そのものではないこと、coarse Atom を作らないことを追記しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/llm_native_archmap_archsig_prd.md`
- `tools/archsig/skills/archmap-creater/SKILL.md`
- `tools/archsig/skills/archmap-creater/references/mapping-guide.md`
- `tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md`
- `tools/archsig/skills/archmap-creater/references/examples.md`
- `tools/archsig/skills/archmap-creater/references/prompt-pack.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: docs index / design tracking.