### PR TITLE
ArchSig axis-wise defect と AMI aggregate を追加

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -68,6 +68,8 @@ The implemented schema records:
 - `bridgeSplitObstructionTransferReadings`
 - `operationSquareCandidates`
 - `pathContinuationTraces`
+- `axisWiseMonodromyDefects`
+- `amiAggregateReadings`
 - `monodromyReadingFamily`
 - `boundaryHolonomyReadingFamily`
 - `representationStrengthReadings`
@@ -200,6 +202,16 @@ The builder:
   candidate path and axis family: static, contract, semantic, state, effect,
   authority, runtime, and projection. Unmeasured axes are retained as
   `missingRefs` and must not be read as zero defect.
+- `axisWiseMonodromyDefects` records `mu_x(sigma)` for each selected operation
+  square and axis. Each defect carries distance kind, measured support,
+  witness refs, source / observation / missing refs, coverage boundary,
+  exactness assumption status, zero-reflection assumptions, and cancellation
+  boundary.
+- `amiAggregateReadings` records `AMI_X(A)` as a bounded weighted aggregate for
+  review prioritization. It reports selected square family, selected axis
+  family, weight policy, top contributors, zero-reflection assumptions, and the
+  aggregate-to-local reading boundary. It is not a single architecture quality
+  score, merge gate, or global path-flatness theorem.
 - axis-forgetting risk records when a coarse observation projection has
   forgotten selected axes or collapsed mixed-axis support. It blocks
   `ZeroReflecting` and `ObstructionReflecting` readings unless explicit axis

--- a/docs/tool/law_policy.md
+++ b/docs/tool/law_policy.md
@@ -77,6 +77,12 @@ The required `archMapStoreRefKinds` are `archmap-delta`, `archmap-commit`,
 `archmap-snapshot`, and `archmap-index`. Raw diffs may scope changed source
 refs, but they do not choose axes, distance, weight, or coverage policy.
 
+`distanceKind` and `weightPolicy` are used by `mu_x(sigma)` and `AMI_X(A)`.
+They define bounded review telemetry over selected operation squares and axes.
+They do not make `AMI_X(A)` a single quality score, merge gate, or global
+flatness theorem. `coveragePolicy` keeps unmeasured axes as missing evidence
+instead of treating them as zero.
+
 Validation does not imply:
 
 - architecture lawfulness

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -5,18 +5,19 @@ use crate::{
     ARCHMAP_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION, ArchMapConcernHintV0,
     ArchMapDocumentV0, ArchMapMoleculeObservationV0, ArchMapSemanticObservationV0,
-    ArchMapSourceRef, ArchSigAatConceptSurfaceV0, ArchSigAnalysisArtifactRefV0,
-    ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationInputV0,
-    ArchSigAnalysisPacketValidationReportV0, ArchSigAnalysisPacketValidationSummaryV0,
-    ArchSigAnalyticRepresentationV0, ArchSigArchMapStoreRefsV0,
-    ArchSigArchitectureObjectProjectionV0, ArchSigArchitectureStateV0,
+    ArchMapSourceRef, ArchSigAatConceptSurfaceV0, ArchSigAmiAggregateReadingV0,
+    ArchSigAmiTopContributorV0, ArchSigAnalysisArtifactRefV0, ArchSigAnalysisPacketV0,
+    ArchSigAnalysisPacketValidationInputV0, ArchSigAnalysisPacketValidationReportV0,
+    ArchSigAnalysisPacketValidationSummaryV0, ArchSigAnalyticRepresentationV0,
+    ArchSigArchMapStoreRefsV0, ArchSigArchitectureObjectProjectionV0, ArchSigArchitectureStateV0,
     ArchSigAtomCompatibilityConflictV0, ArchSigAtomCompatibilityReadingV0,
     ArchSigAtomConfigurationSummaryV0, ArchSigAtomSupportAxisReadingV0,
     ArchSigAxisContinuationTraceV0, ArchSigAxisExcursionV0, ArchSigAxisForgettingRiskReadingV0,
-    ArchSigAxisRestrictionCountV0, ArchSigBoundaryHolonomyReadingFamilyV0,
-    ArchSigBoundaryPreparationRankV0, ArchSigBoundedJudgementV0, ArchSigBridgeAtomFamilyReadingV0,
-    ArchSigBridgeEdgeBreakdownV0, ArchSigBridgeSplitObstructionTransferReadingV0,
-    ArchSigChangeImpactReadingV0, ArchSigCouplingCohesionReadingV0, ArchSigCoverageStatusV0,
+    ArchSigAxisRestrictionCountV0, ArchSigAxisWiseMonodromyDefectV0,
+    ArchSigBoundaryHolonomyReadingFamilyV0, ArchSigBoundaryPreparationRankV0,
+    ArchSigBoundedJudgementV0, ArchSigBridgeAtomFamilyReadingV0, ArchSigBridgeEdgeBreakdownV0,
+    ArchSigBridgeSplitObstructionTransferReadingV0, ArchSigChangeImpactReadingV0,
+    ArchSigCouplingCohesionReadingV0, ArchSigCoverageStatusV0,
     ArchSigCurrentStateEvolutionBoundaryV0, ArchSigDesignPressureReadingV0,
     ArchSigDesignPrincipleReadingV0, ArchSigDiagramFillabilityReadingV0,
     ArchSigDominantAtomFamilyCompositionV0, ArchSigEvolutionRiskRankingV0,
@@ -190,11 +191,20 @@ pub fn build_archsig_analysis_packet(
     let operation_square_candidates = build_operation_square_candidates(archmap, &operation_deltas);
     let path_continuation_traces =
         build_path_continuation_traces(archmap, &operation_square_candidates, &operation_deltas);
+    let axis_wise_monodromy_defects = build_axis_wise_monodromy_defects(
+        law_policy,
+        &operation_square_candidates,
+        &path_continuation_traces,
+    );
+    let ami_aggregate_readings =
+        build_ami_aggregate_readings(law_policy, &axis_wise_monodromy_defects);
     let monodromy_reading_family = build_monodromy_reading_family(
         law_policy,
         &arch_map_store_refs,
         &operation_square_candidates,
         &path_continuation_traces,
+        &axis_wise_monodromy_defects,
+        &ami_aggregate_readings,
     );
     let boundary_holonomy_reading_family = build_boundary_holonomy_reading_family(
         law_policy,
@@ -334,6 +344,8 @@ pub fn build_archsig_analysis_packet(
         bridge_split_obstruction_transfer_readings,
         operation_square_candidates,
         path_continuation_traces,
+        axis_wise_monodromy_defects,
+        ami_aggregate_readings,
         monodromy_reading_family,
         boundary_holonomy_reading_family,
         representation_strength_readings,
@@ -448,6 +460,8 @@ fn build_monodromy_reading_family(
     arch_map_store_refs: &ArchSigArchMapStoreRefsV0,
     operation_square_candidates: &[ArchSigOperationSquareCandidateV0],
     path_continuation_traces: &[ArchSigPathContinuationTraceV0],
+    axis_wise_monodromy_defects: &[ArchSigAxisWiseMonodromyDefectV0],
+    ami_aggregate_readings: &[ArchSigAmiAggregateReadingV0],
 ) -> ArchSigMonodromyReadingFamilyV0 {
     ArchSigMonodromyReadingFamilyV0 {
         reading_family_id: format!(
@@ -468,10 +482,17 @@ fn build_monodromy_reading_family(
             .iter()
             .map(|trace| trace.trace_id.clone())
             .collect(),
-        axis_wise_defect_refs: Vec::new(),
-        aggregate_reading_kind: "ami-precondition-surface".to_string(),
+        axis_wise_defect_refs: axis_wise_monodromy_defects
+            .iter()
+            .map(|defect| defect.defect_id.clone())
+            .collect(),
+        ami_aggregate_reading_refs: ami_aggregate_readings
+            .iter()
+            .map(|aggregate| aggregate.aggregate_id.clone())
+            .collect(),
+        aggregate_reading_kind: "ami-weighted-review-prioritization".to_string(),
         reading_boundary:
-            "records the packet shape for axis-wise defect and AMI readings; concrete defect valuation is introduced by later issues"
+            "records axis-wise defect and AMI aggregate readings as bounded review telemetry, not merge gates or global flatness theorems"
                 .to_string(),
         evidence_boundary:
             "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs"
@@ -742,6 +763,249 @@ fn build_axis_continuation_traces(
         }
     })
     .collect()
+}
+
+fn build_axis_wise_monodromy_defects(
+    law_policy: &LawPolicyDocumentV0,
+    operation_square_candidates: &[ArchSigOperationSquareCandidateV0],
+    path_continuation_traces: &[ArchSigPathContinuationTraceV0],
+) -> Vec<ArchSigAxisWiseMonodromyDefectV0> {
+    operation_square_candidates
+        .iter()
+        .flat_map(|candidate| {
+            let p_trace = path_continuation_traces.iter().find(|trace| {
+                trace.candidate_ref == candidate.candidate_id && trace.path_role == "p"
+            });
+            let q_trace = path_continuation_traces.iter().find(|trace| {
+                trace.candidate_ref == candidate.candidate_id && trace.path_role == "q"
+            });
+            let axis_families = p_trace
+                .into_iter()
+                .flat_map(|trace| {
+                    trace
+                        .axis_traces
+                        .iter()
+                        .map(|axis| axis.axis_family.clone())
+                })
+                .chain(q_trace.into_iter().flat_map(|trace| {
+                    trace
+                        .axis_traces
+                        .iter()
+                        .map(|axis| axis.axis_family.clone())
+                }))
+                .collect::<BTreeSet<_>>();
+
+            axis_families.into_iter().map(move |axis_family| {
+                let p_axis = p_trace.and_then(|trace| {
+                    trace
+                        .axis_traces
+                        .iter()
+                        .find(|axis| axis.axis_family == axis_family)
+                });
+                let q_axis = q_trace.and_then(|trace| {
+                    trace
+                        .axis_traces
+                        .iter()
+                        .find(|axis| axis.axis_family == axis_family)
+                });
+                axis_wise_monodromy_defect(law_policy, candidate, &axis_family, p_axis, q_axis)
+            })
+        })
+        .collect()
+}
+
+fn axis_wise_monodromy_defect(
+    law_policy: &LawPolicyDocumentV0,
+    candidate: &ArchSigOperationSquareCandidateV0,
+    axis_family: &str,
+    p_axis: Option<&ArchSigAxisContinuationTraceV0>,
+    q_axis: Option<&ArchSigAxisContinuationTraceV0>,
+) -> ArchSigAxisWiseMonodromyDefectV0 {
+    let p_refs = p_axis
+        .map(|axis| axis.observation_refs.clone())
+        .unwrap_or_default();
+    let q_refs = q_axis
+        .map(|axis| axis.observation_refs.clone())
+        .unwrap_or_default();
+    let p_missing = p_axis
+        .map(|axis| axis.missing_refs.clone())
+        .unwrap_or_else(|| vec![format!("missing p trace for {axis_family}")]);
+    let q_missing = q_axis
+        .map(|axis| axis.missing_refs.clone())
+        .unwrap_or_else(|| vec![format!("missing q trace for {axis_family}")]);
+    let missing_refs = unique_strings(p_missing.into_iter().chain(q_missing));
+    let measured_support_refs = unique_strings(p_refs.iter().chain(q_refs.iter()).cloned());
+    let witness_refs = unique_strings(
+        measured_support_refs.iter().cloned().chain(
+            missing_refs
+                .iter()
+                .map(|missing| format!("missing-evidence:{missing}")),
+        ),
+    );
+    let both_measured = p_axis.is_some_and(|axis| axis.trace_status != "unmeasured")
+        && q_axis.is_some_and(|axis| axis.trace_status != "unmeasured");
+    let distance_value = both_measured.then(|| symmetric_difference_size(&p_refs, &q_refs) as i64);
+    let axis_ref = p_axis
+        .or(q_axis)
+        .map(|axis| axis.axis_ref.clone())
+        .unwrap_or_else(|| axis_family.to_string());
+
+    ArchSigAxisWiseMonodromyDefectV0 {
+        defect_id: format!(
+            "mu:{}:{}",
+            stable_id(&candidate.candidate_id),
+            stable_id(axis_family)
+        ),
+        candidate_ref: candidate.candidate_id.clone(),
+        axis_family: axis_family.to_string(),
+        axis_ref,
+        distance_kind: law_policy.measurement_policy.distance_kind.clone(),
+        measurement_status: if both_measured {
+            "measured".to_string()
+        } else {
+            "unmeasured".to_string()
+        },
+        distance_value,
+        measured_support_refs: measured_support_refs.clone(),
+        witness_refs,
+        source_refs: candidate.source_refs.clone(),
+        observation_refs: measured_support_refs,
+        missing_refs,
+        coverage_boundary: if both_measured {
+            "covered for selected trace refs; not complete execution semantics".to_string()
+        } else {
+            "coverage gap preserved; unmeasured axis is not zero defect".to_string()
+        },
+        exactness_assumption_status: law_policy
+            .measurement_policy
+            .exactness_assumption_refs
+            .clone(),
+        zero_reflection_assumptions: ami_zero_reflection_assumptions(law_policy),
+        cancellation_boundary:
+            "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions"
+                .to_string(),
+        evidence_boundary:
+            "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality"
+                .to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn build_ami_aggregate_readings(
+    law_policy: &LawPolicyDocumentV0,
+    defects: &[ArchSigAxisWiseMonodromyDefectV0],
+) -> Vec<ArchSigAmiAggregateReadingV0> {
+    let measured_defect_refs = defects
+        .iter()
+        .filter(|defect| defect.distance_value.is_some())
+        .map(|defect| defect.defect_id.clone())
+        .collect::<Vec<_>>();
+    let unmeasured_defect_refs = defects
+        .iter()
+        .filter(|defect| defect.distance_value.is_none())
+        .map(|defect| defect.defect_id.clone())
+        .collect::<Vec<_>>();
+    let aggregate_value = defects
+        .iter()
+        .filter_map(|defect| defect.distance_value)
+        .sum::<i64>();
+    let selected_axis_family = defects
+        .iter()
+        .map(|defect| defect.axis_family.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    vec![ArchSigAmiAggregateReadingV0 {
+        aggregate_id: format!(
+            "ami:{}",
+            stable_id(&law_policy.measurement_policy.policy_id)
+        ),
+        selected_square_family: "operationSquareCandidates".to_string(),
+        selected_axis_family,
+        weight_policy: law_policy.measurement_policy.weight_policy.clone(),
+        distance_kind: law_policy.measurement_policy.distance_kind.clone(),
+        measurement_status: if unmeasured_defect_refs.is_empty() {
+            "measured".to_string()
+        } else {
+            "partial".to_string()
+        },
+        aggregate_value,
+        measured_defect_refs,
+        unmeasured_defect_refs,
+        top_contributors: ami_top_contributors(defects),
+        zero_reflection_assumptions: ami_zero_reflection_assumptions(law_policy),
+        cancellation_boundary:
+            "weighted aggregate is a review prioritization reading; cancellation can hide local defects, so top contributors remain authoritative"
+                .to_string(),
+        aggregate_to_local_reading_boundary:
+            "AMI_X(A) summarizes selected local mu_x(sigma) readings and does not replace axis-wise defect review"
+                .to_string(),
+        review_priority: ami_review_priority(aggregate_value, defects),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }]
+}
+
+fn ami_top_contributors(
+    defects: &[ArchSigAxisWiseMonodromyDefectV0],
+) -> Vec<ArchSigAmiTopContributorV0> {
+    let mut ranked = defects.iter().collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        let left_value = left.distance_value.unwrap_or(i64::MAX);
+        let right_value = right.distance_value.unwrap_or(i64::MAX);
+        right_value
+            .cmp(&left_value)
+            .then(left.axis_family.cmp(&right.axis_family))
+            .then(left.defect_id.cmp(&right.defect_id))
+    });
+    ranked
+        .into_iter()
+        .take(8)
+        .map(|defect| ArchSigAmiTopContributorV0 {
+            defect_ref: defect.defect_id.clone(),
+            candidate_ref: defect.candidate_ref.clone(),
+            axis_family: defect.axis_family.clone(),
+            contribution_weight: 1,
+            contribution_value: defect.distance_value,
+            review_focus: if defect.distance_value.is_some() {
+                format!(
+                    "review {} trace mismatch before treating aggregate value as local agreement",
+                    defect.axis_family
+                )
+            } else {
+                format!(
+                    "supply missing {} trace evidence before interpreting AMI as zero",
+                    defect.axis_family
+                )
+            },
+            witness_refs: defect.witness_refs.clone(),
+        })
+        .collect()
+}
+
+fn ami_zero_reflection_assumptions(law_policy: &LawPolicyDocumentV0) -> Vec<String> {
+    let mut assumptions = law_policy
+        .measurement_policy
+        .exactness_assumption_refs
+        .clone();
+    assumptions
+        .push("all selected operation square candidates and axis traces are measured".to_string());
+    assumptions.push("weighted aggregate has no cancellation of local defects".to_string());
+    assumptions.push("zero aggregate is not global path flatness".to_string());
+    assumptions
+}
+
+fn ami_review_priority(
+    aggregate_value: i64,
+    defects: &[ArchSigAxisWiseMonodromyDefectV0],
+) -> String {
+    if defects.iter().any(|defect| defect.distance_value.is_none()) {
+        "reviewMissingEvidence".to_string()
+    } else if aggregate_value > 0 {
+        "reviewTopContributors".to_string()
+    } else {
+        "reviewZeroReflectionAssumptions".to_string()
+    }
 }
 
 fn inferred_shared_atom_support_refs(archmap: &ArchMapDocumentV0) -> Vec<String> {
@@ -6447,6 +6711,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_aat_structural_reading_surfaces(packet),
         check_current_state_evolution_boundary(packet),
         check_operation_square_trace_surface(packet),
+        check_axis_wise_defect_ami_surface(packet),
         check_monodromy_boundary_schema_foundation(packet),
         check_law_relative_analysis(packet),
         check_signature_and_flatness(packet),
@@ -8579,6 +8844,227 @@ fn check_operation_square_trace_surface(packet: &ArchSigAnalysisPacketV0) -> Val
     )
 }
 
+fn check_axis_wise_defect_ami_surface(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let candidate_ids = set(packet
+        .operation_square_candidates
+        .iter()
+        .map(|candidate| candidate.candidate_id.as_str()));
+    let defect_ids = set(packet
+        .axis_wise_monodromy_defects
+        .iter()
+        .map(|defect| defect.defect_id.as_str()));
+    let mut examples = Vec::new();
+    if packet.axis_wise_monodromy_defects.is_empty() {
+        examples.push(generic_validation_example(
+            "axisWiseMonodromyDefects",
+            "empty",
+            "packet must compute mu_x(sigma) axis-wise defect surfaces",
+        ));
+    }
+    examples.extend(duplicate_examples(
+        "axisWiseMonodromyDefects[].defectId",
+        duplicates(
+            packet
+                .axis_wise_monodromy_defects
+                .iter()
+                .map(|defect| defect.defect_id.as_str()),
+        ),
+    ));
+    for defect in &packet.axis_wise_monodromy_defects {
+        if !candidate_ids.contains(defect.candidate_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &defect.defect_id,
+                &defect.candidate_ref,
+                "axis-wise defect references an unknown operation square candidate",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} distanceKind", defect.defect_id),
+            &defect.distance_kind,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} measurementStatus", defect.defect_id),
+            &defect.measurement_status,
+        );
+        if defect.measurement_status == "measured" && defect.distance_value.is_none() {
+            examples.push(generic_validation_example(
+                &defect.defect_id,
+                "distanceValue",
+                "measured axis-wise defect must carry a distance value",
+            ));
+        }
+        if defect.measurement_status == "unmeasured" && defect.missing_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &defect.defect_id,
+                "missingRefs",
+                "unmeasured axis-wise defect must preserve missing evidence instead of reading as zero",
+            ));
+        }
+        if defect.measured_support_refs.is_empty() && defect.missing_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &defect.defect_id,
+                "measuredSupportRefs/missingRefs",
+                "axis-wise defect must carry measured support or missing refs",
+            ));
+        }
+        if defect.witness_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &defect.defect_id,
+                "witnessRefs",
+                "axis-wise defect must carry witness refs for review",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} coverageBoundary", defect.defect_id),
+            &defect.coverage_boundary,
+        );
+        if defect.zero_reflection_assumptions.is_empty()
+            || has_blank(&defect.zero_reflection_assumptions)
+        {
+            examples.push(generic_validation_example(
+                &defect.defect_id,
+                "zeroReflectionAssumptions",
+                "axis-wise defect must record zero-reflection assumptions",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} cancellationBoundary", defect.defect_id),
+            &defect.cancellation_boundary,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} evidenceBoundary", defect.defect_id),
+            &defect.evidence_boundary,
+        );
+    }
+
+    if packet.ami_aggregate_readings.is_empty() {
+        examples.push(generic_validation_example(
+            "amiAggregateReadings",
+            "empty",
+            "packet must emit AMI aggregate review readings",
+        ));
+    }
+    examples.extend(duplicate_examples(
+        "amiAggregateReadings[].aggregateId",
+        duplicates(
+            packet
+                .ami_aggregate_readings
+                .iter()
+                .map(|aggregate| aggregate.aggregate_id.as_str()),
+        ),
+    ));
+    for aggregate in &packet.ami_aggregate_readings {
+        push_blank(
+            &mut examples,
+            &format!("{} selectedSquareFamily", aggregate.aggregate_id),
+            &aggregate.selected_square_family,
+        );
+        if aggregate.selected_axis_family.is_empty() {
+            examples.push(generic_validation_example(
+                &aggregate.aggregate_id,
+                "selectedAxisFamily",
+                "AMI must report selected axis family",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} weightPolicy", aggregate.aggregate_id),
+            &aggregate.weight_policy,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} distanceKind", aggregate.aggregate_id),
+            &aggregate.distance_kind,
+        );
+        if aggregate.top_contributors.is_empty() {
+            examples.push(generic_validation_example(
+                &aggregate.aggregate_id,
+                "topContributors",
+                "AMI must expose top contributors for review",
+            ));
+        }
+        for contributor in &aggregate.top_contributors {
+            if !defect_ids.contains(contributor.defect_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &aggregate.aggregate_id,
+                    &contributor.defect_ref,
+                    "AMI top contributor references an unknown defect",
+                ));
+            }
+            push_blank(
+                &mut examples,
+                &format!("{} topContributors[].reviewFocus", aggregate.aggregate_id),
+                &contributor.review_focus,
+            );
+        }
+        if aggregate.zero_reflection_assumptions.is_empty()
+            || has_blank(&aggregate.zero_reflection_assumptions)
+        {
+            examples.push(generic_validation_example(
+                &aggregate.aggregate_id,
+                "zeroReflectionAssumptions",
+                "AMI must retain zero-reflection assumptions",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} cancellationBoundary", aggregate.aggregate_id),
+            &aggregate.cancellation_boundary,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} aggregateToLocalReadingBoundary", aggregate.aggregate_id),
+            &aggregate.aggregate_to_local_reading_boundary,
+        );
+        if aggregate
+            .aggregate_to_local_reading_boundary
+            .to_ascii_lowercase()
+            .contains("merge gate")
+        {
+            examples.push(generic_validation_example(
+                &aggregate.aggregate_id,
+                "aggregateToLocalReadingBoundary",
+                "AMI must not be framed as a merge gate",
+            ));
+        }
+    }
+
+    for defect_ref in &packet.monodromy_reading_family.axis_wise_defect_refs {
+        if !defect_ids.contains(defect_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &packet.monodromy_reading_family.reading_family_id,
+                defect_ref,
+                "monodromy reading family references an unknown axis-wise defect",
+            ));
+        }
+    }
+    let aggregate_ids = set(packet
+        .ami_aggregate_readings
+        .iter()
+        .map(|aggregate| aggregate.aggregate_id.as_str()));
+    for aggregate_ref in &packet.monodromy_reading_family.ami_aggregate_reading_refs {
+        if !aggregate_ids.contains(aggregate_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &packet.monodromy_reading_family.reading_family_id,
+                aggregate_ref,
+                "monodromy reading family references an unknown AMI aggregate reading",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-axis-defect-ami-surface",
+        "packet carries mu_x(sigma) axis-wise defects and AMI aggregate review readings without theorem or merge-gate conclusions",
+        examples,
+        "fail",
+    )
+}
+
 fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
     let mut examples = Vec::new();
     let store_refs = &packet.arch_map_store_refs;
@@ -9528,6 +10014,12 @@ fn unique_strings(values: impl Iterator<Item = String>) -> Vec<String> {
     values.collect::<BTreeSet<_>>().into_iter().collect()
 }
 
+fn symmetric_difference_size(left: &[String], right: &[String]) -> usize {
+    let left = left.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let right = right.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    left.symmetric_difference(&right).count()
+}
+
 fn preserved_invariants_for_repair(
     signature_axes: &[ArchSigSignatureAxisReadingV0],
 ) -> Vec<String> {
@@ -9843,6 +10335,19 @@ mod tests {
         assert!(report.checks.iter().any(|check| {
             check.id == "archsig-analysis-packet-operation-square-trace-surface"
                 && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn ami_without_top_contributors_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        packet.ami_aggregate_readings[0].top_contributors.clear();
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-axis-defect-ami-surface" && check.result == "fail"
         }));
     }
 

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -666,6 +666,8 @@ pub struct ArchSigAnalysisPacketV0 {
         Vec<ArchSigBridgeSplitObstructionTransferReadingV0>,
     pub operation_square_candidates: Vec<ArchSigOperationSquareCandidateV0>,
     pub path_continuation_traces: Vec<ArchSigPathContinuationTraceV0>,
+    pub axis_wise_monodromy_defects: Vec<ArchSigAxisWiseMonodromyDefectV0>,
+    pub ami_aggregate_readings: Vec<ArchSigAmiAggregateReadingV0>,
     pub monodromy_reading_family: ArchSigMonodromyReadingFamilyV0,
     pub boundary_holonomy_reading_family: ArchSigBoundaryHolonomyReadingFamilyV0,
     pub representation_strength_readings: Vec<ArchSigRepresentationStrengthReadingV0>,
@@ -751,6 +753,61 @@ pub struct ArchSigAxisContinuationTraceV0 {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ArchSigAxisWiseMonodromyDefectV0 {
+    pub defect_id: String,
+    pub candidate_ref: String,
+    pub axis_family: String,
+    pub axis_ref: String,
+    pub distance_kind: String,
+    pub measurement_status: String,
+    pub distance_value: Option<i64>,
+    pub measured_support_refs: Vec<String>,
+    pub witness_refs: Vec<String>,
+    pub source_refs: Vec<String>,
+    pub observation_refs: Vec<String>,
+    pub missing_refs: Vec<String>,
+    pub coverage_boundary: String,
+    pub exactness_assumption_status: Vec<String>,
+    pub zero_reflection_assumptions: Vec<String>,
+    pub cancellation_boundary: String,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAmiAggregateReadingV0 {
+    pub aggregate_id: String,
+    pub selected_square_family: String,
+    pub selected_axis_family: Vec<String>,
+    pub weight_policy: String,
+    pub distance_kind: String,
+    pub measurement_status: String,
+    pub aggregate_value: i64,
+    pub measured_defect_refs: Vec<String>,
+    pub unmeasured_defect_refs: Vec<String>,
+    pub top_contributors: Vec<ArchSigAmiTopContributorV0>,
+    pub zero_reflection_assumptions: Vec<String>,
+    pub cancellation_boundary: String,
+    pub aggregate_to_local_reading_boundary: String,
+    pub review_priority: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAmiTopContributorV0 {
+    pub defect_ref: String,
+    pub candidate_ref: String,
+    pub axis_family: String,
+    pub contribution_weight: i64,
+    pub contribution_value: Option<i64>,
+    pub review_focus: String,
+    pub witness_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArchSigArchMapStoreRefsV0 {
     pub ref_set_id: String,
     pub arch_map_ref: String,
@@ -776,6 +833,7 @@ pub struct ArchSigMonodromyReadingFamilyV0 {
     pub operation_square_candidate_refs: Vec<String>,
     pub path_continuation_trace_refs: Vec<String>,
     pub axis_wise_defect_refs: Vec<String>,
+    pub ami_aggregate_reading_refs: Vec<String>,
     pub aggregate_reading_kind: String,
     pub reading_boundary: String,
     pub evidence_boundary: String,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1400,6 +1400,51 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "path continuation traces must expose required axis families and keep unmeasured axes as missing evidence"
     );
     assert!(
+        json["axisWiseMonodromyDefects"]
+            .as_array()
+            .is_some_and(|items| {
+                !items.is_empty()
+                    && items.iter().all(|defect| {
+                        defect["distanceKind"].as_str().is_some()
+                            && defect["measuredSupportRefs"].as_array().is_some()
+                            && defect["witnessRefs"]
+                                .as_array()
+                                .is_some_and(|refs| !refs.is_empty())
+                            && defect["coverageBoundary"].as_str().is_some()
+                            && defect["cancellationBoundary"].as_str().is_some()
+                            && (defect["measurementStatus"].as_str() != Some("unmeasured")
+                                || defect["missingRefs"]
+                                    .as_array()
+                                    .is_some_and(|refs| !refs.is_empty()))
+                    })
+            }),
+        "axis-wise defects must carry distance kind, support, witnesses, coverage, and unmeasured boundaries"
+    );
+    assert!(
+        json["amiAggregateReadings"]
+            .as_array()
+            .is_some_and(|items| {
+                !items.is_empty()
+                    && items.iter().all(|aggregate| {
+                        aggregate["selectedSquareFamily"].as_str().is_some()
+                            && aggregate["selectedAxisFamily"]
+                                .as_array()
+                                .is_some_and(|axes| !axes.is_empty())
+                            && aggregate["weightPolicy"].as_str().is_some()
+                            && aggregate["topContributors"]
+                                .as_array()
+                                .is_some_and(|contributors| !contributors.is_empty())
+                            && aggregate["zeroReflectionAssumptions"]
+                                .as_array()
+                                .is_some_and(|assumptions| !assumptions.is_empty())
+                            && aggregate["aggregateToLocalReadingBoundary"]
+                                .as_str()
+                                .is_some_and(|boundary| boundary.contains("local"))
+                    })
+            }),
+        "AMI aggregate readings must remain bounded review aggregates with local-reading boundaries"
+    );
+    assert!(
         json["llmInterpretationPacket"]["structuralReadingReviewSummary"]
             .as_array()
             .is_some_and(|items| !items.is_empty())

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -2965,6 +2965,561 @@
       ]
     }
   ],
+  "axisWiseMonodromyDefects": [
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "authority",
+      "axisRef": "authority / trust boundary axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "unmeasured",
+      "distanceValue": null,
+      "measuredSupportRefs": [],
+      "witnessRefs": [
+        "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [],
+      "missingRefs": [
+        "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+      ],
+      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "contract",
+      "axisRef": "contract axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "atom:contract:create-user"
+      ],
+      "witnessRefs": [
+        "atom:contract:create-user"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "atom:contract:create-user"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "effect",
+      "axisRef": "effect ordering / replay / compensation axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "add observed compensation / authority / effect atoms only after source review",
+        "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+        "split or enrich atoms that currently support the target obstruction"
+      ],
+      "witnessRefs": [
+        "add observed compensation / authority / effect atoms only after source review",
+        "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+        "split or enrich atoms that currently support the target obstruction"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "add observed compensation / authority / effect atoms only after source review",
+        "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+        "split or enrich atoms that currently support the target obstruction"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "projection",
+      "axisRef": "projection / representation axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "projection:aat:route-service",
+        "projection:aat:route-users",
+        "projection:sft:create-user"
+      ],
+      "witnessRefs": [
+        "projection:aat:route-service",
+        "projection:aat:route-users",
+        "projection:sft:create-user"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "projection:aat:route-service",
+        "projection:aat:route-users",
+        "projection:sft:create-user"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "runtime",
+      "axisRef": "runtime interaction axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "semantic",
+      "axisRef": "semantic axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "semantic:create-user-flow"
+      ],
+      "witnessRefs": [
+        "semantic:create-user-flow"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "semantic:create-user-flow"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "state",
+      "axisRef": "state transition axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "unmeasured",
+      "distanceValue": null,
+      "measuredSupportRefs": [],
+      "witnessRefs": [
+        "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [],
+      "missingRefs": [
+        "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+      ],
+      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "axisFamily": "static",
+      "axisRef": "static dependency / support axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "witnessRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
+  "amiAggregateReadings": [
+    {
+      "aggregateId": "ami:measurement-policy-monodromy-boundary-holonomy",
+      "selectedSquareFamily": "operationSquareCandidates",
+      "selectedAxisFamily": [
+        "authority",
+        "contract",
+        "effect",
+        "projection",
+        "runtime",
+        "semantic",
+        "state",
+        "static"
+      ],
+      "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "partial",
+      "aggregateValue": 0,
+      "measuredDefectRefs": [
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static"
+      ],
+      "unmeasuredDefectRefs": [
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state"
+      ],
+      "topContributors": [
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "authority",
+          "contributionWeight": 1,
+          "contributionValue": null,
+          "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
+          "witnessRefs": [
+            "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "state",
+          "contributionWeight": 1,
+          "contributionValue": null,
+          "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
+          "witnessRefs": [
+            "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "contract",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "atom:contract:create-user"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "effect",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "add observed compensation / authority / effect atoms only after source review",
+            "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+            "split or enrich atoms that currently support the target obstruction"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "projection",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "projection:aat:route-service",
+            "projection:aat:route-users",
+            "projection:sft:create-user"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "runtime",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review runtime trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "gap-runtime-user-db-trace"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "semantic",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "semantic:create-user-flow"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "axisFamily": "static",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "atom:component:route-users",
+            "atom:component:service-user",
+            "atom:relation:route-service"
+          ]
+        }
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "weighted aggregate is a review prioritization reading; cancellation can hide local defects, so top contributors remain authoritative",
+      "aggregateToLocalReadingBoundary": "AMI_X(A) summarizes selected local mu_x(sigma) readings and does not replace axis-wise defect review",
+      "reviewPriority": "reviewMissingEvidence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -2983,9 +3538,21 @@
       "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:p",
       "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:q"
     ],
-    "axisWiseDefectRefs": [],
-    "aggregateReadingKind": "ami-precondition-surface",
-    "readingBoundary": "records the packet shape for axis-wise defect and AMI readings; concrete defect valuation is introduced by later issues",
+    "axisWiseDefectRefs": [
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static"
+    ],
+    "amiAggregateReadingRefs": [
+      "ami:measurement-policy-monodromy-boundary-holonomy"
+    ],
+    "aggregateReadingKind": "ami-weighted-review-prioritization",
+    "readingBoundary": "records axis-wise defect and AMI aggregate readings as bounded review telemetry, not merge gates or global flatness theorems",
     "evidenceBoundary": "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs",
     "nonConclusions": [
       "ArchSig analysis packet is not a Lean theorem proof",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -2705,6 +2705,557 @@
       ]
     }
   ],
+  "axisWiseMonodromyDefects": [
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "authority",
+      "axisRef": "authority / trust boundary axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "unmeasured",
+      "distanceValue": null,
+      "measuredSupportRefs": [],
+      "witnessRefs": [
+        "missing-evidence:missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [],
+      "missingRefs": [
+        "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+      ],
+      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "contract",
+      "axisRef": "contract axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "atom:contract:create-user"
+      ],
+      "witnessRefs": [
+        "atom:contract:create-user"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "atom:contract:create-user"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "effect",
+      "axisRef": "effect ordering / replay / compensation axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "add or refine ArchMap atom observations before claiming repair",
+        "no constructed obstruction is transported because no repair candidate exists"
+      ],
+      "witnessRefs": [
+        "add or refine ArchMap atom observations before claiming repair",
+        "no constructed obstruction is transported because no repair candidate exists"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "add or refine ArchMap atom observations before claiming repair",
+        "no constructed obstruction is transported because no repair candidate exists"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "projection",
+      "axisRef": "projection / representation axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "projection:aat:route-service",
+        "projection:aat:route-users",
+        "projection:sft:create-user"
+      ],
+      "witnessRefs": [
+        "projection:aat:route-service",
+        "projection:aat:route-users",
+        "projection:sft:create-user"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "projection:aat:route-service",
+        "projection:aat:route-users",
+        "projection:sft:create-user"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "runtime",
+      "axisRef": "runtime interaction axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "semantic",
+      "axisRef": "semantic axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "semantic:create-user-flow"
+      ],
+      "witnessRefs": [
+        "semantic:create-user-flow"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "semantic:create-user-flow"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "state",
+      "axisRef": "state transition axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "unmeasured",
+      "distanceValue": null,
+      "measuredSupportRefs": [],
+      "witnessRefs": [
+        "missing-evidence:missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [],
+      "missingRefs": [
+        "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+      ],
+      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "axisFamily": "static",
+      "axisRef": "static dependency / support axis",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "measured",
+      "distanceValue": 0,
+      "measuredSupportRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "witnessRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "missingRefs": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "exactnessAssumptionStatus": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
+  "amiAggregateReadings": [
+    {
+      "aggregateId": "ami:measurement-policy-monodromy-boundary-holonomy",
+      "selectedSquareFamily": "operationSquareCandidates",
+      "selectedAxisFamily": [
+        "authority",
+        "contract",
+        "effect",
+        "projection",
+        "runtime",
+        "semantic",
+        "state",
+        "static"
+      ],
+      "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+      "distanceKind": "weighted-axis-l1",
+      "measurementStatus": "partial",
+      "aggregateValue": 0,
+      "measuredDefectRefs": [
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static"
+      ],
+      "unmeasuredDefectRefs": [
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state"
+      ],
+      "topContributors": [
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "authority",
+          "contributionWeight": 1,
+          "contributionValue": null,
+          "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
+          "witnessRefs": [
+            "missing-evidence:missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "state",
+          "contributionWeight": 1,
+          "contributionValue": null,
+          "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
+          "witnessRefs": [
+            "missing-evidence:missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "contract",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "atom:contract:create-user"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "effect",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "add or refine ArchMap atom observations before claiming repair",
+            "no constructed obstruction is transported because no repair candidate exists"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "projection",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "projection:aat:route-service",
+            "projection:aat:route-users",
+            "projection:sft:create-user"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "runtime",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review runtime trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "gap-runtime-user-db-trace"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "semantic",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "semantic:create-user-flow"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "axisFamily": "static",
+          "contributionWeight": 1,
+          "contributionValue": 0,
+          "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "atom:component:route-users",
+            "atom:component:service-user",
+            "atom:relation:route-service"
+          ]
+        }
+      ],
+      "zeroReflectionAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary",
+        "all selected operation square candidates and axis traces are measured",
+        "weighted aggregate has no cancellation of local defects",
+        "zero aggregate is not global path flatness"
+      ],
+      "cancellationBoundary": "weighted aggregate is a review prioritization reading; cancellation can hide local defects, so top contributors remain authoritative",
+      "aggregateToLocalReadingBoundary": "AMI_X(A) summarizes selected local mu_x(sigma) readings and does not replace axis-wise defect review",
+      "reviewPriority": "reviewMissingEvidence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -2722,9 +3273,21 @@
       "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:p",
       "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:q"
     ],
-    "axisWiseDefectRefs": [],
-    "aggregateReadingKind": "ami-precondition-surface",
-    "readingBoundary": "records the packet shape for axis-wise defect and AMI readings; concrete defect valuation is introduced by later issues",
+    "axisWiseDefectRefs": [
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static"
+    ],
+    "amiAggregateReadingRefs": [
+      "ami:measurement-policy-monodromy-boundary-holonomy"
+    ],
+    "aggregateReadingKind": "ami-weighted-review-prioritization",
+    "readingBoundary": "records axis-wise defect and AMI aggregate readings as bounded review telemetry, not merge gates or global flatness theorems",
     "evidenceBoundary": "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs",
     "nonConclusions": [
       "ArchSig analysis packet is not a Lean theorem proof",


### PR DESCRIPTION
## 概要

Closes #1472

#1486 を base にした stacked PR です。#1471 の operation square / continuation trace surface 上に、axis-wise defect `mu_x(sigma)` と AMI aggregate reading を追加します。

- `axisWiseMonodromyDefects` を追加し、distance kind、measured support、witness refs、source / observation / missing refs、coverage boundary、zero-reflection assumptions、cancellation boundary を出力
- `amiAggregateReadings` を追加し、selected square family、selected axis family、weight policy、top contributors、aggregate-to-local reading boundary を出力
- unmeasured axis は `distanceValue: null` と `missingRefs` で保持し、zero defect として扱わない
- AMI を review prioritization reading として扱い、single score / merge gate / global flatness theorem にしない validation と docs を追加
- golden fixture と packet docs / LawPolicy docs を同期

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`
- `docs/tool/law_policy.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は Lean 変更なしのため未実施です。FieldSig 変更なしのため FieldSig test は未実施です。Lean ソース変更なしのため axiom / admit / sorry / unsafe scan は未実施です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `defined only / future proof obligation guardrail` として Issue 側の範囲に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
