### PR TITLE
ArchSig feature extension diagnosis を multi-label 化

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -72,6 +72,7 @@ The implemented schema records:
 - `amiAggregateReadings`
 - `nonzeroMonodromyWitnesses`
 - `featureBoundaryResidualReadings`
+- `featureExtensionDiagnosisReadings`
 - `monodromyReadingFamily`
 - `boundaryHolonomyReadingFamily`
 - `representationStrengthReadings`
@@ -229,6 +230,13 @@ The builder:
   machine-readable non-conclusions. It does not claim an unconditional
   `Ob(B) = Ob(A) + Ob(f) + Hol(Boundary(A,f))` theorem or decide feature
   safety.
+- `featureExtensionDiagnosisReadings` classifies feature-extension witnesses
+  with non-disjoint multi-label attribution. The seven labels are inherited core
+  obstruction, feature-local obstruction, boundary holonomy, lifting failure,
+  filling failure, complexity transfer, and residual coverage gap. A single
+  witness can carry multiple labels; the classifier records this as review
+  attribution, not as a mutually disjoint decomposition, and keeps the ArchSig /
+  FieldSig boundary explicit.
 - axis-forgetting risk records when a coarse observation projection has
   forgotten selected axes or collapsed mixed-axis support. It blocks
   `ZeroReflecting` and `ObstructionReflecting` readings unless explicit axis

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -22,7 +22,8 @@ use crate::{
     ArchSigDesignPrincipleReadingV0, ArchSigDiagramFillabilityReadingV0,
     ArchSigDominantAtomFamilyCompositionV0, ArchSigEvolutionRiskRankingV0,
     ArchSigFeatureBoundaryResidualReadingV0, ArchSigFeatureExtensionAxisSummaryV0,
-    ArchSigFeatureExtensionFormulaReadingV0, ArchSigFlatnessReadingV0,
+    ArchSigFeatureExtensionDiagnosisReadingV0, ArchSigFeatureExtensionFormulaReadingV0,
+    ArchSigFeatureExtensionWitnessAttributionV0, ArchSigFlatnessReadingV0,
     ArchSigHighOverlapMoleculePairV0, ArchSigHomotopyOrderSensitivityReadingV0,
     ArchSigInvariantFamilyReadingV0, ArchSigLawUniverseCoverageReadingV0,
     ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0, ArchSigLlmInterpretationPacketV0,
@@ -210,6 +211,10 @@ pub fn build_archsig_analysis_packet(
         &feature_extension_formula_readings,
         &axis_wise_monodromy_defects,
     );
+    let feature_extension_diagnosis_readings = build_feature_extension_diagnosis_readings(
+        &feature_extension_formula_readings,
+        &feature_boundary_residual_readings,
+    );
     let monodromy_reading_family = build_monodromy_reading_family(
         law_policy,
         &arch_map_store_refs,
@@ -223,7 +228,7 @@ pub fn build_archsig_analysis_packet(
         &arch_map_store_refs,
         &nonzero_monodromy_witnesses,
         &feature_boundary_residual_readings,
-        &split_readiness_readings,
+        &feature_extension_diagnosis_readings,
     );
     let structural_reading_review_surface = build_structural_reading_review_surface(
         &representation_strength_readings,
@@ -300,6 +305,7 @@ pub fn build_archsig_analysis_packet(
         &split_readiness_readings,
         &nonzero_monodromy_witnesses,
         &feature_boundary_residual_readings,
+        &feature_extension_diagnosis_readings,
         &structural_reading_review_surface,
         &current_state_evolution_boundary,
         &repair_operation_candidates,
@@ -362,6 +368,7 @@ pub fn build_archsig_analysis_packet(
         ami_aggregate_readings,
         nonzero_monodromy_witnesses,
         feature_boundary_residual_readings,
+        feature_extension_diagnosis_readings,
         monodromy_reading_family,
         boundary_holonomy_reading_family,
         representation_strength_readings,
@@ -522,7 +529,7 @@ fn build_boundary_holonomy_reading_family(
     arch_map_store_refs: &ArchSigArchMapStoreRefsV0,
     nonzero_monodromy_witnesses: &[ArchSigNonzeroMonodromyWitnessV0],
     feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
-    split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
+    feature_extension_diagnosis_readings: &[ArchSigFeatureExtensionDiagnosisReadingV0],
 ) -> ArchSigBoundaryHolonomyReadingFamilyV0 {
     ArchSigBoundaryHolonomyReadingFamilyV0 {
         reading_family_id: format!(
@@ -543,9 +550,9 @@ fn build_boundary_holonomy_reading_family(
             .iter()
             .map(|reading| reading.reading_id.clone())
             .collect(),
-        extension_diagnosis_refs: split_readiness_readings
+        extension_diagnosis_refs: feature_extension_diagnosis_readings
             .iter()
-            .map(|reading| reading.reading_id.clone())
+            .map(|reading| reading.diagnosis_id.clone())
             .collect(),
         attribution_boundary:
             "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause"
@@ -1287,6 +1294,199 @@ fn boundary_holonomy_axis_residuals(
         }
     })
     .collect()
+}
+
+fn build_feature_extension_diagnosis_readings(
+    feature_extension_formula_readings: &[ArchSigFeatureExtensionFormulaReadingV0],
+    feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
+) -> Vec<ArchSigFeatureExtensionDiagnosisReadingV0> {
+    feature_extension_formula_readings
+        .iter()
+        .map(|formula| {
+            let boundary_residual = feature_boundary_residual_readings
+                .iter()
+                .find(|reading| reading.feature_extension_ref == formula.reading_id);
+            let mut attributions = BTreeMap::<String, ArchSigFeatureExtensionWitnessAttributionV0>::new();
+
+            for witness_ref in &formula.inherited_core_obstruction_refs {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    witness_ref,
+                    "inheritedCoreObstruction",
+                );
+            }
+            for witness_ref in &formula.feature_local_obstruction_refs {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    witness_ref,
+                    "featureLocalObstruction",
+                );
+            }
+            if let Some(boundary_residual) = boundary_residual {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    &boundary_residual.reading_id,
+                    "boundaryHolonomy",
+                );
+                for witness_ref in &boundary_residual.residual_obstruction_refs {
+                    push_feature_extension_attribution(
+                        &mut attributions,
+                        witness_ref,
+                        "boundaryHolonomy",
+                    );
+                }
+            }
+            for witness_ref in &formula.lifting_failure_refs {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    witness_ref,
+                    "liftingFailure",
+                );
+            }
+            for witness_ref in &formula.filling_failure_refs {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    witness_ref,
+                    "fillingFailure",
+                );
+            }
+            for witness_ref in &formula.complexity_transfer_refs {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    witness_ref,
+                    "complexityTransfer",
+                );
+            }
+            for witness_ref in &formula.residual_coverage_gap_refs {
+                push_feature_extension_attribution(
+                    &mut attributions,
+                    witness_ref,
+                    "residualCoverageGap",
+                );
+            }
+
+            let mut attribution_records = attributions.into_values().collect::<Vec<_>>();
+            for record in &mut attribution_records {
+                record.labels = unique_strings(record.labels.drain(..));
+                record.inherited_core_refs = unique_strings(record.inherited_core_refs.drain(..));
+                record.feature_local_refs = unique_strings(record.feature_local_refs.drain(..));
+                record.boundary_holonomy_refs =
+                    unique_strings(record.boundary_holonomy_refs.drain(..));
+                record.lifting_failure_refs =
+                    unique_strings(record.lifting_failure_refs.drain(..));
+                record.filling_failure_refs =
+                    unique_strings(record.filling_failure_refs.drain(..));
+                record.complexity_transfer_refs =
+                    unique_strings(record.complexity_transfer_refs.drain(..));
+                record.residual_coverage_gap_refs =
+                    unique_strings(record.residual_coverage_gap_refs.drain(..));
+                record.reading = format!(
+                    "{} carries non-disjoint feature-extension labels {:?}",
+                    record.witness_ref, record.labels
+                );
+            }
+            let has_multi_label = attribution_records
+                .iter()
+                .any(|record| record.labels.len() > 1);
+            ArchSigFeatureExtensionDiagnosisReadingV0 {
+                diagnosis_id: format!(
+                    "feature-extension-diagnosis:{}",
+                    stable_id(&formula.reading_id)
+                ),
+                feature_extension_ref: formula.reading_id.clone(),
+                boundary_residual_ref: boundary_residual
+                    .map(|reading| reading.reading_id.clone())
+                    .unwrap_or_else(|| "feature-boundary-residual:none-observed".to_string()),
+                status: if has_multi_label {
+                    "multiLabelAttributed".to_string()
+                } else {
+                    "singleLabelAttributed".to_string()
+                },
+                classifier_version: "feature-extension-diagnosis-classifier-v0".to_string(),
+                classification_summary: feature_extension_diagnosis_classification_summary(
+                    formula,
+                    boundary_residual,
+                ),
+                attribution_records,
+                residual_coverage_gap_refs: formula.residual_coverage_gap_refs.clone(),
+                lifting_failure_refs: formula.lifting_failure_refs.clone(),
+                filling_failure_refs: formula.filling_failure_refs.clone(),
+                complexity_transfer_refs: formula.complexity_transfer_refs.clone(),
+                classification_boundary:
+                    "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels"
+                        .to_string(),
+                fieldsig_boundary:
+                    "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis"
+                        .to_string(),
+                evidence_boundary:
+                    "diagnosis is computed from ArchSig packet evidence and does not prove a mutually disjoint Architecture Extension Formula"
+                        .to_string(),
+                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+            }
+        })
+        .collect()
+}
+
+fn push_feature_extension_attribution(
+    attributions: &mut BTreeMap<String, ArchSigFeatureExtensionWitnessAttributionV0>,
+    witness_ref: &str,
+    label: &str,
+) {
+    let entry = attributions
+        .entry(witness_ref.to_string())
+        .or_insert_with(|| ArchSigFeatureExtensionWitnessAttributionV0 {
+            witness_ref: witness_ref.to_string(),
+            labels: Vec::new(),
+            inherited_core_refs: Vec::new(),
+            feature_local_refs: Vec::new(),
+            boundary_holonomy_refs: Vec::new(),
+            lifting_failure_refs: Vec::new(),
+            filling_failure_refs: Vec::new(),
+            complexity_transfer_refs: Vec::new(),
+            residual_coverage_gap_refs: Vec::new(),
+            reading: String::new(),
+        });
+    entry.labels.push(label.to_string());
+    match label {
+        "inheritedCoreObstruction" => entry.inherited_core_refs.push(witness_ref.to_string()),
+        "featureLocalObstruction" => entry.feature_local_refs.push(witness_ref.to_string()),
+        "boundaryHolonomy" => entry.boundary_holonomy_refs.push(witness_ref.to_string()),
+        "liftingFailure" => entry.lifting_failure_refs.push(witness_ref.to_string()),
+        "fillingFailure" => entry.filling_failure_refs.push(witness_ref.to_string()),
+        "complexityTransfer" => entry.complexity_transfer_refs.push(witness_ref.to_string()),
+        "residualCoverageGap" => entry
+            .residual_coverage_gap_refs
+            .push(witness_ref.to_string()),
+        _ => {}
+    }
+}
+
+fn feature_extension_diagnosis_classification_summary(
+    formula: &ArchSigFeatureExtensionFormulaReadingV0,
+    boundary_residual: Option<&ArchSigFeatureBoundaryResidualReadingV0>,
+) -> Vec<ArchSigFeatureExtensionAxisSummaryV0> {
+    let boundary_holonomy_refs = boundary_residual
+        .map(|reading| {
+            let mut refs = vec![reading.reading_id.clone()];
+            refs.extend(reading.residual_obstruction_refs.clone());
+            unique_strings(refs.into_iter())
+        })
+        .unwrap_or_default();
+    vec![
+        extension_axis_summary(
+            "inheritedCoreObstruction",
+            &formula.inherited_core_obstruction_refs,
+        ),
+        extension_axis_summary(
+            "featureLocalObstruction",
+            &formula.feature_local_obstruction_refs,
+        ),
+        extension_axis_summary("boundaryHolonomy", &boundary_holonomy_refs),
+        extension_axis_summary("liftingFailure", &formula.lifting_failure_refs),
+        extension_axis_summary("fillingFailure", &formula.filling_failure_refs),
+        extension_axis_summary("complexityTransfer", &formula.complexity_transfer_refs),
+        extension_axis_summary("residualCoverageGap", &formula.residual_coverage_gap_refs),
+    ]
 }
 
 fn ami_zero_reflection_assumptions(law_policy: &LawPolicyDocumentV0) -> Vec<String> {
@@ -6517,6 +6717,7 @@ fn build_llm_interpretation_packet(
     split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
     nonzero_monodromy_witnesses: &[ArchSigNonzeroMonodromyWitnessV0],
     feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
+    feature_extension_diagnosis_readings: &[ArchSigFeatureExtensionDiagnosisReadingV0],
     structural_reading_review_surface: &ArchSigStructuralReadingReviewSurfaceV0,
     current_state_evolution_boundary: &ArchSigCurrentStateEvolutionBoundaryV0,
     repair_candidates: &[ArchSigRepairOperationCandidateV0],
@@ -6832,6 +7033,27 @@ fn build_llm_interpretation_packet(
                 )
             })
             .collect(),
+        feature_extension_diagnosis_summary: feature_extension_diagnosis_readings
+            .iter()
+            .map(|reading| {
+                let multi_label_count = reading
+                    .attribution_records
+                    .iter()
+                    .filter(|record| record.labels.len() > 1)
+                    .count();
+                format!(
+                    "{} status={} attributions={} multiLabel={} coverageGaps={} lifting={} filling={} complexity={}",
+                    reading.diagnosis_id,
+                    reading.status,
+                    reading.attribution_records.len(),
+                    multi_label_count,
+                    reading.residual_coverage_gap_refs.len(),
+                    reading.lifting_failure_refs.len(),
+                    reading.filling_failure_refs.len(),
+                    reading.complexity_transfer_refs.len()
+                )
+            })
+            .collect(),
         representation_strength_summary: representation_strength_readings
             .iter()
             .map(|reading| {
@@ -7050,6 +7272,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_axis_wise_defect_ami_surface(packet),
         check_nonzero_monodromy_witness_surface(packet),
         check_feature_boundary_residual_surface(packet),
+        check_feature_extension_diagnosis_surface(packet),
         check_monodromy_boundary_schema_foundation(packet),
         check_law_relative_analysis(packet),
         check_signature_and_flatness(packet),
@@ -9723,6 +9946,178 @@ fn check_feature_boundary_residual_surface(packet: &ArchSigAnalysisPacketV0) -> 
     )
 }
 
+fn check_feature_extension_diagnosis_surface(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
+    let feature_extension_ids = set(packet
+        .feature_extension_formula_readings
+        .iter()
+        .map(|reading| reading.reading_id.as_str()));
+    let boundary_residual_ids = set(packet
+        .feature_boundary_residual_readings
+        .iter()
+        .map(|reading| reading.reading_id.as_str()));
+    let diagnosis_ids = set(packet
+        .feature_extension_diagnosis_readings
+        .iter()
+        .map(|reading| reading.diagnosis_id.as_str()));
+    let required_labels = BTreeSet::from([
+        "inheritedCoreObstruction",
+        "featureLocalObstruction",
+        "boundaryHolonomy",
+        "liftingFailure",
+        "fillingFailure",
+        "complexityTransfer",
+        "residualCoverageGap",
+    ]);
+    let mut examples = Vec::new();
+    if !packet.feature_extension_formula_readings.is_empty()
+        && packet.feature_extension_diagnosis_readings.is_empty()
+    {
+        examples.push(generic_validation_example(
+            "featureExtensionDiagnosisReadings",
+            "empty",
+            "feature extension formulas must be classified into multi-label diagnosis readings",
+        ));
+    }
+    examples.extend(duplicate_examples(
+        "featureExtensionDiagnosisReadings[].diagnosisId",
+        duplicates(
+            packet
+                .feature_extension_diagnosis_readings
+                .iter()
+                .map(|reading| reading.diagnosis_id.as_str()),
+        ),
+    ));
+    for reading in &packet.feature_extension_diagnosis_readings {
+        if !feature_extension_ids.contains(reading.feature_extension_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                &reading.feature_extension_ref,
+                "feature extension diagnosis references an unknown feature extension formula",
+            ));
+        }
+        if reading.boundary_residual_ref != "feature-boundary-residual:none-observed"
+            && !boundary_residual_ids.contains(reading.boundary_residual_ref.as_str())
+        {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                &reading.boundary_residual_ref,
+                "feature extension diagnosis references an unknown boundary residual reading",
+            ));
+        }
+        for (field, value) in [
+            ("status", &reading.status),
+            ("classifierVersion", &reading.classifier_version),
+            ("classificationBoundary", &reading.classification_boundary),
+            ("fieldSigBoundary", &reading.fieldsig_boundary),
+            ("evidenceBoundary", &reading.evidence_boundary),
+        ] {
+            push_blank(
+                &mut examples,
+                &format!("{} {field}", reading.diagnosis_id),
+                value,
+            );
+        }
+        if reading.classification_summary.len() != 7 {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                "classificationSummary",
+                "feature extension diagnosis must report all seven classification axes",
+            ));
+        }
+        let summary_labels = reading
+            .classification_summary
+            .iter()
+            .map(|summary| summary.axis.as_str())
+            .collect::<BTreeSet<_>>();
+        if summary_labels != required_labels {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                "classificationSummary.axis",
+                "feature extension diagnosis must retain the seven named attribution labels",
+            ));
+        }
+        if reading.attribution_records.is_empty() {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                "attributionRecords",
+                "feature extension diagnosis must retain witness-level attribution records",
+            ));
+        }
+        if !reading
+            .attribution_records
+            .iter()
+            .any(|record| record.labels.len() > 1)
+        {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                "attributionRecords.labels",
+                "at least one witness must demonstrate non-disjoint multi-label attribution",
+            ));
+        }
+        if reading.non_conclusions.is_empty() || has_blank(&reading.non_conclusions) {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                "nonConclusions",
+                "feature extension diagnosis must retain machine-readable non-conclusions",
+            ));
+        }
+        if !reading.fieldsig_boundary.contains("FieldSig") {
+            examples.push(generic_validation_example(
+                &reading.diagnosis_id,
+                &reading.fieldsig_boundary,
+                "feature extension diagnosis must preserve the ArchSig / FieldSig boundary",
+            ));
+        }
+        for record in &reading.attribution_records {
+            push_blank(
+                &mut examples,
+                &format!("{} attribution.witnessRef", reading.diagnosis_id),
+                &record.witness_ref,
+            );
+            if record.labels.is_empty() || has_blank(&record.labels) {
+                examples.push(generic_validation_example(
+                    &reading.diagnosis_id,
+                    &record.witness_ref,
+                    "witness attribution must carry one or more labels",
+                ));
+            }
+            for label in &record.labels {
+                if !required_labels.contains(label.as_str()) {
+                    examples.push(generic_validation_example(
+                        &reading.diagnosis_id,
+                        label,
+                        "witness attribution carries an unknown feature-extension label",
+                    ));
+                }
+            }
+            push_blank(
+                &mut examples,
+                &format!("{} attribution.reading", reading.diagnosis_id),
+                &record.reading,
+            );
+        }
+    }
+    for diagnosis_ref in &packet
+        .boundary_holonomy_reading_family
+        .extension_diagnosis_refs
+    {
+        if !diagnosis_ids.contains(diagnosis_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &packet.boundary_holonomy_reading_family.reading_family_id,
+                diagnosis_ref,
+                "boundary holonomy reading family references an unknown feature extension diagnosis",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-feature-extension-diagnosis-surface",
+        "packet reports non-disjoint feature-extension multi-label attribution without replacing FieldSig evolution analysis",
+        examples,
+        "fail",
+    )
+}
+
 fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck {
     let mut examples = Vec::new();
     let store_refs = &packet.arch_map_store_refs;
@@ -10302,6 +10697,13 @@ fn check_llm_interpretation_surface(packet: &ArchSigAnalysisPacketV0) -> Validat
             packet
                 .llm_interpretation_packet
                 .feature_boundary_residual_summary
+                .is_empty(),
+        ),
+        (
+            "llmInterpretationPacket.featureExtensionDiagnosisSummary",
+            packet
+                .llm_interpretation_packet
+                .feature_extension_diagnosis_summary
                 .is_empty(),
         ),
     ] {
@@ -11051,6 +11453,22 @@ mod tests {
         assert_eq!(report.summary.result, "fail");
         assert!(report.checks.iter().any(|check| {
             check.id == "archsig-analysis-packet-feature-boundary-residual-surface"
+                && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn feature_extension_diagnosis_without_multi_label_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        for record in &mut packet.feature_extension_diagnosis_readings[0].attribution_records {
+            record.labels.truncate(1);
+        }
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-feature-extension-diagnosis-surface"
                 && check.result == "fail"
         }));
     }

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -528,6 +528,7 @@ fn measurement_expansion_summary(
         "bridgeSplitObstructionTransfer": limited_array_field(llm_packet, "bridgeSplitObstructionTransferSummary", limit),
         "nonzeroMonodromyWitness": limited_array_field(llm_packet, "nonzeroMonodromyWitnessSummary", limit),
         "featureBoundaryResidual": limited_array_field(llm_packet, "featureBoundaryResidualSummary", limit),
+        "featureExtensionDiagnosis": limited_array_field(llm_packet, "featureExtensionDiagnosisSummary", limit),
         "counts": {
             "atomSupportAxisReadings": array_len(packet, "atomSupportAxisReadings"),
             "atomCompatibilityReadings": array_len(packet, "atomCompatibilityReadings"),
@@ -541,7 +542,8 @@ fn measurement_expansion_summary(
             "signatureTrajectoryHomotopyRefutationReadings": array_len(packet, "signatureTrajectoryHomotopyRefutationReadings"),
             "bridgeSplitObstructionTransferReadings": array_len(packet, "bridgeSplitObstructionTransferReadings"),
             "nonzeroMonodromyWitnesses": array_len(packet, "nonzeroMonodromyWitnesses"),
-            "featureBoundaryResidualReadings": array_len(packet, "featureBoundaryResidualReadings")
+            "featureBoundaryResidualReadings": array_len(packet, "featureBoundaryResidualReadings"),
+            "featureExtensionDiagnosisReadings": array_len(packet, "featureExtensionDiagnosisReadings")
         }
     })
 }

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -670,6 +670,7 @@ pub struct ArchSigAnalysisPacketV0 {
     pub ami_aggregate_readings: Vec<ArchSigAmiAggregateReadingV0>,
     pub nonzero_monodromy_witnesses: Vec<ArchSigNonzeroMonodromyWitnessV0>,
     pub feature_boundary_residual_readings: Vec<ArchSigFeatureBoundaryResidualReadingV0>,
+    pub feature_extension_diagnosis_readings: Vec<ArchSigFeatureExtensionDiagnosisReadingV0>,
     pub monodromy_reading_family: ArchSigMonodromyReadingFamilyV0,
     pub boundary_holonomy_reading_family: ArchSigBoundaryHolonomyReadingFamilyV0,
     pub representation_strength_readings: Vec<ArchSigRepresentationStrengthReadingV0>,
@@ -870,6 +871,41 @@ pub struct ArchSigBoundaryHolonomyAxisResidualV0 {
     pub measured_defect_refs: Vec<String>,
     pub support_refs: Vec<String>,
     pub missing_evidence: Vec<String>,
+    pub reading: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigFeatureExtensionDiagnosisReadingV0 {
+    pub diagnosis_id: String,
+    pub feature_extension_ref: String,
+    pub boundary_residual_ref: String,
+    pub status: String,
+    pub classifier_version: String,
+    pub classification_summary: Vec<ArchSigFeatureExtensionAxisSummaryV0>,
+    pub attribution_records: Vec<ArchSigFeatureExtensionWitnessAttributionV0>,
+    pub residual_coverage_gap_refs: Vec<String>,
+    pub lifting_failure_refs: Vec<String>,
+    pub filling_failure_refs: Vec<String>,
+    pub complexity_transfer_refs: Vec<String>,
+    pub classification_boundary: String,
+    pub fieldsig_boundary: String,
+    pub evidence_boundary: String,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigFeatureExtensionWitnessAttributionV0 {
+    pub witness_ref: String,
+    pub labels: Vec<String>,
+    pub inherited_core_refs: Vec<String>,
+    pub feature_local_refs: Vec<String>,
+    pub boundary_holonomy_refs: Vec<String>,
+    pub lifting_failure_refs: Vec<String>,
+    pub filling_failure_refs: Vec<String>,
+    pub complexity_transfer_refs: Vec<String>,
+    pub residual_coverage_gap_refs: Vec<String>,
     pub reading: String,
 }
 
@@ -1961,6 +1997,8 @@ pub struct ArchSigLlmInterpretationPacketV0 {
     pub nonzero_monodromy_witness_summary: Vec<String>,
     #[serde(default)]
     pub feature_boundary_residual_summary: Vec<String>,
+    #[serde(default)]
+    pub feature_extension_diagnosis_summary: Vec<String>,
     pub representation_strength_summary: Vec<String>,
     pub local_curvature_diagram_summary: Vec<String>,
     pub three_layer_flatness_summary: Vec<String>,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1515,6 +1515,42 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "feature boundary residual readings must expose mixed support, Hol_* axes, assumptions, and non-conclusions"
     );
     assert!(
+        json["featureExtensionDiagnosisReadings"]
+            .as_array()
+            .is_some_and(|items| {
+                !items.is_empty()
+                    && items.iter().all(|reading| {
+                        reading["classificationSummary"]
+                            .as_array()
+                            .is_some_and(|summary| summary.len() == 7)
+                            && reading["attributionRecords"]
+                                .as_array()
+                                .is_some_and(|records| {
+                                    !records.is_empty()
+                                        && records.iter().any(|record| {
+                                            record["labels"]
+                                                .as_array()
+                                                .is_some_and(|labels| labels.len() > 1)
+                                        })
+                                })
+                            && reading["residualCoverageGapRefs"].as_array().is_some()
+                            && reading["liftingFailureRefs"].as_array().is_some()
+                            && reading["fillingFailureRefs"].as_array().is_some()
+                            && reading["complexityTransferRefs"].as_array().is_some()
+                            && reading["classificationBoundary"]
+                                .as_str()
+                                .is_some_and(|boundary| boundary.contains("non-disjoint"))
+                            && reading["fieldsigBoundary"]
+                                .as_str()
+                                .is_some_and(|boundary| boundary.contains("FieldSig"))
+                            && reading["nonConclusions"]
+                                .as_array()
+                                .is_some_and(|items| !items.is_empty())
+                    })
+            }),
+        "feature extension diagnosis readings must expose seven non-disjoint labels, witness attribution, separated failure refs, and FieldSig boundary"
+    );
+    assert!(
         json["llmInterpretationPacket"]["structuralReadingReviewSummary"]
             .as_array()
             .is_some_and(|items| !items.is_empty())
@@ -1528,6 +1564,9 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                 .as_array()
                 .is_some_and(|items| !items.is_empty())
             && json["llmInterpretationPacket"]["featureBoundaryResidualSummary"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+            && json["llmInterpretationPacket"]["featureExtensionDiagnosisSummary"]
                 .as_array()
                 .is_some_and(|items| !items.is_empty())
             && json["llmInterpretationPacket"]["atomSupportAxisSummary"]

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -3794,6 +3794,218 @@
       ]
     }
   ],
+  "featureExtensionDiagnosisReadings": [
+    {
+      "diagnosisId": "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation",
+      "featureExtensionRef": "feature-extension-formula:fixture-archmap-atom-observation",
+      "boundaryResidualRef": "feature-boundary-residual:fixture-archmap-atom-observation",
+      "status": "multiLabelAttributed",
+      "classifierVersion": "feature-extension-diagnosis-classifier-v0",
+      "classificationSummary": [
+        {
+          "axis": "inheritedCoreObstruction",
+          "status": "observed",
+          "refs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "reading": "inheritedCoreObstruction is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "featureLocalObstruction",
+          "status": "observed",
+          "refs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "boundaryHolonomy",
+          "status": "observed",
+          "refs": [
+            "feature-boundary-residual:fixture-archmap-atom-observation",
+            "gap-runtime-user-db-trace",
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+            "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "obstruction:semantic-contract-mismatch:computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "liftingFailure",
+          "status": "observed",
+          "refs": [
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "reading": "liftingFailure is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "fillingFailure",
+          "status": "observed",
+          "refs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "reading": "fillingFailure is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "complexityTransfer",
+          "status": "observed",
+          "refs": [
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          ],
+          "reading": "complexityTransfer is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "residualCoverageGap",
+          "status": "observed",
+          "refs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "reading": "residualCoverageGap is classified as a current-state extension coordinate"
+        }
+      ],
+      "attributionRecords": [
+        {
+          "witnessRef": "feature-boundary-residual:fixture-archmap-atom-observation",
+          "labels": [
+            "boundaryHolonomy"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "feature-boundary-residual:fixture-archmap-atom-observation"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "feature-boundary-residual:fixture-archmap-atom-observation carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+        },
+        {
+          "witnessRef": "gap-runtime-user-db-trace",
+          "labels": [
+            "boundaryHolonomy",
+            "residualCoverageGap"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "reading": "gap-runtime-user-db-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
+        },
+        {
+          "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "labels": [
+            "boundaryHolonomy",
+            "complexityTransfer"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          ],
+          "residualCoverageGapRefs": [],
+          "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+        },
+        {
+          "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "labels": [
+            "boundaryHolonomy"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+        },
+        {
+          "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+          "labels": [
+            "boundaryHolonomy",
+            "featureLocalObstruction",
+            "fillingFailure",
+            "inheritedCoreObstruction"
+          ],
+          "inheritedCoreRefs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "featureLocalRefs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "boundaryHolonomyRefs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+        },
+        {
+          "witnessRef": "split-readiness:molecule-user-request-responsibility",
+          "labels": [
+            "boundaryHolonomy",
+            "liftingFailure"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "liftingFailureRefs": [
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "split-readiness:molecule-user-request-responsibility carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"liftingFailure\"]"
+        }
+      ],
+      "residualCoverageGapRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "liftingFailureRefs": [
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "fillingFailureRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "complexityTransferRefs": [
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
+      "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
+      "evidenceBoundary": "diagnosis is computed from ArchSig packet evidence and does not prove a mutually disjoint Architecture Extension Formula",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -3856,7 +4068,7 @@
       "feature-boundary-residual:fixture-archmap-atom-observation"
     ],
     "extensionDiagnosisRefs": [
-      "split-readiness:molecule-user-request-responsibility"
+      "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation"
     ],
     "attributionBoundary": "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause",
     "readingBoundary": "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues",
@@ -5626,6 +5838,9 @@
     ],
     "featureBoundaryResidualSummary": [
       "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=5"
+    ],
+    "featureExtensionDiagnosisSummary": [
+      "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation status=multiLabelAttributed attributions=6 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -3511,6 +3511,160 @@
       ]
     }
   ],
+  "featureExtensionDiagnosisReadings": [
+    {
+      "diagnosisId": "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation",
+      "featureExtensionRef": "feature-extension-formula:fixture-archmap-atom-observation",
+      "boundaryResidualRef": "feature-boundary-residual:fixture-archmap-atom-observation",
+      "status": "multiLabelAttributed",
+      "classifierVersion": "feature-extension-diagnosis-classifier-v0",
+      "classificationSummary": [
+        {
+          "axis": "inheritedCoreObstruction",
+          "status": "unmeasuredOrAbsent",
+          "refs": [],
+          "reading": "inheritedCoreObstruction is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "featureLocalObstruction",
+          "status": "unmeasuredOrAbsent",
+          "refs": [],
+          "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "boundaryHolonomy",
+          "status": "observed",
+          "refs": [
+            "feature-boundary-residual:fixture-archmap-atom-observation",
+            "gap-runtime-user-db-trace",
+            "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "liftingFailure",
+          "status": "observed",
+          "refs": [
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "reading": "liftingFailure is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "fillingFailure",
+          "status": "unmeasuredOrAbsent",
+          "refs": [],
+          "reading": "fillingFailure is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "complexityTransfer",
+          "status": "unmeasuredOrAbsent",
+          "refs": [],
+          "reading": "complexityTransfer is classified as a current-state extension coordinate"
+        },
+        {
+          "axis": "residualCoverageGap",
+          "status": "observed",
+          "refs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "reading": "residualCoverageGap is classified as a current-state extension coordinate"
+        }
+      ],
+      "attributionRecords": [
+        {
+          "witnessRef": "feature-boundary-residual:fixture-archmap-atom-observation",
+          "labels": [
+            "boundaryHolonomy"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "feature-boundary-residual:fixture-archmap-atom-observation"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "feature-boundary-residual:fixture-archmap-atom-observation carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+        },
+        {
+          "witnessRef": "gap-runtime-user-db-trace",
+          "labels": [
+            "boundaryHolonomy",
+            "residualCoverageGap"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "reading": "gap-runtime-user-db-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
+        },
+        {
+          "witnessRef": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect",
+          "labels": [
+            "boundaryHolonomy"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "mu:operation-square-operation-delta-observe-before-repair-operation-delta-observe-before-repair-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+        },
+        {
+          "witnessRef": "split-readiness:molecule-user-request-responsibility",
+          "labels": [
+            "boundaryHolonomy",
+            "liftingFailure"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "liftingFailureRefs": [
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "split-readiness:molecule-user-request-responsibility carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"liftingFailure\"]"
+        }
+      ],
+      "residualCoverageGapRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "liftingFailureRefs": [
+        "split-readiness:molecule-user-request-responsibility"
+      ],
+      "fillingFailureRefs": [],
+      "complexityTransferRefs": [],
+      "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
+      "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
+      "evidenceBoundary": "diagnosis is computed from ArchSig packet evidence and does not prove a mutually disjoint Architecture Extension Formula",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
     "status": "schemaFoundationOnly",
@@ -3571,7 +3725,7 @@
       "feature-boundary-residual:fixture-archmap-atom-observation"
     ],
     "extensionDiagnosisRefs": [
-      "split-readiness:molecule-user-request-responsibility"
+      "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation"
     ],
     "attributionBoundary": "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause",
     "readingBoundary": "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues",
@@ -5156,6 +5310,9 @@
     ],
     "featureBoundaryResidualSummary": [
       "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=3"
+    ],
+    "featureExtensionDiagnosisSummary": [
+      "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation status=multiLabelAttributed attributions=4 multiLabel=2 coverageGaps=1 lifting=1 filling=0 complexity=0"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",


### PR DESCRIPTION
## 概要

Closes #1475

#1490 を base にした stacked PR です。feature boundary residual reading の上に、feature extension diagnosis の multi-label attribution surface を追加します。

- `featureExtensionDiagnosisReadings` を追加し、feature extension witness を7分類で report
- inherited core obstruction / feature-local obstruction / boundary holonomy / lifting failure / filling failure / complexity transfer / residual coverage gap を packet と summary に出力
- witness-level attribution records を追加し、同じ witness が複数分類を持てることを validation と fixture で固定
- residual coverage gap、lifting / filling / complexity transfer refs を分離して保持
- `boundaryHolonomyReadingFamily.extensionDiagnosisRefs` を実 diagnosis IDs に接続し、FieldSig evolution analysis と混同しない境界を machine-readable に残す

## 証明した定理

なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は Lean 変更なしのため未実施です。FieldSig 変更なしのため FieldSig test は未実施です。Lean ソース変更なしのため axiom / admit / sorry / unsafe scan は未実施です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `defined only / tooling attribution boundary` として Issue 側の範囲に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
