### PR TITLE
ArchSig feature boundary residual reading を追加

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -71,6 +71,7 @@ The implemented schema records:
 - `axisWiseMonodromyDefects`
 - `amiAggregateReadings`
 - `nonzeroMonodromyWitnesses`
+- `featureBoundaryResidualReadings`
 - `monodromyReadingFamily`
 - `boundaryHolonomyReadingFamily`
 - `representationStrengthReadings`
@@ -193,8 +194,8 @@ The builder:
   foundation surfaces. They carry selected axes, distance kind, weight policy,
   coverage policy, and the ArchMapStore ref set used by later operation-square,
   axis-wise defect, AMI, boundary residual, and feature-extension attribution
-  readings. In this issue they define the packet shape and validation boundary;
-  later issues fill the concrete valuation fields.
+  readings. They define the shared measurement policy boundary while concrete
+  valuation fields live in the corresponding reading records.
 - `operationSquareCandidates` enumerates supplied or inferred operation pairs as
   path pairs `p = g . f` and `q = f . g`. Inferred candidates are review cues
   derived from shared Atom support, state / effect / contract / semantic /
@@ -219,6 +220,15 @@ The builder:
   observation refs, law refs, signature axis refs, suggested filler / lifting /
   boundary evidence, review focus cues, coverage boundary, and machine-readable
   non-conclusions. It does not assert repair safety or merge safety.
+- `featureBoundaryResidualReadings` records `Boundary(A, f)` review readings for
+  feature-extension boundaries. Each reading separates core-local,
+  feature-local, and mixed boundary support, exposes `Hol_static`,
+  `Hol_contract`, `Hol_semantic`, `Hol_state`, `Hol_effect`, `Hol_authority`,
+  `Hol_runtime`, and `Hol_projection` residual axes, and keeps support
+  separation, coverage, exactness, attribution policy, evidence boundary, and
+  machine-readable non-conclusions. It does not claim an unconditional
+  `Ob(B) = Ob(A) + Ob(f) + Hol(Boundary(A,f))` theorem or decide feature
+  safety.
 - axis-forgetting risk records when a coarse observation projection has
   forgotten selected axes or collapsed mixed-axis support. It blocks
   `ZeroReflecting` and `ObstructionReflecting` readings unless explicit axis

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -14,19 +14,20 @@ use crate::{
     ArchSigAtomConfigurationSummaryV0, ArchSigAtomSupportAxisReadingV0,
     ArchSigAxisContinuationTraceV0, ArchSigAxisExcursionV0, ArchSigAxisForgettingRiskReadingV0,
     ArchSigAxisRestrictionCountV0, ArchSigAxisWiseMonodromyDefectV0,
-    ArchSigBoundaryHolonomyReadingFamilyV0, ArchSigBoundaryPreparationRankV0,
-    ArchSigBoundedJudgementV0, ArchSigBridgeAtomFamilyReadingV0, ArchSigBridgeEdgeBreakdownV0,
-    ArchSigBridgeSplitObstructionTransferReadingV0, ArchSigChangeImpactReadingV0,
-    ArchSigCouplingCohesionReadingV0, ArchSigCoverageStatusV0,
+    ArchSigBoundaryHolonomyAxisResidualV0, ArchSigBoundaryHolonomyReadingFamilyV0,
+    ArchSigBoundaryPreparationRankV0, ArchSigBoundedJudgementV0, ArchSigBridgeAtomFamilyReadingV0,
+    ArchSigBridgeEdgeBreakdownV0, ArchSigBridgeSplitObstructionTransferReadingV0,
+    ArchSigChangeImpactReadingV0, ArchSigCouplingCohesionReadingV0, ArchSigCoverageStatusV0,
     ArchSigCurrentStateEvolutionBoundaryV0, ArchSigDesignPressureReadingV0,
     ArchSigDesignPrincipleReadingV0, ArchSigDiagramFillabilityReadingV0,
     ArchSigDominantAtomFamilyCompositionV0, ArchSigEvolutionRiskRankingV0,
-    ArchSigFeatureExtensionAxisSummaryV0, ArchSigFeatureExtensionFormulaReadingV0,
-    ArchSigFlatnessReadingV0, ArchSigHighOverlapMoleculePairV0,
-    ArchSigHomotopyOrderSensitivityReadingV0, ArchSigInvariantFamilyReadingV0,
-    ArchSigLawUniverseCoverageReadingV0, ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0,
-    ArchSigLlmInterpretationPacketV0, ArchSigLocalCurvatureDiagramReadingV0,
-    ArchSigMoleculeReadingV0, ArchSigMonodromyReadingFamilyV0, ArchSigNonzeroMonodromyWitnessV0,
+    ArchSigFeatureBoundaryResidualReadingV0, ArchSigFeatureExtensionAxisSummaryV0,
+    ArchSigFeatureExtensionFormulaReadingV0, ArchSigFlatnessReadingV0,
+    ArchSigHighOverlapMoleculePairV0, ArchSigHomotopyOrderSensitivityReadingV0,
+    ArchSigInvariantFamilyReadingV0, ArchSigLawUniverseCoverageReadingV0,
+    ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0, ArchSigLlmInterpretationPacketV0,
+    ArchSigLocalCurvatureDiagramReadingV0, ArchSigMoleculeReadingV0,
+    ArchSigMonodromyReadingFamilyV0, ArchSigNonzeroMonodromyWitnessV0,
     ArchSigObservationProjectionReadingV0, ArchSigObstructionCircuitV0,
     ArchSigOperationCalculusLawReadingV0, ArchSigOperationDeltaReadingV0,
     ArchSigOperationInvariantGaloisReadingV0, ArchSigOperationSquareCandidateV0,
@@ -204,6 +205,11 @@ pub fn build_archsig_analysis_packet(
         &path_continuation_traces,
         &axis_wise_monodromy_defects,
     );
+    let feature_boundary_residual_readings = build_feature_boundary_residual_readings(
+        law_policy,
+        &feature_extension_formula_readings,
+        &axis_wise_monodromy_defects,
+    );
     let monodromy_reading_family = build_monodromy_reading_family(
         law_policy,
         &arch_map_store_refs,
@@ -216,7 +222,7 @@ pub fn build_archsig_analysis_packet(
         law_policy,
         &arch_map_store_refs,
         &nonzero_monodromy_witnesses,
-        &feature_extension_formula_readings,
+        &feature_boundary_residual_readings,
         &split_readiness_readings,
     );
     let structural_reading_review_surface = build_structural_reading_review_surface(
@@ -293,6 +299,7 @@ pub fn build_archsig_analysis_packet(
         &operation_invariant_galois_readings,
         &split_readiness_readings,
         &nonzero_monodromy_witnesses,
+        &feature_boundary_residual_readings,
         &structural_reading_review_surface,
         &current_state_evolution_boundary,
         &repair_operation_candidates,
@@ -354,6 +361,7 @@ pub fn build_archsig_analysis_packet(
         axis_wise_monodromy_defects,
         ami_aggregate_readings,
         nonzero_monodromy_witnesses,
+        feature_boundary_residual_readings,
         monodromy_reading_family,
         boundary_holonomy_reading_family,
         representation_strength_readings,
@@ -513,7 +521,7 @@ fn build_boundary_holonomy_reading_family(
     law_policy: &LawPolicyDocumentV0,
     arch_map_store_refs: &ArchSigArchMapStoreRefsV0,
     nonzero_monodromy_witnesses: &[ArchSigNonzeroMonodromyWitnessV0],
-    feature_extension_formula_readings: &[ArchSigFeatureExtensionFormulaReadingV0],
+    feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
     split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
 ) -> ArchSigBoundaryHolonomyReadingFamilyV0 {
     ArchSigBoundaryHolonomyReadingFamilyV0 {
@@ -531,7 +539,7 @@ fn build_boundary_holonomy_reading_family(
             .iter()
             .map(|witness| witness.witness_id.clone())
             .collect(),
-        feature_boundary_residual_refs: feature_extension_formula_readings
+        feature_boundary_residual_refs: feature_boundary_residual_readings
             .iter()
             .map(|reading| reading.reading_id.clone())
             .collect(),
@@ -1122,6 +1130,163 @@ fn compared_trace_summary(
             )
         })
         .collect()
+}
+
+fn build_feature_boundary_residual_readings(
+    law_policy: &LawPolicyDocumentV0,
+    feature_extension_formula_readings: &[ArchSigFeatureExtensionFormulaReadingV0],
+    axis_wise_monodromy_defects: &[ArchSigAxisWiseMonodromyDefectV0],
+) -> Vec<ArchSigFeatureBoundaryResidualReadingV0> {
+    feature_extension_formula_readings
+        .iter()
+        .map(|reading| {
+            let boundary_support_refs = unique_strings(
+                reading
+                    .interaction_obstruction_refs
+                    .iter()
+                    .chain(reading.lifting_failure_refs.iter())
+                    .chain(reading.filling_failure_refs.iter())
+                    .chain(reading.complexity_transfer_refs.iter())
+                    .chain(reading.residual_coverage_gap_refs.iter())
+                    .cloned(),
+            );
+            let mixed_subconfiguration_refs = if boundary_support_refs.is_empty() {
+                vec![format!("boundary-support:{}", stable_id(&reading.scope_ref))]
+            } else {
+                boundary_support_refs.clone()
+            };
+            let holonomy_axes = boundary_holonomy_axis_residuals(
+                axis_wise_monodromy_defects,
+                &mixed_subconfiguration_refs,
+            );
+            let residual_obstruction_refs = unique_strings(
+                holonomy_axes
+                    .iter()
+                    .flat_map(|axis| axis.measured_defect_refs.clone())
+                    .chain(boundary_support_refs.iter().cloned()),
+            );
+            ArchSigFeatureBoundaryResidualReadingV0 {
+                reading_id: format!("feature-boundary-residual:{}", stable_id(&reading.scope_ref)),
+                boundary_ref: format!("Boundary({}, feature-extension)", reading.scope_ref),
+                feature_extension_ref: reading.reading_id.clone(),
+                status: if holonomy_axes
+                    .iter()
+                    .any(|axis| axis.status == "measuredResidual")
+                {
+                    "measuredResidual".to_string()
+                } else {
+                    "coverageBounded".to_string()
+                },
+                core_scope_ref: format!("{}:core", reading.scope_ref),
+                feature_scope_ref: format!("{}:feature", reading.scope_ref),
+                mixed_subconfiguration_refs,
+                core_local_reading_refs: reading.inherited_core_obstruction_refs.clone(),
+                feature_local_reading_refs: reading.feature_local_obstruction_refs.clone(),
+                boundary_support_refs,
+                holonomy_axes,
+                residual_obstruction_refs,
+                support_separation_policy:
+                    "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition"
+                        .to_string(),
+                coverage_assumptions: vec![
+                    format!(
+                        "coveragePolicy={} over selected axes {:?}",
+                        law_policy.measurement_policy.coverage_policy,
+                        law_policy.measurement_policy.selected_axis_refs
+                    ),
+                    "unmeasured boundary support remains residual coverage debt".to_string(),
+                ],
+                exactness_assumptions: if law_policy
+                    .measurement_policy
+                    .exactness_assumption_refs
+                    .is_empty()
+                {
+                    vec![
+                        "no exactness assumption refs supplied; boundary holonomy is an empirical tooling diagnosis"
+                            .to_string(),
+                    ]
+                } else {
+                    law_policy.measurement_policy.exactness_assumption_refs.clone()
+                },
+                attribution_policy:
+                    "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause"
+                        .to_string(),
+                coverage_boundary: reading.evidence_boundary.clone(),
+                exactness_boundary:
+                    "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))"
+                        .to_string(),
+                evidence_boundary:
+                    "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger"
+                        .to_string(),
+                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+            }
+        })
+        .collect()
+}
+
+fn boundary_holonomy_axis_residuals(
+    axis_wise_monodromy_defects: &[ArchSigAxisWiseMonodromyDefectV0],
+    fallback_support_refs: &[String],
+) -> Vec<ArchSigBoundaryHolonomyAxisResidualV0> {
+    [
+        ("static", "Hol_static"),
+        ("contract", "Hol_contract"),
+        ("semantic", "Hol_semantic"),
+        ("state", "Hol_state"),
+        ("effect", "Hol_effect"),
+        ("authority", "Hol_authority"),
+        ("runtime", "Hol_runtime"),
+        ("projection", "Hol_projection"),
+    ]
+    .into_iter()
+    .map(|(axis_family, holonomy_axis_ref)| {
+        let axis_defects = axis_wise_monodromy_defects
+            .iter()
+            .filter(|defect| defect.axis_family == axis_family)
+            .collect::<Vec<_>>();
+        let residual_value = axis_defects
+            .iter()
+            .filter_map(|defect| defect.distance_value)
+            .sum::<i64>();
+        let measured_defect_refs = axis_defects
+            .iter()
+            .filter(|defect| defect.distance_value.is_some_and(|value| value > 0))
+            .map(|defect| defect.defect_id.clone())
+            .collect::<Vec<_>>();
+        let mut support_refs = unique_strings(
+            axis_defects
+                .iter()
+                .flat_map(|defect| defect.observation_refs.clone()),
+        );
+        if support_refs.is_empty() {
+            support_refs = fallback_support_refs.to_vec();
+        }
+        let missing_evidence = unique_strings(
+            axis_defects
+                .iter()
+                .flat_map(|defect| defect.missing_refs.clone()),
+        );
+        let status = if residual_value > 0 {
+            "measuredResidual"
+        } else if missing_evidence.is_empty() {
+            "coveredZeroResidual"
+        } else {
+            "coverageBlocked"
+        };
+        ArchSigBoundaryHolonomyAxisResidualV0 {
+            holonomy_axis_ref: holonomy_axis_ref.to_string(),
+            axis_family: axis_family.to_string(),
+            status: status.to_string(),
+            residual_value,
+            measured_defect_refs,
+            support_refs,
+            missing_evidence,
+            reading: format!(
+                "{holonomy_axis_ref} records boundary-local residual obstruction on the {axis_family} axis"
+            ),
+        }
+    })
+    .collect()
 }
 
 fn ami_zero_reflection_assumptions(law_policy: &LawPolicyDocumentV0) -> Vec<String> {
@@ -6351,6 +6516,7 @@ fn build_llm_interpretation_packet(
     operation_invariant_galois_readings: &[ArchSigOperationInvariantGaloisReadingV0],
     split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
     nonzero_monodromy_witnesses: &[ArchSigNonzeroMonodromyWitnessV0],
+    feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
     structural_reading_review_surface: &ArchSigStructuralReadingReviewSurfaceV0,
     current_state_evolution_boundary: &ArchSigCurrentStateEvolutionBoundaryV0,
     repair_candidates: &[ArchSigRepairOperationCandidateV0],
@@ -6653,6 +6819,19 @@ fn build_llm_interpretation_packet(
                 )
             })
             .collect(),
+        feature_boundary_residual_summary: feature_boundary_residual_readings
+            .iter()
+            .map(|reading| {
+                format!(
+                    "{} boundary={} status={} axes={} residualRefs={}",
+                    reading.reading_id,
+                    reading.boundary_ref,
+                    reading.status,
+                    reading.holonomy_axes.len(),
+                    reading.residual_obstruction_refs.len()
+                )
+            })
+            .collect(),
         representation_strength_summary: representation_strength_readings
             .iter()
             .map(|reading| {
@@ -6870,6 +7049,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_operation_square_trace_surface(packet),
         check_axis_wise_defect_ami_surface(packet),
         check_nonzero_monodromy_witness_surface(packet),
+        check_feature_boundary_residual_surface(packet),
         check_monodromy_boundary_schema_foundation(packet),
         check_law_relative_analysis(packet),
         check_signature_and_flatness(packet),
@@ -9369,6 +9549,180 @@ fn check_nonzero_monodromy_witness_surface(packet: &ArchSigAnalysisPacketV0) -> 
     )
 }
 
+fn check_feature_boundary_residual_surface(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let feature_extension_ids = set(packet
+        .feature_extension_formula_readings
+        .iter()
+        .map(|reading| reading.reading_id.as_str()));
+    let reading_ids = set(packet
+        .feature_boundary_residual_readings
+        .iter()
+        .map(|reading| reading.reading_id.as_str()));
+    let defect_ids = set(packet
+        .axis_wise_monodromy_defects
+        .iter()
+        .map(|defect| defect.defect_id.as_str()));
+    let required_axes = BTreeSet::from([
+        "Hol_static",
+        "Hol_contract",
+        "Hol_semantic",
+        "Hol_state",
+        "Hol_effect",
+        "Hol_authority",
+        "Hol_runtime",
+        "Hol_projection",
+    ]);
+    let mut examples = Vec::new();
+    if !packet.feature_extension_formula_readings.is_empty()
+        && packet.feature_boundary_residual_readings.is_empty()
+    {
+        examples.push(generic_validation_example(
+            "featureBoundaryResidualReadings",
+            "empty",
+            "feature extension formulas must be lifted to Boundary(A,f) residual readings",
+        ));
+    }
+    examples.extend(duplicate_examples(
+        "featureBoundaryResidualReadings[].readingId",
+        duplicates(
+            packet
+                .feature_boundary_residual_readings
+                .iter()
+                .map(|reading| reading.reading_id.as_str()),
+        ),
+    ));
+    for reading in &packet.feature_boundary_residual_readings {
+        if !feature_extension_ids.contains(reading.feature_extension_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                &reading.feature_extension_ref,
+                "feature boundary residual references an unknown feature extension formula",
+            ));
+        }
+        for (field, value) in [
+            ("boundaryRef", &reading.boundary_ref),
+            ("status", &reading.status),
+            ("coreScopeRef", &reading.core_scope_ref),
+            ("featureScopeRef", &reading.feature_scope_ref),
+            (
+                "supportSeparationPolicy",
+                &reading.support_separation_policy,
+            ),
+            ("attributionPolicy", &reading.attribution_policy),
+            ("coverageBoundary", &reading.coverage_boundary),
+            ("exactnessBoundary", &reading.exactness_boundary),
+            ("evidenceBoundary", &reading.evidence_boundary),
+        ] {
+            push_blank(
+                &mut examples,
+                &format!("{} {field}", reading.reading_id),
+                value,
+            );
+        }
+        if reading.mixed_subconfiguration_refs.is_empty()
+            || reading.boundary_support_refs.is_empty()
+        {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                "mixedSubconfigurationRefs/boundarySupportRefs",
+                "Boundary(A,f) reading must expose mixed core/feature boundary support",
+            ));
+        }
+        if reading.coverage_assumptions.is_empty() || reading.exactness_assumptions.is_empty() {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                "coverageAssumptions/exactnessAssumptions",
+                "feature boundary residual must record support coverage and exactness assumptions",
+            ));
+        }
+        if !reading
+            .exactness_boundary
+            .contains("does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))")
+        {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                &reading.exactness_boundary,
+                "feature boundary residual must not claim the boundary holonomy conjecture as a theorem",
+            ));
+        }
+        if reading.non_conclusions.is_empty() || has_blank(&reading.non_conclusions) {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                "nonConclusions",
+                "feature boundary residual must retain machine-readable non-conclusions",
+            ));
+        }
+        let axis_refs = reading
+            .holonomy_axes
+            .iter()
+            .map(|axis| axis.holonomy_axis_ref.as_str())
+            .collect::<BTreeSet<_>>();
+        if axis_refs != required_axes {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                "holonomyAxes",
+                "feature boundary residual must expose all Hol_* axes",
+            ));
+        }
+        for axis in &reading.holonomy_axes {
+            for (field, value) in [
+                ("holonomyAxisRef", &axis.holonomy_axis_ref),
+                ("axisFamily", &axis.axis_family),
+                ("status", &axis.status),
+                ("reading", &axis.reading),
+            ] {
+                push_blank(
+                    &mut examples,
+                    &format!("{} {} {field}", reading.reading_id, axis.holonomy_axis_ref),
+                    value,
+                );
+            }
+            if axis.support_refs.is_empty() {
+                examples.push(generic_validation_example(
+                    &reading.reading_id,
+                    &axis.holonomy_axis_ref,
+                    "each Hol_* axis must keep boundary support refs traceable",
+                ));
+            }
+            if axis.residual_value > 0 && axis.measured_defect_refs.is_empty() {
+                examples.push(generic_validation_example(
+                    &reading.reading_id,
+                    &axis.holonomy_axis_ref,
+                    "positive Hol_* residual value must reference measured defects",
+                ));
+            }
+            for defect_ref in &axis.measured_defect_refs {
+                if !defect_ids.contains(defect_ref.as_str()) {
+                    examples.push(generic_validation_example(
+                        &reading.reading_id,
+                        defect_ref,
+                        "Hol_* axis references an unknown axis-wise defect",
+                    ));
+                }
+            }
+        }
+    }
+    for residual_ref in &packet
+        .boundary_holonomy_reading_family
+        .feature_boundary_residual_refs
+    {
+        if !reading_ids.contains(residual_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &packet.boundary_holonomy_reading_family.reading_family_id,
+                residual_ref,
+                "boundary holonomy reading family references an unknown feature boundary residual",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-feature-boundary-residual-surface",
+        "packet surfaces Boundary(A,f) residual holonomy axes as bounded review telemetry",
+        examples,
+        "fail",
+    )
+}
+
 fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
     let mut examples = Vec::new();
     let store_refs = &packet.arch_map_store_refs;
@@ -9934,6 +10288,20 @@ fn check_llm_interpretation_surface(packet: &ArchSigAnalysisPacketV0) -> Validat
             packet
                 .llm_interpretation_packet
                 .bridge_split_obstruction_transfer_summary
+                .is_empty(),
+        ),
+        (
+            "llmInterpretationPacket.nonzeroMonodromyWitnessSummary",
+            packet
+                .llm_interpretation_packet
+                .nonzero_monodromy_witness_summary
+                .is_empty(),
+        ),
+        (
+            "llmInterpretationPacket.featureBoundaryResidualSummary",
+            packet
+                .llm_interpretation_packet
+                .feature_boundary_residual_summary
                 .is_empty(),
         ),
     ] {
@@ -10667,6 +11035,22 @@ mod tests {
         assert_eq!(report.summary.result, "fail");
         assert!(report.checks.iter().any(|check| {
             check.id == "archsig-analysis-packet-nonzero-monodromy-witness-surface"
+                && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn feature_boundary_residual_without_holonomy_axes_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        packet.feature_boundary_residual_readings[0]
+            .holonomy_axes
+            .clear();
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-feature-boundary-residual-surface"
                 && check.result == "fail"
         }));
     }

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -527,6 +527,7 @@ fn measurement_expansion_summary(
         "signatureTrajectoryHomotopyRefutation": limited_array_field(llm_packet, "signatureTrajectoryHomotopyRefutationSummary", limit),
         "bridgeSplitObstructionTransfer": limited_array_field(llm_packet, "bridgeSplitObstructionTransferSummary", limit),
         "nonzeroMonodromyWitness": limited_array_field(llm_packet, "nonzeroMonodromyWitnessSummary", limit),
+        "featureBoundaryResidual": limited_array_field(llm_packet, "featureBoundaryResidualSummary", limit),
         "counts": {
             "atomSupportAxisReadings": array_len(packet, "atomSupportAxisReadings"),
             "atomCompatibilityReadings": array_len(packet, "atomCompatibilityReadings"),
@@ -539,7 +540,8 @@ fn measurement_expansion_summary(
             "axisForgettingRiskReadings": array_len(packet, "axisForgettingRiskReadings"),
             "signatureTrajectoryHomotopyRefutationReadings": array_len(packet, "signatureTrajectoryHomotopyRefutationReadings"),
             "bridgeSplitObstructionTransferReadings": array_len(packet, "bridgeSplitObstructionTransferReadings"),
-            "nonzeroMonodromyWitnesses": array_len(packet, "nonzeroMonodromyWitnesses")
+            "nonzeroMonodromyWitnesses": array_len(packet, "nonzeroMonodromyWitnesses"),
+            "featureBoundaryResidualReadings": array_len(packet, "featureBoundaryResidualReadings")
         }
     })
 }

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -669,6 +669,7 @@ pub struct ArchSigAnalysisPacketV0 {
     pub axis_wise_monodromy_defects: Vec<ArchSigAxisWiseMonodromyDefectV0>,
     pub ami_aggregate_readings: Vec<ArchSigAmiAggregateReadingV0>,
     pub nonzero_monodromy_witnesses: Vec<ArchSigNonzeroMonodromyWitnessV0>,
+    pub feature_boundary_residual_readings: Vec<ArchSigFeatureBoundaryResidualReadingV0>,
     pub monodromy_reading_family: ArchSigMonodromyReadingFamilyV0,
     pub boundary_holonomy_reading_family: ArchSigBoundaryHolonomyReadingFamilyV0,
     pub representation_strength_readings: Vec<ArchSigRepresentationStrengthReadingV0>,
@@ -832,6 +833,44 @@ pub struct ArchSigNonzeroMonodromyWitnessV0 {
     pub recommended_review_focus: Vec<String>,
     pub evidence_boundary: String,
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigFeatureBoundaryResidualReadingV0 {
+    pub reading_id: String,
+    pub boundary_ref: String,
+    pub feature_extension_ref: String,
+    pub status: String,
+    pub core_scope_ref: String,
+    pub feature_scope_ref: String,
+    pub mixed_subconfiguration_refs: Vec<String>,
+    pub core_local_reading_refs: Vec<String>,
+    pub feature_local_reading_refs: Vec<String>,
+    pub boundary_support_refs: Vec<String>,
+    pub holonomy_axes: Vec<ArchSigBoundaryHolonomyAxisResidualV0>,
+    pub residual_obstruction_refs: Vec<String>,
+    pub support_separation_policy: String,
+    pub coverage_assumptions: Vec<String>,
+    pub exactness_assumptions: Vec<String>,
+    pub attribution_policy: String,
+    pub coverage_boundary: String,
+    pub exactness_boundary: String,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigBoundaryHolonomyAxisResidualV0 {
+    pub holonomy_axis_ref: String,
+    pub axis_family: String,
+    pub status: String,
+    pub residual_value: i64,
+    pub measured_defect_refs: Vec<String>,
+    pub support_refs: Vec<String>,
+    pub missing_evidence: Vec<String>,
+    pub reading: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1920,6 +1959,8 @@ pub struct ArchSigLlmInterpretationPacketV0 {
     pub bridge_split_obstruction_transfer_summary: Vec<String>,
     #[serde(default)]
     pub nonzero_monodromy_witness_summary: Vec<String>,
+    #[serde(default)]
+    pub feature_boundary_residual_summary: Vec<String>,
     pub representation_strength_summary: Vec<String>,
     pub local_curvature_diagram_summary: Vec<String>,
     pub three_layer_flatness_summary: Vec<String>,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1479,6 +1479,42 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "nonzero monodromy witnesses must expose operation/path pairs, positive defect value, traceable refs, review focus, and non-conclusions"
     );
     assert!(
+        json["featureBoundaryResidualReadings"]
+            .as_array()
+            .is_some_and(|items| {
+                !items.is_empty()
+                    && items.iter().all(|reading| {
+                        reading["mixedSubconfigurationRefs"]
+                            .as_array()
+                            .is_some_and(|refs| !refs.is_empty())
+                            && reading["boundarySupportRefs"]
+                                .as_array()
+                                .is_some_and(|refs| !refs.is_empty())
+                            && reading["holonomyAxes"].as_array().is_some_and(|axes| {
+                                axes.len() == 8
+                                    && axes.iter().all(|axis| {
+                                        axis["holonomyAxisRef"]
+                                            .as_str()
+                                            .is_some_and(|axis_ref| axis_ref.starts_with("Hol_"))
+                                            && axis["supportRefs"]
+                                                .as_array()
+                                                .is_some_and(|refs| !refs.is_empty())
+                                    })
+                            })
+                            && reading["coverageAssumptions"]
+                                .as_array()
+                                .is_some_and(|items| !items.is_empty())
+                            && reading["exactnessAssumptions"]
+                                .as_array()
+                                .is_some_and(|items| !items.is_empty())
+                            && reading["nonConclusions"]
+                                .as_array()
+                                .is_some_and(|items| !items.is_empty())
+                    })
+            }),
+        "feature boundary residual readings must expose mixed support, Hol_* axes, assumptions, and non-conclusions"
+    );
+    assert!(
         json["llmInterpretationPacket"]["structuralReadingReviewSummary"]
             .as_array()
             .is_some_and(|items| !items.is_empty())
@@ -1489,6 +1525,9 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                 .as_array()
                 .is_some_and(|items| !items.is_empty())
             && json["llmInterpretationPacket"]["nonzeroMonodromyWitnessSummary"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+            && json["llmInterpretationPacket"]["featureBoundaryResidualSummary"]
                 .as_array()
                 .is_some_and(|items| !items.is_empty())
             && json["llmInterpretationPacket"]["atomSupportAxisSummary"]

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -3619,6 +3619,181 @@
       ]
     }
   ],
+  "featureBoundaryResidualReadings": [
+    {
+      "readingId": "feature-boundary-residual:fixture-archmap-atom-observation",
+      "boundaryRef": "Boundary(fixture-archmap-atom-observation, feature-extension)",
+      "featureExtensionRef": "feature-extension-formula:fixture-archmap-atom-observation",
+      "status": "measuredResidual",
+      "coreScopeRef": "fixture-archmap-atom-observation:core",
+      "featureScopeRef": "fixture-archmap-atom-observation:feature",
+      "mixedSubconfigurationRefs": [
+        "gap-runtime-user-db-trace",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+        "obstruction:semantic-contract-mismatch:computed",
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "coreLocalReadingRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "featureLocalReadingRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "boundarySupportRefs": [
+        "gap-runtime-user-db-trace",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+        "obstruction:semantic-contract-mismatch:computed",
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "holonomyAxes": [
+        {
+          "holonomyAxisRef": "Hol_static",
+          "axisFamily": "static",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "atom:component:route-users",
+            "atom:component:service-user",
+            "atom:relation:route-service"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_static records boundary-local residual obstruction on the static axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_contract",
+          "axisFamily": "contract",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "atom:contract:create-user"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_contract records boundary-local residual obstruction on the contract axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_semantic",
+          "axisFamily": "semantic",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "semantic:create-user-flow"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_semantic records boundary-local residual obstruction on the semantic axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_state",
+          "axisFamily": "state",
+          "status": "coverageBlocked",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "gap-runtime-user-db-trace",
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+            "obstruction:semantic-contract-mismatch:computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "missingEvidence": [
+            "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          ],
+          "reading": "Hol_state records boundary-local residual obstruction on the state axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_effect",
+          "axisFamily": "effect",
+          "status": "measuredResidual",
+          "residualValue": 2,
+          "measuredDefectRefs": [
+            "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+          ],
+          "supportRefs": [
+            "add observed compensation / authority / effect atoms only after source review",
+            "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+            "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+            "split or enrich atoms that currently support the target obstruction"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_authority",
+          "axisFamily": "authority",
+          "status": "coverageBlocked",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "gap-runtime-user-db-trace",
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+            "obstruction:semantic-contract-mismatch:computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "missingEvidence": [
+            "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          ],
+          "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_runtime",
+          "axisFamily": "runtime",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_projection",
+          "axisFamily": "projection",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "projection:aat:route-service",
+            "projection:aat:route-users",
+            "projection:sft:create-user"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_projection records boundary-local residual obstruction on the projection axis"
+        }
+      ],
+      "residualObstructionRefs": [
+        "gap-runtime-user-db-trace",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "obstruction:semantic-contract-mismatch:computed",
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
+      "coverageAssumptions": [
+        "coveragePolicy=measure only selected axes with declared coverage; missing coverage remains blocked, not zero over selected axes [\"axis:layer-violation\", \"axis:semantic-inconsistency\"]",
+        "unmeasured boundary support remains residual coverage debt"
+      ],
+      "exactnessAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
+      "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
+      "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -3678,7 +3853,7 @@
       "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect"
     ],
     "featureBoundaryResidualRefs": [
-      "feature-extension-formula:fixture-archmap-atom-observation"
+      "feature-boundary-residual:fixture-archmap-atom-observation"
     ],
     "extensionDiagnosisRefs": [
       "split-readiness:molecule-user-request-responsibility"
@@ -5448,6 +5623,9 @@
     ],
     "nonzeroMonodromyWitnessSummary": [
       "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2"
+    ],
+    "featureBoundaryResidualSummary": [
+      "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=5"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -3351,6 +3351,166 @@
       ]
     }
   ],
+  "featureBoundaryResidualReadings": [
+    {
+      "readingId": "feature-boundary-residual:fixture-archmap-atom-observation",
+      "boundaryRef": "Boundary(fixture-archmap-atom-observation, feature-extension)",
+      "featureExtensionRef": "feature-extension-formula:fixture-archmap-atom-observation",
+      "status": "measuredResidual",
+      "coreScopeRef": "fixture-archmap-atom-observation:core",
+      "featureScopeRef": "fixture-archmap-atom-observation:feature",
+      "mixedSubconfigurationRefs": [
+        "gap-runtime-user-db-trace",
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "coreLocalReadingRefs": [],
+      "featureLocalReadingRefs": [],
+      "boundarySupportRefs": [
+        "gap-runtime-user-db-trace",
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "holonomyAxes": [
+        {
+          "holonomyAxisRef": "Hol_static",
+          "axisFamily": "static",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "atom:component:route-users",
+            "atom:component:service-user",
+            "atom:relation:route-service"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_static records boundary-local residual obstruction on the static axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_contract",
+          "axisFamily": "contract",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "atom:contract:create-user"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_contract records boundary-local residual obstruction on the contract axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_semantic",
+          "axisFamily": "semantic",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "semantic:create-user-flow"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_semantic records boundary-local residual obstruction on the semantic axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_state",
+          "axisFamily": "state",
+          "status": "coverageBlocked",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "gap-runtime-user-db-trace",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "missingEvidence": [
+            "missing state observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
+          ],
+          "reading": "Hol_state records boundary-local residual obstruction on the state axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_effect",
+          "axisFamily": "effect",
+          "status": "measuredResidual",
+          "residualValue": 2,
+          "measuredDefectRefs": [
+            "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect"
+          ],
+          "supportRefs": [
+            "add or refine ArchMap atom observations before claiming repair",
+            "derived-effect-order:p:operation-delta-observe-before-repair-continuation-operation-delta-observe-before-repair",
+            "derived-effect-order:q:operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation",
+            "no constructed obstruction is transported because no repair candidate exists"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_authority",
+          "axisFamily": "authority",
+          "status": "coverageBlocked",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "gap-runtime-user-db-trace",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "missingEvidence": [
+            "missing authority observation for operation-square:operation-delta-observe-before-repair:operation-delta-observe-before-repair-continuation"
+          ],
+          "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_runtime",
+          "axisFamily": "runtime",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
+        },
+        {
+          "holonomyAxisRef": "Hol_projection",
+          "axisFamily": "projection",
+          "status": "coveredZeroResidual",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
+          "supportRefs": [
+            "projection:aat:route-service",
+            "projection:aat:route-users",
+            "projection:sft:create-user"
+          ],
+          "missingEvidence": [],
+          "reading": "Hol_projection records boundary-local residual obstruction on the projection axis"
+        }
+      ],
+      "residualObstructionRefs": [
+        "gap-runtime-user-db-trace",
+        "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
+      "coverageAssumptions": [
+        "coveragePolicy=measure only selected axes with declared coverage; missing coverage remains blocked, not zero over selected axes [\"axis:layer-violation\"]",
+        "unmeasured boundary support remains residual coverage debt"
+      ],
+      "exactnessAssumptions": [
+        "selected LawPolicy exactness assumptions",
+        "ArchMapStore compaction boundary"
+      ],
+      "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
+      "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
+      "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -3408,7 +3568,7 @@
       "nonzero-monodromy-witness:mu-operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation-effect"
     ],
     "featureBoundaryResidualRefs": [
-      "feature-extension-formula:fixture-archmap-atom-observation"
+      "feature-boundary-residual:fixture-archmap-atom-observation"
     ],
     "extensionDiagnosisRefs": [
       "split-readiness:molecule-user-request-responsibility"
@@ -4993,6 +5153,9 @@
     ],
     "nonzeroMonodromyWitnessSummary": [
       "nonzero-monodromy-witness:mu-operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation-effect axis=effect defect=2 affectedAtoms=4 missingEvidence=0 focus=2"
+    ],
+    "featureBoundaryResidualSummary": [
+      "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=3"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",


### PR DESCRIPTION
## 概要

Closes #1474

#1489 を base にした stacked PR です。#1473 の nonzero monodromy witness surface 上に、feature boundary residual reading を追加します。

- `featureBoundaryResidualReadings` を追加し、`Boundary(A, f)` の mixed core / feature boundary support を packet に出力
- `Hol_static` / `Hol_contract` / `Hol_semantic` / `Hol_state` / `Hol_effect` / `Hol_authority` / `Hol_runtime` / `Hol_projection` の residual axes を出力
- core-local / feature-local / mixed boundary support、coverage assumptions、exactness assumptions、attribution policy、coverage / exactness / evidence boundary を保持
- `boundaryHolonomyReadingFamily.featureBoundaryResidualRefs` を実 residual reading IDs に接続
- summary / LLM interpretation packet と validation / fixture / docs を更新し、boundary holonomy conjecture を theorem として主張しない境界を残す

## 証明した定理

なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は Lean 変更なしのため未実施です。FieldSig 変更なしのため FieldSig test は未実施です。Lean ソース変更なしのため axiom / admit / sorry / unsafe scan は未実施です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical tooling diagnosis / future proof obligation` として Issue 側の範囲に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
