### PR TITLE
ArchSig release archive に skills を同梱

### DIFF
--- a/.github/workflows/archsig-release.yml
+++ b/.github/workflows/archsig-release.yml
@@ -108,6 +108,7 @@ jobs:
           cp LICENSE package/LICENSE
           cp tools/archsig/README.md package/README.md
           cp tools/archsig/docs/commands.md package/docs/commands.md
+          cp -R tools/archsig/skills package/skills
 
       - name: Create tar archive
         if: matrix.archive_format == 'tar.gz'
@@ -134,40 +135,11 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  package-skills:
-    name: Package ArchSig skills
-    needs: release-context
-    runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${{ needs.release-context.outputs.tag }}
-      ASSET_TAG: ${{ needs.release-context.outputs.asset_tag }}
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-context.outputs.tag }}
-
-      - name: Create skills archive
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mkdir -p dist
-          tar -czf "dist/archsig-skills-${ASSET_TAG}.tar.gz" -C tools/archsig skills
-
-      - name: Upload skills archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: archsig-skills
-          path: dist/*
-          if-no-files-found: error
-
   publish-assets:
     name: Upload release assets
     needs:
       - release-context
       - build-binaries
-      - package-skills
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -60,12 +60,10 @@ existing tag. The workflow uploads:
 - `archsig-<tag>-linux-x86_64.tar.gz`
 - `archsig-<tag>-macos-universal.tar.gz`
 - `archsig-<tag>-windows-x86_64.zip`
-- `archsig-skills-<tag>.tar.gz`
 - `SHA256SUMS.txt`
 
 Each binary archive contains the `archsig` executable, the repository license,
-and the ArchSig README / command guide. The skills archive contains
-`tools/archsig/skills`.
+the ArchSig README / command guide, and the ArchSig skills directory.
 
 Use version-only tags such as `v0.1.0` or prerelease tags such as
 `v0.1.0-rc.1`. Do not include `archsig` in the tag name; asset names already


### PR DESCRIPTION
## 概要

ArchSig の release asset 構成を、各 platform binary archive に skills ディレクトリも同梱する形へ変更します。利用者は自分の platform 用 archive を 1 つ取得すれば、CLI と ArchMap 作成用 skill / prompt pack をまとめて使えます。

この変更により、別建ての archsig-skills asset と package-skills job は削除します。

対象 Issue: なし（release 配布設計の follow-up）

## 証明した定理

- なし

## 編集したドキュメント

- tools/archsig/README.md

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [ ] cargo test --manifest-path tools/archsig/Cargo.toml（Rust 変更なしのため未実施）
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）

追加確認:

- [x] Ruby YAML parse による .github/workflows/archsig-release.yml の構文確認
- [x] release package 構成のローカル再現で skills/archmap-creater 配下の agents / references 同梱を確認

## チェックリスト

- [ ] 対象 Issue を Closes 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした（Lean 変更なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない