### PR TITLE
ArchMapの水平shard設計を追加する

### DIFF
--- a/docs/tool/llm_native_archmap_archsig_prd.md
+++ b/docs/tool/llm_native_archmap_archsig_prd.md
@@ -134,6 +134,23 @@ uncertainty、non-conclusions を持つ候補 packet にとどめる。最終 Ar
 重複を解消し、source refs を `sourceUniverse` に解決し、coarse candidate を適切な
 surface に分配し、agent 間の不一致を confidence / uncertainty / gap として保存する。
 
+巨大な `archmap.json` を直接編集・review する必要がある場合は、authoring-side の
+`archmap-shard-manifest-v0` を使って水平 shard に分割できる。標準 shard は schema field
+ごとの垂直分割ではなく、authority/authentication、state/model、effects/jobs、
+provider/trust、domain/contracts、runtime/framework、docs/governance などの bounded
+observation slice である。各 `archmap-observation-slice-v0` は、local source universe
+fragment、provenance fragment、Atom / Molecule / Semantic observations、gaps、
+projections、concerns、non-conclusions を持つ。manifest は slice path、surface、
+owned source scope、cross-slice reference rule、bundle/export policy、fixture policy を
+保持する。
+
+sharded ArchMap は新しい分析面ではない。現在の互換 contract は、bundle/export 後の
+monolithic `archmap-observation-map-v0` である。bundle/export validation は、shard path、
+required/optional slice、id collision、source refs、molecule / semantic / projection /
+concern の cross-reference、cross-slice reference、non-conclusions の保持を確認する。
+ただし、source completeness、lawfulness、Lean theorem discharge、forecast correctness は
+証明しない。
+
 ### R2. ArchMap は law-independent に保つ
 
 ArchMap は Atom、Molecule、Semantic observation、Observation gap を記録する。
@@ -316,6 +333,8 @@ ArchSig は FieldSig の forecast、governance、calibration、operational feedb
   observation の根拠そのものではないことが明記されている。
 - 大規模 repository 向けに、sub-agent の候補 packet と integrator の統合責務が
   ArchMap authoring 境界として定義されている。
+- `archmap-shard-manifest-v0` の manifest、水平 bounded observation slice、monolithic
+  export 互換方針、cross-reference validation、fixture 方針が定義されている。
 - Non-Goals が、LLM truth、extractor completeness、Lean theorem discharge、future safety、
   SFT forecast correctness を明確に除外している。
 - 破壊的変更を許容し、既存 `archmap-v0` / report / fixture / CLI surface との後方互換性を

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -19,6 +19,10 @@ forecast, governance, calibration, and operational feedback under
 | ArchSig analysis | `archsig-analysis`, `llm-native-workflow` | ArchSig combines ArchMap and LawPolicy into law-relative molecule readings, obstruction circuits, signature axes, flatness readings, repair candidates, and LLM interpretation notes. |
 | Schema | `schema-catalog` | The catalog lists only the current LLM Atom ArchMap artifacts. |
 
+Large ArchMaps may be authored in shards for review and parallel generation,
+but current commands consume the exported monolithic
+`archmap-observation-map-v0` artifact.
+
 Pre-Atom ArchSig commands were removed instead of kept as compatibility shims.
 Git history is the archive for those workflows.
 
@@ -50,6 +54,7 @@ scan-first path is no longer an ArchSig workflow.
 
 - [Command Guide](docs/commands.md)
 - [Artifacts And Boundaries](docs/artifacts-and-boundaries.md)
+- [Sharded ArchMap Design](docs/sharded-archmap.md)
 
 ## Test
 

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -25,11 +25,18 @@ candidate observations. The final ArchMap still requires an integration pass
 that deduplicates candidates, resolves source refs, preserves gaps, and promotes
 only primitive source-grounded facts to `atomObservations`.
 
+Large ArchMaps may be authored as horizontal bounded observation slices. This is
+a review and authoring layout headed by `archmap-shard-manifest-v0`; the current
+compatibility contract remains exported `archmap-observation-map-v0`. Current
+ArchSig analysis commands consume the exported monolithic artifact, not slice
+fragments.
+
 ## Current Artifacts
 
 | artifact | schemaVersion | role |
 | --- | --- | --- |
 | ArchMap observation map | `archmap-observation-map-v0` | Source-grounded Atom observation evidence. It records `atomObservations`, `moleculeObservations`, `semanticObservations`, `observationGaps`, `projectionInfo`, `concernHints`, provenance, and non-conclusions. It is law-independent and does not own obstruction circuits, lawfulness, zero curvature, repair conclusions, or Lean theorem discharge. |
+| ArchMap shard manifest | `archmap-shard-manifest-v0` | Planned authoring-side manifest for splitting large ArchMaps into horizontal bounded observation slices such as authority, state, effects, providers, runtime, domain, and governance. It is not a LawPolicy, runtime trace, or source inventory. It must bundle/export to `archmap-observation-map-v0` before current analysis. |
 | ArchMap validation report | `archmap-validation-report-v0` | Checks schema support, identity, references, provenance, source refs, observation / concern guardrails, projection separation, gap boundaries, and formal-promotion non-conclusions. |
 | LawPolicy | `law-policy-v0` | Selected LawUniverse / witness-rule / molecule-pattern / obstruction-definition / signature-axis policy for one review context. |
 | LawPolicy validation report | `law-policy-validation-report-v0` | Checks LawPolicy identity, uniqueness, cross references, witness / obstruction guardrails, coverage requirements, exactness assumptions, and non-conclusions. |

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -35,6 +35,39 @@ The command emits only:
 reading. It is not a natural-language judgement, Lean proof, architecture
 lawfulness certificate, or automatic repair instruction.
 
+## Sharded ArchMap Authoring
+
+Large ArchMaps may be drafted in a sharded authoring layout documented in
+`tools/archsig/docs/sharded-archmap.md`:
+
+```text
+.archsig/archmap/
+  manifest.json
+  slices/
+    authority.archmap-slice.json
+    state.archmap-slice.json
+    effects.archmap-slice.json
+    providers.archmap-slice.json
+    runtime.archmap-slice.json
+```
+
+The manifest schema is `archmap-shard-manifest-v0`. This is an authoring-side
+layout, not a current analysis input. The primary sharding model is horizontal:
+each `archmap-observation-slice-v0` file is a bounded observation slice over a
+repository surface or sub-agent assignment. Bundle/export must produce a
+monolithic `archmap-observation-map-v0` file before running:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- archmap \
+  --input .archsig/archmap/archmap.json \
+  --out .archsig/llm-native/archmap-validation.json
+```
+
+Current commands intentionally keep the analysis contract monolithic. A future
+bundle/export command should validate slice paths, duplicate ids, dangling
+cross-slice refs, required/optional slice policy, allowed cross-slice
+references, and source refs before writing the exported ArchMap.
+
 ## Step Commands
 
 ```bash

--- a/tools/archsig/docs/sharded-archmap.md
+++ b/tools/archsig/docs/sharded-archmap.md
@@ -1,0 +1,195 @@
+# Sharded ArchMap Design
+
+This document defines the planned sharded ArchMap authoring format. The current
+runtime artifact remains `archmap-observation-map-v0`; sharding is an authoring
+and review layout that must bundle/export back to the monolithic artifact before
+current `archsig archmap`, `archsig archsig-analysis`, or
+`archsig llm-native-workflow` commands consume it.
+
+The primary sharding model is horizontal: each shard is a bounded observation
+slice over a repository surface, subsystem, package, team-owned area, or
+sub-agent assignment. Vertical shards by schema field are allowed only as a
+secondary export optimization; they are not the recommended authoring shape for
+large codebases.
+
+## Directory Shape
+
+Use this layout by default:
+
+```text
+.archsig/archmap/
+  manifest.json
+  slices/
+    authority.archmap-slice.json
+    state.archmap-slice.json
+    effects.archmap-slice.json
+    providers.archmap-slice.json
+    runtime.archmap-slice.json
+```
+
+Each slice owns a small ArchMap-like fragment:
+
+- local source universe fragment
+- local provenance and generation boundary
+- atom observations
+- molecule observations
+- semantic observations
+- observation gaps
+- projection hints
+- concern hints
+- local non-conclusions
+
+The manifest owns ordering, slice identity, export policy, and validation
+boundary. The manifest is not a source inventory, runtime trace, or LawPolicy.
+
+## Manifest Shape
+
+Minimal manifest:
+
+```json
+{
+  "schemaVersion": "archmap-shard-manifest-v0",
+  "manifestId": "archmap-manifest-<scope>",
+  "mapId": "archmap-<scope>",
+  "architectureId": "<architecture-id>",
+  "canonicalSchemaVersion": "archmap-observation-map-v0",
+  "root": ".archsig/archmap",
+  "shardingMode": "horizontal-bounded-observation-slices",
+  "slices": [
+    {
+      "sliceId": "authority",
+      "sliceKind": "boundedObservationSlice",
+      "surface": "authority/authentication",
+      "path": "slices/authority.archmap-slice.json",
+      "ownedSourceScopes": ["src/auth", "src/routes"],
+      "mayReferenceSlices": ["state", "providers"],
+      "required": true
+    },
+    {
+      "sliceId": "effects",
+      "sliceKind": "boundedObservationSlice",
+      "surface": "effects/jobs",
+      "path": "slices/effects.archmap-slice.json",
+      "ownedSourceScopes": ["src/jobs", "src/mail", "src/events"],
+      "mayReferenceSlices": ["state", "providers"],
+      "required": false
+    }
+  ],
+  "exportPolicy": {
+    "targetSchemaVersion": "archmap-observation-map-v0",
+    "targetPath": "archmap.json",
+    "sliceOrdering": ["authority", "state", "effects", "providers", "runtime"],
+    "idCollisionPolicy": "fail",
+    "missingSlicePolicy": "fail-required-warn-optional",
+    "sourceUniverseMergePolicy": "union-with-boundary-preservation",
+    "nonConclusions": [
+      "bundle/export preserves JSON observation refs; it does not prove source completeness"
+    ]
+  },
+  "crossReferenceValidation": {
+    "requiredChecks": [
+      "all slice paths resolve under manifest root",
+      "all slice ids are unique",
+      "all observation ids are globally unique after bundling",
+      "all accepted sourceRefs[].artifactId resolve to the exported sourceUniverse.includedRefs[] unless they are explicit gap/private/unavailable refs",
+      "molecule atomObservationRefs resolve to bundled atomObservations[]",
+      "semantic atomObservationRefs resolve to bundled atomObservations[]",
+      "semantic moleculeObservationRefs resolve to bundled moleculeObservations[]",
+      "projection sourceObservationRef resolves to bundled atom, molecule, or semantic observations",
+      "concern refs resolve to bundled atom, molecule, or semantic observations",
+      "cross-slice references are either allowed by mayReferenceSlices or downgraded to uncertainty/gap before export"
+    ],
+    "nonConclusions": [
+      "cross-reference validation is not architecture lawfulness",
+      "cross-reference validation is not certified Atom truth"
+    ]
+  },
+  "fixturePolicy": {
+    "minimalFixture": "two bounded slices that export to a valid monolithic ArchMap shape",
+    "largeFixture": "many synthetic bounded slices with duplicate-id, dangling-ref, optional-slice, missing-required-slice, and cross-slice-reference cases",
+    "privateDataPolicy": "fixtures must not contain private real-codebase source content"
+  },
+  "nonConclusions": [
+    "sharded ArchMap is an authoring layout, not a new proof surface",
+    "monolithic export remains the compatibility contract for current ArchSig analysis"
+  ]
+}
+```
+
+## Slice Shape
+
+A horizontal slice uses this shape:
+
+```json
+{
+  "schemaVersion": "archmap-observation-slice-v0",
+  "sliceId": "authority",
+  "sliceKind": "boundedObservationSlice",
+  "surface": "authority/authentication",
+  "generationBoundary": {},
+  "sourceUniverseFragment": {},
+  "provenanceFragment": {},
+  "atomObservations": [],
+  "moleculeObservations": [],
+  "semanticObservations": [],
+  "observationGaps": [],
+  "projectionInfo": [],
+  "concernHints": [],
+  "nonConclusions": []
+}
+```
+
+The field names intentionally mirror `archmap-observation-map-v0` so export is a
+structural merge rather than semantic reinterpretation.
+
+Recommended slice surfaces:
+
+| Surface | Typical owner | Notes |
+| --- | --- | --- |
+| `authority/authentication` | roles, session, route gates, admin bypasses | Good first slice because authority observations often cite many source areas. |
+| `state/model` | schemas, migrations, persisted state, projections | Cross-references effects and contracts. |
+| `effects/jobs` | writes, queues, workers, emails, provider calls | Keeps effect atoms close to job/runtime gaps. |
+| `providers/trust` | webhooks, tokens, LLM/provider outputs, delegated credentials | Keeps trust boundary and provider uncertainty local. |
+| `domain/contracts` | DTO validation, contract tests, invariants, operation terms | Often feeds semantic observations. |
+| `runtime/framework` | traces, generated code, framework conventions, dynamic loading | Often mostly gaps and uncertainty. |
+| `docs/governance` | architecture policy, layer docs, review rules | Provides policy readings without claiming lawfulness. |
+
+## Bundle / Export Compatibility
+
+The bundle/export step must produce one valid `archmap-observation-map-v0` JSON
+document. Current downstream commands consume only the exported monolithic file.
+
+Export rules:
+
+- preserve all ids exactly
+- preserve source refs exactly
+- merge source-universe fragments by artifact id, path, kind, and boundary
+- fail on duplicate observation ids across slices
+- fail when required slices are missing
+- warn, but do not fail, when optional slices are absent and the exported
+  monolithic artifact still satisfies validation
+- fail when bundled cross-reference refs are dangling
+- keep unavailable/private/generated/framework evidence as gaps or boundary
+  notes, never as observed absence
+- keep `nonConclusions` from manifest and slices in the exported artifact
+- keep per-slice provenance in the exported provenance or non-conclusion notes
+
+## Validation Test Plan
+
+When bundle/export is implemented, add tests for:
+
+- minimal horizontal-slice fixture exports to a monolithic ArchMap accepted by
+  `archsig archmap`
+- synthetic large fixture exports deterministically with stable slice ordering
+- duplicate ids across slices fail validation
+- dangling atom/molecule/semantic/projection/concern refs fail validation
+- missing required slice fails validation
+- missing optional slice warns when monolithic validation still passes
+- cross-slice references not allowed by `mayReferenceSlices` fail or require
+  explicit uncertainty before export
+- source refs outside exported `sourceUniverse.includedRefs[]` fail unless they
+  are explicit gap/private/unavailable refs
+
+These tests validate JSON packaging and reference integrity only. They do not
+prove source completeness, architecture lawfulness, Lean theorem discharge, or
+forecast correctness.

