### PR TITLE
ArchSig release tag 命名規則を README に追記

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -67,6 +67,10 @@ Each binary archive contains the `archsig` executable, the repository license,
 and the ArchSig README / command guide. The skills archive contains
 `tools/archsig/skills`.
 
+Use version-only tags such as `v0.1.0` or prerelease tags such as
+`v0.1.0-rc.1`. Do not include `archsig` in the tag name; asset names already
+carry the `archsig-` prefix.
+
 ## Docs
 
 - [Command Guide](docs/commands.md)


### PR DESCRIPTION
## 概要

ArchSig release asset の名前が二重 prefix にならないよう、release tag は v0.1.0 / v0.1.0-rc.1 のような version-only 形式にし、tag 名に archsig を含めない運用を README に追記します。

対象 Issue: なし（会話起点の docs 追記）

## 証明した定理

- なし

## 編集したドキュメント

- tools/archsig/README.md

## 実施したテスト

- [ ] lake build（README のみの変更のため未実施）
- [ ] cargo test --manifest-path tools/archsig/Cargo.toml（README のみの変更のため未実施）
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）

## チェックリスト

- [ ] 対象 Issue を Closes 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした（Lean 変更なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない