### PR TITLE
ArchSig monodromy schema foundation を追加

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -22,7 +22,8 @@ ArchSig Analysis Packet
   axes, path signature trajectories, homotopy / operation-order sensitivity,
   diagram fillability, bounded judgements, repair operation candidates,
   operation deltas, path / homotopy / diagram readings, child-level evidence
-  boundaries, and an LLM interpretation packet.
+  boundaries, ArchMapStore refs, monodromy / boundary holonomy reading family
+  policy surfaces, and an LLM interpretation packet.
 ```
 
 ## Responsibility
@@ -35,6 +36,7 @@ The implemented schema records:
 - `interpretationProfileRef`
 - `selectedLawPolicyRef`
 - `archMapRef`
+- `archMapStoreRefs`
 - `architectureState`
 - `designPressure`
 - `changeImpact`
@@ -64,6 +66,8 @@ The implemented schema records:
 - `axisForgettingRiskReadings`
 - `signatureTrajectoryHomotopyRefutationReadings`
 - `bridgeSplitObstructionTransferReadings`
+- `monodromyReadingFamily`
+- `boundaryHolonomyReadingFamily`
 - `representationStrengthReadings`
 - `localCurvatureDiagramReadings`
 - `threeLayerFlatnessReadings`
@@ -91,9 +95,10 @@ AAT concept coverage, bounded judgement statuses, analytic axes, workflow risk
 readings, spectral analysis readings, spectral mode readings, design principle
 readings, spectral drilldown readings, transfer bridge readings and bridge-edge
 source refs, v0.3.0 measurement expansion readings, AAT structural state
-readings, law-relative obstruction links, signature / flatness references,
-repair candidate guardrails, LLM interpretation notes, evidence boundary, and
-required non-conclusions.
+readings, ArchMapStore delta / commit / snapshot / index refs, monodromy /
+boundary holonomy reading family policy surfaces, law-relative obstruction
+links, signature / flatness references, repair candidate guardrails, LLM
+interpretation notes, evidence boundary, and required non-conclusions.
 Each obstruction circuit, signature axis reading, and repair operation candidate
 must carry its own `missingEvidence` and `excludedReadings`. Packet-level
 `excludedReadings` does not stand in for child-record evidence boundaries.
@@ -173,6 +178,17 @@ The builder:
   evidence; `ArchMapSnapshot` and `ArchMapIndex` support large-repository
   current-state inspection. Raw source diffs may narrow source refs, but they
   are not canonical semantic inputs to this packet.
+- `archMapStoreRefs` records the packet's canonical history substrate:
+  `archmap-delta-v0`, `archmap-commit-v0`, `archmap-snapshot-v0`, and
+  `archmap-index-v0`. It also records raw-diff and compaction boundaries so
+  review readers can distinguish change-local evidence from snapshot-level
+  current-state evidence.
+- `monodromyReadingFamily` and `boundaryHolonomyReadingFamily` are schema
+  foundation surfaces. They carry selected axes, distance kind, weight policy,
+  coverage policy, and the ArchMapStore ref set used by later operation-square,
+  axis-wise defect, AMI, boundary residual, and feature-extension attribution
+  readings. In this issue they define the packet shape and validation boundary;
+  later issues fill the concrete valuation fields.
 - axis-forgetting risk records when a coarse observation projection has
   forgotten selected axes or collapsed mixed-axis support. It blocks
   `ZeroReflecting` and `ObstructionReflecting` readings unless explicit axis

--- a/docs/tool/law_policy.md
+++ b/docs/tool/law_policy.md
@@ -11,7 +11,8 @@ ArchMap
 
 InterpretationProfile
   selects laws, witness rules, molecule patterns, obstruction definitions,
-  signature axes, coverage requirements, and exactness assumptions.
+  signature axes, monodromy measurement policy, coverage requirements, and
+  exactness assumptions.
 
 ArchSig
   reads ArchMap + InterpretationProfile and computes the AAT analysis packet.
@@ -24,8 +25,8 @@ ArchMapDelta / ArchMapCommit / ArchMapSnapshot / ArchMapIndex
   record observation history and lookup structure.
 
 InterpretationProfile
-  selects the laws, axes, coverage, and exactness assumptions used to read that
-  history.
+  selects the laws, axes, distance kind, weight policy, coverage policy, and
+  exactness assumptions used to read that history.
 ```
 
 Raw source diffs may help an adapter choose source refs, but they do not select
@@ -47,6 +48,7 @@ The implemented schema records:
 - `moleculePatterns`
 - `obstructionCircuitDefinitions`
 - `signatureAxisDefinitions`
+- `measurementPolicy`
 - `exactnessAssumptions`
 - `coverageRequirements`
 - `excludedReadings`
@@ -56,7 +58,24 @@ The implemented schema records:
 
 Profile validation checks schema support, identity, uniqueness,
 cross-reference integrity, witness / obstruction boundaries, coverage
-requirements, exactness assumptions, and required non-conclusions.
+requirements, exactness assumptions, the monodromy measurement policy surface,
+and required non-conclusions.
+
+`measurementPolicy` fixes the ArchSig reading policy for the current
+monodromy / boundary holonomy family. It records:
+
+- `selectedAxisRefs`
+- `distanceKind`
+- `weightPolicy`
+- `coveragePolicy`
+- `archMapStoreRefKinds`
+- `measurementBoundary`
+- `exactnessAssumptionRefs`
+- `nonConclusions`
+
+The required `archMapStoreRefKinds` are `archmap-delta`, `archmap-commit`,
+`archmap-snapshot`, and `archmap-index`. Raw diffs may scope changed source
+refs, but they do not choose axes, distance, weight, or coverage policy.
 
 Validation does not imply:
 

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -8,12 +8,13 @@ use crate::{
     ArchMapSourceRef, ArchSigAatConceptSurfaceV0, ArchSigAnalysisArtifactRefV0,
     ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationInputV0,
     ArchSigAnalysisPacketValidationReportV0, ArchSigAnalysisPacketValidationSummaryV0,
-    ArchSigAnalyticRepresentationV0, ArchSigArchitectureObjectProjectionV0,
-    ArchSigArchitectureStateV0, ArchSigAtomCompatibilityConflictV0,
-    ArchSigAtomCompatibilityReadingV0, ArchSigAtomConfigurationSummaryV0,
-    ArchSigAtomSupportAxisReadingV0, ArchSigAxisExcursionV0, ArchSigAxisForgettingRiskReadingV0,
-    ArchSigAxisRestrictionCountV0, ArchSigBoundaryPreparationRankV0, ArchSigBoundedJudgementV0,
-    ArchSigBridgeAtomFamilyReadingV0, ArchSigBridgeEdgeBreakdownV0,
+    ArchSigAnalyticRepresentationV0, ArchSigArchMapStoreRefsV0,
+    ArchSigArchitectureObjectProjectionV0, ArchSigArchitectureStateV0,
+    ArchSigAtomCompatibilityConflictV0, ArchSigAtomCompatibilityReadingV0,
+    ArchSigAtomConfigurationSummaryV0, ArchSigAtomSupportAxisReadingV0, ArchSigAxisExcursionV0,
+    ArchSigAxisForgettingRiskReadingV0, ArchSigAxisRestrictionCountV0,
+    ArchSigBoundaryHolonomyReadingFamilyV0, ArchSigBoundaryPreparationRankV0,
+    ArchSigBoundedJudgementV0, ArchSigBridgeAtomFamilyReadingV0, ArchSigBridgeEdgeBreakdownV0,
     ArchSigBridgeSplitObstructionTransferReadingV0, ArchSigChangeImpactReadingV0,
     ArchSigCouplingCohesionReadingV0, ArchSigCoverageStatusV0,
     ArchSigCurrentStateEvolutionBoundaryV0, ArchSigDesignPressureReadingV0,
@@ -24,7 +25,8 @@ use crate::{
     ArchSigHomotopyOrderSensitivityReadingV0, ArchSigInvariantFamilyReadingV0,
     ArchSigLawUniverseCoverageReadingV0, ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0,
     ArchSigLlmInterpretationPacketV0, ArchSigLocalCurvatureDiagramReadingV0,
-    ArchSigMoleculeReadingV0, ArchSigObservationProjectionReadingV0, ArchSigObstructionCircuitV0,
+    ArchSigMoleculeReadingV0, ArchSigMonodromyReadingFamilyV0,
+    ArchSigObservationProjectionReadingV0, ArchSigObstructionCircuitV0,
     ArchSigOperationCalculusLawReadingV0, ArchSigOperationDeltaReadingV0,
     ArchSigOperationInvariantGaloisReadingV0, ArchSigPathHomotopyDiagramReadingV0,
     ArchSigPathSignatureTrajectoryReadingV0, ArchSigRepairAxisDeltaReadingV0,
@@ -80,6 +82,7 @@ pub fn build_archsig_analysis_packet(
         &law_policy.schema_version,
         law_policy_path,
     );
+    let arch_map_store_refs = build_arch_map_store_refs(archmap);
     let molecule_readings = build_molecule_readings(archmap, law_policy);
     let obstruction_circuits = build_obstruction_circuits(archmap, law_policy, &molecule_readings);
     let signature_axes = build_signature_axes(archmap, law_policy, &obstruction_circuits);
@@ -183,6 +186,19 @@ pub fn build_archsig_analysis_packet(
         );
     let bridge_split_obstruction_transfer_readings =
         build_bridge_split_obstruction_transfer_readings(&split_readiness_readings);
+    let monodromy_reading_family = build_monodromy_reading_family(
+        law_policy,
+        &arch_map_store_refs,
+        &path_homotopy_diagram_readings,
+        &path_signature_trajectory_readings,
+    );
+    let boundary_holonomy_reading_family = build_boundary_holonomy_reading_family(
+        law_policy,
+        &arch_map_store_refs,
+        &homotopy_order_sensitivity_readings,
+        &feature_extension_formula_readings,
+        &split_readiness_readings,
+    );
     let structural_reading_review_surface = build_structural_reading_review_surface(
         &representation_strength_readings,
         &local_curvature_diagram_readings,
@@ -282,6 +298,7 @@ pub fn build_archsig_analysis_packet(
             &law_policy.schema_version,
             law_policy_path,
         ),
+        arch_map_store_refs,
         architecture_state,
         design_pressure,
         change_impact,
@@ -311,6 +328,8 @@ pub fn build_archsig_analysis_packet(
         axis_forgetting_risk_readings,
         signature_trajectory_homotopy_refutation_readings,
         bridge_split_obstruction_transfer_readings,
+        monodromy_reading_family,
+        boundary_holonomy_reading_family,
         representation_strength_readings,
         local_curvature_diagram_readings,
         three_layer_flatness_readings,
@@ -375,6 +394,125 @@ fn build_atom_configuration_summary(
                 .to_string(),
         coverage_summary: coverage_summary(archmap),
         source_refs,
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_arch_map_store_refs(archmap: &ArchMapDocumentV0) -> ArchSigArchMapStoreRefsV0 {
+    let base_id = stable_id(&archmap.map_id);
+    ArchSigArchMapStoreRefsV0 {
+        ref_set_id: format!("archmap-store-refs:{base_id}"),
+        arch_map_ref: archmap.map_id.clone(),
+        delta_ref: artifact_ref(
+            &format!("archmap-delta:{base_id}:current"),
+            "archmap-delta",
+            "archmap-delta-v0",
+            None,
+        ),
+        commit_ref: artifact_ref(
+            &format!("archmap-commit:{base_id}:current"),
+            "archmap-commit",
+            "archmap-commit-v0",
+            None,
+        ),
+        snapshot_ref: artifact_ref(
+            &format!("archmap-snapshot:{base_id}:current"),
+            "archmap-snapshot",
+            "archmap-snapshot-v0",
+            None,
+        ),
+        index_ref: artifact_ref(
+            &format!("archmap-index:{base_id}:current"),
+            "archmap-index",
+            "archmap-index-v0",
+            None,
+        ),
+        raw_diff_boundary:
+            "raw diffs may scope review, but ArchSig semantic readings use ArchMapStore delta / commit / snapshot / index refs"
+                .to_string(),
+        compaction_boundary:
+            "snapshot and index compaction may lose per-change granularity; compaction loss remains explicit evidence boundary"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_monodromy_reading_family(
+    law_policy: &LawPolicyDocumentV0,
+    arch_map_store_refs: &ArchSigArchMapStoreRefsV0,
+    path_homotopy_diagram_readings: &[ArchSigPathHomotopyDiagramReadingV0],
+    path_signature_trajectory_readings: &[ArchSigPathSignatureTrajectoryReadingV0],
+) -> ArchSigMonodromyReadingFamilyV0 {
+    ArchSigMonodromyReadingFamilyV0 {
+        reading_family_id: format!(
+            "monodromy-reading-family:{}",
+            stable_id(&law_policy.measurement_policy.policy_id)
+        ),
+        status: "schemaFoundationOnly".to_string(),
+        arch_map_store_ref_set_ref: arch_map_store_refs.ref_set_id.clone(),
+        selected_axis_refs: law_policy.measurement_policy.selected_axis_refs.clone(),
+        distance_kind: law_policy.measurement_policy.distance_kind.clone(),
+        weight_policy: law_policy.measurement_policy.weight_policy.clone(),
+        coverage_policy: law_policy.measurement_policy.coverage_policy.clone(),
+        operation_square_candidate_refs: path_homotopy_diagram_readings
+            .iter()
+            .map(|reading| reading.reading_id.clone())
+            .collect(),
+        path_continuation_trace_refs: path_signature_trajectory_readings
+            .iter()
+            .map(|reading| reading.reading_id.clone())
+            .collect(),
+        axis_wise_defect_refs: Vec::new(),
+        aggregate_reading_kind: "ami-precondition-surface".to_string(),
+        reading_boundary:
+            "records the packet shape for axis-wise defect and AMI readings; concrete defect valuation is introduced by later issues"
+                .to_string(),
+        evidence_boundary:
+            "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_boundary_holonomy_reading_family(
+    law_policy: &LawPolicyDocumentV0,
+    arch_map_store_refs: &ArchSigArchMapStoreRefsV0,
+    homotopy_order_sensitivity_readings: &[ArchSigHomotopyOrderSensitivityReadingV0],
+    feature_extension_formula_readings: &[ArchSigFeatureExtensionFormulaReadingV0],
+    split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
+) -> ArchSigBoundaryHolonomyReadingFamilyV0 {
+    ArchSigBoundaryHolonomyReadingFamilyV0 {
+        reading_family_id: format!(
+            "boundary-holonomy-reading-family:{}",
+            stable_id(&law_policy.measurement_policy.policy_id)
+        ),
+        status: "schemaFoundationOnly".to_string(),
+        arch_map_store_ref_set_ref: arch_map_store_refs.ref_set_id.clone(),
+        selected_axis_refs: law_policy.measurement_policy.selected_axis_refs.clone(),
+        distance_kind: law_policy.measurement_policy.distance_kind.clone(),
+        weight_policy: law_policy.measurement_policy.weight_policy.clone(),
+        coverage_policy: law_policy.measurement_policy.coverage_policy.clone(),
+        nonzero_monodromy_witness_refs: homotopy_order_sensitivity_readings
+            .iter()
+            .map(|reading| reading.reading_id.clone())
+            .collect(),
+        feature_boundary_residual_refs: feature_extension_formula_readings
+            .iter()
+            .map(|reading| reading.reading_id.clone())
+            .collect(),
+        extension_diagnosis_refs: split_readiness_readings
+            .iter()
+            .map(|reading| reading.reading_id.clone())
+            .collect(),
+        attribution_boundary:
+            "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause"
+                .to_string(),
+        reading_boundary:
+            "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues"
+                .to_string(),
+        evidence_boundary:
+            "boundary holonomy readings use ArchMapStore refs and LawPolicy axes; raw diff hunks remain scoping hints only"
+                .to_string(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
 }
@@ -5969,6 +6107,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_transfer_bridge_surface(packet),
         check_aat_structural_reading_surfaces(packet),
         check_current_state_evolution_boundary(packet),
+        check_monodromy_boundary_schema_foundation(packet),
         check_law_relative_analysis(packet),
         check_signature_and_flatness(packet),
         check_repair_candidates(packet),
@@ -7893,6 +8032,209 @@ fn check_current_state_evolution_boundary(packet: &ArchSigAnalysisPacketV0) -> V
     )
 }
 
+fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let mut examples = Vec::new();
+    let store_refs = &packet.arch_map_store_refs;
+    let axis_refs = packet
+        .signature_axes
+        .iter()
+        .flat_map(|axis| [axis.signature_axis_id.as_str(), axis.axis_ref.as_str()])
+        .collect::<BTreeSet<_>>();
+
+    push_blank(
+        &mut examples,
+        "archMapStoreRefs.refSetId",
+        &store_refs.ref_set_id,
+    );
+    if store_refs.arch_map_ref != packet.arch_map_ref.artifact_id {
+        examples.push(generic_validation_example(
+            "archMapStoreRefs.archMapRef",
+            &store_refs.arch_map_ref,
+            "ArchMapStore refs must connect back to the packet ArchMap ref",
+        ));
+    }
+    for (field, artifact, kind, schema_version) in [
+        (
+            "deltaRef",
+            &store_refs.delta_ref,
+            "archmap-delta",
+            "archmap-delta-v0",
+        ),
+        (
+            "commitRef",
+            &store_refs.commit_ref,
+            "archmap-commit",
+            "archmap-commit-v0",
+        ),
+        (
+            "snapshotRef",
+            &store_refs.snapshot_ref,
+            "archmap-snapshot",
+            "archmap-snapshot-v0",
+        ),
+        (
+            "indexRef",
+            &store_refs.index_ref,
+            "archmap-index",
+            "archmap-index-v0",
+        ),
+    ] {
+        push_blank(
+            &mut examples,
+            &format!("archMapStoreRefs.{field}.artifactId"),
+            &artifact.artifact_id,
+        );
+        if artifact.artifact_kind != kind || artifact.schema_version != schema_version {
+            examples.push(generic_validation_example(
+                &format!("archMapStoreRefs.{field}"),
+                &format!("{}:{}", artifact.artifact_kind, artifact.schema_version),
+                "ArchMapStore refs must preserve delta / commit / snapshot / index schema kinds",
+            ));
+        }
+    }
+    push_blank(
+        &mut examples,
+        "archMapStoreRefs.rawDiffBoundary",
+        &store_refs.raw_diff_boundary,
+    );
+    push_blank(
+        &mut examples,
+        "archMapStoreRefs.compactionBoundary",
+        &store_refs.compaction_boundary,
+    );
+    if store_refs.non_conclusions.is_empty() || has_blank(&store_refs.non_conclusions) {
+        examples.push(generic_validation_example(
+            &store_refs.ref_set_id,
+            "nonConclusions",
+            "ArchMapStore refs must keep non-conclusions explicit",
+        ));
+    }
+
+    check_monodromy_family(
+        "monodromyReadingFamily",
+        &packet.monodromy_reading_family.reading_family_id,
+        &packet.monodromy_reading_family.status,
+        &packet.monodromy_reading_family.arch_map_store_ref_set_ref,
+        &packet.monodromy_reading_family.selected_axis_refs,
+        &packet.monodromy_reading_family.distance_kind,
+        &packet.monodromy_reading_family.weight_policy,
+        &packet.monodromy_reading_family.coverage_policy,
+        &packet.monodromy_reading_family.reading_boundary,
+        &packet.monodromy_reading_family.evidence_boundary,
+        &packet.monodromy_reading_family.non_conclusions,
+        &store_refs.ref_set_id,
+        &axis_refs,
+        &mut examples,
+    );
+    check_monodromy_family(
+        "boundaryHolonomyReadingFamily",
+        &packet.boundary_holonomy_reading_family.reading_family_id,
+        &packet.boundary_holonomy_reading_family.status,
+        &packet
+            .boundary_holonomy_reading_family
+            .arch_map_store_ref_set_ref,
+        &packet.boundary_holonomy_reading_family.selected_axis_refs,
+        &packet.boundary_holonomy_reading_family.distance_kind,
+        &packet.boundary_holonomy_reading_family.weight_policy,
+        &packet.boundary_holonomy_reading_family.coverage_policy,
+        &packet.boundary_holonomy_reading_family.reading_boundary,
+        &packet.boundary_holonomy_reading_family.evidence_boundary,
+        &packet.boundary_holonomy_reading_family.non_conclusions,
+        &store_refs.ref_set_id,
+        &axis_refs,
+        &mut examples,
+    );
+    push_blank(
+        &mut examples,
+        "monodromyReadingFamily.aggregateReadingKind",
+        &packet.monodromy_reading_family.aggregate_reading_kind,
+    );
+    push_blank(
+        &mut examples,
+        "boundaryHolonomyReadingFamily.attributionBoundary",
+        &packet.boundary_holonomy_reading_family.attribution_boundary,
+    );
+
+    check_from_examples(
+        "archsig-analysis-packet-monodromy-boundary-foundation",
+        "packet defines ArchMapStore refs and monodromy / boundary holonomy reading family policy surfaces",
+        examples,
+        "fail",
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_monodromy_family(
+    field: &str,
+    reading_family_id: &str,
+    status: &str,
+    arch_map_store_ref_set_ref: &str,
+    selected_axis_refs: &[String],
+    distance_kind: &str,
+    weight_policy: &str,
+    coverage_policy: &str,
+    reading_boundary: &str,
+    evidence_boundary: &str,
+    non_conclusions: &[String],
+    expected_ref_set_id: &str,
+    known_axis_refs: &BTreeSet<&str>,
+    examples: &mut Vec<ValidationExample>,
+) {
+    push_blank(
+        examples,
+        &format!("{field}.readingFamilyId"),
+        reading_family_id,
+    );
+    push_blank(examples, &format!("{field}.status"), status);
+    if arch_map_store_ref_set_ref != expected_ref_set_id {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            arch_map_store_ref_set_ref,
+            "reading family must reference archMapStoreRefs.refSetId",
+        ));
+    }
+    if selected_axis_refs.is_empty() {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            "selectedAxisRefs",
+            "reading family must retain selected measurement axes",
+        ));
+    }
+    for axis_ref in selected_axis_refs {
+        if !known_axis_refs.contains(axis_ref.as_str()) {
+            examples.push(generic_validation_example(
+                reading_family_id,
+                axis_ref,
+                "reading family selectedAxisRefs must resolve to packet signature axis refs",
+            ));
+        }
+    }
+    push_blank(examples, &format!("{field}.distanceKind"), distance_kind);
+    push_blank(examples, &format!("{field}.weightPolicy"), weight_policy);
+    push_blank(
+        examples,
+        &format!("{field}.coveragePolicy"),
+        coverage_policy,
+    );
+    push_blank(
+        examples,
+        &format!("{field}.readingBoundary"),
+        reading_boundary,
+    );
+    push_blank(
+        examples,
+        &format!("{field}.evidenceBoundary"),
+        evidence_boundary,
+    );
+    if non_conclusions.is_empty() || has_blank(non_conclusions) {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            "nonConclusions",
+            "reading family must keep non-conclusions explicit",
+        ));
+    }
+}
+
 fn check_law_relative_analysis(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
     let axis_ids = set(packet
         .signature_axes
@@ -8840,6 +9182,36 @@ mod tests {
     }
 
     #[test]
+    fn missing_required_monodromy_packet_field_is_rejected() {
+        let mut value =
+            serde_json::to_value(static_archsig_analysis_packet()).expect("packet serializes");
+        value
+            .as_object_mut()
+            .expect("packet is object")
+            .remove("monodromyReadingFamily");
+
+        let error = serde_json::from_value::<ArchSigAnalysisPacketV0>(value)
+            .expect_err("missing monodromy reading family must be rejected");
+
+        assert!(error.to_string().contains("missing field"));
+    }
+
+    #[test]
+    fn invalid_monodromy_schema_foundation_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        packet.arch_map_store_refs.delta_ref.artifact_kind = "raw-diff".to_string();
+        packet.monodromy_reading_family.selected_axis_refs = vec!["axis:missing".to_string()];
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-monodromy-boundary-foundation"
+                && check.result == "fail"
+        }));
+    }
+
+    #[test]
     fn canonical_fixture_matches_static_analysis_packet() {
         let fixture: ArchSigAnalysisPacketV0 = serde_json::from_str(include_str!(
             "../tests/fixtures/minimal/archsig_analysis_packet.json"
@@ -8912,6 +9284,7 @@ mod tests {
         law_policy
             .signature_axis_definitions
             .retain(|axis| axis.law_ref == "law:layer-respecting");
+        law_policy.measurement_policy.selected_axis_refs = vec!["axis:layer-violation".to_string()];
 
         let packet = build_archsig_analysis_packet(&archmap, &law_policy, None, None);
         let report = validate_archsig_analysis_packet_report(&packet, "layer-only.json");

--- a/tools/archsig/src/law_policy.rs
+++ b/tools/archsig/src/law_policy.rs
@@ -4,7 +4,8 @@ use crate::validation::{count_checks, duplicates, generic_validation_example, va
 use crate::{
     LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
     LawPolicyAxisDefinitionV0, LawPolicyCoverageRequirementV0, LawPolicyDocumentV0,
-    LawPolicyMoleculePatternV0, LawPolicyObstructionCircuitDefinitionV0, LawPolicySelectedLawV0,
+    LawPolicyMeasurementPolicyV0, LawPolicyMoleculePatternV0,
+    LawPolicyObstructionCircuitDefinitionV0, LawPolicySelectedLawV0,
     LawPolicySignatureAxisDefinitionV0, LawPolicyValidationInputV0, LawPolicyValidationReportV0,
     LawPolicyValidationSummaryV0, LawPolicyWitnessRuleV0, ValidationCheck, ValidationExample,
 };
@@ -131,6 +132,34 @@ pub fn static_law_policy() -> LawPolicyDocumentV0 {
                 "count constructed SemanticMismatchCircuit witnesses",
             ),
         ],
+        measurement_policy: LawPolicyMeasurementPolicyV0 {
+            policy_id: "measurement-policy:monodromy-boundary-holonomy".to_string(),
+            selected_axis_refs: vec![
+                "axis:layer-violation".to_string(),
+                "axis:semantic-inconsistency".to_string(),
+            ],
+            distance_kind: "weighted-axis-l1".to_string(),
+            weight_policy:
+                "unit weights until repo-specific calibration is declared in a future policy"
+                    .to_string(),
+            coverage_policy:
+                "measure only selected axes with declared coverage; missing coverage remains blocked, not zero"
+                    .to_string(),
+            arch_map_store_ref_kinds: vec![
+                "archmap-delta".to_string(),
+                "archmap-commit".to_string(),
+                "archmap-snapshot".to_string(),
+                "archmap-index".to_string(),
+            ],
+            measurement_boundary:
+                "monodromy and boundary holonomy readings are finite ArchMapStore telemetry over selected axes, not theorem proofs"
+                    .to_string(),
+            exactness_assumption_refs: vec![
+                "selected LawPolicy exactness assumptions".to_string(),
+                "ArchMapStore compaction boundary".to_string(),
+            ],
+            non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+        },
         exactness_assumptions: vec![
             "the selected witness rules cover only policy-declared laws".to_string(),
             "zero readings are exact only for observed atoms and declared coverage requirements"
@@ -175,6 +204,7 @@ pub fn validate_law_policy_report(
         check_axis_refs(policy),
         check_witness_and_obstruction_boundaries(policy),
         check_coverage_and_exactness(policy),
+        check_measurement_policy(policy),
         check_non_conclusions(policy),
     ];
     let summary = LawPolicyValidationSummaryV0 {
@@ -208,6 +238,100 @@ pub fn validate_law_policy_report(
         summary,
         checks,
     }
+}
+
+fn check_measurement_policy(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let axis_ids = policy
+        .required_zero_axes
+        .iter()
+        .chain(policy.optional_axes.iter())
+        .map(|axis| axis.axis_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let signature_axis_ids = set(policy
+        .signature_axis_definitions
+        .iter()
+        .map(|axis| axis.signature_axis_id.as_str()));
+    let required_store_kinds = BTreeSet::from([
+        "archmap-delta",
+        "archmap-commit",
+        "archmap-snapshot",
+        "archmap-index",
+    ]);
+    let present_store_kinds = policy
+        .measurement_policy
+        .arch_map_store_ref_kinds
+        .iter()
+        .map(|kind| kind.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = Vec::new();
+
+    push_blank(
+        &mut examples,
+        "measurementPolicy.policyId",
+        &policy.measurement_policy.policy_id,
+    );
+    if policy.measurement_policy.selected_axis_refs.is_empty() {
+        examples.push(generic_validation_example(
+            &policy.measurement_policy.policy_id,
+            "selectedAxisRefs",
+            "measurement policy must select axes for monodromy and boundary holonomy readings",
+        ));
+    }
+    for axis_ref in &policy.measurement_policy.selected_axis_refs {
+        if !axis_ids.contains(axis_ref.as_str()) && !signature_axis_ids.contains(axis_ref.as_str())
+        {
+            examples.push(generic_validation_example(
+                &policy.measurement_policy.policy_id,
+                axis_ref,
+                "measurement policy selectedAxisRefs must reference known axes or signature axes",
+            ));
+        }
+    }
+    for required_kind in required_store_kinds {
+        if !present_store_kinds.contains(required_kind) {
+            examples.push(generic_validation_example(
+                &policy.measurement_policy.policy_id,
+                required_kind,
+                "measurement policy must declare every ArchMapStore ref kind",
+            ));
+        }
+    }
+    push_blank(
+        &mut examples,
+        "measurementPolicy.distanceKind",
+        &policy.measurement_policy.distance_kind,
+    );
+    push_blank(
+        &mut examples,
+        "measurementPolicy.weightPolicy",
+        &policy.measurement_policy.weight_policy,
+    );
+    push_blank(
+        &mut examples,
+        "measurementPolicy.coveragePolicy",
+        &policy.measurement_policy.coverage_policy,
+    );
+    push_blank(
+        &mut examples,
+        "measurementPolicy.measurementBoundary",
+        &policy.measurement_policy.measurement_boundary,
+    );
+    if policy.measurement_policy.non_conclusions.is_empty()
+        || has_blank(&policy.measurement_policy.non_conclusions)
+    {
+        examples.push(generic_validation_example(
+            &policy.measurement_policy.policy_id,
+            "nonConclusions",
+            "measurement policy must keep non-conclusions explicit",
+        ));
+    }
+
+    check_from_examples(
+        "law-policy-monodromy-measurement-policy",
+        "LawPolicy declares selected axes, distance, weight, coverage, and ArchMapStore ref kinds for monodromy readings",
+        examples,
+        "fail",
+    )
 }
 
 fn check_schema_version(policy: &LawPolicyDocumentV0) -> ValidationCheck {
@@ -857,6 +981,31 @@ mod tests {
         assert!(id_check.examples.iter().any(|example| {
             example.source.as_deref() == Some("coverageRequirements[].coverageRequirementId")
         }));
+    }
+
+    #[test]
+    fn invalid_measurement_policy_fails() {
+        let mut policy = static_law_policy();
+        policy.measurement_policy.selected_axis_refs = vec!["axis:missing".to_string()];
+        policy.measurement_policy.arch_map_store_ref_kinds = vec!["archmap-delta".to_string()];
+
+        let report = validate_law_policy_report(&policy, "bad-law-policy.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "law-policy-monodromy-measurement-policy" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn unknown_top_level_law_policy_field_is_rejected() {
+        let mut value = serde_json::to_value(static_law_policy()).expect("policy serializes");
+        value["unexpectedField"] = serde_json::json!("unknown");
+
+        let error = serde_json::from_value::<LawPolicyDocumentV0>(value)
+            .expect_err("unknown top-level fields must be rejected");
+
+        assert!(error.to_string().contains("unknown field"));
     }
 
     #[test]

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -428,7 +428,7 @@ pub struct ArchMapLeanPreservationChecklistEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LawPolicyDocumentV0 {
     pub schema_version: String,
     pub law_policy_id: String,
@@ -444,10 +444,29 @@ pub struct LawPolicyDocumentV0 {
     pub molecule_patterns: Vec<LawPolicyMoleculePatternV0>,
     pub obstruction_circuit_definitions: Vec<LawPolicyObstructionCircuitDefinitionV0>,
     pub signature_axis_definitions: Vec<LawPolicySignatureAxisDefinitionV0>,
+    pub measurement_policy: LawPolicyMeasurementPolicyV0,
     pub exactness_assumptions: Vec<String>,
     pub coverage_requirements: Vec<LawPolicyCoverageRequirementV0>,
     #[serde(default)]
     pub excluded_readings: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyMeasurementPolicyV0 {
+    pub policy_id: String,
+    #[serde(default)]
+    pub selected_axis_refs: Vec<String>,
+    pub distance_kind: String,
+    pub weight_policy: String,
+    pub coverage_policy: String,
+    #[serde(default)]
+    pub arch_map_store_ref_kinds: Vec<String>,
+    pub measurement_boundary: String,
+    #[serde(default)]
+    pub exactness_assumption_refs: Vec<String>,
+    #[serde(default)]
     pub non_conclusions: Vec<String>,
 }
 
@@ -594,7 +613,7 @@ pub struct LawPolicyValidationSummaryV0 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArchSigAnalysisPacketV0 {
     pub schema_version: String,
     pub analysis_id: String,
@@ -602,6 +621,7 @@ pub struct ArchSigAnalysisPacketV0 {
     pub arch_map_ref: ArchSigAnalysisArtifactRefV0,
     pub interpretation_profile_ref: ArchSigAnalysisArtifactRefV0,
     pub selected_law_policy_ref: ArchSigAnalysisArtifactRefV0,
+    pub arch_map_store_refs: ArchSigArchMapStoreRefsV0,
     pub architecture_state: ArchSigArchitectureStateV0,
     pub design_pressure: Vec<ArchSigDesignPressureReadingV0>,
     pub change_impact: ArchSigChangeImpactReadingV0,
@@ -644,6 +664,8 @@ pub struct ArchSigAnalysisPacketV0 {
     #[serde(default)]
     pub bridge_split_obstruction_transfer_readings:
         Vec<ArchSigBridgeSplitObstructionTransferReadingV0>,
+    pub monodromy_reading_family: ArchSigMonodromyReadingFamilyV0,
+    pub boundary_holonomy_reading_family: ArchSigBoundaryHolonomyReadingFamilyV0,
     pub representation_strength_readings: Vec<ArchSigRepresentationStrengthReadingV0>,
     pub local_curvature_diagram_readings: Vec<ArchSigLocalCurvatureDiagramReadingV0>,
     pub three_layer_flatness_readings: Vec<ArchSigThreeLayerFlatnessReadingV0>,
@@ -667,6 +689,58 @@ pub struct ArchSigAnalysisPacketV0 {
     pub interpretation_notes_for_llm: Vec<String>,
     #[serde(default)]
     pub excluded_readings: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigArchMapStoreRefsV0 {
+    pub ref_set_id: String,
+    pub arch_map_ref: String,
+    pub delta_ref: ArchSigAnalysisArtifactRefV0,
+    pub commit_ref: ArchSigAnalysisArtifactRefV0,
+    pub snapshot_ref: ArchSigAnalysisArtifactRefV0,
+    pub index_ref: ArchSigAnalysisArtifactRefV0,
+    pub raw_diff_boundary: String,
+    pub compaction_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigMonodromyReadingFamilyV0 {
+    pub reading_family_id: String,
+    pub status: String,
+    pub arch_map_store_ref_set_ref: String,
+    pub selected_axis_refs: Vec<String>,
+    pub distance_kind: String,
+    pub weight_policy: String,
+    pub coverage_policy: String,
+    pub operation_square_candidate_refs: Vec<String>,
+    pub path_continuation_trace_refs: Vec<String>,
+    pub axis_wise_defect_refs: Vec<String>,
+    pub aggregate_reading_kind: String,
+    pub reading_boundary: String,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigBoundaryHolonomyReadingFamilyV0 {
+    pub reading_family_id: String,
+    pub status: String,
+    pub arch_map_store_ref_set_ref: String,
+    pub selected_axis_refs: Vec<String>,
+    pub distance_kind: String,
+    pub weight_policy: String,
+    pub coverage_policy: String,
+    pub nonzero_monodromy_witness_refs: Vec<String>,
+    pub feature_boundary_residual_refs: Vec<String>,
+    pub extension_diagnosis_refs: Vec<String>,
+    pub attribution_boundary: String,
+    pub reading_boundary: String,
+    pub evidence_boundary: String,
     pub non_conclusions: Vec<String>,
 }
 

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1323,6 +1323,29 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "current-state/evolution boundary must separate ArchSig and FieldSig responsibilities"
     );
     assert!(
+        json["archMapStoreRefs"]["deltaRef"]["artifactKind"] == "archmap-delta"
+            && json["archMapStoreRefs"]["commitRef"]["artifactKind"] == "archmap-commit"
+            && json["archMapStoreRefs"]["snapshotRef"]["artifactKind"] == "archmap-snapshot"
+            && json["archMapStoreRefs"]["indexRef"]["artifactKind"] == "archmap-index"
+            && json["archMapStoreRefs"]["rawDiffBoundary"]
+                .as_str()
+                .is_some_and(|boundary| boundary.contains("raw diffs")),
+        "ArchMapStore refs must expose delta / commit / snapshot / index and raw diff boundary"
+    );
+    for family in ["monodromyReadingFamily", "boundaryHolonomyReadingFamily"] {
+        assert!(
+            json[family]["archMapStoreRefSetRef"] == json["archMapStoreRefs"]["refSetId"]
+                && json[family]["selectedAxisRefs"]
+                    .as_array()
+                    .is_some_and(|items| !items.is_empty())
+                && json[family]["distanceKind"].as_str().is_some()
+                && json[family]["weightPolicy"].as_str().is_some()
+                && json[family]["coveragePolicy"].as_str().is_some()
+                && json[family]["evidenceBoundary"].as_str().is_some(),
+            "{family} must connect to ArchMapStore refs and carry measurement policy"
+        );
+    }
+    assert!(
         json["llmInterpretationPacket"]["structuralReadingReviewSummary"]
             .as_array()
             .is_some_and(|items| !items.is_empty())

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -20,6 +20,41 @@
     "schemaVersion": "law-policy-v0",
     "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
   },
+  "archMapStoreRefs": {
+    "refSetId": "archmap-store-refs:fixture-archmap-atom-observation",
+    "archMapRef": "fixture-archmap-atom-observation",
+    "deltaRef": {
+      "artifactId": "archmap-delta:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-delta",
+      "schemaVersion": "archmap-delta-v0"
+    },
+    "commitRef": {
+      "artifactId": "archmap-commit:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-commit",
+      "schemaVersion": "archmap-commit-v0"
+    },
+    "snapshotRef": {
+      "artifactId": "archmap-snapshot:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-snapshot",
+      "schemaVersion": "archmap-snapshot-v0"
+    },
+    "indexRef": {
+      "artifactId": "archmap-index:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-index",
+      "schemaVersion": "archmap-index-v0"
+    },
+    "rawDiffBoundary": "raw diffs may scope review, but ArchSig semantic readings use ArchMapStore delta / commit / snapshot / index refs",
+    "compactionBoundary": "snapshot and index compaction may lose per-change granularity; compaction loss remains explicit evidence boundary",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
   "architectureState": {
     "stateId": "architecture-state:archmap-fixture-repo",
     "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
@@ -2537,6 +2572,71 @@
       ]
     }
   ],
+  "monodromyReadingFamily": {
+    "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+    "status": "schemaFoundationOnly",
+    "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "distanceKind": "weighted-axis-l1",
+    "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+    "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+    "operationSquareCandidateRefs": [
+      "path:semantic-operation-flow",
+      "diagram:obstruction-filling"
+    ],
+    "pathContinuationTraceRefs": [
+      "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+    ],
+    "axisWiseDefectRefs": [],
+    "aggregateReadingKind": "ami-precondition-surface",
+    "readingBoundary": "records the packet shape for axis-wise defect and AMI readings; concrete defect valuation is introduced by later issues",
+    "evidenceBoundary": "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
+  "boundaryHolonomyReadingFamily": {
+    "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+    "status": "schemaFoundationOnly",
+    "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "distanceKind": "weighted-axis-l1",
+    "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+    "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+    "nonzeroMonodromyWitnessRefs": [
+      "homotopy-order-sensitivity:selected-operations"
+    ],
+    "featureBoundaryResidualRefs": [
+      "feature-extension-formula:fixture-archmap-atom-observation"
+    ],
+    "extensionDiagnosisRefs": [
+      "split-readiness:molecule-user-request-responsibility"
+    ],
+    "attributionBoundary": "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause",
+    "readingBoundary": "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues",
+    "evidenceBoundary": "boundary holonomy readings use ArchMapStore refs and LawPolicy axes; raw diff hunks remain scoping hints only",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
   "representationStrengthReadings": [
     {
       "readingId": "representation-strength:analytic-weighted-adjacency",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -20,6 +20,41 @@
     "schemaVersion": "law-policy-v0",
     "path": "tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json"
   },
+  "archMapStoreRefs": {
+    "refSetId": "archmap-store-refs:fixture-archmap-atom-observation",
+    "archMapRef": "fixture-archmap-atom-observation",
+    "deltaRef": {
+      "artifactId": "archmap-delta:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-delta",
+      "schemaVersion": "archmap-delta-v0"
+    },
+    "commitRef": {
+      "artifactId": "archmap-commit:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-commit",
+      "schemaVersion": "archmap-commit-v0"
+    },
+    "snapshotRef": {
+      "artifactId": "archmap-snapshot:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-snapshot",
+      "schemaVersion": "archmap-snapshot-v0"
+    },
+    "indexRef": {
+      "artifactId": "archmap-index:fixture-archmap-atom-observation:current",
+      "artifactKind": "archmap-index",
+      "schemaVersion": "archmap-index-v0"
+    },
+    "rawDiffBoundary": "raw diffs may scope review, but ArchSig semantic readings use ArchMapStore delta / commit / snapshot / index refs",
+    "compactionBoundary": "snapshot and index compaction may lose per-change granularity; compaction loss remains explicit evidence boundary",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
   "architectureState": {
     "stateId": "architecture-state:archmap-fixture-repo",
     "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
@@ -2280,6 +2315,69 @@
       ]
     }
   ],
+  "monodromyReadingFamily": {
+    "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+    "status": "schemaFoundationOnly",
+    "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
+    "selectedAxisRefs": [
+      "axis:layer-violation"
+    ],
+    "distanceKind": "weighted-axis-l1",
+    "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+    "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+    "operationSquareCandidateRefs": [
+      "path:semantic-operation-flow",
+      "diagram:obstruction-filling"
+    ],
+    "pathContinuationTraceRefs": [
+      "path-signature-trajectory:operation-delta-observe-before-repair"
+    ],
+    "axisWiseDefectRefs": [],
+    "aggregateReadingKind": "ami-precondition-surface",
+    "readingBoundary": "records the packet shape for axis-wise defect and AMI readings; concrete defect valuation is introduced by later issues",
+    "evidenceBoundary": "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
+  "boundaryHolonomyReadingFamily": {
+    "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+    "status": "schemaFoundationOnly",
+    "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
+    "selectedAxisRefs": [
+      "axis:layer-violation"
+    ],
+    "distanceKind": "weighted-axis-l1",
+    "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+    "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+    "nonzeroMonodromyWitnessRefs": [
+      "homotopy-order-sensitivity:selected-operations"
+    ],
+    "featureBoundaryResidualRefs": [
+      "feature-extension-formula:fixture-archmap-atom-observation"
+    ],
+    "extensionDiagnosisRefs": [
+      "split-readiness:molecule-user-request-responsibility"
+    ],
+    "attributionBoundary": "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause",
+    "readingBoundary": "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues",
+    "evidenceBoundary": "boundary holonomy readings use ArchMapStore refs and LawPolicy axes; raw diff hunks remain scoping hints only",
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
   "representationStrengthReadings": [
     {
       "readingId": "representation-strength:analytic-weighted-adjacency",

--- a/tools/archsig/tests/fixtures/minimal/law_policy.json
+++ b/tools/archsig/tests/fixtures/minimal/law_policy.json
@@ -268,6 +268,34 @@
       ]
     }
   ],
+  "measurementPolicy": {
+    "policyId": "measurement-policy:monodromy-boundary-holonomy",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "distanceKind": "weighted-axis-l1",
+    "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+    "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+    "archMapStoreRefKinds": [
+      "archmap-delta",
+      "archmap-commit",
+      "archmap-snapshot",
+      "archmap-index"
+    ],
+    "measurementBoundary": "monodromy and boundary holonomy readings are finite ArchMapStore telemetry over selected axes, not theorem proofs",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions",
+      "ArchMapStore compaction boundary"
+    ],
+    "nonConclusions": [
+      "law policy is selected analysis policy, not AAT itself",
+      "law policy validation does not prove architecture lawfulness",
+      "law policy validation does not certify atom truth",
+      "missing coverage is not measured zero",
+      "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"

--- a/tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/law_policy_layer_only.json
@@ -171,6 +171,33 @@
       ]
     }
   ],
+  "measurementPolicy": {
+    "policyId": "measurement-policy:monodromy-boundary-holonomy",
+    "selectedAxisRefs": [
+      "axis:layer-violation"
+    ],
+    "distanceKind": "weighted-axis-l1",
+    "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+    "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+    "archMapStoreRefKinds": [
+      "archmap-delta",
+      "archmap-commit",
+      "archmap-snapshot",
+      "archmap-index"
+    ],
+    "measurementBoundary": "monodromy and boundary holonomy readings are finite ArchMapStore telemetry over selected axes, not theorem proofs",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions",
+      "ArchMapStore compaction boundary"
+    ],
+    "nonConclusions": [
+      "law policy is selected analysis policy, not AAT itself",
+      "law policy validation does not prove architecture lawfulness",
+      "law policy validation does not certify atom truth",
+      "missing coverage is not measured zero",
+      "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"


### PR DESCRIPTION
## 概要

Closes #1470

#1484 を base にした stacked PR です。#1483 の ArchMapStore 境界を前提に、ArchSig の monodromy / boundary holonomy schema foundation と LawPolicy measurement policy surface を追加します。

- LawPolicy に `measurementPolicy` を追加し、selected axes / distance kind / weight policy / coverage policy / ArchMapStore ref kinds を固定
- `archsig-analysis-packet-v0` に `archMapStoreRefs`, `monodromyReadingFamily`, `boundaryHolonomyReadingFamily` を追加
- validation で ArchMapStore ref kinds、selected axis refs、missing required field、unknown top-level field、non-conclusion boundary を確認
- minimal / layer-only fixtures と docs/tool を schema に同期

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`
- `docs/tool/law_policy.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は Lean 変更なしのため未実施です。FieldSig 変更なしのため FieldSig test は未実施です。Lean ソース変更なしのため axiom / admit / sorry / unsafe scan は未実施です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `defined only / tooling schema boundary` として Issue 側の範囲に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