--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -149,6 +149,50 @@ Integration rules:
 - Preserve each agent's blind spots and excluded readings in `sourceUniverse`, `provenance`, `observationGaps[]`, or `nonConclusions[]`.
 - Do not merge all candidates mechanically. The final ArchMap is an integrated bounded observation map.
 
+## Sharded ArchMap Authoring
+
+For large maps, author shards under `.archsig/archmap/` and keep
+`manifest.json` as the review index. Use horizontal bounded observation slices
+by repository surface, subsystem, package, team-owned area, or sub-agent
+assignment. Sharding is an authoring layout only; export to monolithic
+`archmap-observation-map-v0` before handing the artifact to current ArchSig
+analysis commands.
+
+Default shard layout:
+
+```text
+.archsig/archmap/
+  manifest.json
+  slices/
+    authority.archmap-slice.json
+    state.archmap-slice.json
+    effects.archmap-slice.json
+    providers.archmap-slice.json
+    runtime.archmap-slice.json
+```
+
+Use `archmap-shard-manifest-v0` for the manifest. It should list slice ids,
+surfaces, paths, owned source scopes, allowed cross-slice references,
+required/optional status, export policy, cross-reference validation checks,
+fixture policy, and non-conclusions.
+
+Each `archmap-observation-slice-v0` should contain a local
+`sourceUniverseFragment`, `provenanceFragment`, `generationBoundary`,
+`atomObservations[]`, `moleculeObservations[]`, `semanticObservations[]`,
+`observationGaps[]`, `projectionInfo[]`, `concernHints[]`, and
+`nonConclusions[]`.
+
+Bundle/export rules:
+
+- Export must produce one valid `archmap-observation-map-v0` JSON file.
+- Required missing slices fail; optional missing slices may warn.
+- Duplicate observation ids across slices fail.
+- Source-universe fragments merge by artifact id, path, kind, and boundary.
+- Dangling molecule, semantic, projection, concern, and source refs fail unless the reference is explicitly a gap/private/unavailable boundary.
+- Disallowed cross-slice references fail or must be downgraded to uncertainty/gap before export.
+- Source refs for observed atoms must resolve to exported `sourceUniverse.includedRefs[]`.
+- Sharding does not prove source completeness, lawfulness, certified Atom truth, or Lean theorem discharge.
+
 ## Workflow
 
 1. Identify the bounded source universe.

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -13,6 +13,10 @@ fn expressiveness_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/expressiveness")
 }
 
+fn sharded_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sharded")
+}
+
 #[test]
 fn cli_help_exposes_only_llm_atom_archmap_surface() {
     let output = run_sig0_output(&["--help"]);
@@ -146,6 +150,46 @@ fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
     );
     let llm_packet = read_json(&out_dir.join("llm-interpretation-packet.json"));
     assert_eq!(llm_packet, analysis_packet);
+}
+
+#[test]
+fn sharded_archmap_design_fixture_uses_horizontal_slices() {
+    let root = sharded_root();
+    let manifest = read_json(&root.join("manifest.json"));
+    assert_eq!(manifest["schemaVersion"], "archmap-shard-manifest-v0");
+    assert_eq!(
+        manifest["shardingMode"],
+        "horizontal-bounded-observation-slices"
+    );
+
+    let slices = manifest["slices"]
+        .as_array()
+        .expect("manifest slices are an array");
+    assert!(
+        slices.len() >= 2,
+        "horizontal fixture should include multiple bounded slices"
+    );
+    for slice in slices {
+        assert_eq!(slice["sliceKind"], "boundedObservationSlice");
+        let path = slice["path"].as_str().expect("slice path is present");
+        let slice_json = read_json(&root.join(path));
+        assert_eq!(slice_json["schemaVersion"], "archmap-observation-slice-v0");
+        assert_eq!(slice_json["sliceId"], slice["sliceId"]);
+        assert_eq!(slice_json["surface"], slice["surface"]);
+        assert!(
+            slice_json.get("sourceUniverseFragment").is_some(),
+            "slice {path} must carry its local source universe fragment"
+        );
+        assert!(
+            slice_json.get("atomObservations").is_some(),
+            "slice {path} must retain ArchMap observation arrays"
+        );
+    }
+
+    assert_eq!(
+        manifest["exportPolicy"]["targetSchemaVersion"],
+        "archmap-observation-map-v0"
+    );
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/sharded/README.md
+++ b/tools/archsig/tests/fixtures/sharded/README.md
@@ -1,0 +1,15 @@
+# Sharded ArchMap Fixtures
+
+These fixtures define the planned horizontal sharded authoring layout for large
+ArchMaps. They are design fixtures, not current CLI inputs.
+
+- `manifest.json` uses `archmap-shard-manifest-v0`.
+- `slices/*.archmap-slice.json` use `archmap-observation-slice-v0`.
+- Each slice is a bounded observation slice over one repository surface, such as
+  authority, state, or runtime evidence.
+- A future bundle/export command should combine these shards into one
+  `archmap-observation-map-v0` JSON document before running current ArchSig
+  validation or analysis commands.
+
+The fixtures use synthetic source refs only. They must not include private
+real-codebase source content.

--- a/tools/archsig/tests/fixtures/sharded/manifest.json
+++ b/tools/archsig/tests/fixtures/sharded/manifest.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "archmap-shard-manifest-v0",
+  "manifestId": "archmap-manifest-fixture-horizontal",
+  "mapId": "fixture-archmap-horizontal-slices",
+  "architectureId": "archmap-fixture-repo",
+  "canonicalSchemaVersion": "archmap-observation-map-v0",
+  "root": "tools/archsig/tests/fixtures/sharded",
+  "shardingMode": "horizontal-bounded-observation-slices",
+  "slices": [
+    {
+      "sliceId": "authority",
+      "sliceKind": "boundedObservationSlice",
+      "surface": "authority/authentication",
+      "path": "slices/authority.archmap-slice.json",
+      "ownedSourceScopes": ["src/routes", "src/auth"],
+      "mayReferenceSlices": ["state"],
+      "required": true
+    },
+    {
+      "sliceId": "state",
+      "sliceKind": "boundedObservationSlice",
+      "surface": "state/model",
+      "path": "slices/state.archmap-slice.json",
+      "ownedSourceScopes": ["src/services", "src/models"],
+      "mayReferenceSlices": ["authority"],
+      "required": true
+    },
+    {
+      "sliceId": "runtime",
+      "sliceKind": "boundedObservationSlice",
+      "surface": "runtime/framework",
+      "path": "slices/runtime.archmap-slice.json",
+      "ownedSourceScopes": [".archsig/runtime"],
+      "mayReferenceSlices": ["authority", "state"],
+      "required": false
+    }
+  ],
+  "exportPolicy": {
+    "targetSchemaVersion": "archmap-observation-map-v0",
+    "targetPath": "archmap.json",
+    "sliceOrdering": ["authority", "state", "runtime"],
+    "idCollisionPolicy": "fail",
+    "missingSlicePolicy": "fail-required-warn-optional",
+    "sourceUniverseMergePolicy": "union-with-boundary-preservation",
+    "nonConclusions": [
+      "bundle/export preserves JSON observation refs; it does not prove source completeness"
+    ]
+  },
+  "crossReferenceValidation": {
+    "requiredChecks": [
+      "all slice paths resolve under manifest root",
+      "all slice ids are unique",
+      "all observation ids are globally unique after bundling",
+      "all accepted sourceRefs[].artifactId resolve to the exported sourceUniverse.includedRefs[] unless they are explicit gap/private/unavailable refs",
+      "molecule atomObservationRefs resolve to bundled atomObservations[]",
+      "semantic atomObservationRefs resolve to bundled atomObservations[]",
+      "semantic moleculeObservationRefs resolve to bundled moleculeObservations[]",
+      "projection sourceObservationRef resolves to bundled atom, molecule, or semantic observations",
+      "concern refs resolve to bundled atom, molecule, or semantic observations",
+      "cross-slice references are either allowed by mayReferenceSlices or downgraded to uncertainty/gap before export"
+    ],
+    "nonConclusions": [
+      "cross-reference validation is not architecture lawfulness",
+      "cross-reference validation is not certified Atom truth"
+    ]
+  },
+  "fixturePolicy": {
+    "minimalFixture": "two bounded slices that export to a valid monolithic ArchMap shape",
+    "largeFixture": "many synthetic bounded slices with duplicate-id, dangling-ref, optional-slice, missing-required-slice, and cross-slice-reference cases",
+    "privateDataPolicy": "fixtures must not contain private real-codebase source content"
+  },
+  "nonConclusions": [
+    "sharded ArchMap is an authoring layout, not a new proof surface",
+    "monolithic export remains the compatibility contract for current ArchSig analysis"
+  ]
+}

--- a/tools/archsig/tests/fixtures/sharded/slices/authority.archmap-slice.json
+++ b/tools/archsig/tests/fixtures/sharded/slices/authority.archmap-slice.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "archmap-observation-slice-v0",
+  "sliceId": "authority",
+  "sliceKind": "boundedObservationSlice",
+  "surface": "authority/authentication",
+  "generationBoundary": {
+    "tokenBudget": "fixture",
+    "scope": ["src/routes", "src/auth"],
+    "excludedRefs": [],
+    "privateRefs": [],
+    "unavailableRefs": [],
+    "nonConclusions": [
+      "authority slice does not imply complete permission coverage"
+    ]
+  },
+  "sourceUniverseFragment": {
+    "root": ".",
+    "includedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      }
+    ],
+    "excludedRefs": [],
+    "unavailableRefs": [],
+    "privateRefs": [],
+    "hashes": [],
+    "knownBlindSpots": [],
+    "selectionBoundary": "authority slice over user route evidence"
+  },
+  "provenanceFragment": {
+    "observer": "human-reviewed-fixture",
+    "observationMethod": "bounded authority slice fixture",
+    "sourceRoot": ".",
+    "observationBoundary": "source-grounded authority observations only",
+    "reviewedRefs": [
+      {
+        "artifactId": "src-route-users",
+        "kind": "file",
+        "path": "src/routes/users.ts",
+        "symbol": "createUserRoute",
+        "line": 42
+      }
+    ],
+    "excludedReadings": [
+      "global permission correctness",
+      "lawfulness"
+    ],
+    "nonConclusions": [
+      "slice provenance is not complete repository coverage"
+    ]
+  },
+  "atomObservations": [
+    {
+      "atomObservationId": "atom:authority:user-route-member-gate",
+      "atomFamily": "authority",
+      "predicate": "user route checks member authority before create-user operation",
+      "subjectRef": "route.users.create",
+      "objectRefs": ["authority.member"],
+      "sourceRefs": [
+        {
+          "artifactId": "src-route-users",
+          "kind": "file",
+          "path": "src/routes/users.ts",
+          "symbol": "createUserRoute",
+          "line": 42
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [
+        "other routes are outside this authority slice"
+      ],
+      "projectionRefs": [],
+      "nonConclusions": [
+        "authority atom does not prove complete permission coverage"
+      ]
+    }
+  ],
+  "moleculeObservations": [],
+  "semanticObservations": [],
+  "observationGaps": [],
+  "projectionInfo": [],
+  "concernHints": [],
+  "nonConclusions": [
+    "authority slice is candidate ArchMap evidence until bundled and validated"
+  ]
+}

--- a/tools/archsig/tests/fixtures/sharded/slices/runtime.archmap-slice.json
+++ b/tools/archsig/tests/fixtures/sharded/slices/runtime.archmap-slice.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": "archmap-observation-slice-v0",
+  "sliceId": "runtime",
+  "sliceKind": "boundedObservationSlice",
+  "surface": "runtime/framework",
+  "generationBoundary": {
+    "tokenBudget": "fixture",
+    "scope": [".archsig/runtime"],
+    "excludedRefs": [],
+    "privateRefs": [],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "nonConclusions": [
+      "missing runtime trace is not measured zero"
+    ]
+  },
+  "sourceUniverseFragment": {
+    "root": ".",
+    "includedRefs": [],
+    "excludedRefs": [],
+    "unavailableRefs": [
+      {
+        "kind": "runtimeTrace",
+        "path": ".lake/runtime-trace.json"
+      }
+    ],
+    "privateRefs": [],
+    "hashes": [],
+    "knownBlindSpots": [
+      "runtime traces not supplied"
+    ],
+    "selectionBoundary": "runtime slice records unavailable trace evidence"
+  },
+  "provenanceFragment": {
+    "observer": "human-reviewed-fixture",
+    "observationMethod": "bounded runtime slice fixture",
+    "sourceRoot": ".",
+    "observationBoundary": "unavailable runtime evidence is recorded as a gap",
+    "reviewedRefs": [],
+    "excludedReadings": [
+      "measured runtime absence"
+    ],
+    "nonConclusions": [
+      "unavailable runtime slice is not runtime measurement"
+    ]
+  },
+  "atomObservations": [],
+  "moleculeObservations": [],
+  "semanticObservations": [],
+  "observationGaps": [
+    {
+      "gapId": "gap-runtime-user-route-trace",
+      "gapKind": "UnavailableRuntimeTrace",
+      "subjectRef": "runtime.route.users",
+      "evidenceStatus": "unavailable",
+      "reason": "runtime route trace was not supplied",
+      "expectedAtomFamilies": ["runtimeInteraction"],
+      "sourceRefs": [
+        {
+          "kind": "runtimeTrace",
+          "path": ".lake/runtime-trace.json"
+        }
+      ],
+      "nonConclusions": [
+        "unavailable runtime trace is not measured zero"
+      ]
+    }
+  ],
+  "projectionInfo": [],
+  "concernHints": [],
+  "nonConclusions": [
+    "runtime slice records a gap, not observed absence"
+  ]
+}

--- a/tools/archsig/tests/fixtures/sharded/slices/state.archmap-slice.json
+++ b/tools/archsig/tests/fixtures/sharded/slices/state.archmap-slice.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "archmap-observation-slice-v0",
+  "sliceId": "state",
+  "sliceKind": "boundedObservationSlice",
+  "surface": "state/model",
+  "generationBoundary": {
+    "tokenBudget": "fixture",
+    "scope": ["src/services", "src/models"],
+    "excludedRefs": [],
+    "privateRefs": [],
+    "unavailableRefs": [],
+    "nonConclusions": [
+      "state slice does not imply complete data model coverage"
+    ]
+  },
+  "sourceUniverseFragment": {
+    "root": ".",
+    "includedRefs": [
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      }
+    ],
+    "excludedRefs": [],
+    "unavailableRefs": [],
+    "privateRefs": [],
+    "hashes": [],
+    "knownBlindSpots": [],
+    "selectionBoundary": "state slice over user service state evidence"
+  },
+  "provenanceFragment": {
+    "observer": "human-reviewed-fixture",
+    "observationMethod": "bounded state slice fixture",
+    "sourceRoot": ".",
+    "observationBoundary": "source-grounded state observations only",
+    "reviewedRefs": [
+      {
+        "artifactId": "src-service-user",
+        "kind": "file",
+        "path": "src/services/user.ts",
+        "symbol": "UserService",
+        "line": 12
+      }
+    ],
+    "excludedReadings": [
+      "complete data model coverage",
+      "runtime database state"
+    ],
+    "nonConclusions": [
+      "slice provenance is not complete repository coverage"
+    ]
+  },
+  "atomObservations": [
+    {
+      "atomObservationId": "atom:state:user-record",
+      "atomFamily": "state",
+      "predicate": "user service persists user record state",
+      "subjectRef": "state.userRecord",
+      "objectRefs": ["service.user"],
+      "sourceRefs": [
+        {
+          "artifactId": "src-service-user",
+          "kind": "file",
+          "path": "src/services/user.ts",
+          "symbol": "UserService",
+          "line": 12
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "high",
+      "uncertainty": [
+        "runtime database contents were not inspected"
+      ],
+      "projectionRefs": [],
+      "nonConclusions": [
+        "state atom does not prove persistence correctness"
+      ]
+    }
+  ],
+  "moleculeObservations": [],
+  "semanticObservations": [],
+  "observationGaps": [],
+  "projectionInfo": [],
+  "concernHints": [],
+  "nonConclusions": [
+    "state slice is candidate ArchMap evidence until bundled and validated"
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1392
Closes #1387

大規模 ArchMap authoring 向けに、水平分割の sharded ArchMap 設計を追加しました。schema field ごとの垂直分割ではなく、authority/state/effects/provider/runtime などの bounded observation slice を primary design として固定しています。

- `archmap-shard-manifest-v0` と `archmap-observation-slice-v0` の設計文書を追加
- monolithic `archmap-observation-map-v0` への bundle/export 互換方針を明記
- cross-slice / cross-reference validation 方針を追加
- 水平 slice fixture と regression test を追加
- README / command docs / artifact boundary / SKILL.md / PRD に反映

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/docs/sharded-archmap.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`
- `tools/archsig/README.md`
- `tools/archsig/skills/archmap-creater/SKILL.md`
- `docs/tool/llm_native_archmap_archsig_prd.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない