### PR TITLE
ArchSigのSKILL検証とサマリを本体に寄せる

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -16,7 +16,7 @@ forecast, governance, calibration, and operational feedback under
 | --- | --- | --- |
 | ArchMap validation | `archmap`, `archmap-generate` | ArchMap records source-grounded Atom observations and concern hints. It does not select laws or output obstruction circuits. |
 | Interpretation profile | `law-policy`, `interpretation-profile` | The profile selects the LawUniverse, witness rules, signature axes, coverage requirements, exactness assumptions, and non-conclusions. It is not AAT itself. |
-| ArchSig analysis | `archsig-analysis`, `aat-analysis`, `llm-native-workflow`, `north-star-workflow` | ArchSig combines ArchMap and the profile into AAT concept surfaces, architecture state, design pressure, change impact, analytic axes, semantic coupling/cohesion, workflow risk readings, spectral analysis readings, spectral mode readings, spectral drilldown readings, transfer bridge readings with edge source refs / review focus / cut recommendations, representation strength, local curvature diagrams, three-layer flatness, observation projection, state transition algebra, operation / invariant Galois readings, split readiness, a structural reading review surface, a current-state/evolution boundary, design principle readings, bounded judgements, repair operation deltas, and an LLM interpretation packet. |
+| ArchSig analysis | `archsig-analysis`, `aat-analysis`, `llm-native-workflow`, `north-star-workflow`, `analysis-summary`, `summary` | ArchSig combines ArchMap and the profile into AAT concept surfaces, architecture state, design pressure, change impact, analytic axes, semantic coupling/cohesion, workflow risk readings, spectral analysis readings, spectral mode readings, spectral drilldown readings, transfer bridge readings with edge source refs / review focus / cut recommendations, representation strength, local curvature diagrams, three-layer flatness, observation projection, state transition algebra, operation / invariant Galois readings, split readiness, a structural reading review surface, a current-state/evolution boundary, design principle readings, bounded judgements, repair operation deltas, and an LLM interpretation packet. `analysis-summary` emits a compact review summary from an existing packet. |
 | Schema | `schema-catalog` | The catalog lists only the current LLM Atom ArchMap artifacts. |
 
 Large ArchMaps may be authored in shards for review and parallel generation,
@@ -51,6 +51,28 @@ merge approval, or automatic repair instruction.
 
 Calling `archsig` without a subcommand intentionally fails. The old implicit
 scan-first path is no longer an ArchSig workflow.
+
+## Skills
+
+The `tools/archsig/skills` directory is part of the ArchSig release surface. A
+released ArchSig bundle is expected to work with the binary plus the skills
+directory; the skills do not require the AAT mathematical docs, test fixtures,
+Cargo project, or Git history at runtime.
+
+| Skill | Purpose |
+| --- | --- |
+| `archmap-creater` | Create bounded `archmap-observation-map-v0` artifacts from repository evidence. It keeps ArchMap as source-grounded Atom observations, molecule observations, semantic readings, concern hints, and gaps, not law-relative analysis. |
+| `law-policy-creater` | Create project-specific `law-policy-v0` interpretation profiles from repository coding conventions, architecture rules, and user decisions. If docs do not define the law universe, ask the user before selecting laws. |
+| `archsig-reader` | Run an ArchMap with a selected LawPolicy, read the `archsig-analysis-packet-v0`, compare high-priority readings with source evidence, and propose bounded improvements. It does not silently use a generic LawPolicy as project analysis. |
+
+Typical use:
+
+1. Use `archmap-creater` to produce or refine the ArchMap.
+2. Use `law-policy-creater` to produce the selected LawPolicy for the target
+   repository or subsystem.
+3. Run `llm-native-workflow`.
+4. Use `archsig-reader` to interpret the packet and compare it with source
+   evidence before proposing improvements.
 
 ## Release Assets
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -45,6 +45,20 @@ The command emits only:
 reading. It is not a natural-language judgement, Lean proof, architecture
 lawfulness certificate, or automatic repair instruction.
 
+To emit a compact review summary from an existing packet, run:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary \
+  --packet .archsig/llm-native/archsig-analysis-packet.json \
+  --archmap-validation .archsig/llm-native/archmap-validation.json \
+  --law-policy-validation .archsig/llm-native/law-policy-validation.json \
+  --analysis-validation .archsig/llm-native/archsig-analysis-validation.json \
+  --out .archsig/llm-native/archsig-analysis-summary.json
+```
+
+`summary` is a visible alias. The summary is a reading aid for human / LLM
+review. It does not replace the full packet or validation reports.
+
 ## Sharded ArchMap Authoring
 
 Large ArchMaps may be drafted in a sharded authoring layout documented in
@@ -95,6 +109,10 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- aat-analysis \
   --out .archsig/llm-native/archsig-analysis-packet.json \
   --validation-out .archsig/llm-native/archsig-analysis-validation.json \
   --llm-interpretation-out .archsig/llm-native/llm-interpretation-packet.json
+
+cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary \
+  --packet .archsig/llm-native/archsig-analysis-packet.json \
+  --out .archsig/llm-native/archsig-analysis-summary.json
 ```
 
 `law-policy` / `interpretation-profile` validate the selected analysis profile.

--- a/tools/archsig/skills/archsig-reader/SKILL.md
+++ b/tools/archsig/skills/archsig-reader/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: archsig-reader
+description: Run ArchMap artifacts through ArchSig, read archsig-analysis-packet-v0 outputs, compare the findings against source code evidence, and propose bounded architecture improvements. Use when Codex is asked to analyze an ArchMap with ArchSig, interpret ArchSig output, review workflow risk / spectral / transfer bridge / split readiness readings, validate ArchSig artifacts, or turn ArchSig analysis into concrete source-review and improvement proposals.
+---
+
+# ArchSig Reader
+
+## Purpose
+
+Turn a supplied `archmap-observation-map-v0` into an ArchSig analysis, read the resulting structured packet, verify the packet against source evidence, and propose practical improvements without overclaiming.
+
+ArchSig reads current AAT structural state from `ArchMap + LawPolicy`. It does not prove source completeness, architecture lawfulness, semantic correctness, zero curvature, forecast correctness, repair safety, or Lean theorem discharge.
+
+This skill must work with only:
+
+- a built `archsig` executable
+- this skill directory, including `references/`
+- the user's ArchMap, source repository, and any supplied LawPolicy
+
+Do not require the ArchSig source repository, `docs/tool`, AAT mathematical documents, test fixtures, Cargo project files, or Git history. Those may help during development, but they are not runtime dependencies for the released skill bundle.
+
+## Inputs
+
+Collect:
+
+- ArchMap path, usually `.archsig/<scope>/archmap.json` or `.archsig/archmap/archmap.json`
+- LawPolicy path, if supplied
+- output directory for fresh artifacts
+- repository root or source paths needed for evidence comparison
+- user goal: quick diagnosis, detailed review, improvement proposals, public note, or PR planning
+
+If the user does not provide a LawPolicy, look for one in this order:
+
+1. the ArchMap directory, such as `law_policy.json` or `interpretation_profile.json`
+2. existing sibling output packet `selectedLawPolicyRef.path`
+
+State which LawPolicy was used. If no project-specific LawPolicy is found, stop before user-facing analysis and ask for a LawPolicy or explicit approval to run the bundled baseline policy as a smoke check.
+
+The bundled `references/default_law_policy.json` is not an analysis default. It exists only so a released skill bundle can verify that the ArchSig binary and packet-reading workflow operate without the ArchSig source repository. Use it only when the user explicitly asks for a generic baseline / smoke test, or explicitly approves that the output will be LawPolicy-generic and not a project-specific architectural diagnosis.
+
+## Run Workflow
+
+Use a fresh output directory. Do not overwrite user-authored ArchMap files.
+
+Resolve the skill directory from the loaded skill path when possible. In examples below, set `SKILL_DIR` to this `archsig-reader` directory.
+
+Resolve the ArchSig binary before running:
+
+1. use `ARCHSIG_BIN` when the environment variable is set
+2. use `archsig` from `PATH`
+3. look for released binaries near the skill bundle, such as `bin/archsig`, `../bin/archsig`, or `../../bin/archsig`
+4. if working inside a source checkout, optionally use an already-built checkout binary such as `tools/archsig/target/release/archsig` or `tools/archsig/target/debug/archsig`
+
+If none exists, stop and ask the user for the binary path. Do not require Cargo or the ArchSig source tree in a released skill-only environment.
+
+Before passing a LawPolicy-like file to ArchSig, verify it is JSON with `schemaVersion: "law-policy-v0"`. The file may be named `interpretation_profile.json`, but the schema must still be `law-policy-v0`. If the schema is absent or different, do not pass it as LawPolicy; continue the search order or ask the user.
+
+```bash
+SKILL_DIR=<path-to-archsig-reader-skill>
+LAW_POLICY=<project-law-policy.json>
+ARCHSIG_BIN=${ARCHSIG_BIN:-archsig}
+
+"$ARCHSIG_BIN" llm-native-workflow \
+  --archmap <archmap.json> \
+  --law-policy "$LAW_POLICY" \
+  --out-dir <out-dir>
+```
+
+Expected files:
+
+- `archmap-validation.json`
+- `law-policy-validation.json`
+- `archsig-analysis-packet.json`
+- `archsig-analysis-validation.json`
+- `llm-interpretation-packet.json`
+
+Then summarize the packet with ArchSig:
+
+```bash
+"$ARCHSIG_BIN" analysis-summary \
+  --packet <out-dir>/archsig-analysis-packet.json \
+  --archmap-validation <out-dir>/archmap-validation.json \
+  --law-policy-validation <out-dir>/law-policy-validation.json \
+  --analysis-validation <out-dir>/archsig-analysis-validation.json \
+  --out <out-dir>/archsig-analysis-summary.json
+```
+
+Read `references/output-reading-guide.md` from this skill directory for the field priority.
+
+## Standalone Resource Checklist
+
+Before assuming a path exists, check whether it is part of the release bundle:
+
+- `analysis-summary` is provided by the `archsig` binary.
+- `references/output-reading-guide.md` is bundled and may be read for packet interpretation.
+- `references/default_law_policy.json` is bundled only for explicit generic baseline / smoke-test runs. Do not silently use it for project analysis.
+- Repository docs, fixtures, and source-code tests are not bundled; never make them required for this skill to operate.
+
+## Reading Workflow
+
+Read in this order:
+
+1. Validation summaries
+   - Stop and report blockers if any failed check exists.
+   - Keep warnings visible; warnings are often coverage or projection boundaries, not tool failures.
+
+2. Analysis boundary
+   - Record `archMapRef`, `selectedLawPolicyRef`, `currentStateEvolutionBoundary`, `nonConclusions`, and `excludedReadings`.
+   - Avoid saying "the architecture is bad/good"; say "under this selected LawPolicy and bounded ArchMap, ArchSig reads..."
+   - If the bundled baseline LawPolicy was explicitly used, label the output as a generic baseline run and avoid project-specific obstruction conclusions unless source comparison and user context justify them.
+
+3. Flatness and signature axes
+   - Read `flatnessReading.status`, `zeroSignatureAxisRefs`, `nonzeroSignatureAxisRefs`, `blockedByCoverageGaps`, and `signatureAxes[]`.
+   - Treat nonzero axes as review pressure, not defect proof.
+   - Treat coverage gaps as unknown remainder, not measured zero.
+
+4. Dominant pressure
+   - Read top `workflowRiskReadings[]` by `riskScore`.
+   - Read `spectralAnalysisReadings[]`, especially dominant workflow row, dominant axis column, molecule overlap hub, obstruction curvature, and operation delta coupling.
+   - If workflow risk or spectral readings are empty, do not force a risk narrative. Shift to `signatureAxes[]`, `obstructionCircuits[]`, `repairOperationCandidates[]`, `operationDeltas[]`, and coverage gaps.
+
+5. Transfer bridge and split readiness
+   - Read `transferBridgeReadings[].bridgeAtomFamilies[].edgeBreakdowns[]`.
+   - Surface each edge's `sourceRefs`, `sourceRefRationale`, `dependencyKind`, `recommendedCutKind`, and `reviewFocus`.
+   - Read `splitReadinessReadings[]` sorted by low `readinessScore`; low score and `blockedByBridgeEdge` usually means boundary preparation should precede refactoring.
+   - If transfer bridge or split readiness readings are empty, report that no bridge/split surface was emitted for this packet variant and prioritize obstruction / repair / coverage evidence instead.
+
+6. LLM interpretation packet
+   - Use `llmInterpretationPacket.recommendedHumanReviewFocus`, `structuralReadingReviewSummary`, `currentStateEvolutionBoundarySummary`, and `transferBridgeEdgeSummary` as a human-review index.
+   - Do not treat the LLM packet as a separate source of truth.
+
+7. Packet variant fallback
+   - Some valid packets are obstruction/repair/coverage-heavy and have empty `workflowRiskReadings`, `spectralAnalysisReadings`, `transferBridgeReadings`, or `splitReadinessReadings`.
+   - In that case, summarize nonzero `signatureAxes[]`, constructed `obstructionCircuits[]`, `repairOperationCandidates[]`, `operationDeltas[]`, `flatnessReading.blockedByCoverageGaps`, and child-level `missingEvidence` / `excludedReadings`.
+   - Source comparison should then start from obstruction and repair candidate `sourceRefs`, not from workflow or bridge edges.
+
+## Source Comparison Workflow
+
+Always compare high-priority readings against real source evidence before proposing changes.
+
+1. Select a small review queue:
+   - top 2-4 workflow risk molecules
+   - transfer bridge edges with high `reviewRisk`
+   - low split-readiness molecules
+   - nonzero signature axes and their source refs
+   - coverage gaps blocking the user's decision
+
+2. Resolve source refs:
+   - Use ArchMap `sourceUniverse.includedRefs[]` and packet `sourceRefs` to find files, symbols, sections, or tests.
+   - If a ref cannot be resolved locally, report it as an evidence gap instead of guessing.
+
+3. Inspect code:
+   - Use `rg`, `sed`, language-aware tests, and local docs.
+   - Check whether source evidence supports the ArchSig reading.
+   - Distinguish confirmed source evidence, plausible but unverified interpretation, and contradicted/stale evidence.
+
+4. Propose improvements:
+   - Start with review actions that reduce uncertainty: route audit, runtime trace capture, provider log review, test evidence, model relationship audit.
+   - Then propose architecture changes only where source evidence supports the pressure: policy boundary, transaction boundary, anti-corruption layer, interface contract, idempotency/retry/status finalization, provider output validation.
+   - Keep proposals tied to source refs and ArchSig fields.
+
+## Output Shape
+
+For a normal user report, answer in this order:
+
+1. Run result and artifact paths
+2. Validation status
+3. Main architecture readings
+4. Source-code comparison findings
+5. Improvement proposals and next checks
+6. Claim boundary / non-conclusions
+
+Use concise Japanese when working in this repository.
+
+Recommended phrasing:
+
+- "ArchSig reads this as..."
+- "The packet marks this as `needsReview` because..."
+- "Source comparison supports / partially supports / does not yet support this reading..."
+- "The next useful improvement is..."
+
+Avoid:
+
+- "This proves a violation"
+- "This is definitely broken"
+- "The architecture score is..."
+- "No risk exists because the axis is zero"
+- "ArchSig recommends this refactor automatically"
+
+## Maintainer Validation
+
+When editing this skill inside a source checkout, validate the skill metadata. This command is a maintenance check, not a runtime requirement for released skill users:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary \
+  --packet tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json \
+  --out .lake/archsig-reader-summary-validation.json
+```
+
+If the skill-creator validator is available in the local Codex installation, run it too. If it is missing dependencies such as `PyYAML`, report that as an environment issue rather than a skill runtime blocker.
+
+Do not make source-repository tests a prerequisite for released skill usage.

--- a/tools/archsig/skills/archsig-reader/agents/openai.yaml
+++ b/tools/archsig/skills/archsig-reader/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ArchSig Reader"
+  short_description: "Run ArchMap through ArchSig and interpret results"
+  default_prompt: "Use $archsig-reader to run an ArchMap through ArchSig, read the analysis packet, compare findings with source code, and propose improvements."

--- a/tools/archsig/skills/archsig-reader/references/default_law_policy.json
+++ b/tools/archsig/skills/archsig-reader/references/default_law_policy.json
@@ -1,0 +1,336 @@
+{
+  "schemaVersion": "law-policy-v0",
+  "lawPolicyId": "archsig-reader-default-law-policy",
+  "policyVersion": "v0",
+  "scope": "Bundled baseline LawPolicy for ArchSig Reader skill-only releases",
+  "archmapSchemaRef": "archmap-observation-map-v0",
+  "selectedLaws": [
+    {
+      "lawId": "law:layer-respecting",
+      "lawFamily": "dependency-direction",
+      "description": "Dependencies should respect the selected architectural boundary order.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed ArchMap Atom records; this bundled policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredWitnessRefs": [
+        "witness:layer-violation"
+      ],
+      "requiredAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "lawId": "law:semantic-contract-alignment",
+      "lawFamily": "semantic-contract",
+      "description": "Semantic observations and contract observations should agree on selected operation meaning.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed ArchMap Atom records; this bundled policy does not prove lawfulness",
+      "appliesToAtomFamilies": [
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "requiredWitnessRefs": [
+        "witness:semantic-contract-mismatch"
+      ],
+      "requiredAxisRefs": [
+        "axis:semantic-inconsistency"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "requiredZeroAxes": [
+    {
+      "axisId": "axis:layer-violation",
+      "axisFamily": "dependency-direction",
+      "valueType": "nat",
+      "zeroReading": "zero means no required layer violation witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed relation atoms",
+        "observed boundary membership atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "axisId": "axis:semantic-inconsistency",
+      "axisFamily": "semantic-contract",
+      "valueType": "nat",
+      "zeroReading": "zero means no required semantic contract mismatch witness was constructed under this policy",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed semantic atoms",
+        "observed contract atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "optionalAxes": [
+    {
+      "axisId": "axis:observation-gap",
+      "axisFamily": "coverage",
+      "valueType": "nat",
+      "zeroReading": "zero means no policy-required observation gap was reported",
+      "measurementBoundary": "coverageBoundary",
+      "evidenceRequirements": [
+        "observation gap records"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "witnessRules": [
+    {
+      "witnessRuleId": "witness:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessKind": "forbidden-dependency-direction",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "relation",
+        "boundaryAuthority"
+      ],
+      "moleculePatternRefs": [
+        "molecule:layered-component"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "witnessRuleId": "witness:semantic-contract-mismatch",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessKind": "semantic-contract-noncommutation",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "moleculePatternRefs": [
+        "molecule:operation-contract"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "moleculePatterns": [
+    {
+      "moleculePatternId": "molecule:layered-component",
+      "roleName": "layered component",
+      "requiredAtomFamilies": [
+        "existence",
+        "boundaryAuthority"
+      ],
+      "optionalAtomFamilies": [
+        "relation"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "moleculePatternId": "molecule:operation-contract",
+      "roleName": "operation contract",
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification"
+      ],
+      "optionalAtomFamilies": [
+        "semanticInterpretation",
+        "effect"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "obstructionCircuitDefinitions": [
+    {
+      "obstructionCircuitId": "obstruction:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "witnessRuleRef": "witness:layer-violation",
+      "circuitKind": "BoundaryLeakCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:layer-violation"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "obstructionCircuitId": "obstruction:semantic-contract-mismatch",
+      "lawRef": "law:semantic-contract-alignment",
+      "witnessRuleRef": "witness:semantic-contract-mismatch",
+      "circuitKind": "SemanticMismatchCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:semantic-inconsistency"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "signatureAxisDefinitions": [
+    {
+      "signatureAxisId": "sig-axis:layer-violation",
+      "lawRef": "law:layer-respecting",
+      "axisRef": "axis:layer-violation",
+      "valuationRule": "count constructed BoundaryLeakCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "signatureAxisId": "sig-axis:semantic-inconsistency",
+      "lawRef": "law:semantic-contract-alignment",
+      "axisRef": "axis:semantic-inconsistency",
+      "valuationRule": "count constructed SemanticMismatchCircuit witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "exactnessAssumptions": [
+    "the selected witness rules cover only policy-declared laws",
+    "zero readings are exact only for observed atoms and declared coverage requirements"
+  ],
+  "coverageRequirements": [
+    {
+      "coverageRequirementId": "coverage:layer-atoms",
+      "appliesToLawRefs": [
+        "law:layer-respecting"
+      ],
+      "requiredAtomFamilies": [
+        "existence",
+        "relation",
+        "boundaryAuthority"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "symbol"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    },
+    {
+      "coverageRequirementId": "coverage:semantic-contract-atoms",
+      "appliesToLawRefs": [
+        "law:semantic-contract-alignment"
+      ],
+      "requiredAtomFamilies": [
+        "capability",
+        "contractSpecification",
+        "semanticInterpretation"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "doc-section",
+        "test"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "excludedReadings": [
+    "global architecture truth",
+    "Lean theorem discharge",
+    "SFT forecast correctness"
+  ],
+  "nonConclusions": [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+  ]
+}

--- a/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
+++ b/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
@@ -1,0 +1,78 @@
+# ArchSig Output Reading Guide
+
+Use this reference when deciding what to read first in an `archsig-analysis-packet-v0`.
+
+## Priority Fields
+
+| Field | Why it matters |
+| --- | --- |
+| `archMapRef`, `selectedLawPolicyRef` | Identifies the observed source state and selected law universe. |
+| `flatnessReading` | States whether selected signature axes are zero/nonzero and which coverage gaps block exactness. |
+| `signatureAxes[]` | Gives axis-local support refs, missing evidence, exactness assumptions, and excluded readings. |
+| `workflowRiskReadings[]` | Prioritizes molecule-local review pressure such as permission, LLM mediation, state/effect reconciliation, and domain cohesion. |
+| `spectralAnalysisReadings[]` | Shows dominant rows/columns and coupling surfaces across workflows, molecules, obstructions, and operation deltas. |
+| `transferBridgeReadings[]` | Connects repair transfer axes, molecule overlap paths, bridge edge source refs, review focus, and boundary preparation. |
+| `splitReadinessReadings[]` | Shows which molecules are blocked by bridge edges or need boundary preparation before feature extraction or refactoring. |
+| `structuralReadingReviewSurface` | Summarizes AAT structural review surfaces across representation, curvature, projection, state algebra, Galois, and split readiness. |
+| `currentStateEvolutionBoundary` | Keeps ArchSig current-state analysis separate from FieldSig evolution / PR / diff / forecast analysis. |
+| `llmInterpretationPacket` | Gives a compact review index. Use it as a guide, not independent evidence. |
+
+## LawPolicy Boundary
+
+Do not treat LawPolicy as a harmless default. It defines the selected law universe, witness rules, signature axes, exactness assumptions, and coverage requirements. Changing LawPolicy changes what ArchSig can read as obstruction, nonzero axis, flatness pressure, repair candidate, or non-conclusion.
+
+Use a project-specific LawPolicy for real analysis. If only the bundled `default_law_policy.json` is available, use it only as an explicit generic baseline / smoke test and label the result that way. A bundled baseline run can show that the toolchain and packet-reading workflow work; it should not be presented as the repository's intended architecture law analysis.
+
+## Interpreting Status
+
+- `pass` in validation means packet shape and guardrails passed; it is not architecture lawfulness.
+- `actionable` means the bounded reading has enough evidence for review action.
+- `needsReview` means human/source review is required before conclusions or implementation decisions.
+- `blockedByCoverageGap` means missing evidence must be carried as unknown remainder.
+- `nonConclusion` means ArchSig explicitly refuses a conclusion on that surface.
+
+## Packet Variant Fallback
+
+Some valid packets do not emit every high-level review surface. If `workflowRiskReadings[]`, `spectralAnalysisReadings[]`, `transferBridgeReadings[]`, or `splitReadinessReadings[]` are empty, do not invent those readings.
+
+Use this fallback order:
+
+1. `flatnessReading`: status, nonzero axes, zero axes, coverage gaps
+2. `signatureAxes[]`: values, source refs, missing evidence, coverage status
+3. `obstructionCircuits[]`: law refs, witness rules, atom refs, molecule refs, concern refs, missing evidence
+4. `repairOperationCandidates[]`: operation kind, preconditions, support refs, transferred obstructions, excluded readings
+5. `operationDeltas[]`: decreased axes, transferred obstructions, side-effect axes
+6. `boundedJudgements[]` and `llmInterpretationPacket.recommendedHumanReviewFocus`
+
+For source comparison in this variant, build the review queue from nonzero axes, obstruction source refs, repair candidate support refs, and coverage gaps.
+
+## Common Improvement Mapping
+
+| ArchSig pressure | First evidence check | Likely improvement family |
+| --- | --- | --- |
+| `permissionCoverage` | route-by-route dependency and tenant/workspace scope | policy boundary / permission audit |
+| `authorityTrustBoundary` | auth/session/token/provider trust handoffs | authority boundary / trust boundary hardening |
+| `stateEffectReconciliation` | commit ownership, retries, idempotency, status finalization | transaction boundary / recovery contract |
+| `llmOutputMediation` | prompt context, provider output filtering, persistence gates | anti-corruption layer / output validation |
+| `sourceBackedDomainCohesion` | domain identity, source relations, contracts | explicit interface / model relationship audit |
+| high molecule overlap | shared atom refs and source refs | split only after boundary preparation |
+| nonzero operation transfer | operation delta touches non-target axes | avoid local repair that transfers complexity |
+
+## Source Comparison Checklist
+
+- Resolve packet refs to ArchMap source refs before reading code.
+- Confirm whether the source still matches the ArchMap observation.
+- Check tests only when tests were part of the ArchMap scope or when the user asks for improvement validation.
+- Preserve private/unavailable/runtime gaps; do not infer from missing files.
+- When a reading depends on route coverage, runtime traces, provider logs, or model relationships, report the missing evidence explicitly.
+- Tie every improvement proposal to a packet field and source ref.
+
+## Report Boundaries
+
+Always include:
+
+- selected LawPolicy
+- coverage gaps that block exactness
+- whether source comparison was performed
+- which source refs were confirmed, stale, missing, or not inspected
+- non-conclusions relevant to the user's decision

--- a/tools/archsig/skills/law-policy-creater/SKILL.md
+++ b/tools/archsig/skills/law-policy-creater/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: law-policy-creater
+description: Create and validate ArchSig law-policy-v0 artifacts from repository coding conventions, architecture rules, review policies, and user decisions. Use when Codex is asked to draft, update, or review a LawPolicy / interpretation_profile.json for ArchSig; derive laws, witness rules, signature axes, coverage requirements, and exactness assumptions from repo docs or coding standards; ask the user to decide missing architecture laws when no documentation exists; or prepare a project-specific LawPolicy before running ArchMap through ArchSig.
+---
+
+# LawPolicy Creater
+
+## Purpose
+
+Create a project-specific `law-policy-v0` artifact for ArchSig.
+
+LawPolicy is not a harmless default. It selects the law universe, witness rules, signature axes, coverage requirements, exactness assumptions, and non-conclusions used by ArchSig. Changing LawPolicy changes what ArchSig can read as obstruction, nonzero signature axis, flatness pressure, repair candidate, or non-conclusion.
+
+This skill must work with only:
+
+- this skill directory, including `references/`
+- a built `archsig` executable when validation is requested
+- the user's repository files, ArchMap, docs, and direct answers
+
+Do not require the ArchSig source repository, AAT mathematical documents, test fixtures, Cargo project files, or Git history. Those may help during development, but they are not runtime dependencies for the released skill bundle.
+
+## Inputs
+
+Collect:
+
+- target repository root
+- intended LawPolicy path, usually `.archsig/<scope>/law_policy.json` or `.archsig/<scope>/interpretation_profile.json`
+- ArchMap path if available
+- repository docs or coding convention files
+- user goal: strict review, baseline diagnosis, release gate, migration planning, subsystem-specific analysis, or exploratory research
+
+If no output path is supplied, prefer `.archsig/<scope>/law_policy.json` next to the ArchMap.
+
+## Convention Discovery
+
+Search repository-owned evidence before asking broad questions.
+
+Read `references/convention-survey.md` when the repo is unfamiliar. Look for:
+
+- `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`
+- `README*`, `CONTRIBUTING*`, `ARCHITECTURE*`, `docs/**`
+- coding style configs such as `pyproject.toml`, `ruff.toml`, `.eslintrc*`, `tsconfig.json`, `go.mod`, `Cargo.toml`
+- framework routing / dependency conventions
+- security / permission / tenancy / transaction / provider-boundary docs
+- test strategy docs and CI workflow files
+
+Classify evidence:
+
+- **Normative**: must/shall/required, architectural decision records, coding standards, policy docs, CI gates.
+- **Conventional**: repeated patterns in source, framework idioms, naming conventions, review habits.
+- **Observed only**: current implementation without a stated rule.
+- **Missing**: no repo evidence.
+
+Only normative or explicitly user-approved conventions should become selected laws. Conventional or observed-only evidence can become coverage requirements, review assumptions, or question prompts.
+
+## Ask When Docs Are Missing
+
+If no clear normative source exists, stop before inventing laws and ask the user targeted questions. Use `references/question-bank.md`.
+
+Ask for decisions such as:
+
+- Which dependency directions must hold?
+- Which permission / tenancy boundaries are mandatory?
+- Which state/effect ordering, idempotency, retry, and finalization contracts matter?
+- Which provider / LLM / external integration outputs must be mediated?
+- Which semantic contracts are important enough to count as selected laws?
+- Which evidence is required before a zero axis can be trusted?
+
+Record user answers as source evidence in the LawPolicy scope or in an accompanying note. Do not silently promote your own preference into LawPolicy.
+
+## Authoring Workflow
+
+1. Define scope.
+   - Write `lawPolicyId`, `policyVersion`, `scope`, and `archmapSchemaRef`.
+   - Make the scope narrow enough to be defensible. Prefer subsystem-specific policy over vague repository-wide policy when evidence is partial.
+
+2. Select laws.
+   - A selected law is a user/repo-approved architectural expectation, not a detected violation.
+   - Each law needs `lawId`, `lawFamily`, `description`, `enforcementBoundary`, `appliesToAtomFamilies`, `requiredWitnessRefs`, `requiredAxisRefs`, and non-conclusions.
+
+3. Define axes.
+   - Add one `requiredZeroAxes[]` entry for each law-backed axis expected to be zero.
+   - Use `optionalAxes[]` for auxiliary review dimensions that are useful but not selected zero obligations.
+   - Zero means "no witness constructed under declared evidence and exactness assumptions", not global correctness.
+
+4. Define witness rules and obstruction circuits.
+   - Witness rules describe what ArchSig may construct from observed ArchMap atoms.
+   - Obstruction circuit definitions connect witness rules to circuit kinds and signature axes.
+   - Do not put concrete findings or ArchMap observation ids into the policy unless the policy is intentionally scoped to a fixed fixture. Normally leave `atomObservationRefs` empty.
+
+5. Define molecule patterns.
+   - Use molecule patterns to name role interpretations over atoms, such as layered component, operation contract, tenant boundary, provider mediation, transaction boundary, or source-domain artifact.
+   - A molecule pattern is not a primitive atom.
+
+6. Define coverage and exactness.
+   - Coverage requirements are first-class. They say what evidence must be present before zeros reflect the selected policy.
+   - Missing coverage must report a gap and block zero-reflection.
+   - Add exactness assumptions that limit witness completeness.
+
+7. Add non-conclusions.
+   - Preserve these boundaries: LawPolicy is selected analysis policy, not AAT itself; validation does not prove architecture lawfulness or atom truth; missing coverage is not measured zero; signature zero requires ArchSig analysis with coverage and exactness assumptions.
+
+8. Validate.
+   - Run `archsig law-policy`.
+   - Treat ArchSig validation as the authoritative schema, reference, uniqueness, coverage, exactness, and non-conclusion check.
+
+## Commands
+
+Resolve the ArchSig binary only when validation or fixture emission is needed:
+
+1. use `ARCHSIG_BIN` when set
+2. use `archsig` from `PATH`
+3. look for released binaries near the skill bundle, such as `bin/archsig`, `../bin/archsig`, or `../../bin/archsig`
+4. if working inside a source checkout, optionally use an already-built checkout binary such as `tools/archsig/target/release/archsig` or `tools/archsig/target/debug/archsig`
+
+ArchSig validation:
+
+```bash
+${ARCHSIG_BIN:-archsig} law-policy \
+  --input <law_policy.json> \
+  --out <law-policy-validation.json>
+```
+
+If no binary exists, report that validation was not performed. Do not substitute a separate local checker for ArchSig validation.
+
+Use `references/starter_law_policy.json` as a structural starting point, not as an analysis default. Replace ids, laws, axes, witness rules, coverage requirements, and scope with project-specific decisions.
+
+## Output Shape
+
+When delivering a LawPolicy, include:
+
+1. LawPolicy path
+2. Evidence summary: docs read, conventions found, user answers used
+3. Selected laws and why they are in scope
+4. Signature axes and zero-reading boundaries
+5. Coverage requirements and exactness assumptions
+6. Open questions / unresolved policy decisions
+7. Validation result
+
+Use concise Japanese when working in this repository.
+
+Avoid:
+
+- using a generic policy as project analysis
+- turning current code shape into law without docs or user approval
+- treating LawPolicy validation as architecture lawfulness
+- treating absent evidence as measured zero
+- mixing FieldSig forecast / governance claims into ArchSig LawPolicy
+
+## References
+
+- `references/schema-guide.md`: LawPolicy field guide and cross-reference rules
+- `references/convention-survey.md`: how to find repo coding conventions
+- `references/question-bank.md`: questions to ask when docs are missing
+- `references/starter_law_policy.json`: structural JSON starter template
+
+## Maintainer Validation
+
+When editing this skill inside a source checkout, validate the starter policy with ArchSig:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy \
+  --input tools/archsig/skills/law-policy-creater/references/starter_law_policy.json \
+  --out .lake/law-policy-creater-starter-validation.json
+```
+
+If the skill-creator validator is available, run it too. If it is missing dependencies such as `PyYAML`, report that as an environment issue rather than a skill runtime blocker.

--- a/tools/archsig/skills/law-policy-creater/agents/openai.yaml
+++ b/tools/archsig/skills/law-policy-creater/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LawPolicy Creater"
+  short_description: "Create ArchSig LawPolicy artifacts"
+  default_prompt: "Use $law-policy-creater to derive a law-policy-v0 artifact from repository conventions, ask for missing architecture decisions, and validate the result."

--- a/tools/archsig/skills/law-policy-creater/references/convention-survey.md
+++ b/tools/archsig/skills/law-policy-creater/references/convention-survey.md
@@ -1,0 +1,49 @@
+# Convention Survey
+
+Use this when deriving LawPolicy from an unfamiliar repository.
+
+## Search Targets
+
+Start with explicit instructions:
+
+```bash
+rg -n "must|shall|required|forbid|forbidden|boundary|permission|tenant|transaction|idempot|retry|provider|LLM|OpenAI|architecture|layer|dependency|policy" \
+  AGENTS.md README* CONTRIBUTING* docs .github 2>/dev/null
+```
+
+Then inspect likely config and architecture surfaces:
+
+- `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`
+- `README*`, `CONTRIBUTING*`, `docs/**`, `architecture/**`, ADRs
+- CI workflows and required checks
+- framework config and route/dependency declarations
+- security, tenancy, permissions, auth, transaction, provider, LLM, and runtime docs
+- tests that encode required behavior, when tests are in scope
+
+## Evidence Classification
+
+- **Normative**: explicit rules or user-approved decisions. Eligible for `selectedLaws[]`.
+- **Conventional**: repeated source pattern without explicit rule. Good for coverage requirements or questions.
+- **Observed only**: current code shape. Do not promote to law without user confirmation.
+- **Missing**: no evidence. Ask questions before writing a selected law.
+
+## Mapping Evidence To Policy
+
+| Evidence | LawPolicy surface |
+| --- | --- |
+| "Routes must use permission dependency X" | selected law + permission axis + coverage requirement for routes |
+| "Tenant data must be scoped by workspace/org" | selected law + tenant boundary witness + model/route coverage |
+| "External provider output must be validated before persistence" | selected law + provider mediation witness + trust/effect/contract coverage |
+| "Jobs must be idempotent and retry-safe" | selected law + state/effect ordering axis + runtime/test coverage |
+| "Repository owns transaction flush" | selected law + transaction boundary witness + state/effect coverage |
+| repeated but undocumented pattern | question to user, not selected law yet |
+
+## Survey Output
+
+Before drafting JSON, summarize:
+
+- docs and files read
+- candidate laws with evidence refs
+- candidate coverage requirements
+- decisions that need user confirmation
+- blind spots and excluded evidence

--- a/tools/archsig/skills/law-policy-creater/references/question-bank.md
+++ b/tools/archsig/skills/law-policy-creater/references/question-bank.md
@@ -1,0 +1,46 @@
+# LawPolicy Question Bank
+
+Ask only the questions needed for the target scope. Prefer 3-6 high-signal questions over a long interview.
+
+## Core Scope
+
+- Which subsystem or repository slice should this LawPolicy govern?
+- Is the policy intended for strict review, exploratory diagnosis, release gating, or migration planning?
+- Should the policy apply to all code, or only selected routes/services/jobs/models/providers?
+
+## Dependency And Layering
+
+- Are there dependency directions that must hold?
+- Which components are allowed to depend on infrastructure, repositories, providers, or frameworks?
+- Are cyclic dependencies forbidden, tolerated, or out of scope?
+
+## Authority And Tenancy
+
+- Which permission checks are mandatory for routes or commands?
+- What tenant/workspace/org boundaries must be preserved?
+- Are admin bypasses allowed, and if so under what explicit constraints?
+
+## State, Effects, And Runtime
+
+- Which operations must be idempotent or replay-safe?
+- Which state changes must commit before or after external effects?
+- What retry, compensation, rollback, or finalization behavior is required?
+- What runtime traces, logs, or tests are required before a zero axis is trusted?
+
+## Provider, LLM, And External Boundary
+
+- Which provider outputs must be validated, filtered, or translated before persistence?
+- Are LLM/tool outputs allowed to become domain facts directly?
+- Which secrets, tokens, webhook signatures, or provider identities are trust boundaries?
+
+## Semantic Contracts
+
+- Which domain meanings or DTO/API contracts are important enough to become selected laws?
+- Which tests or docs define semantic correctness for the target scope?
+- Which mismatches should become ArchSig obstruction witnesses versus review-only concern hints?
+
+## Coverage And Exactness
+
+- What evidence is required for zero-reading to be meaningful?
+- Which evidence is unavailable and must remain an observation gap?
+- Which claims must the policy explicitly exclude?

--- a/tools/archsig/skills/law-policy-creater/references/schema-guide.md
+++ b/tools/archsig/skills/law-policy-creater/references/schema-guide.md
@@ -1,0 +1,79 @@
+# LawPolicy Schema Guide
+
+Use this guide when authoring `law-policy-v0`.
+
+## Required Top-Level Fields
+
+- `schemaVersion`: must be `law-policy-v0`
+- `lawPolicyId`: stable id for this project policy
+- `policyVersion`: project policy version
+- `scope`: bounded analysis scope
+- `archmapSchemaRef`: normally `archmap-observation-map-v0`
+- `selectedLaws[]`
+- `requiredZeroAxes[]`
+- `optionalAxes[]`
+- `witnessRules[]`
+- `moleculePatterns[]`
+- `obstructionCircuitDefinitions[]`
+- `signatureAxisDefinitions[]`
+- `exactnessAssumptions[]`
+- `coverageRequirements[]`
+- `excludedReadings[]`
+- `nonConclusions[]`
+
+## Cross-Reference Rules
+
+- `selectedLaws[].requiredWitnessRefs[]` must resolve to `witnessRules[].witnessRuleId`.
+- `selectedLaws[].requiredAxisRefs[]` must resolve to `requiredZeroAxes[].axisId` or `optionalAxes[].axisId`.
+- `witnessRules[].lawRef` must resolve to `selectedLaws[].lawId`.
+- `witnessRules[].moleculePatternRefs[]` must resolve to `moleculePatterns[].moleculePatternId`.
+- `obstructionCircuitDefinitions[].lawRef` must resolve to `selectedLaws[].lawId`.
+- `obstructionCircuitDefinitions[].witnessRuleRef` must resolve to `witnessRules[].witnessRuleId`.
+- `obstructionCircuitDefinitions[].signatureAxisRefs[]` must resolve to axis ids.
+- `signatureAxisDefinitions[].lawRef` must resolve to `selectedLaws[].lawId`.
+- `signatureAxisDefinitions[].axisRef` must resolve to an axis id.
+- `coverageRequirements[].appliesToLawRefs[]` must resolve to `selectedLaws[].lawId`.
+
+## Common Law Families
+
+Use project-specific names when needed, but common families include:
+
+- `dependency-direction`
+- `authority-boundary`
+- `tenant-boundary`
+- `semantic-contract`
+- `state-effect-ordering`
+- `idempotency-replay`
+- `provider-output-mediation`
+- `transaction-boundary`
+- `data-model-ownership`
+- `source-domain-cohesion`
+
+## Atom Families
+
+Use ArchMap atom family names in `appliesToAtomFamilies`, `requiredAtomFamilies`, and coverage requirements. Common names:
+
+- `existence`
+- `relation`
+- `capability`
+- `state`
+- `effect`
+- `authority`
+- `trust`
+- `contractSpecification`
+- `semantic`
+- `runtimeInteraction`
+
+If an existing policy uses historical names such as `boundaryAuthority` or `semanticInterpretation`, keep them only when the ArchMap and ArchSig binary expect them. Prefer current ArchMap atom family names for new project policies.
+
+## Required Non-Conclusions
+
+Keep these ideas in every policy:
+
+- LawPolicy is selected analysis policy, not AAT itself.
+- LawPolicy validation does not prove architecture lawfulness.
+- LawPolicy validation does not certify atom truth.
+- Missing coverage is not measured zero.
+- Signature zero requires ArchSig analysis with declared coverage and exactness assumptions.
+
+Exact wording may vary, but the boundaries must remain clear.

--- a/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
+++ b/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
@@ -1,0 +1,184 @@
+{
+  "schemaVersion": "law-policy-v0",
+  "lawPolicyId": "project-law-policy",
+  "policyVersion": "v0",
+  "scope": "Replace with the bounded repository or subsystem scope",
+  "archmapSchemaRef": "archmap-observation-map-v0",
+  "selectedLaws": [
+    {
+      "lawId": "law:project-boundary-example",
+      "lawFamily": "authority-boundary",
+      "description": "Replace with a project-approved architecture rule.",
+      "enforcementBoundary": "ArchSig computes witnesses from observed ArchMap atoms under this selected policy; this policy does not prove architecture lawfulness",
+      "appliesToAtomFamilies": [
+        "authority",
+        "contractSpecification",
+        "relation"
+      ],
+      "requiredWitnessRefs": [
+        "witness:project-boundary-example"
+      ],
+      "requiredAxisRefs": [
+        "axis:project-boundary-example"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "requiredZeroAxes": [
+    {
+      "axisId": "axis:project-boundary-example",
+      "axisFamily": "authority-boundary",
+      "valueType": "nat",
+      "zeroReading": "zero means no required witness was constructed under this policy and declared coverage",
+      "measurementBoundary": "computedFromObservedAtoms",
+      "evidenceRequirements": [
+        "observed authority atoms",
+        "observed contract atoms",
+        "observed relation atoms"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "optionalAxes": [],
+  "witnessRules": [
+    {
+      "witnessRuleId": "witness:project-boundary-example",
+      "lawRef": "law:project-boundary-example",
+      "witnessKind": "policy-boundary-review",
+      "atomObservationRefs": [],
+      "requiredAtomFamilies": [
+        "authority",
+        "contractSpecification",
+        "relation"
+      ],
+      "moleculePatternRefs": [
+        "molecule:project-boundary-example"
+      ],
+      "evidenceBoundary": "construct only from observed ArchMap Atom observations; concern hints are not obstruction circuits",
+      "missingEvidenceBehavior": "report observation gap; do not infer measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "moleculePatterns": [
+    {
+      "moleculePatternId": "molecule:project-boundary-example",
+      "roleName": "project boundary example",
+      "requiredAtomFamilies": [
+        "authority",
+        "contractSpecification"
+      ],
+      "optionalAtomFamilies": [
+        "relation",
+        "trust"
+      ],
+      "interpretationBoundary": "molecule pattern is role interpretation over atoms, not a primitive atom",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "obstructionCircuitDefinitions": [
+    {
+      "obstructionCircuitId": "obstruction:project-boundary-example",
+      "lawRef": "law:project-boundary-example",
+      "witnessRuleRef": "witness:project-boundary-example",
+      "circuitKind": "PolicyBoundaryCircuit",
+      "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+      "evidenceBoundary": "law-relative ArchSig witness, not ArchMap observation and not Lean theorem discharge",
+      "signatureAxisRefs": [
+        "axis:project-boundary-example"
+      ],
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "signatureAxisDefinitions": [
+    {
+      "signatureAxisId": "sig-axis:project-boundary-example",
+      "lawRef": "law:project-boundary-example",
+      "axisRef": "axis:project-boundary-example",
+      "valuationRule": "count constructed project boundary witnesses",
+      "valueType": "nat",
+      "zeroReading": "zero means no matching required witness was constructed under declared coverage and exactness assumptions",
+      "coverageBoundary": "coverage gaps remain observation gaps, not measured zero",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "exactnessAssumptions": [
+    "the selected witness rules cover only policy-declared laws",
+    "zero readings are exact only for observed atoms and declared coverage requirements"
+  ],
+  "coverageRequirements": [
+    {
+      "coverageRequirementId": "coverage:project-boundary-example",
+      "appliesToLawRefs": [
+        "law:project-boundary-example"
+      ],
+      "requiredAtomFamilies": [
+        "authority",
+        "contractSpecification",
+        "relation"
+      ],
+      "requiredSourceRefKinds": [
+        "file",
+        "symbol",
+        "docSection",
+        "test"
+      ],
+      "missingCoverageBehavior": "report observation gap and block signature-zero reflection",
+      "nonConclusions": [
+        "law policy is selected analysis policy, not AAT itself",
+        "law policy validation does not prove architecture lawfulness",
+        "law policy validation does not certify atom truth",
+        "missing coverage is not measured zero",
+        "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+      ]
+    }
+  ],
+  "excludedReadings": [
+    "global architecture truth",
+    "Lean theorem discharge",
+    "SFT forecast correctness",
+    "automatic repair safety"
+  ],
+  "nonConclusions": [
+    "law policy is selected analysis policy, not AAT itself",
+    "law policy validation does not prove architecture lawfulness",
+    "law policy validation does not certify atom truth",
+    "missing coverage is not measured zero",
+    "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+  ]
+}

--- a/tools/archsig/src/law_policy.rs
+++ b/tools/archsig/src/law_policy.rs
@@ -825,6 +825,41 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_law_policy_ids_fail() {
+        let mut policy = static_law_policy();
+        policy.selected_laws[1].law_id = policy.selected_laws[0].law_id.clone();
+        policy.witness_rules[1].witness_rule_id = policy.witness_rules[0].witness_rule_id.clone();
+        policy.coverage_requirements[1].coverage_requirement_id = policy.coverage_requirements[0]
+            .coverage_requirement_id
+            .clone();
+
+        let report = validate_law_policy_report(&policy, "bad-law-policy.json");
+
+        assert_eq!(report.summary.result, "fail");
+        let id_check = report
+            .checks
+            .iter()
+            .find(|check| check.id == "law-policy-ids-unique")
+            .expect("ids uniqueness check is emitted");
+        assert_eq!(id_check.result, "fail");
+        assert!(
+            id_check
+                .examples
+                .iter()
+                .any(|example| example.source.as_deref() == Some("selectedLaws[].lawId"))
+        );
+        assert!(
+            id_check
+                .examples
+                .iter()
+                .any(|example| example.source.as_deref() == Some("witnessRules[].witnessRuleId"))
+        );
+        assert!(id_check.examples.iter().any(|example| {
+            example.source.as_deref() == Some("coverageRequirements[].coverageRequirementId")
+        }));
+    }
+
+    #[test]
     fn canonical_fixture_matches_static_law_policy() {
         let fixture: LawPolicyDocumentV0 =
             serde_json::from_str(include_str!("../tests/fixtures/minimal/law_policy.json"))

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -5,10 +5,11 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use archsig::{
-    ArchMapDocumentV0, ArchMapSourceInventoryInput, ArchMapSourceInventoryV0,
-    ArchMapValidationReportV0, LawPolicyDocumentV0, SchemaVersionCatalogV0,
-    build_archsig_analysis_packet, static_law_policy, static_schema_version_catalog,
-    validate_archmap_report, validate_archsig_analysis_packet_report, validate_law_policy_report,
+    ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ArchMapDocumentV0, ArchMapSourceInventoryInput,
+    ArchMapSourceInventoryV0, ArchMapValidationReportV0, LawPolicyDocumentV0,
+    SchemaVersionCatalogV0, build_archsig_analysis_packet, static_law_policy,
+    static_schema_version_catalog, validate_archmap_report,
+    validate_archsig_analysis_packet_report, validate_law_policy_report,
 };
 use clap::{Parser, Subcommand};
 
@@ -73,6 +74,34 @@ enum Command {
         /// Optional LLM interpretation packet output path. This writes the same structured packet for LLM reading.
         #[arg(long = "llm-interpretation-out")]
         llm_interpretation_out: Option<PathBuf>,
+    },
+
+    /// Summarize an archsig-analysis-packet-v0 for human and LLM review.
+    #[command(visible_alias = "summary")]
+    AnalysisSummary {
+        /// Input archsig-analysis-packet-v0 JSON path.
+        #[arg(long)]
+        packet: PathBuf,
+
+        /// Optional ArchMap validation report path.
+        #[arg(long = "archmap-validation")]
+        archmap_validation: Option<PathBuf>,
+
+        /// Optional LawPolicy validation report path.
+        #[arg(long = "law-policy-validation")]
+        law_policy_validation: Option<PathBuf>,
+
+        /// Optional ArchSig analysis validation report path.
+        #[arg(long = "analysis-validation")]
+        analysis_validation: Option<PathBuf>,
+
+        /// Maximum number of ranked readings to include.
+        #[arg(long, default_value_t = 6)]
+        limit: usize,
+
+        /// Output summary JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
     },
 
     /// Emit a bounded external-agent protocol for generating ArchMap JSON.
@@ -237,6 +266,39 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 ExitCode::SUCCESS
             })
         }
+        Some(Command::AnalysisSummary {
+            packet,
+            archmap_validation,
+            law_policy_validation,
+            analysis_validation,
+            limit,
+            out,
+        }) => {
+            let packet_document: serde_json::Value = read_json(&packet)?;
+            if !packet_document.is_object() {
+                return Err("--packet must be a JSON object".into());
+            }
+            if packet_document.get("schemaVersion").and_then(|value| value.as_str())
+                != Some(ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION)
+            {
+                return Err(format!(
+                    "--packet must have schemaVersion {ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION}"
+                )
+                .into());
+            }
+            let archmap_validation = read_optional_json(archmap_validation.as_ref())?;
+            let law_policy_validation = read_optional_json(law_policy_validation.as_ref())?;
+            let analysis_validation = read_optional_json(analysis_validation.as_ref())?;
+            let summary = build_analysis_summary(
+                &packet_document,
+                archmap_validation.as_ref(),
+                law_policy_validation.as_ref(),
+                analysis_validation.as_ref(),
+                limit,
+            );
+            write_json(out, &summary)?;
+            Ok(ExitCode::SUCCESS)
+        }
         Some(Command::ArchmapGenerate {
             source_inventory,
             prompt_pack,
@@ -391,6 +453,252 @@ fn write_json<T: serde::Serialize>(out: Option<PathBuf>, value: &T) -> Result<()
 
 fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T, Box<dyn Error>> {
     Ok(serde_json::from_reader(File::open(path)?)?)
+}
+
+fn read_optional_json(path: Option<&PathBuf>) -> Result<Option<serde_json::Value>, Box<dyn Error>> {
+    path.map(read_json).transpose()
+}
+
+fn build_analysis_summary(
+    packet: &serde_json::Value,
+    archmap_validation: Option<&serde_json::Value>,
+    law_policy_validation: Option<&serde_json::Value>,
+    analysis_validation: Option<&serde_json::Value>,
+    limit: usize,
+) -> serde_json::Value {
+    let flatness = packet
+        .get("flatnessReading")
+        .unwrap_or(&serde_json::Value::Null);
+    let llm_packet = packet
+        .get("llmInterpretationPacket")
+        .unwrap_or(&serde_json::Value::Null);
+
+    serde_json::json!({
+        "packet": {
+            "schemaVersion": json_field(packet, "schemaVersion"),
+            "analysisId": json_field(packet, "analysisId"),
+            "archMapRef": json_field(packet, "archMapRef"),
+            "selectedLawPolicyRef": json_field(packet, "selectedLawPolicyRef"),
+            "generatedAt": json_field(packet, "generatedAt")
+        },
+        "validation": {
+            "archmap": validation_summary(archmap_validation),
+            "lawPolicy": validation_summary(law_policy_validation),
+            "analysis": validation_summary(analysis_validation)
+        },
+        "flatness": {
+            "status": json_field(flatness, "status"),
+            "zeroSignatureAxisRefs": array_field(flatness, "zeroSignatureAxisRefs"),
+            "nonzeroSignatureAxisRefs": array_field(flatness, "nonzeroSignatureAxisRefs"),
+            "blockedByCoverageGaps": array_field(flatness, "blockedByCoverageGaps")
+        },
+        "signatureAxes": signature_axis_summary(packet),
+        "topWorkflowRisks": top_workflow_risks(packet, limit),
+        "spectralAnalysis": spectral_summary(packet),
+        "transferBridges": transfer_bridge_summary(packet),
+        "splitReadiness": split_readiness_summary(packet, limit),
+        "llmReviewIndex": {
+            "structuralReadingReviewSummary": array_field(llm_packet, "structuralReadingReviewSummary"),
+            "currentStateEvolutionBoundarySummary": array_field(llm_packet, "currentStateEvolutionBoundarySummary"),
+            "recommendedHumanReviewFocus": limited_array_field(llm_packet, "recommendedHumanReviewFocus", limit),
+            "transferBridgeEdgeSummary": array_field(llm_packet, "transferBridgeEdgeSummary")
+        },
+        "nonConclusions": array_field(packet, "nonConclusions")
+    })
+}
+
+fn validation_summary(report: Option<&serde_json::Value>) -> serde_json::Value {
+    let Some(report) = report else {
+        return serde_json::Value::Null;
+    };
+    if let Some(summary) = report.get("summary") {
+        return summary.clone();
+    }
+    serde_json::json!({
+        "result": json_field(report, "status"),
+        "failedCheckCount": json_field(report, "failedChecks"),
+        "warningCheckCount": json_field(report, "warningChecks"),
+        "passedCheckCount": json_field(report, "passedChecks")
+    })
+}
+
+fn top_workflow_risks(packet: &serde_json::Value, limit: usize) -> serde_json::Value {
+    let mut readings = array_items(packet, "workflowRiskReadings");
+    readings.sort_by_key(|reading| std::cmp::Reverse(i64_field(reading, "riskScore", 0)));
+    serde_json::Value::Array(
+        readings
+            .into_iter()
+            .take(limit)
+            .map(|reading| {
+                serde_json::json!({
+                    "molecule": json_field(reading, "moleculeObservationRef"),
+                    "roleName": json_field(reading, "roleName"),
+                    "status": json_field(reading, "status"),
+                    "riskScore": json_field(reading, "riskScore"),
+                    "riskTier": json_field(reading, "riskTier"),
+                    "topAxes": top_axis_summary(reading),
+                    "reviewFocus": array_field(reading, "reviewFocus")
+                })
+            })
+            .collect(),
+    )
+}
+
+fn top_axis_summary(reading: &serde_json::Value) -> serde_json::Value {
+    serde_json::Value::Array(
+        array_items(reading, "topAxes")
+            .into_iter()
+            .take(3)
+            .map(|axis| {
+                serde_json::json!({
+                    "axis": json_field(axis, "axis"),
+                    "score": json_field(axis, "score"),
+                    "status": json_field(axis, "status"),
+                    "coverageGapRefs": array_field(axis, "coverageGapRefs")
+                })
+            })
+            .collect(),
+    )
+}
+
+fn spectral_summary(packet: &serde_json::Value) -> serde_json::Value {
+    serde_json::Value::Array(
+        array_items(packet, "spectralAnalysisReadings")
+            .into_iter()
+            .map(|reading| {
+                serde_json::json!({
+                    "id": json_field(reading, "spectralReadingId"),
+                    "family": json_field(reading, "representationFamily"),
+                    "status": json_field(reading, "status"),
+                    "shape": json_field(reading, "matrixShape"),
+                    "values": array_field(reading, "values"),
+                    "dominantComponents": array_field(reading, "dominantComponents"),
+                    "recommendedNextAction": json_field(reading, "recommendedNextAction")
+                })
+            })
+            .collect(),
+    )
+}
+
+fn transfer_bridge_summary(packet: &serde_json::Value) -> serde_json::Value {
+    let mut bridges = Vec::new();
+    for reading in array_items(packet, "transferBridgeReadings") {
+        for bridge in array_items(reading, "bridgeAtomFamilies") {
+            let edges = serde_json::Value::Array(
+                array_items(bridge, "edgeBreakdowns")
+                    .into_iter()
+                    .map(|edge| {
+                        serde_json::json!({
+                            "edgeId": json_field(edge, "edgeId"),
+                            "source": json_field(edge, "sourceMoleculeRef"),
+                            "target": json_field(edge, "targetMoleculeRef"),
+                            "overlapScore": json_field(edge, "overlapScore"),
+                            "sharedAtomFamilies": array_field(edge, "sharedAtomFamilies"),
+                            "dependencyKind": json_field(edge, "dependencyKind"),
+                            "recommendedCutKind": json_field(edge, "recommendedCutKind"),
+                            "sourceRefCount": array_len(edge, "sourceRefs"),
+                            "reviewFocus": array_field(edge, "reviewFocus")
+                        })
+                    })
+                    .collect(),
+            );
+            bridges.push(serde_json::json!({
+                "transferBridgeId": json_field(reading, "transferBridgeId"),
+                "status": json_field(reading, "status"),
+                "bridgeId": json_field(bridge, "bridgeId"),
+                "sourceHub": json_field(bridge, "sourceHubMoleculeRef"),
+                "targetHub": json_field(bridge, "targetHubMoleculeRef"),
+                "intermediateMoleculeRefs": array_field(bridge, "intermediateMoleculeRefs"),
+                "bridgeScore": json_field(bridge, "bridgeScore"),
+                "reviewRisk": json_field(bridge, "reviewRisk"),
+                "sharedAxisRefs": array_field(bridge, "sharedAxisRefs"),
+                "pathPairRefs": array_field(bridge, "pathPairRefs"),
+                "edges": edges
+            }));
+        }
+    }
+    serde_json::Value::Array(bridges)
+}
+
+fn split_readiness_summary(packet: &serde_json::Value, limit: usize) -> serde_json::Value {
+    let mut readings = array_items(packet, "splitReadinessReadings");
+    readings.sort_by_key(|reading| i64_field(reading, "readinessScore", i64::MAX));
+    serde_json::Value::Array(
+        readings
+            .into_iter()
+            .take(limit)
+            .map(|reading| {
+                serde_json::json!({
+                    "molecule": json_field(reading, "moleculeRef"),
+                    "status": json_field(reading, "status"),
+                    "readinessScore": json_field(reading, "readinessScore"),
+                    "liftingEvidenceStatus": json_field(reading, "liftingEvidenceStatus"),
+                    "recommendedBoundaryOperation": json_field(reading, "recommendedBoundaryOperation"),
+                    "bridgeEdgeRefs": array_field(reading, "bridgeEdgeRefs"),
+                    "interactionObstructionRefs": array_field(reading, "interactionObstructionRefs")
+                })
+            })
+            .collect(),
+    )
+}
+
+fn signature_axis_summary(packet: &serde_json::Value) -> serde_json::Value {
+    serde_json::Value::Array(
+        array_items(packet, "signatureAxes")
+            .into_iter()
+            .map(|axis| {
+                serde_json::json!({
+                    "axis": json_field(axis, "signatureAxisId"),
+                    "lawRef": json_field(axis, "lawRef"),
+                    "value": json_field(axis, "value"),
+                    "coverageStatus": json_field(axis, "coverageStatus"),
+                    "missingEvidenceCount": array_len(axis, "missingEvidence"),
+                    "sourceRefCount": array_len(axis, "sourceRefs")
+                })
+            })
+            .collect(),
+    )
+}
+
+fn json_field(value: &serde_json::Value, key: &str) -> serde_json::Value {
+    value.get(key).cloned().unwrap_or(serde_json::Value::Null)
+}
+
+fn array_field(value: &serde_json::Value, key: &str) -> serde_json::Value {
+    serde_json::Value::Array(array_items(value, key).into_iter().cloned().collect())
+}
+
+fn limited_array_field(value: &serde_json::Value, key: &str, limit: usize) -> serde_json::Value {
+    serde_json::Value::Array(
+        array_items(value, key)
+            .into_iter()
+            .take(limit)
+            .cloned()
+            .collect(),
+    )
+}
+
+fn array_items<'a>(value: &'a serde_json::Value, key: &str) -> Vec<&'a serde_json::Value> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(|items| items.iter().collect())
+        .unwrap_or_default()
+}
+
+fn array_len(value: &serde_json::Value, key: &str) -> usize {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or_default()
+}
+
+fn i64_field(value: &serde_json::Value, key: &str, default: i64) -> i64 {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(default)
 }
 
 fn resolve_archmap_sidecar_path(archmap_path: &Path, sidecar_path: &str) -> Option<PathBuf> {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -30,6 +30,8 @@ fn cli_help_exposes_only_llm_atom_archmap_surface() {
         "interpretation-profile",
         "archsig-analysis",
         "aat-analysis",
+        "analysis-summary",
+        "summary",
         "llm-native-workflow",
         "north-star-workflow",
         "schema-catalog",
@@ -46,6 +48,75 @@ fn cli_help_exposes_only_llm_atom_archmap_surface() {
             "ArchSig help still exposes removed command {removed}\n{stdout}"
         );
     }
+}
+
+#[test]
+fn cli_summarizes_archsig_analysis_packet() {
+    let out_dir = temp_dir("analysis-summary");
+    let root = fixture_root();
+    let summary = out_dir.join("archsig-analysis-summary.json");
+
+    run_sig0(&[
+        "analysis-summary",
+        "--packet",
+        root.join("archsig_analysis_packet.json")
+            .to_str()
+            .expect("packet path is utf-8"),
+        "--limit",
+        "2",
+        "--out",
+        summary.to_str().expect("summary path is utf-8"),
+    ]);
+
+    let json = read_json(&summary);
+    assert_eq!(
+        json["packet"]["schemaVersion"],
+        "archsig-analysis-packet-v0"
+    );
+    assert_eq!(
+        json["packet"]["analysisId"],
+        "archsig-analysis:fixture-archmap-atom-observation:llm-native-aat-law-policy-fixture"
+    );
+    assert_eq!(json["validation"]["archmap"], Value::Null);
+    assert!(
+        json["signatureAxes"]
+            .as_array()
+            .is_some_and(|axes| !axes.is_empty())
+    );
+    assert!(
+        json["topWorkflowRisks"]
+            .as_array()
+            .is_some_and(|risks| risks.len() <= 2)
+    );
+    assert!(
+        json["splitReadiness"]
+            .as_array()
+            .is_some_and(|readings| readings.len() <= 2)
+    );
+    assert!(
+        json["nonConclusions"]
+            .as_array()
+            .is_some_and(|non_conclusions| !non_conclusions.is_empty())
+    );
+}
+
+#[test]
+fn cli_rejects_summary_for_non_analysis_packet() {
+    let root = fixture_root();
+    let output = run_sig0_output(&[
+        "analysis-summary",
+        "--packet",
+        root.join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--packet must have schemaVersion archsig-analysis-packet-v0"),
+        "{stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #1444

ArchSig released skill bundle の validation / summary logic を Python helper ではなく archsig binary 側に寄せました。law-policy-creater は archsig law-policy を authoritative validation として案内し、archsig-reader は新しい analysis-summary command で packet summary を出す構成にしています。

## 証明した定理

- なし

## 編集したドキュメント

- tools/archsig/README.md
- tools/archsig/docs/commands.md
- tools/archsig/skills/archsig-reader/SKILL.md
- tools/archsig/skills/archsig-reader/references/output-reading-guide.md
- tools/archsig/skills/law-policy-creater/SKILL.md
- tools/archsig/skills/law-policy-creater/references/*.md

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [x] cargo test --manifest-path tools/archsig/Cargo.toml
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）
- [x] cargo fmt --manifest-path tools/archsig/Cargo.toml --check
- [x] cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy --input tools/archsig/skills/law-policy-creater/references/starter_law_policy.json --out .lake/law-policy-creater-starter-validation.json
- [x] cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary --packet tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json --limit 2 --out .lake/archsig-reader-summary-validation.json

## チェックリスト

- [x] 対象 Issue を Closes #1444 形式で本文に記載した
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした（Lean 変更なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない