### PR TITLE
handoff e2eチェック名を実態に合わせる

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo test --manifest-path tools/fieldsig/Cargo.toml
 
   llm-native-e2e:
-    name: llm-native ArchMap/ArchSig e2e
+    name: ArchSig/FieldSig handoff e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -108,3 +108,14 @@ jobs:
         with:
           name: llm-native-e2e-${{ github.run_id }}
           path: .lake/llm-native-e2e
+
+  llm-native-e2e-required-status:
+    name: llm-native ArchMap/ArchSig e2e
+    runs-on: ubuntu-latest
+    needs: llm-native-e2e
+    if: always()
+    steps:
+      - name: Require ArchSig/FieldSig handoff e2e
+        shell: bash
+        run: |
+          test "${{ needs.llm-native-e2e.result }}" = "success"


### PR DESCRIPTION

## 概要

CI 一覧で意図が伝わるように、`llm-native-e2e` job の表示名を `ArchSig/FieldSig handoff e2e` に変更しました。job id と実行内容は変更していません。

対象 Issue: なし（CI 表示名の整理）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（workflow 表示名のみの変更のため未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（Rust 実装変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（Rust 実装変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] `.github/workflows/lean.yml` の YAML parse

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
