### PR TITLE
ArchSig release upload の repository 指定を追加

### DIFF
--- a/.github/workflows/archsig-release.yml
+++ b/.github/workflows/archsig-release.yml
@@ -171,6 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       RELEASE_TAG: ${{ needs.release-context.outputs.tag }}
     steps:
       - name: Download packaged assets
@@ -193,8 +194,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --generate-notes
+          if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" --repo "$GH_REPO" --title "$RELEASE_TAG" --generate-notes
           fi
 
       - name: Upload assets to release
@@ -202,4 +203,4 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh release upload "$RELEASE_TAG" dist/* --clobber
+          gh release upload "$RELEASE_TAG" dist/* --repo "$GH_REPO" --clobber


### PR DESCRIPTION
## 概要

Release asset upload job は checkout を行わないため、GitHub CLI が repository を推定できずに失敗していた。GH_REPO と --repo を明示して、checkout なしでも release view / create / upload が動くようにする。

対象 Issue: なし（release 検証中に見つかった follow-up 修正）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] lake build（workflow のみの変更のため未実施）
- [ ] cargo test --manifest-path tools/archsig/Cargo.toml（Rust 変更なしのため未実施）
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）

追加確認:

- [x] Ruby YAML parse による .github/workflows/archsig-release.yml の構文確認

## チェックリスト

- [ ] 対象 Issue を Closes 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした（Lean 変更なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない