### PR TITLE
ArchSigのスペクトルとホモトピー計測PRDを追加

### DIFF
--- a/docs/note/curvature_transfer_spectrum_theorem.md
+++ b/docs/note/curvature_transfer_spectrum_theorem.md
@@ -1,0 +1,617 @@
+## 提案する新定理：AAT 曲率スペクトル定理
+
+**AAT Curvature–Transfer Spectrum Theorem / ACTS**
+
+狙いは、普通の依存グラフのスペクトルではなく、**AAT の Atom 軸ごとの obstruction が、コードベース全体でどこに局在し、どの軸へ転送され、どこで循環・増幅するか**を測ることです。
+
+AAT では Atom が `component / relation / capability / state / effect / authority / contract / semantic / runtime_interaction` などを含む型付き事実として定義されており、各 Atom は `axis` を持ちます。つまり、最初から「静的依存だけではない多軸の構造」を扱える設計になっています。 また、AAT では static flatness から runtime flatness や semantic flatness は一般には従わないため、静的解析だけでは見えない品質劣化を測る余地があります。
+
+---
+
+# 1. 直感
+
+普通の静的解析はだいたい次を見ます。
+
+```text
+module A imports B
+class X depends on Y
+package cycle exists
+layer violation exists
+```
+
+これは AAT 的には主に `relation / dependency` 軸だけを見ています。
+
+一方、私たちが作りたいツールは、次のような「コード全体に潜むアーキテクチャ品質」を見たい。
+
+```text
+依存グラフは acyclic だが、意味的には order-sensitive
+interface に依存しているが、semantic contract が壊れている
+retry / timeout はあるが、effect が冪等でない
+state 更新と event emission の順序が一貫しない
+authority は通っているが、trust boundary が曖昧
+feature 同士は静的には独立だが、計算順序で結果が変わる
+```
+
+そこで、依存グラフの隣接行列だけでなく、AAT の law / obstruction / signature / curvature を使って、**多軸の曲率付きスペクトル**を作ります。
+
+---
+
+# 2. 定義：曲率付き Law Complex
+
+コードベース全体を Atomize して、architecture object を作る。
+
+```text
+F = Atomize_V(Repo)
+F => A
+```
+
+選ぶものは次です。
+
+```text
+U : law universe
+X : selected axes
+W : measured witness family
+```
+
+ここで `X` は例えば次。
+
+```text
+X = {
+  dependency,
+  projection,
+  substitution,
+  state,
+  effect,
+  authority,
+  runtime,
+  semantic,
+  monodromy
+}
+```
+
+`W` は、コード全体から構成される witness / diagram / square の集合です。
+
+```text
+σ ∈ W
+```
+
+各 witness `σ` と axis `x` について、局所曲率を置きます。
+
+```text
+κ_{σ,x}(A)
+  =
+distance(Obs_x(lhs(σ)), Obs_x(rhs(σ)))
+```
+
+これは既存 AAT の local curvature の考え方そのものです。AAT では diagram `D` の local curvature を `distance(Obs(lhs(D)), Obs(rhs(D)))` と読め、global curvature は重み付き和として扱えます。
+
+---
+
+# 3. 曲率サポート・ラプラシアン
+
+各 witness がどの component / operation / state / effect / contract / semantic Atom に関わるかを incidence vector として表します。
+
+```text
+b_{σ,x} ∈ R^{Support(A) × X}
+```
+
+そして、次の正半定値行列を作る。
+
+```text
+L^κ_{U,X}(A)
+  =
+Σ_{σ ∈ W}
+Σ_{x ∈ X}
+  w_{σ,x} κ_{σ,x}(A) b_{σ,x} b_{σ,x}ᵀ
+```
+
+これを **AAT curvature support Laplacian** と呼びます。
+
+このスペクトルを、
+
+```text
+Spec^κ_{U,X}(A) = spectrum(L^κ_{U,X}(A))
+```
+
+と定義します。
+
+直感的には、これは「どこで obstruction が発生しているか」だけでなく、**その obstruction がどれだけ広い support にまたがっているか、どの軸を巻き込んでいるか、どの塊として現れているか**を測ります。
+
+---
+
+# 4. 新定理：AAT 曲率スペクトル定理
+
+## 定理 1：Curvature Spectrum Zero-Reflection
+
+有限 architecture object `A`、law universe `U`、selected axes `X`、measured witness family `W` を取る。
+
+次を仮定する。
+
+```text
+1. finite coverage:
+   W は selected law universe U の required witness を有限個として覆う
+
+2. positive weight:
+   required witness には w_{σ,x} > 0 が与えられる
+
+3. zero-reflecting distance:
+   κ_{σ,x}(A) = 0 iff selected local law が σ,x 上で満たされる
+
+4. nonempty support:
+   required witness の incidence vector b_{σ,x} は 0 ではない
+
+5. axis exactness:
+   selected signature axis が対応する law failure を exact に読む
+```
+
+このとき、
+
+```text
+Spec^κ_{U,X}(A) = {0}
+```
+
+は次と同値である。
+
+```text
+forall required σ,x,
+  κ_{σ,x}(A) = 0
+```
+
+さらに `W` が witness-complete で、`X` が required signature axes を exact に読むなら、
+
+```text
+Spec^κ_{U,X}(A) = {0}
+  iff RequiredSignatureAxesZero_X(A)
+  iff Flat_U(A)
+  iff Lawful_U(A)
+```
+
+つまり、**曲率スペクトルが完全に zero であることは、選ばれた law universe に対する architecture quality が flat であることと一致する**。
+
+これは既存の AAT zero curvature / signature flatness と整合します。AAT では、law failure を exact に読む curvature valuation があるとき、`Lawful_U(A)`, `NoRequiredObstruction`, `RequiredSignatureAxesZero`, `ZeroCurvature_U(A)` が一致します。 また、解析表現から構造へ戻るには `ZeroReflecting / ObstructionReflecting` の仮定、coverage、witness completeness、axis exactness が必要であることも既存の整理と一致します。
+
+---
+
+# 5. 証明スケッチ
+
+`L^κ` は次の和です。
+
+```text
+L^κ
+  =
+Σ w_{σ,x} κ_{σ,x} b_{σ,x} b_{σ,x}ᵀ
+```
+
+各項は正半定値です。
+
+したがって、
+
+```text
+L^κ = 0
+```
+
+なら、trace も 0 です。
+
+```text
+trace(L^κ)
+  =
+Σ w_{σ,x} κ_{σ,x} ||b_{σ,x}||²
+```
+
+すべての項は非負で、required witness では
+
+```text
+w_{σ,x} > 0
+||b_{σ,x}||² > 0
+```
+
+なので、
+
+```text
+trace(L^κ) = 0
+```
+
+から
+
+```text
+κ_{σ,x} = 0
+```
+
+が全 required witness について従います。
+
+逆に、全 `κ_{σ,x}=0` なら明らかに `L^κ=0` で、したがってスペクトルも全て 0 です。
+
+最後に、`κ` が law failure を exact に読み、witness family が complete なら、AAT の zero curvature theorem / signature flatness によって `Flat_U(A)` と一致します。
+
+---
+
+# 6. さらに重要：Transfer Spectrum
+
+上の `L^κ` は「どこに obstruction があるか」を測ります。
+
+ただし、アーキテクチャ品質計測ツールとして本当に欲しいのは、もう一段進んで、**obstruction がどの軸からどの軸へ転送されるか**です。
+
+そこで、状態空間を次にします。
+
+```text
+State = Support(A) × Axis
+```
+
+例えば、
+
+```text
+(OrderService, semantic)
+(PaymentService, effect)
+(UserRepository, authority)
+(CouponService, runtime)
+```
+
+この上に、非負行列 `T^κ` を作る。
+
+```text
+T^κ_{(s,x),(t,y)}(A)
+  =
+Σ measured transfer σ : (s,x) -> (t,y)
+  w_σ κ_σ(A)
+```
+
+これを **AAT obstruction transfer operator** と呼ぶ。
+
+---
+
+# 7. 定理 2：Recurrent Obstruction Spectrum
+
+`T^κ` を有限非負行列とする。
+
+このとき、
+
+```text
+ρ(T^κ) > 0
+```
+
+であることと、次は同値である。
+
+```text
+Support(A) × Axis 上に、
+正の defect を持つ closed walk が存在する
+```
+
+つまり、
+
+```text
+(s0,x0) -> (s1,x1) -> ... -> (sn,xn) = (s0,x0)
+```
+
+で、経路上の transfer defect が正である。
+
+これを **recurrent architecture obstruction** と呼ぶ。
+
+---
+
+# 8. これが普通の静的解析と違うところ
+
+通常の dependency spectrum は、せいぜいこれを見ます。
+
+```text
+component -> component
+```
+
+しかし `T^κ` はこれを見ます。
+
+```text
+(component, dependency)
+  -> (operation, semantic)
+  -> (effect, runtime)
+  -> (resource, authority)
+  -> (component, dependency)
+```
+
+つまり、静的依存グラフとしては循環していなくても、AAT transfer spectrum では循環することがある。
+
+例えば、
+
+```text
+OrderService --static--> PaymentService
+PaymentService --semantic--> PaymentAccepted
+PaymentAccepted --effect--> CaptureMoney
+CaptureMoney --runtime--> RetryPolicy
+RetryPolicy --semantic--> OrderConfirmed
+```
+
+のような循環です。
+
+これは `import cycle` ではないので普通の静的解析では出にくい。しかし、semantic / effect / runtime / authority を Atom として保持している AAT なら検出対象にできます。AAT では semantic Atom が static flatness と semantic flatness を分け、runtime interaction Atom も relation Atom や effect Atom に潰さず独立に保持されます。
+
+---
+
+# 9. 定理 3：Spectral Review Focus Theorem
+
+`L^κ` の最大固有値に対応する固有ベクトルを `v_max` とする。
+
+```text
+L^κ v_max = λ_max v_max
+```
+
+`λ_max > 0` なら、`v_max` の大きな成分は、次のいずれかを含む。
+
+```text
+1. nonzero local curvature witness の support
+2. 複数 witness を接続する mixed-axis support
+3. obstruction transfer の強連結成分
+4. coverage gap を含む boundary support
+```
+
+したがって、ツールは単に
+
+```text
+violation count = 17
+```
+
+と出すのではなく、
+
+```text
+この codebase の最大 obstruction mode は:
+  CouponService / PricingPolicy / TaxCalculation / PaymentAmount
+  axes:
+    semantic, state, effect
+  witnesses:
+    discount-tax-rounding non-commutation
+    PaymentAmount != FinalAmount
+    ReceiptAmount != FinalAmount
+```
+
+のように出せます。
+
+これは PR レビュー向けではなく、**コード全体の architecture health scan** に向いています。
+
+---
+
+# 10. AMI との関係
+
+既存の AAT には Architecture Monodromy Index, AMI があります。
+
+```text
+AMI_X(A)
+  =
+Σ_{σ in measured squares}
+Σ_{x in selected axes}
+  w_{σ,x} * μ_x(σ)
+```
+
+AMI は単一の quality score ではなく、top contributor を選ぶための aggregate reading とされています。さらに、`μ_x(σ)>0` なら selected continuation が異なり、selected homotopy refutation や non-fillability witness につながる、という bounded soundness が整理されています。
+
+今回の提案は、AMI をこう拡張します。
+
+```text
+AMI:
+  scalar aggregate
+
+ACTS:
+  spectral aggregate
+```
+
+つまり、
+
+```text
+AMI_X(A)
+  = total amount of measured monodromy
+
+Spec^κ_{U,X}(A)
+  = shape, locality, coupling, recurrence of measured monodromy
+```
+
+です。
+
+AMI が「総量」を出すなら、ACTS は「モード」を出す。
+
+---
+
+# 11. ツール設計
+
+
+出力は単一スコアではなく、次の report にする。
+
+```text
+ArchitectureSpectrumReport
+  = selected law universe
+  + selected axes
+  + coverage boundary
+  + Spec(L^κ)
+  + ρ(T^κ)
+  + top eigenmodes
+  + top witness clusters
+  + missing evidence
+  + non-conclusions
+```
+
+AAT では aggregate は signature 全体の代替ではなく、異なる obstruction は異なる axis に残る、と整理されています。 したがって、ツールも「総合点 82 点」ではなく、次のような多軸診断にすべきです。
+
+```text
+static spectrum:
+  低い。依存循環は少ない。
+
+semantic spectrum:
+  高い。価格計算・税・丸め・支払い金額に集中。
+
+runtime/effect transfer spectrum:
+  中程度。retry と external effect の周辺に recurrent mode。
+
+authority spectrum:
+  局所的に高い。管理者操作と hidden resource access に集中。
+
+coverage:
+  semantic contract evidence が 62%。
+  runtime observation evidence が 41%。
+  したがって zero conclusion は出さない。
+```
+
+---
+
+# 12. 実装の最小版
+
+最初から完全な sheaf / Hodge Laplacian にしなくても、MVP は作れます。
+
+## Step 1: Atom extraction
+
+```text
+component
+relation/import/call/read/write
+state
+effect
+contract
+semantic
+runtime_interaction
+authority/trust
+```
+
+AAT では実コード断片から、宣言、参照、呼び出し、状態更新、外部作用、型注釈、意味注釈を Atom family として抽出する想定がすでにあります。
+
+## Step 2: witness generation
+
+まずはこの witness だけでよい。
+
+```text
+dependency cycle
+layer violation
+state-before-effect ordering
+effect idempotency missing
+retry-without-idempotency
+contract substitution mismatch
+semantic calculation non-commutation
+authority-required-but-missing
+runtime call without timeout / breaker
+event emitted but handler missing
+```
+
+## Step 3: local curvature
+
+```text
+κ = 0 or 1
+```
+
+から始める。
+
+後で距離を richer にする。
+
+```text
+boolean mismatch
+count
+edit distance
+semantic distance
+policy distance
+contract refinement distance
+state transition distance
+```
+
+## Step 4: curvature support Laplacian
+
+```text
+L^κ
+  =
+Σ wκ bbᵀ
+```
+
+## Step 5: transfer operator
+
+```text
+T^κ_{(support,axis),(support,axis)}
+```
+
+## Step 6: report
+
+```text
+largest eigenmode
+top contributing witness
+top affected axis
+coverage gap
+recommended review focus
+```
+
+---
+
+# 13. この定理で測れる「普通は見えない品質」
+
+特に強いのは次です。
+
+## 1. 静的には acyclic だが semantic に非可換
+
+```text
+round(tax(discount(subtotal)))
+round(discount(tax(subtotal)))
+```
+
+この差は dependency graph では見えません。しかし selected semantic axis では continuation が戻らないので、curvature / monodromy として測れます。AAT の coupon / tax / rounding 例でも、final dependency graph が同じでも semantic continuation が同じ位置へ戻らないケースが説明されています。
+
+## 2. interface 依存だが contract が弱い
+
+DIP 的には正しく見えるが、
+
+```text
+contract(Base) not refined by contract(Impl)
+```
+
+なら substitution obstruction です。
+
+## 3. retry はあるが effect が冪等でない
+
+静的には resilience 実装があるように見える。しかし runtime/effect 軸では obstruction です。
+
+## 4. state 更新と event emission の順序が破れる
+
+```text
+emit UserCreated
+before persist User
+```
+
+これは call graph ではなく state/effect law の問題です。
+
+## 5. 権限は通っているが trust boundary が曖昧
+
+`can call` と `authorized to effect` は別 Atom なので、authority spectrum に出せます。
+
+---
+
+# 14. 重要な注意：スペクトルは「真理」ではなく reading
+
+この定理は、スペクトル値だけで architecture object の全構造を復元できるとは主張しません。
+
+AAT では解析表現は selected axes の読みであり、同じ解析値を持つ二つの architecture object が同一とは限らない、という non-reduction が明示されています。 また、projection / matrix / spectral / aggregate reading を安全に使うには、ZeroReflecting と ObstructionReflecting の仮定を明示する必要があります。
+
+したがって、ツールは必ずこう出すべきです。
+
+```text
+This report claims:
+  measured selected-axis obstruction modes
+
+This report does not claim:
+  architecture is globally correct
+  unmeasured axes are flat
+  missing evidence means absence of defect
+```
+
+これは AAT 的にかなり重要です。
+
+---
+
+# 15. まとめ
+
+提案する新定理はこれです。
+
+```text
+AAT Curvature–Transfer Spectrum Theorem
+
+コードベース全体から Atom family を抽出し、
+selected law universe と selected axes に対する witness family を作り、
+各 witness の local curvature を重み付き incidence operator に載せる。
+
+その curvature support Laplacian の zero spectrum は、
+coverage / exactness / zero-reflection の下で、
+selected law universe に対する flatness と同値である。
+
+さらに obstruction transfer operator の spectral radius が正なら、
+support × axis 上に recurrent obstruction が存在する。
+これは dependency graph だけでは見えない、
+semantic / runtime / effect / authority をまたぐ architecture quality degradation を示す。
+```
+
+この定理を使うと、AAT ベースのツールは「PR 差分の指摘」ではなく、**コード全体の architecture quality spectrum を測る検査器**として設計できます。単一スコアではなく、`top eigenmodes + witness + axis + coverage gap` を出すのが一番 AAT らしいです。

--- a/docs/note/homotopy_holonomy_stokes.md
+++ b/docs/note/homotopy_holonomy_stokes.md
@@ -1,0 +1,1025 @@
+# 提案：AAT Homotopy–Holonomy Stokes Theorem
+
+日本語名なら、
+
+```text
+AAT ホモトピー・ホロノミー・ストークス定理
+```
+
+です。
+
+前回のスペクトラム案が、
+
+```text
+obstruction の分布・局在・固有モードを見る
+```
+
+ものだとすると、今回の案は、
+
+```text
+コード上の複数の経路が、同じ場所へ戻るはずなのに戻らない
+コード上の loop が、law によって埋められるはずなのに埋まらない
+```
+
+ことを測ります。
+
+AAT 既存部にも、path は architecture operation の列、homotopy は operation 列の変形、monodromy は continuation trace の差として定義されています。特に、homotopy generator が selected observation を保存するなら homotopic path は同じ observation を持ち、signature trajectory が異なれば selected homotopy を反証できる、という形がすでにあります。 また、selected continuation `Cont_x(p)` と monodromy defect `mu_x(f,g;A)` も既存の AAT 用語として定義されており、`mu_x > 0` なら selected observation difference として読める、という設計になっています。
+
+---
+
+# 1. 直感：ソースコードを幾何的に見る
+
+普通の静的解析は、ソースコードをだいたいこう見ます。
+
+```text
+file
+module
+class
+function
+dependency edge
+call edge
+```
+
+つまり 1 次元の graph として見る。
+
+でも AAT 的には、ソースコードはもっと高次元に見られる。
+
+```text
+0-cell : component / function / state / event / contract / resource
+1-cell : call / read / write / emit / authorize / transform / project
+2-cell : law / commutative square / substitution / projection / roundtrip / retry law
+3-cell : 複数の law の整合性、feature 境界、migration cube
+```
+
+つまり、コードベース全体を次のような **cell complex** として見る。
+
+```text
+K_A = CodeGeometry(A)
+```
+
+このとき、アーキテクチャ品質の悪さは単なる「辺の向き」ではなく、次の二種類で現れます。
+
+```text
+1. 曲率:
+   loop は埋められるが、中の law が曲がっている
+
+2. 穴:
+   loop は存在するが、それを埋める law / abstraction / contract / filler がない
+```
+
+この二つを分けられるのが、ホモトピー路線の強みです。
+
+---
+
+# 2. 新定理の中心アイデア
+
+コード上には「同じ意味に到達するはずの複数経路」がたくさんあります。
+
+例えば、
+
+```text
+subtotal -> discount -> tax -> round
+subtotal -> tax -> discount -> round
+```
+
+この二つは、最終的な型や依存先は同じに見えるかもしれない。しかし semantic continuation が違えば、AAT 的には戻っていない。実際、coupon / tax / rounding の例では、static graph では独立に見えても selected semantic axis では continuation が同じ位置へ戻らないケースが説明されています。
+
+他にも、
+
+```text
+CreateUser -> persist User -> emit UserCreated
+CreateUser -> emit UserCreated -> persist User
+```
+
+```text
+Command -> Event -> Projection -> QueryResult
+Command -> DirectRead -> QueryResult
+```
+
+```text
+Authorize -> CallExternalAPI -> Persist
+Persist -> Authorize -> CallExternalAPI
+```
+
+```text
+Encode -> Store -> Load -> Decode
+id
+```
+
+```text
+Retry -> Effect
+Effect
+```
+
+などがある。
+
+これらは全部、
+
+```text
+二つの path p, q : a -> b
+```
+
+として見られます。
+
+もし law が正しければ、
+
+```text
+p ~ q
+```
+
+つまり homotopic に読める。
+
+しかし、観測される continuation が違うなら、
+
+```text
+Cont_x(p) != Cont_x(q)
+```
+
+であり、これは selected homotopy の反証になる。
+
+---
+
+# 3. 定義：Architecture Homotopy Complex
+
+Architecture object `A` から、selected law universe `U` と selected axes `X` に対して、2 次元 cell complex を作る。
+
+```text
+K_U^X(A)
+```
+
+これを **Architecture Homotopy Complex** と呼ぶ。
+
+## 0-cells
+
+```text
+component
+operation
+state
+effect
+event
+contract
+semantic object
+resource
+authority scope
+```
+
+## 1-cells
+
+```text
+call
+read
+write
+emit
+handle
+authorize
+project
+substitute
+serialize
+deserialize
+retry
+compensate
+migrate
+calculate
+```
+
+## 2-cells
+
+2-cell は、「この二つの path は同じものとして読めるべき」という law witness です。
+
+```text
+independent square
+same contract replacement
+repair filler
+identity insertion / deletion
+associativity reassociation
+projection square
+substitution square
+state/effect ordering square
+encode/decode roundtrip
+retry idempotency square
+compensation square
+authorization square
+semantic calculation square
+```
+
+AAT では diagram filling もすでに幾何的に整理されていて、diagram は object と operation からなる図式、filler は図式を可換にするデータ、non-fillability は要求される可換性や law を同時に満たす filler が存在しないこととして読めます。 さらに、law / obstruction / operation / path / homotopy / diagram filling は一つの幾何を形成する、と明示されています。
+
+---
+
+# 4. Homotopy Holonomy
+
+axis `x` に対して、path `p` に沿った continuation を置く。
+
+```text
+Cont_x(p)
+```
+
+そして同じ始点・終点を持つ二つの path
+
+```text
+p, q : a -> b
+```
+
+について、
+
+```text
+Hol_x(p,q)
+  =
+d_x(Cont_x(p), Cont_x(q))
+```
+
+と定義する。
+
+`p` と `q` をつなぐ loop を `ℓ = p ⋅ q^{-1}` と書けば、
+
+```text
+Hol_x(ℓ)
+```
+
+は「その loop を一周して戻ってきたときに、selected axis x 上で本当に戻ったか」を表す。
+
+```text
+Hol_x(ℓ) = 0
+```
+
+なら戻っている。
+
+```text
+Hol_x(ℓ) > 0
+```
+
+なら戻っていない。
+
+これが **architecture holonomy** です。
+
+---
+
+# 5. 新定理：AAT Homotopy–Holonomy Stokes Theorem
+
+## 定理
+
+有限 architecture object `A`、selected law universe `U`、selected axes `X` を取る。
+
+`A` から構成される selected architecture homotopy complex を
+
+```text
+K = K_U^X(A)
+```
+
+とする。
+
+各 2-cell `c` に local curvature を置く。
+
+```text
+κ_x(c)
+  =
+d_x(Cont_x(upper boundary of c),
+    Cont_x(lower boundary of c))
+```
+
+つまり、その 2-cell が主張する「二つの path は同じである」が、axis `x` 上でどれだけ壊れているかを測る。
+
+ここで次を仮定する。
+
+```text
+1. finite coverage:
+   測定対象の path / loop / 2-cell は有限に列挙される
+
+2. compositional continuation:
+   Cont_x は path composition と identity を保つ
+
+3. homotopy generator soundness:
+   zero-curvature 2-cell は selected continuation を保存する
+
+4. metric subadditivity:
+   path の接合による差分は三角不等式で評価できる
+
+5. filling coverage:
+   measured null-homotopy は selected 2-cell の合成として表現できる
+
+6. positive witness reflection:
+   Hol_x > 0 または κ_x > 0 は selected observation difference として読める
+```
+
+このとき、任意の 2-chain `S` について、
+
+```text
+Hol_x(∂S)
+  <=
+Σ_{c in S} |n_c| κ_x(c)
+```
+
+が成り立つ。
+
+これを **AAT discrete Stokes inequality** と呼ぶ。
+
+特に、
+
+```text
+Hol_x(∂S) > 0
+```
+
+なら、
+
+```text
+exists c in S, κ_x(c) > 0
+```
+
+である。
+
+つまり、
+
+```text
+埋められる loop の周りで holonomy が非ゼロなら、
+その内部のどこかの law cell が曲がっている。
+```
+
+---
+
+# 6. もっと重要な系：穴と曲率を分離できる
+
+この定理の良いところは、品質問題を二種類に分けられることです。
+
+## Case 1: loop は埋められるが holonomy がある
+
+```text
+ℓ = ∂S
+Hol_x(ℓ) > 0
+```
+
+この場合、定理により、
+
+```text
+S の中に κ_x(c) > 0 の 2-cell がある
+```
+
+と結論できる。
+
+これは **local law failure** です。
+
+例：
+
+```text
+discount と tax は独立なはず
+しかし semantic continuation が違う
+```
+
+```text
+retry しても同じ effect のはず
+しかし payment capture が二重になる
+```
+
+```text
+encode/decode は roundtrip のはず
+しかし domain semantic が落ちる
+```
+
+## Case 2: loop が埋められない
+
+```text
+ℓ ∈ Z_1(K)
+ℓ ∉ B_1(K)
+```
+
+つまり loop はあるが、
+
+```text
+ℓ = ∂S
+```
+
+となる filling `S` がない。
+
+これは **architectural hole** です。
+
+この場合、ツールは「違反」とは断言しない。代わりに、
+
+```text
+この二つの経路が同じだと主張するための
+contract / abstraction / law / test / runtime evidence / semantic evidence がない
+```
+
+と報告する。
+
+これは普通の静的解析にはかなり出しにくいです。
+
+---
+
+# 7. Homology としての品質指標
+
+`K` の chain complex を作る。
+
+```text
+C_2(K) -> C_1(K) -> C_0(K)
+```
+
+すると、
+
+```text
+Z_1(K) = ker ∂_1
+B_1(K) = im ∂_2
+H_1(K) = Z_1(K) / B_1(K)
+```
+
+を計算できる。
+
+ここで、
+
+```text
+H_1(K)
+```
+
+は「コードベース内にある、埋められていない architectural loop」を表します。
+
+これは dependency cycle とは違います。
+
+dependency graph の cycle は、
+
+```text
+A imports B
+B imports C
+C imports A
+```
+
+のような 1-skeleton 上の循環です。
+
+一方、AAT homology の loop は例えば、
+
+```text
+Command -> Event -> Projection -> Query
+Command -> DirectRead -> Query
+```
+
+のような「意味的に同じところへ行くはずの経路」です。
+
+静的依存は acyclic でも、semantic / effect / runtime / authority の空間には loop ができます。AAT では static / runtime / semantic の flatness は一般には互いに含意しないため、静的依存が整っていても runtime retry storm や semantic contract mismatch が残る、と整理されています。
+
+---
+
+# 8. ツールで出すべき指標
+
+この案に基づくツールは、次のような report を出します。
+
+```text
+ArchitectureHomotopyReport
+  = homotopy complex summary
+  + measured loops
+  + filled loops
+  + unfilled loops
+  + nonzero holonomy loops
+  + top curvature cells
+  + H1 rank
+  + loop support localization
+  + missing filler evidence
+  + non-conclusions
+```
+
+具体的な指標はこれです。
+
+```text
+β1_arch(A)
+  = rank H_1(K_U^X(A))
+```
+
+これは「埋められていない architectural hole の独立数」。
+
+```text
+HolMass_X(A)
+  =
+Σ_{ℓ in measured loops}
+Σ_{x in X}
+  w_{ℓ,x} Hol_x(ℓ)
+```
+
+これは「戻ってくるはずの loop が戻っていない総量」。
+
+```text
+FillRatio_X(A)
+  =
+# filled measured loops / # measured loops
+```
+
+これは「コード上の alternative path に対して、どれだけ law / contract / evidence が存在するか」。
+
+```text
+CurvedFillMass_X(A)
+  =
+Σ_{filled ℓ}
+Σ_{c in filling(ℓ)}
+Σ_x w_{c,x} κ_x(c)
+```
+
+これは「埋められるが中身が曲がっている loop の総量」。
+
+```text
+HoleHolonomy_X(A)
+  =
+Σ_{unfilled ℓ}
+Σ_x w_{ℓ,x} Hol_x(ℓ)
+```
+
+これは「穴であり、しかも観測差がある loop」。
+
+この `HoleHolonomy` はかなり面白いです。なぜなら、
+
+```text
+違反を証明できるほど law は揃っていないが、
+挙動差は観測されている
+```
+
+という、レビューで最も見落としやすい領域だからです。
+
+---
+
+# 9. これで測れる品質
+
+## 1. 暗黙の二重経路
+
+例えば同じ `UserProfile` を得るのに、
+
+```text
+UserService -> UserRepository -> UserProfile
+UserService -> Cache -> UserProfile
+```
+
+の二経路がある。
+
+型は同じ。依存も許可されている。
+
+しかし、
+
+```text
+Cont_semantic(repo path) != Cont_semantic(cache path)
+```
+
+なら、cache invalidation / projection freshness / semantic identity の loop が戻っていない。
+
+これは普通の静的解析では出にくい。
+
+---
+
+## 2. Eventual consistency の穴
+
+```text
+Command -> Event -> Projection -> QueryResult
+Command -> ImmediateRead -> QueryResult
+```
+
+この二つは常に同じである必要はない。
+
+しかし、アーキテクチャが「特定条件下では同じ」と主張しているなら、その条件を 2-cell として持つ必要がある。
+
+```text
+filler = consistency window law
+```
+
+これがないなら、
+
+```text
+unfilled loop
+```
+
+として出る。
+
+つまりツールは、
+
+```text
+この eventual consistency の差は意図された設計か？
+それとも contract が欠けているだけか？
+```
+
+を問える。
+
+---
+
+## 3. retry / idempotency の曲率
+
+```text
+op
+retry(op)
+```
+
+が同じ effect trace へ戻るべきなら、loop ができる。
+
+```text
+op ; op
+op
+```
+
+冪等 law が 2-cell。
+
+もし payment capture や email send が二重になるなら、
+
+```text
+Hol_effect(loop) > 0
+```
+
+になる。
+
+これは `retry` があること自体を褒める静的チェックより強い。
+
+---
+
+## 4. authorization bypass の穴
+
+```text
+Controller -> Policy -> Resource
+BatchJob -> Resource
+```
+
+同じ resource に到達する二経路がある。
+
+`BatchJob -> Resource` に authorization 2-cell がないなら、
+
+```text
+unfilled authority loop
+```
+
+になる。
+
+もし actor / scope / tenant が違えば、
+
+```text
+Hol_authority(loop) > 0
+```
+
+になる。
+
+---
+
+## 5. abstraction が本当に abstraction か
+
+```text
+Client -> Interface -> Impl -> Effect
+Client -> Impl -> Effect
+```
+
+この二経路が同じなら、interface は本当に抽象境界として働いている。
+
+しかし、
+
+```text
+Cont_contract(path through interface)
+  !=
+Cont_contract(path through impl)
+```
+
+なら、DIP 的には良く見えても、semantic / contract axis では戻っていない。AAT の例でも、interface に依存していても semantic contract が不一致なら obstruction は残り、依存方向だけでは flatness は決まらないとされています。
+
+---
+
+# 10. 前回の Spectrum 案との違い
+
+前回の案は、
+
+```text
+curvature support Laplacian
+obstruction transfer spectrum
+```
+
+でした。
+
+今回の案は、
+
+```text
+homotopy complex
+homology
+holonomy
+filling
+```
+
+です。
+
+違いを整理すると、
+
+```text
+Spectrum:
+  obstruction がどこに集中しているか
+  どの軸へ伝播しているか
+  固有モードとしてどこが危険か
+
+Homotopy:
+  そもそも同じものとして扱っている経路が本当に同じか
+  その同一性を支える filler があるか
+  loop が戻らないのは局所曲率か、構造的な穴か
+```
+
+スペクトラムは「熱地図」。
+
+ホモトピーは「地形図」。
+
+---
+
+# 11. 実装 MVP
+
+最初から一般の cell complex を作らなくてもよいです。
+
+## Step 1: path source を決める
+
+最初はこのへんだけでよい。
+
+```text
+calculation path
+state transition path
+event projection path
+authorization path
+serialization roundtrip
+retry/effect path
+interface/implementation path
+cache/repository path
+migration old/new path
+```
+
+## Step 2: 同じ endpoint を持つ path pair を作る
+
+```text
+p, q : source -> target
+```
+
+例：
+
+```text
+repository path vs cache path
+event projection path vs direct read path
+interface path vs concrete path
+old schema path vs new schema path
+retry path vs single effect path
+```
+
+## Step 3: filler candidate を探す
+
+```text
+contract
+test
+type refinement
+schema invariant
+idempotency annotation
+authorization policy
+event ordering guarantee
+transaction boundary
+compensation law
+domain invariant
+```
+
+これらがあれば 2-cell。
+
+なければ unfilled loop。
+
+## Step 4: continuation を測る
+
+axis ごとに測る。
+
+```text
+Cont_static
+Cont_contract
+Cont_semantic
+Cont_state
+Cont_effect
+Cont_authority
+Cont_runtime
+```
+
+## Step 5: report
+
+```text
+Top architectural holes:
+  1. Cache/UserRepository/UserProfile semantic loop
+  2. Command/Event/Projection/Query consistency loop
+  3. BatchJob/Policy/Resource authority loop
+
+Top holonomy loops:
+  1. retry/payment-capture effect loop
+  2. coupon/tax/rounding semantic loop
+  3. migration decode/encode roundtrip loop
+
+Top missing fillers:
+  1. idempotency evidence
+  2. projection freshness contract
+  3. tenant authority policy
+  4. semantic equivalence between interface and impl
+```
+
+---
+
+# 12. 具体例：User 登録
+
+コードがこうなっているとする。
+
+```text
+CreateUser
+  -> UserRepository.save
+  -> EventBus.publish(UserCreated)
+
+UserCreatedHandler
+  -> MailService.sendWelcomeMail
+```
+
+期待 law は、
+
+```text
+User is persisted before UserCreated is observed
+WelcomeMail uses persisted email
+Retry(UserCreatedHandler) is idempotent
+```
+
+ここから loop を作る。
+
+```text
+Path p:
+  CreateUser -> save email -> publish event -> handler -> send mail
+
+Path q:
+  CreateUser -> publish event -> handler -> read email -> send mail
+```
+
+もし `q` が存在してしまう、または event handler が保存前の状態を読みうるなら、
+
+```text
+Hol_state(loop) > 0
+Hol_effect(loop) > 0
+```
+
+になる。
+
+このとき report は、
+
+```text
+static dependency:
+  flat
+
+homotopy:
+  nonzero state/effect holonomy
+
+missing filler:
+  transaction boundary or event-after-persist law
+
+architectural interpretation:
+  event emission path and persisted-state path are not homotopic
+```
+
+と出せる。
+
+この種の問題は、単なる call graph では見えにくい。AAT の例でも、User model の quality は cycle axis だけでなく、state ordering、effect law、semantic consistency axis の組として読むとされています。
+
+---
+
+# 13. 証明スケッチ
+
+2-cell `c` は、二つの境界 path を持つ。
+
+```text
+∂c = p_c - q_c
+```
+
+local curvature は、
+
+```text
+κ_x(c)
+  =
+d_x(Cont_x(p_c), Cont_x(q_c))
+```
+
+2-chain
+
+```text
+S = Σ n_c c
+```
+
+の境界は loop になる。
+
+```text
+∂S = ℓ
+```
+
+`Cont_x` が composition に対して整合し、`d_x` が三角不等式を満たすなら、境界 loop の continuation 差は、内部 2-cell の continuation 差の和で上から抑えられる。
+
+```text
+Hol_x(ℓ)
+  =
+Hol_x(∂S)
+  <=
+Σ |n_c| κ_x(c)
+```
+
+したがって、もし内部の全 2-cell が flat なら、
+
+```text
+forall c in S, κ_x(c)=0
+```
+
+より、
+
+```text
+Hol_x(∂S)=0
+```
+
+です。
+
+対偶を取ると、
+
+```text
+Hol_x(∂S)>0
+```
+
+なら、
+
+```text
+exists c in S, κ_x(c)>0
+```
+
+となる。
+
+これが定理の核です。
+
+---
+
+# 14. この定理のツール上の強さ
+
+この定理は、PR レビューではなく **コード全体検査** にかなり向いています。
+
+なぜなら、path pair や loop は差分ではなく、コードベース全体から発見するものだからです。
+
+```text
+all event flows
+all cache/repository alternatives
+all retry/effect pairs
+all interface/implementation paths
+all migration roundtrips
+all authorization access paths
+all calculation ordering alternatives
+```
+
+を repo 全体から集める。
+
+そして、
+
+```text
+どの loop が埋まっているか
+どの loop が埋まっていないか
+どの loop が戻ってこないか
+どの filler が欠けているか
+```
+
+を出す。
+
+これは普通の静的解析の、
+
+```text
+循環依存があります
+未使用 import があります
+複雑度が高いです
+```
+
+とはかなり違う。
+
+むしろ、
+
+```text
+このコードベースは、同じ意味へ到達する複数経路を持っているが、
+それらを同一視する幾何的証拠が足りない
+```
+
+を測る。
+
+---
+
+# 15. 最終形の theorem statement
+
+まとめると、こうです。
+
+```text
+AAT Homotopy–Holonomy Stokes Theorem
+
+AAT architecture object A から、
+selected law universe U と selected axes X に対する
+finite architecture homotopy complex K_U^X(A) を構成する。
+
+K の 1-cell は code-level architecture transition、
+2-cell は law / contract / filler / commutative square を表す。
+
+各 axis x について selected continuation Cont_x を置き、
+各 2-cell c の local curvature κ_x(c) を、
+その境界二経路の continuation difference として定義する。
+
+このとき、任意の measured filling S に対して、
+
+  Hol_x(∂S) <= Σ_{c in S} |n_c| κ_x(c)
+
+が成り立つ。
+
+したがって、fill 可能な loop の holonomy が非ゼロなら、
+その filling 内に selected law failure が存在する。
+
+一方、loop が fill 不可能なら、
+それは violation ではなく architectural hole として報告される。
+その hole は、missing contract、missing abstraction、
+missing runtime guarantee、missing semantic equivalence、
+missing authority proof などとして局在化される。
+```
+
+この案は、かなり AAT らしいと思います。
+
+前回の **Curvature–Transfer Spectrum** は「どこが歪んでいるか」を測る道具。
+
+今回の **Homotopy–Holonomy Stokes** は「コード空間にどんな穴があり、どの loop が戻ってこないか」を測る道具。
+
+両方を組み合わせると、AAT ベースの品質計測ツールはかなり強くなります。

--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -38,6 +38,8 @@ Forward design PRDs:
 - [ArchSig AAT Analysis Engine PRD](archsig_aat_analysis_engine_prd.md)
 - [ArchSig v0.3.0 Measurement Expansion PRD](archsig_v0_3_0_measurement_expansion_prd.md)
 - [ArchSig Monodromy / Boundary Holonomy Measurement PRD](archsig_monodromy_boundary_holonomy_prd.md)
+- [ArchSig Curvature / Transfer Spectrum PRD](archsig_curvature_transfer_spectrum_prd.md)
+- [ArchSig Homotopy / Holonomy Stokes PRD](archsig_homotopy_holonomy_stokes_prd.md)
 - [ArchSig Monodromy / Boundary Holonomy Validation](archsig_monodromy_boundary_holonomy_validation.md)
 
 New implementation-facing specification documents should be added here only when they match the implementation and keep those boundaries explicit. Forward PRDs should keep future schema and migration work separate from the current source-of-truth boundaries above.

--- a/docs/tool/archsig_curvature_transfer_spectrum_prd.md
+++ b/docs/tool/archsig_curvature_transfer_spectrum_prd.md
@@ -1,0 +1,429 @@
+# ArchSig Curvature / Transfer Spectrum PRD
+
+この PRD は、AAT Curvature-Transfer Spectrum Theorem / ACTS を
+ArchSig の実用計測面として追加するための要求を定義する。
+
+中心方針は次である。
+
+```text
+ArchSig measurement first
+  > bounded AAT theorem support
+  > Lean guardrail where useful
+  > AAT / tool / website documentation alignment
+```
+
+この PRD では、Lean で完全な spectral / transfer 理論を形式化することを
+主目的にしない。ArchSig が supplied ArchMap、LawPolicy、analysis packet から、
+selected axes 上の curvature support、obstruction transfer、recurrent mode、
+review focus を計測できることを第一の目的にする。
+
+ArchSig の出力は、次の形の bounded diagnosis として読む。
+
+```text
+ArchSig measured selected-axis curvature and transfer modes
+under recorded coverage, distance, weight, and exactness assumptions.
+```
+
+これは architecture lawfulness、global flatness、semantic correctness、
+future safety、Lean theorem discharge を結論するものではない。
+
+## 要求
+
+### R0. ArchSig で計測できることを最優先にする
+
+ArchSig は、curvature / transfer spectrum を数学的 decoration ではなく、
+codebase inspection と design diagnosis に使える計測面として扱わなければならない。
+
+優先する問いは次である。
+
+```text
+どの support / axis に nonzero curvature が局在しているか。
+どの obstruction が support と axis をまたいで結合しているか。
+どの transfer mode が recurrent obstruction として戻ってくるか。
+どの coverage gap により zero conclusion を出せないか。
+```
+
+ArchSig は、少なくとも次を出力できなければならない。
+
+- selected law universe / LawPolicy refs
+- selected axis family
+- measured witness family
+- distance kind and weight policy
+- curvature support operator reading
+- transfer operator reading
+- top curvature modes
+- top transfer / recurrent modes
+- witness clusters
+- affected Atom / molecule / component / boundary refs
+- source refs / observation refs
+- coverage boundary
+- exactness assumption status
+- missing evidence
+- recommended review focus
+- non-conclusions
+
+### R1. 一般のエンジニアが得るアウトカムを定義する
+
+この実装により、一般のエンジニアは次を得られなければならない。
+
+第一に、巨大な codebase のどこから見ればよいかが分かる。
+ArchSig は、violation count や抽象的な health score ではなく、support、axis、
+witness cluster、source refs をまとめて、調査すべき architecture hotspot を提示する。
+これにより、engineer は「どこかが複雑そう」ではなく、
+「semantic / state / effect の nonzero mode がこの subsystem に集中している」と読める。
+
+第二に、静的依存グラフでは見えない設計劣化を見つけられる。
+import cycle がない、layering が綺麗、interface 経由で依存している、という状態でも、
+semantic contract、state transition、runtime retry、effect idempotency、authority boundary が
+ずれていれば、ArchSig は selected-axis curvature として出す。
+これにより、engineer は「依存関係は正しいのに動作や意味が壊れる」種類の問題を
+architecture review の対象にできる。
+
+第三に、局所的な不具合と構造的な再発パターンを分けられる。
+ArchSig は、単発の nonzero witness と、support / axis をまたいで戻ってくる
+recurrent obstruction を区別する。
+これにより、engineer は一つの TODO を直すべきか、boundary、contract、state / effect policy、
+runtime pattern をまとめて見直すべきかを判断しやすくなる。
+
+第四に、レビューや設計相談の説明が traceable になる。
+ArchSig は、top mode に affected Atom refs、source refs、witness refs、coverage status、
+missing evidence を付ける。
+これにより、reviewer は「この設計は危ない気がする」ではなく、
+「この witness cluster は selected semantic axis と effect axis で nonzero curvature を持ち、
+この source refs に根拠がある」と説明できる。
+
+第五に、測定できた危険と測定できていない危険を分けられる。
+ArchSig は、coverage gap、unmeasured axis、exactness assumption status を report に含める。
+これにより、engineer は `zero` を安全証明として誤読せず、
+「ここは measured zero」「ここは unmeasured」「ここは additional evidence が必要」を
+分けて読める。
+
+第六に、次の action が明確になる。
+ArchSig は automatic repair を結論しないが、review focus、追加すべき witness、
+補うべき semantic contract、確認すべき runtime evidence、分離すべき boundary を提示する。
+これにより、engineer は report を読んだ後に、調査、docs 補強、test 追加、contract 明文化、
+refactor candidate のどれに進むべきかを選べる。
+
+### R2. LawPolicy に spectrum reading の前提を持たせる
+
+LawPolicy は、curvature / transfer spectrum を読むために必要な選択を
+ArchSig へ明示的に渡さなければならない。
+
+LawPolicy が直接宣言するのは、law-relative な前提に限る。
+
+- selected law universe
+- selected axes
+- required witness rules
+- coverage requirement
+- exactness assumption status
+- excluded readings
+- non-conclusions
+
+距離、重み、support projection、transfer edge extraction、mode ranking のような
+計測レシピは、LawPolicy root を肥大化させず、同じ `law-policy-v0` artifact 内の
+optional `spectrumMeasurementProfile` subobject として持つ。
+これは別ファイルを要求しない。必要になった場合だけ、再利用用に外部参照できるようにする。
+
+`spectrumMeasurementProfile` は少なくとも次を持てる。
+
+- measured witness family rule
+- distance kind per axis
+- weight policy
+- support projection rule
+- transfer edge rule
+- clustering / ranking options
+- report focus options
+
+同じ ArchMap は複数の LawPolicy で再分析できる。
+同じ LawPolicy 内で複数の `spectrumMeasurementProfile` を比較してもよいが、
+profile の差分を law universe の差分として扱ってはならない。
+ArchMap は law-independent な observation map に留め、curvature support、
+transfer edge、obstruction circuit、flatness judgement を first-class output として持たない。
+
+### R3. Policy composition を LLM-native skill flow にする
+
+ACTS 用 LawPolicy / `spectrumMeasurementProfile` は、人間が内容を設計して
+書く artifact ではなく、LLM agent が repository evidence、ArchMap、user goal、
+project conventions を読んで構成する intermediate artifact として扱う。
+
+Primary flow は次である。
+
+```text
+human intent
+  -> tools/archsig/skills/archmap-creater
+  -> tools/archsig/skills/law-policy-creater
+  -> ArchSig validation
+  -> tools/archsig/skills/archsig-reader
+  -> bounded architecture reading
+```
+
+人間が指定するのは、policy の詳細ではなく、意図と制約である。
+
+- analysis goal: baseline diagnosis, strict review, migration planning, subsystem inspection
+- risk focus: semantic contract, state/effect, runtime, authority, provider boundary, dependency direction
+- source scope: repository, subsystem, feature, service, package
+- normative evidence: architecture docs, coding standards, ADR, review policy, direct user decision
+- excluded readings and private / unavailable evidence
+- how conservative the zero-reading should be
+
+LLM は `tools/archsig/skills/law-policy-creater` を使って、normative evidence と
+user intent から LawPolicy を構成する。LLM は、law、witness、axis、coverage、
+exactness、distance、weight、support projection、transfer edge rule を
+人間の手作業ではなく skill-guided synthesis として組み立てる。
+
+ただし、LLM は自分の設計嗜好を selected law として昇格してはならない。
+Normative source または user decision がない law は、selected law ではなく
+question、optional reading、coverage gap、excluded reading として残す。
+
+生成された policy は、少なくとも次を記録する。
+
+- source evidence used
+- user intent used
+- generated fields
+- LLM-inferred fields
+- user-confirmed fields
+- unresolved questions
+- risky defaults
+- validation warnings
+- non-conclusions
+
+Policy JSON は human editing surface ではなく、LLM / ArchSig の machine-readable
+contract である。人間向け surface は、why this law was selected、which source evidence
+supports it、which assumptions block zero-reflection、which questions remain、という
+explanation である。
+
+ACTS 実装では、`tools/archsig/skills/law-policy-creater` と
+`tools/archsig/skills/archsig-reader` を更新し、spectrum measurement profile の構成、
+検証、読み取りを LLM が実行できるようにする。
+
+### R4. Curvature support reading を analysis packet に追加する
+
+ArchSig は、measured witness `sigma` と selected axis `x` について、
+local curvature value、weight、support incidence を読めなければならない。
+
+最小実装では curvature value は 0 / 1 でよい。
+ただし schema は、後続で richer distance を追加できるようにする。
+
+例:
+
+- boolean mismatch
+- mismatch count
+- edit distance
+- semantic witness mismatch count
+- contract refinement distance
+- state transition distance
+- effect replay mismatch count
+- authorization mismatch count
+- runtime trace distance
+
+ArchSig は、curvature support operator を bounded report reading として出力する。
+
+```text
+L^kappa
+  = sum weight(sigma, x) * kappa(sigma, x) * support(sigma, x) * support(sigma, x)^T
+```
+
+この reading は、support / axis coupling、top eigenmode、top witness cluster を
+説明するための report surface である。ArchSig は `Spec(L^kappa) = {0}` だけから
+unmeasured axes や global correctness を結論してはならない。
+
+### R5. Transfer spectrum reading を analysis packet に追加する
+
+ArchSig は、state space を `support x axis` として、measured transfer edge を
+有限非負 operator として読めなければならない。
+
+```text
+T^kappa[(s, x), (t, y)]
+  = sum measured transfer defect from (s, x) to (t, y)
+```
+
+ArchSig は、transfer edge ごとに次を保持する。
+
+- source support / axis
+- target support / axis
+- witness refs
+- defect value
+- weight
+- source refs / observation refs
+- transfer explanation
+- coverage boundary
+- non-conclusions
+
+ArchSig は、positive closed walk を recurrent obstruction reading として出力できる。
+`rho(T^kappa) > 0` は recurrent mode の存在として読む。
+増幅、将来の障害、運用コスト増加を結論する場合は、別の empirical calibration を要求する。
+
+### R6. Architecture Spectrum Report を追加する
+
+ArchSig は、curvature support と transfer spectrum をまとめた
+`ArchitectureSpectrumReport` を出力できなければならない。
+
+Report は少なくとも次を含む。
+
+- schema version
+- selected LawPolicy ref
+- ArchMap / analysis packet refs
+- selected axes
+- measured witness summary
+- distance / weight policy summary
+- curvature support summary
+- transfer operator summary
+- spectral radius reading
+- top eigenmodes
+- top witness clusters
+- recurrent obstruction readings
+- coverage gaps
+- exactness assumptions
+- recommended review focus
+- non-conclusions
+
+Report は単一スコアを出してはならない。
+必要に応じて aggregate value を出してもよいが、主 surface は
+`top modes + witnesses + axes + support + coverage gap` とする。
+
+### R7. Codebase inspection を primary use case にする
+
+ACTS の primary surface は PR diff review ではなく、repository / codebase 全体の
+architecture health scan である。
+
+ArchSig は、次を読めるようにする。
+
+- static dependency は acyclic だが semantic / effect / runtime に nonzero mode がある箇所
+- interface dependency は正しく見えるが contract refinement が弱い箇所
+- retry / timeout はあるが effect idempotency が不足する箇所
+- state update と event emission の順序に curvature がある箇所
+- authority call と authorized effect がずれている箇所
+- semantic / state / effect / runtime / authority をまたぐ recurrent obstruction
+
+PR review surface へ展開する場合も、raw diff ではなく ArchMap / ArchMapDelta /
+LawPolicy に基づく bounded diagnosis として扱う。
+
+### R8. Lean 形式化は理論的裏付けとして必要な範囲に絞る
+
+Lean 側では、ArchSig implementation の完全性を証明しない。
+必要な範囲の guardrail と theorem boundary を追加する。
+
+Lean で扱う候補は次である。
+
+- finite weighted curvature support aggregate
+- positive weight / nonempty support の下で aggregate zero から local curvature zero を戻す bridge
+- finite nonnegative transfer relation と positive closed walk の bounded recurrence reading
+- `Spec = all zero` を selected measured curvature zero と接続する small theorem package
+- non-conclusions を記録する theorem package / schema
+
+Lean は、実コード extractor completeness、semantic correctness、LawPolicy authoring correctness、
+ArchSig implementation correctness、global semantic flatness、future safety を証明しない。
+
+### R9. AAT 数学本文と関連 docs を更新する
+
+ACTS を実装するときは、AAT / tool / website の説明面を同期する。
+
+更新対象は少なくとも次を含む。
+
+- AAT 数学本文: curvature / analytic representation / spectral reading の位置づけ
+- `docs/aat/proof_obligations.md`: Lean で支える範囲、future proof obligation、empirical hypothesis
+- `docs/aat/lean_theorem_index.md`: 追加した Lean definition / theorem / non-conclusion
+- `docs/tool/README.md`: ArchSig analysis packet における spectrum report の位置づけ
+- `docs/tool/law_policy.md`: spectrum measurement policy
+- `docs/tool/archsig_analysis_packet.md`: ArchitectureSpectrumReport の読み方
+- website / public manual: public surface に出す場合の reading guide
+
+AAT 数学本文では、tool implementation status、Issue 番号、fixture 詳細を混ぜない。
+tool docs では、AAT theorem と ArchSig report reading を混同しない。
+
+### R10. Non-conclusions を report と docs に残す
+
+ArchSig は、ACTS report に次の non-conclusions を必ず含める。
+
+- spectrum value は architecture object の全構造を復元しない
+- unmeasured axis は zero ではない
+- missing evidence は defect absence ではない
+- `Spec(L^kappa) = {0}` は coverage / exactness / zero-reflection なしに lawfulness を示さない
+- `rho(T^kappa) > 0` は future incident や empirical cost increase を示さない
+- top eigenmode は review focus であり、automatic repair conclusion ではない
+- ArchSig report は Lean theorem discharge ではない
+
+### R11. Validation fixture を用意する
+
+ArchSig は、最小 fixture で ACTS report を安定して出力できなければならない。
+
+必要な fixture は次である。
+
+- zero curvature support fixture
+- nonzero semantic curvature fixture
+- transfer cycle fixture
+- coverage gap fixture
+- coupon / tax / rounding style fixture
+
+Validation は schema shape、non-conclusions、coverage boundary、top mode refs、
+transfer edge refs、recurrent mode refs を確認する。
+Validation は architecture lawfulness や Lean theorem discharge を証明しない。
+
+## スコープ
+
+この PRD のスコープ内:
+
+- LawPolicy に spectrum measurement policy を追加する。
+- ArchSig analysis packet に ArchitectureSpectrumReport を追加する。
+- finite measured witness family から curvature support reading を出す。
+- finite transfer edge family から recurrent obstruction reading を出す。
+- top eigenmode / top witness cluster / recurrent mode / coverage gap を report に出す。
+- codebase inspection surface で spectrum report を読めるようにする。
+- `tools/archsig/skills/law-policy-creater` が ACTS 用 profile を LLM-native に構成できるようにする。
+- `tools/archsig/skills/archsig-reader` が ArchitectureSpectrumReport を読めるようにする。
+- Lean 側に minimal theorem guardrail を追加する。
+- AAT 数学本文、AAT proof obligation / theorem index、tool docs、必要な website surface を同期する。
+
+この PRD のスコープ外:
+
+- ArchMap を law-relative artifact に変更する。
+- ArchSig を Lean 証明器にする。
+- raw source から完全な Atom / witness universe を自動抽出する。
+- PR diff / FieldSig longitudinal forecast を ACTS だけで置き換える。
+- 完全な sheaf / Hodge Laplacian 理論を最初から実装する。
+- empirical incident risk、review cost、future safety の calibration をこの PRD で完了する。
+
+## Non-Goals
+
+- ACTS report を単一の architecture quality score にすること。
+- `Spec(L^kappa) = {0}` から無条件に global flatness / global lawfulness を結論すること。
+- `rho(T^kappa) > 0` から無条件に障害発生、品質劣化、コスト増を結論すること。
+- unmeasured semantic / runtime / authority axis を measured zero として扱うこと。
+- coverage gap を absence of defect として扱うこと。
+- ArchMap に obstruction circuit、curvature support、transfer edge、flatness judgement を保存すること。
+- Lean で ArchSig implementation correctness や extractor completeness を証明すること。
+- AAT 数学本文に tool の実装状況、fixture、CLI 詳細を混ぜること。
+- 一般の engineer に law / witness / distance / exactness の詳細設計を要求すること。
+- Generic preset を project-specific architectural diagnosis として扱うこと。
+- LLM が source evidence や user decision なしに selected law を発明すること。
+
+## Acceptance Criteria / 完了条件
+
+- LawPolicy が spectrum measurement policy を表現できる。
+- ACTS 用 LawPolicy / `spectrumMeasurementProfile` は、
+  `tools/archsig/skills/law-policy-creater` が human intent、repository evidence、ArchMap から
+  LLM-native に構成できる。
+- 一般の engineer は law / witness / distance / exactness の詳細を設計せず、
+  analysis goal、risk focus、source scope、normative evidence、除外条件を指定すればよい。
+- Generated policy に source evidence、user intent、LLM-inferred fields、user-confirmed fields、
+  unresolved questions、validation warnings、non-conclusions が記録される。
+- `tools/archsig/skills/archsig-reader` が ArchitectureSpectrumReport を読み、
+  LLM が bounded architecture reading と next action を説明できる。
+- ArchSig が supplied ArchMap + LawPolicy から ArchitectureSpectrumReport を生成できる。
+- Report に selected axes、witness family、distance / weight policy、curvature support summary、
+  transfer summary、top modes、witness clusters、coverage gaps、non-conclusions が含まれる。
+- Report から、hotspot、静的依存では見えない設計劣化、recurrent obstruction、
+  traceable review explanation、測定境界、次の action を読める。
+- Report は単一スコアではなく、review focus と traceable refs を primary surface にする。
+- `Spec(L^kappa) = {0}` の reading は coverage / exactness / zero-reflection 前提つきに限定される。
+- `rho(T^kappa) > 0` の reading は recurrent obstruction に限定され、empirical amplification は結論しない。
+- zero fixture、nonzero curvature fixture、transfer cycle fixture、coverage gap fixture が追加される。
+- ArchSig validation test が schema shape、refs、coverage boundary、non-conclusions を確認する。
+- Lean 側に minimal theorem guardrail が追加され、`lake build` が通る。
+- `docs/aat/proof_obligations.md` と `docs/aat/lean_theorem_index.md` が Lean 追加分と claim boundary を反映する。
+- AAT 数学本文が ACTS の位置づけを、実装状況ではなく理論的 reading として反映する。
+- `docs/tool/README.md`、`docs/tool/law_policy.md`、`docs/tool/archsig_analysis_packet.md` が ACTS report を説明する。
+- public website / manual に出す場合は、spectrum report の読み方と non-conclusions が同期される。
+- `cargo test --manifest-path tools/archsig/Cargo.toml` が通る。
+- Lean 変更を含む場合は `lake build` が通る。
+- `git diff --check` と hidden / bidirectional Unicode scan が通る。

--- a/docs/tool/archsig_homotopy_holonomy_stokes_prd.md
+++ b/docs/tool/archsig_homotopy_holonomy_stokes_prd.md
@@ -1,0 +1,447 @@
+# ArchSig Homotopy / Holonomy Stokes PRD
+
+この PRD は、AAT Homotopy-Holonomy Stokes Theorem を ArchSig の
+実用計測面として追加するための要求を定義する。
+
+中心方針は次である。
+
+```text
+LLM-native ArchSig measurement
+  > architectural holes and filler evidence
+  > bounded Stokes-style theorem support
+  > minimal Lean guardrail
+  > AAT / tool / website documentation alignment
+```
+
+この PRD では、Lean で完全な homotopy / homology / Stokes 理論を形式化することを
+主目的にしない。ArchSig が supplied ArchMap、LawPolicy、analysis packet から、
+codebase 上の path pair、loop、filler、unfilled hole、nonzero holonomy を測定し、
+一般の engineer と LLM agent が読める architecture diagnosis を出すことを第一の目的にする。
+
+既存の [ArchSig Monodromy / Boundary Holonomy Measurement PRD](archsig_monodromy_boundary_holonomy_prd.md)
+は、operation square、path continuation trace、boundary holonomy、feature extension diagnosis を
+主に扱う。この PRD はそれを置き換えない。今回の主対象は、codebase 全体を
+selected homotopy complex として読み、loop が戻らない理由を local curvature と
+architectural hole に分けることである。
+
+ArchSig の出力は、次の形の bounded diagnosis として読む。
+
+```text
+ArchSig measured selected path loops, fillers, holes, and holonomy
+under recorded LawPolicy, coverage, continuation, distance, and exactness assumptions.
+```
+
+これは architecture lawfulness、global semantic flatness、future safety、
+Lean theorem discharge、source extraction completeness を結論するものではない。
+
+## 要求
+
+### R0. LLM-native ArchSig 計測を最優先にする
+
+ArchSig は、homotopy / holonomy / Stokes reading を数学的 decoration ではなく、
+LLM が叩いて codebase inspection を進めるための計測面として扱わなければならない。
+
+優先する問いは次である。
+
+```text
+同じ意味に到達するはずの複数 path は、本当に同じ selected observation に戻るか。
+その同一性を支える contract / law / test / runtime evidence / semantic evidence はあるか。
+loop が戻らない場合、それは埋められる loop 内部の local curvature か。
+それとも filler がない architectural hole か。
+```
+
+ArchSig は、少なくとも次を出力できなければならない。
+
+- selected LawPolicy refs
+- selected axes
+- homotopy complex summary
+- measured path pairs
+- measured loops
+- filled loops
+- unfilled loops
+- filler candidates
+- missing filler evidence
+- nonzero holonomy loops
+- top local curvature cells
+- architectural hole readings
+- loop support localization
+- source refs / observation refs
+- coverage boundary
+- exactness assumption status
+- recommended review focus
+- non-conclusions
+
+### R1. 一般のエンジニアが得るアウトカムを定義する
+
+この実装により、一般の engineer は次を得られなければならない。
+
+第一に、同じ結果へ行く複数経路が本当に同じ意味を保っているかを確認できる。
+例えば repository path と cache path、event projection path と direct read path、
+interface path と implementation path、old schema path と new schema path を比較し、
+selected semantic / state / effect / authority axis で戻っているかを読める。
+
+第二に、違反と断言できないが設計証拠が欠けている領域を見つけられる。
+ArchSig は、loop が存在するが filler がない場合、それを violation ではなく
+architectural hole として出す。
+これにより、engineer は「この二経路は同じはず」という暗黙知に対して、
+contract、test、runtime guarantee、semantic equivalence、authority proof があるかを確認できる。
+
+第三に、戻らない loop の原因を local curvature と missing filler に分けられる。
+埋められる loop の holonomy が非ゼロなら、内部の law cell に selected local curvature がある。
+埋められない loop なら、まず filler evidence が不足している。
+この区別により、bug fix、contract 明文化、test 追加、boundary 設計、runtime evidence 収集の
+どれへ進むべきかを選びやすくなる。
+
+第四に、eventual consistency、cache freshness、retry idempotency、authorization bypass、
+serialization roundtrip のような問題を静的依存とは別軸で読める。
+static dependency graph が acyclic でも、semantic / state / runtime / effect / authority の
+空間には loop と hole が残りうる。
+
+第五に、レビュー説明が traceable になる。
+ArchSig は、path pair、loop、filler candidate、missing evidence、source refs、
+observation refs、coverage status を report に残す。
+これにより、reviewer は「この設計は曖昧」ではなく、
+「この cache / repository loop は selected semantic axis で nonzero holonomy を持ち、
+projection freshness filler が missing」と説明できる。
+
+第六に、LLM agent が次の調査を進めやすくなる。
+Report は、人間向けの巨大証明ではなく、LLM が source refs を再確認し、
+missing filler を探し、LawPolicy の unresolved question を整理し、
+ArchSig を再実行できる structured reading として設計する。
+
+### R2. Homotopy reading を LLM-native skill flow に組み込む
+
+Homotopy / Stokes 用の LawPolicy、measurement profile、path discovery rule は、
+人間が詳細設計して書く artifact ではない。
+LLM agent が `tools/archsig/skills` を使って構成、検証、読み取りを行う。
+
+Primary flow は次である。
+
+```text
+human intent
+  -> tools/archsig/skills/archmap-creater
+  -> tools/archsig/skills/law-policy-creater
+  -> ArchSig validation
+  -> tools/archsig/skills/archsig-reader
+  -> bounded homotopy / holonomy reading
+```
+
+人間が指定するのは、policy 詳細ではなく次の意図と制約である。
+
+- analysis goal: codebase inspection, migration review, cache consistency review, event flow review
+- risk focus: semantic equivalence, state/effect ordering, retry idempotency, authority, serialization, projection freshness
+- source scope: repository, subsystem, feature, service, package
+- normative evidence: architecture docs, coding standards, ADR, review policy, direct user decision
+- excluded readings and private / unavailable evidence
+- how conservative the zero / filler reading should be
+
+LLM は selected law を発明してはならない。
+Normative source または user decision がない同一性主張は、selected law ではなく
+question、optional reading、unfilled loop、coverage gap、excluded reading として残す。
+
+### R3. Architecture Homotopy Complex を bounded report reading として作る
+
+ArchSig は、supplied ArchMap と LawPolicy から selected architecture homotopy complex
+summary を構成できなければならない。
+
+最小の reading は次を持つ。
+
+- `0-cells`: component, operation, state, effect, event, contract, semantic object, resource, authority scope
+- `1-cells`: call, read, write, emit, handle, authorize, project, substitute, serialize, deserialize, retry, compensate, migrate, calculate
+- `2-cells`: law witness, contract filler, commutative square, substitution square, projection square, state/effect ordering square, retry idempotency square, authorization square, semantic calculation square
+
+この complex は source truth ではない。
+ArchMap observations、LawPolicy、LLM-discovered candidates、coverage boundary から作る
+bounded analysis object である。
+
+### R4. Path pair と loop candidate を列挙する
+
+ArchSig は、同じ endpoint を持つ candidate path pair を列挙できなければならない。
+
+最小の path source は次である。
+
+- calculation path
+- state transition path
+- event projection path
+- authorization path
+- serialization roundtrip
+- retry / effect path
+- interface / implementation path
+- cache / repository path
+- migration old / new path
+
+Candidate は少なくとも次を区別する。
+
+- LLM-discovered candidate
+- LawPolicy-required candidate
+- ArchMap-supplied candidate
+- source-confirmed candidate
+- unresolved / needsReview candidate
+
+Candidate は review cue であり、path truth ではない。
+
+### R5. Filler candidate と architectural hole を分ける
+
+ArchSig は、各 loop について filler candidate を探し、filled / unfilled を区別できなければならない。
+
+Filler candidate は少なくとも次を含む。
+
+- contract
+- test
+- type refinement
+- schema invariant
+- idempotency evidence
+- authorization policy
+- event ordering guarantee
+- transaction boundary
+- compensation law
+- domain invariant
+- runtime observation
+- semantic equivalence note
+
+Filler がない loop は violation ではなく `architectural hole` として出す。
+Report は、missing filler evidence と、追加確認すべき source refs / docs refs / runtime refs を示す。
+
+### R6. Homotopy holonomy を selected axis ごとに計測する
+
+ArchSig は、path `p` と `q` の selected continuation trace を axis ごとに比較できなければならない。
+
+```text
+Hol_x(p, q)
+  = distance_x(Cont_x(p), Cont_x(q))
+```
+
+扱う axis は少なくとも次を含む。
+
+- static / support
+- contract
+- semantic
+- state
+- effect
+- authority / trust
+- runtime
+- projection / representation
+
+各 holonomy reading は次を持つ。
+
+- path pair refs
+- loop ref
+- axis id
+- distance kind
+- value
+- compared continuation summary
+- source refs / observation refs
+- filler refs or missing filler refs
+- coverage boundary
+- exactness assumption status
+- non-conclusions
+
+### R7. Discrete Stokes reading を report する
+
+ArchSig は、measured filling `S` がある loop について、bounded Stokes-style reading を出せなければならない。
+
+```text
+Hol_x(boundary(S))
+  <= sum local curvature cells in S
+```
+
+Tool report では、これを theorem proof ではなく、次の review logic として使う。
+
+```text
+filled loop has nonzero holonomy
+  -> inspect local curvature cells in its measured filling
+
+loop has no filler
+  -> report architectural hole and missing evidence
+```
+
+ArchSig は、measured filling がない loop について、内部 local curvature を結論してはならない。
+その場合は unfilled loop / architectural hole として扱う。
+
+### R8. Architecture Homotopy Report を追加する
+
+ArchSig は、homotopy / holonomy / filler reading をまとめた
+`ArchitectureHomotopyReport` を出力できなければならない。
+
+Report は少なくとも次を含む。
+
+- schema version
+- selected LawPolicy ref
+- ArchMap / analysis packet refs
+- selected axes
+- homotopy complex summary
+- measured path pair summary
+- measured loop summary
+- filled loops
+- unfilled loops
+- nonzero holonomy loops
+- top local curvature cells
+- missing filler evidence
+- architectural hole readings
+- optional `beta1` / hole rank reading when bounded chain data is available
+- optional `HolMass`, `FillRatio`, `CurvedFillMass`, `HoleHolonomy` aggregate readings
+- recommended review focus
+- non-conclusions
+
+Aggregate readings are not single architecture quality scores.
+They are review prioritization readings and must carry coverage / exactness / selected-axis boundaries.
+
+### R9. Codebase inspection を primary use case にする
+
+この surface の primary use case は PR diff review ではなく、repository / codebase 全体の
+architecture health scan である。
+
+ArchSig は、次を読めるようにする。
+
+- cache / repository alternative path の semantic loop
+- event projection / direct read consistency loop
+- retry / effect idempotency loop
+- authorization bypass style loop
+- interface / implementation contract loop
+- serialization / deserialization roundtrip loop
+- migration old / new schema roundtrip loop
+- calculation ordering loop
+
+PR review へ展開する場合も、raw diff ではなく ArchMap / ArchMapDelta / LawPolicy に基づく
+bounded diagnosis として扱う。
+
+### R10. Lean 形式化は minimal guardrail に絞る
+
+Lean 側では、ArchSig implementation の完全性や一般 homology 理論を証明しない。
+必要な範囲の guardrail と theorem boundary を追加する。
+
+Lean で扱う候補は次である。
+
+- finite measured path / loop / 2-cell family
+- selected continuation function
+- local curvature for measured 2-cell boundary paths
+- holonomy for measured path pair
+- compositional continuation assumptions
+- triangle inequality / subadditivity assumptions
+- bounded Stokes inequality for measured filling
+- nonzero boundary holonomy implies at least one nonzero measured local curvature under filling
+- unfilled loop is not a violation conclusion
+- non-conclusions theorem package / schema
+
+Lean は、実コード extractor completeness、semantic correctness、LawPolicy authoring correctness、
+ArchSig implementation correctness、global homotopy completeness、future safety を証明しない。
+
+### R11. AAT 数学本文と関連 docs を更新する
+
+実装時には、AAT / tool / website の説明面を同期する。
+
+更新対象は少なくとも次を含む。
+
+- AAT 数学本文: path / homotopy / diagram filling / holonomy / Stokes-style reading の位置づけ
+- `docs/aat/proof_obligations.md`: Lean で支える範囲、future proof obligation、empirical hypothesis
+- `docs/aat/lean_theorem_index.md`: 追加した Lean definition / theorem / non-conclusion
+- `docs/tool/README.md`: Homotopy report の位置づけ
+- `docs/tool/law_policy.md`: homotopy / filler / loop measurement policy
+- `docs/tool/archsig_analysis_packet.md`: ArchitectureHomotopyReport の読み方
+- `tools/archsig/skills/law-policy-creater`: homotopy measurement profile の LLM-native 構成
+- `tools/archsig/skills/archsig-reader`: ArchitectureHomotopyReport の LLM-native 読み取り
+- website / public manual: public surface に出す場合の reading guide
+
+AAT 数学本文では、tool implementation status、Issue 番号、fixture 詳細を混ぜない。
+tool docs では、AAT theorem と ArchSig report reading を混同しない。
+
+### R12. Non-conclusions を report と docs に残す
+
+ArchSig は、homotopy report に次の non-conclusions を必ず含める。
+
+- Homotopy report は architecture object の全構造を復元しない
+- unmeasured path は flat / equivalent ではない
+- missing filler は violation proof ではない
+- unfilled loop は architectural hole reading であり defect absence でも defect proof でもない
+- nonzero holonomy は selected-axis observation difference であり future incident proof ではない
+- filled loop の nonzero holonomy から local curvature を読むには measured filling と assumptions が必要
+- `beta1` / hole rank reading は selected measured complex に相対化される
+- ArchSig report は Lean theorem discharge ではない
+
+### R13. Validation fixture を用意する
+
+ArchSig は、最小 fixture で ArchitectureHomotopyReport を安定して出力できなければならない。
+
+必要な fixture は次である。
+
+- zero holonomy filled loop fixture
+- nonzero holonomy filled loop fixture
+- unfilled architectural hole fixture
+- cache / repository semantic loop fixture
+- event projection / direct read consistency fixture
+- retry / idempotency effect fixture
+- authorization bypass hole fixture
+- coupon / tax / rounding semantic loop fixture
+
+Validation は schema shape、non-conclusions、coverage boundary、path refs、
+filler refs、missing filler refs、holonomy refs、local curvature refs を確認する。
+Validation は architecture lawfulness や Lean theorem discharge を証明しない。
+
+## スコープ
+
+この PRD のスコープ内:
+
+- ArchSig analysis packet に ArchitectureHomotopyReport を追加する。
+- finite measured path pair / loop / filler family から homotopy reading を出す。
+- filled loop と unfilled loop を分離する。
+- nonzero holonomy と missing filler evidence を report に出す。
+- measured filling がある loop について Stokes-style review reading を出す。
+- optional aggregate reading として `beta1`, `HolMass`, `FillRatio`, `CurvedFillMass`, `HoleHolonomy` を扱う。
+- codebase inspection surface で homotopy report を読めるようにする。
+- `tools/archsig/skills/law-policy-creater` が homotopy measurement profile を LLM-native に構成できるようにする。
+- `tools/archsig/skills/archsig-reader` が ArchitectureHomotopyReport を読めるようにする。
+- Lean 側に minimal theorem guardrail を追加する。
+- AAT 数学本文、AAT proof obligation / theorem index、tool docs、必要な website surface を同期する。
+
+この PRD のスコープ外:
+
+- ArchMap を law-relative artifact に変更する。
+- ArchSig を Lean 証明器にする。
+- raw source から完全な cell complex を自動抽出する。
+- PR diff / FieldSig longitudinal forecast を HomotopyReport だけで置き換える。
+- 完全な sheaf / Hodge / homology library を最初から実装する。
+- empirical incident risk、review cost、future safety の calibration をこの PRD で完了する。
+
+## Non-Goals
+
+- Homotopy report を単一の architecture quality score にすること。
+- selected measured complex の `beta1` を repository 全体の真の topology として扱うこと。
+- unfilled loop を無条件に violation として扱うこと。
+- missing evidence を defect absence として扱うこと。
+- nonzero holonomy から unmeasured axes の obstruction を結論すること。
+- filled loop でないものに Stokes-style local curvature conclusion を出すこと。
+- ArchMap に filler conclusion、homology rank、holonomy judgement、flatness judgement を保存すること。
+- 一般の engineer に law / witness / distance / exactness / chain complex の詳細設計を要求すること。
+- LLM が source evidence や user decision なしに selected law / filler law を発明すること。
+- Lean で ArchSig implementation correctness や extractor completeness を証明すること。
+- AAT 数学本文に tool の実装状況、fixture、CLI 詳細を混ぜること。
+
+## Acceptance Criteria / 完了条件
+
+- ArchitectureHomotopyReport が schema として表現できる。
+- ArchSig が supplied ArchMap + LawPolicy から ArchitectureHomotopyReport を生成できる。
+- Report に selected axes、path pairs、loops、filled loops、unfilled loops、filler candidates、
+  nonzero holonomy loops、top local curvature cells、missing filler evidence、non-conclusions が含まれる。
+- Report から、同じ意味へ行く複数 path の selected-axis 差、architectural hole、
+  missing filler、local curvature candidate、次の action を読める。
+- ACTS / spectrum report とは別に、homotopy / filler / hole / Stokes-style reading として責務が分かれている。
+- `tools/archsig/skills/law-policy-creater` が homotopy measurement profile を
+  human intent、repository evidence、ArchMap から LLM-native に構成できる。
+- `tools/archsig/skills/archsig-reader` が ArchitectureHomotopyReport を読み、
+  LLM が bounded architecture reading と next action を説明できる。
+- 一般の engineer は chain complex、homology、distance、exactness の詳細を設計せず、
+  analysis goal、risk focus、source scope、normative evidence、除外条件を指定すればよい。
+- Filled loop の nonzero holonomy reading は、measured filling と Stokes-style assumptions に限定される。
+- Unfilled loop は violation proof ではなく architectural hole と missing filler evidence として出る。
+- zero holonomy fixture、nonzero holonomy filled loop fixture、unfilled hole fixture、
+  cache / repository fixture、event projection fixture、retry / idempotency fixture、
+  authorization fixture が追加される。
+- ArchSig validation test が schema shape、refs、coverage boundary、non-conclusions を確認する。
+- Lean 側に minimal theorem guardrail が追加され、`lake build` が通る。
+- `docs/aat/proof_obligations.md` と `docs/aat/lean_theorem_index.md` が Lean 追加分と claim boundary を反映する。
+- AAT 数学本文が Homotopy-Holonomy Stokes の位置づけを、実装状況ではなく理論的 reading として反映する。
+- `docs/tool/README.md`、`docs/tool/law_policy.md`、`docs/tool/archsig_analysis_packet.md` が HomotopyReport を説明する。
+- public website / manual に出す場合は、homotopy report の読み方と non-conclusions が同期される。
+- `cargo test --manifest-path tools/archsig/Cargo.toml` が通る。
+- Lean 変更を含む場合は `lake build` が通る。
+- `git diff --check` と hidden / bidirectional Unicode scan が通る。


### PR DESCRIPTION
## 概要

ArchSig の新しい計測面として、Curvature / Transfer Spectrum と Homotopy / Holonomy Stokes の2つのPRDを追加します。あわせて、元 note を docs/note に追加し、docs/tool/README.md から新PRDへリンクしました。

対象 Issue: なし

## 証明した定理

- なし

## 編集したドキュメント

- docs/note/curvature_transfer_spectrum_theorem.md
- docs/note/homotopy_holonomy_stokes.md
- docs/tool/archsig_curvature_transfer_spectrum_prd.md
- docs/tool/archsig_homotopy_holonomy_stokes_prd.md
- docs/tool/README.md

## 実施したテスト

- [ ] `lake build`（未実施: docs/note と PRD のみ）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（未実施: Rust 実装変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（未実施: FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（未実施: Lean source 変更なし）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない