### PR TITLE
ArchSig PRレビュー用Skillを追加

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -67,6 +67,7 @@ Cargo project, or Git history at runtime.
 | `archmap-creater` | Create bounded `archmap-observation-map-v0` artifacts from repository evidence. It keeps ArchMap as source-grounded Atom observations, molecule observations, semantic readings, concern hints, and gaps, not law-relative analysis. |
 | `law-policy-creater` | Create project-specific `law-policy-v0` interpretation profiles from repository coding conventions, architecture rules, and user decisions. If docs do not define the law universe, ask the user before selecting laws. |
 | `archsig-reader` | Run an ArchMap with a selected LawPolicy, read the `archsig-analysis-packet-v0`, compare high-priority readings with source evidence, and propose bounded improvements. It does not silently use a generic LawPolicy as project analysis. |
+| `archsig-pr-reviewer` | Derive PR-local `archmap-delta-v0` from the base branch diff, run `pr-review` with base ArchMap and LawPolicy, read the changed code, and explain review focus in human code-review language. It stops if the base ArchMap or LawPolicy is missing. |
 
 Typical use:
 
@@ -76,6 +77,12 @@ Typical use:
 3. Run `analyze`.
 4. Use `archsig-reader` to interpret the packet and compare it with source
    evidence before proposing improvements.
+
+For pull requests, use `archsig-pr-reviewer` after a base ArchMap and LawPolicy
+exist. It derives the PR-local `archmap-delta-v0` from the base branch diff,
+runs `pr-review`, then compares the report with source evidence before writing
+human-facing review comments. It treats `archsig-pr-review-report-v1` as review
+focus rather than merge approval.
 
 ## Release Assets
 

--- a/tools/archsig/skills/archsig-pr-reviewer/SKILL.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/SKILL.md
@@ -44,6 +44,11 @@ available. Load these references as needed:
   `archsig-pr-review-report-v1` without source repository docs.
 - `references/human-review-guide.md`: how to turn the report and source
   inspection into human code-review language.
+- `../archmap-creater/references/mapping-guide.md`,
+  `../archmap-creater/references/schema-cheatsheet.md`, and
+  `../archmap-creater/references/examples.md`: atom observation boundaries to
+  read when the PR introduces new architectural facts or when a delta item
+  cannot be mapped confidently to the base ArchMap.
 
 ## Inputs
 

--- a/tools/archsig/skills/archsig-pr-reviewer/SKILL.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: archsig-pr-reviewer
+description: Run ArchSig lightweight PR review from base ArchMap, base-branch-derived PR-local archmap-delta-v0, and LawPolicy; read archsig-pr-review-report-v1 outputs; and turn the report into bounded source-first review questions. Use when Codex is asked to prepare, run, interpret, or automate ArchSig PR review for a pull request.
+---
+
+# ArchSig PR Reviewer
+
+## Purpose
+
+Run ArchSig's lightweight PR review surface and turn the JSON report into
+bounded review focus.
+
+`pr-review` is change-local. It reads:
+
+- base `archmap-observation-map-v0`
+- PR-local `archmap-delta-v0`
+- required `law-policy-v0`
+
+It does not read raw diff, `archmap-commit-v0`, base/head
+`archsig-analysis-packet-v0`, FieldSig forecasts, CI status, or GitHub approval
+state. No LawPolicy, no ArchSig judgement.
+
+This skill must work with only:
+
+- a built `archsig` executable
+- this skill directory
+- the user's base ArchMap, LawPolicy, PR/base branch diff, and repository
+  evidence
+
+Do not require the ArchSig source repository, test fixtures, Cargo project
+files, or AAT mathematical docs at runtime. The user's PR diff may come from
+local Git history, GitHub PR metadata, or a supplied base/head file list.
+
+## References
+
+This skill is designed for release bundles where only the binary and skills are
+available. Load these references as needed:
+
+- `references/release-runtime.md`: release-only runtime assumptions, binary
+  resolution, required artifacts, and stop conditions.
+- `references/source-diff-to-delta.md`: how to derive `archmap-delta-v0` from
+  the base branch diff.
+- `references/pr-review-report-guide.md`: how to read
+  `archsig-pr-review-report-v1` without source repository docs.
+- `references/human-review-guide.md`: how to turn the report and source
+  inspection into human code-review language.
+
+## Inputs
+
+Collect:
+
+- repository root or selected source paths for source comparison
+- base ArchMap path, usually `.archsig/<scope>/archmap.json`
+- base branch or merge base ref, such as `origin/main...HEAD`
+- PR-local delta output path, usually `.archsig/pr-review/archmap_delta.json`
+- LawPolicy path, usually `.archsig/<scope>/law_policy.json`
+- output path, usually `.archsig/pr-review/archsig-pr-review.json`
+- PR context: changed files, branch, issue/PR summary, reviewer concerns, and
+  any unavailable private evidence
+
+Required stop conditions:
+
+- If the base ArchMap does not exist, stop. Do not invent one inside this PR
+  review skill; use `archmap-creater` first.
+- If the LawPolicy does not exist, stop. Do not run PR review with a generic or
+  implied policy; use `law-policy-creater` first.
+- If the base branch / merge-base diff cannot be determined or supplied, ask for
+  that diff boundary before authoring the delta.
+
+Always create the PR-local `archmap-delta-v0` from the base branch difference
+for the current PR review. An existing delta can be used only as a draft to
+compare against the fresh base-branch-derived delta; do not trust stale delta
+files silently. Do not pass raw diff directly to `archsig pr-review`.
+
+In release-only environments, read `references/release-runtime.md` before
+assuming any repository-local ArchSig paths, fixtures, or docs exist.
+
+Required procedure:
+
+1. Check that the base ArchMap exists and has `schemaVersion:
+   "archmap-observation-map-v0"`. If it does not, stop.
+2. Create the PR-local `archmap-delta-v0` from the base branch difference.
+3. Check that the LawPolicy exists and has `schemaVersion: "law-policy-v0"`. If
+   it does not, stop.
+4. Run `archsig pr-review` with the base ArchMap, freshly created delta, and
+   LawPolicy.
+
+## ArchMap Delta Authoring
+
+For non-trivial PRs, read `references/source-diff-to-delta.md` before drafting
+the delta.
+
+`archmap-delta-v0` records which existing or PR-local ArchMap observations are
+touched by the pull request, as read from the base branch difference. It is not
+a parser output, merge-safety claim, or semantic diff proof.
+
+Build the delta in this order:
+
+1. Determine the base diff boundary from PR metadata or the user, such as
+   `origin/main...HEAD`.
+2. List changed files from the base branch diff.
+3. Inspect the changed files and nearby source/docs/tests needed to understand
+   the architectural facts touched by the PR.
+4. Resolve touched facts to base ArchMap observation refs.
+5. Write only those refs into `changedObservationRefs[]`.
+6. Put the diff-derived files, symbols, docs, or tests in
+   `reviewIntent.sourceFirstTargets[]`.
+
+Minimal shape:
+
+```json
+{
+  "schemaVersion": "archmap-delta-v0",
+  "deltaId": "delta:<short-pr-scope>",
+  "baseSnapshotRef": "archmap-snapshot:<scope>:base",
+  "headSnapshotRef": "archmap-snapshot:<scope>:head",
+  "changedObservationRefs": [
+    "atom:<family>:<id>"
+  ],
+  "changeLocalBoundary": "PR review delta records ArchMap-level observations, not raw source diff semantics",
+  "reviewIntent": {
+    "summary": "Short source-grounded description of the PR-local change.",
+    "expectedReviewAxes": [],
+    "sourceFirstTargets": []
+  },
+  "nonConclusions": [
+    "ArchMapDelta is not a language parser output guarantee",
+    "delta evidence is not merge safety"
+  ]
+}
+```
+
+Delta authoring rules:
+
+- Resolve every `changedObservationRefs[]` entry against the base ArchMap or a
+  clearly marked PR-local ArchMap observation.
+- Derive `changedObservationRefs[]` from the base branch difference, not from
+  remembered context or an old report.
+- Prefer a small review set: touched authority, state, effect, trust, contract,
+  relation, and semantic observations.
+- Put changed file paths or symbols in `reviewIntent.sourceFirstTargets[]`.
+- Put expected LawPolicy axes in `reviewIntent.expectedReviewAxes[]` only when
+  source evidence or repo policy supports them.
+- Preserve unavailable or private evidence as boundary text; do not turn missing
+  evidence into measured absence.
+- If the PR creates new architectural facts that the base ArchMap does not
+  contain, update/refine the ArchMap with `archmap-creater` first or mark the
+  delta as PR-local and report the unresolved base-map gap.
+
+## Run Workflow
+
+Resolve the ArchSig binary before running:
+
+1. use `ARCHSIG_BIN` when the environment variable is set
+2. use `archsig` from `PATH`
+3. look for released binaries near the skill bundle, such as `bin/archsig`,
+   `../bin/archsig`, or `../../bin/archsig`
+4. if working inside a source checkout, optionally use an already-built checkout
+   binary such as `tools/archsig/target/release/archsig` or
+   `tools/archsig/target/debug/archsig`
+
+Before running, verify the three JSON inputs have these `schemaVersion` values:
+
+- base ArchMap: `archmap-observation-map-v0`
+- delta ArchMap: `archmap-delta-v0`
+- LawPolicy: `law-policy-v0`
+
+Run:
+
+```bash
+ARCHSIG_BIN=${ARCHSIG_BIN:-archsig}
+
+"$ARCHSIG_BIN" pr-review \
+  --base-archmap <archmap.json> \
+  --delta-archmap <archmap_delta.json> \
+  --law-policy <law_policy.json> \
+  --out <archsig-pr-review.json>
+```
+
+If no binary exists, stop and ask for the binary path. Do not require Cargo or
+the ArchSig source tree in a released skill-only environment.
+
+## Reading Workflow
+
+For field-level guidance, read `references/pr-review-report-guide.md`.
+
+Read the `archsig-pr-review-report-v1` in this order:
+
+1. `canonicalInputs`
+   - Confirm the paths and schema versions are the intended base ArchMap,
+     PR-local delta, and LawPolicy.
+   - If the wrong LawPolicy was used, stop and rerun with the selected policy.
+
+2. `policyBoundary`
+   - Keep `No LawPolicy, no ArchSig judgement` visible.
+   - Treat selected axes and coverage policy as the review lens, not global
+     architecture truth.
+
+3. `changeLocalDiagnosis`
+   - Use `changedObservationCount`, `matchedBaseObservationCount`,
+     `changedAtomFamilies`, `policyMatchedLawCount`,
+     `policyMatchedAxisRefs`, and `sourceTargetCount` to size the review.
+   - A low matched-base count usually means the ArchMap or delta needs review
+     before architectural judgement.
+
+4. `changedObservations`
+   - Check which changed refs matched base ArchMap observations.
+   - Unmatched refs are evidence gaps or PR-local observations, not failures by
+     themselves.
+
+5. `policyMatchedLaws`
+   - Convert matched laws into review questions.
+   - Do not claim a violation merely because a law matched a changed atom
+     family.
+
+6. `sourceTargets`
+   - Inspect source refs first. Confirm whether the PR actually touches the
+     files, symbols, docs, or tests named by the delta/report.
+
+Before writing a human-facing review, read
+`references/human-review-guide.md`. It explains how to translate the report
+into reviewer-facing code questions without exposing AAT or ArchSig internal
+representation as the answer.
+
+## Source-First Review
+
+Always compare report focus against source evidence before telling the user what
+to change.
+
+Recommended review queue:
+
+- changed observations with `matched: true`
+- unmatched changed refs that look important to the PR goal
+- policy-matched laws and axes
+- source targets from `reviewIntent.sourceFirstTargets[]`
+- coverage or boundary text that blocks a confident reading
+
+For each item, classify it as:
+
+- supported by source comparison
+- partially supported / needs more evidence
+- stale or contradicted by current source
+- unavailable because evidence is private, generated, dynamic, or out of scope
+
+Do not hand the raw ArchSig diagnosis to a human reviewer as the final answer.
+Use ArchSig to choose what to read, then report what the code evidence supports.
+
+## Output Shape
+
+For a normal user report, answer in this order:
+
+1. Run result and artifact path
+2. Input and schema status
+3. Plain-language PR summary
+4. Human review focus
+5. Source comparison findings
+6. Suggested PR comments or next checks
+7. Claim boundary / non-conclusions
+
+Use concise Japanese when working in this repository.
+
+Recommended phrasing:
+
+- "このPRは主に ... を変更しています。"
+- "ArchSig はレビュー対象を絞るために使いました。実際に読むべき箇所は..."
+- "コードを読む限り、この懸念は supported / partially supported / not supported です。"
+- "この LawPolicy match は違反証明ではなく、確認すべきレビュー観点です。"
+
+Avoid:
+
+- "ArchSig approved/rejected the PR"
+- "This proves the PR is safe/unsafe"
+- "No risk exists because no law matched"
+- "The raw diff was analyzed by ArchSig"
+- "FieldSig forecast says..."
+- exposing raw AAT / ArchSig labels when ordinary code-review language is
+  clearer
+
+## Maintainer Validation
+
+When editing this skill inside a source checkout, smoke-test the command with
+the bundled fixtures:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- pr-review \
+  --base-archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --delta-archmap tools/archsig/tests/fixtures/pr_review/archmap_delta.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out .lake/archsig-pr-reviewer-validation.json
+```
+
+Then confirm the output has `schemaVersion: "archsig-pr-review-report-v1"` and
+does not contain a raw-diff input field.
+These are maintenance checks, not runtime requirements for released skill users.

--- a/tools/archsig/skills/archsig-pr-reviewer/agents/openai.yaml
+++ b/tools/archsig/skills/archsig-pr-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ArchSig PR Reviewer"
+  short_description: "Run PR-local ArchSig review"
+  default_prompt: "Use $archsig-pr-reviewer to derive a PR-local ArchMap delta, run ArchSig pr-review, read the changed code, and explain the review focus in human code-review language."

--- a/tools/archsig/skills/archsig-pr-reviewer/references/human-review-guide.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/references/human-review-guide.md
@@ -1,0 +1,138 @@
+# Human Review Guide
+
+Use this guide after `archsig pr-review` emits
+`archsig-pr-review-report-v1`, before writing a human-facing review.
+
+The goal is to turn ArchSig output into concrete review work:
+
+- what changed
+- which project rules or boundaries may matter
+- which files to read
+- what the reviewer should verify
+- what the code evidence actually supports
+
+Do not explain AAT, obstruction circuits, signature axes, flatness, or internal
+ArchSig representation unless the user explicitly asks. Human reviewers need a
+source-grounded review note, not a theory lecture.
+
+## Review Translation Workflow
+
+1. Start from the PR goal.
+   - Read the PR title/body, issue link, changed file list, and delta
+     `reviewIntent.summary`.
+   - Write one plain sentence: "This PR appears to change..."
+
+2. Read ArchSig as a triage signal.
+   - Use `changedObservations[]` to identify the architectural facts that may
+     be touched.
+   - Use `policyMatchedLaws[]` to identify project rules or boundaries that may
+     need review.
+   - Use `sourceTargets[]` and `reviewIntent.sourceFirstTargets[]` to build the
+     file-reading queue.
+   - Treat unmatched observations as map/delta coverage gaps, not accusations.
+
+3. Read code before judging.
+   - Inspect the changed files first.
+   - Then inspect nearby callers, callees, tests, policy docs, or config that
+     decide whether the concern is real.
+   - If source evidence is missing, say what evidence is missing.
+
+4. Write findings in reviewer language.
+   - Prefer "please verify..." or "this change appears to move..." over
+     ArchSig-internal labels.
+   - Tie every concern to file paths, functions, contracts, tests, or policy
+     docs.
+   - Separate confirmed issues from follow-up checks.
+
+5. Preserve the boundary.
+   - ArchSig PR review is not merge approval.
+   - A matched LawPolicy law is a review question, not a violation proof.
+   - A missing match is not proof of safety.
+
+## Output Pattern
+
+Use this structure for a normal human-facing review:
+
+1. Summary
+   - One or two sentences about what the PR changes.
+
+2. Review focus
+   - Two to five bullets describing what a human should inspect.
+   - Each bullet should name files, code paths, tests, docs, or runtime evidence.
+
+3. Source findings
+   - Confirmed by code: items supported by source inspection.
+   - Needs verification: items that require tests, traces, owner input, or docs.
+   - Not supported / stale: report items contradicted by current source.
+
+4. Suggested PR comments
+   - Draft only comments that a reviewer could reasonably leave on the PR.
+   - Keep comments actionable and specific.
+
+5. Boundary
+   - One short sentence such as: "ArchSig was used as review triage; the final
+     judgement depends on the code and tests above."
+
+## Translation Rules
+
+Translate ArchSig fields into reviewer concepts:
+
+| ArchSig field | Human-facing reading |
+| --- | --- |
+| `changedObservationRefs[]` | The architectural facts this PR may touch |
+| `matched: true` in `changedObservations[]` | This delta item matched the base map and can be checked against source |
+| `matched: false` | The map or delta may need updating before this concern is reliable |
+| `changedAtomFamilies[]` | The kind of code boundary touched, such as state, effect, authority, trust, relation, or contract |
+| `policyMatchedLaws[]` | Project rules that should guide review |
+| `policyMatchedAxisRefs[]` | Review dimensions selected by policy; do not show raw axis ids unless useful |
+| `sourceTargets[]` | Start reading here |
+| `evidenceBoundary` | What ArchSig did and did not inspect |
+
+When explaining `changedAtomFamilies[]`, use ordinary code-review wording:
+
+- `authority`: permission, ownership, tenancy, or role checks
+- `state`: persisted state, lifecycle status, cache, or config
+- `effect`: writes, messages, jobs, external calls, or side effects
+- `trust`: external input, provider output, tokens, webhooks, or delegated data
+- `contractSpecification`: input/output shape, validation, invariants, error
+  behavior, idempotency, or retry expectations
+- `relation`: dependency, call path, import, ownership, or data flow
+- `semantic`: domain meaning, workflow meaning, or business-rule interpretation
+
+## Review Comment Style
+
+Good:
+
+- "This PR changes the create-user route and service contract. Please verify
+  that validation still happens before the write path and that the existing
+  error-shape tests cover the new branch."
+- "ArchSig matched this change against the project boundary policy, so I read
+  `src/routes/users.ts` and `src/services/user-service.ts`. The policy concern
+  is supported: the route now owns part of the service contract."
+- "The delta references an observation that does not exist in the base map. The
+  review should update the ArchMap or remove this PR-review item before treating
+  it as an architecture concern."
+
+Avoid:
+
+- "This PR has an obstruction circuit."
+- "The signature axis is nonzero, so the PR is unsafe."
+- "ArchSig proves this violates the architecture."
+- "No policy matched, so this PR is safe."
+- "AAT says this must be refactored."
+
+## Severity Guidance
+
+Use normal code-review severity, not ArchSig-internal intensity:
+
+- Blocking: source evidence shows the PR breaks a selected project rule,
+  security/authority boundary, data integrity rule, or required contract.
+- Needs change: source evidence supports a likely maintainability or boundary
+  problem, but the PR can be fixed locally.
+- Needs verification: the signal is plausible but requires tests, traces, docs,
+  owner confirmation, or a map/policy update.
+- Informational: the report helps reviewers inspect the change but does not
+  justify a requested code change.
+
+When in doubt, downgrade to "needs verification" and say what evidence would
+settle the question.

--- a/tools/archsig/skills/archsig-pr-reviewer/references/pr-review-report-guide.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/references/pr-review-report-guide.md
@@ -1,0 +1,105 @@
+# PR Review Report Guide
+
+Use this reference when reading `archsig-pr-review-report-v1`.
+
+The report is a triage artifact. It helps select code-review focus from the
+base ArchMap, PR-local delta, and LawPolicy. It is not merge approval, a defect
+proof, a complete diff analysis, or a FieldSig forecast.
+
+## Top-Level Fields
+
+| Field | Meaning | Reviewer action |
+| --- | --- | --- |
+| `schemaVersion` | Report schema. Must be `archsig-pr-review-report-v1`. | Stop if different. |
+| `reviewId` | Combined id from base map, delta, and policy. | Use for traceability only. |
+| `canonicalInputs` | Paths, ids, and schema versions of the three inputs. | Confirm the intended artifacts were used. |
+| `policyBoundary` | LawPolicy requirement and selected policy lens. | Keep the selected policy visible. |
+| `changeLocalDiagnosis` | Counts and matched families/axes. | Size the review and detect coverage problems. |
+| `changedObservations` | Delta refs matched against the base ArchMap. | Build the code-reading queue. |
+| `policyMatchedLaws` | LawPolicy laws related to changed atom families. | Turn into review questions. |
+| `sourceTargets` | Source refs attached to changed observations and delta intent. | Start source inspection here. |
+| `evidenceBoundary` | What the command did and did not inspect. | Include the boundary in the final note. |
+
+## Reading Order
+
+1. Confirm `schemaVersion`.
+2. Check `canonicalInputs`:
+   - base ArchMap is the intended project/scope
+   - delta is the freshly created PR-local delta
+   - LawPolicy is the selected project policy
+3. Read `changeLocalDiagnosis`:
+   - `changedObservationCount`: size of the delta
+   - `matchedBaseObservationCount`: how many refs resolved to base map entries
+   - `changedAtomFamilies`: kinds of boundaries touched
+   - `policyMatchedLawCount`: how many selected laws are relevant
+   - `policyMatchedAxisRefs`: review dimensions selected by policy
+   - `sourceTargetCount`: how much source evidence was named
+4. Read `changedObservations` and separate matched vs unmatched refs.
+5. Read `policyMatchedLaws` and rewrite each as a plain review question.
+6. Read `sourceTargets` and inspect those files before making claims.
+
+## Count Interpretation
+
+Use counts conservatively:
+
+- high `changedObservationCount`: review scope may be broad; split by file or
+  family
+- low `matchedBaseObservationCount`: map/delta coverage issue; do not overclaim
+- zero `policyMatchedLawCount`: no selected law matched these atom families; not
+  proof of safety
+- nonempty `policyMatchedAxisRefs`: selected review dimensions to check in code
+- zero `sourceTargetCount`: delta/report is too weak for source-first review
+
+## Human Questions From Report Data
+
+Convert report fields into ordinary review questions:
+
+- `authority`: Does the PR preserve permission, ownership, tenancy, or role
+  checks?
+- `state`: Does the PR preserve state lifecycle, migrations, persistence, or
+  cache invariants?
+- `effect`: Does the PR preserve write ordering, side effects, retries, jobs, or
+  external calls?
+- `trust`: Does the PR validate external input, provider output, tokens,
+  webhooks, or delegated authority?
+- `contractSpecification`: Does the PR preserve input/output contracts,
+  validation, errors, idempotency, or retry semantics?
+- `relation`: Does the PR change dependency direction, ownership, call paths,
+  or data flow?
+- `semantic`: Does the PR change business meaning or workflow interpretation?
+
+If the report names raw ids, translate them into file/function/test language
+after reading source.
+
+## Suggested Final Summary
+
+Use this pattern:
+
+```text
+ArchSig was used to choose review focus, not to approve the PR.
+
+This PR appears to change <plain-language summary>.
+
+Review focus:
+- <file/function>: verify <specific condition>.
+- <test/doc/runtime evidence>: check <specific evidence>.
+
+Source findings:
+- Supported: <what code confirms>.
+- Needs verification: <what evidence is still missing>.
+- Not supported/stale: <what report item did not match current source>.
+
+Boundary: the judgement depends on the code and tests above; the PR-review
+report is a triage artifact over the selected base ArchMap and LawPolicy.
+```
+
+## Common Mistakes
+
+Avoid:
+
+- using `policyMatchedLaws[]` as violation findings
+- hiding unmatched refs instead of reporting map/delta coverage gaps
+- showing raw axis ids to human reviewers when a code-review question is clearer
+- saying ArchSig analyzed raw diff
+- treating CI success or failure as part of the ArchSig report
+- claiming no risk when the report has no matches

--- a/tools/archsig/skills/archsig-pr-reviewer/references/release-runtime.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/references/release-runtime.md
@@ -1,0 +1,92 @@
+# Release Runtime
+
+Use this reference when the ArchSig source repository is not available.
+
+The released skill environment may contain only:
+
+- an `archsig` binary
+- the `skills/` directory
+- the user's repository, PR context, and ArchSig artifacts
+
+Do not assume these exist:
+
+- `tools/archsig/`
+- Cargo project files
+- test fixtures
+- `docs/tool`
+- AAT mathematical documents
+- prior Git history beyond what the user repository exposes
+
+## Binary Resolution
+
+Try binary locations in this order:
+
+1. `ARCHSIG_BIN` environment variable
+2. `archsig` on `PATH`
+3. `bin/archsig` beside the release root
+4. `../bin/archsig` or `../../bin/archsig` relative to the skill directory
+5. a user-supplied path
+
+If none exists, stop and ask for the binary path.
+
+Use this command shape:
+
+```bash
+"$ARCHSIG_BIN" pr-review \
+  --base-archmap <archmap.json> \
+  --delta-archmap <archmap_delta.json> \
+  --law-policy <law_policy.json> \
+  --out <archsig-pr-review.json>
+```
+
+Do not ask the user to install Rust or build from source in a release-only
+workflow unless they explicitly want to develop ArchSig itself.
+
+## Required Artifacts
+
+For `pr-review`, the release-only required artifacts are:
+
+| Artifact | Required schemaVersion | How to obtain |
+| --- | --- | --- |
+| base ArchMap | `archmap-observation-map-v0` | Existing project ArchMap. If absent, stop and use `archmap-creater`. |
+| PR-local delta | `archmap-delta-v0` | Create from the current PR's base branch diff. |
+| LawPolicy | `law-policy-v0` | Existing selected project policy. If absent, stop and use `law-policy-creater`. |
+| PR review report | `archsig-pr-review-report-v1` | Output from `archsig pr-review`. |
+
+No bundled default LawPolicy is valid for PR review. A generic LawPolicy would
+change the review meaning and should not be substituted silently.
+
+## Local Checks Without Repository Fixtures
+
+Before running `archsig pr-review`, inspect the input JSON directly:
+
+- `schemaVersion`
+- ids such as `mapId`, `deltaId`, `lawPolicyId`
+- `changedObservationRefs[]`
+- `reviewIntent.sourceFirstTargets[]`
+- `nonConclusions[]`
+
+After running, inspect the report:
+
+- `schemaVersion` is `archsig-pr-review-report-v1`
+- `canonicalInputs` point to the intended files
+- `policyBoundary.lawPolicyRequired` is true
+- there is no raw diff input field
+
+If JSON parsing tools are unavailable, read the files as text and check these
+fields manually. The ArchSig binary remains the authoritative validator for the
+PR-review command surface.
+
+## Failure Handling
+
+Stop instead of guessing when:
+
+- the base ArchMap path is unknown or missing
+- the LawPolicy path is unknown or missing
+- the base branch diff cannot be determined or supplied
+- the ArchSig binary cannot be found
+- a JSON file has the wrong `schemaVersion`
+- changed observations cannot be mapped to the base ArchMap and the user asked
+  for a confident architecture review
+
+Report the missing prerequisite and name the next skill or user input needed.

--- a/tools/archsig/skills/archsig-pr-reviewer/references/source-diff-to-delta.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/references/source-diff-to-delta.md
@@ -1,0 +1,113 @@
+# Source Diff To Delta
+
+Use this reference when creating the PR-local `archmap-delta-v0` from the base
+branch difference.
+
+The delta is a compact review artifact. It says which ArchMap observations the
+PR appears to touch. It is not a raw diff, parser result, approval decision, or
+complete semantic analysis.
+
+## Inputs
+
+Collect:
+
+- base branch or merge-base range, such as `origin/main...HEAD`
+- changed file list and, when available, changed symbols or hunks
+- base ArchMap JSON
+- PR title/body or issue summary
+- user-stated review concerns
+
+If the base branch range is unknown, ask for it before authoring the delta.
+
+## Diff Reading Steps
+
+1. List changed files from the base branch diff.
+2. Group them by likely review surface:
+   - routes/controllers/API entry points
+   - services/use cases/domain logic
+   - persistence/models/migrations
+   - background jobs/events/messages
+   - external providers/webhooks/LLM integrations
+   - auth/permissions/tenancy/trust boundaries
+   - tests/docs/config
+3. Read the changed files. For each surface, identify the architectural fact
+   touched by the PR.
+4. Search the base ArchMap for observations whose source refs, subject refs,
+   object refs, predicates, molecule refs, or semantic refs match the touched
+   fact.
+5. Add only relevant observation refs to `changedObservationRefs[]`.
+6. Put changed files, symbols, tests, docs, and runtime evidence targets in
+   `reviewIntent.sourceFirstTargets[]`.
+7. Add expected policy axes only when the base ArchMap, LawPolicy, or repo docs
+   give a reason.
+
+## Mapping Heuristics
+
+Use these hints to map source changes to ArchMap observations:
+
+| Source change | Likely ArchMap family |
+| --- | --- |
+| New or changed permission check | `authority` |
+| Tenant / owner / visibility condition | `authority` or `trust` |
+| Input validation, DTO, error shape, return shape | `contractSpecification` |
+| Database write, migration, cache mutation | `state` or `effect` |
+| Queue, email, external API call, provider write | `effect` or `trust` |
+| Webhook, token, provider output, LLM output | `trust` |
+| Import/call path/dependency direction | `relation` |
+| Business-rule meaning or workflow interpretation | `semantic` |
+| Cross-file responsibility or role composition | molecule observation |
+
+When a change touches a responsibility, look for the primitive observations
+behind it first. Molecules and semantic observations can be included, but they
+should not replace primitive changed atom refs when those refs exist.
+
+## Delta Quality Rules
+
+Good delta:
+
+- small enough for a reviewer to inspect
+- tied to source files changed by the PR
+- uses observation refs present in the base ArchMap
+- records source targets for human review
+- names missing evidence or map gaps explicitly
+
+Bad delta:
+
+- lists every observation in a subsystem
+- uses stale refs copied from an old report
+- treats a changed file path as proof that every nearby observation changed
+- hides new architectural facts by forcing them into unrelated base refs
+- turns missing base-map coverage into a claim that nothing changed
+
+## Handling New Facts
+
+If the PR introduces a fact not present in the base ArchMap:
+
+1. Record the source target in `reviewIntent.sourceFirstTargets[]`.
+2. Add a short boundary note in `changeLocalBoundary`.
+3. Prefer updating the ArchMap with `archmap-creater` before confident review.
+4. If the user wants a quick review, mark the item as "needs map update" in the
+   human-facing report instead of pretending it matched the base map.
+
+## Minimal Delta Template
+
+```json
+{
+  "schemaVersion": "archmap-delta-v0",
+  "deltaId": "delta:<pr-or-branch-scope>",
+  "baseSnapshotRef": "archmap-snapshot:<scope>:base",
+  "headSnapshotRef": "archmap-snapshot:<scope>:head",
+  "changedObservationRefs": [],
+  "changeLocalBoundary": "Derived from base branch diff; records ArchMap-level touched observations, not raw diff semantics or merge safety.",
+  "reviewIntent": {
+    "summary": "This PR appears to change <plain-language change>.",
+    "expectedReviewAxes": [],
+    "sourceFirstTargets": []
+  },
+  "nonConclusions": [
+    "ArchMapDelta is not a language parser output guarantee",
+    "delta evidence is not merge safety",
+    "unchanged observation refs are not proof of unchanged runtime behavior"
+  ]
+}
+```

--- a/tools/archsig/skills/archsig-pr-reviewer/references/source-diff-to-delta.md
+++ b/tools/archsig/skills/archsig-pr-reviewer/references/source-diff-to-delta.md
@@ -19,6 +19,23 @@ Collect:
 
 If the base branch range is unknown, ask for it before authoring the delta.
 
+## Atom Observation References
+
+This PR-review skill does not duplicate the full atom observation guide. The
+release bundle includes `archmap-creater`; use its references when the diff
+introduces new architectural facts, when a changed fact is hard to classify, or
+when you need to update the base ArchMap before confident PR review:
+
+- `../archmap-creater/references/mapping-guide.md`: atom family selection and
+  atom-vs-molecule-vs-semantic boundaries.
+- `../archmap-creater/references/schema-cheatsheet.md`: required fields and
+  schema-level boundaries for `atomObservations[]`.
+- `../archmap-creater/references/examples.md`: code-to-atom examples and
+  common bad atom examples.
+
+Use these before inventing a new observation ref or forcing a new fact into an
+unrelated base-map observation.
+
 ## Diff Reading Steps
 
 1. List changed files from the base branch diff.


### PR DESCRIPTION
## 概要

Release バンドルに同梱する `archsig-pr-reviewer` Skill を追加します。

対象 Issue: なし（会話起点の release skill bundle 整備のため、Closes #N は未記載）

主な設計判断:

- base ArchMap が存在しない場合は終了し、Skill 内で作りません。
- PR-local `archmap-delta-v0` は base branch diff から毎回作成します。
- LawPolicy が存在しない場合は終了し、generic policy では代替しません。
- ArchSig の内部表現をそのまま人間に渡さず、コードを読んだ上で human code-review language に翻訳します。
- Release バンドルが binary + skills のみでも LLM が理解できるよう、runtime / delta / report / human review references を同梱します。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/skills/archsig-pr-reviewer/SKILL.md`
- `tools/archsig/skills/archsig-pr-reviewer/agents/openai.yaml`
- `tools/archsig/skills/archsig-pr-reviewer/references/human-review-guide.md`
- `tools/archsig/skills/archsig-pr-reviewer/references/pr-review-report-guide.md`
- `tools/archsig/skills/archsig-pr-reviewer/references/release-runtime.md`
- `tools/archsig/skills/archsig-pr-reviewer/references/source-diff-to-delta.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_pr_review_reads_archmapstore_inputs`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（PR 作成時の shell 誤解釈で実行、成功）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加確認:

- [x] YAML parse + `references/...` 実在チェック

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
