### PR TITLE
ArchSig monodromy / boundary holonomy 計測PRDを追加

### DIFF
--- a/docs/note/boundary_holonomy_conjecture.md
+++ b/docs/note/boundary_holonomy_conjecture.md
@@ -1,0 +1,428 @@
+# 境界ホロノミー予想
+
+**Boundary Holonomy Conjecture for Software Architecture Extension**
+
+AAT では feature extension は `ext_f : A -> B` と書かれ、Atom level では既存 Atom family `F_A` に feature 側の Atom family `F_f` を加えて `F_B = F_A union F_f` と読む、という形になっています。また、split extension は「元 core を壊さず、追加 feature を独立した subconfiguration として読める」拡張であり、さらに interaction law が満たされるなら `Lawful_U(A) -> Lawful_U(B)` が成り立つ、という保存命題が置かれています。
+
+その上で、次の予想を立てます。
+
+---
+
+## 予想：拡張の obstruction は境界に局在化する
+
+`A` を既存 architecture object、`ext_f : A -> B` を feature extension とする。
+`U` を selected law universe、`S` を required signature axes、`κ_U` を curvature valuation とする。
+
+feature extension に対して、core と feature の接触部分を
+
+```text
+∂f = Boundary(A, f)
+```
+
+と書く。これは、core 側 Atom と feature 側 Atom のあいだに現れる
+
+```text
+relation
+capability use
+contract refinement
+state read/write
+effect ordering
+authority / trust
+runtime interaction
+semantic interpretation
+```
+
+の混合 subconfiguration である。
+
+このとき、十分な coverage、witness completeness、axis exactness、semantic/runtime observation の exactness があるなら、拡張後の新しい obstruction は次の三成分に分解できる。
+
+```text
+κ_U(B)
+  =
+κ_U(A)
+  + κ_U(f)
+  + Hol_U(∂f)
+```
+
+ここで、
+
+```text
+κ_U(A)      : 既存 core にすでにあった curvature
+κ_U(f)      : feature 内部の curvature
+Hol_U(∂f)   : core と feature の境界に生じる holonomy
+```
+
+である。
+
+特に、`A` が lawful で、feature `f` も内部的に lawful である場合、
+
+```text
+Flat_U(B)
+  iff
+Flat_U(A)
+and Flat_U(f)
+and Hol_U(∂f) = 0
+```
+
+が成り立つ。
+
+これを **境界ホロノミー予想** と呼びたいです。
+
+---
+
+## 直感
+
+この予想が言っているのは、かなり現場的にはこうです。
+
+「既存システムも綺麗、追加 feature も単体では綺麗。それでも壊れるとしたら、壊れている場所は feature の内部ではなく、core と feature の境界にある。」
+
+つまり、拡張の危険性は feature の大きさそのものではなく、
+
+```text
+feature が core のどの contract を使うか
+feature が core のどの state を読むか
+feature がどの effect order を変えるか
+feature が既存 semantic をどう解釈するか
+feature が runtime interaction を増やすか
+feature が authority / trust boundary を越えるか
+```
+
+に局在化する、という主張です。
+
+AAT 本文にはすでに、feature extension の obstruction が
+
+```text
+inherited core obstruction
+feature-local obstruction
+interaction obstruction
+lifting failure
+filling failure
+complexity transfer
+residual coverage gap
+```
+
+として分類される、という Architecture Extension Formula があります。
+この予想は、その分類のうち特に `interaction obstruction`、`lifting failure`、`filling failure` を **境界ホロノミー** という一つの幾何的対象にまとめられるのではないか、という強化です。
+
+---
+
+## Holonomy の定義案
+
+境界ホロノミー `Hol_U(∂f)` は、core と feature をまたぐ mixed diagram の非可換性として定義します。
+
+たとえば、ある値・状態・効果・意味が、二つの path で読めるとします。
+
+```text
+core state
+  -> feature operation
+  -> core effect
+```
+
+と
+
+```text
+core state
+  -> declared interface
+  -> core effect
+```
+
+が同じ観測に落ちるべきなら、次の diagram が可換である必要があります。
+
+```text
+Obs(path_1) = Obs(path_2)
+```
+
+ずれがあるなら、
+
+```text
+Hol_U(∂f) != 0
+```
+
+です。
+
+AAT では law failure を curvature として読み、lawfulness、required obstruction absence、signature axes zero、zero curvature が exactness の下で一致する、という zero curvature theorem が置かれています。
+境界ホロノミー予想は、その zero curvature theorem を **feature extension の相対版** にするものです。
+
+---
+
+## もう少し数学的な形
+
+より美しく書くなら、extension に対する相対 signature を置きます。
+
+```text
+Sig_rel(ext_f)
+  =
+Sig(B) / (Sig(A) + Sig(f))
+```
+
+ただし、ここでの `/` は単純な数値除算ではなく、「core 由来の軸」と「feature-local 由来の軸」を除いたあとの residual signature です。
+
+予想は次の形になります。
+
+```text
+Sig_rel(ext_f) ≅ Hol_U(∂f)
+```
+
+つまり、
+
+```text
+拡張によって新しく生まれた residual obstruction
+=
+境界を一周したときに戻ってこない量
+```
+
+です。
+
+さらに、exact sequence 風に書くとこうです。
+
+```text
+0
+-> Ob_U(A)
+-> Ob_U(B)
+-> Ob_U(f) ⊕ Hol_U(∂f)
+-> CovGap_U(ext_f)
+-> 0
+```
+
+coverage gap が 0 の場合、
+
+```text
+Ob_U(B) ≅ Ob_U(A) ⊕ Ob_U(f) ⊕ Hol_U(∂f)
+```
+
+になる。
+
+この形はかなり AAT らしいと思います。
+なぜなら、AAT は architecture quality を単一値ではなく、多軸 signature、obstruction、curvature、operation path、homotopy の構造として読む理論だからです。
+
+---
+
+## 非自明性
+
+これは単なる「依存を増やさなければ安全」という話ではありません。
+
+AAT では static / runtime / semantic flatness は一般には互いに含意しない、とされています。つまり、static dependency が綺麗でも runtime retry storm や semantic contract mismatch は残りうる。
+
+したがって、境界ホロノミーは単一値ではなく、
+
+```text
+Hol_U(∂f)
+  =
+(
+  Hol_static(∂f),
+  Hol_runtime(∂f),
+  Hol_semantic(∂f),
+  Hol_effect(∂f),
+  Hol_authority(∂f)
+)
+```
+
+のような多軸量でなければならない。
+
+ここが非自明です。
+
+たとえば static には安全に見える feature extension でも、semantic boundary で壊れることがあります。AAT の coupon extension の例では、coupon feature は price calculation に Atom を追加しますが、rounding、tax、payment amount の law が壊れると semantic obstruction が生じます。
+
+つまり、
+
+```text
+Hol_static(∂f) = 0
+```
+
+でも、
+
+```text
+Hol_semantic(∂f) != 0
+```
+
+が起こりうる。
+
+これがこの予想の強さです。
+
+---
+
+## 現場的な意味
+
+この予想が正しいなら、実務ではかなり役に立ちます。
+
+feature を追加するとき、全システムを再解析する代わりに、次を調べればよい。
+
+```text
+1. core は既に flat か
+2. feature 単体は flat か
+3. core-feature boundary の Hol_U(∂f) は 0 か
+```
+
+これが成立すれば、
+
+```text
+feature extension is safe
+```
+
+と判定できる可能性があります。
+
+逆に、障害や設計劣化が起きたときも、
+
+```text
+core が悪いのか
+feature が悪いのか
+境界が悪いのか
+観測 coverage が足りないのか
+```
+
+を分解できます。
+
+これは現場では、
+
+```text
+PR / CI での architecture regression check
+feature flag rollout の事前検査
+microservice 追加時の contract boundary 検査
+DDD aggregate 追加時の semantic boundary 検査
+event-driven system の handler / effect ordering 検査
+permission / authority leak の検査
+```
+
+に使えるはずです。
+
+---
+
+## Coupon Extension での読み
+
+AAT の coupon extension では、次の law が出ています。
+
+```text
+FinalAmount = round(tax(discount(subtotal)))
+PaymentAmount = FinalAmount
+ReceiptAmount = FinalAmount
+```
+
+もし feature 内部では coupon calculation が正しく、既存 checkout core も正しいのに、
+
+```text
+subtotal -> discount -> tax -> round
+subtotal -> tax -> discount -> round
+```
+
+の二つが異なる値を返すなら、それは feature 内部だけの失敗でも core 内部だけの失敗でもありません。core の price semantics と coupon feature の discount semantics の境界で発生する obstruction です。AAT 本文でも、このような rounding order や discount application order の観測差は semantic obstruction として読まれています。
+
+境界ホロノミー予想では、これは
+
+```text
+Hol_semantic(∂coupon) != 0
+```
+
+と読む。
+
+そして repair は、
+
+```text
+discount と tax の順序を固定する
+FinalAmount contract を強化する
+PaymentAmount / ReceiptAmount との diagram を可換にする
+rounding policy を boundary contract に昇格する
+```
+
+のいずれかになる。
+
+---
+
+## Homotopy 版の派生予想
+
+この予想には、美しい派生形があります。
+
+二つの feature extension
+
+```text
+ext_f : A -> A_f
+ext_g : A -> A_g
+```
+
+があるとき、AAT では独立な feature extension は可換 square を作り、`f` の後に `g` を行う path と `g` の後に `f` を行う path は homotopic に読める、という形が示されています。
+
+そこで次の派生予想が立てられます。
+
+```text
+ext_g . ext_f  ~  ext_f . ext_g
+  iff
+Hol_U(∂f, ∂g) = 0
+```
+
+つまり、
+
+```text
+二つの feature の追加順序が architecture 的に同じである
+```
+
+ことと、
+
+```text
+二つの feature の相互境界 holonomy が 0 である
+```
+
+ことが対応する。
+
+これはとても実務的です。
+ロードマップ上で feature `f` と `g` の追加順序を入れ替えてよいか、という判断が、
+
+```text
+pairwise boundary holonomy
+```
+
+の計算問題になります。
+
+---
+
+## CS への寄与可能性
+
+この予想が成立すると、ソフトウェア工学に次の方向を開けます。
+
+第一に、**modular architecture verification** です。全体を毎回検証するのではなく、拡張境界の diagram だけを見ることで安全性を判定する理論になります。
+
+第二に、**feature interaction problem の代数化**です。feature 同士の干渉を、ad hoc な経験則ではなく、mixed boundary holonomy として扱える。
+
+第三に、**architecture CI の理論的基礎**になります。PR が追加した Atom family `F_f` と、既存 core `F_A` の境界 `∂f` だけから、semantic regression、effect ordering regression、authority leak を検出する設計が可能になります。
+
+第四に、**architecture synthesis / no-solution certificate** につながります。ある boundary holonomy が消せないなら、「この制約のままでは安全な extension は存在しない」という certificate になる可能性があります。AAT では no-solution soundness には制約言語、decision procedure、coverage、exactness の明示が必要とされているので、この予想はその certificate の具体的な候補にもなります。
+
+---
+
+## 予想の短い定式化
+
+最後に、論文向けに短く書くならこうです。
+
+```text
+Conjecture: Boundary Holonomy of Feature Extension
+
+Let ext_f : A -> B be a feature extension in an AAT model
+with exact witness family W, required signature axes S,
+and curvature valuation κ_U.
+
+Assume:
+  1. A is U-flat.
+  2. f is internally U-flat.
+  3. observation over A, f, and ∂f is W-complete and S-exact.
+  4. residual coverage gap is zero.
+
+Then:
+  B is U-flat
+  iff
+  Hol_U(∂f) = 0.
+
+More generally:
+  κ_U(B)
+    =
+  κ_U(A) + κ_U(f) + Hol_U(∂f)
+  up to the selected signature equivalence.
+```
+
+日本語では：
+
+```text
+完全観測かつ exact な AAT model において、
+既存 core と追加 feature がそれぞれ flat であるなら、
+拡張後 architecture の flatness を妨げる obstruction は
+core-feature 境界の holonomy によって完全に測られる。
+```
+
+これが、AAT におけるソフトウェアアーキテクチャ拡張のかなり有望な中心予想だと思います。

--- a/docs/note/path_monodromy_obstruction_theorem.md
+++ b/docs/note/path_monodromy_obstruction_theorem.md
@@ -1,0 +1,535 @@
+# AAT 解析接続ホロノミー定理
+
+## Path-Monodromy Obstruction Theorem
+
+AAT本文では、すでに Atom から architecture object・law・obstruction・signature・operation が立ち上がること、そして operation は Atom configuration の変換として扱えることが置かれています。さらに、零曲率・zero obstruction・required signature axes zero が exactness の下で一致し、path は signature trajectory を持ち、homotopy は selected observation / trajectory を保存する、という土台もあります。
+
+---
+
+## 1. 新しい観測量：Architecture Monodromy Index
+
+AATの既存の `Sig(A)` は対象 `A` の多軸状態を読む。ここでさらに、**対象そのものではなく、対象へ到達する経路の解析接続**を読む。
+
+二つの操作 `f, g` が、粗い観測では独立に見えるとする。
+
+```text
+A --f--> A_f
+|        |
+g        g
+v        v
+A_g --f--> A_fg
+```
+
+このとき二つの path がある。
+
+```text
+p = g ∘ f : A -> A_fg
+q = f ∘ g : A -> A_fg
+```
+
+既存AATでは、独立ならこの square は可換であり、二つの path は homotopic に読める。逆に signature trajectory が違えば、その selected homotopy に関しては同値ではない。
+
+ここで各 signature axis `x` について、path に沿って signature / witness / state transition を解析接続する写像を置く。
+
+```text
+Cont_x(p)
+```
+
+そして square の **monodromy defect** を定義する。
+
+```text
+mu_x(f,g;A)
+  = d_x( Cont_x(g ∘ f), Cont_x(f ∘ g) )
+```
+
+`d_x` は axis ごとの距離でよい。
+
+```text
+boolean mismatch
+count
+edit distance
+semantic distance
+state transition distance
+contract mismatch count
+effect replay mismatch count
+authorization mismatch count
+```
+
+そして全体量を次で置く。
+
+```text
+AMI_X(A)
+  = sum_{claimed independent squares sigma}
+    sum_{x in X} w_{sigma,x} * mu_x(sigma)
+```
+
+これを **Architecture Monodromy Index**, 略して **AMI** と呼ぶ。
+
+---
+
+## 2. 定理本体
+
+**定理：AAT 解析接続ホロノミー定理**
+
+`A` を architecture object、`U` を selected law universe、`X` を観測する signature axes の集合とする。`Ops` を feature extension、repair、migration、substitution、split、protect などの operation family とし、それらから生成される operation path complex を `K_O(A)` とする。
+
+次を仮定する。
+
+```text
+1. 各 axis x in X の距離 d_x は zero-reflecting である。
+   d_x(u,v)=0 iff selected observation 上で u=v
+
+2. witness family は U に関して complete である。
+
+3. signature axes X は selected law failure を exact に読む。
+
+4. homotopy generator は selected continuation を保存する。
+
+5. K_O(A) の covered loop / square は、選ばれた generator で生成される。
+```
+
+このとき、次が成り立つ。
+
+```text
+AMI_X(A) = 0
+```
+
+であることは、covered operation complex 上で次と同値である。
+
+```text
+すべての claimed independent square は fillable である
+すべての covered path pair は selected homotopy の下で同値である
+解析接続 Cont_x は path-independent である
+covered axes X 上に mixed-axis obstruction は存在しない
+```
+
+逆に、
+
+```text
+AMI_X(A) > 0
+```
+
+なら、ある operation square `sigma` と axis `x` が存在して、
+
+```text
+mu_x(sigma) > 0
+```
+
+となる。したがって、その square は selected observation に関して fill できず、対応する law failure の obstruction circuit が存在する。
+
+つまり、
+
+```text
+nonzero monodromy
+  -> non-fillability
+  -> obstruction
+  -> non-flatness on selected covered axes
+```
+
+である。
+
+---
+
+## 3. さらに強い帰結：局所零曲率でも大域 obstruction は残る
+
+この定理の意外性はここです。
+
+通常の静的解析やレビューは、しばしば次を見る。
+
+```text
+final dependency graph
+cycle count
+layering
+endpoint object
+local contract check
+single operation diff
+```
+
+しかし AAT の path calculus では、同じ endpoint に到達する二つの path が異なる signature trajectory を持ちうる。
+
+したがって、次が起こる。
+
+```text
+kappa_local(A_i) = 0 for every local step
+static_projection(g ∘ f)(A) = static_projection(f ∘ g)(A)
+but
+AMI_X(A) > 0
+```
+
+この場合、局所チェックは全部通っている。最終 dependency graph も同じに見える。それでも、operation を一周させたときに runtime / semantic / state / effect axis が戻ってこない。
+
+これを AAT では次のように読む。
+
+```text
+local zero curvature
+  does not imply
+global flatness
+
+local zero curvature + zero monodromy
+  implies
+covered global flatness
+```
+
+これは既存の Architecture Zero Curvature Theorem の path 版です。既存定理は「対象 `A` の zero curvature」を lawfulness と結ぶ。一方この新定理は、「operation space 上の解析接続の holonomy zero」を path-independent lawfulness と結ぶ。零曲率 theorem が点の幾何なら、これは **経路空間の幾何** です。
+
+---
+
+## 4. 証明スケッチ
+
+### Step 1：非ゼロ AMI は非ゼロ局所 defect を含む
+
+`AMI_X(A)` は非負重み付き和として定義される。
+
+```text
+AMI_X(A)
+  = sum w * mu
+```
+
+すべての重みが正で値域が nonnegative なら、全体が zero であることから各項の zero が従う、という形の zero-reflection はAAT本文にも置かれている。
+
+したがって、
+
+```text
+AMI_X(A) > 0
+```
+
+なら、ある `sigma, x` について、
+
+```text
+mu_x(sigma) > 0
+```
+
+である。
+
+### Step 2：`mu_x > 0` は path homotopy を壊す
+
+`mu_x(sigma)` は二つの path の解析接続結果の距離である。
+
+```text
+mu_x(f,g;A)
+  = d_x( Cont_x(g ∘ f), Cont_x(f ∘ g) )
+```
+
+`d_x` が zero-reflecting なので、
+
+```text
+mu_x > 0
+```
+
+なら、
+
+```text
+Cont_x(g ∘ f) != Cont_x(f ∘ g)
+```
+
+である。
+
+AAT本文では、selected signature trajectory が homotopy generator によって保存されるなら、homotopic path は同じ trajectory を持つ。反対向きに、trajectory が違えばその selected homotopy では同値でない。
+
+したがって、
+
+```text
+mu_x > 0
+  -> not (g ∘ f ~ f ∘ g)
+```
+
+である。
+
+### Step 3：非同値 square は filler を持たない
+
+AAT本文では、law failure が diagram の非可換性として表されるなら、その obstruction は non-fillability witness として読める。
+
+よって、
+
+```text
+Cont_x(g ∘ f) != Cont_x(f ∘ g)
+```
+
+は、
+
+```text
+no filler for the square
+```
+
+を与える。
+
+### Step 4：non-fillability は obstruction である
+
+AATの obstruction valuation / curvature / signature axes が exact であるなら、
+
+```text
+law failure
+  <-> obstruction
+  <-> nonzero curvature
+  <-> required signature axis nonzero
+```
+
+という対応が使える。
+
+したがって、
+
+```text
+AMI_X(A) > 0
+  -> selected obstruction exists
+```
+
+である。
+
+### Step 5：局所零曲率でも AMI は残りうる
+
+AAT本文では、analytic representation は selected axes の読みであり、解析値だけから architecture object 全体は還元できない。また、axis を忘れる projection は coarse reading を保存できても、forgotten axes や mixed-axis support がある場合、coarse zero から structural zero は一般には反射しない。
+
+したがって、
+
+```text
+static_projection = 0
+local_static_curvature = 0
+```
+
+でも、
+
+```text
+semantic / runtime / state / effect monodromy != 0
+```
+
+はありうる。
+
+これが、この定理が静的解析との差分を作る点です。
+
+---
+
+## 5. なぜこれは「普通の静的解析」では出にくいか
+
+静的解析は主に `G(A)` や `M(A)`、つまり dependency graph、reachability、cycle、layering、matrix nilpotence などを見る。AAT本文でも graph / matrix representation は dependency や walk count を読むものとして位置づけられている。
+
+しかし AMI が見るのは、対象 `A` ではなく、
+
+```text
+operation path pair
+operation square
+path-dependent signature trajectory
+state transition composition
+effect replay composition
+semantic continuation
+```
+
+である。
+
+つまり比較対象はこれです。
+
+```text
+static analyzer:
+  inspect final A
+
+AAT monodromy analyzer:
+  compare g ∘ f with f ∘ g
+  compare their continued witnesses
+  measure the commutator on each axis
+```
+
+これはレビューの「この変更は大丈夫そうか」という単発判断ではなく、**変更の交換可能性そのものを測る**。レビューが見ている object-level difference ではなく、AAT は path-level noncommutativity を見る。
+
+---
+
+## 6. 具体例：Coupon / Tax / Rounding
+
+AAT本文の coupon feature 例は、この定理の典型例です。coupon extension は price calculation、discount policy、rounding、tax、payment、event emission に Atom を追加し、static dependency が増えなくても rounding law や payment amount law が壊れるなら semantic obstruction が生じる、とされています。
+
+二つの操作を置く。
+
+```text
+f = add coupon discount
+g = add tax / rounding rule
+```
+
+粗い静的観測では、どちらの順に入れても最終的な component set や dependency graph は同じに見えるかもしれない。
+
+しかし計算 path は違う。
+
+```text
+p = round(tax(discount(subtotal)))
+q = round(discount(tax(subtotal)))
+```
+
+このとき、
+
+```text
+mu_amount(f,g;Checkout)
+  = | p(subtotal) - q(subtotal) |
+```
+
+と置ける。
+
+さらに payment / receipt まで含めるなら、
+
+```text
+mu_payment
+  = count(PaymentAmount != FinalAmount)
+    + count(ReceiptAmount != FinalAmount)
+```
+
+したがって、
+
+```text
+AMI_price > 0
+```
+
+なら、
+
+```text
+coupon-tax square is not fillable
+```
+
+であり、semantic / state / effect axis 上の obstruction がある。AAT本文でも、discount と tax が可換である law が成り立つ場合に限り二つの path は同じ calculation として読め、可換でないなら homotopy は存在しない、とされています。
+
+---
+
+## 7. ツールで測る方法
+
+実装可能な測定仕様はかなり明確です。
+
+### 7.1 入力
+
+```text
+A          : current architecture object
+Ops        : candidate operations
+X          : selected axes
+U          : law universe
+R(A)       : analytic representation
+```
+
+AAT本文では analytic representation は次の族です。
+
+```text
+R(A) = (G(A), M(A), Sig(A), kappa(A), State(A))
+```
+
+したがって AMI は、この `Sig`, `kappa`, `State` を path 上に拡張して測ります。
+
+### 7.2 候補 square の列挙
+
+ペア `f, g` を列挙する。
+
+```text
+same support に触る operation
+同じ state を読む/書く operation
+同じ effect を発生させる operation
+同じ contract / semantic Atom に触る operation
+同じ authority / trust boundary を横断する operation
+```
+
+feature extension では、AAT本文がすでに core embedding、feature view、lifting data、runtime / semantic coverage に相対化して split を読む構造を持っているため、split claim の検査点として AMI を差し込める。
+
+### 7.3 二つの順序を実行またはシミュレート
+
+```text
+A_p = g(f(A))
+A_q = f(g(A))
+```
+
+それぞれについて、
+
+```text
+Sig(A_p), Sig(A_q)
+kappa(A_p), kappa(A_q)
+StateTransition(p), StateTransition(q)
+EffectTrace(p), EffectTrace(q)
+SemanticWitness(p), SemanticWitness(q)
+```
+
+を取る。
+
+### 7.4 axis ごとの defect
+
+```text
+mu_static       = distance(G(A_p), G(A_q))
+mu_contract     = count(contract witness mismatch)
+mu_semantic     = count(semantic witness mismatch)
+mu_state        = count or metric of t_p(s) != t_q(s)
+mu_effect       = replay / idempotency / compensation mismatch count
+mu_authority    = permission / access path mismatch count
+mu_projection   = projection soundness mismatch count
+```
+
+State / effect に関しては、AAT本文で effect または operation が state transition を誘導し、transition law は可換性・冪等性・保存性・補償性として読まれる、と定義されています。
+
+### 7.5 出力
+
+ツールは次を返せばよい。
+
+```text
+AMI_X(A)
+top nonzero squares
+offending operation pair
+axis x
+witness atoms
+p = g ∘ f の trace
+q = f ∘ g の trace
+mu_x value
+suggested filler / lifting / boundary evidence
+```
+
+これにより、単なる「循環があります」「依存方向が逆です」ではなく、
+
+```text
+この二つの変更は単独では安全だが、順序を交換すると semantic amount が変わる
+この repair は cycle を減らすが、contract axis に monodromy を生む
+この split は static には成功するが、runtime handler / effect ordering の filler がない
+```
+
+という診断ができます。
+
+---
+
+## 8. AAT本文に追加するなら、この形がよい
+
+そのまま第II部の Homotopy と Diagram Filling の後、または第III部の Analytic Representation の後に入れるなら、次の節名がよいです。
+
+```text
+## Architecture Analytic Continuation and Monodromy
+```
+
+追加する定義・定理はこれです。
+
+```text
+定義: Operation Complex
+定義: Analytic Continuation along Architecture Path
+定義: Square Monodromy
+定義: Architecture Monodromy Index
+定理: Path-Monodromy Obstruction Theorem
+系: Local Flatness Does Not Imply Global Path-Flatness
+系: Zero Local Curvature + Zero Monodromy Implies Covered Global Flatness
+系: Static-Zero / Semantic-Monodromy Separation
+```
+
+特に最後の系が、静的解析との差分になります。
+
+```text
+StaticZero(A,p,q) and AMI_semantic(p,q) > 0
+------------------------------------------------
+There exists a semantic obstruction invisible to static projection.
+```
+
+これはAAT本文にある「static flat でも semantic obstruction が残る」「三層 flatness は一般に相互含意しない」という既存主張を、path と解析接続の言葉で強化したものです。
+
+---
+
+## 9. 一文でいうと
+
+この定理の核心は、次です。
+
+```text
+アーキテクチャの危険は、最終状態の形だけでなく、
+「そこへ至る変更経路を一周させたとき、意味・状態・effect が元に戻るか」
+に現れる。
+```
+
+その戻り損ねが
+
+```text
+AMI_X(A) > 0
+```
+
+であり、それは selected exactness の下で obstruction の存在を証明する。
+
+これなら、AATの既存要素である Atom、signature、curvature、operation、path、homotopy、diagram filling、analytic representation を全部使い、しかもツールで定量測定できます。Static graph が acyclic、final object が同じ、レビュー上は自然、という状況でも、operation square の monodromy が非ゼロなら AAT は「ここに obstruction がある」と言えます。

--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -32,5 +32,6 @@ Forward design PRDs:
 - [LLM-native ArchMap / ArchSig PRD](llm_native_archmap_archsig_prd.md)
 - [ArchSig AAT Analysis Engine PRD](archsig_aat_analysis_engine_prd.md)
 - [ArchSig v0.3.0 Measurement Expansion PRD](archsig_v0_3_0_measurement_expansion_prd.md)
+- [ArchSig Monodromy / Boundary Holonomy Measurement PRD](archsig_monodromy_boundary_holonomy_prd.md)
 
 New implementation-facing specification documents should be added here only when they match the implementation and keep those boundaries explicit. Forward PRDs should keep future schema and migration work separate from the current source-of-truth boundaries above.

--- a/docs/tool/archsig_monodromy_boundary_holonomy_prd.md
+++ b/docs/tool/archsig_monodromy_boundary_holonomy_prd.md
@@ -1,0 +1,474 @@
+# ArchSig Monodromy / Boundary Holonomy Measurement PRD
+
+この PRD は、ArchSig に path monodromy と boundary holonomy の実用計測面を追加するための要求を定義する。
+
+中心方針は次である。
+
+```text
+practical ArchSig measurement
+  > bounded claim boundary
+  > minimal Lean guardrail
+  > AAT mathematical exposition
+  > later workflow polish
+```
+
+この PRD では、Lean で完全な monodromy 理論を証明することを主目的にしない。
+ArchSig が実 repository / supplied ArchMap / LawPolicy / analysis packet から、変更順序、
+feature boundary、semantic / state / effect / authority の交換不能性を実用的に読めることを
+第一の目的にする。
+
+ArchSig の出力は、次の形の bounded diagnosis として読む。
+
+```text
+ArchSig detected nonzero measured monodromy
+on selected axes under recorded coverage and exactness assumptions.
+```
+
+これは architecture lawfulness、global safety、future correctness、Lean theorem discharge を
+結論するものではない。
+
+## 要求
+
+### R0. ArchSig の実用計測を最優先にする
+
+ArchSig は、path monodromy と boundary holonomy を theoretical decoration ではなく、
+review / design diagnosis に使える測定面として扱わなければならない。
+
+優先する問いは次である。
+
+```text
+この二つの operation は順序を入れ替えても同じ architecture reading を保つか。
+この feature extension は core / feature boundary で semantic, state, effect, authority を戻せるか。
+この obstruction は core 内部、feature 内部、境界、coverage gap のどこに局在するか。
+```
+
+ArchSig は、少なくとも次を出力できなければならない。
+
+- measured operation pair
+- compared path pair
+- selected axes
+- axis-wise defect
+- aggregate monodromy index
+- affected Atom / molecule / component / boundary refs
+- source refs / observation refs
+- coverage status
+- exactness assumption status
+- top nonzero measured squares
+- suggested filler / lifting / boundary evidence
+- non-conclusions
+
+### R1. 現場アウトカムを定義する
+
+この実装により、現場のエンジニアは次を得られなければならない。
+
+第一に、変更順序の危険を merge 前に読めるようになる。
+ArchSig は、二つの operation を入れ替えたときに semantic、state、effect、authority の
+読みが変わる箇所を、operation-order sensitivity として示す。
+これにより、engineer は「単独では安全に見える二つの変更」が組み合わさると壊れるケースを
+PR review や設計レビューで早く見つけられる。
+
+第二に、feature extension の調査範囲を core、feature、boundary、coverage gap に分けられる。
+障害や設計劣化が起きたとき、ArchSig は全体を漠然と疑うのではなく、core-local、
+feature-local、boundary holonomy、lifting failure、filling failure、residual coverage gap の
+どこに measured witness があるかを示す。
+これにより、debug / review / refactoring の焦点を絞れる。
+
+第三に、static dependency graph では見えにくい semantic / runtime / state / effect の
+交換不能性を review surface に出せる。
+循環がない、layering が綺麗、final component set が同じ、という粗い観測だけでは見落とす
+coupon / tax / rounding、payment / receipt、authorization / trust boundary のようなズレを、
+axis-wise defect と witness refs で読めるようにする。
+
+第四に、review comment を主観的な違和感から traceable evidence へ変える。
+ArchSig は、nonzero monodromy witness に source refs、observation refs、affected Atom refs、
+law / signature refs、missing evidence を付ける。
+これにより、reviewer は「この変更は危険そう」ではなく、
+「この operation pair は selected semantic axis でこの witness により交換不能に見える」と
+説明できる。
+
+第五に、設計判断の next action を明確にする。
+ArchSig は automatic repair を出すのではなく、filler、lifting evidence、boundary contract、
+coverage 追加、semantic witness 追加など、次に確認すべき証拠を recommended review focus として
+提示する。
+これにより、engineer は調査を止めずに次の設計作業へ進める。
+
+第六に、tool の結論を過大評価しないための境界も同時に得る。
+ArchSig は coverage status、exactness assumption status、non-conclusions を report に含める。
+これにより、測定された危険、未測定の危険、証明していない安全性を区別できる。
+
+このアウトカムは、二つの利用形態に分けて提供する。
+現時点の ArchSig surface には `PR review mode` はまだ存在しない。
+この PRD では、FieldSig が担う本格的な PR / diff / change-vector evolution analysis とは別に、
+ArchSig 単体でも使える軽量な PR review mode を追加候補として定義する。
+
+```text
+PR review mode
+  = change-local diagnosis
+
+codebase inspection mode
+  = current-state architectural diagnosis
+```
+
+`PR review mode` では、PR / diff / supplied change set に含まれる operation pair、
+feature boundary、touched Atom support を優先して読む。
+目的は、merge 前に operation-order sensitivity、boundary holonomy、missing filler /
+lifting evidence、coverage gap を reviewer に示すことである。
+この mode は merge safety を結論しないが、reviewer が確認すべき measured witness と
+next action を提示する。
+この mode は、FieldSig の forecast、governance、calibration、operational feedback、
+change-vector evolution を置き換えない。
+FieldSig ほど大きな evolution analysis が不要で、PR review のための bounded AAT diagnosis だけを
+欲しい利用者のための lightweight surface とする。
+
+`codebase inspection mode` では、現在の repository / ArchMap / analysis packet 全体から、
+既存の subsystem boundary、feature-like cluster、operation-like relation、semantic / state /
+effect / authority interaction を scan する。
+目的は、どの boundary に measured residual obstruction が溜まっているか、どの subsystem pair や
+operation square が order-sensitive に見えるかを、architecture health review の材料として示す
+ことである。
+この mode は repository 全体の lawfulness や global safety を結論しない。
+
+### R2. Operation square candidate を列挙する
+
+ArchSig は、supplied ArchMap と selected LawPolicy から、測定対象となる operation square
+candidate を列挙できなければならない。
+
+candidate は次のような operation pair から作る。
+
+```text
+f : A -> A_f
+g : A -> A_g
+
+p = g . f
+q = f . g
+```
+
+candidate source は少なくとも次を含む。
+
+- shared Atom support に触る operation pair
+- 同じ state subject を read / write する operation pair
+- 同じ effect family を発生させる operation pair
+- 同じ contract / semantic Atom に触る operation pair
+- 同じ authority / trust boundary を横断する operation pair
+- feature extension と repair / migration / substitution の operation pair
+- ArchMap / analysis packet が明示的に supplied operation pair として持つもの
+
+ArchSig は、operation pair を自動推定した場合と、入力で明示された場合を区別して記録する。
+自動推定は review cue であり、operation truth ではない。
+
+### R3. Path continuation trace を axis ごとに記録する
+
+ArchSig は、各 candidate square について、二つの path の selected continuation trace を
+axis ごとに記録できなければならない。
+
+少なくとも次の axis family を扱う。
+
+- static dependency / support axis
+- contract axis
+- semantic axis
+- state transition axis
+- effect ordering / replay / compensation axis
+- authority / trust boundary axis
+- runtime interaction axis
+- projection / representation axis
+
+trace は、完全な実行意味論ではなく、bounded observation trace として扱う。
+ArchSig は trace に source refs、observation refs、derived refs、missing refs を付ける。
+
+### R4. Axis-wise monodromy defect を計測する
+
+ArchSig は、operation square `sigma` と axis `x` に対して、次の形の defect を計測できなければ
+ならない。
+
+```text
+mu_x(sigma)
+  = distance_x(Cont_x(g . f), Cont_x(f . g))
+```
+
+`distance_x` は axis ごとの bounded distance でよい。
+
+例:
+
+- boolean mismatch
+- mismatch count
+- set symmetric difference size
+- ordered trace edit distance
+- semantic witness mismatch count
+- state transition mismatch count
+- effect replay mismatch count
+- authorization mismatch count
+- projection loss / reflection blocker count
+
+各 `mu_x` は、値だけでなく、次を持つ。
+
+- unit / distance kind
+- measured support
+- compared observations
+- positive witness refs
+- missing witness refs
+- coverage boundary
+- exactness assumption status
+
+### R5. Architecture Monodromy Index を aggregate reading として出す
+
+ArchSig は、finite measured square family 上で aggregate reading を出せなければならない。
+
+```text
+AMI_X(A)
+  = sum_{sigma in measured squares}
+    sum_{x in selected axes}
+      weight_{sigma,x} * mu_x(sigma)
+```
+
+この `AMI_X(A)` は、single quality score ではない。
+review prioritization のための aggregate reading であり、次を必ず併記する。
+
+- selected square family
+- selected axis family
+- weight policy
+- zero-reflection assumptions
+- cancellation がないことの前提
+- top contributors
+- aggregate-to-local reading boundary
+
+ArchSig は、`AMI_X(A) = 0` から global path flatness、global homotopy completeness、
+future safety を結論してはならない。
+
+### R6. Nonzero monodromy witness を review surface にする
+
+ArchSig は、`mu_x(sigma) > 0` の measured witness を review で読める形にする。
+
+各 witness は少なくとも次を持つ。
+
+- operation pair id
+- path `p = g . f`
+- path `q = f . g`
+- axis id
+- defect value
+- compared trace summary
+- affected Atom refs
+- affected law / signature axis refs
+- source refs
+- observation refs
+- suggested filler / lifting / boundary evidence
+- recommended review focus
+- non-conclusions
+
+recommended review focus は命令ではなく cue として扱う。
+ArchSig は automatic repair safety や merge safety を結論しない。
+
+### R7. Boundary holonomy を feature extension reading として出す
+
+ArchSig は、feature extension `ext_f : A -> B` について、core / feature boundary に局在する
+measured residual obstruction を boundary holonomy reading として出せなければならない。
+
+境界は次の混合 subconfiguration として読む。
+
+```text
+Boundary(A, f)
+  = core Atom と feature Atom のあいだの
+    relation / capability use / contract refinement /
+    state read-write / effect ordering / authority /
+    runtime interaction / semantic interpretation
+```
+
+出力する boundary holonomy axes は少なくとも次を含む。
+
+- `Hol_static`
+- `Hol_contract`
+- `Hol_semantic`
+- `Hol_state`
+- `Hol_effect`
+- `Hol_authority`
+- `Hol_runtime`
+- `Hol_projection`
+
+ArchSig は、boundary holonomy を次の residual diagnosis として扱う。
+
+```text
+new measured residual obstruction
+  after accounting for core-local and feature-local readings
+```
+
+これは、`Ob(B)` が `Ob(A) + Ob(f) + Hol(Boundary(A,f))` に無条件に直和分解するという
+主張ではない。support separation、coverage、exactness、residual attribution policy を
+明示した範囲での reading とする。
+
+### R8. Feature extension diagnosis を実務的に分解する
+
+ArchSig は、feature extension の measured obstruction を次に分解して報告できなければならない。
+
+- inherited core obstruction
+- feature-local obstruction
+- boundary holonomy
+- lifting failure
+- filling failure
+- complexity transfer
+- residual coverage gap
+
+この分解は、mutually disjoint な theorem decomposition ではない。
+同じ witness が複数分類を持つ場合、ArchSig は multi-label attribution として記録する。
+
+### R9. Coupon / tax / rounding fixture を最小実例にする
+
+ArchSig は、coupon / tax / rounding の実例で nonzero semantic monodromy を表現できなければ
+ならない。
+
+最小例は次を含む。
+
+```text
+f = add coupon discount
+g = add tax / rounding rule
+
+p = round(tax(discount(subtotal)))
+q = round(discount(tax(subtotal)))
+```
+
+この fixture では、少なくとも次を出力する。
+
+- `mu_semantic > 0`
+- amount / rounding witness
+- `PaymentAmount = FinalAmount` または `ReceiptAmount = FinalAmount` への影響
+- static projection では見えにくい semantic obstruction reading
+- boundary holonomy reading for coupon feature boundary
+- coverage / exactness assumptions
+- non-conclusions
+
+### R10. Lean 形式化は minimal guardrail に絞る
+
+Lean 側では、ArchSig の全測定仕様を完全証明することを要求しない。
+必要なのは、ArchSig report が主張してよい範囲を支える minimal guardrail である。
+
+Lean で優先する形式化は次である。
+
+- measured square
+- selected axis
+- axis defect
+- finite measured square family
+- nonnegative weighted aggregate
+- aggregate zero から measured local zero を読む補題
+- defect nonzero から selected observation difference を読む補題
+- selected observation difference から selected homotopy refutation / non-fillability witness へ接続する補題
+
+Lean は次を主張しない。
+
+- 全 operation path の homotopy completeness
+- all axes の semantic completeness
+- extractor completeness
+- global architecture truth
+- feature extension safety
+- ArchSig measurement correctness in the wild
+
+### R11. AAT 数学本文では証明済み核・予想・tool diagnosis を分離する
+
+AAT 数学本文に取り込む場合、次を分けて書く。
+
+- proved / formalized guardrail
+- design-level theorem candidate
+- boundary holonomy conjecture
+- ArchSig measurement diagnosis
+- non-conclusions
+
+`Path-Monodromy Obstruction Theorem` は、Lean で支えた片方向の soundness と、
+追加仮定が必要な completeness / equivalence を分ける。
+
+`Boundary Holonomy Conjecture` は、feature extension の中心予想として置く。
+ただし、ArchSig 実装はこの予想を証明するものではなく、selected measured axes 上の
+boundary holonomy witness を report するものとして扱う。
+
+## スコープ
+
+この PRD のスコープは次である。
+
+- ArchSig に path monodromy measurement を追加する要求。
+- ArchSig に boundary holonomy reading を追加する要求。
+- 現場エンジニアに提供する実用アウトカム。
+- PR review mode と codebase inspection mode の分離。
+- FieldSig の本格的な evolution analysis と ArchSig の lightweight PR review surface の責務分離。
+- ArchSig に lightweight PR review mode を追加する要求。
+- operation square candidate の列挙。
+- axis-wise continuation trace の記録。
+- axis-wise monodromy defect の計測。
+- Architecture Monodromy Index の aggregate reading。
+- nonzero monodromy witness の review surface。
+- feature extension obstruction の boundary-local diagnosis。
+- coupon / tax / rounding fixture。
+- Lean minimal guardrail の要求。
+- AAT 数学本文での証明済み核、予想、tool diagnosis の責務分離。
+
+実装設計で具体化するものは次である。
+
+- `archsig-analysis-packet-v0` へ追加する monodromy / boundary holonomy reading family。
+- PR / diff / supplied change set を入力として受ける lightweight PR review command または workflow。
+- PR review mode 用の change-local report layout。
+- PR review mode で出力する measured witness、recommended review focus、coverage / exactness boundary。
+- schema field 名と validation rule。
+- LawPolicy 側で必要な selected axes / distance / weight / coverage policy。
+- fixture と golden output。
+- report 表示。
+- docs/tool の packet 説明更新。
+- AAT 数学本文との cross-reference。
+- Lean theorem index / proof obligations での bounded status 記録。
+
+## Non-Goals
+
+この PRD は次を目標にしない。
+
+- ArchSig を theorem prover にする。
+- ArchSig を merge safety 判定器、future safety 判定器、automatic repair system にする。
+- `AMI_X(A)` を single architecture quality score にする。
+- `AMI_X(A) = 0` から global path flatness や all operation commutativity を結論する。
+- `mu_x > 0` から unmeasured axes の obstruction を結論する。
+- boundary holonomy から feature extension の安全性または危険性を無条件に結論する。
+- core / feature / boundary obstruction が互いに素に分解できることを無条件に主張する。
+- supplied ArchMap や LLM observation を canonical architecture truth として扱う。
+- source extraction completeness、runtime telemetry completeness、semantic universe completeness を主張する。
+- FieldSig の forecast、governance、calibration、operational feedback schema を再設計する。
+- FieldSig が担う本格的な PR / diff / change-vector evolution analysis を ArchSig の責務にする。
+- ArchSig の lightweight PR review mode から FieldSig の forecast / governance / calibration と同等の
+  結論を出す。
+- Lean で完全な monodromy / holonomy 理論を形式化する。
+- AAT 数学本文で boundary holonomy を証明済み theorem として扱う。
+- UI / report polish、large repository authoring ergonomics、release packaging を主目的にする。
+
+## Acceptance Criteria / 完了条件
+
+- ArchSig の優先順位が、practical measurement、bounded claim boundary、minimal Lean guardrail、
+  AAT exposition、later workflow polish の順で定義されている。
+- 現場アウトカムが、変更順序の危険検出、feature extension の調査範囲分解、
+  static graph では見えにくい semantic / runtime / state / effect の交換不能性検出、
+  traceable review evidence、next action cue、coverage / exactness boundary として
+  定義されている。
+- 利用形態が、PR / diff / supplied change set を読む `PR review mode` と、
+  repository / ArchMap / analysis packet 全体を読む `codebase inspection mode` に分離され、
+  それぞれ change-local diagnosis と current-state architectural diagnosis として定義されている。
+- `PR review mode` は現行 ArchSig surface にはまだ存在しない追加要求であり、FieldSig の
+  PR / diff / change-vector evolution analysis を置き換えない lightweight surface として
+  定義されている。
+- ArchSig の lightweight PR review mode が、PR / diff / supplied change set を入力し、
+  operation-order sensitivity、boundary holonomy、missing filler / lifting evidence、
+  coverage gap、non-conclusions を change-local report として出す要求として定義されている。
+- operation square candidate が、shared Atom support、state、effect、contract、semantic、
+  authority、runtime interaction、supplied operation pair から列挙されることが要求されている。
+- path continuation trace が、static、contract、semantic、state、effect、authority、runtime、
+  projection axis ごとに記録されることが要求されている。
+- axis-wise defect `mu_x(sigma)` が、distance kind、measured support、witness refs、
+  coverage boundary、exactness assumption status とともに要求されている。
+- `AMI_X(A)` が aggregate review reading であり、single score や global theorem conclusion では
+  ないことが明記されている。
+- nonzero monodromy witness が、operation pair、path pair、axis、defect value、affected Atom refs、
+  law / signature refs、suggested filler / lifting / boundary evidence を持つ review surface として
+  要求されている。
+- boundary holonomy が、core / feature boundary の measured residual obstruction reading として
+  要求されている。
+- feature extension diagnosis が、inherited core obstruction、feature-local obstruction、
+  boundary holonomy、lifting failure、filling failure、complexity transfer、residual coverage gap の
+  multi-label attribution として要求されている。
+- coupon / tax / rounding fixture が、semantic monodromy と boundary holonomy の最小実例として
+  要求されている。
+- Lean 形式化が minimal guardrail に限定され、complete monodromy theory や extractor correctness を
+  要求しないことが明記されている。
+- AAT 数学本文では、証明済み核、design-level theorem candidate、boundary holonomy conjecture、
+  ArchSig measurement diagnosis、non-conclusions を分離することが要求されている。
+- Non-Goals が、theorem prover 化、single score 化、global path flatness、automatic safety、
+  extractor completeness、FieldSig 再設計、完全 Lean 形式化を明確に除外している。


### PR DESCRIPTION
## 概要

Closes #1467

ArchSig に path monodromy / boundary holonomy の実用計測面を追加するための設計 PRD と、前段の研究メモを追加します。

設計判断は次です。

- ArchSig の practical measurement を最優先にし、Lean は minimal guardrail に絞る
- path monodromy を基礎、boundary holonomy を feature extension 応用として整理する
- ArchSig の lightweight PR review mode と codebase inspection mode を分ける
- FieldSig の本格的な PR / diff / change-vector evolution analysis と ArchSig の簡易 PR review surface を混同しない

## 証明した定理

- なし

## 編集したドキュメント

- docs/note/boundary_holonomy_conjecture.md
- docs/note/path_monodromy_obstruction_theorem.md
- docs/tool/archsig_monodromy_boundary_holonomy_prd.md
- docs/tool/README.md

## 実施したテスト

- [ ] `lake build`（未実施: ドキュメントのみの変更で Lean source は未変更）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（未実施: Rust source は未変更）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（未実施: FieldSig source は未変更）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（未実施: Lean source は未変更）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
