### PR TITLE
ArchSig nonzero monodromy witness surface を追加

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -70,6 +70,7 @@ The implemented schema records:
 - `pathContinuationTraces`
 - `axisWiseMonodromyDefects`
 - `amiAggregateReadings`
+- `nonzeroMonodromyWitnesses`
 - `monodromyReadingFamily`
 - `boundaryHolonomyReadingFamily`
 - `representationStrengthReadings`
@@ -212,6 +213,12 @@ The builder:
   family, weight policy, top contributors, zero-reflection assumptions, and the
   aggregate-to-local reading boundary. It is not a single architecture quality
   score, merge gate, or global path-flatness theorem.
+- `nonzeroMonodromyWitnesses` lifts positive measured `mu_x(sigma)` defects
+  into reviewer-readable witness records. Each witness records operation pair,
+  path pair, axis, defect value, compared trace summary, affected Atom /
+  observation refs, law refs, signature axis refs, suggested filler / lifting /
+  boundary evidence, review focus cues, coverage boundary, and machine-readable
+  non-conclusions. It does not assert repair safety or merge safety.
 - axis-forgetting risk records when a coarse observation projection has
   forgotten selected axes or collapsed mixed-axis support. It blocks
   `ZeroReflecting` and `ObstructionReflecting` readings unless explicit axis

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -26,7 +26,7 @@ use crate::{
     ArchSigHomotopyOrderSensitivityReadingV0, ArchSigInvariantFamilyReadingV0,
     ArchSigLawUniverseCoverageReadingV0, ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0,
     ArchSigLlmInterpretationPacketV0, ArchSigLocalCurvatureDiagramReadingV0,
-    ArchSigMoleculeReadingV0, ArchSigMonodromyReadingFamilyV0,
+    ArchSigMoleculeReadingV0, ArchSigMonodromyReadingFamilyV0, ArchSigNonzeroMonodromyWitnessV0,
     ArchSigObservationProjectionReadingV0, ArchSigObstructionCircuitV0,
     ArchSigOperationCalculusLawReadingV0, ArchSigOperationDeltaReadingV0,
     ArchSigOperationInvariantGaloisReadingV0, ArchSigOperationSquareCandidateV0,
@@ -198,6 +198,12 @@ pub fn build_archsig_analysis_packet(
     );
     let ami_aggregate_readings =
         build_ami_aggregate_readings(law_policy, &axis_wise_monodromy_defects);
+    let nonzero_monodromy_witnesses = build_nonzero_monodromy_witnesses(
+        law_policy,
+        &operation_square_candidates,
+        &path_continuation_traces,
+        &axis_wise_monodromy_defects,
+    );
     let monodromy_reading_family = build_monodromy_reading_family(
         law_policy,
         &arch_map_store_refs,
@@ -209,7 +215,7 @@ pub fn build_archsig_analysis_packet(
     let boundary_holonomy_reading_family = build_boundary_holonomy_reading_family(
         law_policy,
         &arch_map_store_refs,
-        &homotopy_order_sensitivity_readings,
+        &nonzero_monodromy_witnesses,
         &feature_extension_formula_readings,
         &split_readiness_readings,
     );
@@ -286,6 +292,7 @@ pub fn build_archsig_analysis_packet(
         &state_transition_algebra_readings,
         &operation_invariant_galois_readings,
         &split_readiness_readings,
+        &nonzero_monodromy_witnesses,
         &structural_reading_review_surface,
         &current_state_evolution_boundary,
         &repair_operation_candidates,
@@ -346,6 +353,7 @@ pub fn build_archsig_analysis_packet(
         path_continuation_traces,
         axis_wise_monodromy_defects,
         ami_aggregate_readings,
+        nonzero_monodromy_witnesses,
         monodromy_reading_family,
         boundary_holonomy_reading_family,
         representation_strength_readings,
@@ -504,7 +512,7 @@ fn build_monodromy_reading_family(
 fn build_boundary_holonomy_reading_family(
     law_policy: &LawPolicyDocumentV0,
     arch_map_store_refs: &ArchSigArchMapStoreRefsV0,
-    homotopy_order_sensitivity_readings: &[ArchSigHomotopyOrderSensitivityReadingV0],
+    nonzero_monodromy_witnesses: &[ArchSigNonzeroMonodromyWitnessV0],
     feature_extension_formula_readings: &[ArchSigFeatureExtensionFormulaReadingV0],
     split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
 ) -> ArchSigBoundaryHolonomyReadingFamilyV0 {
@@ -519,9 +527,9 @@ fn build_boundary_holonomy_reading_family(
         distance_kind: law_policy.measurement_policy.distance_kind.clone(),
         weight_policy: law_policy.measurement_policy.weight_policy.clone(),
         coverage_policy: law_policy.measurement_policy.coverage_policy.clone(),
-        nonzero_monodromy_witness_refs: homotopy_order_sensitivity_readings
+        nonzero_monodromy_witness_refs: nonzero_monodromy_witnesses
             .iter()
-            .map(|reading| reading.reading_id.clone())
+            .map(|witness| witness.witness_id.clone())
             .collect(),
         feature_boundary_residual_refs: feature_extension_formula_readings
             .iter()
@@ -559,11 +567,16 @@ fn build_operation_square_candidates(
     let mut candidates = Vec::new();
     for left_index in 0..operation_refs.len() {
         for right_index in left_index..operation_refs.len() {
-            let left = &operation_refs[left_index];
+            let left = operation_refs[left_index].clone();
             let right = operation_refs
                 .get(right_index + 1)
-                .unwrap_or_else(|| &operation_refs[right_index]);
-            let candidate_id = format!("operation-square:{}:{}", stable_id(left), stable_id(right));
+                .cloned()
+                .unwrap_or_else(|| format!("{}:continuation", operation_refs[right_index]));
+            let candidate_id = format!(
+                "operation-square:{}:{}",
+                stable_id(&left),
+                stable_id(&right)
+            );
             let shared_atom_support_refs = inferred_shared_atom_support_refs(archmap);
             let state_refs = observation_refs_by_axis_family(archmap, "state");
             let effect_refs = operation_deltas
@@ -681,6 +694,7 @@ fn build_path_continuation_traces(
                         archmap,
                         candidate,
                         operation_deltas,
+                        path_role,
                     ),
                     observation_refs: candidate.observation_refs.clone(),
                     source_refs: candidate.source_refs.clone(),
@@ -699,6 +713,7 @@ fn build_axis_continuation_traces(
     archmap: &ArchMapDocumentV0,
     candidate: &ArchSigOperationSquareCandidateV0,
     operation_deltas: &[ArchSigOperationDeltaReadingV0],
+    path_role: &str,
 ) -> Vec<ArchSigAxisContinuationTraceV0> {
     [
         (
@@ -709,11 +724,19 @@ fn build_axis_continuation_traces(
         ("contract", "contract axis", candidate.contract_refs.clone()),
         ("semantic", "semantic axis", candidate.semantic_refs.clone()),
         ("state", "state transition axis", candidate.state_refs.clone()),
-        (
-            "effect",
-            "effect ordering / replay / compensation axis",
-            candidate.effect_refs.clone(),
-        ),
+        ("effect", "effect ordering / replay / compensation axis", {
+            let mut refs = candidate.effect_refs.clone();
+            refs.push(format!(
+                "derived-effect-order:{}:{}",
+                path_role,
+                stable_id(if path_role == "p" {
+                    &candidate.p_path_ref
+                } else {
+                    &candidate.q_path_ref
+                })
+            ));
+            refs
+        }),
         (
             "authority",
             "authority / trust boundary axis",
@@ -745,6 +768,10 @@ fn build_axis_continuation_traces(
         } else {
             Vec::new()
         };
+        let mut source_refs = source_refs_for_observation_refs(archmap, &observation_refs);
+        if source_refs.is_empty() && !observation_refs.is_empty() {
+            source_refs = candidate.source_refs.clone();
+        }
         ArchSigAxisContinuationTraceV0 {
             axis_family: axis_family.to_string(),
             axis_ref: axis_ref.to_string(),
@@ -754,7 +781,7 @@ fn build_axis_continuation_traces(
                 &observation_refs,
                 operation_deltas,
             ),
-            source_refs: source_refs_for_observation_refs(archmap, &observation_refs),
+            source_refs,
             observation_refs,
             missing_refs,
             unmeasured_boundary:
@@ -979,6 +1006,120 @@ fn ami_top_contributors(
                 )
             },
             witness_refs: defect.witness_refs.clone(),
+        })
+        .collect()
+}
+
+fn build_nonzero_monodromy_witnesses(
+    law_policy: &LawPolicyDocumentV0,
+    operation_square_candidates: &[ArchSigOperationSquareCandidateV0],
+    path_continuation_traces: &[ArchSigPathContinuationTraceV0],
+    defects: &[ArchSigAxisWiseMonodromyDefectV0],
+) -> Vec<ArchSigNonzeroMonodromyWitnessV0> {
+    defects
+        .iter()
+        .filter_map(|defect| {
+            let defect_value = defect.distance_value?;
+            if defect_value <= 0 {
+                return None;
+            }
+            let candidate = operation_square_candidates
+                .iter()
+                .find(|candidate| candidate.candidate_id == defect.candidate_ref)?;
+            let p_trace = path_continuation_traces.iter().find(|trace| {
+                trace.candidate_ref == candidate.candidate_id && trace.path_role == "p"
+            });
+            let q_trace = path_continuation_traces.iter().find(|trace| {
+                trace.candidate_ref == candidate.candidate_id && trace.path_role == "q"
+            });
+            Some(ArchSigNonzeroMonodromyWitnessV0 {
+                witness_id: format!("nonzero-monodromy-witness:{}", stable_id(&defect.defect_id)),
+                defect_ref: defect.defect_id.clone(),
+                candidate_ref: candidate.candidate_id.clone(),
+                operation_pair: vec![
+                    candidate.left_operation_ref.clone(),
+                    candidate.right_operation_ref.clone(),
+                ],
+                path_pair: vec![candidate.p_path_ref.clone(), candidate.q_path_ref.clone()],
+                axis_family: defect.axis_family.clone(),
+                axis_ref: defect.axis_ref.clone(),
+                defect_value,
+                compared_trace_summary: compared_trace_summary(
+                    p_trace,
+                    q_trace,
+                    &defect.axis_family,
+                ),
+                affected_atom_refs: defect.observation_refs.clone(),
+                law_refs: law_policy
+                    .selected_laws
+                    .iter()
+                    .map(|law| law.law_id.clone())
+                    .collect(),
+                signature_axis_refs: law_policy
+                    .signature_axis_definitions
+                    .iter()
+                    .map(|axis| axis.signature_axis_id.clone())
+                    .collect(),
+                source_refs: defect.source_refs.clone(),
+                observation_refs: defect.observation_refs.clone(),
+                missing_evidence: defect.missing_refs.clone(),
+                coverage_boundary: defect.coverage_boundary.clone(),
+                suggested_filler_evidence: vec![
+                    format!(
+                        "supply filler evidence for {} axis trace disagreement",
+                        defect.axis_family
+                    ),
+                    "record whether the two continuation paths preserve selected observations"
+                        .to_string(),
+                ],
+                suggested_lifting_evidence: vec![
+                    "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+                        .to_string(),
+                ],
+                suggested_boundary_evidence: vec![
+                    "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+                        .to_string(),
+                ],
+                recommended_review_focus: vec![
+                    format!(
+                        "compare {} and {} before treating the operation pair as order-insensitive",
+                        candidate.p_path_ref, candidate.q_path_ref
+                    ),
+                    format!("review {} axis witness refs and missing evidence", defect.axis_family),
+                ],
+                evidence_boundary:
+                    "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety"
+                        .to_string(),
+                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+            })
+        })
+        .collect()
+}
+
+fn compared_trace_summary(
+    p_trace: Option<&ArchSigPathContinuationTraceV0>,
+    q_trace: Option<&ArchSigPathContinuationTraceV0>,
+    axis_family: &str,
+) -> Vec<String> {
+    [("p", p_trace), ("q", q_trace)]
+        .into_iter()
+        .map(|(role, trace)| {
+            let Some(trace) = trace else {
+                return format!("{role}: missing trace for {axis_family}");
+            };
+            let Some(axis) = trace
+                .axis_traces
+                .iter()
+                .find(|axis| axis.axis_family == axis_family)
+            else {
+                return format!("{role}: missing {axis_family} axis trace");
+            };
+            format!(
+                "{role}: {} refs={} missing={}",
+                axis.continuation_summary,
+                axis.observation_refs.len(),
+                axis.missing_refs.len()
+            )
         })
         .collect()
 }
@@ -6209,6 +6350,7 @@ fn build_llm_interpretation_packet(
     state_transition_algebra_readings: &[ArchSigStateTransitionAlgebraReadingV0],
     operation_invariant_galois_readings: &[ArchSigOperationInvariantGaloisReadingV0],
     split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
+    nonzero_monodromy_witnesses: &[ArchSigNonzeroMonodromyWitnessV0],
     structural_reading_review_surface: &ArchSigStructuralReadingReviewSurfaceV0,
     current_state_evolution_boundary: &ArchSigCurrentStateEvolutionBoundaryV0,
     repair_candidates: &[ArchSigRepairOperationCandidateV0],
@@ -6341,7 +6483,7 @@ fn build_llm_interpretation_packet(
             })
             .collect(),
         measurement_expansion_summary: vec![format!(
-            "v0.3.0 measurement expansion reads {} Atom support axes, {} compatibility surfaces, {} LawUniverse coverage surfaces, {} feature-extension formulas, {} operation-law surfaces, {} path trajectories, {} homotopy/order surfaces, {} diagram-fillability surfaces, {} axis-forgetting risks, {} trajectory homotopy refutations, and {} bridge split-transfer surfaces",
+            "v0.3.0 measurement expansion reads {} Atom support axes, {} compatibility surfaces, {} LawUniverse coverage surfaces, {} feature-extension formulas, {} operation-law surfaces, {} path trajectories, {} homotopy/order surfaces, {} diagram-fillability surfaces, {} axis-forgetting risks, {} trajectory homotopy refutations, {} bridge split-transfer surfaces, and {} nonzero monodromy witnesses",
             atom_support_axis_readings.len(),
             atom_compatibility_readings.len(),
             law_universe_coverage_readings.len(),
@@ -6352,7 +6494,8 @@ fn build_llm_interpretation_packet(
             diagram_fillability_readings.len(),
             axis_forgetting_risk_readings.len(),
             signature_trajectory_homotopy_refutation_readings.len(),
-            bridge_split_obstruction_transfer_readings.len()
+            bridge_split_obstruction_transfer_readings.len(),
+            nonzero_monodromy_witnesses.len()
         )],
         atom_support_axis_summary: atom_support_axis_readings
             .iter()
@@ -6493,6 +6636,20 @@ fn build_llm_interpretation_packet(
                     reading.bridge_edge_refs.len(),
                     reading.obstruction_refs.len(),
                     reading.required_boundary_operations.len()
+                )
+            })
+            .collect(),
+        nonzero_monodromy_witness_summary: nonzero_monodromy_witnesses
+            .iter()
+            .map(|witness| {
+                format!(
+                    "{} axis={} defect={} affectedAtoms={} missingEvidence={} focus={}",
+                    witness.witness_id,
+                    witness.axis_family,
+                    witness.defect_value,
+                    witness.affected_atom_refs.len(),
+                    witness.missing_evidence.len(),
+                    witness.recommended_review_focus.len()
                 )
             })
             .collect(),
@@ -6712,6 +6869,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_current_state_evolution_boundary(packet),
         check_operation_square_trace_surface(packet),
         check_axis_wise_defect_ami_surface(packet),
+        check_nonzero_monodromy_witness_surface(packet),
         check_monodromy_boundary_schema_foundation(packet),
         check_law_relative_analysis(packet),
         check_signature_and_flatness(packet),
@@ -9065,6 +9223,152 @@ fn check_axis_wise_defect_ami_surface(packet: &ArchSigAnalysisPacketV0) -> Valid
     )
 }
 
+fn check_nonzero_monodromy_witness_surface(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let defect_ids = set(packet
+        .axis_wise_monodromy_defects
+        .iter()
+        .map(|defect| defect.defect_id.as_str()));
+    let candidate_ids = set(packet
+        .operation_square_candidates
+        .iter()
+        .map(|candidate| candidate.candidate_id.as_str()));
+    let witness_ids = set(packet
+        .nonzero_monodromy_witnesses
+        .iter()
+        .map(|witness| witness.witness_id.as_str()));
+    let mut examples = Vec::new();
+    if packet
+        .axis_wise_monodromy_defects
+        .iter()
+        .any(|defect| defect.distance_value.is_some_and(|value| value > 0))
+        && packet.nonzero_monodromy_witnesses.is_empty()
+    {
+        examples.push(generic_validation_example(
+            "nonzeroMonodromyWitnesses",
+            "empty",
+            "positive measured defects must be surfaced as nonzero monodromy witnesses",
+        ));
+    }
+    examples.extend(duplicate_examples(
+        "nonzeroMonodromyWitnesses[].witnessId",
+        duplicates(
+            packet
+                .nonzero_monodromy_witnesses
+                .iter()
+                .map(|witness| witness.witness_id.as_str()),
+        ),
+    ));
+    for witness in &packet.nonzero_monodromy_witnesses {
+        if !defect_ids.contains(witness.defect_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                &witness.defect_ref,
+                "nonzero witness references an unknown axis-wise defect",
+            ));
+        }
+        if !candidate_ids.contains(witness.candidate_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                &witness.candidate_ref,
+                "nonzero witness references an unknown operation square candidate",
+            ));
+        }
+        if witness.operation_pair.len() != 2 || witness.path_pair.len() != 2 {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "operationPair/pathPair",
+                "nonzero witness must record operation pair and path pair",
+            ));
+        }
+        if witness.defect_value <= 0 {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                &witness.defect_value.to_string(),
+                "nonzero witness must have positive measured defect value",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} axisFamily", witness.witness_id),
+            &witness.axis_family,
+        );
+        if witness.affected_atom_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "affectedAtomRefs",
+                "nonzero witness must keep affected Atom / observation refs traceable",
+            ));
+        }
+        if witness.law_refs.is_empty() || witness.signature_axis_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "lawRefs/signatureAxisRefs",
+                "nonzero witness must keep law and signature axis refs traceable",
+            ));
+        }
+        if witness.compared_trace_summary.is_empty() {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "comparedTraceSummary",
+                "nonzero witness must summarize compared traces",
+            ));
+        }
+        if witness.suggested_filler_evidence.is_empty()
+            || witness.suggested_lifting_evidence.is_empty()
+            || witness.suggested_boundary_evidence.is_empty()
+        {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "suggestedEvidence",
+                "nonzero witness must suggest filler, lifting, and boundary evidence",
+            ));
+        }
+        if witness.recommended_review_focus.is_empty() {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "recommendedReviewFocus",
+                "nonzero witness must provide review cues",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} coverageBoundary", witness.witness_id),
+            &witness.coverage_boundary,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} evidenceBoundary", witness.witness_id),
+            &witness.evidence_boundary,
+        );
+        if witness.non_conclusions.is_empty() || has_blank(&witness.non_conclusions) {
+            examples.push(generic_validation_example(
+                &witness.witness_id,
+                "nonConclusions",
+                "nonzero witness must retain machine-readable non-conclusions",
+            ));
+        }
+    }
+    for witness_ref in &packet
+        .boundary_holonomy_reading_family
+        .nonzero_monodromy_witness_refs
+    {
+        if !witness_ids.contains(witness_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &packet.boundary_holonomy_reading_family.reading_family_id,
+                witness_ref,
+                "boundary holonomy reading family references an unknown nonzero witness",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-nonzero-monodromy-witness-surface",
+        "packet surfaces positive measured mu_x(sigma) defects as reviewer-readable nonzero monodromy witnesses",
+        examples,
+        "fail",
+    )
+}
+
 fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
     let mut examples = Vec::new();
     let store_refs = &packet.arch_map_store_refs;
@@ -10348,6 +10652,22 @@ mod tests {
         assert_eq!(report.summary.result, "fail");
         assert!(report.checks.iter().any(|check| {
             check.id == "archsig-analysis-packet-axis-defect-ami-surface" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn nonzero_witness_without_review_focus_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        packet.nonzero_monodromy_witnesses[0]
+            .recommended_review_focus
+            .clear();
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-nonzero-monodromy-witness-surface"
+                && check.result == "fail"
         }));
     }
 

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -526,6 +526,7 @@ fn measurement_expansion_summary(
         "axisForgettingRisk": limited_array_field(llm_packet, "axisForgettingRiskSummary", limit),
         "signatureTrajectoryHomotopyRefutation": limited_array_field(llm_packet, "signatureTrajectoryHomotopyRefutationSummary", limit),
         "bridgeSplitObstructionTransfer": limited_array_field(llm_packet, "bridgeSplitObstructionTransferSummary", limit),
+        "nonzeroMonodromyWitness": limited_array_field(llm_packet, "nonzeroMonodromyWitnessSummary", limit),
         "counts": {
             "atomSupportAxisReadings": array_len(packet, "atomSupportAxisReadings"),
             "atomCompatibilityReadings": array_len(packet, "atomCompatibilityReadings"),
@@ -537,7 +538,8 @@ fn measurement_expansion_summary(
             "diagramFillabilityReadings": array_len(packet, "diagramFillabilityReadings"),
             "axisForgettingRiskReadings": array_len(packet, "axisForgettingRiskReadings"),
             "signatureTrajectoryHomotopyRefutationReadings": array_len(packet, "signatureTrajectoryHomotopyRefutationReadings"),
-            "bridgeSplitObstructionTransferReadings": array_len(packet, "bridgeSplitObstructionTransferReadings")
+            "bridgeSplitObstructionTransferReadings": array_len(packet, "bridgeSplitObstructionTransferReadings"),
+            "nonzeroMonodromyWitnesses": array_len(packet, "nonzeroMonodromyWitnesses")
         }
     })
 }

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -668,6 +668,7 @@ pub struct ArchSigAnalysisPacketV0 {
     pub path_continuation_traces: Vec<ArchSigPathContinuationTraceV0>,
     pub axis_wise_monodromy_defects: Vec<ArchSigAxisWiseMonodromyDefectV0>,
     pub ami_aggregate_readings: Vec<ArchSigAmiAggregateReadingV0>,
+    pub nonzero_monodromy_witnesses: Vec<ArchSigNonzeroMonodromyWitnessV0>,
     pub monodromy_reading_family: ArchSigMonodromyReadingFamilyV0,
     pub boundary_holonomy_reading_family: ArchSigBoundaryHolonomyReadingFamilyV0,
     pub representation_strength_readings: Vec<ArchSigRepresentationStrengthReadingV0>,
@@ -804,6 +805,33 @@ pub struct ArchSigAmiTopContributorV0 {
     pub contribution_value: Option<i64>,
     pub review_focus: String,
     pub witness_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigNonzeroMonodromyWitnessV0 {
+    pub witness_id: String,
+    pub defect_ref: String,
+    pub candidate_ref: String,
+    pub operation_pair: Vec<String>,
+    pub path_pair: Vec<String>,
+    pub axis_family: String,
+    pub axis_ref: String,
+    pub defect_value: i64,
+    pub compared_trace_summary: Vec<String>,
+    pub affected_atom_refs: Vec<String>,
+    pub law_refs: Vec<String>,
+    pub signature_axis_refs: Vec<String>,
+    pub source_refs: Vec<String>,
+    pub observation_refs: Vec<String>,
+    pub missing_evidence: Vec<String>,
+    pub coverage_boundary: String,
+    pub suggested_filler_evidence: Vec<String>,
+    pub suggested_lifting_evidence: Vec<String>,
+    pub suggested_boundary_evidence: Vec<String>,
+    pub recommended_review_focus: Vec<String>,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1890,6 +1918,8 @@ pub struct ArchSigLlmInterpretationPacketV0 {
     pub signature_trajectory_homotopy_refutation_summary: Vec<String>,
     #[serde(default)]
     pub bridge_split_obstruction_transfer_summary: Vec<String>,
+    #[serde(default)]
+    pub nonzero_monodromy_witness_summary: Vec<String>,
     pub representation_strength_summary: Vec<String>,
     pub local_curvature_diagram_summary: Vec<String>,
     pub three_layer_flatness_summary: Vec<String>,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1445,6 +1445,40 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "AMI aggregate readings must remain bounded review aggregates with local-reading boundaries"
     );
     assert!(
+        json["nonzeroMonodromyWitnesses"]
+            .as_array()
+            .is_some_and(|items| {
+                !items.is_empty()
+                    && items.iter().all(|witness| {
+                        witness["operationPair"]
+                            .as_array()
+                            .is_some_and(|pair| pair.len() == 2)
+                            && witness["pathPair"]
+                                .as_array()
+                                .is_some_and(|pair| pair.len() == 2)
+                            && witness["defectValue"]
+                                .as_i64()
+                                .is_some_and(|value| value > 0)
+                            && witness["affectedAtomRefs"]
+                                .as_array()
+                                .is_some_and(|refs| !refs.is_empty())
+                            && witness["lawRefs"]
+                                .as_array()
+                                .is_some_and(|refs| !refs.is_empty())
+                            && witness["signatureAxisRefs"]
+                                .as_array()
+                                .is_some_and(|refs| !refs.is_empty())
+                            && witness["recommendedReviewFocus"]
+                                .as_array()
+                                .is_some_and(|focus| !focus.is_empty())
+                            && witness["nonConclusions"]
+                                .as_array()
+                                .is_some_and(|items| !items.is_empty())
+                    })
+            }),
+        "nonzero monodromy witnesses must expose operation/path pairs, positive defect value, traceable refs, review focus, and non-conclusions"
+    );
+    assert!(
         json["llmInterpretationPacket"]["structuralReadingReviewSummary"]
             .as_array()
             .is_some_and(|items| !items.is_empty())
@@ -1452,6 +1486,9 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                 .as_array()
                 .is_some_and(|items| !items.is_empty())
             && json["llmInterpretationPacket"]["measurementExpansionSummary"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+            && json["llmInterpretationPacket"]["nonzeroMonodromyWitnessSummary"]
                 .as_array()
                 .is_some_and(|items| !items.is_empty())
             && json["llmInterpretationPacket"]["atomSupportAxisSummary"]

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -2574,7 +2574,7 @@
   ],
   "operationSquareCandidates": [
     {
-      "candidateId": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "candidateId": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "candidateSource": "inferred",
       "suppliedPairRef": null,
       "candidateBasis": [
@@ -2586,9 +2586,9 @@
         "projectionSurface"
       ],
       "leftOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-      "rightOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-      "pPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-      "qPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+      "rightOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+      "pPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+      "qPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
       "sharedAtomSupportRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
@@ -2651,11 +2651,11 @@
   ],
   "pathContinuationTraces": [
     {
-      "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:p",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-      "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:p",
+      "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+      "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
       "pathRole": "p",
-      "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+      "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
       "axisTraces": [
         {
           "axisFamily": "static",
@@ -2711,7 +2711,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2719,13 +2719,20 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 3 observation ref(s) across 1 operation delta(s)",
+          "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
           "observationRefs": [
             "add observed compensation / authority / effect atoms only after source review",
             "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-            "split or enrich atoms that currently support the target obstruction"
+            "split or enrich atoms that currently support the target obstruction",
+            "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
           ],
-          "sourceRefs": [],
+          "sourceRefs": [
+            ".lake/runtime-trace.json",
+            "doc-architecture",
+            "src-route-users",
+            "src-service-user",
+            "test-user-contract"
+          ],
           "missingRefs": [],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2737,7 +2744,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2808,11 +2815,11 @@
       ]
     },
     {
-      "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:q",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-      "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:q",
+      "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+      "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
       "pathRole": "q",
-      "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+      "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
       "axisTraces": [
         {
           "axisFamily": "static",
@@ -2868,7 +2875,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2876,13 +2883,20 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 3 observation ref(s) across 1 operation delta(s)",
+          "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
           "observationRefs": [
             "add observed compensation / authority / effect atoms only after source review",
             "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-            "split or enrich atoms that currently support the target obstruction"
+            "split or enrich atoms that currently support the target obstruction",
+            "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ],
-          "sourceRefs": [],
+          "sourceRefs": [
+            ".lake/runtime-trace.json",
+            "doc-architecture",
+            "src-route-users",
+            "src-service-user",
+            "test-user-contract"
+          ],
           "missingRefs": [],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2894,7 +2908,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2967,8 +2981,8 @@
   ],
   "axisWiseMonodromyDefects": [
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "authority",
       "axisRef": "authority / trust boundary axis",
       "distanceKind": "weighted-axis-l1",
@@ -2976,7 +2990,7 @@
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
       ],
       "sourceRefs": [
         ".lake/runtime-trace.json",
@@ -2987,7 +3001,7 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
       ],
       "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
@@ -3014,8 +3028,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "contract",
       "axisRef": "contract axis",
       "distanceKind": "weighted-axis-l1",
@@ -3063,20 +3077,24 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
       "distanceKind": "weighted-axis-l1",
       "measurementStatus": "measured",
-      "distanceValue": 0,
+      "distanceValue": 2,
       "measuredSupportRefs": [
         "add observed compensation / authority / effect atoms only after source review",
+        "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
         "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
         "split or enrich atoms that currently support the target obstruction"
       ],
       "witnessRefs": [
         "add observed compensation / authority / effect atoms only after source review",
+        "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
         "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
         "split or enrich atoms that currently support the target obstruction"
       ],
@@ -3089,6 +3107,8 @@
       ],
       "observationRefs": [
         "add observed compensation / authority / effect atoms only after source review",
+        "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
         "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
         "split or enrich atoms that currently support the target obstruction"
       ],
@@ -3118,8 +3138,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "projection",
       "axisRef": "projection / representation axis",
       "distanceKind": "weighted-axis-l1",
@@ -3173,8 +3193,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "runtime",
       "axisRef": "runtime interaction axis",
       "distanceKind": "weighted-axis-l1",
@@ -3222,8 +3242,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "semantic",
       "axisRef": "semantic axis",
       "distanceKind": "weighted-axis-l1",
@@ -3271,8 +3291,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "state",
       "axisRef": "state transition axis",
       "distanceKind": "weighted-axis-l1",
@@ -3280,7 +3300,7 @@
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
       ],
       "sourceRefs": [
         ".lake/runtime-trace.json",
@@ -3291,7 +3311,7 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
       ],
       "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
@@ -3318,8 +3338,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static",
-      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+      "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
       "axisFamily": "static",
       "axisRef": "static dependency / support axis",
       "distanceKind": "weighted-axis-l1",
@@ -3390,45 +3410,60 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "distanceKind": "weighted-axis-l1",
       "measurementStatus": "partial",
-      "aggregateValue": 0,
+      "aggregateValue": 2,
       "measuredDefectRefs": [
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static"
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
       ],
       "unmeasuredDefectRefs": [
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state"
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state"
       ],
       "topContributors": [
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "authority",
           "contributionWeight": 1,
           "contributionValue": null,
           "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "state",
           "contributionWeight": 1,
           "contributionValue": null,
           "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "axisFamily": "effect",
+          "contributionWeight": 1,
+          "contributionValue": 2,
+          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "add observed compensation / authority / effect atoms only after source review",
+            "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+            "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+            "split or enrich atoms that currently support the target obstruction"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "contract",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3438,21 +3473,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "axisFamily": "effect",
-          "contributionWeight": 1,
-          "contributionValue": 0,
-          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
-          "witnessRefs": [
-            "add observed compensation / authority / effect atoms only after source review",
-            "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-            "split or enrich atoms that currently support the target obstruction"
-          ]
-        },
-        {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "projection",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3464,8 +3486,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "runtime",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3475,8 +3497,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "semantic",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3486,8 +3508,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static",
-          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
+          "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
           "axisFamily": "static",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3520,6 +3542,83 @@
       ]
     }
   ],
+  "nonzeroMonodromyWitnesses": [
+    {
+      "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
+      "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+      "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+      "operationPair": [
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+      ],
+      "pathPair": [
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+      ],
+      "axisFamily": "effect",
+      "axisRef": "effect ordering / replay / compensation axis",
+      "defectValue": 2,
+      "comparedTraceSummary": [
+        "p: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0",
+        "q: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0"
+      ],
+      "affectedAtomRefs": [
+        "add observed compensation / authority / effect atoms only after source review",
+        "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+        "split or enrich atoms that currently support the target obstruction"
+      ],
+      "lawRefs": [
+        "law:layer-respecting",
+        "law:semantic-contract-alignment"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "add observed compensation / authority / effect atoms only after source review",
+        "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+        "split or enrich atoms that currently support the target obstruction"
+      ],
+      "missingEvidence": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "suggestedFillerEvidence": [
+        "supply filler evidence for effect axis trace disagreement",
+        "record whether the two continuation paths preserve selected observations"
+      ],
+      "suggestedLiftingEvidence": [
+        "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+      ],
+      "suggestedBoundaryEvidence": [
+        "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+      ],
+      "recommendedReviewFocus": [
+        "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
+        "review effect axis witness refs and missing evidence"
+      ],
+      "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -3532,21 +3631,21 @@
     "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
     "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
     "operationSquareCandidateRefs": [
-      "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+      "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
     ],
     "pathContinuationTraceRefs": [
-      "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:p",
-      "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:q"
+      "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+      "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q"
     ],
     "axisWiseDefectRefs": [
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:authority",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:contract",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:effect",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:projection",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:runtime",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:semantic",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:state",
-      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed:static"
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+      "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
     ],
     "amiAggregateReadingRefs": [
       "ami:measurement-policy-monodromy-boundary-holonomy"
@@ -3576,7 +3675,7 @@
     "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
     "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
     "nonzeroMonodromyWitnessRefs": [
-      "homotopy-order-sensitivity:selected-operations"
+      "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect"
     ],
     "featureBoundaryResidualRefs": [
       "feature-extension-formula:fixture-archmap-atom-observation"
@@ -5311,7 +5410,7 @@
     ],
     "transferBridgeEdgeSummary": [],
     "measurementExpansionSummary": [
-      "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, and 1 bridge split-transfer surfaces"
+      "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
     ],
     "atomSupportAxisSummary": [
       "fixture-archmap-atom-observation support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent",
@@ -5346,6 +5445,9 @@
     ],
     "bridgeSplitObstructionTransferSummary": [
       "split-readiness:molecule-user-request-responsibility transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
+    ],
+    "nonzeroMonodromyWitnessSummary": [
+      "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -2317,7 +2317,7 @@
   ],
   "operationSquareCandidates": [
     {
-      "candidateId": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "candidateId": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "candidateSource": "inferred",
       "suppliedPairRef": null,
       "candidateBasis": [
@@ -2329,9 +2329,9 @@
         "projectionSurface"
       ],
       "leftOperationRef": "operation-delta:observe-before-repair",
-      "rightOperationRef": "operation-delta:observe-before-repair",
-      "pPathRef": "operation-delta:observe-before-repair . operation-delta:observe-before-repair",
-      "qPathRef": "operation-delta:observe-before-repair . operation-delta:observe-before-repair",
+      "rightOperationRef": "operation-delta:observe-before-repair:continuation",
+      "pPathRef": "operation-delta:observe-before-repair:continuation . operation-delta:observe-before-repair",
+      "qPathRef": "operation-delta:observe-before-repair . operation-delta:observe-before-repair:continuation",
       "sharedAtomSupportRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
@@ -2393,11 +2393,11 @@
   ],
   "pathContinuationTraces": [
     {
-      "traceId": "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:p",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
-      "pathRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair:p",
+      "traceId": "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:p",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
+      "pathRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation:p",
       "pathRole": "p",
-      "pathExpression": "operation-delta:observe-before-repair . operation-delta:observe-before-repair",
+      "pathExpression": "operation-delta:observe-before-repair:continuation . operation-delta:observe-before-repair",
       "axisTraces": [
         {
           "axisFamily": "static",
@@ -2453,7 +2453,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+            "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2461,12 +2461,19 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "continuationSummary": "effect continuation reads 3 observation ref(s) across 1 operation delta(s)",
           "observationRefs": [
             "add or refine ArchMap atom observations before claiming repair",
-            "no constructed obstruction is transported because no repair candidate exists"
+            "no constructed obstruction is transported because no repair candidate exists",
+            "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair"
           ],
-          "sourceRefs": [],
+          "sourceRefs": [
+            ".lake/runtime-trace.json",
+            "doc-architecture",
+            "src-route-users",
+            "src-service-user",
+            "test-user-contract"
+          ],
           "missingRefs": [],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2478,7 +2485,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+            "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2549,11 +2556,11 @@
       ]
     },
     {
-      "traceId": "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:q",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
-      "pathRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair:q",
+      "traceId": "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:q",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
+      "pathRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation:q",
       "pathRole": "q",
-      "pathExpression": "operation-delta:observe-before-repair . operation-delta:observe-before-repair",
+      "pathExpression": "operation-delta:observe-before-repair . operation-delta:observe-before-repair:continuation",
       "axisTraces": [
         {
           "axisFamily": "static",
@@ -2609,7 +2616,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+            "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2617,12 +2624,19 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "continuationSummary": "effect continuation reads 3 observation ref(s) across 1 operation delta(s)",
           "observationRefs": [
             "add or refine ArchMap atom observations before claiming repair",
-            "no constructed obstruction is transported because no repair candidate exists"
+            "no constructed obstruction is transported because no repair candidate exists",
+            "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation"
           ],
-          "sourceRefs": [],
+          "sourceRefs": [
+            ".lake/runtime-trace.json",
+            "doc-architecture",
+            "src-route-users",
+            "src-service-user",
+            "test-user-contract"
+          ],
           "missingRefs": [],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2634,7 +2648,7 @@
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
-            "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+            "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
           ],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
@@ -2707,8 +2721,8 @@
   ],
   "axisWiseMonodromyDefects": [
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:authority",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "authority",
       "axisRef": "authority / trust boundary axis",
       "distanceKind": "weighted-axis-l1",
@@ -2716,7 +2730,7 @@
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+        "missing-evidence:missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
       ],
       "sourceRefs": [
         ".lake/runtime-trace.json",
@@ -2727,7 +2741,7 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+        "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
       ],
       "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
@@ -2754,8 +2768,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:contract",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "contract",
       "axisRef": "contract axis",
       "distanceKind": "weighted-axis-l1",
@@ -2803,19 +2817,23 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
       "distanceKind": "weighted-axis-l1",
       "measurementStatus": "measured",
-      "distanceValue": 0,
+      "distanceValue": 2,
       "measuredSupportRefs": [
         "add or refine ArchMap atom observations before claiming repair",
+        "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+        "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
         "no constructed obstruction is transported because no repair candidate exists"
       ],
       "witnessRefs": [
         "add or refine ArchMap atom observations before claiming repair",
+        "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+        "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
         "no constructed obstruction is transported because no repair candidate exists"
       ],
       "sourceRefs": [
@@ -2827,6 +2845,8 @@
       ],
       "observationRefs": [
         "add or refine ArchMap atom observations before claiming repair",
+        "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+        "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
         "no constructed obstruction is transported because no repair candidate exists"
       ],
       "missingRefs": [],
@@ -2855,8 +2875,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:projection",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "projection",
       "axisRef": "projection / representation axis",
       "distanceKind": "weighted-axis-l1",
@@ -2910,8 +2930,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:runtime",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "runtime",
       "axisRef": "runtime interaction axis",
       "distanceKind": "weighted-axis-l1",
@@ -2959,8 +2979,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:semantic",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "semantic",
       "axisRef": "semantic axis",
       "distanceKind": "weighted-axis-l1",
@@ -3008,8 +3028,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:state",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "state",
       "axisRef": "state transition axis",
       "distanceKind": "weighted-axis-l1",
@@ -3017,7 +3037,7 @@
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+        "missing-evidence:missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
       ],
       "sourceRefs": [
         ".lake/runtime-trace.json",
@@ -3028,7 +3048,7 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+        "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
       ],
       "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
@@ -3055,8 +3075,8 @@
       ]
     },
     {
-      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static",
-      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+      "defectId": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:static",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
       "axisFamily": "static",
       "axisRef": "static dependency / support axis",
       "distanceKind": "weighted-axis-l1",
@@ -3127,45 +3147,59 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "distanceKind": "weighted-axis-l1",
       "measurementStatus": "partial",
-      "aggregateValue": 0,
+      "aggregateValue": 2,
       "measuredDefectRefs": [
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static"
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:contract",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:projection",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:runtime",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:semantic",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:static"
       ],
       "unmeasuredDefectRefs": [
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
-        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state"
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:authority",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:state"
       ],
       "topContributors": [
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:authority",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "authority",
           "contributionWeight": 1,
           "contributionValue": null,
           "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+            "missing-evidence:missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:state",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "state",
           "contributionWeight": 1,
           "contributionValue": null,
           "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+            "missing-evidence:missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
+          "axisFamily": "effect",
+          "contributionWeight": 1,
+          "contributionValue": 2,
+          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "add or refine ArchMap atom observations before claiming repair",
+            "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+            "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
+            "no constructed obstruction is transported because no repair candidate exists"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:contract",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "contract",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3175,20 +3209,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
-          "axisFamily": "effect",
-          "contributionWeight": 1,
-          "contributionValue": 0,
-          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
-          "witnessRefs": [
-            "add or refine ArchMap atom observations before claiming repair",
-            "no constructed obstruction is transported because no repair candidate exists"
-          ]
-        },
-        {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:projection",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "projection",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3200,8 +3222,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:runtime",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "runtime",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3211,8 +3233,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:semantic",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "semantic",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3222,8 +3244,8 @@
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static",
-          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair",
+          "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:static",
+          "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
           "axisFamily": "static",
           "contributionWeight": 1,
           "contributionValue": 0,
@@ -3256,6 +3278,79 @@
       ]
     }
   ],
+  "nonzeroMonodromyWitnesses": [
+    {
+      "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation-effect",
+      "defectRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+      "candidateRef": "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation",
+      "operationPair": [
+        "operation-delta:observe-before-repair",
+        "operation-delta:observe-before-repair:continuation"
+      ],
+      "pathPair": [
+        "operation-delta:observe-before-repair:continuation . operation-delta:observe-before-repair",
+        "operation-delta:observe-before-repair . operation-delta:observe-before-repair:continuation"
+      ],
+      "axisFamily": "effect",
+      "axisRef": "effect ordering / replay / compensation axis",
+      "defectValue": 2,
+      "comparedTraceSummary": [
+        "p: effect continuation reads 3 observation ref(s) across 1 operation delta(s) refs=3 missing=0",
+        "q: effect continuation reads 3 observation ref(s) across 1 operation delta(s) refs=3 missing=0"
+      ],
+      "affectedAtomRefs": [
+        "add or refine ArchMap atom observations before claiming repair",
+        "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+        "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
+        "no constructed obstruction is transported because no repair candidate exists"
+      ],
+      "lawRefs": [
+        "law:layer-respecting"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "sourceRefs": [
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "observationRefs": [
+        "add or refine ArchMap atom observations before claiming repair",
+        "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+        "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
+        "no constructed obstruction is transported because no repair candidate exists"
+      ],
+      "missingEvidence": [],
+      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "suggestedFillerEvidence": [
+        "supply filler evidence for effect axis trace disagreement",
+        "record whether the two continuation paths preserve selected observations"
+      ],
+      "suggestedLiftingEvidence": [
+        "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+      ],
+      "suggestedBoundaryEvidence": [
+        "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+      ],
+      "recommendedReviewFocus": [
+        "compare operation-delta:observe-before-repair:continuation . operation-delta:observe-before-repair and operation-delta:observe-before-repair . operation-delta:observe-before-repair:continuation before treating the operation pair as order-insensitive",
+        "review effect axis witness refs and missing evidence"
+      ],
+      "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -3267,21 +3362,21 @@
     "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
     "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
     "operationSquareCandidateRefs": [
-      "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair"
+      "operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
     ],
     "pathContinuationTraceRefs": [
-      "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:p",
-      "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:q"
+      "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:p",
+      "path-continuation-trace:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:q"
     ],
     "axisWiseDefectRefs": [
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:authority",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:contract",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:effect",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:projection",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:runtime",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:semantic",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:state",
-      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair:static"
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:authority",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:contract",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:projection",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:runtime",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:semantic",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:state",
+      "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:static"
     ],
     "amiAggregateReadingRefs": [
       "ami:measurement-policy-monodromy-boundary-holonomy"
@@ -3310,7 +3405,7 @@
     "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
     "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
     "nonzeroMonodromyWitnessRefs": [
-      "homotopy-order-sensitivity:selected-operations"
+      "nonzero-monodromy-witness:mu-operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation-effect"
     ],
     "featureBoundaryResidualRefs": [
       "feature-extension-formula:fixture-archmap-atom-observation"
@@ -4860,7 +4955,7 @@
     ],
     "transferBridgeEdgeSummary": [],
     "measurementExpansionSummary": [
-      "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, and 1 bridge split-transfer surfaces"
+      "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
     ],
     "atomSupportAxisSummary": [
       "fixture-archmap-atom-observation support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent",
@@ -4895,6 +4990,9 @@
     ],
     "bridgeSplitObstructionTransferSummary": [
       "split-readiness:molecule-user-request-responsibility transferRisk=notObserved bridgeEdges=0 obstructions=0 boundaryOps=1"
+    ],
+    "nonzeroMonodromyWitnessSummary": [
+      "nonzero-monodromy-witness:mu-operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation-effect axis=effect defect=2 affectedAtoms=4 missingEvidence=0 focus=2"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",


### PR DESCRIPTION
## 概要

Closes #1473

#1488 を base にした stacked PR です。#1472 の axis-wise defect / AMI aggregate 上に、positive measured `mu_x(sigma)` を reviewer-readable な nonzero monodromy witness surface として追加します。

- `nonzeroMonodromyWitnesses` を追加し、operation pair / path pair / axis / defect value / compared trace summary を出力
- affected Atom / observation refs、law refs、signature axis refs、source refs、missing evidence、coverage boundary を保持
- suggested filler / lifting / boundary evidence と recommended review focus を cue として出力
- `boundaryHolonomyReadingFamily.nonzeroMonodromyWitnessRefs` を実 witness IDs に接続
- summary / LLM interpretation packet からも witness を読めるようにし、automatic repair safety / merge safety を結論しない validation と docs を追加

## 証明した定理

なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は Lean 変更なしのため未実施です。FieldSig 変更なしのため FieldSig test は未実施です。Lean ソース変更なしのため axiom / admit / sorry / unsafe scan は未実施です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `defined only / tooling review surface` として Issue 側の範囲に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
