### PR TITLE
ArchSig primary workflow を analyze として見せる

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -40,24 +40,24 @@ jobs:
       - name: Test FieldSig
         run: cargo test --manifest-path tools/fieldsig/Cargo.toml
 
-  llm-native-e2e:
-    name: ArchSig/FieldSig handoff e2e
+  archsig-analyze-e2e:
+    name: ArchSig analyze / FieldSig handoff e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run LLM-native ArchMap to FieldSig handoff
+      - name: Run ArchSig analyze to FieldSig handoff
         shell: bash
         run: |
           set -euo pipefail
 
-          out_dir=".lake/llm-native-e2e"
+          out_dir=".lake/archsig-analyze-e2e"
           archsig_dir="$out_dir/archsig"
           fieldsig_dir="$out_dir/fieldsig"
           mkdir -p "$archsig_dir" "$fieldsig_dir"
 
-          cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
+          cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
             --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
             --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
             --out-dir "$archsig_dir"
@@ -103,8 +103,8 @@ jobs:
             exit 1
           fi
 
-      - name: Upload LLM-native e2e artifacts
+      - name: Upload ArchSig analyze e2e artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: llm-native-e2e-${{ github.run_id }}
-          path: .lake/llm-native-e2e
+          name: archsig-analyze-e2e-${{ github.run_id }}
+          path: .lake/archsig-analyze-e2e

--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -1,7 +1,7 @@
 # Tool Docs
 
-`docs/tool/` is built around the LLM-native ArchMap / interpretation profile /
-ArchSig AAT analysis workflow.
+`docs/tool/` is built around the ArchMap / interpretation profile / ArchSig
+`analyze` workflow.
 
 The previous mixed tool documents are archived under:
 
@@ -12,7 +12,7 @@ Current source-of-truth boundaries:
 - ArchMap starts from supplied `archmap-observation-map-v0` evidence read as a source-grounded Atom observation map. It records `atomObservations`, `moleculeObservations`, `semanticObservations`, `observationGaps`, `projectionInfo`, `concernHints`, provenance, and non-conclusions.
 - The selected interpretation profile currently uses the `law-policy-v0` JSON schema. It selects laws, witness rules, molecule patterns, obstruction circuit definitions, signature axes, coverage requirements, and exactness assumptions separately from ArchMap. It is a profile, not AAT itself.
 - ArchSig reads ArchMap + interpretation profile and computes the North Star AAT analysis packet: AAT concept surfaces, architecture state, design pressure, change impact, architecture object projections, invariant family readings, LawUniverse reading, obstruction circuits, signature axes, analytic representations, semantic coupling/cohesion, workflow risk readings, spectral analysis readings, spectral mode readings, spectral drilldown readings, transfer bridge readings with edge source refs / review focus / cut recommendations, representation strength, local curvature diagrams, three-layer flatness, observation projection, state transition algebra, operation / invariant Galois readings, split readiness, structural reading review surface, current-state/evolution boundary, design principle readings, bounded judgements, repair operation deltas, path / homotopy / diagram readings, and LLM interpretation. Obstruction circuits, spectral readings, spectral modes, spectral drilldowns, transfer bridges, structural readings, and zero-curvature readings are not first-class ArchMap outputs.
-- `llm-native-workflow` / `north-star-workflow` and `archsig-analysis` / `aat-analysis` are the normal ArchSig entry points. Removed pre-Atom workflows remain available only through Git history; they are not current ArchSig surface or compatibility inputs.
+- `analyze` is the primary ArchSig workflow entry point. `llm-native-workflow` / `north-star-workflow` remain compatibility aliases for the same workflow, and `archsig-analysis` / `aat-analysis` remain step commands for building a packet from supplied inputs. Removed pre-Atom workflows remain available only through Git history; they are not current ArchSig surface or compatibility inputs.
 - `concernHints` are review cues. They are not obstruction circuits, not law violations, and not theorem evidence.
 - ArchMap validation rejects non-current root fields. Authoring must use the Atom observation fields above; pre-Atom ArchMap shapes are not compatibility inputs.
 - The ArchSig schema catalog contains only ArchMap, interpretation profile (`law-policy-v0`), ArchSig analysis packet, and their validation reports.
@@ -25,7 +25,7 @@ Atom handoff checklist:
 - [LawPolicy](law_policy.md)
 - [ArchSig Analysis Packet](archsig_analysis_packet.md)
 - [LLM-Native Golden Corpus](golden_corpus.md)
-- [LLM-native E2E Workflow](llm_native_e2e_workflow.md)
+- [ArchSig Analyze E2E Workflow](llm_native_e2e_workflow.md)
 
 Forward design PRDs:
 

--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -173,7 +173,7 @@ The builder:
 
 ## Downstream Handoff
 
-`llm-native-workflow` treats the analysis packet as the source artifact and
+`analyze` treats the analysis packet as the source artifact and
 emits only ArchMap validation, LawPolicy validation, the analysis packet, packet
 validation, and the LLM interpretation packet. Pre-Atom projections and review
 surfaces are not current ArchSig CLI surface or compatibility commands.

--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -1,8 +1,8 @@
-# LLM-native ArchMap / ArchSig E2E Workflow
+# ArchSig Analyze E2E Workflow
 
-This document fixes the end-to-end workflow required by the LLM-native
-ArchMap / interpretation profile / ArchSig redesign. It is an implementation
-transcript, not a new theory document.
+This document fixes the end-to-end workflow for ArchMap / interpretation
+profile / ArchSig `analyze`. It is an implementation transcript, not a new
+theory document.
 
 ## Flow
 
@@ -24,25 +24,25 @@ analysis packet as bounded current AAT structural state.
 Run the ArchSig workflow:
 
 ```bash
-mkdir -p .lake/llm-native-e2e/archsig .lake/llm-native-e2e/fieldsig
+mkdir -p .lake/archsig-analyze-e2e/archsig .lake/archsig-analyze-e2e/fieldsig
 
-cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
+cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out-dir .lake/llm-native-e2e/archsig
+  --out-dir .lake/archsig-analyze-e2e/archsig
 ```
 
-`north-star-workflow` is the equivalent visible command alias for the same
-ArchSig-owned route.
+`llm-native-workflow` and `north-star-workflow` are compatibility aliases for
+the same ArchSig-owned route. Use `analyze` in new scripts and CI.
 
 Expected ArchSig outputs:
 
 ```text
-.lake/llm-native-e2e/archsig/archmap-validation.json
-.lake/llm-native-e2e/archsig/law-policy-validation.json
-.lake/llm-native-e2e/archsig/archsig-analysis-packet.json
-.lake/llm-native-e2e/archsig/archsig-analysis-validation.json
-.lake/llm-native-e2e/archsig/llm-interpretation-packet.json
+.lake/archsig-analyze-e2e/archsig/archmap-validation.json
+.lake/archsig-analyze-e2e/archsig/law-policy-validation.json
+.lake/archsig-analyze-e2e/archsig/archsig-analysis-packet.json
+.lake/archsig-analyze-e2e/archsig/archsig-analysis-validation.json
+.lake/archsig-analyze-e2e/archsig/llm-interpretation-packet.json
 ```
 
 The LLM interpretation packet is byte-for-byte the same structured analysis
@@ -50,16 +50,16 @@ packet:
 
 ```bash
 cmp \
-  .lake/llm-native-e2e/archsig/archsig-analysis-packet.json \
-  .lake/llm-native-e2e/archsig/llm-interpretation-packet.json
+  .lake/archsig-analyze-e2e/archsig/archsig-analysis-packet.json \
+  .lake/archsig-analyze-e2e/archsig/llm-interpretation-packet.json
 ```
 
 Project the ArchSig analysis packet into FieldSig:
 
 ```bash
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
-  --analysis-packet .lake/llm-native-e2e/archsig/archsig-analysis-packet.json \
-  --out .lake/llm-native-e2e/fieldsig/operation-support-estimate.json
+  --analysis-packet .lake/archsig-analyze-e2e/archsig/archsig-analysis-packet.json \
+  --out .lake/archsig-analyze-e2e/fieldsig/operation-support-estimate.json
 ```
 
 The output must be `operation-support-estimate-v0` with
@@ -91,7 +91,7 @@ The E2E flow must preserve these boundaries:
 
 ## CI
 
-`.github/workflows/lean.yml` contains the `llm-native ArchMap/ArchSig e2e` job.
+`.github/workflows/lean.yml` contains the ArchSig analyze e2e job.
 The job runs the transcript above, validates key schema and boundary fields with
 `jq`, rejects raw ArchMap handoff to FieldSig, and uploads
-`.lake/llm-native-e2e` as an artifact.
+`.lake/archsig-analyze-e2e` as an artifact.

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -16,7 +16,7 @@ forecast, governance, calibration, and operational feedback under
 | --- | --- | --- |
 | ArchMap validation | `archmap`, `archmap-generate` | ArchMap records source-grounded Atom observations and concern hints. It does not select laws or output obstruction circuits. |
 | Interpretation profile | `law-policy`, `interpretation-profile` | The profile selects the LawUniverse, witness rules, signature axes, coverage requirements, exactness assumptions, and non-conclusions. It is not AAT itself. |
-| ArchSig analysis | `archsig-analysis`, `aat-analysis`, `llm-native-workflow`, `north-star-workflow`, `analysis-summary`, `summary` | ArchSig combines ArchMap and the profile into AAT concept surfaces, architecture state, design pressure, change impact, analytic axes, semantic coupling/cohesion, workflow risk readings, spectral analysis readings, spectral mode readings, spectral drilldown readings, transfer bridge readings with edge source refs / review focus / cut recommendations, representation strength, local curvature diagrams, three-layer flatness, observation projection, state transition algebra, operation / invariant Galois readings, split readiness, a structural reading review surface, a current-state/evolution boundary, design principle readings, bounded judgements, repair operation deltas, and an LLM interpretation packet. `analysis-summary` emits a compact review summary from an existing packet. |
+| ArchSig analysis | `analyze`, `llm-native-workflow`, `north-star-workflow`, `archsig-analysis`, `aat-analysis`, `analysis-summary`, `summary` | `analyze` is the primary workflow from ArchMap + LawPolicy to validation reports, `archsig-analysis-packet-v0`, and the LLM interpretation packet. `llm-native-workflow` and `north-star-workflow` remain compatibility aliases for the same workflow. `archsig-analysis` / `aat-analysis` build a packet from already validated inputs. `analysis-summary` emits a compact review summary from an existing packet. |
 | Schema | `schema-catalog` | The catalog lists only the current LLM Atom ArchMap artifacts. |
 
 Large ArchMaps may be authored in shards for review and parallel generation,
@@ -29,21 +29,22 @@ Git history is the archive for those workflows.
 ## Quick Start
 
 ```bash
-cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
+cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out-dir .archsig/llm-native
+  --out-dir .archsig/analyze
 ```
 
-`north-star-workflow` is the same current workflow under the North Star name.
+`llm-native-workflow` and `north-star-workflow` are compatibility aliases for
+the same workflow. Use `analyze` in new docs, scripts, and CI.
 
 This writes:
 
-- `.archsig/llm-native/archmap-validation.json`
-- `.archsig/llm-native/law-policy-validation.json`
-- `.archsig/llm-native/archsig-analysis-packet.json`
-- `.archsig/llm-native/archsig-analysis-validation.json`
-- `.archsig/llm-native/llm-interpretation-packet.json`
+- `.archsig/analyze/archmap-validation.json`
+- `.archsig/analyze/law-policy-validation.json`
+- `.archsig/analyze/archsig-analysis-packet.json`
+- `.archsig/analyze/archsig-analysis-validation.json`
+- `.archsig/analyze/llm-interpretation-packet.json`
 
 `llm-interpretation-packet.json` is the same structured packet written for LLM
 reading. It is not a natural-language judgment, Lean proof, architecture truth,
@@ -70,7 +71,7 @@ Typical use:
 1. Use `archmap-creater` to produce or refine the ArchMap.
 2. Use `law-policy-creater` to produce the selected LawPolicy for the target
    repository or subsystem.
-3. Run `llm-native-workflow`.
+3. Run `analyze`.
 4. Use `archsig-reader` to interpret the packet and compare it with source
    evidence before proposing improvements.
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -18,19 +18,20 @@ calibration commands under `tools/fieldsig`.
 ## Primary Workflow
 
 ```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .archsig/analyze
+```
+
+`llm-native-workflow` and `north-star-workflow` are visible compatibility
+aliases for the same workflow. Use `analyze` in new docs, scripts, and CI:
+
+```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- llm-native-workflow \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out-dir .archsig/llm-native
-```
-
-`north-star-workflow` is a visible alias for the same workflow:
-
-```bash
-cargo run --manifest-path tools/archsig/Cargo.toml -- north-star-workflow \
-  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
-  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out-dir .archsig/north-star
+  --out-dir .archsig/compat
 ```
 
 The command emits only:
@@ -49,11 +50,11 @@ To emit a compact review summary from an existing packet, run:
 
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary \
-  --packet .archsig/llm-native/archsig-analysis-packet.json \
-  --archmap-validation .archsig/llm-native/archmap-validation.json \
-  --law-policy-validation .archsig/llm-native/law-policy-validation.json \
-  --analysis-validation .archsig/llm-native/archsig-analysis-validation.json \
-  --out .archsig/llm-native/archsig-analysis-summary.json
+  --packet .archsig/analyze/archsig-analysis-packet.json \
+  --archmap-validation .archsig/analyze/archmap-validation.json \
+  --law-policy-validation .archsig/analyze/law-policy-validation.json \
+  --analysis-validation .archsig/analyze/archsig-analysis-validation.json \
+  --out .archsig/analyze/archsig-analysis-summary.json
 ```
 
 `summary` is a visible alias. The summary is a reading aid for human / LLM
@@ -84,7 +85,7 @@ monolithic `archmap-observation-map-v0` file before running:
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- archmap \
   --input .archsig/archmap/archmap.json \
-  --out .archsig/llm-native/archmap-validation.json
+  --out .archsig/analyze/archmap-validation.json
 ```
 
 Current commands intentionally keep the analysis contract monolithic. A future
@@ -97,22 +98,22 @@ references, and source refs before writing the exported ArchMap.
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- archmap \
   --input tools/archsig/tests/fixtures/minimal/archmap.json \
-  --out .archsig/llm-native/archmap-validation.json
+  --out .archsig/analyze/archmap-validation.json
 
 cargo run --manifest-path tools/archsig/Cargo.toml -- interpretation-profile \
   --input tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out .archsig/llm-native/law-policy-validation.json
+  --out .archsig/analyze/law-policy-validation.json
 
 cargo run --manifest-path tools/archsig/Cargo.toml -- aat-analysis \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out .archsig/llm-native/archsig-analysis-packet.json \
-  --validation-out .archsig/llm-native/archsig-analysis-validation.json \
-  --llm-interpretation-out .archsig/llm-native/llm-interpretation-packet.json
+  --out .archsig/analyze/archsig-analysis-packet.json \
+  --validation-out .archsig/analyze/archsig-analysis-validation.json \
+  --llm-interpretation-out .archsig/analyze/llm-interpretation-packet.json
 
 cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary \
-  --packet .archsig/llm-native/archsig-analysis-packet.json \
-  --out .archsig/llm-native/archsig-analysis-summary.json
+  --packet .archsig/analyze/archsig-analysis-packet.json \
+  --out .archsig/analyze/archsig-analysis-summary.json
 ```
 
 `law-policy` / `interpretation-profile` validate the selected analysis profile.
@@ -128,7 +129,7 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- archmap-generate \
   --prompt-pack tools/archsig/skills/archmap-creater/references/prompt-pack.md \
   --provider external-agent \
   --model-id unspecified \
-  --out .archsig/llm-native/archmap-generation-protocol.json
+  --out .archsig/analyze/archmap-generation-protocol.json
 ```
 
 This command emits a bounded protocol for an external agent to produce

--- a/tools/archsig/docs/sharded-archmap.md
+++ b/tools/archsig/docs/sharded-archmap.md
@@ -3,8 +3,8 @@
 This document defines the planned sharded ArchMap authoring format. The current
 runtime artifact remains `archmap-observation-map-v0`; sharding is an authoring
 and review layout that must bundle/export back to the monolithic artifact before
-current `archsig archmap`, `archsig archsig-analysis`, or
-`archsig llm-native-workflow` commands consume it.
+current `archsig archmap`, `archsig archsig-analysis`, or `archsig analyze`
+commands consume it.
 
 The primary sharding model is horizontal: each shard is a bounded observation
 slice over a repository surface, subsystem, package, team-owned area, or

--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -266,7 +266,7 @@ ${ARCHSIG_BIN:-archsig} archmap \
 
 ```
 
-6. Build downstream analysis only through the LLM-native path when a LawPolicy is available.
+6. Build downstream analysis through `archsig analyze` when a LawPolicy is available.
 
 ```bash
 ${ARCHSIG_BIN:-archsig} law-policy \
@@ -279,10 +279,10 @@ ${ARCHSIG_BIN:-archsig} archsig-analysis \
   --out .archsig/analysis/packet.json \
   --validation-out .archsig/analysis/validation.json
 
-${ARCHSIG_BIN:-archsig} llm-native-workflow \
+${ARCHSIG_BIN:-archsig} analyze \
   --archmap .archsig/archmap/archmap.json \
   --law-policy <law-policy.json> \
-  --out-dir .archsig/llm-native
+  --out-dir .archsig/analyze
 ```
 
 7. Read the validation report before handing the artifact downstream.

--- a/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
+++ b/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
@@ -242,8 +242,8 @@ ${ARCHSIG_BIN:-archsig} archsig-analysis \
   --out .archsig/analysis/packet.json \
   --validation-out .archsig/analysis/validation.json
 
-${ARCHSIG_BIN:-archsig} llm-native-workflow \
+${ARCHSIG_BIN:-archsig} analyze \
   --archmap <archmap.json> \
   --law-policy <law-policy.json> \
-  --out-dir .archsig/llm-native
+  --out-dir .archsig/analyze
 ```

--- a/tools/archsig/skills/archsig-reader/SKILL.md
+++ b/tools/archsig/skills/archsig-reader/SKILL.md
@@ -60,7 +60,7 @@ SKILL_DIR=<path-to-archsig-reader-skill>
 LAW_POLICY=<project-law-policy.json>
 ARCHSIG_BIN=${ARCHSIG_BIN:-archsig}
 
-"$ARCHSIG_BIN" llm-native-workflow \
+"$ARCHSIG_BIN" analyze \
   --archmap <archmap.json> \
   --law-policy "$LAW_POLICY" \
   --out-dir <out-dir>

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -16,7 +16,7 @@ use clap::{Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(
     version,
-    about = "Validate LLM-native ArchMap, LawPolicy, and ArchSig analysis artifacts"
+    about = "Validate ArchMap, LawPolicy, and ArchSig analysis artifacts"
 )]
 struct Args {
     #[command(subcommand)]
@@ -50,6 +50,22 @@ enum Command {
         /// Output LawPolicy fixture or validation report JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
+    },
+
+    /// Run the primary ArchMap + LawPolicy -> ArchSig analysis workflow.
+    #[command(visible_aliases = ["llm-native-workflow", "north-star-workflow"])]
+    Analyze {
+        /// Input ArchMap observation artifact path.
+        #[arg(long)]
+        archmap: PathBuf,
+
+        /// Input LawPolicy artifact path.
+        #[arg(long = "law-policy")]
+        law_policy: PathBuf,
+
+        /// Output directory for ArchSig analysis workflow artifacts.
+        #[arg(long = "out-dir")]
+        out_dir: PathBuf,
     },
 
     /// Build an ArchSig AAT analysis packet from ArchMap + interpretation profile.
@@ -125,22 +141,6 @@ enum Command {
         /// Output generation protocol JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
-    },
-
-    /// Run the ArchMap -> interpretation profile -> ArchSig North Star workflow.
-    #[command(visible_alias = "north-star-workflow")]
-    LlmNativeWorkflow {
-        /// Input ArchMap observation artifact path.
-        #[arg(long)]
-        archmap: PathBuf,
-
-        /// Input LawPolicy artifact path.
-        #[arg(long = "law-policy")]
-        law_policy: PathBuf,
-
-        /// Output directory for LLM-native workflow artifacts.
-        #[arg(long = "out-dir")]
-        out_dir: PathBuf,
     },
 
     /// Emit the current LLM Atom ArchMap schema catalog.
@@ -344,7 +344,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             write_json(out, &protocol)?;
             Ok(ExitCode::SUCCESS)
         }
-        Some(Command::LlmNativeWorkflow {
+        Some(Command::Analyze {
             archmap,
             law_policy,
             out_dir,
@@ -424,7 +424,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             Ok(ExitCode::SUCCESS)
         }
         None => {
-            Err("ArchSig is LLM-native ArchMap/LawPolicy/analysis-packet primary; use `archsig llm-native-workflow` for the main analysis path.".into())
+            Err("ArchSig is ArchMap/LawPolicy/analysis-packet primary; use `archsig analyze` for the main analysis path.".into())
         }
     }
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -32,6 +32,7 @@ fn cli_help_exposes_only_llm_atom_archmap_surface() {
         "aat-analysis",
         "analysis-summary",
         "summary",
+        "analyze",
         "llm-native-workflow",
         "north-star-workflow",
         "schema-catalog",
@@ -120,8 +121,8 @@ fn cli_rejects_summary_for_non_analysis_packet() {
 }
 
 #[test]
-fn cli_accepts_north_star_command_aliases() {
-    let out_dir = temp_dir("north-star-aliases");
+fn cli_accepts_analysis_command_aliases() {
+    let out_dir = temp_dir("analysis-aliases");
     let root = fixture_root();
     let profile_validation = out_dir.join("interpretation-profile-validation.json");
     run_sig0(&[
@@ -152,7 +153,7 @@ fn cli_accepts_north_star_command_aliases() {
     ]);
     assert_north_star_packet_surfaces(&read_json(&packet));
 
-    let workflow_dir = out_dir.join("workflow");
+    let workflow_dir = out_dir.join("legacy-workflow");
     run_sig0(&[
         "north-star-workflow",
         "--archmap",
@@ -167,6 +168,26 @@ fn cli_accepts_north_star_command_aliases() {
         workflow_dir.to_str().expect("workflow dir is utf-8"),
     ]);
     assert!(workflow_dir.join("archsig-analysis-packet.json").is_file());
+
+    let llm_native_dir = out_dir.join("llm-native-alias");
+    run_sig0(&[
+        "llm-native-workflow",
+        "--archmap",
+        root.join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("profile path is utf-8"),
+        "--out-dir",
+        llm_native_dir.to_str().expect("workflow dir is utf-8"),
+    ]);
+    assert!(
+        llm_native_dir
+            .join("archsig-analysis-packet.json")
+            .is_file()
+    );
 }
 
 #[test]
@@ -175,8 +196,9 @@ fn cli_rejects_implicit_scan_default() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("LLM-native ArchMap/LawPolicy/analysis-packet primary"),
-        "implicit scan should be rejected with an LLM-native boundary\n{stderr}"
+        stderr.contains("ArchMap/LawPolicy/analysis-packet primary")
+            && stderr.contains("archsig analyze"),
+        "implicit scan should be rejected with the analyze boundary\n{stderr}"
     );
 }
 
@@ -192,14 +214,14 @@ fn removed_legacy_commands_are_not_accepted() {
 }
 
 #[test]
-fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
-    let out_dir = temp_dir("llm-native-workflow");
+fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
+    let out_dir = temp_dir("analyze-workflow");
     let root = fixture_root();
     let archmap = root.join("archmap.json");
     let law_policy = root.join("law_policy.json");
 
     run_sig0(&[
-        "llm-native-workflow",
+        "analyze",
         "--archmap",
         archmap.to_str().expect("archmap path is utf-8"),
         "--law-policy",
@@ -218,7 +240,7 @@ fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
     for file in expected {
         assert!(
             out_dir.join(file).is_file(),
-            "LLM-native workflow must write {file}"
+            "analyze workflow must write {file}"
         );
     }
     for removed_file in [
@@ -231,7 +253,7 @@ fn cli_runs_llm_native_archmap_lawpolicy_archsig_workflow() {
     ] {
         assert!(
             !out_dir.join(removed_file).exists(),
-            "LLM-native workflow must not emit legacy artifact {removed_file}"
+            "analyze workflow must not emit legacy artifact {removed_file}"
         );
     }
 

--- a/tools/fieldsig/skills/archmap-creater/SKILL.md
+++ b/tools/fieldsig/skills/archmap-creater/SKILL.md
@@ -76,7 +76,7 @@ ${ARCHSIG_BIN:-archsig} archmap \
 
 ```
 
-5. Build downstream analysis only through the LLM-native path when a LawPolicy is available.
+5. Build downstream analysis through `archsig analyze` when a LawPolicy is available.
 
 ```bash
 ${ARCHSIG_BIN:-archsig} law-policy \
@@ -89,10 +89,10 @@ ${ARCHSIG_BIN:-archsig} archsig-analysis \
   --out .archsig/analysis/packet.json \
   --validation-out .archsig/analysis/validation.json
 
-${ARCHSIG_BIN:-archsig} llm-native-workflow \
+${ARCHSIG_BIN:-archsig} analyze \
   --archmap <archmap.json> \
   --law-policy <law-policy.json> \
-  --out-dir .archsig/llm-native
+  --out-dir .archsig/analyze
 ```
 
 6. Read the validation report before handing the artifact downstream.

--- a/tools/fieldsig/skills/archmap-creater/references/schema-cheatsheet.md
+++ b/tools/fieldsig/skills/archmap-creater/references/schema-cheatsheet.md
@@ -209,8 +209,8 @@ ${ARCHSIG_BIN:-archsig} archsig-analysis \
   --out .archsig/analysis/packet.json \
   --validation-out .archsig/analysis/validation.json
 
-${ARCHSIG_BIN:-archsig} llm-native-workflow \
+${ARCHSIG_BIN:-archsig} analyze \
   --archmap <archmap.json> \
   --law-policy <law-policy.json> \
-  --out-dir .archsig/llm-native
+  --out-dir .archsig/analyze
 ```


### PR DESCRIPTION
## 概要

Closes #1443

ArchSig の primary workflow command として `analyze` を追加し、ArchMap + LawPolicy から validation reports / `archsig-analysis-packet-v0` / LLM interpretation packet を出す本線として表示されるようにしました。`llm-native-workflow` / `north-star-workflow` は互換 alias として維持し、README / command guide / skills / CI e2e は `analyze` primary に更新しています。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/docs/sharded-archmap.md`
- `tools/archsig/skills/archmap-creater/SKILL.md`
- `tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md`
- `tools/archsig/skills/archsig-reader/SKILL.md`
- `tools/fieldsig/skills/archmap-creater/SKILL.md`
- `tools/fieldsig/skills/archmap-creater/references/schema-cheatsheet.md`
- `docs/tool/README.md`
- `docs/tool/llm_native_e2e_workflow.md`
- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [x] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean ソース変更なしのため未実施）
- [x] `cargo fmt --manifest-path tools/archsig/Cargo.toml --check`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/tests/fixtures/minimal/archmap.json --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json --out-dir .lake/issue-1443-analyze-check`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- --help`

## チェックリスト

- [x] 対象 Issue を `Closes #1443` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない