### PR TITLE
ArchSig lightweight PR review command を追加

### DIFF
--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -101,6 +101,9 @@ The E2E flow must preserve these boundaries:
 - Future ArchSig PR review mode reads ArchMapStore deltas / commits as
   change-local structural evidence for CI. FieldSig reads ArchMapStore and
   ArchSig packet chains in batch for longitudinal evolution monitoring.
+- The implemented lightweight `archsig pr-review` command takes
+  `ArchMapDelta`, `ArchMapCommit`, and base/head ArchSig packets as canonical
+  inputs. Raw diff is recorded only as an optional scoping hint.
 - Coverage gaps are carried as unknown remainder; they are not rounded to
   absence, measured zero, or forecast truth.
 - ArchSig emits only the current ArchMap validation, profile validation,

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -17,6 +17,7 @@ forecast, governance, calibration, and operational feedback under
 | ArchMap validation | `archmap`, `archmap-generate` | ArchMap records source-grounded Atom observations and concern hints. It does not select laws or output obstruction circuits. |
 | Interpretation profile | `law-policy`, `interpretation-profile` | The profile selects the LawUniverse, witness rules, signature axes, coverage requirements, exactness assumptions, and non-conclusions. It is not AAT itself. |
 | ArchSig analysis | `analyze`, `llm-native-workflow`, `north-star-workflow`, `archsig-analysis`, `aat-analysis`, `analysis-summary`, `summary` | `analyze` is the primary workflow from ArchMap + LawPolicy to validation reports, `archsig-analysis-packet-v0`, and the LLM interpretation packet. `llm-native-workflow` and `north-star-workflow` remain compatibility aliases for the same workflow. `archsig-analysis` / `aat-analysis` build a packet from already validated inputs. `analysis-summary` emits a compact review summary from an existing packet. |
+| Lightweight PR review | `pr-review` | Reads `archmap-delta-v0`, `archmap-commit-v0`, and base/head `archsig-analysis-packet-v0` artifacts. Raw diff is only an optional scoping hint, and the report is not merge safety or FieldSig evolution analysis. |
 | Schema | `schema-catalog` | The catalog lists only the current LLM Atom ArchMap artifacts. |
 
 Large ArchMaps may be authored in shards for review and parallel generation,

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -10,8 +10,10 @@ archmap-observation-map-v0
   -> FieldSig handoff
 ```
 
-ArchSig no longer exposes pre-Atom scan, projection, report, or PR-review
-commands. Git history is the archive for those workflows.
+ArchSig no longer exposes pre-Atom scan, projection, report, or legacy raw-diff
+PR-review commands. Git history is the archive for those workflows. The
+retained `pr-review` command reads ArchMapStore change artifacts and ArchSig
+packets; raw diff is only an optional scoping hint.
 FieldSig owns SFT forecast, IntentMap, operational feedback, governance, and
 calibration commands under `tools/fieldsig`.
 
@@ -59,6 +61,28 @@ cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary \
 
 `summary` is a visible alias. The summary is a reading aid for human / LLM
 review. It does not replace the full packet or validation reports.
+
+## Lightweight PR Review
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- pr-review \
+  --delta tools/archsig/tests/fixtures/pr_review/archmap_delta.json \
+  --commit tools/archsig/tests/fixtures/pr_review/archmap_commit.json \
+  --base-packet tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json \
+  --head-packet tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json \
+  --diff-hint tools/archsig/tests/fixtures/pr_review/raw_diff_hint.diff \
+  --out .archsig/pr-review/archsig-pr-review.json
+```
+
+`pr-review` is the CI-friendly ArchSig surface for small PR review. Its
+canonical inputs are `archmap-delta-v0`, `archmap-commit-v0`, and base/head
+`archsig-analysis-packet-v0` artifacts. The optional `--diff-hint` path is
+recorded as scope only; ArchSig does not parse raw diff as semantic, state,
+effect, authority, or boundary evidence. The report summarizes measured
+monodromy witnesses, operation-order sensitivity, boundary holonomy, missing
+filler / lifting evidence, coverage gaps, and review focus. It is not a merge
+safety decision and does not replace FieldSig PR / diff / change-vector
+evolution analysis.
 
 ## Sharded ArchMap Authoring
 

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -120,6 +120,33 @@ enum Command {
         out: Option<PathBuf>,
     },
 
+    /// Produce a lightweight ArchSig PR review report from ArchMapStore change artifacts.
+    PrReview {
+        /// Input archmap-delta-v0 JSON path. This is the canonical change-local input.
+        #[arg(long)]
+        delta: PathBuf,
+
+        /// Input archmap-commit-v0 JSON path. This connects the delta to the ArchMapStore chain.
+        #[arg(long)]
+        commit: PathBuf,
+
+        /// Base archsig-analysis-packet-v0 JSON path.
+        #[arg(long = "base-packet")]
+        base_packet: PathBuf,
+
+        /// Head archsig-analysis-packet-v0 JSON path.
+        #[arg(long = "head-packet")]
+        head_packet: PathBuf,
+
+        /// Optional raw diff scoping hint. The file is referenced but not parsed as semantic input.
+        #[arg(long = "diff-hint")]
+        diff_hint: Option<PathBuf>,
+
+        /// Output archsig-pr-review-report-v0 JSON path. If omitted, JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
     /// Emit a bounded external-agent protocol for generating ArchMap JSON.
     ArchmapGenerate {
         /// Source inventory JSON path used by the external agent.
@@ -299,6 +326,44 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             write_json(out, &summary)?;
             Ok(ExitCode::SUCCESS)
         }
+        Some(Command::PrReview {
+            delta,
+            commit,
+            base_packet,
+            head_packet,
+            diff_hint,
+            out,
+        }) => {
+            let delta_document: serde_json::Value = read_json(&delta)?;
+            require_schema(&delta_document, "archmap-delta-v0", "--delta")?;
+            let commit_document: serde_json::Value = read_json(&commit)?;
+            require_schema(&commit_document, "archmap-commit-v0", "--commit")?;
+            let base_packet_document: serde_json::Value = read_json(&base_packet)?;
+            require_schema(
+                &base_packet_document,
+                ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
+                "--base-packet",
+            )?;
+            let head_packet_document: serde_json::Value = read_json(&head_packet)?;
+            require_schema(
+                &head_packet_document,
+                ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
+                "--head-packet",
+            )?;
+            let report = build_pr_review_report(
+                &delta,
+                &delta_document,
+                &commit,
+                &commit_document,
+                &base_packet,
+                &base_packet_document,
+                &head_packet,
+                &head_packet_document,
+                diff_hint.as_ref(),
+            );
+            write_json(out, &report)?;
+            Ok(ExitCode::SUCCESS)
+        }
         Some(Command::ArchmapGenerate {
             source_inventory,
             prompt_pack,
@@ -457,6 +522,149 @@ fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T, Box<dy
 
 fn read_optional_json(path: Option<&PathBuf>) -> Result<Option<serde_json::Value>, Box<dyn Error>> {
     path.map(read_json).transpose()
+}
+
+fn require_schema(
+    document: &serde_json::Value,
+    expected: &str,
+    field_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let actual = document
+        .get("schemaVersion")
+        .or_else(|| document.get("schema"))
+        .and_then(|value| value.as_str());
+    if actual != Some(expected) {
+        return Err(format!("{field_name} must have schemaVersion {expected}").into());
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_pr_review_report(
+    delta_path: &Path,
+    delta: &serde_json::Value,
+    commit_path: &Path,
+    commit: &serde_json::Value,
+    base_packet_path: &Path,
+    base_packet: &serde_json::Value,
+    head_packet_path: &Path,
+    head_packet: &serde_json::Value,
+    diff_hint: Option<&PathBuf>,
+) -> serde_json::Value {
+    let head_llm = head_packet
+        .get("llmInterpretationPacket")
+        .unwrap_or(&serde_json::Value::Null);
+    let base_nonzero_count = array_len(base_packet, "nonzeroMonodromyWitnesses");
+    let head_nonzero_count = array_len(head_packet, "nonzeroMonodromyWitnesses");
+    let measured_witnesses = serde_json::Value::Array(
+        array_items(head_packet, "nonzeroMonodromyWitnesses")
+            .into_iter()
+            .take(8)
+            .map(|witness| {
+                serde_json::json!({
+                    "witnessId": json_field(witness, "witnessId"),
+                    "axisFamily": json_field(witness, "axisFamily"),
+                    "defectValue": json_field(witness, "defectValue"),
+                    "operationPair": array_field(witness, "operationPair"),
+                    "pathPair": array_field(witness, "pathPair"),
+                    "affectedAtomRefs": array_field(witness, "affectedAtomRefs"),
+                    "missingEvidence": array_field(witness, "missingEvidence"),
+                    "recommendedReviewFocus": array_field(witness, "recommendedReviewFocus"),
+                    "nonConclusions": array_field(witness, "nonConclusions")
+                })
+            })
+            .collect(),
+    );
+    let review_focus = serde_json::Value::Array(
+        array_items(head_llm, "recommendedHumanReviewFocus")
+            .into_iter()
+            .take(8)
+            .chain(
+                array_items(head_packet, "nonzeroMonodromyWitnesses")
+                    .into_iter()
+                    .flat_map(|witness| array_items(witness, "recommendedReviewFocus"))
+                    .take(8),
+            )
+            .cloned()
+            .collect(),
+    );
+
+    serde_json::json!({
+        "schemaVersion": "archsig-pr-review-report-v0",
+        "reviewId": format!(
+            "archsig-pr-review:{}:{}",
+            json_string(delta, "deltaId", "delta"),
+            json_string(commit, "commitId", "commit")
+        ),
+        "canonicalInputs": {
+            "archMapDelta": {
+                "path": delta_path.display().to_string(),
+                "schemaVersion": schema_string(delta),
+                "deltaId": json_field(delta, "deltaId"),
+                "changedObservationRefs": array_field(delta, "changedObservationRefs")
+            },
+            "archMapCommit": {
+                "path": commit_path.display().to_string(),
+                "schemaVersion": schema_string(commit),
+                "commitId": json_field(commit, "commitId"),
+                "parentRefs": array_field(commit, "parentRefs"),
+                "deltaRefs": array_field(commit, "deltaRefs")
+            },
+            "basePacket": {
+                "path": base_packet_path.display().to_string(),
+                "analysisId": json_field(base_packet, "analysisId"),
+                "archMapRef": json_field(base_packet, "archMapRef")
+            },
+            "headPacket": {
+                "path": head_packet_path.display().to_string(),
+                "analysisId": json_field(head_packet, "analysisId"),
+                "archMapRef": json_field(head_packet, "archMapRef")
+            }
+        },
+        "rawDiffHint": {
+            "provided": diff_hint.is_some(),
+            "path": diff_hint.map(|path| path.display().to_string()),
+            "readingBoundary": "raw diff is an optional scoping hint and is not parsed as semantic, state, effect, authority, or boundary evidence"
+        },
+        "changeLocalDiagnosis": {
+            "nonzeroWitnessDelta": (head_nonzero_count as i64) - (base_nonzero_count as i64),
+            "operationOrderSensitivity": limited_array_field(head_llm, "homotopyOrderSensitivitySummary", 6),
+            "boundaryHolonomy": {
+                "nonzeroMonodromyWitnessCount": head_nonzero_count,
+                "featureBoundaryResidualCount": array_len(head_packet, "featureBoundaryResidualReadings"),
+                "featureExtensionDiagnosisCount": array_len(head_packet, "featureExtensionDiagnosisReadings"),
+                "summary": limited_array_field(head_llm, "featureBoundaryResidualSummary", 6)
+            },
+            "missingFillerEvidence": limited_array_field(head_llm, "diagramFillabilitySummary", 6),
+            "liftingEvidence": limited_array_field(head_llm, "featureExtensionDiagnosisSummary", 6),
+            "coverageGaps": json_field(head_packet.get("flatnessReading").unwrap_or(&serde_json::Value::Null), "blockedByCoverageGaps")
+        },
+        "measuredWitnesses": measured_witnesses,
+        "recommendedReviewFocus": review_focus,
+        "evidenceBoundary": "ArchSig PR review reads ArchMapDelta / ArchMapCommit and ArchSig packets as change-local structural telemetry; it is not a merge safety decision",
+        "nonConclusions": [
+            "ArchSig PR review does not replace FieldSig PR / diff / change-vector evolution analysis",
+            "ArchSig PR review does not parse raw diff as primary semantic evidence",
+            "ArchSig PR review is not a merge approval or automatic repair safety certificate",
+            "ArchSig PR review is not forecast, governance, calibration, or longitudinal quality monitoring"
+        ]
+    })
+}
+
+fn schema_string(document: &serde_json::Value) -> serde_json::Value {
+    document
+        .get("schemaVersion")
+        .or_else(|| document.get("schema"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null)
+}
+
+fn json_string(document: &serde_json::Value, field: &str, fallback: &str) -> String {
+    document
+        .get(field)
+        .and_then(|value| value.as_str())
+        .unwrap_or(fallback)
+        .to_string()
 }
 
 fn build_analysis_summary(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -17,6 +17,10 @@ fn coupon_rounding_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/coupon_rounding")
 }
 
+fn pr_review_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pr_review")
+}
+
 fn sharded_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sharded")
 }
@@ -36,6 +40,7 @@ fn cli_help_exposes_only_llm_atom_archmap_surface() {
         "aat-analysis",
         "analysis-summary",
         "summary",
+        "pr-review",
         "analyze",
         "llm-native-workflow",
         "north-star-workflow",
@@ -455,6 +460,83 @@ fn coupon_tax_rounding_fixture_locks_semantic_monodromy() {
     );
     assert!(golden.to_string().contains("PaymentAmount"));
     assert!(golden.to_string().contains("ReceiptAmount"));
+}
+
+#[test]
+fn cli_pr_review_reads_archmapstore_inputs() {
+    let out_dir = temp_dir("pr-review");
+    let review = pr_review_root();
+    let minimal = fixture_root();
+    let coupon = coupon_rounding_root();
+    let report = out_dir.join("archsig-pr-review.json");
+
+    run_sig0(&[
+        "pr-review",
+        "--delta",
+        review
+            .join("archmap_delta.json")
+            .to_str()
+            .expect("delta path is utf-8"),
+        "--commit",
+        review
+            .join("archmap_commit.json")
+            .to_str()
+            .expect("commit path is utf-8"),
+        "--base-packet",
+        minimal
+            .join("archsig_analysis_packet.json")
+            .to_str()
+            .expect("base packet path is utf-8"),
+        "--head-packet",
+        coupon
+            .join("archsig_analysis_packet.json")
+            .to_str()
+            .expect("head packet path is utf-8"),
+        "--diff-hint",
+        review
+            .join("raw_diff_hint.diff")
+            .to_str()
+            .expect("diff hint path is utf-8"),
+        "--out",
+        report.to_str().expect("report path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "archsig-pr-review-report-v0");
+    assert_eq!(
+        json["canonicalInputs"]["archMapDelta"]["schemaVersion"],
+        "archmap-delta-v0"
+    );
+    assert_eq!(
+        json["canonicalInputs"]["archMapCommit"]["schemaVersion"],
+        "archmap-commit-v0"
+    );
+    assert_eq!(json["rawDiffHint"]["provided"], true);
+    assert!(
+        json["rawDiffHint"]["readingBoundary"]
+            .as_str()
+            .is_some_and(|boundary| boundary.contains("optional scoping hint"))
+    );
+    assert!(
+        json["measuredWitnesses"]
+            .as_array()
+            .is_some_and(|witnesses| witnesses.iter().any(|witness| {
+                witness["axisFamily"] == "semantic"
+                    && witness["defectValue"]
+                        .as_i64()
+                        .is_some_and(|value| value > 0)
+            }))
+    );
+    assert!(
+        json["recommendedReviewFocus"]
+            .as_array()
+            .is_some_and(|focus| !focus.is_empty())
+    );
+    assert!(json["nonConclusions"].as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item.as_str().is_some_and(|text| text.contains("FieldSig")))
+    }));
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/pr_review/archmap_commit.json
+++ b/tools/archsig/tests/fixtures/pr_review/archmap_commit.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "archmap-commit-v0",
+  "commitId": "archmap-commit:coupon-tax-rounding-pr",
+  "parentRefs": [
+    "archmap-snapshot:pricing:base"
+  ],
+  "deltaRefs": [
+    "delta:coupon-tax-rounding-pr"
+  ],
+  "headSnapshotRef": "archmap-snapshot:pricing:head",
+  "commitBoundary": "commit links ArchMapStore artifacts for lightweight ArchSig PR review",
+  "nonConclusions": [
+    "ArchMapCommit is not FieldSig longitudinal evolution analysis",
+    "commit chain does not certify repository safety"
+  ]
+}

--- a/tools/archsig/tests/fixtures/pr_review/archmap_delta.json
+++ b/tools/archsig/tests/fixtures/pr_review/archmap_delta.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "archmap-delta-v0",
+  "deltaId": "delta:coupon-tax-rounding-pr",
+  "baseSnapshotRef": "archmap-snapshot:pricing:base",
+  "headSnapshotRef": "archmap-snapshot:pricing:head",
+  "changedObservationRefs": [
+    "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+    "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+    "semantic:coupon-tax-rounding-paths"
+  ],
+  "changeLocalBoundary": "PR review delta records ArchMap-level pricing observations, not raw source diff semantics",
+  "nonConclusions": [
+    "ArchMapDelta is not a language parser output guarantee",
+    "delta evidence is not merge safety"
+  ]
+}

--- a/tools/archsig/tests/fixtures/pr_review/raw_diff_hint.diff
+++ b/tools/archsig/tests/fixtures/pr_review/raw_diff_hint.diff
@@ -1,0 +1,3 @@
+diff --git a/src/pricing/checkout.ts b/src/pricing/checkout.ts
+@@
++// scoping hint only: coupon, tax, and rounding order changed.


### PR DESCRIPTION
## 概要

Closes #1476

#1492 を base にした stacked PR です。ArchSig 単体で使える lightweight PR review command を追加します。

- `pr-review` command を追加し、`ArchMapDelta` / `ArchMapCommit` / base packet / head packet を canonical input として読む
- raw diff は `--diff-hint` の optional scoping hint として report に記録し、semantic / state / effect / authority / boundary evidence としては読まない
- `archsig-pr-review-report-v0` に measured witnesses、operation-order sensitivity、boundary holonomy、missing filler / lifting evidence、coverage gaps、recommended review focus を出力
- FieldSig PR / diff / change-vector evolution analysis、merge safety、forecast / governance / calibration を置き換えない non-conclusions を report と docs に残す
- CLI test と ArchMapStore PR review fixtures を追加

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`
- `docs/tool/llm_native_e2e_workflow.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は Lean 変更なしのため未実施です。FieldSig 変更なしのため FieldSig test は未実施です。Lean ソース変更なしのため axiom / admit / sorry / unsafe scan は未実施です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `not applicable / tooling workflow` として Issue 側の範囲に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
