### PR TITLE
旧handoff e2e互換ジョブを削除

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -108,14 +108,3 @@ jobs:
         with:
           name: llm-native-e2e-${{ github.run_id }}
           path: .lake/llm-native-e2e
-
-  llm-native-e2e-required-status:
-    name: llm-native ArchMap/ArchSig e2e
-    runs-on: ubuntu-latest
-    needs: llm-native-e2e
-    if: always()
-    steps:
-      - name: Require ArchSig/FieldSig handoff e2e
-        shell: bash
-        run: |
-          test "${{ needs.llm-native-e2e.result }}" = "success"


### PR DESCRIPTION

## 概要

ruleset の required status check が `ArchSig/FieldSig handoff e2e` に切り替わったため、旧名 `llm-native ArchMap/ArchSig e2e` を出す互換 job を削除しました。実体の handoff e2e job と検証内容は維持しています。

対象 Issue: なし（CI 設定整理）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（workflow 互換 job 削除のみのためローカル未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（Rust 実装変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（Rust 実装変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] `.github/workflows/lean.yml` の YAML parse
- [x] ruleset required status check が `ArchSig/FieldSig handoff e2e` を要求していることを確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
