### PR TITLE
ArchMap observation surface の責務境界を固定する

### DIFF
--- a/docs/tool/llm_native_archmap_archsig_prd.md
+++ b/docs/tool/llm_native_archmap_archsig_prd.md
@@ -115,6 +115,10 @@ primitive fact を `atomObservations` に置き、責務は `moleculeObservation
 reading は `semanticObservations`、不足 evidence は `observationGaps`、review cue は
 `concernHints` に分離する。
 
+LLM は workflow-first に source を読んで Atom 候補を発見してよい。ただし artifact としての
+ArchMap では、workflow そのものを Atom として保存しない。workflow reading は、参照する
+Atom / Molecule refs を明示した semantic observation として保存する。
+
 ### R2. ArchMap は law-independent に保つ
 
 ArchMap は Atom、Molecule、Semantic observation、Observation gap を記録する。

--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -80,6 +80,21 @@ If a source can support both a primitive fact and a larger interpretation, write
 
 See `references/mapping-guide.md` for atomFamily-specific yes/no examples and `references/schema-cheatsheet.md` for required evidence metadata.
 
+## Observation Surface Decision Rules
+
+Choose the output surface by the role of the reading, not by how important it feels:
+
+| Candidate reading | Use | Do not use |
+| --- | --- | --- |
+| One primitive source-grounded architectural fact | `atomObservations[]` | `moleculeObservations[]` just because the fact is important |
+| A responsibility, role, or pattern composed from several atom refs | `moleculeObservations[]` | `atomObservations[]` with `atomFamily: "responsibility"` |
+| A workflow, operation meaning, contract behavior reading, policy reading, or commutation cue over atoms/molecules | `semanticObservations[]` | A coarse `semantic` atom that hides multiple facts |
+| Missing, private, unavailable, unmeasured, or out-of-scope evidence | `observationGaps[]` | An observed atom claiming absence |
+| A downstream AAT/SFT handoff hint | `projectionInfo[]` | A proof, forecast, lawfulness, or quality claim |
+| A source-grounded review cue | `concernHints[]` | An obstruction circuit or law violation |
+
+Workflow-first exploration is allowed: you may read a workflow to discover atoms. The ArchMap output must still put primitive facts in atoms and the workflow reading in `semanticObservations[]` after the atoms exist.
+
 ## Workflow
 
 1. Identify the bounded source universe.

--- a/tools/archsig/skills/archmap-creater/references/mapping-guide.md
+++ b/tools/archsig/skills/archmap-creater/references/mapping-guide.md
@@ -51,6 +51,28 @@ Anti-patterns:
 - Do not use atom families such as `responsibility`, `workflow`, `policy`, `obstruction`, `lawViolation`, `forecast`, `qualityScore`, or `incidentCausality`.
 - Do not turn an unavailable trace, private secret, unexpanded framework convention, or unreviewed generated file into an observed atom.
 
+## Atom Vs Molecule Vs Semantic
+
+Use this decision boundary after the atomFamily check.
+
+| Question | If yes | If no |
+| --- | --- | --- |
+| Can the reading be stated as one primitive source-grounded architecture fact? | It may be an `atomObservations[]` entry. | Do not force it into an atom. |
+| Does the reading name a role, responsibility, responsibility overload, or pattern over several atoms? | Use `moleculeObservations[]`. | Continue checking. |
+| Does the reading describe workflow meaning, operation behavior, contract behavior, policy meaning, or commutation over atoms/molecules? | Use `semanticObservations[]`. | Continue checking. |
+| Is the reading a review cue about risk, overload, missing compensation, missing runtime evidence, or disagreement? | Use `concernHints[]`. | Continue checking. |
+| Is the required evidence unavailable, private, unmeasured, generated, or out of scope? | Use `observationGaps[]`. | Read more source or discard the candidate. |
+
+Examples:
+
+- `route.users calls UserService.create` is a relation atom.
+- `route.users + service.user + create-user contract form user request orchestration` is a responsibility molecule.
+- `the route/service/contract group describes create-user behavior` is a semantic observation.
+- `the create-user workflow may lack compensation evidence` is a concern hint.
+- `runtime DB trace for create-user was not supplied` is an observation gap.
+
+Do not use `semantic` atom as a dumping ground for broad workflow readings. A `semantic` atom is only for primitive source-supported meaning, such as an identity meaning, unit meaning, ownership meaning, or status meaning.
+
 ## AAT-Facing Vs SFT-Facing
 
 AAT-facing observations preserve architecture structure:

--- a/tools/archsig/skills/archmap-creater/references/prompt-pack.md
+++ b/tools/archsig/skills/archmap-creater/references/prompt-pack.md
@@ -55,6 +55,8 @@ Before emitting an observed atom:
 - Use `concernHints[]` for review cues only. A concern hint is not an obstruction circuit.
 - Use `nonConclusions[]` to state what the artifact does not prove.
 
+Workflow-first reading is allowed for discovery, but the output must not contain coarse workflow atoms. Split primitive source facts into `atomObservations[]`, compose responsibilities in `moleculeObservations[]`, and put workflow or behavior readings in `semanticObservations[]`.
+
 ## Output Requirements
 
 - Output valid JSON only when asked for the artifact.

--- a/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
+++ b/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
@@ -117,6 +117,9 @@ Each `moleculeObservations[]` entry should include:
 - `nonConclusions`
 
 Responsibility is a molecule over atom observations, not a primitive atom.
+Use molecule observations for composed roles or patterns whose meaning depends on multiple atom observations. A molecule should reference the atom observations it composes; it should not replace those atoms.
+
+Do not create an atom with `atomFamily: "responsibility"`, `atomFamily: "workflow"`, or `atomFamily: "policy"` to avoid building the molecule/semantic layer.
 
 ## Semantic Observations
 
@@ -136,6 +139,9 @@ Each `semanticObservations[]` entry should include:
 - `nonConclusions`
 
 Scope semantic observations to the selected source refs. Do not generalize a test, fixture, or doc section into global semantic correctness.
+Use semantic observations for workflow meaning, operation meaning, behavior readings, contract readings, policy readings, and commutation cues. Do not use a coarse `semantic` atom when the reading combines multiple primitive facts.
+
+If a semantic observation depends on primitive facts, list their `atomObservationRefs`. If it depends on a composed role, list the relevant `moleculeObservationRefs`.
 
 ## Observation Gaps
 

--- a/tools/archsig/tests/fixtures/expressiveness/archmap_atom_observation_suite_v0.json
+++ b/tools/archsig/tests/fixtures/expressiveness/archmap_atom_observation_suite_v0.json
@@ -291,7 +291,8 @@
       "evidenceBoundary": "sourceObserved",
       "confidence": "medium",
       "nonConclusions": [
-        "responsibility is a molecule over atoms, not a primitive atom"
+        "responsibility is a molecule over atoms, not a primitive atom",
+        "this fixture must not encode responsibility as a coarse atom"
       ]
     }
   ],
@@ -325,7 +326,8 @@
       "observationStatus": "observed",
       "evidenceBoundary": "sourceObserved",
       "nonConclusions": [
-        "semantic observation is not a proof of global semantic correctness"
+        "semantic observation is not a proof of global semantic correctness",
+        "workflow meaning is represented here, not as a coarse semantic atom"
       ]
     }
   ],
@@ -423,6 +425,7 @@
     "concernHints are review cues, not obstruction circuits",
     "observation gaps are not measured zero",
     "Atom observations are source-grounded observations, not universal atom truth",
+    "coarse workflow, responsibility, and policy readings are not atom observations",
     "archmap-atom-observation-suite-v0 is an Atom observation regression over current root fields"
   ]
 }


### PR DESCRIPTION
## 概要

Closes #1390

- `archmap-creater` の `SKILL.md` に observation surface decision rules を追加し、atom / molecule / semantic / gap / projection / concern の配置判断を明文化しました。
- mapping guide / schema cheatsheet / prompt pack / PRD に、workflow-first に探索しても出力では coarse atom を作らない方針を同期しました。
- expressiveness fixture に、responsibility と workflow meaning を atom ではなく molecule / semanticObservation に置く regression 意図を追記しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/llm_native_archmap_archsig_prd.md`
- `tools/archsig/skills/archmap-creater/SKILL.md`
- `tools/archsig/skills/archmap-creater/references/mapping-guide.md`
- `tools/archsig/skills/archmap-creater/references/prompt-pack.md`
- `tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md`
- `tools/archsig/tests/fixtures/expressiveness/archmap_atom_observation_suite_v0.json`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: docs index / design tracking.