### PR TITLE
ArchSigをAAT North Star解析packetへ拡張する

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -1,6 +1,7 @@
 # Tool Docs
 
-`docs/tool/` is built around the LLM-native ArchMap / LawPolicy / ArchSig workflow.
+`docs/tool/` is built around the LLM-native ArchMap / interpretation profile /
+ArchSig AAT analysis workflow.
 
 The previous mixed tool documents are archived under:
 
@@ -9,12 +10,12 @@ The previous mixed tool documents are archived under:
 Current source-of-truth boundaries:
 
 - ArchMap starts from supplied `archmap-observation-map-v0` evidence read as a source-grounded Atom observation map. It records `atomObservations`, `moleculeObservations`, `semanticObservations`, `observationGaps`, `projectionInfo`, `concernHints`, provenance, and non-conclusions.
-- LawPolicy selects laws, witness rules, molecule patterns, obstruction circuit definitions, signature axes, coverage requirements, and exactness assumptions separately from ArchMap.
-- ArchSig reads ArchMap + LawPolicy and computes law-relative obstruction / signature analysis. Obstruction circuits and zero-curvature readings are not first-class ArchMap outputs.
-- `llm-native-workflow` and `archsig-analysis` are the normal ArchSig entry points. Removed pre-Atom workflows remain available only through Git history; they are not current ArchSig surface or compatibility inputs.
+- The selected interpretation profile currently uses the `law-policy-v0` JSON schema. It selects laws, witness rules, molecule patterns, obstruction circuit definitions, signature axes, coverage requirements, and exactness assumptions separately from ArchMap. It is a profile, not AAT itself.
+- ArchSig reads ArchMap + interpretation profile and computes the North Star AAT analysis packet: AAT concept surfaces, architecture state, design pressure, change impact, architecture object projections, invariant family readings, LawUniverse reading, obstruction circuits, signature axes, analytic representations, semantic coupling/cohesion, design principle readings, bounded judgements, repair operation deltas, path / homotopy / diagram readings, and LLM interpretation. Obstruction circuits and zero-curvature readings are not first-class ArchMap outputs.
+- `llm-native-workflow` / `north-star-workflow` and `archsig-analysis` / `aat-analysis` are the normal ArchSig entry points. Removed pre-Atom workflows remain available only through Git history; they are not current ArchSig surface or compatibility inputs.
 - `concernHints` are review cues. They are not obstruction circuits, not law violations, and not theorem evidence.
 - ArchMap validation rejects non-current root fields. Authoring must use the Atom observation fields above; pre-Atom ArchMap shapes are not compatibility inputs.
-- The ArchSig schema catalog contains only ArchMap, LawPolicy, ArchSig analysis packet, and their validation reports.
+- The ArchSig schema catalog contains only ArchMap, interpretation profile (`law-policy-v0`), ArchSig analysis packet, and their validation reports.
 - ArchSig validation does not prove extractor completeness, semantic correctness, architecture lawfulness, global safety, certified universal atom truth, zero curvature, SFT forecast correctness, or Lean theorem discharge.
 - FieldSig / SFT forecast and governance surfaces are not owned by ArchSig. FieldSig consumes `archsig-analysis-packet-v0` as bounded local AAT state and projects obstruction circuits, signature axes, repair candidates, and coverage gaps into SFT input boundaries. It does not read raw ArchMap observations as forecast truth.
 

--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -1,20 +1,23 @@
 # ArchSig Analysis Packet
 
-`archsig-analysis-packet-v0` is the LLM-native ArchSig output artifact.
-It reads a source-grounded ArchMap together with one selected LawPolicy and
-records AAT-based, law-relative analysis.
+`archsig-analysis-packet-v0` is the North Star ArchSig output artifact.
+It reads a source-grounded ArchMap together with one selected interpretation
+profile and records AAT-based, bounded analysis for LLM and human review.
 
 ```text
 ArchMap
   records law-independent Atom observations.
 
-LawPolicy
+InterpretationProfile
   selects the LawUniverse, witness rules, signature axes, coverage, and exactness.
+  The current JSON artifact is still named law-policy-v0 for the profile input.
 
 ArchSig Analysis Packet
-  records molecule readings, obstruction circuits, signature axes, flatness
-  reading, repair operation candidates, child-level evidence boundaries, and
-  LLM notes.
+  records AAT concept surfaces, architecture state, design pressure, change
+  impact, molecule readings, obstruction circuits, signature axes, analytic
+  representations, design principle readings, bounded judgements, repair
+  operation candidates, operation deltas, path / homotopy / diagram readings,
+  child-level evidence boundaries, and an LLM interpretation packet.
 ```
 
 ## Responsibility
@@ -24,15 +27,30 @@ a single architecture quality score.
 
 The implemented schema records:
 
+- `interpretationProfileRef`
 - `selectedLawPolicyRef`
 - `archMapRef`
+- `architectureState`
+- `designPressure`
+- `changeImpact`
+- `aatConceptSurfaces`
 - `atomConfigurationSummary`
+- `architectureObjectProjections`
+- `invariantFamilyReadings`
+- `lawUniverseReading`
 - `moleculeReadings`
 - `obstructionCircuits`
 - `signatureAxes`
+- `analyticRepresentations`
+- `couplingCohesionReadings`
+- `designPrincipleReadings`
 - `flatnessReading`
 - `staticRuntimeSemanticLayerSplit`
 - `repairOperationCandidates`
+- `operationDeltas`
+- `pathHomotopyDiagramReadings`
+- `boundedJudgements`
+- `llmInterpretationPacket`
 - `evidenceBoundary`
 - `interpretationNotesForLLM`
 - `excludedReadings`
@@ -40,9 +58,11 @@ The implemented schema records:
 
 ## Validation Boundary
 
-Packet validation checks identity, ArchMap / LawPolicy references, law-relative
-obstruction links, signature / flatness references, repair candidate guardrails,
-LLM interpretation notes, evidence boundary, and required non-conclusions.
+Packet validation checks identity, ArchMap / interpretation profile references,
+AAT concept coverage, bounded judgement statuses, analytic axes, design
+principle readings, law-relative obstruction links, signature / flatness
+references, repair candidate guardrails, LLM interpretation notes, evidence
+boundary, and required non-conclusions.
 Each obstruction circuit, signature axis reading, and repair operation candidate
 must carry its own `missingEvidence` and `excludedReadings`. Packet-level
 `excludedReadings` does not stand in for child-record evidence boundaries.
@@ -55,6 +75,9 @@ Validation does not imply:
 - universal quality score
 - global flatness proof
 - automatic repair safety
+- source extraction completeness
+- merge approval
+- LLM output as architecture truth
 
 ## Current Fixture
 
@@ -71,15 +94,27 @@ records both `archsig-analysis-packet-v0` and
 
 The builder:
 
-- evaluates selected LawPolicy witness rules over ArchMap atom and semantic observations
+- evaluates selected interpretation-profile witness rules over ArchMap atom and semantic observations
 - uses `concernHints` only as auxiliary evidence
 - constructs obstruction circuits only as ArchSig outputs
 - values required signature axes from constructed obstruction circuits
 - preserves observation gaps as flatness blockers, not measured zero
+- emits AAT concept surfaces for Atom, Configuration, ArchitectureObject,
+  Invariant, LawUniverse, ObstructionCircuit, ArchitectureSignature, Operation,
+  Path, Homotopy, Diagram, and AnalyticRepresentation
+- emits architecture state, design pressure, change impact, bounded judgements,
+  LLM interpretation, analytic representation, semantic coupling/cohesion, and
+  design principle readings
+- analytic representations include weighted adjacency, walk count, reachable
+  cone size, nilpotence boundary, selected subgraph spectrum, propagation depth,
+  spectral radius, curvature valuation, state algebra boundary, and
+  zero-reflecting aggregate boundary
 - emits repair operation candidates with preserved invariants, preconditions,
   transfer risks, evidence boundaries, and non-conclusions
+- emits operation deltas and path / homotopy / diagram readings for repair
+  planning and review focus
 - fills child-level `missingEvidence` / `excludedReadings` from ArchMap
-  observation gaps, LawPolicy coverage and exactness assumptions, selected
+  observation gaps, interpretation-profile coverage and exactness assumptions, selected
   witness rules, and repair-candidate evidence limits
 
 ## Downstream Handoff

--- a/docs/tool/law_policy.md
+++ b/docs/tool/law_policy.md
@@ -1,7 +1,7 @@
-# LawPolicy
+# Interpretation Profile
 
-`law-policy-v0` is the selected LawUniverse artifact used by the
-LLM-native ArchMap / ArchSig pipeline.
+`law-policy-v0` is the current JSON schema for the selected interpretation
+profile used by the ArchMap / ArchSig AAT analysis pipeline.
 
 It is intentionally separate from ArchMap.
 
@@ -9,18 +9,19 @@ It is intentionally separate from ArchMap.
 ArchMap
   records law-independent Atom observations.
 
-LawPolicy
+InterpretationProfile
   selects laws, witness rules, molecule patterns, obstruction definitions,
   signature axes, coverage requirements, and exactness assumptions.
 
 ArchSig
-  reads ArchMap + LawPolicy and computes law-relative analysis.
+  reads ArchMap + InterpretationProfile and computes the AAT analysis packet.
 ```
 
 ## Responsibility
 
-LawPolicy owns the selected analysis policy for a specific review context.
-It does not define AAT and does not prove architecture lawfulness.
+The interpretation profile owns the selected analysis policy for a specific
+review context. It does not define AAT, does not act as a design-rule
+collection, and does not prove architecture lawfulness.
 
 The implemented schema records:
 
@@ -39,9 +40,9 @@ The implemented schema records:
 
 ## Validation Boundary
 
-LawPolicy validation checks schema support, identity, uniqueness, cross-reference
-integrity, witness / obstruction boundaries, coverage requirements, exactness
-assumptions, and required non-conclusions.
+Profile validation checks schema support, identity, uniqueness,
+cross-reference integrity, witness / obstruction boundaries, coverage
+requirements, exactness assumptions, and required non-conclusions.
 
 Validation does not imply:
 
@@ -58,4 +59,7 @@ Missing coverage remains a coverage gap. It is not measured zero.
 - `tools/archsig/tests/fixtures/minimal/law_policy.json`
 
 The fixture is locked against the static Rust builder and the schema catalog
-records both `law-policy-v0` and `law-policy-validation-report-v0`.
+records both `law-policy-v0` and `law-policy-validation-report-v0`. The schema
+name remains historical; the current ArchSig output treats it as
+`interpretationProfileRef`, while preserving `selectedLawPolicyRef` as
+provenance for existing profile content.

--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -1,15 +1,15 @@
 # LLM-native ArchMap / ArchSig E2E Workflow
 
 This document fixes the end-to-end workflow required by the LLM-native
-ArchMap / LawPolicy / ArchSig redesign. It is an implementation transcript,
-not a new theory document.
+ArchMap / interpretation profile / ArchSig redesign. It is an implementation
+transcript, not a new theory document.
 
 ## Flow
 
 ```text
 source artifacts
   -> supplied archmap-observation-map-v0
-  -> selected law-policy-v0
+  -> selected interpretation profile (law-policy-v0 JSON)
   -> archsig-analysis-packet-v0
   -> llm-interpretation-packet.json
   -> operation-support-estimate-v0
@@ -31,6 +31,9 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
   --out-dir .lake/llm-native-e2e/archsig
 ```
+
+`north-star-workflow` is the equivalent visible command alias for the same
+ArchSig-owned route.
 
 Expected ArchSig outputs:
 
@@ -67,16 +70,20 @@ The output must be `operation-support-estimate-v0` with
 The E2E flow must preserve these boundaries:
 
 - ArchMap remains law-independent source-grounded Atom observation evidence.
-- LawPolicy is the selected law universe and witness-rule artifact.
-- ArchSig computes law-relative obstruction circuits, signature axes, flatness
-  readings, repair candidates, coverage gaps, and non-conclusions.
+- The interpretation profile is the selected LawUniverse, witness-rule,
+  coverage, and exactness artifact. The current schema name is `law-policy-v0`.
+- ArchSig computes AAT concept surfaces, architecture state, design pressure,
+  change impact, law-relative obstruction circuits, signature axes, analytic
+  representations, coupling/cohesion readings, design principle readings,
+  bounded judgements, repair candidates, operation deltas, coverage gaps, and
+  non-conclusions.
 - `llm-interpretation-packet.json` is structured analysis input for an LLM, not
   a natural-language judgement, proof, or automatic repair instruction.
 - FieldSig accepts `archsig-analysis-packet-v0` and rejects raw ArchMap JSON as
   the current handoff input.
 - Coverage gaps are carried as unknown remainder; they are not rounded to
   absence, measured zero, or forecast truth.
-- ArchSig emits only the current ArchMap validation, LawPolicy validation,
+- ArchSig emits only the current ArchMap validation, profile validation,
   analysis packet, analysis validation, and LLM interpretation packet in the
   current E2E route. Pre-Atom artifacts are not compatibility outputs.
 

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -1,9 +1,9 @@
 # ArchSig
 
-`archsig` is the ArchMap / LawPolicy / ArchSig analysis CLI. It is intentionally
-small: the current surface is the LLM Atom ArchMap route from supplied
-`archmap-observation-map-v0` evidence and selected `law-policy-v0` into an
-`archsig-analysis-packet-v0`.
+`archsig` is the ArchMap -> AAT analysis packet CLI. It reads supplied
+`archmap-observation-map-v0` evidence and a selected interpretation profile
+(`law-policy-v0` JSON) into a North Star `archsig-analysis-packet-v0` for LLM
+and human review.
 
 ArchSig is not a Lean prover, extractor-completeness claim, architecture
 lawfulness oracle, merge approval system, or SFT forecast engine. FieldSig owns
@@ -15,8 +15,8 @@ forecast, governance, calibration, and operational feedback under
 | Surface | Commands | Boundary |
 | --- | --- | --- |
 | ArchMap validation | `archmap`, `archmap-generate` | ArchMap records source-grounded Atom observations and concern hints. It does not select laws or output obstruction circuits. |
-| LawPolicy | `law-policy` | LawPolicy selects the law universe, witness rules, signature axes, coverage requirements, and non-conclusions. |
-| ArchSig analysis | `archsig-analysis`, `llm-native-workflow` | ArchSig combines ArchMap and LawPolicy into law-relative molecule readings, obstruction circuits, signature axes, flatness readings, repair candidates, and LLM interpretation notes. |
+| Interpretation profile | `law-policy`, `interpretation-profile` | The profile selects the LawUniverse, witness rules, signature axes, coverage requirements, exactness assumptions, and non-conclusions. It is not AAT itself. |
+| ArchSig analysis | `archsig-analysis`, `aat-analysis`, `llm-native-workflow`, `north-star-workflow` | ArchSig combines ArchMap and the profile into AAT concept surfaces, architecture state, design pressure, change impact, analytic axes, semantic coupling/cohesion, design principle readings, bounded judgements, repair operation deltas, and an LLM interpretation packet. |
 | Schema | `schema-catalog` | The catalog lists only the current LLM Atom ArchMap artifacts. |
 
 Large ArchMaps may be authored in shards for review and parallel generation,
@@ -35,6 +35,8 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
   --out-dir .archsig/llm-native
 ```
 
+`north-star-workflow` is the same current workflow under the North Star name.
+
 This writes:
 
 - `.archsig/llm-native/archmap-validation.json`
@@ -44,8 +46,8 @@ This writes:
 - `.archsig/llm-native/llm-interpretation-packet.json`
 
 `llm-interpretation-packet.json` is the same structured packet written for LLM
-reading. It is not a natural-language judgment, Lean proof, or automatic repair
-instruction.
+reading. It is not a natural-language judgment, Lean proof, architecture truth,
+merge approval, or automatic repair instruction.
 
 Calling `archsig` without a subcommand intentionally fails. The old implicit
 scan-first path is no longer an ArchSig workflow.

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -1,11 +1,12 @@
 # ArchSig Commands
 
-`archsig` is now a small LLM Atom ArchMap CLI. The current route is:
+`archsig` is now the AAT analysis engine over ArchMap. The current route is:
 
 ```text
 archmap-observation-map-v0
-  + law-policy-v0
+  + interpretation profile (law-policy-v0 JSON)
   -> archsig-analysis-packet-v0
+  -> LLM interpretation
   -> FieldSig handoff
 ```
 
@@ -21,6 +22,15 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
   --out-dir .archsig/llm-native
+```
+
+`north-star-workflow` is a visible alias for the same workflow:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- north-star-workflow \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .archsig/north-star
 ```
 
 The command emits only:
@@ -75,11 +85,11 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- archmap \
   --input tools/archsig/tests/fixtures/minimal/archmap.json \
   --out .archsig/llm-native/archmap-validation.json
 
-cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy \
+cargo run --manifest-path tools/archsig/Cargo.toml -- interpretation-profile \
   --input tools/archsig/tests/fixtures/minimal/law_policy.json \
   --out .archsig/llm-native/law-policy-validation.json
 
-cargo run --manifest-path tools/archsig/Cargo.toml -- archsig-analysis \
+cargo run --manifest-path tools/archsig/Cargo.toml -- aat-analysis \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
   --out .archsig/llm-native/archsig-analysis-packet.json \
@@ -87,7 +97,10 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- archsig-analysis \
   --llm-interpretation-out .archsig/llm-native/llm-interpretation-packet.json
 ```
 
-`law-policy --fixture` emits the canonical minimal `law-policy-v0` fixture.
+`law-policy` / `interpretation-profile` validate the selected analysis profile.
+The JSON schema name remains `law-policy-v0`, but ArchSig treats it as a
+profile selecting LawUniverse, witness rules, axes, coverage, and exactness.
+`law-policy --fixture` emits the canonical minimal profile fixture.
 
 ## ArchMap Generation Protocol
 

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -4,10 +4,16 @@ use crate::validation::{count_checks, duplicates, generic_validation_example, va
 use crate::{
     ARCHMAP_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION, ArchMapDocumentV0, ArchMapSourceRef,
-    ArchSigAnalysisArtifactRefV0, ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationInputV0,
-    ArchSigAnalysisPacketValidationReportV0, ArchSigAnalysisPacketValidationSummaryV0,
-    ArchSigAtomConfigurationSummaryV0, ArchSigFlatnessReadingV0, ArchSigLayerSplitV0,
-    ArchSigMoleculeReadingV0, ArchSigObstructionCircuitV0, ArchSigRepairOperationCandidateV0,
+    ArchSigAatConceptSurfaceV0, ArchSigAnalysisArtifactRefV0, ArchSigAnalysisPacketV0,
+    ArchSigAnalysisPacketValidationInputV0, ArchSigAnalysisPacketValidationReportV0,
+    ArchSigAnalysisPacketValidationSummaryV0, ArchSigAnalyticRepresentationV0,
+    ArchSigArchitectureObjectProjectionV0, ArchSigArchitectureStateV0,
+    ArchSigAtomConfigurationSummaryV0, ArchSigBoundedJudgementV0, ArchSigChangeImpactReadingV0,
+    ArchSigCouplingCohesionReadingV0, ArchSigDesignPressureReadingV0,
+    ArchSigDesignPrincipleReadingV0, ArchSigFlatnessReadingV0, ArchSigInvariantFamilyReadingV0,
+    ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0, ArchSigLlmInterpretationPacketV0,
+    ArchSigMoleculeReadingV0, ArchSigObstructionCircuitV0, ArchSigOperationDeltaReadingV0,
+    ArchSigPathHomotopyDiagramReadingV0, ArchSigRepairOperationCandidateV0,
     ArchSigSignatureAxisReadingV0, LAW_POLICY_SCHEMA_VERSION, LawPolicyDocumentV0,
     LawPolicyObstructionCircuitDefinitionV0, LawPolicySignatureAxisDefinitionV0,
     LawPolicyWitnessRuleV0, ValidationCheck, ValidationExample,
@@ -22,264 +28,20 @@ const REQUIRED_NON_CONCLUSIONS: [&str; 6] = [
     "repair operation candidates are not automatic safe refactorings",
 ];
 
-pub fn static_archsig_analysis_packet() -> ArchSigAnalysisPacketV0 {
-    ArchSigAnalysisPacketV0 {
-        schema_version: ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION.to_string(),
-        analysis_id: "archsig-analysis-fixture".to_string(),
-        generated_at: "2026-05-23T00:00:00Z".to_string(),
-        arch_map_ref: artifact_ref(
-            "fixture-archmap-atom-observation",
-            "archmap",
-            ARCHMAP_SCHEMA_VERSION,
-            Some("tools/archsig/tests/fixtures/minimal/archmap.json"),
-        ),
-        selected_law_policy_ref: artifact_ref(
-            "llm-native-aat-law-policy-fixture",
-            "law-policy",
-            LAW_POLICY_SCHEMA_VERSION,
-            Some("tools/archsig/tests/fixtures/minimal/law_policy.json"),
-        ),
-        atom_configuration_summary: ArchSigAtomConfigurationSummaryV0 {
-            atom_observation_count: 4,
-            molecule_observation_count: 1,
-            semantic_observation_count: 1,
-            observation_gap_count: 1,
-            concern_hint_count: 1,
-            configuration_boundary:
-                "counts are read from one bounded ArchMap fixture, not complete architecture enumeration"
-                    .to_string(),
-            coverage_summary: vec![
-                "static source atoms observed".to_string(),
-                "semantic contract observation observed".to_string(),
-                "runtime trace remains unavailable".to_string(),
-            ],
-            source_refs: strings(&[
-                "atom:component:route-users",
-                "atom:component:service-user",
-                "atom:relation:route-service",
-                "atom:contract:create-user",
-                "gap-runtime-user-db-trace",
-            ]),
-            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-        },
-        molecule_readings: vec![ArchSigMoleculeReadingV0 {
-            molecule_reading_id: "molecule-reading:user-request-responsibility".to_string(),
-            molecule_observation_ref: "molecule:user-request-responsibility".to_string(),
-            law_refs: vec!["law:semantic-contract-alignment".to_string()],
-            atom_observation_refs: strings(&[
-                "atom:relation:route-service",
-                "atom:contract:create-user",
-            ]),
-            reading:
-                "observed route/service/contract atoms form one operation-responsibility molecule"
-                    .to_string(),
-            evidence_summary:
-                "molecule reading uses ArchMap atom observations and the selected semantic-contract law"
-                    .to_string(),
-            evidence_boundary:
-                "law-relative reading over observed atoms; not a primitive atom and not theorem evidence"
-                    .to_string(),
-            source_refs: strings(&["doc-architecture", "test-user-contract"]),
-            interpretation_notes_for_llm: vec![
-                "Explain this as a responsibility grouping over observed atoms.".to_string(),
-            ],
-            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-        }],
-        obstruction_circuits: vec![ArchSigObstructionCircuitV0 {
-            obstruction_circuit_id: "obstruction:semantic-contract-mismatch:create-user"
-                .to_string(),
-            law_ref: "law:semantic-contract-alignment".to_string(),
-            witness_rule_ref: "witness:semantic-contract-mismatch".to_string(),
-            circuit_kind: "SemanticMismatchCircuit".to_string(),
-            atom_observation_refs: strings(&[
-                "atom:relation:route-service",
-                "atom:contract:create-user",
-            ]),
-            molecule_reading_refs: vec![
-                "molecule-reading:user-request-responsibility".to_string(),
-            ],
-            concern_hint_refs: vec!["concern:missing-compensation".to_string()],
-            signature_axis_refs: vec!["sig-axis:semantic-inconsistency".to_string()],
-            minimality_reading:
-                "minimal within the selected operation molecule and semantic contract witness rule"
-                    .to_string(),
-            evidence_summary:
-                "constructed from the concern hint, contract atom, relation atom, and semantic molecule reading"
-                    .to_string(),
-            evidence_boundary:
-                "computed ArchSig witness under selected LawPolicy; not an ArchMap observation"
-                    .to_string(),
-            missing_evidence: vec![
-                "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
-                    .to_string(),
-                "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection"
-                    .to_string(),
-            ],
-            excluded_readings: vec![
-                "single architecture quality score".to_string(),
-                "global architecture lawfulness".to_string(),
-                "zero readings are exact only for observed atoms and declared coverage requirements"
-                    .to_string(),
-            ],
-            interpretation_notes_for_llm: vec![
-                "Describe the obstruction as law-relative, not as a universal architecture defect."
-                    .to_string(),
-            ],
-            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-        }],
-        signature_axes: vec![
-            ArchSigSignatureAxisReadingV0 {
-                signature_axis_id: "sig-axis:layer-violation".to_string(),
-                law_ref: "law:layer-respecting".to_string(),
-                axis_ref: "axis:layer-violation".to_string(),
-                value_type: "nat".to_string(),
-                value: 0,
-                zero_reading:
-                    "zero means no selected layer violation witness was constructed under declared coverage"
-                        .to_string(),
-                coverage_status: "covered-for-selected-static-atoms".to_string(),
-                exactness_assumptions: vec![
-                    "selected layer law observes only declared route/service relation atoms".to_string(),
-                ],
-                evidence_summary:
-                    "no BoundaryLeakCircuit witness was constructed from the fixture atoms"
-                        .to_string(),
-                source_refs: strings(&["atom:relation:route-service"]),
-                missing_evidence: vec![
-                    "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
-                        .to_string(),
-                    "coverage:layer-atoms: report observation gap and block signature-zero reflection"
-                        .to_string(),
-                ],
-                excluded_readings: vec![
-                    "global architecture lawfulness".to_string(),
-                    "automatic repair safety".to_string(),
-                    "zero readings are exact only for observed atoms and declared coverage requirements"
-                        .to_string(),
-                ],
-                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-            },
-            ArchSigSignatureAxisReadingV0 {
-                signature_axis_id: "sig-axis:semantic-inconsistency".to_string(),
-                law_ref: "law:semantic-contract-alignment".to_string(),
-                axis_ref: "axis:semantic-inconsistency".to_string(),
-                value_type: "nat".to_string(),
-                value: 1,
-                zero_reading:
-                    "nonzero means one selected semantic mismatch witness was constructed"
-                        .to_string(),
-                coverage_status: "runtime-gap-blocked".to_string(),
-                exactness_assumptions: vec![
-                    "runtime trace gap blocks global zero reflection".to_string(),
-                ],
-                evidence_summary:
-                    "one SemanticMismatchCircuit witness is present under the selected LawPolicy"
-                        .to_string(),
-                source_refs: strings(&[
-                    "atom:contract:create-user",
-                    "concern:missing-compensation",
-                ]),
-                missing_evidence: vec![
-                    "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
-                        .to_string(),
-                    "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection"
-                        .to_string(),
-                ],
-                excluded_readings: vec![
-                    "single architecture quality score".to_string(),
-                    "global architecture lawfulness".to_string(),
-                    "zero readings are exact only for observed atoms and declared coverage requirements"
-                        .to_string(),
-                ],
-                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-            },
-        ],
-        flatness_reading: ArchSigFlatnessReadingV0 {
-            reading_id: "flatness:selected-law-policy".to_string(),
-            selected_law_policy_ref: "llm-native-aat-law-policy-fixture".to_string(),
-            status: "nonflatUnderSelectedPolicy".to_string(),
-            zero_signature_axis_refs: vec!["sig-axis:layer-violation".to_string()],
-            nonzero_signature_axis_refs: vec!["sig-axis:semantic-inconsistency".to_string()],
-            blocked_by_coverage_gaps: vec!["gap-runtime-user-db-trace".to_string()],
-            evidence_boundary:
-                "flatness is read from selected signature axes; coverage gaps block global zero claims"
-                    .to_string(),
-            interpretation_notes_for_llm: vec![
-                "Report this as selected-policy non-flatness, not global architecture quality."
-                    .to_string(),
-            ],
-            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-        },
-        static_runtime_semantic_layer_split: ArchSigLayerSplitV0 {
-            static_observation_refs: strings(&[
-                "atom:component:route-users",
-                "atom:component:service-user",
-                "atom:relation:route-service",
-            ]),
-            runtime_observation_refs: vec!["gap-runtime-user-db-trace".to_string()],
-            semantic_observation_refs: strings(&[
-                "atom:contract:create-user",
-                "semantic:create-user-flow",
-            ]),
-            split_boundary:
-                "runtime layer is gap-preserved and must not be rounded into measured zero"
-                    .to_string(),
-            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-        },
-        repair_operation_candidates: vec![ArchSigRepairOperationCandidateV0 {
-            repair_operation_candidate_id: "repair:add-compensation-path".to_string(),
-            operation_kind: "add-compensation-operation".to_string(),
-            target_obstruction_refs: vec![
-                "obstruction:semantic-contract-mismatch:create-user".to_string(),
-            ],
-            preserved_invariants: vec![
-                "preserve route/service dependency direction".to_string(),
-                "preserve create-user contract visibility".to_string(),
-            ],
-            preconditions: vec![
-                "identify authoritative compensation owner".to_string(),
-                "supply runtime trace evidence before claiming global zero".to_string(),
-            ],
-            expected_signature_axis_effects: vec![
-                "decrease sig-axis:semantic-inconsistency if compensation semantics are observed"
-                    .to_string(),
-            ],
-            transfer_risks: vec![
-                "may transfer complexity into runtime retry or idempotency layer".to_string(),
-            ],
-            evidence_boundary:
-                "repair candidate is an operation hypothesis over the selected packet, not an automatic patch"
-                    .to_string(),
-            missing_evidence: vec![
-                "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
-                    .to_string(),
-                "implementation patch and verification evidence are not supplied by ArchSig analysis"
-                    .to_string(),
-            ],
-            excluded_readings: vec![
-                "automatic repair safety".to_string(),
-                "causal forecast correctness".to_string(),
-                "global architecture lawfulness".to_string(),
-            ],
-            interpretation_notes_for_llm: vec![
-                "Explain preserved invariants before proposing implementation work.".to_string(),
-            ],
-            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-        }],
-        evidence_boundary:
-            "packet is computed from one ArchMap fixture and one selected LawPolicy fixture"
-                .to_string(),
-        interpretation_notes_for_llm: vec![
-            "Lead with selected LawPolicy scope and evidence gaps.".to_string(),
-            "Explain each nonzero signature axis with source refs and non-conclusions.".to_string(),
-        ],
-        excluded_readings: vec![
-            "single architecture quality score".to_string(),
-            "global architecture lawfulness".to_string(),
-            "automatic repair safety".to_string(),
-        ],
-        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
-    }
+#[cfg(test)]
+fn static_archsig_analysis_packet() -> ArchSigAnalysisPacketV0 {
+    let archmap: ArchMapDocumentV0 =
+        serde_json::from_str(include_str!("../tests/fixtures/minimal/archmap.json"))
+            .expect("static ArchMap fixture parses");
+    let law_policy: LawPolicyDocumentV0 =
+        serde_json::from_str(include_str!("../tests/fixtures/minimal/law_policy.json"))
+            .expect("static LawPolicy fixture parses");
+    build_archsig_analysis_packet(
+        &archmap,
+        &law_policy,
+        Some("tools/archsig/tests/fixtures/minimal/archmap.json"),
+        Some("tools/archsig/tests/fixtures/minimal/law_policy.json"),
+    )
 }
 
 pub fn build_archsig_analysis_packet(
@@ -288,12 +50,66 @@ pub fn build_archsig_analysis_packet(
     archmap_path: Option<&str>,
     law_policy_path: Option<&str>,
 ) -> ArchSigAnalysisPacketV0 {
+    let interpretation_profile_ref = artifact_ref(
+        &law_policy.law_policy_id,
+        "interpretation-profile",
+        &law_policy.schema_version,
+        law_policy_path,
+    );
     let molecule_readings = build_molecule_readings(archmap, law_policy);
     let obstruction_circuits = build_obstruction_circuits(archmap, law_policy, &molecule_readings);
     let signature_axes = build_signature_axes(archmap, law_policy, &obstruction_circuits);
     let flatness_reading = build_flatness_reading(archmap, law_policy, &signature_axes);
     let repair_operation_candidates =
         build_repair_candidates(archmap, &obstruction_circuits, &signature_axes);
+    let architecture_object_projections = build_architecture_object_projections(archmap);
+    let invariant_family_readings =
+        build_invariant_family_readings(archmap, law_policy, &obstruction_circuits);
+    let law_universe_reading = build_law_universe_reading(law_policy);
+    let analytic_representations =
+        build_analytic_representations(archmap, &signature_axes, &obstruction_circuits);
+    let coupling_cohesion_readings = build_coupling_cohesion_readings(archmap);
+    let design_principle_readings = build_design_principle_readings(
+        archmap,
+        &invariant_family_readings,
+        &obstruction_circuits,
+        &repair_operation_candidates,
+    );
+    let operation_deltas =
+        build_operation_deltas(archmap, &repair_operation_candidates, &signature_axes);
+    let path_homotopy_diagram_readings =
+        build_path_homotopy_diagram_readings(archmap, &molecule_readings, &obstruction_circuits);
+    let bounded_judgements = build_bounded_judgements(
+        archmap,
+        &obstruction_circuits,
+        &signature_axes,
+        &design_principle_readings,
+    );
+    let architecture_state =
+        build_architecture_state(archmap, &signature_axes, &invariant_family_readings);
+    let design_pressure = build_design_pressure(archmap, &obstruction_circuits, &signature_axes);
+    let change_impact = build_change_impact(
+        &repair_operation_candidates,
+        &operation_deltas,
+        &signature_axes,
+    );
+    let aat_concept_surfaces = build_aat_concept_surfaces(
+        archmap,
+        law_policy,
+        &obstruction_circuits,
+        &signature_axes,
+        &repair_operation_candidates,
+        &analytic_representations,
+    );
+    let llm_interpretation_packet = build_llm_interpretation_packet(
+        archmap,
+        &architecture_state,
+        &design_pressure,
+        &signature_axes,
+        &analytic_representations,
+        &repair_operation_candidates,
+        &bounded_judgements,
+    );
 
     ArchSigAnalysisPacketV0 {
         schema_version: ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION.to_string(),
@@ -308,21 +124,36 @@ pub fn build_archsig_analysis_packet(
             &archmap.schema_version,
             archmap_path,
         ),
+        interpretation_profile_ref,
         selected_law_policy_ref: artifact_ref(
             &law_policy.law_policy_id,
             "law-policy",
             &law_policy.schema_version,
             law_policy_path,
         ),
+        architecture_state,
+        design_pressure,
+        change_impact,
+        aat_concept_surfaces,
         atom_configuration_summary: build_atom_configuration_summary(archmap),
+        architecture_object_projections,
+        invariant_family_readings,
+        law_universe_reading,
         molecule_readings,
         obstruction_circuits,
         signature_axes,
+        analytic_representations,
+        coupling_cohesion_readings,
+        design_principle_readings,
         flatness_reading,
         static_runtime_semantic_layer_split: build_layer_split(archmap),
         repair_operation_candidates,
+        operation_deltas,
+        path_homotopy_diagram_readings,
+        bounded_judgements,
+        llm_interpretation_packet,
         evidence_boundary: format!(
-            "computed from ArchMap {} and selected LawPolicy {}; concernHints are auxiliary cues only",
+            "computed from ArchMap {} and selected interpretation profile {}; concernHints are auxiliary cues only",
             archmap.map_id, law_policy.law_policy_id
         ),
         interpretation_notes_for_llm: vec![
@@ -478,6 +309,39 @@ fn build_signature_axes(
             } else {
                 "coverage-gap-preserved"
             };
+            let mut source_refs = obstruction_circuits
+                .iter()
+                .filter(|circuit| {
+                    circuit
+                        .signature_axis_refs
+                        .contains(&definition.signature_axis_id)
+                })
+                .flat_map(|circuit| circuit.atom_observation_refs.clone())
+                .collect::<Vec<_>>();
+            if source_refs.is_empty() {
+                source_refs = archmap
+                    .atom_observations
+                    .iter()
+                    .filter(|atom| {
+                        law_policy
+                            .selected_laws
+                            .iter()
+                            .filter(|law| law.law_id == definition.law_ref)
+                            .any(|law| {
+                                law.applies_to_atom_families
+                                    .iter()
+                                    .any(|family| family_matches(&atom.atom_family, family))
+                            })
+                    })
+                    .map(|atom| atom.atom_observation_id.clone())
+                    .collect();
+            }
+            if source_refs.is_empty() {
+                source_refs.push(format!(
+                    "{}: no direct source refs under selected coverage",
+                    definition.signature_axis_id
+                ));
+            }
             ArchSigSignatureAxisReadingV0 {
                 signature_axis_id: definition.signature_axis_id.clone(),
                 law_ref: definition.law_ref.clone(),
@@ -501,15 +365,7 @@ fn build_signature_axes(
                     "{} obstruction circuit(s) contribute to {}",
                     value, definition.signature_axis_id
                 ),
-                source_refs: obstruction_circuits
-                    .iter()
-                    .filter(|circuit| {
-                        circuit
-                            .signature_axis_refs
-                            .contains(&definition.signature_axis_id)
-                    })
-                    .flat_map(|circuit| circuit.atom_observation_refs.clone())
-                    .collect(),
+                source_refs,
                 missing_evidence: signature_axis_missing_evidence(archmap, law_policy, definition),
                 excluded_readings: signature_axis_excluded_readings(law_policy, definition),
                 non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
@@ -595,6 +451,1114 @@ fn build_layer_split(archmap: &ArchMapDocumentV0) -> ArchSigLayerSplitV0 {
     }
 }
 
+fn build_architecture_state(
+    archmap: &ArchMapDocumentV0,
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+    invariant_readings: &[ArchSigInvariantFamilyReadingV0],
+) -> ArchSigArchitectureStateV0 {
+    ArchSigArchitectureStateV0 {
+        state_id: format!("architecture-state:{}", stable_id(&archmap.architecture_id)),
+        reading: format!(
+            "{} is represented as {} atom observations, {} molecules, {} semantic observations, and {} preserved observation gaps",
+            archmap.architecture_id,
+            archmap.atom_observations.len(),
+            archmap.molecule_observations.len(),
+            archmap.semantic_observations.len(),
+            archmap.observation_gaps.len()
+        ),
+        atom_family_refs: unique_strings(
+            archmap
+                .atom_observations
+                .iter()
+                .map(|atom| atom.atom_family.clone()),
+        ),
+        molecule_refs: archmap
+            .molecule_observations
+            .iter()
+            .map(|molecule| molecule.molecule_observation_id.clone())
+            .collect(),
+        workflow_refs: archmap
+            .semantic_observations
+            .iter()
+            .map(|semantic| semantic.semantic_observation_id.clone())
+            .collect(),
+        boundary_refs: archmap
+            .observation_gaps
+            .iter()
+            .map(|gap| gap.gap_id.clone())
+            .collect(),
+        invariant_refs: invariant_readings
+            .iter()
+            .map(|reading| reading.invariant_id.clone())
+            .collect(),
+        signature_axis_refs: signature_axes
+            .iter()
+            .map(|axis| axis.signature_axis_id.clone())
+            .collect(),
+        coverage_boundary:
+            "state is an ArchMap-relative architecture state, not a complete source reconstruction"
+                .to_string(),
+        recommended_next_action:
+            "review nonzero axes, stressed principles, and preserved observation gaps before planning repair"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_design_pressure(
+    archmap: &ArchMapDocumentV0,
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+) -> Vec<ArchSigDesignPressureReadingV0> {
+    let obstruction_refs = obstruction_circuits
+        .iter()
+        .map(|circuit| circuit.obstruction_circuit_id.clone())
+        .collect::<Vec<_>>();
+    let signature_axis_refs = signature_axes
+        .iter()
+        .filter(|axis| axis.value != 0)
+        .map(|axis| axis.signature_axis_id.clone())
+        .collect::<Vec<_>>();
+    vec![ArchSigDesignPressureReadingV0 {
+        pressure_id: "design-pressure:selected-atom-configuration".to_string(),
+        status: if obstruction_refs.is_empty() {
+            "needsReview"
+        } else {
+            "actionable"
+        }
+        .to_string(),
+        reading: format!(
+            "{} selected obstruction circuit(s) and {} coverage gap(s) define the current pressure surface",
+            obstruction_refs.len(),
+            archmap.observation_gaps.len()
+        ),
+        atom_configuration_refs: archmap
+            .atom_observations
+            .iter()
+            .map(|atom| atom.atom_observation_id.clone())
+            .collect(),
+        obstruction_refs,
+        signature_axis_refs,
+        coverage_boundary:
+            "pressure is relative to the observed finite Atom configuration and selected profile"
+                .to_string(),
+        recommended_next_action:
+            "use bounded judgements to decide whether to inspect source refs, add evidence, or plan repair"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }]
+}
+
+fn build_change_impact(
+    repair_candidates: &[ArchSigRepairOperationCandidateV0],
+    operation_deltas: &[ArchSigOperationDeltaReadingV0],
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+) -> ArchSigChangeImpactReadingV0 {
+    ArchSigChangeImpactReadingV0 {
+        impact_id: "change-impact:selected-repair-operations".to_string(),
+        operation_scope: "repair, extension, migration, and refactor operations over observed ArchMap atoms".to_string(),
+        signature_delta_summary: operation_deltas
+            .iter()
+            .flat_map(|delta| delta.signature_delta.clone())
+            .collect(),
+        affected_boundaries: signature_axes
+            .iter()
+            .map(|axis| format!("{}: {}", axis.signature_axis_id, axis.coverage_status))
+            .collect(),
+        complexity_transfer_notes: repair_candidates
+            .iter()
+            .flat_map(|candidate| candidate.transfer_risks.clone())
+            .collect(),
+        coverage_boundary:
+            "impact is a pre-change operation reading; it is not evidence that a future patch is safe"
+                .to_string(),
+        recommended_next_action:
+            "compare operation deltas before and after the patch and keep transferred obstruction notes"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_aat_concept_surfaces(
+    archmap: &ArchMapDocumentV0,
+    law_policy: &LawPolicyDocumentV0,
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+    repair_candidates: &[ArchSigRepairOperationCandidateV0],
+    analytic_representations: &[ArchSigAnalyticRepresentationV0],
+) -> Vec<ArchSigAatConceptSurfaceV0> {
+    let concept_specs = [
+        (
+            "Atom",
+            archmap.atom_observations.len(),
+            all_atom_refs(archmap),
+        ),
+        (
+            "Configuration",
+            archmap.atom_observations.len() + archmap.molecule_observations.len(),
+            all_atom_refs(archmap),
+        ),
+        (
+            "ArchitectureObject",
+            archmap.projection_info.len().max(1),
+            archmap
+                .projection_info
+                .iter()
+                .map(|projection| projection.projection_id.clone())
+                .collect(),
+        ),
+        (
+            "Invariant",
+            law_policy.selected_laws.len(),
+            law_policy
+                .selected_laws
+                .iter()
+                .map(|law| law.law_id.clone())
+                .collect(),
+        ),
+        (
+            "LawUniverse",
+            law_policy.selected_laws.len(),
+            law_policy
+                .selected_laws
+                .iter()
+                .map(|law| law.law_id.clone())
+                .collect(),
+        ),
+        (
+            "ObstructionCircuit",
+            obstruction_circuits.len(),
+            obstruction_circuits
+                .iter()
+                .map(|circuit| circuit.obstruction_circuit_id.clone())
+                .collect(),
+        ),
+        (
+            "ArchitectureSignature",
+            signature_axes.len(),
+            signature_axes
+                .iter()
+                .map(|axis| axis.signature_axis_id.clone())
+                .collect(),
+        ),
+        (
+            "Operation",
+            repair_candidates.len(),
+            repair_candidates
+                .iter()
+                .map(|candidate| candidate.repair_operation_candidate_id.clone())
+                .collect(),
+        ),
+        (
+            "Path",
+            archmap.molecule_observations.len().max(1),
+            archmap
+                .molecule_observations
+                .iter()
+                .map(|molecule| molecule.molecule_observation_id.clone())
+                .collect(),
+        ),
+        (
+            "Homotopy",
+            archmap.semantic_observations.len().max(1),
+            archmap
+                .semantic_observations
+                .iter()
+                .map(|semantic| semantic.semantic_observation_id.clone())
+                .collect(),
+        ),
+        (
+            "Diagram",
+            obstruction_circuits.len().max(1),
+            obstruction_circuits
+                .iter()
+                .map(|circuit| circuit.obstruction_circuit_id.clone())
+                .collect(),
+        ),
+        (
+            "AnalyticRepresentation",
+            analytic_representations.len(),
+            analytic_representations
+                .iter()
+                .map(|representation| representation.representation_id.clone())
+                .collect(),
+        ),
+    ];
+
+    concept_specs
+        .into_iter()
+        .map(|(concept, count, evidence_refs)| ArchSigAatConceptSurfaceV0 {
+            concept: concept.to_string(),
+            status: if count == 0 {
+                "unmeasured"
+            } else {
+                "observedOrRepresented"
+            }
+            .to_string(),
+            reading: format!("{concept} is represented with {count} bounded packet record(s)"),
+            evidence_refs,
+            coverage_boundary:
+                "concept surface records packet expressiveness, not theorem proof or extraction completeness"
+                    .to_string(),
+            exactness_boundary:
+                "exactness is relative to ArchMap coverage and selected interpretation profile"
+                    .to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        })
+        .collect()
+}
+
+fn build_architecture_object_projections(
+    archmap: &ArchMapDocumentV0,
+) -> Vec<ArchSigArchitectureObjectProjectionV0> {
+    if archmap.projection_info.is_empty() {
+        return vec![ArchSigArchitectureObjectProjectionV0 {
+            projection_id: "architecture-object:default-observed-configuration".to_string(),
+            projection_family: "observedAtomConfiguration".to_string(),
+            atom_refs: all_atom_refs(archmap),
+            molecule_refs: archmap
+                .molecule_observations
+                .iter()
+                .map(|molecule| molecule.molecule_observation_id.clone())
+                .collect(),
+            semantic_refs: archmap
+                .semantic_observations
+                .iter()
+                .map(|semantic| semantic.semantic_observation_id.clone())
+                .collect(),
+            reading:
+                "default architecture object projection formed from observed atoms, molecules, and semantic records"
+                    .to_string(),
+            projection_boundary: "synthetic projection used because ArchMap provided no explicit projectionInfo".to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        }];
+    }
+
+    archmap
+        .projection_info
+        .iter()
+        .map(|projection| ArchSigArchitectureObjectProjectionV0 {
+            projection_id: projection.projection_id.clone(),
+            projection_family: projection.projection_family.clone(),
+            atom_refs: archmap
+                .atom_observations
+                .iter()
+                .filter(|atom| atom.projection_refs.contains(&projection.projection_id))
+                .map(|atom| atom.atom_observation_id.clone())
+                .collect(),
+            molecule_refs: vec![],
+            semantic_refs: vec![projection.source_observation_ref.clone()],
+            reading: projection.reading.clone(),
+            projection_boundary: projection.projection_boundary.clone(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        })
+        .collect()
+}
+
+fn build_invariant_family_readings(
+    archmap: &ArchMapDocumentV0,
+    law_policy: &LawPolicyDocumentV0,
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+) -> Vec<ArchSigInvariantFamilyReadingV0> {
+    law_policy
+        .selected_laws
+        .iter()
+        .map(|law| {
+            let obstruction_refs = obstruction_circuits
+                .iter()
+                .filter(|circuit| circuit.law_ref == law.law_id)
+                .map(|circuit| circuit.obstruction_circuit_id.clone())
+                .collect::<Vec<_>>();
+            ArchSigInvariantFamilyReadingV0 {
+                invariant_id: format!("invariant:{}", stable_id(&law.law_id)),
+                invariant_family: law.law_family.clone(),
+                status: if obstruction_refs.is_empty() {
+                    "preservedForConstructedWitnesses"
+                } else {
+                    "stressed"
+                }
+                .to_string(),
+                law_refs: vec![law.law_id.clone()],
+                atom_refs: archmap
+                    .atom_observations
+                    .iter()
+                    .filter(|atom| {
+                        law.applies_to_atom_families
+                            .iter()
+                            .any(|family| family_matches(&atom.atom_family, family))
+                    })
+                    .map(|atom| atom.atom_observation_id.clone())
+                    .collect(),
+                obstruction_refs,
+                reading: format!(
+                    "{} is read as an invariant family selected by the interpretation profile",
+                    law.description
+                ),
+                evidence_boundary: law.enforcement_boundary.clone(),
+                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+            }
+        })
+        .collect()
+}
+
+fn build_law_universe_reading(law_policy: &LawPolicyDocumentV0) -> ArchSigLawUniverseReadingV0 {
+    ArchSigLawUniverseReadingV0 {
+        law_universe_id: format!("law-universe:{}", stable_id(&law_policy.law_policy_id)),
+        profile_ref: law_policy.law_policy_id.clone(),
+        selected_law_refs: law_policy
+            .selected_laws
+            .iter()
+            .map(|law| law.law_id.clone())
+            .collect(),
+        witness_rule_refs: law_policy
+            .witness_rules
+            .iter()
+            .map(|rule| rule.witness_rule_id.clone())
+            .collect(),
+        signature_axis_refs: law_policy
+            .signature_axis_definitions
+            .iter()
+            .map(|axis| axis.signature_axis_id.clone())
+            .collect(),
+        exactness_assumptions: law_policy.exactness_assumptions.clone(),
+        coverage_requirements: law_policy
+            .coverage_requirements
+            .iter()
+            .map(|requirement| requirement.coverage_requirement_id.clone())
+            .collect(),
+        reading:
+            "LawPolicy is interpreted as an analysis profile selecting a bounded LawUniverse, witnesses, axes, coverage, and exactness assumptions"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_analytic_representations(
+    archmap: &ArchMapDocumentV0,
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+) -> Vec<ArchSigAnalyticRepresentationV0> {
+    let relation_count = archmap
+        .atom_observations
+        .iter()
+        .filter(|atom| atom.atom_family.to_ascii_lowercase().contains("relation"))
+        .count();
+    let node_count = unique_strings(
+        archmap
+            .atom_observations
+            .iter()
+            .flat_map(|atom| atom.object_refs.clone()),
+    )
+    .len()
+    .max(archmap.atom_observations.len());
+    let reachable_cone_size = node_count + relation_count;
+    let walk_count = relation_count + archmap.molecule_observations.len();
+    let propagation_depth = if relation_count == 0 { 0 } else { 1 };
+    let nilpotence_boundary = if archmap.observation_gaps.is_empty() {
+        "candidateNilpotentForSelectedStaticGraph"
+    } else {
+        "blockedByCoverageGap"
+    };
+    let spectral_proxy = if node_count == 0 {
+        "unavailable".to_string()
+    } else {
+        format!("{:.3}", relation_count as f64 / node_count as f64)
+    };
+    vec![
+        analytic_representation(
+            "analytic:weighted-adjacency",
+            "weightedAdjacencyMatrix",
+            "measured",
+            "matrixShape",
+            &format!("{node_count}x{node_count}; edgeCount={relation_count}"),
+            all_atom_refs(archmap),
+            signature_axes,
+            "selected relation atoms induce a bounded weighted adjacency representation",
+        ),
+        analytic_representation(
+            "analytic:reachable-cone-size",
+            "reachableConeSize",
+            "measured",
+            "nat",
+            &reachable_cone_size.to_string(),
+            all_atom_refs(archmap),
+            signature_axes,
+            "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+        ),
+        analytic_representation(
+            "analytic:walk-count",
+            "walkCount",
+            "measured",
+            "nat",
+            &walk_count.to_string(),
+            all_atom_refs(archmap),
+            signature_axes,
+            "walk count is a bounded proxy from observed relation atoms and molecule paths",
+        ),
+        analytic_representation(
+            "analytic:nilpotence-boundary",
+            "nilpotenceBoundary",
+            "needsReview",
+            "boundaryStatus",
+            nilpotence_boundary,
+            all_atom_refs(archmap),
+            signature_axes,
+            "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+        ),
+        analytic_representation(
+            "analytic:selected-subgraph-spectrum",
+            "selectedSubgraphSpectrum",
+            "measured",
+            "vector",
+            &format!("[{spectral_proxy}]"),
+            all_atom_refs(archmap),
+            signature_axes,
+            "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+        ),
+        analytic_representation(
+            "analytic:propagation-depth",
+            "propagationDepth",
+            "measured",
+            "nat",
+            &propagation_depth.to_string(),
+            all_atom_refs(archmap),
+            signature_axes,
+            "propagation depth is computed over observed relation atoms only",
+        ),
+        analytic_representation(
+            "analytic:spectral-radius-proxy",
+            "spectralRadius",
+            if spectral_proxy == "unavailable" {
+                "unavailable"
+            } else {
+                "measured"
+            },
+            "float",
+            &spectral_proxy,
+            all_atom_refs(archmap),
+            signature_axes,
+            "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+        ),
+        analytic_representation(
+            "analytic:curvature-valuation",
+            "curvatureValuation",
+            "measured",
+            "nat",
+            &obstruction_circuits.len().to_string(),
+            obstruction_circuits
+                .iter()
+                .map(|circuit| circuit.obstruction_circuit_id.clone())
+                .collect(),
+            signature_axes,
+            "curvature valuation counts constructed obstruction circuits under the selected profile",
+        ),
+        analytic_representation(
+            "analytic:state-algebra-boundary",
+            "stateAlgebra",
+            if archmap
+                .observation_gaps
+                .iter()
+                .any(|gap| gap.gap_kind.to_ascii_lowercase().contains("runtime"))
+            {
+                "unmeasured"
+            } else {
+                "needsReview"
+            },
+            "boundaryStatus",
+            "state/effect algebra requires explicit state transition and runtime/effect atoms",
+            all_atom_refs(archmap),
+            signature_axes,
+            "state algebra is preserved as a first-class analytic boundary even when state evidence is unavailable",
+        ),
+        analytic_representation(
+            "analytic:zero-reflecting-aggregate-boundary",
+            "zeroReflectingAggregateBoundary",
+            "needsReview",
+            "boundaryStatus",
+            if archmap.observation_gaps.is_empty() {
+                "candidateForSelectedCoverage"
+            } else {
+                "blockedByObservationGaps"
+            },
+            archmap
+                .observation_gaps
+                .iter()
+                .map(|gap| gap.gap_id.clone())
+                .collect(),
+            signature_axes,
+            "zero-reflecting aggregate boundary says when zero axes may and may not be read as absence",
+        ),
+    ]
+}
+
+fn analytic_representation(
+    representation_id: &str,
+    representation_family: &str,
+    status: &str,
+    value_type: &str,
+    value: &str,
+    graph_scope_refs: Vec<String>,
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+    reading: &str,
+) -> ArchSigAnalyticRepresentationV0 {
+    ArchSigAnalyticRepresentationV0 {
+        representation_id: representation_id.to_string(),
+        representation_family: representation_family.to_string(),
+        status: status.to_string(),
+        value_type: value_type.to_string(),
+        value: value.to_string(),
+        graph_scope_refs,
+        axis_refs: signature_axes
+            .iter()
+            .map(|axis| axis.signature_axis_id.clone())
+            .collect(),
+        reading: reading.to_string(),
+        coverage_boundary:
+            "analytic value is relative to selected graph / matrix representation and is not a quality score"
+                .to_string(),
+        zero_reflecting_boundary:
+            "zero reflects only the selected representation when coverage and exactness assumptions hold"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_coupling_cohesion_readings(
+    archmap: &ArchMapDocumentV0,
+) -> Vec<ArchSigCouplingCohesionReadingV0> {
+    let relation_refs = archmap
+        .atom_observations
+        .iter()
+        .filter(|atom| atom.atom_family.to_ascii_lowercase().contains("relation"))
+        .map(|atom| atom.atom_observation_id.clone())
+        .collect::<Vec<_>>();
+    let contract_refs = archmap
+        .atom_observations
+        .iter()
+        .filter(|atom| atom.atom_family.to_ascii_lowercase().contains("contract"))
+        .map(|atom| atom.atom_observation_id.clone())
+        .collect::<Vec<_>>();
+    let semantic_refs = archmap
+        .semantic_observations
+        .iter()
+        .map(|semantic| semantic.semantic_observation_id.clone())
+        .collect::<Vec<_>>();
+    let gap_refs = archmap
+        .observation_gaps
+        .iter()
+        .map(|gap| gap.gap_id.clone())
+        .collect::<Vec<_>>();
+
+    vec![
+        coupling_reading(
+            "coupling:static-dependency",
+            "staticDependencyCoupling",
+            relation_refs.len(),
+            relation_refs,
+            vec![],
+            "static relation atoms show direct source-level coupling",
+        ),
+        coupling_reading(
+            "cohesion:semantic-contract",
+            "contractCohesion",
+            contract_refs.len() + semantic_refs.len(),
+            contract_refs.into_iter().chain(semantic_refs).collect(),
+            vec![],
+            "contract and semantic observations give a semantic cohesion reading",
+        ),
+        coupling_reading(
+            "coupling:state-effect",
+            "stateEffectCoupling",
+            gap_refs.len(),
+            gap_refs.clone(),
+            gap_refs,
+            "state/effect coupling remains stressed when runtime or effect evidence is unavailable",
+        ),
+        coupling_reading(
+            "coupling:authority-trust",
+            "authorityTrustCoupling",
+            archmap
+                .atom_observations
+                .iter()
+                .filter(|atom| {
+                    let family = atom.atom_family.to_ascii_lowercase();
+                    family.contains("authority") || family.contains("trust")
+                })
+                .count(),
+            all_atom_refs(archmap),
+            archmap
+                .observation_gaps
+                .iter()
+                .map(|gap| gap.gap_id.clone())
+                .collect(),
+            "authority and trust coupling are unmeasured unless ArchMap records explicit authority/trust atoms",
+        ),
+    ]
+}
+
+fn coupling_reading(
+    reading_id: &str,
+    axis: &str,
+    value: usize,
+    supporting_refs: Vec<String>,
+    stressed_refs: Vec<String>,
+    reading: &str,
+) -> ArchSigCouplingCohesionReadingV0 {
+    ArchSigCouplingCohesionReadingV0 {
+        reading_id: reading_id.to_string(),
+        axis: axis.to_string(),
+        status: if value == 0 {
+            "unmeasured"
+        } else if stressed_refs.is_empty() {
+            "actionable"
+        } else {
+            "needsReview"
+        }
+        .to_string(),
+        value_type: "boundedCount".to_string(),
+        value: value.to_string(),
+        supporting_refs,
+        stressed_refs,
+        reading: reading.to_string(),
+        coverage_boundary:
+            "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth"
+                .to_string(),
+        recommended_next_action:
+            "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_design_principle_readings(
+    archmap: &ArchMapDocumentV0,
+    invariant_readings: &[ArchSigInvariantFamilyReadingV0],
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+    repair_candidates: &[ArchSigRepairOperationCandidateV0],
+) -> Vec<ArchSigDesignPrincipleReadingV0> {
+    let specs = [
+        (
+            "InformationHiding",
+            "representation, state, effect, and provider details stay inside declared boundaries",
+        ),
+        (
+            "Encapsulation",
+            "state mutation, effect execution, and authority checks are owned by the selected boundary",
+        ),
+        (
+            "SeparationOfConcerns",
+            "semantic concern, state transition, effect, policy, and presentation remain unmixed",
+        ),
+        (
+            "Substitutability",
+            "replacement preserves contract, effect, state transition, and semantic reading",
+        ),
+        (
+            "OpenClosedExtension",
+            "feature extension preserves core invariants without new interaction obstruction",
+        ),
+        (
+            "DependencyInversion",
+            "abstract boundary semantics remain aligned with implementation obligations",
+        ),
+        (
+            "RepresentationIndependence",
+            "internal representation changes preserve selected observations and contracts",
+        ),
+        (
+            "IdempotencyAndReplaySafety",
+            "retry, replay, jobs, and external effects preserve selected state transition law",
+        ),
+        (
+            "AuthorityAndTrustBoundary",
+            "authority labels and trust handoffs survive operation paths",
+        ),
+    ];
+    let gap_refs = archmap
+        .observation_gaps
+        .iter()
+        .map(|gap| gap.gap_id.clone())
+        .collect::<Vec<_>>();
+    let obstruction_refs = obstruction_circuits
+        .iter()
+        .map(|circuit| circuit.obstruction_circuit_id.clone())
+        .collect::<Vec<_>>();
+    let invariant_refs = invariant_readings
+        .iter()
+        .map(|reading| reading.invariant_id.clone())
+        .collect::<Vec<_>>();
+    let operation_refs = repair_candidates
+        .iter()
+        .map(|candidate| candidate.repair_operation_candidate_id.clone())
+        .collect::<Vec<_>>();
+    specs
+        .into_iter()
+        .map(|(principle, reading)| {
+            let status = principle_status(principle, archmap, obstruction_circuits);
+            ArchSigDesignPrincipleReadingV0 {
+                principle_id: format!("principle:{}", stable_id(principle)),
+                principle: principle.to_string(),
+                status: status.to_string(),
+                aat_reading: format!("{principle} is read as invariant preservation / obstruction / operation preservation: {reading}"),
+                invariant_refs: invariant_refs.clone(),
+                obstruction_refs: obstruction_refs.clone(),
+                operation_refs: operation_refs.clone(),
+                evidence_refs: all_atom_refs(archmap),
+                confidence: if status == "unmeasured" { "low" } else { "medium" }.to_string(),
+                coverage_boundary:
+                    "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule"
+                        .to_string(),
+                exactness_blockers: if gap_refs.is_empty() {
+                    vec!["exactness remains selected-profile-relative".to_string()]
+                } else {
+                    gap_refs.clone()
+                },
+                recommended_next_action:
+                    "turn stressed readings into source review questions or repair preconditions"
+                        .to_string(),
+                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+            }
+        })
+        .collect()
+}
+
+fn principle_status(
+    principle: &str,
+    archmap: &ArchMapDocumentV0,
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+) -> &'static str {
+    let lower = principle.to_ascii_lowercase();
+    if lower.contains("idempotency")
+        || lower.contains("authority")
+        || lower.contains("representation")
+    {
+        if archmap.observation_gaps.is_empty() {
+            "needsReview"
+        } else {
+            "unmeasured"
+        }
+    } else if obstruction_circuits.is_empty() {
+        "preserved"
+    } else {
+        "stressed"
+    }
+}
+
+fn build_operation_deltas(
+    archmap: &ArchMapDocumentV0,
+    repair_candidates: &[ArchSigRepairOperationCandidateV0],
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+) -> Vec<ArchSigOperationDeltaReadingV0> {
+    if repair_candidates.is_empty() {
+        return vec![ArchSigOperationDeltaReadingV0 {
+            operation_delta_id: "operation-delta:observe-before-repair".to_string(),
+            operation_kind: "evidence-enrichment".to_string(),
+            support_refs: all_atom_refs(archmap),
+            preconditions: repair_preconditions(archmap),
+            atom_transformations: vec![
+                "add or refine ArchMap atom observations before claiming repair".to_string(),
+            ],
+            transition_relation:
+                "ArchMap enrichment changes analysis coverage without changing source architecture"
+                    .to_string(),
+            invariant_preservation_claims: vec![
+                "preserve all existing source-grounded atom observation refs".to_string(),
+            ],
+            obstruction_transport: vec![
+                "no constructed obstruction is transported because no repair candidate exists"
+                    .to_string(),
+            ],
+            signature_delta: signature_axes
+                .iter()
+                .map(|axis| format!("{} remains {}", axis.signature_axis_id, axis.value))
+                .collect(),
+            decreased_axes: vec![],
+            transferred_obstructions: archmap
+                .observation_gaps
+                .iter()
+                .map(|gap| gap.gap_id.clone())
+                .collect(),
+            excluded_readings: vec![
+                "evidence enrichment is not a source-code repair".to_string(),
+                "no automatic patch safety".to_string(),
+            ],
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        }];
+    }
+
+    repair_candidates
+        .iter()
+        .map(|candidate| ArchSigOperationDeltaReadingV0 {
+            operation_delta_id: format!(
+                "operation-delta:{}",
+                stable_id(&candidate.repair_operation_candidate_id)
+            ),
+            operation_kind: candidate.operation_kind.clone(),
+            support_refs: candidate.target_obstruction_refs.clone(),
+            preconditions: candidate.preconditions.clone(),
+            atom_transformations: vec![
+                "split or enrich atoms that currently support the target obstruction".to_string(),
+                "add observed compensation / authority / effect atoms only after source review"
+                    .to_string(),
+            ],
+            transition_relation:
+                "operation maps the current bounded Atom configuration to a candidate repaired configuration"
+                    .to_string(),
+            invariant_preservation_claims: candidate.preserved_invariants.clone(),
+            obstruction_transport: candidate
+                .target_obstruction_refs
+                .iter()
+                .map(|target| {
+                    format!("{target} may decrease or move to a runtime/state/effect axis")
+                })
+                .collect(),
+            signature_delta: candidate.expected_signature_axis_effects.clone(),
+            decreased_axes: signature_axes
+                .iter()
+                .filter(|axis| axis.value != 0)
+                .map(|axis| axis.signature_axis_id.clone())
+                .collect(),
+            transferred_obstructions: candidate.transfer_risks.clone(),
+            excluded_readings: candidate.excluded_readings.clone(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        })
+        .collect()
+}
+
+fn build_path_homotopy_diagram_readings(
+    archmap: &ArchMapDocumentV0,
+    molecule_readings: &[ArchSigMoleculeReadingV0],
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+) -> Vec<ArchSigPathHomotopyDiagramReadingV0> {
+    vec![
+        ArchSigPathHomotopyDiagramReadingV0 {
+            reading_id: "path:semantic-operation-flow".to_string(),
+            surface: "Path".to_string(),
+            status: if archmap.semantic_observations.is_empty() {
+                "unmeasured"
+            } else {
+                "observedOrRepresented"
+            }
+            .to_string(),
+            path_refs: archmap
+                .semantic_observations
+                .iter()
+                .map(|semantic| semantic.semantic_observation_id.clone())
+                .collect(),
+            homotopy_refs: molecule_readings
+                .iter()
+                .map(|reading| reading.molecule_reading_id.clone())
+                .collect(),
+            diagram_refs: obstruction_circuits
+                .iter()
+                .map(|circuit| circuit.obstruction_circuit_id.clone())
+                .collect(),
+            filling_boundary:
+                "path reading is a source-grounded semantic workflow proxy, not a free-category proof"
+                    .to_string(),
+            reading: "semantic observations and molecules provide path candidates for review".to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        },
+        ArchSigPathHomotopyDiagramReadingV0 {
+            reading_id: "diagram:obstruction-filling".to_string(),
+            surface: "Diagram".to_string(),
+            status: if obstruction_circuits.is_empty() {
+                "needsReview"
+            } else {
+                "actionable"
+            }
+            .to_string(),
+            path_refs: all_atom_refs(archmap),
+            homotopy_refs: molecule_readings
+                .iter()
+                .map(|reading| reading.molecule_reading_id.clone())
+                .collect(),
+            diagram_refs: obstruction_circuits
+                .iter()
+                .map(|circuit| circuit.obstruction_circuit_id.clone())
+                .collect(),
+            filling_boundary:
+                "diagram filling is reported as obstruction / repair planning surface, not theorem discharge"
+                    .to_string(),
+            reading: "constructed obstruction circuits identify diagrams whose filling requires review or repair".to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        },
+    ]
+}
+
+fn build_bounded_judgements(
+    archmap: &ArchMapDocumentV0,
+    obstruction_circuits: &[ArchSigObstructionCircuitV0],
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+    design_principles: &[ArchSigDesignPrincipleReadingV0],
+) -> Vec<ArchSigBoundedJudgementV0> {
+    let mut judgements = vec![ArchSigBoundedJudgementV0 {
+        judgement_id: "judgement:architecture-state".to_string(),
+        status: "actionable".to_string(),
+        aat_concept: "ArchitectureObject".to_string(),
+        reading: "observed atoms, molecules, semantic records, gaps, and signature axes define a bounded architecture state".to_string(),
+        evidence_refs: all_atom_refs(archmap),
+        confidence: "medium".to_string(),
+        uncertainty: archmap
+            .observation_gaps
+            .iter()
+            .map(|gap| gap.reason.clone())
+            .collect(),
+        coverage_boundary: "bounded to supplied ArchMap and selected interpretation profile".to_string(),
+        exactness_boundary: "not global architecture truth and not Lean theorem proof".to_string(),
+        recommended_next_action: "review nonzero axes and stressed principle readings first".to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }];
+
+    for circuit in obstruction_circuits {
+        judgements.push(ArchSigBoundedJudgementV0 {
+            judgement_id: format!("judgement:{}", stable_id(&circuit.obstruction_circuit_id)),
+            status: "actionable".to_string(),
+            aat_concept: "ObstructionCircuit".to_string(),
+            reading: circuit.evidence_summary.clone(),
+            evidence_refs: circuit
+                .atom_observation_refs
+                .iter()
+                .chain(circuit.molecule_reading_refs.iter())
+                .chain(circuit.concern_hint_refs.iter())
+                .cloned()
+                .collect(),
+            confidence: "medium".to_string(),
+            uncertainty: circuit.missing_evidence.clone(),
+            coverage_boundary: circuit.evidence_boundary.clone(),
+            exactness_boundary: "witness is selected-profile-relative".to_string(),
+            recommended_next_action: "inspect source refs and repair operation preconditions"
+                .to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        });
+    }
+
+    for axis in signature_axes {
+        judgements.push(ArchSigBoundedJudgementV0 {
+            judgement_id: format!("judgement:{}", stable_id(&axis.signature_axis_id)),
+            status: if axis.value == 0 {
+                "needsReview"
+            } else {
+                "actionable"
+            }
+            .to_string(),
+            aat_concept: "ArchitectureSignature".to_string(),
+            reading: axis.evidence_summary.clone(),
+            evidence_refs: axis.source_refs.clone(),
+            confidence: if axis.value == 0 { "low" } else { "medium" }.to_string(),
+            uncertainty: axis.missing_evidence.clone(),
+            coverage_boundary: axis.coverage_status.clone(),
+            exactness_boundary: axis.exactness_assumptions.join("; "),
+            recommended_next_action:
+                "use zero axes only with exactness assumptions; review nonzero axes as design pressure"
+                    .to_string(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        });
+    }
+
+    for principle in design_principles {
+        judgements.push(ArchSigBoundedJudgementV0 {
+            judgement_id: format!("judgement:{}", stable_id(&principle.principle_id)),
+            status: match principle.status.as_str() {
+                "preserved" => "needsReview",
+                "stressed" => "actionable",
+                "unmeasured" => "blocked",
+                _ => "needsReview",
+            }
+            .to_string(),
+            aat_concept: "Invariant".to_string(),
+            reading: principle.aat_reading.clone(),
+            evidence_refs: principle.evidence_refs.clone(),
+            confidence: principle.confidence.clone(),
+            uncertainty: principle.exactness_blockers.clone(),
+            coverage_boundary: principle.coverage_boundary.clone(),
+            exactness_boundary: "design principle reading is not static lint and not theorem proof"
+                .to_string(),
+            recommended_next_action: principle.recommended_next_action.clone(),
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        });
+    }
+
+    judgements
+}
+
+fn build_llm_interpretation_packet(
+    archmap: &ArchMapDocumentV0,
+    architecture_state: &ArchSigArchitectureStateV0,
+    design_pressure: &[ArchSigDesignPressureReadingV0],
+    signature_axes: &[ArchSigSignatureAxisReadingV0],
+    analytic_representations: &[ArchSigAnalyticRepresentationV0],
+    repair_candidates: &[ArchSigRepairOperationCandidateV0],
+    bounded_judgements: &[ArchSigBoundedJudgementV0],
+) -> ArchSigLlmInterpretationPacketV0 {
+    ArchSigLlmInterpretationPacketV0 {
+        packet_id: format!("llm-interpretation:{}", stable_id(&archmap.map_id)),
+        short_diagnosis: format!(
+            "{} actionable judgement(s), {} design pressure reading(s), and {} observation gap(s) require review",
+            bounded_judgements
+                .iter()
+                .filter(|judgement| judgement.status == "actionable")
+                .count(),
+            design_pressure.len(),
+            archmap.observation_gaps.len()
+        ),
+        aat_concept_map: vec![
+            "Atom -> Configuration -> ArchitectureObject".to_string(),
+            "InvariantFamily -> LawUniverse -> ObstructionCircuit -> ArchitectureSignature"
+                .to_string(),
+            "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation".to_string(),
+        ],
+        observed_atoms_summary: architecture_state.atom_family_refs.clone(),
+        obstruction_summary: design_pressure
+            .iter()
+            .flat_map(|pressure| pressure.obstruction_refs.clone())
+            .collect(),
+        signature_axes_summary: signature_axes
+            .iter()
+            .map(|axis| {
+                format!(
+                    "{}={} ({})",
+                    axis.signature_axis_id, axis.value, axis.coverage_status
+                )
+            })
+            .collect(),
+        analytic_readings_summary: analytic_representations
+            .iter()
+            .map(|reading| {
+                format!(
+                    "{}={} ({})",
+                    reading.representation_family, reading.value, reading.status
+                )
+            })
+            .collect(),
+        repair_operation_summary: repair_candidates
+            .iter()
+            .map(|candidate| {
+                format!(
+                    "{} targets {:?}",
+                    candidate.repair_operation_candidate_id, candidate.target_obstruction_refs
+                )
+            })
+            .collect(),
+        complexity_transfer_notes: repair_candidates
+            .iter()
+            .flat_map(|candidate| candidate.transfer_risks.clone())
+            .collect(),
+        coverage_gaps_and_exactness_blockers: archmap_gap_missing_evidence(archmap),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        recommended_human_review_focus: bounded_judgements
+            .iter()
+            .filter(|judgement| judgement.status != "nonConclusion")
+            .map(|judgement| {
+                format!(
+                    "{}: {}",
+                    judgement.judgement_id, judgement.recommended_next_action
+                )
+            })
+            .collect(),
+    }
+}
+
 fn build_repair_candidates(
     archmap: &ArchMapDocumentV0,
     obstruction_circuits: &[ArchSigObstructionCircuitV0],
@@ -644,6 +1608,9 @@ pub fn validate_archsig_analysis_packet_report(
     let checks = vec![
         check_schema_version(packet),
         check_refs_and_identity(packet),
+        check_north_star_aat_surfaces(packet),
+        check_bounded_judgement_surface(packet),
+        check_analytic_and_principle_surfaces(packet),
         check_law_relative_analysis(packet),
         check_signature_and_flatness(packet),
         check_repair_candidates(packet),
@@ -658,10 +1625,16 @@ pub fn validate_archsig_analysis_packet_report(
         } else {
             "pass".to_string()
         },
+        aat_concept_surface_count: packet.aat_concept_surfaces.len(),
         molecule_reading_count: packet.molecule_readings.len(),
         obstruction_circuit_count: packet.obstruction_circuits.len(),
         signature_axis_count: packet.signature_axes.len(),
+        analytic_representation_count: packet.analytic_representations.len(),
+        coupling_cohesion_reading_count: packet.coupling_cohesion_readings.len(),
+        design_principle_reading_count: packet.design_principle_readings.len(),
         repair_operation_candidate_count: packet.repair_operation_candidates.len(),
+        operation_delta_count: packet.operation_deltas.len(),
+        bounded_judgement_count: packet.bounded_judgements.len(),
         failed_check_count: count_checks(&checks, "fail"),
         warning_check_count: count_checks(&checks, "warn"),
     };
@@ -711,6 +1684,11 @@ fn check_refs_and_identity(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck 
     );
     push_blank(
         &mut examples,
+        "interpretationProfileRef.artifactId",
+        &packet.interpretation_profile_ref.artifact_id,
+    );
+    push_blank(
+        &mut examples,
         "selectedLawPolicyRef.artifactId",
         &packet.selected_law_policy_ref.artifact_id,
     );
@@ -731,6 +1709,203 @@ fn check_refs_and_identity(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck 
     check_from_examples(
         "archsig-analysis-packet-refs-and-identity",
         "analysis identity and ArchMap / LawPolicy references are recorded",
+        examples,
+        "fail",
+    )
+}
+
+fn check_north_star_aat_surfaces(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let required_concepts = BTreeSet::from([
+        "Atom",
+        "Configuration",
+        "ArchitectureObject",
+        "Invariant",
+        "LawUniverse",
+        "ObstructionCircuit",
+        "ArchitectureSignature",
+        "Operation",
+        "Path",
+        "Homotopy",
+        "Diagram",
+        "AnalyticRepresentation",
+    ]);
+    let present = packet
+        .aat_concept_surfaces
+        .iter()
+        .map(|surface| surface.concept.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = required_concepts
+        .iter()
+        .filter(|concept| !present.contains(**concept))
+        .map(|concept| {
+            generic_validation_example(
+                "aatConceptSurfaces",
+                concept,
+                "North Star packet must represent every AAT concept surface",
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if packet.architecture_object_projections.is_empty() {
+        examples.push(generic_validation_example(
+            "architectureObjectProjections",
+            "empty",
+            "packet must expose ArchitectureObject projection surface",
+        ));
+    }
+    if packet.invariant_family_readings.is_empty() {
+        examples.push(generic_validation_example(
+            "invariantFamilyReadings",
+            "empty",
+            "packet must expose invariant family readings",
+        ));
+    }
+    if packet.law_universe_reading.selected_law_refs.is_empty() {
+        examples.push(generic_validation_example(
+            "lawUniverseReading.selectedLawRefs",
+            "empty",
+            "packet must expose selected law universe/profile refs",
+        ));
+    }
+    if packet.path_homotopy_diagram_readings.is_empty() {
+        examples.push(generic_validation_example(
+            "pathHomotopyDiagramReadings",
+            "empty",
+            "packet must expose path, homotopy, and diagram readings",
+        ));
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-north-star-aat-surfaces",
+        "packet represents all AAT concept surfaces required by the North Star PRD",
+        examples,
+        "fail",
+    )
+}
+
+fn check_bounded_judgement_surface(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let allowed = BTreeSet::from(["actionable", "needsReview", "blocked", "nonConclusion"]);
+    let mut examples = Vec::new();
+    if packet.bounded_judgements.is_empty() {
+        examples.push(generic_validation_example(
+            "boundedJudgements",
+            "empty",
+            "packet must provide bounded judgement records",
+        ));
+    }
+    for judgement in &packet.bounded_judgements {
+        if !allowed.contains(judgement.status.as_str()) {
+            examples.push(generic_validation_example(
+                &judgement.judgement_id,
+                &judgement.status,
+                "bounded judgement status must be actionable, needsReview, blocked, or nonConclusion",
+            ));
+        }
+        if judgement.evidence_refs.is_empty() || has_blank(&judgement.evidence_refs) {
+            examples.push(generic_validation_example(
+                &judgement.judgement_id,
+                "evidenceRefs",
+                "bounded judgement must carry evidence refs",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} coverageBoundary", judgement.judgement_id),
+            &judgement.coverage_boundary,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} exactnessBoundary", judgement.judgement_id),
+            &judgement.exactness_boundary,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} recommendedNextAction", judgement.judgement_id),
+            &judgement.recommended_next_action,
+        );
+    }
+    check_from_examples(
+        "archsig-analysis-packet-bounded-judgement-surface",
+        "packet makes non-conclusion usable through bounded judgement records",
+        examples,
+        "fail",
+    )
+}
+
+fn check_analytic_and_principle_surfaces(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let required_principles = BTreeSet::from([
+        "InformationHiding",
+        "Encapsulation",
+        "SeparationOfConcerns",
+        "Substitutability",
+        "OpenClosedExtension",
+        "DependencyInversion",
+        "RepresentationIndependence",
+        "IdempotencyAndReplaySafety",
+        "AuthorityAndTrustBoundary",
+    ]);
+    let present_principles = packet
+        .design_principle_readings
+        .iter()
+        .map(|reading| reading.principle.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = required_principles
+        .iter()
+        .filter(|principle| !present_principles.contains(**principle))
+        .map(|principle| {
+            generic_validation_example(
+                "designPrincipleReadings",
+                principle,
+                "packet must expose static-hard design principles as AAT readings",
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for required_axis in [
+        "weightedAdjacencyMatrix",
+        "walkCount",
+        "reachableConeSize",
+        "nilpotenceBoundary",
+        "selectedSubgraphSpectrum",
+        "propagationDepth",
+        "spectralRadius",
+        "curvatureValuation",
+        "stateAlgebra",
+        "zeroReflectingAggregateBoundary",
+    ] {
+        if !packet
+            .analytic_representations
+            .iter()
+            .any(|reading| reading.representation_family == required_axis)
+        {
+            examples.push(generic_validation_example(
+                "analyticRepresentations",
+                required_axis,
+                "packet must expose graph/matrix/spectrum/curvature analytic axes",
+            ));
+        }
+    }
+    for required_axis in [
+        "staticDependencyCoupling",
+        "contractCohesion",
+        "stateEffectCoupling",
+        "authorityTrustCoupling",
+    ] {
+        if !packet
+            .coupling_cohesion_readings
+            .iter()
+            .any(|reading| reading.axis == required_axis)
+        {
+            examples.push(generic_validation_example(
+                "couplingCohesionReadings",
+                required_axis,
+                "packet must expose semantic coupling/cohesion axes",
+            ));
+        }
+    }
+    check_from_examples(
+        "archsig-analysis-packet-analytic-and-principle-surfaces",
+        "packet exposes analytic axes, semantic coupling/cohesion, and static-hard design principle readings",
         examples,
         "fail",
     )
@@ -1352,6 +2527,18 @@ fn repair_preconditions(archmap: &ArchMapDocumentV0) -> Vec<String> {
             .map(|gap| format!("resolve or explicitly accept coverage gap {}", gap.gap_id)),
     );
     preconditions
+}
+
+fn all_atom_refs(archmap: &ArchMapDocumentV0) -> Vec<String> {
+    archmap
+        .atom_observations
+        .iter()
+        .map(|atom| atom.atom_observation_id.clone())
+        .collect()
+}
+
+fn unique_strings(values: impl Iterator<Item = String>) -> Vec<String> {
+    values.collect::<BTreeSet<_>>().into_iter().collect()
 }
 
 fn preserved_invariants_for_repair(

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -7,8 +7,7 @@ mod validation;
 
 pub use archmap::{ArchMapSourceInventoryInput, validate_archmap_report};
 pub use archsig_analysis_packet::{
-    build_archsig_analysis_packet, static_archsig_analysis_packet,
-    validate_archsig_analysis_packet_report,
+    build_archsig_analysis_packet, validate_archsig_analysis_packet_report,
 };
 pub use law_policy::{static_law_policy, validate_law_policy_report};
 pub(crate) use schema::*;

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -35,7 +35,8 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Validate or emit a LawPolicy artifact for LLM-native ArchSig analysis.
+    /// Validate or emit an interpretation profile artifact for ArchSig AAT analysis.
+    #[command(visible_alias = "interpretation-profile")]
     LawPolicy {
         /// Optional LawPolicy JSON path. If omitted, the static fixture policy is validated.
         #[arg(long)]
@@ -50,7 +51,8 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Build an ArchSig analysis packet from ArchMap + LawPolicy.
+    /// Build an ArchSig AAT analysis packet from ArchMap + interpretation profile.
+    #[command(visible_alias = "aat-analysis")]
     ArchsigAnalysis {
         /// Input ArchMap observation artifact path.
         #[arg(long)]
@@ -96,7 +98,8 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Run the LLM-native ArchMap -> LawPolicy -> ArchSig analysis workflow.
+    /// Run the ArchMap -> interpretation profile -> ArchSig North Star workflow.
+    #[command(visible_alias = "north-star-workflow")]
     LlmNativeWorkflow {
         /// Input ArchMap observation artifact path.
         #[arg(long)]

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -600,14 +600,30 @@ pub struct ArchSigAnalysisPacketV0 {
     pub analysis_id: String,
     pub generated_at: String,
     pub arch_map_ref: ArchSigAnalysisArtifactRefV0,
+    pub interpretation_profile_ref: ArchSigAnalysisArtifactRefV0,
     pub selected_law_policy_ref: ArchSigAnalysisArtifactRefV0,
+    pub architecture_state: ArchSigArchitectureStateV0,
+    pub design_pressure: Vec<ArchSigDesignPressureReadingV0>,
+    pub change_impact: ArchSigChangeImpactReadingV0,
+    pub aat_concept_surfaces: Vec<ArchSigAatConceptSurfaceV0>,
     pub atom_configuration_summary: ArchSigAtomConfigurationSummaryV0,
+    pub architecture_object_projections: Vec<ArchSigArchitectureObjectProjectionV0>,
+    pub invariant_family_readings: Vec<ArchSigInvariantFamilyReadingV0>,
+    pub law_universe_reading: ArchSigLawUniverseReadingV0,
     pub molecule_readings: Vec<ArchSigMoleculeReadingV0>,
     pub obstruction_circuits: Vec<ArchSigObstructionCircuitV0>,
     pub signature_axes: Vec<ArchSigSignatureAxisReadingV0>,
+    pub analytic_representations: Vec<ArchSigAnalyticRepresentationV0>,
+    pub coupling_cohesion_readings: Vec<ArchSigCouplingCohesionReadingV0>,
+    pub design_principle_readings: Vec<ArchSigDesignPrincipleReadingV0>,
     pub flatness_reading: ArchSigFlatnessReadingV0,
     pub static_runtime_semantic_layer_split: ArchSigLayerSplitV0,
     pub repair_operation_candidates: Vec<ArchSigRepairOperationCandidateV0>,
+    pub operation_deltas: Vec<ArchSigOperationDeltaReadingV0>,
+    pub path_homotopy_diagram_readings: Vec<ArchSigPathHomotopyDiagramReadingV0>,
+    pub bounded_judgements: Vec<ArchSigBoundedJudgementV0>,
+    #[serde(rename = "llmInterpretationPacket")]
+    pub llm_interpretation_packet: ArchSigLlmInterpretationPacketV0,
     pub evidence_boundary: String,
     #[serde(rename = "interpretationNotesForLLM")]
     pub interpretation_notes_for_llm: Vec<String>,
@@ -630,6 +646,61 @@ pub struct ArchSigAnalysisArtifactRefV0 {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ArchSigArchitectureStateV0 {
+    pub state_id: String,
+    pub reading: String,
+    pub atom_family_refs: Vec<String>,
+    pub molecule_refs: Vec<String>,
+    pub workflow_refs: Vec<String>,
+    pub boundary_refs: Vec<String>,
+    pub invariant_refs: Vec<String>,
+    pub signature_axis_refs: Vec<String>,
+    pub coverage_boundary: String,
+    pub recommended_next_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigDesignPressureReadingV0 {
+    pub pressure_id: String,
+    pub status: String,
+    pub reading: String,
+    pub atom_configuration_refs: Vec<String>,
+    pub obstruction_refs: Vec<String>,
+    pub signature_axis_refs: Vec<String>,
+    pub coverage_boundary: String,
+    pub recommended_next_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigChangeImpactReadingV0 {
+    pub impact_id: String,
+    pub operation_scope: String,
+    pub signature_delta_summary: Vec<String>,
+    pub affected_boundaries: Vec<String>,
+    pub complexity_transfer_notes: Vec<String>,
+    pub coverage_boundary: String,
+    pub recommended_next_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAatConceptSurfaceV0 {
+    pub concept: String,
+    pub status: String,
+    pub reading: String,
+    pub evidence_refs: Vec<String>,
+    pub coverage_boundary: String,
+    pub exactness_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArchSigAtomConfigurationSummaryV0 {
     pub atom_observation_count: usize,
     pub molecule_observation_count: usize,
@@ -639,6 +710,47 @@ pub struct ArchSigAtomConfigurationSummaryV0 {
     pub configuration_boundary: String,
     pub coverage_summary: Vec<String>,
     pub source_refs: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigArchitectureObjectProjectionV0 {
+    pub projection_id: String,
+    pub projection_family: String,
+    pub atom_refs: Vec<String>,
+    pub molecule_refs: Vec<String>,
+    pub semantic_refs: Vec<String>,
+    pub reading: String,
+    pub projection_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigInvariantFamilyReadingV0 {
+    pub invariant_id: String,
+    pub invariant_family: String,
+    pub status: String,
+    pub law_refs: Vec<String>,
+    pub atom_refs: Vec<String>,
+    pub obstruction_refs: Vec<String>,
+    pub reading: String,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigLawUniverseReadingV0 {
+    pub law_universe_id: String,
+    pub profile_ref: String,
+    pub selected_law_refs: Vec<String>,
+    pub witness_rule_refs: Vec<String>,
+    pub signature_axis_refs: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub coverage_requirements: Vec<String>,
+    pub reading: String,
     pub non_conclusions: Vec<String>,
 }
 
@@ -704,6 +816,56 @@ pub struct ArchSigSignatureAxisReadingV0 {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ArchSigAnalyticRepresentationV0 {
+    pub representation_id: String,
+    pub representation_family: String,
+    pub status: String,
+    pub value_type: String,
+    pub value: String,
+    pub graph_scope_refs: Vec<String>,
+    pub axis_refs: Vec<String>,
+    pub reading: String,
+    pub coverage_boundary: String,
+    pub zero_reflecting_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigCouplingCohesionReadingV0 {
+    pub reading_id: String,
+    pub axis: String,
+    pub status: String,
+    pub value_type: String,
+    pub value: String,
+    pub supporting_refs: Vec<String>,
+    pub stressed_refs: Vec<String>,
+    pub reading: String,
+    pub coverage_boundary: String,
+    pub recommended_next_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigDesignPrincipleReadingV0 {
+    pub principle_id: String,
+    pub principle: String,
+    pub status: String,
+    pub aat_reading: String,
+    pub invariant_refs: Vec<String>,
+    pub obstruction_refs: Vec<String>,
+    pub operation_refs: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub confidence: String,
+    pub coverage_boundary: String,
+    pub exactness_blockers: Vec<String>,
+    pub recommended_next_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArchSigFlatnessReadingV0 {
     pub reading_id: String,
     pub selected_law_policy_ref: String,
@@ -749,6 +911,71 @@ pub struct ArchSigRepairOperationCandidateV0 {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ArchSigOperationDeltaReadingV0 {
+    pub operation_delta_id: String,
+    pub operation_kind: String,
+    pub support_refs: Vec<String>,
+    pub preconditions: Vec<String>,
+    pub atom_transformations: Vec<String>,
+    pub transition_relation: String,
+    pub invariant_preservation_claims: Vec<String>,
+    pub obstruction_transport: Vec<String>,
+    pub signature_delta: Vec<String>,
+    pub decreased_axes: Vec<String>,
+    pub transferred_obstructions: Vec<String>,
+    pub excluded_readings: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigPathHomotopyDiagramReadingV0 {
+    pub reading_id: String,
+    pub surface: String,
+    pub status: String,
+    pub path_refs: Vec<String>,
+    pub homotopy_refs: Vec<String>,
+    pub diagram_refs: Vec<String>,
+    pub filling_boundary: String,
+    pub reading: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigBoundedJudgementV0 {
+    pub judgement_id: String,
+    pub status: String,
+    pub aat_concept: String,
+    pub reading: String,
+    pub evidence_refs: Vec<String>,
+    pub confidence: String,
+    pub uncertainty: Vec<String>,
+    pub coverage_boundary: String,
+    pub exactness_boundary: String,
+    pub recommended_next_action: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigLlmInterpretationPacketV0 {
+    pub packet_id: String,
+    pub short_diagnosis: String,
+    pub aat_concept_map: Vec<String>,
+    pub observed_atoms_summary: Vec<String>,
+    pub obstruction_summary: Vec<String>,
+    pub signature_axes_summary: Vec<String>,
+    pub analytic_readings_summary: Vec<String>,
+    pub repair_operation_summary: Vec<String>,
+    pub complexity_transfer_notes: Vec<String>,
+    pub coverage_gaps_and_exactness_blockers: Vec<String>,
+    pub non_conclusions: Vec<String>,
+    pub recommended_human_review_focus: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArchSigAnalysisPacketValidationReportV0 {
     pub schema_version: String,
     pub input: ArchSigAnalysisPacketValidationInputV0,
@@ -771,10 +998,16 @@ pub struct ArchSigAnalysisPacketValidationInputV0 {
 #[serde(rename_all = "camelCase")]
 pub struct ArchSigAnalysisPacketValidationSummaryV0 {
     pub result: String,
+    pub aat_concept_surface_count: usize,
     pub molecule_reading_count: usize,
     pub obstruction_circuit_count: usize,
     pub signature_axis_count: usize,
+    pub analytic_representation_count: usize,
+    pub coupling_cohesion_reading_count: usize,
+    pub design_principle_reading_count: usize,
     pub repair_operation_candidate_count: usize,
+    pub operation_delta_count: usize,
+    pub bounded_judgement_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
 }

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -46,17 +46,18 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
             ),
             artifact(
                 "law-policy",
-                "Selected LawPolicy artifact",
+                "Selected interpretation profile artifact",
                 LAW_POLICY_SCHEMA_VERSION,
                 "primary",
-                "LLM Atom ArchMap",
+                "ArchSig North Star AAT analysis",
                 vec![
+                    "docs/tool/archsig_aat_analysis_engine_prd.md",
                     "docs/tool/llm_native_archmap_archsig_prd.md",
                     "docs/tool/README.md",
                 ],
-                "LawPolicy owns selected laws, witness rules, molecule patterns, obstruction definitions, signature axis definitions, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations.",
+                "The law-policy-v0 JSON contract is used as an interpretation profile: it selects laws, witness rules, molecule patterns, obstruction definitions, signature axes, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations. It is not the center of ArchSig output.",
                 vec![
-                    "LawPolicy is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
+                    "Interpretation profile is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
                     "Adding a law family must preserve missing coverage as distinct from measured zero.",
                 ],
             ),
@@ -78,12 +79,13 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "ArchSig AAT analysis packet",
                 ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
                 "primary",
-                "LLM Atom ArchMap",
+                "ArchSig North Star AAT analysis",
                 vec![
+                    "docs/tool/archsig_aat_analysis_engine_prd.md",
                     "docs/tool/archsig_analysis_packet.md",
                     "docs/tool/llm_native_archmap_archsig_prd.md",
                 ],
-                "ArchSig analysis packet owns law-relative molecule readings, obstruction circuits, signature axes, flatness reading, static/runtime/semantic split, repair operation candidates, evidence boundary, LLM interpretation notes, excluded readings, and non-conclusions.",
+                "ArchSig analysis packet owns AAT concept surfaces, architecture state, design pressure, change impact, architecture object projections, invariant family readings, LawUniverse reading, molecule readings, obstruction circuits, signature axes, analytic representations, coupling/cohesion readings, design principle readings, operation deltas, path/homotopy/diagram readings, bounded judgements, LLM interpretation packet, evidence boundary, excluded readings, and non-conclusions.",
                 vec![
                     "Analysis packet is not a Lean theorem proof, global architecture truth, extractor completeness proof, quality score, or automatic safe repair.",
                     "Analysis packet compatibility is a JSON contract, not a semantic-preservation theorem.",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -27,8 +27,11 @@ fn cli_help_exposes_only_llm_atom_archmap_surface() {
         "archmap",
         "archmap-generate",
         "law-policy",
+        "interpretation-profile",
         "archsig-analysis",
+        "aat-analysis",
         "llm-native-workflow",
+        "north-star-workflow",
         "schema-catalog",
     ] {
         assert!(
@@ -43,6 +46,56 @@ fn cli_help_exposes_only_llm_atom_archmap_surface() {
             "ArchSig help still exposes removed command {removed}\n{stdout}"
         );
     }
+}
+
+#[test]
+fn cli_accepts_north_star_command_aliases() {
+    let out_dir = temp_dir("north-star-aliases");
+    let root = fixture_root();
+    let profile_validation = out_dir.join("interpretation-profile-validation.json");
+    run_sig0(&[
+        "interpretation-profile",
+        "--input",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("profile path is utf-8"),
+        "--out",
+        profile_validation
+            .to_str()
+            .expect("profile validation path is utf-8"),
+    ]);
+
+    let packet = out_dir.join("aat-analysis-packet.json");
+    run_sig0(&[
+        "aat-analysis",
+        "--archmap",
+        root.join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("profile path is utf-8"),
+        "--out",
+        packet.to_str().expect("packet path is utf-8"),
+    ]);
+    assert_north_star_packet_surfaces(&read_json(&packet));
+
+    let workflow_dir = out_dir.join("workflow");
+    run_sig0(&[
+        "north-star-workflow",
+        "--archmap",
+        root.join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("profile path is utf-8"),
+        "--out-dir",
+        workflow_dir.to_str().expect("workflow dir is utf-8"),
+    ]);
+    assert!(workflow_dir.join("archsig-analysis-packet.json").is_file());
 }
 
 #[test]
@@ -143,10 +196,22 @@ fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
             ),
         "analysis packet must value required signature axes"
     );
+    assert_north_star_packet_surfaces(&analysis_packet);
     let analysis_validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
     assert_eq!(
         analysis_validation["summary"]["result"].as_str(),
         Some("pass")
+    );
+    assert_eq!(analysis_validation["summary"]["aatConceptSurfaceCount"], 12);
+    assert_eq!(
+        analysis_validation["summary"]["designPrincipleReadingCount"],
+        9
+    );
+    assert!(
+        analysis_validation["summary"]["boundedJudgementCount"]
+            .as_u64()
+            .is_some_and(|count| count >= 10),
+        "validation summary must count bounded judgements"
     );
     let llm_packet = read_json(&out_dir.join("llm-interpretation-packet.json"));
     assert_eq!(llm_packet, analysis_packet);
@@ -219,6 +284,7 @@ fn cli_archsig_analysis_step_outputs_packet_and_validation() {
     let packet_json = read_json(&packet);
     let validation_json = read_json(&validation);
     assert_eq!(packet_json["schemaVersion"], "archsig-analysis-packet-v0");
+    assert_north_star_packet_surfaces(&packet_json);
     assert_eq!(
         validation_json["schemaVersion"],
         "archsig-analysis-packet-validation-report-v0"
@@ -374,6 +440,7 @@ fn cli_locks_archmap_atom_observation_regression() {
             .expect("full validation path is utf-8"),
     ]);
     let full = read_json(&full_packet);
+    assert_north_star_packet_surfaces(&full);
     assert!(
         full["obstructionCircuits"]
             .as_array()
@@ -595,6 +662,87 @@ fn has_check_result(json: &Value, id: &str, result: &str) -> bool {
             })
         })
     })
+}
+
+fn assert_north_star_packet_surfaces(json: &Value) {
+    for concept in [
+        "Atom",
+        "Configuration",
+        "ArchitectureObject",
+        "Invariant",
+        "LawUniverse",
+        "ObstructionCircuit",
+        "ArchitectureSignature",
+        "Operation",
+        "Path",
+        "Homotopy",
+        "Diagram",
+        "AnalyticRepresentation",
+    ] {
+        assert!(
+            json["aatConceptSurfaces"]
+                .as_array()
+                .expect("aat concept surfaces are array")
+                .iter()
+                .any(|entry| entry["concept"] == concept),
+            "North Star packet must expose AAT concept {concept}"
+        );
+    }
+    for family in [
+        "weightedAdjacencyMatrix",
+        "walkCount",
+        "reachableConeSize",
+        "nilpotenceBoundary",
+        "selectedSubgraphSpectrum",
+        "propagationDepth",
+        "spectralRadius",
+        "curvatureValuation",
+        "stateAlgebra",
+        "zeroReflectingAggregateBoundary",
+    ] {
+        assert!(
+            json["analyticRepresentations"]
+                .as_array()
+                .expect("analytic representations are array")
+                .iter()
+                .any(|entry| entry["representationFamily"] == family),
+            "North Star packet must expose analytic representation {family}"
+        );
+    }
+    for principle in [
+        "InformationHiding",
+        "Encapsulation",
+        "SeparationOfConcerns",
+        "Substitutability",
+        "OpenClosedExtension",
+        "DependencyInversion",
+        "RepresentationIndependence",
+        "IdempotencyAndReplaySafety",
+        "AuthorityAndTrustBoundary",
+    ] {
+        assert!(
+            json["designPrincipleReadings"]
+                .as_array()
+                .expect("design principle readings are array")
+                .iter()
+                .any(|entry| entry["principle"] == principle),
+            "North Star packet must expose design principle {principle}"
+        );
+    }
+    assert!(
+        json["boundedJudgements"]
+            .as_array()
+            .expect("bounded judgements are array")
+            .iter()
+            .any(|entry| entry["status"] == "actionable"),
+        "bounded judgements must include actionable readings"
+    );
+    assert!(
+        json["llmInterpretationPacket"]["recommendedHumanReviewFocus"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "LLM interpretation packet must provide review focus"
+    );
 }
 
 fn collect_files(root: &Path) -> Vec<PathBuf> {

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "archsig-analysis-packet-v0",
-  "analysisId": "archsig-analysis-fixture",
+  "analysisId": "archsig-analysis:fixture-archmap-atom-observation:llm-native-aat-law-policy-fixture",
   "generatedAt": "2026-05-23T00:00:00Z",
   "archMapRef": {
     "artifactId": "fixture-archmap-atom-observation",
@@ -8,29 +8,363 @@
     "schemaVersion": "archmap-observation-map-v0",
     "path": "tools/archsig/tests/fixtures/minimal/archmap.json"
   },
+  "interpretationProfileRef": {
+    "artifactId": "llm-native-aat-law-policy-fixture",
+    "artifactKind": "interpretation-profile",
+    "schemaVersion": "law-policy-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
+  },
   "selectedLawPolicyRef": {
     "artifactId": "llm-native-aat-law-policy-fixture",
     "artifactKind": "law-policy",
     "schemaVersion": "law-policy-v0",
     "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
   },
+  "architectureState": {
+    "stateId": "architecture-state:archmap-fixture-repo",
+    "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
+    "atomFamilyRefs": [
+      "contractSpecification",
+      "existence",
+      "relation"
+    ],
+    "moleculeRefs": [
+      "molecule:user-request-responsibility"
+    ],
+    "workflowRefs": [
+      "semantic:create-user-flow"
+    ],
+    "boundaryRefs": [
+      "gap-runtime-user-db-trace"
+    ],
+    "invariantRefs": [
+      "invariant:law-layer-respecting",
+      "invariant:law-semantic-contract-alignment"
+    ],
+    "signatureAxisRefs": [
+      "sig-axis:layer-violation",
+      "sig-axis:semantic-inconsistency"
+    ],
+    "coverageBoundary": "state is an ArchMap-relative architecture state, not a complete source reconstruction",
+    "recommendedNextAction": "review nonzero axes, stressed principles, and preserved observation gaps before planning repair",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "designPressure": [
+    {
+      "pressureId": "design-pressure:selected-atom-configuration",
+      "status": "actionable",
+      "reading": "1 selected obstruction circuit(s) and 1 coverage gap(s) define the current pressure surface",
+      "atomConfigurationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:semantic-inconsistency"
+      ],
+      "coverageBoundary": "pressure is relative to the observed finite Atom configuration and selected profile",
+      "recommendedNextAction": "use bounded judgements to decide whether to inspect source refs, add evidence, or plan repair",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "changeImpact": {
+    "impactId": "change-impact:selected-repair-operations",
+    "operationScope": "repair, extension, migration, and refactor operations over observed ArchMap atoms",
+    "signatureDeltaSummary": [
+      "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+    ],
+    "affectedBoundaries": [
+      "sig-axis:layer-violation: coverage-gap-preserved",
+      "sig-axis:semantic-inconsistency: coverage-gap-preserved"
+    ],
+    "complexityTransferNotes": [
+      "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+    ],
+    "coverageBoundary": "impact is a pre-change operation reading; it is not evidence that a future patch is safe",
+    "recommendedNextAction": "compare operation deltas before and after the patch and keep transferred obstruction notes",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "aatConceptSurfaces": [
+    {
+      "concept": "Atom",
+      "status": "observedOrRepresented",
+      "reading": "Atom is represented with 4 bounded packet record(s)",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Configuration",
+      "status": "observedOrRepresented",
+      "reading": "Configuration is represented with 5 bounded packet record(s)",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "ArchitectureObject",
+      "status": "observedOrRepresented",
+      "reading": "ArchitectureObject is represented with 3 bounded packet record(s)",
+      "evidenceRefs": [
+        "projection:aat:route-users",
+        "projection:aat:route-service",
+        "projection:sft:create-user"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Invariant",
+      "status": "observedOrRepresented",
+      "reading": "Invariant is represented with 2 bounded packet record(s)",
+      "evidenceRefs": [
+        "law:layer-respecting",
+        "law:semantic-contract-alignment"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "LawUniverse",
+      "status": "observedOrRepresented",
+      "reading": "LawUniverse is represented with 2 bounded packet record(s)",
+      "evidenceRefs": [
+        "law:layer-respecting",
+        "law:semantic-contract-alignment"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "ObstructionCircuit",
+      "status": "observedOrRepresented",
+      "reading": "ObstructionCircuit is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "ArchitectureSignature",
+      "status": "observedOrRepresented",
+      "reading": "ArchitectureSignature is represented with 2 bounded packet record(s)",
+      "evidenceRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Operation",
+      "status": "observedOrRepresented",
+      "reading": "Operation is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Path",
+      "status": "observedOrRepresented",
+      "reading": "Path is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Homotopy",
+      "status": "observedOrRepresented",
+      "reading": "Homotopy is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "semantic:create-user-flow"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Diagram",
+      "status": "observedOrRepresented",
+      "reading": "Diagram is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "AnalyticRepresentation",
+      "status": "observedOrRepresented",
+      "reading": "AnalyticRepresentation is represented with 10 bounded packet record(s)",
+      "evidenceRefs": [
+        "analytic:weighted-adjacency",
+        "analytic:reachable-cone-size",
+        "analytic:walk-count",
+        "analytic:nilpotence-boundary",
+        "analytic:selected-subgraph-spectrum",
+        "analytic:propagation-depth",
+        "analytic:spectral-radius-proxy",
+        "analytic:curvature-valuation",
+        "analytic:state-algebra-boundary",
+        "analytic:zero-reflecting-aggregate-boundary"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
   "atomConfigurationSummary": {
     "atomObservationCount": 4,
     "moleculeObservationCount": 1,
     "semanticObservationCount": 1,
     "observationGapCount": 1,
     "concernHintCount": 1,
-    "configurationBoundary": "counts are read from one bounded ArchMap fixture, not complete architecture enumeration",
+    "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
     "coverageSummary": [
-      "static source atoms observed",
-      "semantic contract observation observed",
-      "runtime trace remains unavailable"
+      "4 atom observations",
+      "1 molecule observations",
+      "1 semantic observations",
+      "1 observation gaps preserved as gaps"
     ],
     "sourceRefs": [
       "atom:component:route-users",
       "atom:component:service-user",
-      "atom:relation:route-service",
       "atom:contract:create-user",
+      "atom:relation:route-service",
       "gap-runtime-user-db-trace"
     ],
     "nonConclusions": [
@@ -42,26 +376,172 @@
       "repair operation candidates are not automatic safe refactorings"
     ]
   },
-  "moleculeReadings": [
+  "architectureObjectProjections": [
     {
-      "moleculeReadingId": "molecule-reading:user-request-responsibility",
-      "moleculeObservationRef": "molecule:user-request-responsibility",
+      "projectionId": "projection:aat:route-users",
+      "projectionFamily": "object",
+      "atomRefs": [
+        "atom:component:route-users"
+      ],
+      "moleculeRefs": [],
+      "semanticRefs": [
+        "atom:component:route-users"
+      ],
+      "reading": "route.users is an observed component object",
+      "projectionBoundary": "derived from observed source atom; not primary ArchMap law claim",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "projectionId": "projection:aat:route-service",
+      "projectionFamily": "relation",
+      "atomRefs": [
+        "atom:relation:route-service"
+      ],
+      "moleculeRefs": [],
+      "semanticRefs": [
+        "atom:relation:route-service"
+      ],
+      "reading": "route.users to service.user is an observed relation",
+      "projectionBoundary": "derived from observed source atom; runtime frequency unmeasured",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "projectionId": "projection:sft:create-user",
+      "projectionFamily": "signatureAxis",
+      "atomRefs": [],
+      "moleculeRefs": [],
+      "semanticRefs": [
+        "semantic:create-user-flow"
+      ],
+      "reading": "semantic observation can be handed off as bounded SFT evidence",
+      "projectionBoundary": "SFT consequence analysis is not owned by ArchMap",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "invariantFamilyReadings": [
+    {
+      "invariantId": "invariant:law-layer-respecting",
+      "invariantFamily": "dependency-direction",
+      "status": "preservedForConstructedWitnesses",
+      "lawRefs": [
+        "law:layer-respecting"
+      ],
+      "atomRefs": [
+        "atom:relation:route-service"
+      ],
+      "obstructionRefs": [],
+      "reading": "Dependencies must respect the selected layer order. is read as an invariant family selected by the interpretation profile",
+      "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "invariantId": "invariant:law-semantic-contract-alignment",
+      "invariantFamily": "semantic-contract",
+      "status": "stressed",
       "lawRefs": [
         "law:semantic-contract-alignment"
       ],
+      "atomRefs": [
+        "atom:contract:create-user"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "reading": "Semantic observations and contract observations must agree on the selected operation meaning. is read as an invariant family selected by the interpretation profile",
+      "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "lawUniverseReading": {
+    "lawUniverseId": "law-universe:llm-native-aat-law-policy-fixture",
+    "profileRef": "llm-native-aat-law-policy-fixture",
+    "selectedLawRefs": [
+      "law:layer-respecting",
+      "law:semantic-contract-alignment"
+    ],
+    "witnessRuleRefs": [
+      "witness:layer-violation",
+      "witness:semantic-contract-mismatch"
+    ],
+    "signatureAxisRefs": [
+      "sig-axis:layer-violation",
+      "sig-axis:semantic-inconsistency"
+    ],
+    "exactnessAssumptions": [
+      "the selected witness rules cover only policy-declared laws",
+      "zero readings are exact only for observed atoms and declared coverage requirements"
+    ],
+    "coverageRequirements": [
+      "coverage:layer-atoms",
+      "coverage:semantic-contract-atoms"
+    ],
+    "reading": "LawPolicy is interpreted as an analysis profile selecting a bounded LawUniverse, witnesses, axes, coverage, and exactness assumptions",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "moleculeReadings": [
+    {
+      "moleculeReadingId": "molecule-reading:molecule-user-request-responsibility",
+      "moleculeObservationRef": "molecule:user-request-responsibility",
+      "lawRefs": [
+        "law:layer-respecting",
+        "law:semantic-contract-alignment"
+      ],
       "atomObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "reading": "observed route/service/contract atoms form one operation-responsibility molecule",
-      "evidenceSummary": "molecule reading uses ArchMap atom observations and the selected semantic-contract law",
-      "evidenceBoundary": "law-relative reading over observed atoms; not a primitive atom and not theorem evidence",
+      "reading": "molecule:user-request-responsibility is read as a responsibility molecule under selected LawPolicy",
+      "evidenceSummary": "molecule uses 4 atom observation refs and 1 source refs",
+      "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
       "sourceRefs": [
-        "doc-architecture",
-        "test-user-contract"
+        "doc-architecture"
       ],
       "interpretationNotesForLLM": [
-        "Explain this as a responsibility grouping over observed atoms."
+        "Explain molecule readings as grouped observed atoms before discussing laws."
       ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
@@ -75,16 +555,15 @@
   ],
   "obstructionCircuits": [
     {
-      "obstructionCircuitId": "obstruction:semantic-contract-mismatch:create-user",
+      "obstructionCircuitId": "obstruction:semantic-contract-mismatch:computed",
       "lawRef": "law:semantic-contract-alignment",
       "witnessRuleRef": "witness:semantic-contract-mismatch",
       "circuitKind": "SemanticMismatchCircuit",
       "atomObservationRefs": [
-        "atom:relation:route-service",
         "atom:contract:create-user"
       ],
       "moleculeReadingRefs": [
-        "molecule-reading:user-request-responsibility"
+        "molecule-reading:molecule-user-request-responsibility"
       ],
       "concernHintRefs": [
         "concern:missing-compensation"
@@ -92,11 +571,26 @@
       "signatureAxisRefs": [
         "sig-axis:semantic-inconsistency"
       ],
-      "minimalityReading": "minimal within the selected operation molecule and semantic contract witness rule",
-      "evidenceSummary": "constructed from the concern hint, contract atom, relation atom, and semantic molecule reading",
-      "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; not an ArchMap observation",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceSummary": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
+      "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+      "missingEvidence": [
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+      ],
+      "excludedReadings": [
+        "Lean theorem discharge",
+        "SFT forecast correctness",
+        "automatic repair safety",
+        "exactness-limited: the selected witness rules cover only policy-declared laws",
+        "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+        "global architecture lawfulness",
+        "global architecture truth",
+        "single architecture quality score"
+      ],
       "interpretationNotesForLLM": [
-        "Describe the obstruction as law-relative, not as a universal architecture defect."
+        "Explain this obstruction as selected LawPolicy-relative."
       ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
@@ -105,15 +599,6 @@
         "signature axes are law-policy-relative, not universal quality scores",
         "flatness reading is blocked by coverage gaps and exactness assumptions",
         "repair operation candidates are not automatic safe refactorings"
-      ],
-      "missingEvidence": [
-        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection"
-      ],
-      "excludedReadings": [
-        "single architecture quality score",
-        "global architecture lawfulness",
-        "zero readings are exact only for observed atoms and declared coverage requirements"
       ]
     }
   ],
@@ -124,14 +609,30 @@
       "axisRef": "axis:layer-violation",
       "valueType": "nat",
       "value": 0,
-      "zeroReading": "zero means no selected layer violation witness was constructed under declared coverage",
-      "coverageStatus": "covered-for-selected-static-atoms",
+      "zeroReading": "zero means no axis:layer-violation witness was constructed under declared coverage",
+      "coverageStatus": "coverage-gap-preserved",
       "exactnessAssumptions": [
-        "selected layer law observes only declared route/service relation atoms"
+        "the selected witness rules cover only policy-declared laws",
+        "zero readings are exact only for observed atoms and declared coverage requirements"
       ],
-      "evidenceSummary": "no BoundaryLeakCircuit witness was constructed from the fixture atoms",
+      "evidenceSummary": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
       "sourceRefs": [
         "atom:relation:route-service"
+      ],
+      "missingEvidence": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "excludedReadings": [
+        "Lean theorem discharge",
+        "SFT forecast correctness",
+        "automatic repair safety",
+        "exactness-limited: the selected witness rules cover only policy-declared laws",
+        "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+        "global architecture lawfulness",
+        "global architecture truth",
+        "sig-axis:layer-violation coverage boundary: coverage gaps remain observation gaps, not measured zero",
+        "single architecture quality score"
       ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
@@ -140,15 +641,6 @@
         "signature axes are law-policy-relative, not universal quality scores",
         "flatness reading is blocked by coverage gaps and exactness assumptions",
         "repair operation candidates are not automatic safe refactorings"
-      ],
-      "missingEvidence": [
-        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-        "coverage:layer-atoms: report observation gap and block signature-zero reflection"
-      ],
-      "excludedReadings": [
-        "global architecture lawfulness",
-        "automatic repair safety",
-        "zero readings are exact only for observed atoms and declared coverage requirements"
       ]
     },
     {
@@ -157,15 +649,30 @@
       "axisRef": "axis:semantic-inconsistency",
       "valueType": "nat",
       "value": 1,
-      "zeroReading": "nonzero means one selected semantic mismatch witness was constructed",
-      "coverageStatus": "runtime-gap-blocked",
+      "zeroReading": "nonzero means axis:semantic-inconsistency witness count is present under selected LawPolicy",
+      "coverageStatus": "coverage-gap-preserved",
       "exactnessAssumptions": [
-        "runtime trace gap blocks global zero reflection"
+        "the selected witness rules cover only policy-declared laws",
+        "zero readings are exact only for observed atoms and declared coverage requirements"
       ],
-      "evidenceSummary": "one SemanticMismatchCircuit witness is present under the selected LawPolicy",
+      "evidenceSummary": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
       "sourceRefs": [
-        "atom:contract:create-user",
-        "concern:missing-compensation"
+        "atom:contract:create-user"
+      ],
+      "missingEvidence": [
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "excludedReadings": [
+        "Lean theorem discharge",
+        "SFT forecast correctness",
+        "automatic repair safety",
+        "exactness-limited: the selected witness rules cover only policy-declared laws",
+        "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+        "global architecture lawfulness",
+        "global architecture truth",
+        "sig-axis:semantic-inconsistency coverage boundary: coverage gaps remain observation gaps, not measured zero",
+        "single architecture quality score"
       ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
@@ -174,20 +681,711 @@
         "signature axes are law-policy-relative, not universal quality scores",
         "flatness reading is blocked by coverage gaps and exactness assumptions",
         "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "analyticRepresentations": [
+    {
+      "representationId": "analytic:weighted-adjacency",
+      "representationFamily": "weightedAdjacencyMatrix",
+      "status": "measured",
+      "valueType": "matrixShape",
+      "value": "4x4; edgeCount=1",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
       ],
-      "missingEvidence": [
-        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection"
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
       ],
-      "excludedReadings": [
-        "single architecture quality score",
-        "global architecture lawfulness",
-        "zero readings are exact only for observed atoms and declared coverage requirements"
+      "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:reachable-cone-size",
+      "representationFamily": "reachableConeSize",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "5",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:walk-count",
+      "representationFamily": "walkCount",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "2",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:nilpotence-boundary",
+      "representationFamily": "nilpotenceBoundary",
+      "status": "needsReview",
+      "valueType": "boundaryStatus",
+      "value": "blockedByCoverageGap",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:selected-subgraph-spectrum",
+      "representationFamily": "selectedSubgraphSpectrum",
+      "status": "measured",
+      "valueType": "vector",
+      "value": "[0.250]",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:propagation-depth",
+      "representationFamily": "propagationDepth",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "1",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "propagation depth is computed over observed relation atoms only",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:spectral-radius-proxy",
+      "representationFamily": "spectralRadius",
+      "status": "measured",
+      "valueType": "float",
+      "value": "0.250",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:curvature-valuation",
+      "representationFamily": "curvatureValuation",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "1",
+      "graphScopeRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "curvature valuation counts constructed obstruction circuits under the selected profile",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:state-algebra-boundary",
+      "representationFamily": "stateAlgebra",
+      "status": "unmeasured",
+      "valueType": "boundaryStatus",
+      "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "state algebra is preserved as a first-class analytic boundary even when state evidence is unavailable",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:zero-reflecting-aggregate-boundary",
+      "representationFamily": "zeroReflectingAggregateBoundary",
+      "status": "needsReview",
+      "valueType": "boundaryStatus",
+      "value": "blockedByObservationGaps",
+      "graphScopeRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "reading": "zero-reflecting aggregate boundary says when zero axes may and may not be read as absence",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "couplingCohesionReadings": [
+    {
+      "readingId": "coupling:static-dependency",
+      "axis": "staticDependencyCoupling",
+      "status": "actionable",
+      "valueType": "boundedCount",
+      "value": "1",
+      "supportingRefs": [
+        "atom:relation:route-service"
+      ],
+      "stressedRefs": [],
+      "reading": "static relation atoms show direct source-level coupling",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "cohesion:semantic-contract",
+      "axis": "contractCohesion",
+      "status": "actionable",
+      "valueType": "boundedCount",
+      "value": "2",
+      "supportingRefs": [
+        "atom:contract:create-user",
+        "semantic:create-user-flow"
+      ],
+      "stressedRefs": [],
+      "reading": "contract and semantic observations give a semantic cohesion reading",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "coupling:state-effect",
+      "axis": "stateEffectCoupling",
+      "status": "needsReview",
+      "valueType": "boundedCount",
+      "value": "1",
+      "supportingRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "stressedRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "reading": "state/effect coupling remains stressed when runtime or effect evidence is unavailable",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "coupling:authority-trust",
+      "axis": "authorityTrustCoupling",
+      "status": "unmeasured",
+      "valueType": "boundedCount",
+      "value": "0",
+      "supportingRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "stressedRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "reading": "authority and trust coupling are unmeasured unless ArchMap records explicit authority/trust atoms",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "designPrincipleReadings": [
+    {
+      "principleId": "principle:informationhiding",
+      "principle": "InformationHiding",
+      "status": "stressed",
+      "aatReading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:encapsulation",
+      "principle": "Encapsulation",
+      "status": "stressed",
+      "aatReading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:separationofconcerns",
+      "principle": "SeparationOfConcerns",
+      "status": "stressed",
+      "aatReading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:substitutability",
+      "principle": "Substitutability",
+      "status": "stressed",
+      "aatReading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:openclosedextension",
+      "principle": "OpenClosedExtension",
+      "status": "stressed",
+      "aatReading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:dependencyinversion",
+      "principle": "DependencyInversion",
+      "status": "stressed",
+      "aatReading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:representationindependence",
+      "principle": "RepresentationIndependence",
+      "status": "unmeasured",
+      "aatReading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:idempotencyandreplaysafety",
+      "principle": "IdempotencyAndReplaySafety",
+      "status": "unmeasured",
+      "aatReading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:authorityandtrustboundary",
+      "principle": "AuthorityAndTrustBoundary",
+      "status": "unmeasured",
+      "aatReading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "obstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "operationRefs": [
+        "repair:obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
       ]
     }
   ],
   "flatnessReading": {
-    "readingId": "flatness:selected-law-policy",
+    "readingId": "flatness:llm-native-aat-law-policy-fixture",
     "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture",
     "status": "nonflatUnderSelectedPolicy",
     "zeroSignatureAxisRefs": [
@@ -199,9 +1397,9 @@
     "blockedByCoverageGaps": [
       "gap-runtime-user-db-trace"
     ],
-    "evidenceBoundary": "flatness is read from selected signature axes; coverage gaps block global zero claims",
+    "evidenceBoundary": "flatness is relative to selected signature axes, coverage gaps, and exactness assumptions",
     "interpretationNotesForLLM": [
-      "Report this as selected-policy non-flatness, not global architecture quality."
+      "Do not turn zero signature axes into global lawfulness claims."
     ],
     "nonConclusions": [
       "ArchSig analysis packet is not a Lean theorem proof",
@@ -225,7 +1423,7 @@
       "atom:contract:create-user",
       "semantic:create-user-flow"
     ],
-    "splitBoundary": "runtime layer is gap-preserved and must not be rounded into measured zero",
+    "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
     "nonConclusions": [
       "ArchSig analysis packet is not a Lean theorem proof",
       "ArchSig analysis packet is not global architecture truth",
@@ -237,28 +1435,45 @@
   },
   "repairOperationCandidates": [
     {
-      "repairOperationCandidateId": "repair:add-compensation-path",
-      "operationKind": "add-compensation-operation",
+      "repairOperationCandidateId": "repair:obstruction-semantic-contract-mismatch-computed",
+      "operationKind": "repair-semanticmismatchcircuit",
       "targetObstructionRefs": [
-        "obstruction:semantic-contract-mismatch:create-user"
+        "obstruction:semantic-contract-mismatch:computed"
       ],
       "preservedInvariants": [
-        "preserve route/service dependency direction",
-        "preserve create-user contract visibility"
+        "preserve zero reading for sig-axis:layer-violation"
       ],
       "preconditions": [
-        "identify authoritative compensation owner",
-        "supply runtime trace evidence before claiming global zero"
+        "human review selects a repair operation",
+        "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
       ],
       "expectedSignatureAxisEffects": [
-        "decrease sig-axis:semantic-inconsistency if compensation semantics are observed"
+        "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
       ],
       "transferRisks": [
-        "may transfer complexity into runtime retry or idempotency layer"
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
       ],
-      "evidenceBoundary": "repair candidate is an operation hypothesis over the selected packet, not an automatic patch",
+      "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
+      "missingEvidence": [
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "implementation patch and verification evidence are not supplied by ArchSig analysis",
+        "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+      ],
+      "excludedReadings": [
+        "Lean theorem discharge",
+        "SFT forecast correctness",
+        "automatic repair safety",
+        "causal forecast correctness",
+        "exactness-limited: the selected witness rules cover only policy-declared laws",
+        "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+        "global architecture lawfulness",
+        "global architecture truth",
+        "merge approval",
+        "single architecture quality score"
+      ],
       "interpretationNotesForLLM": [
-        "Explain preserved invariants before proposing implementation work."
+        "Explain preconditions and transfer risks before implementation advice."
       ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
@@ -267,27 +1482,541 @@
         "signature axes are law-policy-relative, not universal quality scores",
         "flatness reading is blocked by coverage gaps and exactness assumptions",
         "repair operation candidates are not automatic safe refactorings"
-      ],
-      "missingEvidence": [
-        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-        "implementation patch and verification evidence are not supplied by ArchSig analysis"
-      ],
-      "excludedReadings": [
-        "automatic repair safety",
-        "causal forecast correctness",
-        "global architecture lawfulness"
       ]
     }
   ],
-  "evidenceBoundary": "packet is computed from one ArchMap fixture and one selected LawPolicy fixture",
+  "operationDeltas": [
+    {
+      "operationDeltaId": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+      "operationKind": "repair-semanticmismatchcircuit",
+      "supportRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "preconditions": [
+        "human review selects a repair operation",
+        "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+      ],
+      "atomTransformations": [
+        "split or enrich atoms that currently support the target obstruction",
+        "add observed compensation / authority / effect atoms only after source review"
+      ],
+      "transitionRelation": "operation maps the current bounded Atom configuration to a candidate repaired configuration",
+      "invariantPreservationClaims": [
+        "preserve zero reading for sig-axis:layer-violation"
+      ],
+      "obstructionTransport": [
+        "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis"
+      ],
+      "signatureDelta": [
+        "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+      ],
+      "decreasedAxes": [
+        "sig-axis:semantic-inconsistency"
+      ],
+      "transferredObstructions": [
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "excludedReadings": [
+        "Lean theorem discharge",
+        "SFT forecast correctness",
+        "automatic repair safety",
+        "causal forecast correctness",
+        "exactness-limited: the selected witness rules cover only policy-declared laws",
+        "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+        "global architecture lawfulness",
+        "global architecture truth",
+        "merge approval",
+        "single architecture quality score"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "pathHomotopyDiagramReadings": [
+    {
+      "readingId": "path:semantic-operation-flow",
+      "surface": "Path",
+      "status": "observedOrRepresented",
+      "pathRefs": [
+        "semantic:create-user-flow"
+      ],
+      "homotopyRefs": [
+        "molecule-reading:molecule-user-request-responsibility"
+      ],
+      "diagramRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "fillingBoundary": "path reading is a source-grounded semantic workflow proxy, not a free-category proof",
+      "reading": "semantic observations and molecules provide path candidates for review",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "diagram:obstruction-filling",
+      "surface": "Diagram",
+      "status": "actionable",
+      "pathRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "homotopyRefs": [
+        "molecule-reading:molecule-user-request-responsibility"
+      ],
+      "diagramRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "fillingBoundary": "diagram filling is reported as obstruction / repair planning surface, not theorem discharge",
+      "reading": "constructed obstruction circuits identify diagrams whose filling requires review or repair",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "boundedJudgements": [
+    {
+      "judgementId": "judgement:architecture-state",
+      "status": "actionable",
+      "aatConcept": "ArchitectureObject",
+      "reading": "observed atoms, molecules, semantic records, gaps, and signature axes define a bounded architecture state",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "runtime trace was requested but not supplied"
+      ],
+      "coverageBoundary": "bounded to supplied ArchMap and selected interpretation profile",
+      "exactnessBoundary": "not global architecture truth and not Lean theorem proof",
+      "recommendedNextAction": "review nonzero axes and stressed principle readings first",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:obstruction-semantic-contract-mismatch-computed",
+      "status": "actionable",
+      "aatConcept": "ObstructionCircuit",
+      "reading": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
+      "evidenceRefs": [
+        "atom:contract:create-user",
+        "molecule-reading:molecule-user-request-responsibility",
+        "concern:missing-compensation"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+      ],
+      "coverageBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+      "exactnessBoundary": "witness is selected-profile-relative",
+      "recommendedNextAction": "inspect source refs and repair operation preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:sig-axis-layer-violation",
+      "status": "needsReview",
+      "aatConcept": "ArchitectureSignature",
+      "reading": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+      "evidenceRefs": [
+        "atom:relation:route-service"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "coverageBoundary": "coverage-gap-preserved",
+      "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+      "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:sig-axis-semantic-inconsistency",
+      "status": "actionable",
+      "aatConcept": "ArchitectureSignature",
+      "reading": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
+      "evidenceRefs": [
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "coverageBoundary": "coverage-gap-preserved",
+      "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+      "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-informationhiding",
+      "status": "actionable",
+      "aatConcept": "Invariant",
+      "reading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-encapsulation",
+      "status": "actionable",
+      "aatConcept": "Invariant",
+      "reading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-separationofconcerns",
+      "status": "actionable",
+      "aatConcept": "Invariant",
+      "reading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-substitutability",
+      "status": "actionable",
+      "aatConcept": "Invariant",
+      "reading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-openclosedextension",
+      "status": "actionable",
+      "aatConcept": "Invariant",
+      "reading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-dependencyinversion",
+      "status": "actionable",
+      "aatConcept": "Invariant",
+      "reading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-representationindependence",
+      "status": "blocked",
+      "aatConcept": "Invariant",
+      "reading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-idempotencyandreplaysafety",
+      "status": "blocked",
+      "aatConcept": "Invariant",
+      "reading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-authorityandtrustboundary",
+      "status": "blocked",
+      "aatConcept": "Invariant",
+      "reading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "llmInterpretationPacket": {
+    "packetId": "llm-interpretation:fixture-archmap-atom-observation",
+    "shortDiagnosis": "9 actionable judgement(s), 1 design pressure reading(s), and 1 observation gap(s) require review",
+    "aatConceptMap": [
+      "Atom -> Configuration -> ArchitectureObject",
+      "InvariantFamily -> LawUniverse -> ObstructionCircuit -> ArchitectureSignature",
+      "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation"
+    ],
+    "observedAtomsSummary": [
+      "contractSpecification",
+      "existence",
+      "relation"
+    ],
+    "obstructionSummary": [
+      "obstruction:semantic-contract-mismatch:computed"
+    ],
+    "signatureAxesSummary": [
+      "sig-axis:layer-violation=0 (coverage-gap-preserved)",
+      "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
+    ],
+    "analyticReadingsSummary": [
+      "weightedAdjacencyMatrix=4x4; edgeCount=1 (measured)",
+      "reachableConeSize=5 (measured)",
+      "walkCount=2 (measured)",
+      "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
+      "selectedSubgraphSpectrum=[0.250] (measured)",
+      "propagationDepth=1 (measured)",
+      "spectralRadius=0.250 (measured)",
+      "curvatureValuation=1 (measured)",
+      "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
+      "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
+    ],
+    "repairOperationSummary": [
+      "repair:obstruction-semantic-contract-mismatch-computed targets [\"obstruction:semantic-contract-mismatch:computed\"]"
+    ],
+    "complexityTransferNotes": [
+      "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+    ],
+    "coverageGapsAndExactnessBlockers": [
+      "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ],
+    "recommendedHumanReviewFocus": [
+      "judgement:architecture-state: review nonzero axes and stressed principle readings first",
+      "judgement:obstruction-semantic-contract-mismatch-computed: inspect source refs and repair operation preconditions",
+      "judgement:sig-axis-layer-violation: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+      "judgement:sig-axis-semantic-inconsistency: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+      "judgement:principle-informationhiding: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-encapsulation: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-separationofconcerns: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-substitutability: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-openclosedextension: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-dependencyinversion: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-representationindependence: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-idempotencyandreplaysafety: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-authorityandtrustboundary: turn stressed readings into source review questions or repair preconditions"
+    ]
+  },
+  "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected interpretation profile llm-native-aat-law-policy-fixture; concernHints are auxiliary cues only",
   "interpretationNotesForLLM": [
     "Lead with selected LawPolicy scope and evidence gaps.",
-    "Explain each nonzero signature axis with source refs and non-conclusions."
+    "Explain nonzero signature axes as law-relative ArchSig outputs.",
+    "Do not describe concernHints as obstruction circuits."
   ],
   "excludedReadings": [
     "single architecture quality score",
     "global architecture lawfulness",
-    "automatic repair safety"
+    "automatic repair safety",
+    "concern hint promoted without LawPolicy witness rule"
   ],
   "nonConclusions": [
     "ArchSig analysis packet is not a Lean theorem proof",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -8,12 +8,327 @@
     "schemaVersion": "archmap-observation-map-v0",
     "path": "tools/archsig/tests/fixtures/minimal/archmap.json"
   },
+  "interpretationProfileRef": {
+    "artifactId": "layer-only-law-policy-fixture",
+    "artifactKind": "interpretation-profile",
+    "schemaVersion": "law-policy-v0",
+    "path": "tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json"
+  },
   "selectedLawPolicyRef": {
     "artifactId": "layer-only-law-policy-fixture",
     "artifactKind": "law-policy",
     "schemaVersion": "law-policy-v0",
     "path": "tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json"
   },
+  "architectureState": {
+    "stateId": "architecture-state:archmap-fixture-repo",
+    "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
+    "atomFamilyRefs": [
+      "contractSpecification",
+      "existence",
+      "relation"
+    ],
+    "moleculeRefs": [
+      "molecule:user-request-responsibility"
+    ],
+    "workflowRefs": [
+      "semantic:create-user-flow"
+    ],
+    "boundaryRefs": [
+      "gap-runtime-user-db-trace"
+    ],
+    "invariantRefs": [
+      "invariant:law-layer-respecting"
+    ],
+    "signatureAxisRefs": [
+      "sig-axis:layer-violation"
+    ],
+    "coverageBoundary": "state is an ArchMap-relative architecture state, not a complete source reconstruction",
+    "recommendedNextAction": "review nonzero axes, stressed principles, and preserved observation gaps before planning repair",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "designPressure": [
+    {
+      "pressureId": "design-pressure:selected-atom-configuration",
+      "status": "needsReview",
+      "reading": "0 selected obstruction circuit(s) and 1 coverage gap(s) define the current pressure surface",
+      "atomConfigurationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "obstructionRefs": [],
+      "signatureAxisRefs": [],
+      "coverageBoundary": "pressure is relative to the observed finite Atom configuration and selected profile",
+      "recommendedNextAction": "use bounded judgements to decide whether to inspect source refs, add evidence, or plan repair",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "changeImpact": {
+    "impactId": "change-impact:selected-repair-operations",
+    "operationScope": "repair, extension, migration, and refactor operations over observed ArchMap atoms",
+    "signatureDeltaSummary": [
+      "sig-axis:layer-violation remains 0"
+    ],
+    "affectedBoundaries": [
+      "sig-axis:layer-violation: coverage-gap-preserved"
+    ],
+    "complexityTransferNotes": [],
+    "coverageBoundary": "impact is a pre-change operation reading; it is not evidence that a future patch is safe",
+    "recommendedNextAction": "compare operation deltas before and after the patch and keep transferred obstruction notes",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "aatConceptSurfaces": [
+    {
+      "concept": "Atom",
+      "status": "observedOrRepresented",
+      "reading": "Atom is represented with 4 bounded packet record(s)",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Configuration",
+      "status": "observedOrRepresented",
+      "reading": "Configuration is represented with 5 bounded packet record(s)",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "ArchitectureObject",
+      "status": "observedOrRepresented",
+      "reading": "ArchitectureObject is represented with 3 bounded packet record(s)",
+      "evidenceRefs": [
+        "projection:aat:route-users",
+        "projection:aat:route-service",
+        "projection:sft:create-user"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Invariant",
+      "status": "observedOrRepresented",
+      "reading": "Invariant is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "law:layer-respecting"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "LawUniverse",
+      "status": "observedOrRepresented",
+      "reading": "LawUniverse is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "law:layer-respecting"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "ObstructionCircuit",
+      "status": "unmeasured",
+      "reading": "ObstructionCircuit is represented with 0 bounded packet record(s)",
+      "evidenceRefs": [],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "ArchitectureSignature",
+      "status": "observedOrRepresented",
+      "reading": "ArchitectureSignature is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Operation",
+      "status": "unmeasured",
+      "reading": "Operation is represented with 0 bounded packet record(s)",
+      "evidenceRefs": [],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Path",
+      "status": "observedOrRepresented",
+      "reading": "Path is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Homotopy",
+      "status": "observedOrRepresented",
+      "reading": "Homotopy is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [
+        "semantic:create-user-flow"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "Diagram",
+      "status": "observedOrRepresented",
+      "reading": "Diagram is represented with 1 bounded packet record(s)",
+      "evidenceRefs": [],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "concept": "AnalyticRepresentation",
+      "status": "observedOrRepresented",
+      "reading": "AnalyticRepresentation is represented with 10 bounded packet record(s)",
+      "evidenceRefs": [
+        "analytic:weighted-adjacency",
+        "analytic:reachable-cone-size",
+        "analytic:walk-count",
+        "analytic:nilpotence-boundary",
+        "analytic:selected-subgraph-spectrum",
+        "analytic:propagation-depth",
+        "analytic:spectral-radius-proxy",
+        "analytic:curvature-valuation",
+        "analytic:state-algebra-boundary",
+        "analytic:zero-reflecting-aggregate-boundary"
+      ],
+      "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+      "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
   "atomConfigurationSummary": {
     "atomObservationCount": 4,
     "moleculeObservationCount": 1,
@@ -34,6 +349,122 @@
       "atom:relation:route-service",
       "gap-runtime-user-db-trace"
     ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ]
+  },
+  "architectureObjectProjections": [
+    {
+      "projectionId": "projection:aat:route-users",
+      "projectionFamily": "object",
+      "atomRefs": [
+        "atom:component:route-users"
+      ],
+      "moleculeRefs": [],
+      "semanticRefs": [
+        "atom:component:route-users"
+      ],
+      "reading": "route.users is an observed component object",
+      "projectionBoundary": "derived from observed source atom; not primary ArchMap law claim",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "projectionId": "projection:aat:route-service",
+      "projectionFamily": "relation",
+      "atomRefs": [
+        "atom:relation:route-service"
+      ],
+      "moleculeRefs": [],
+      "semanticRefs": [
+        "atom:relation:route-service"
+      ],
+      "reading": "route.users to service.user is an observed relation",
+      "projectionBoundary": "derived from observed source atom; runtime frequency unmeasured",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "projectionId": "projection:sft:create-user",
+      "projectionFamily": "signatureAxis",
+      "atomRefs": [],
+      "moleculeRefs": [],
+      "semanticRefs": [
+        "semantic:create-user-flow"
+      ],
+      "reading": "semantic observation can be handed off as bounded SFT evidence",
+      "projectionBoundary": "SFT consequence analysis is not owned by ArchMap",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "invariantFamilyReadings": [
+    {
+      "invariantId": "invariant:law-layer-respecting",
+      "invariantFamily": "dependency-direction",
+      "status": "preservedForConstructedWitnesses",
+      "lawRefs": [
+        "law:layer-respecting"
+      ],
+      "atomRefs": [
+        "atom:relation:route-service"
+      ],
+      "obstructionRefs": [],
+      "reading": "Dependencies must respect the selected layer order. is read as an invariant family selected by the interpretation profile",
+      "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "lawUniverseReading": {
+    "lawUniverseId": "law-universe:layer-only-law-policy-fixture",
+    "profileRef": "layer-only-law-policy-fixture",
+    "selectedLawRefs": [
+      "law:layer-respecting"
+    ],
+    "witnessRuleRefs": [
+      "witness:layer-violation"
+    ],
+    "signatureAxisRefs": [
+      "sig-axis:layer-violation"
+    ],
+    "exactnessAssumptions": [
+      "the selected witness rules cover only policy-declared laws",
+      "zero readings are exact only for observed atoms and declared coverage requirements"
+    ],
+    "coverageRequirements": [
+      "coverage:layer-atoms"
+    ],
+    "reading": "LawPolicy is interpreted as an analysis profile selecting a bounded LawUniverse, witnesses, axes, coverage, and exactness assumptions",
     "nonConclusions": [
       "ArchSig analysis packet is not a Lean theorem proof",
       "ArchSig analysis packet is not global architecture truth",
@@ -90,7 +521,9 @@
         "zero readings are exact only for observed atoms and declared coverage requirements"
       ],
       "evidenceSummary": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
-      "sourceRefs": [],
+      "sourceRefs": [
+        "atom:relation:route-service"
+      ],
       "missingEvidence": [
         "coverage:layer-atoms: report observation gap and block signature-zero reflection",
         "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
@@ -106,6 +539,649 @@
         "sig-axis:layer-violation coverage boundary: coverage gaps remain observation gaps, not measured zero",
         "single architecture quality score"
       ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "analyticRepresentations": [
+    {
+      "representationId": "analytic:weighted-adjacency",
+      "representationFamily": "weightedAdjacencyMatrix",
+      "status": "measured",
+      "valueType": "matrixShape",
+      "value": "4x4; edgeCount=1",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:reachable-cone-size",
+      "representationFamily": "reachableConeSize",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "5",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:walk-count",
+      "representationFamily": "walkCount",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "2",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:nilpotence-boundary",
+      "representationFamily": "nilpotenceBoundary",
+      "status": "needsReview",
+      "valueType": "boundaryStatus",
+      "value": "blockedByCoverageGap",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:selected-subgraph-spectrum",
+      "representationFamily": "selectedSubgraphSpectrum",
+      "status": "measured",
+      "valueType": "vector",
+      "value": "[0.250]",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:propagation-depth",
+      "representationFamily": "propagationDepth",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "1",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "propagation depth is computed over observed relation atoms only",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:spectral-radius-proxy",
+      "representationFamily": "spectralRadius",
+      "status": "measured",
+      "valueType": "float",
+      "value": "0.250",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:curvature-valuation",
+      "representationFamily": "curvatureValuation",
+      "status": "measured",
+      "valueType": "nat",
+      "value": "0",
+      "graphScopeRefs": [],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "curvature valuation counts constructed obstruction circuits under the selected profile",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:state-algebra-boundary",
+      "representationFamily": "stateAlgebra",
+      "status": "unmeasured",
+      "valueType": "boundaryStatus",
+      "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+      "graphScopeRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "state algebra is preserved as a first-class analytic boundary even when state evidence is unavailable",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "representationId": "analytic:zero-reflecting-aggregate-boundary",
+      "representationFamily": "zeroReflectingAggregateBoundary",
+      "status": "needsReview",
+      "valueType": "boundaryStatus",
+      "value": "blockedByObservationGaps",
+      "graphScopeRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "axisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "reading": "zero-reflecting aggregate boundary says when zero axes may and may not be read as absence",
+      "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "couplingCohesionReadings": [
+    {
+      "readingId": "coupling:static-dependency",
+      "axis": "staticDependencyCoupling",
+      "status": "actionable",
+      "valueType": "boundedCount",
+      "value": "1",
+      "supportingRefs": [
+        "atom:relation:route-service"
+      ],
+      "stressedRefs": [],
+      "reading": "static relation atoms show direct source-level coupling",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "cohesion:semantic-contract",
+      "axis": "contractCohesion",
+      "status": "actionable",
+      "valueType": "boundedCount",
+      "value": "2",
+      "supportingRefs": [
+        "atom:contract:create-user",
+        "semantic:create-user-flow"
+      ],
+      "stressedRefs": [],
+      "reading": "contract and semantic observations give a semantic cohesion reading",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "coupling:state-effect",
+      "axis": "stateEffectCoupling",
+      "status": "needsReview",
+      "valueType": "boundedCount",
+      "value": "1",
+      "supportingRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "stressedRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "reading": "state/effect coupling remains stressed when runtime or effect evidence is unavailable",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "coupling:authority-trust",
+      "axis": "authorityTrustCoupling",
+      "status": "unmeasured",
+      "valueType": "boundedCount",
+      "value": "0",
+      "supportingRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "stressedRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "reading": "authority and trust coupling are unmeasured unless ArchMap records explicit authority/trust atoms",
+      "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+      "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "designPrincipleReadings": [
+    {
+      "principleId": "principle:informationhiding",
+      "principle": "InformationHiding",
+      "status": "preserved",
+      "aatReading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:encapsulation",
+      "principle": "Encapsulation",
+      "status": "preserved",
+      "aatReading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:separationofconcerns",
+      "principle": "SeparationOfConcerns",
+      "status": "preserved",
+      "aatReading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:substitutability",
+      "principle": "Substitutability",
+      "status": "preserved",
+      "aatReading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:openclosedextension",
+      "principle": "OpenClosedExtension",
+      "status": "preserved",
+      "aatReading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:dependencyinversion",
+      "principle": "DependencyInversion",
+      "status": "preserved",
+      "aatReading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:representationindependence",
+      "principle": "RepresentationIndependence",
+      "status": "unmeasured",
+      "aatReading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:idempotencyandreplaysafety",
+      "principle": "IdempotencyAndReplaySafety",
+      "status": "unmeasured",
+      "aatReading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "principleId": "principle:authorityandtrustboundary",
+      "principle": "AuthorityAndTrustBoundary",
+      "status": "unmeasured",
+      "aatReading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+      "invariantRefs": [
+        "invariant:law-layer-respecting"
+      ],
+      "obstructionRefs": [],
+      "operationRefs": [],
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBlockers": [
+        "gap-runtime-user-db-trace"
+      ],
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -164,7 +1240,454 @@
     ]
   },
   "repairOperationCandidates": [],
-  "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected LawPolicy layer-only-law-policy-fixture; concernHints are auxiliary cues only",
+  "operationDeltas": [
+    {
+      "operationDeltaId": "operation-delta:observe-before-repair",
+      "operationKind": "evidence-enrichment",
+      "supportRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "preconditions": [
+        "human review selects a repair operation",
+        "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+      ],
+      "atomTransformations": [
+        "add or refine ArchMap atom observations before claiming repair"
+      ],
+      "transitionRelation": "ArchMap enrichment changes analysis coverage without changing source architecture",
+      "invariantPreservationClaims": [
+        "preserve all existing source-grounded atom observation refs"
+      ],
+      "obstructionTransport": [
+        "no constructed obstruction is transported because no repair candidate exists"
+      ],
+      "signatureDelta": [
+        "sig-axis:layer-violation remains 0"
+      ],
+      "decreasedAxes": [],
+      "transferredObstructions": [
+        "gap-runtime-user-db-trace"
+      ],
+      "excludedReadings": [
+        "evidence enrichment is not a source-code repair",
+        "no automatic patch safety"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "pathHomotopyDiagramReadings": [
+    {
+      "readingId": "path:semantic-operation-flow",
+      "surface": "Path",
+      "status": "observedOrRepresented",
+      "pathRefs": [
+        "semantic:create-user-flow"
+      ],
+      "homotopyRefs": [
+        "molecule-reading:molecule-user-request-responsibility"
+      ],
+      "diagramRefs": [],
+      "fillingBoundary": "path reading is a source-grounded semantic workflow proxy, not a free-category proof",
+      "reading": "semantic observations and molecules provide path candidates for review",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "readingId": "diagram:obstruction-filling",
+      "surface": "Diagram",
+      "status": "needsReview",
+      "pathRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "homotopyRefs": [
+        "molecule-reading:molecule-user-request-responsibility"
+      ],
+      "diagramRefs": [],
+      "fillingBoundary": "diagram filling is reported as obstruction / repair planning surface, not theorem discharge",
+      "reading": "constructed obstruction circuits identify diagrams whose filling requires review or repair",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "boundedJudgements": [
+    {
+      "judgementId": "judgement:architecture-state",
+      "status": "actionable",
+      "aatConcept": "ArchitectureObject",
+      "reading": "observed atoms, molecules, semantic records, gaps, and signature axes define a bounded architecture state",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "runtime trace was requested but not supplied"
+      ],
+      "coverageBoundary": "bounded to supplied ArchMap and selected interpretation profile",
+      "exactnessBoundary": "not global architecture truth and not Lean theorem proof",
+      "recommendedNextAction": "review nonzero axes and stressed principle readings first",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:sig-axis-layer-violation",
+      "status": "needsReview",
+      "aatConcept": "ArchitectureSignature",
+      "reading": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+      "evidenceRefs": [
+        "atom:relation:route-service"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "coverageBoundary": "coverage-gap-preserved",
+      "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+      "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-informationhiding",
+      "status": "needsReview",
+      "aatConcept": "Invariant",
+      "reading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-encapsulation",
+      "status": "needsReview",
+      "aatConcept": "Invariant",
+      "reading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-separationofconcerns",
+      "status": "needsReview",
+      "aatConcept": "Invariant",
+      "reading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-substitutability",
+      "status": "needsReview",
+      "aatConcept": "Invariant",
+      "reading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-openclosedextension",
+      "status": "needsReview",
+      "aatConcept": "Invariant",
+      "reading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-dependencyinversion",
+      "status": "needsReview",
+      "aatConcept": "Invariant",
+      "reading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "medium",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-representationindependence",
+      "status": "blocked",
+      "aatConcept": "Invariant",
+      "reading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-idempotencyandreplaysafety",
+      "status": "blocked",
+      "aatConcept": "Invariant",
+      "reading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    },
+    {
+      "judgementId": "judgement:principle-authorityandtrustboundary",
+      "status": "blocked",
+      "aatConcept": "Invariant",
+      "reading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+      "evidenceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "confidence": "low",
+      "uncertainty": [
+        "gap-runtime-user-db-trace"
+      ],
+      "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+      "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings"
+      ]
+    }
+  ],
+  "llmInterpretationPacket": {
+    "packetId": "llm-interpretation:fixture-archmap-atom-observation",
+    "shortDiagnosis": "1 actionable judgement(s), 1 design pressure reading(s), and 1 observation gap(s) require review",
+    "aatConceptMap": [
+      "Atom -> Configuration -> ArchitectureObject",
+      "InvariantFamily -> LawUniverse -> ObstructionCircuit -> ArchitectureSignature",
+      "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation"
+    ],
+    "observedAtomsSummary": [
+      "contractSpecification",
+      "existence",
+      "relation"
+    ],
+    "obstructionSummary": [],
+    "signatureAxesSummary": [
+      "sig-axis:layer-violation=0 (coverage-gap-preserved)"
+    ],
+    "analyticReadingsSummary": [
+      "weightedAdjacencyMatrix=4x4; edgeCount=1 (measured)",
+      "reachableConeSize=5 (measured)",
+      "walkCount=2 (measured)",
+      "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
+      "selectedSubgraphSpectrum=[0.250] (measured)",
+      "propagationDepth=1 (measured)",
+      "spectralRadius=0.250 (measured)",
+      "curvatureValuation=0 (measured)",
+      "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
+      "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
+    ],
+    "repairOperationSummary": [],
+    "complexityTransferNotes": [],
+    "coverageGapsAndExactnessBlockers": [
+      "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings"
+    ],
+    "recommendedHumanReviewFocus": [
+      "judgement:architecture-state: review nonzero axes and stressed principle readings first",
+      "judgement:sig-axis-layer-violation: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+      "judgement:principle-informationhiding: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-encapsulation: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-separationofconcerns: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-substitutability: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-openclosedextension: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-dependencyinversion: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-representationindependence: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-idempotencyandreplaysafety: turn stressed readings into source review questions or repair preconditions",
+      "judgement:principle-authorityandtrustboundary: turn stressed readings into source review questions or repair preconditions"
+    ]
+  },
+  "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected interpretation profile layer-only-law-policy-fixture; concernHints are auxiliary cues only",
   "interpretationNotesForLLM": [
     "Lead with selected LawPolicy scope and evidence gaps.",
     "Explain nonzero signature axes as law-relative ArchSig outputs.",

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -61,18 +61,19 @@
     },
     {
       "artifactId": "law-policy",
-      "artifactName": "Selected LawPolicy artifact",
+      "artifactName": "Selected interpretation profile artifact",
       "schemaVersionName": "law-policy-v0",
       "artifactRole": "primary",
-      "ownerPhase": "LLM Atom ArchMap",
+      "ownerPhase": "ArchSig North Star AAT analysis",
       "status": "implemented",
       "primaryDocs": [
+        "docs/tool/archsig_aat_analysis_engine_prd.md",
         "docs/tool/llm_native_archmap_archsig_prd.md",
         "docs/tool/README.md"
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "LawPolicy owns selected laws, witness rules, molecule patterns, obstruction definitions, signature axis definitions, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations.",
+        "fieldMappingPolicy": "The law-policy-v0 JSON contract is used as an interpretation profile: it selects laws, witness rules, molecule patterns, obstruction definitions, signature axes, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations. It is not the center of ArchSig output.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",
@@ -82,7 +83,7 @@
           "Coverage and exactness are artifact-local and do not imply semantic completeness."
         ],
         "nonConclusions": [
-          "LawPolicy is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
+          "Interpretation profile is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
           "Adding a law family must preserve missing coverage as distinct from measured zero."
         ]
       }
@@ -119,15 +120,16 @@
       "artifactName": "ArchSig AAT analysis packet",
       "schemaVersionName": "archsig-analysis-packet-v0",
       "artifactRole": "primary",
-      "ownerPhase": "LLM Atom ArchMap",
+      "ownerPhase": "ArchSig North Star AAT analysis",
       "status": "implemented",
       "primaryDocs": [
+        "docs/tool/archsig_aat_analysis_engine_prd.md",
         "docs/tool/archsig_analysis_packet.md",
         "docs/tool/llm_native_archmap_archsig_prd.md"
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "ArchSig analysis packet owns law-relative molecule readings, obstruction circuits, signature axes, flatness reading, static/runtime/semantic split, repair operation candidates, evidence boundary, LLM interpretation notes, excluded readings, and non-conclusions.",
+        "fieldMappingPolicy": "ArchSig analysis packet owns AAT concept surfaces, architecture state, design pressure, change impact, architecture object projections, invariant family readings, LawUniverse reading, molecule readings, obstruction circuits, signature axes, analytic representations, coupling/cohesion readings, design principle readings, operation deltas, path/homotopy/diagram readings, bounded judgements, LLM interpretation packet, evidence boundary, excluded readings, and non-conclusions.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",


### PR DESCRIPTION
## 概要

ArchSig を static lint / rule violation checker ではなく、AAT の North Star 解析 packet を生成する engine として拡張する。

- `archsig-analysis-packet-v0` に AAT concept surface、architecture state、design pressure、change impact、architecture object projection、invariant family、LawUniverse reading、analytic representation、semantic coupling/cohesion、design principle reading、operation delta、path / homotopy / diagram reading、bounded judgement、LLM interpretation packet を追加
- `law-policy-v0` を出力の主役ではなく selected interpretation profile として扱い、`interpretationProfileRef` と CLI alias を追加
- spectrum 周辺の weighted adjacency、walk count、reachable cone、nilpotence boundary、selected subgraph spectrum、propagation depth、spectral radius、curvature、state algebra、zero-reflecting boundary を packet surface と validation guard に追加
- golden fixture、schema catalog、CLI regression、docs / README / command guide を North Star 要求へ同期

Closes #1403
Closes #1404
Closes #1405
Closes #1406
Closes #1407
Closes #1408
Closes #1409
Closes #1410
Closes #1411
Closes #1412
Closes #1413
Closes #1414
Closes #1415
Closes #1416
Closes #1417

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/README.md`
- `docs/tool/archsig_analysis_packet.md`
- `docs/tool/law_policy.md`
- `docs/tool/llm_native_e2e_workflow.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [x] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `admit` / `sorry` / `unsafe` scan

補足:

- `lake build` は既存 Lean linter warning を 2 件表示したが build は成功。
- Lean ソースに `admit` / `sorry` / `unsafe` は検出されなかった。
- `axiom` は現在の Atom foundation 本文・コメントに既存語彙として出現するため、今回の変更では新規導入なし。
- Rust の `expect` 検索は test / `#[cfg(test)]` fixture parse のみ。production ArchSig surface には新規 panic path を追加していない。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling validation / future proof obligation.
