### PR TITLE
LawPolicyにspectrumMeasurementProfileを追加

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -9,7 +9,8 @@ ArchMap
   records law-independent Atom observations.
 
 InterpretationProfile
-  selects the LawUniverse, witness rules, signature axes, coverage, and exactness.
+  selects the LawUniverse, witness rules, signature axes, coverage, exactness,
+  and optional spectrum measurement profile.
   The current JSON artifact is still named law-policy-v0 for the profile input.
 
 ArchSig Analysis Packet
@@ -290,8 +291,9 @@ The builder:
 - emits operation deltas and path / homotopy / diagram readings for repair
   planning and review focus
 - fills child-level `missingEvidence` / `excludedReadings` from ArchMap
-  observation gaps, interpretation-profile coverage and exactness assumptions, selected
-  witness rules, and repair-candidate evidence limits
+  observation gaps, interpretation-profile coverage, exactness assumptions,
+  selected witness rules, optional spectrum measurement boundaries, and
+  repair-candidate evidence limits
 
 ## Downstream Handoff
 

--- a/docs/tool/law_policy.md
+++ b/docs/tool/law_policy.md
@@ -11,8 +11,8 @@ ArchMap
 
 InterpretationProfile
   selects laws, witness rules, molecule patterns, obstruction definitions,
-  signature axes, monodromy measurement policy, coverage requirements, and
-  exactness assumptions.
+  signature axes, measurement policy, optional spectrum measurement profile,
+  coverage requirements, and exactness assumptions.
 
 ArchSig
   reads ArchMap + InterpretationProfile and computes the AAT analysis packet.
@@ -49,6 +49,7 @@ The implemented schema records:
 - `obstructionCircuitDefinitions`
 - `signatureAxisDefinitions`
 - `measurementPolicy`
+- `spectrumMeasurementProfile` (optional)
 - `exactnessAssumptions`
 - `coverageRequirements`
 - `excludedReadings`
@@ -89,6 +90,44 @@ The policy selects how ArchSig reads structural telemetry; it does not authorize
 FieldSig forecast, governance, calibration, or longitudinal evolution claims.
 FieldSig may consume ArchSig packet chains downstream, but it owns those
 evolution readings separately from this profile.
+
+## Spectrum Measurement Profile
+
+`spectrumMeasurementProfile` is an optional subobject inside `law-policy-v0`.
+It is used by the Curvature / Transfer Spectrum reading family. It does not
+select a different law universe and does not make ArchMap law-relative.
+
+The profile records the measurement recipe for ACTS-style readings:
+
+- `profileId`
+- `selectedAxisRefs`
+- `measuredWitnessRuleRefs`
+- `distanceKinds`
+- `weightPolicy`
+- `supportProjectionRule`
+- `transferEdgeRule`
+- `clusteringRankingOptions`
+- `reportFocusOptions`
+- `coverageRequirementRefs`
+- `coverageBoundary`
+- `exactnessAssumptionRefs`
+- `measurementBoundary`
+- `nonConclusions`
+
+Changing `spectrumMeasurementProfile` changes how ArchSig ranks, clusters, and
+reports selected curvature / transfer telemetry. It does not change which laws
+are selected. If a profile wants to treat a different architecture expectation
+as law, that expectation must be represented in `selectedLaws`, witness rules,
+axes, coverage requirements, and exactness assumptions instead.
+
+Validation checks that profile refs resolve to known axes, witness rules, and
+coverage requirements, and that profile-level non-conclusions remain explicit.
+Important boundaries:
+
+- profile differences are not law-universe differences
+- unmeasured axes are not zero
+- spectrum zero requires coverage, exactness, and zero-reflection assumptions
+- spectrum readings are bounded ArchSig diagnostics, not Lean theorem discharge
 
 Validation does not imply:
 

--- a/tools/archsig/src/law_policy.rs
+++ b/tools/archsig/src/law_policy.rs
@@ -6,7 +6,8 @@ use crate::{
     LawPolicyAxisDefinitionV0, LawPolicyCoverageRequirementV0, LawPolicyDocumentV0,
     LawPolicyMeasurementPolicyV0, LawPolicyMoleculePatternV0,
     LawPolicyObstructionCircuitDefinitionV0, LawPolicySelectedLawV0,
-    LawPolicySignatureAxisDefinitionV0, LawPolicyValidationInputV0, LawPolicyValidationReportV0,
+    LawPolicySignatureAxisDefinitionV0, LawPolicySpectrumDistanceKindV0,
+    LawPolicySpectrumMeasurementProfileV0, LawPolicyValidationInputV0, LawPolicyValidationReportV0,
     LawPolicyValidationSummaryV0, LawPolicyWitnessRuleV0, ValidationCheck, ValidationExample,
 };
 
@@ -16,6 +17,13 @@ const REQUIRED_NON_CONCLUSIONS: [&str; 5] = [
     "law policy validation does not certify atom truth",
     "missing coverage is not measured zero",
     "signature zero requires ArchSig analysis with declared coverage and exactness assumptions",
+];
+
+const REQUIRED_SPECTRUM_PROFILE_NON_CONCLUSIONS: [&str; 4] = [
+    "spectrum measurement profile is a measurement recipe, not a law universe",
+    "profile differences are not law universe differences",
+    "unmeasured axes are not zero",
+    "spectrum zero requires coverage, exactness, and zero-reflection assumptions",
 ];
 
 pub fn static_law_policy() -> LawPolicyDocumentV0 {
@@ -160,6 +168,55 @@ pub fn static_law_policy() -> LawPolicyDocumentV0 {
             ],
             non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
         },
+        spectrum_measurement_profile: Some(LawPolicySpectrumMeasurementProfileV0 {
+            profile_id: "spectrum-profile:curvature-transfer-default".to_string(),
+            selected_axis_refs: vec![
+                "axis:layer-violation".to_string(),
+                "axis:semantic-inconsistency".to_string(),
+            ],
+            measured_witness_rule_refs: vec![
+                "witness:layer-violation".to_string(),
+                "witness:semantic-contract-mismatch".to_string(),
+            ],
+            distance_kinds: vec![
+                LawPolicySpectrumDistanceKindV0 {
+                    axis_ref: "axis:layer-violation".to_string(),
+                    distance_kind: "boolean-mismatch".to_string(),
+                },
+                LawPolicySpectrumDistanceKindV0 {
+                    axis_ref: "axis:semantic-inconsistency".to_string(),
+                    distance_kind: "semantic-witness-mismatch-count".to_string(),
+                },
+            ],
+            weight_policy: "unit weights until repo-specific calibration is declared".to_string(),
+            support_projection_rule:
+                "project witness support to observed Atom refs and selected axis ids".to_string(),
+            transfer_edge_rule:
+                "construct transfer edges only from measured witness support overlap under selected axes"
+                    .to_string(),
+            clustering_ranking_options: vec![
+                "rank top curvature modes by weighted measured curvature".to_string(),
+                "rank recurrent modes only inside the selected measured support x axis state space"
+                    .to_string(),
+            ],
+            report_focus_options: vec![
+                "surface top modes with witness refs, source refs, coverage gaps, and non-conclusions"
+                    .to_string(),
+            ],
+            coverage_requirement_refs: vec![
+                "coverage:layer-atoms".to_string(),
+                "coverage:semantic-contract-atoms".to_string(),
+            ],
+            coverage_boundary:
+                "missing coverage blocks spectrum zero reflection and remains a report gap".to_string(),
+            exactness_assumption_refs: vec![
+                "selected LawPolicy exactness assumptions".to_string(),
+            ],
+            measurement_boundary:
+                "curvature-transfer spectrum readings are bounded ArchSig diagnostics, not theorem discharge"
+                    .to_string(),
+            non_conclusions: strings(&REQUIRED_SPECTRUM_PROFILE_NON_CONCLUSIONS),
+        }),
         exactness_assumptions: vec![
             "the selected witness rules cover only policy-declared laws".to_string(),
             "zero readings are exact only for observed atoms and declared coverage requirements"
@@ -205,6 +262,7 @@ pub fn validate_law_policy_report(
         check_witness_and_obstruction_boundaries(policy),
         check_coverage_and_exactness(policy),
         check_measurement_policy(policy),
+        check_spectrum_measurement_profile(policy),
         check_non_conclusions(policy),
     ];
     let summary = LawPolicyValidationSummaryV0 {
@@ -329,6 +387,175 @@ fn check_measurement_policy(policy: &LawPolicyDocumentV0) -> ValidationCheck {
     check_from_examples(
         "law-policy-monodromy-measurement-policy",
         "LawPolicy declares selected axes, distance, weight, coverage, and ArchMapStore ref kinds for monodromy readings",
+        examples,
+        "fail",
+    )
+}
+
+fn check_spectrum_measurement_profile(policy: &LawPolicyDocumentV0) -> ValidationCheck {
+    let Some(profile) = &policy.spectrum_measurement_profile else {
+        return validation_check(
+            "law-policy-spectrum-measurement-profile",
+            "optional spectrum measurement profile is absent; LawPolicy remains valid without ACTS readings",
+            "pass",
+        );
+    };
+
+    let axis_ids = policy
+        .required_zero_axes
+        .iter()
+        .chain(policy.optional_axes.iter())
+        .map(|axis| axis.axis_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let signature_axis_ids = set(policy
+        .signature_axis_definitions
+        .iter()
+        .map(|axis| axis.signature_axis_id.as_str()));
+    let witness_ids = set(policy
+        .witness_rules
+        .iter()
+        .map(|rule| rule.witness_rule_id.as_str()));
+    let coverage_ids = set(policy
+        .coverage_requirements
+        .iter()
+        .map(|requirement| requirement.coverage_requirement_id.as_str()));
+    let present_non_conclusions = profile
+        .non_conclusions
+        .iter()
+        .map(|value| value.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = Vec::new();
+
+    push_blank(
+        &mut examples,
+        "spectrumMeasurementProfile.profileId",
+        &profile.profile_id,
+    );
+    if profile.selected_axis_refs.is_empty() {
+        examples.push(generic_validation_example(
+            &profile.profile_id,
+            "selectedAxisRefs",
+            "spectrum profile must select axes for curvature support readings",
+        ));
+    }
+    for axis_ref in &profile.selected_axis_refs {
+        if !axis_ids.contains(axis_ref.as_str()) && !signature_axis_ids.contains(axis_ref.as_str())
+        {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                axis_ref,
+                "spectrum profile selectedAxisRefs must reference known axes or signature axes",
+            ));
+        }
+    }
+    if profile.measured_witness_rule_refs.is_empty() {
+        examples.push(generic_validation_example(
+            &profile.profile_id,
+            "measuredWitnessRuleRefs",
+            "spectrum profile must declare measured witness rule refs",
+        ));
+    }
+    for witness_ref in &profile.measured_witness_rule_refs {
+        if !witness_ids.contains(witness_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                witness_ref,
+                "spectrum profile measuredWitnessRuleRefs must reference known witness rules",
+            ));
+        }
+    }
+    if profile.distance_kinds.is_empty() {
+        examples.push(generic_validation_example(
+            &profile.profile_id,
+            "distanceKinds",
+            "spectrum profile must declare at least one axis distance kind",
+        ));
+    }
+    for distance in &profile.distance_kinds {
+        if !axis_ids.contains(distance.axis_ref.as_str())
+            && !signature_axis_ids.contains(distance.axis_ref.as_str())
+        {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                &distance.axis_ref,
+                "spectrum distanceKinds[].axisRef must reference known axes or signature axes",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("spectrum distance kind for {}", distance.axis_ref),
+            &distance.distance_kind,
+        );
+    }
+    push_blank(
+        &mut examples,
+        "spectrumMeasurementProfile.weightPolicy",
+        &profile.weight_policy,
+    );
+    push_blank(
+        &mut examples,
+        "spectrumMeasurementProfile.supportProjectionRule",
+        &profile.support_projection_rule,
+    );
+    push_blank(
+        &mut examples,
+        "spectrumMeasurementProfile.transferEdgeRule",
+        &profile.transfer_edge_rule,
+    );
+    if profile.coverage_requirement_refs.is_empty() {
+        examples.push(generic_validation_example(
+            &profile.profile_id,
+            "coverageRequirementRefs",
+            "spectrum profile must reference coverage requirements",
+        ));
+    }
+    for coverage_ref in &profile.coverage_requirement_refs {
+        if !coverage_ids.contains(coverage_ref.as_str()) {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                coverage_ref,
+                "spectrum profile coverageRequirementRefs must reference known coverage requirements",
+            ));
+        }
+    }
+    push_blank(
+        &mut examples,
+        "spectrumMeasurementProfile.coverageBoundary",
+        &profile.coverage_boundary,
+    );
+    if profile.exactness_assumption_refs.is_empty() || has_blank(&profile.exactness_assumption_refs)
+    {
+        examples.push(generic_validation_example(
+            &profile.profile_id,
+            "exactnessAssumptionRefs",
+            "spectrum profile must record exactness assumption refs",
+        ));
+    }
+    push_blank(
+        &mut examples,
+        "spectrumMeasurementProfile.measurementBoundary",
+        &profile.measurement_boundary,
+    );
+    if profile.non_conclusions.is_empty() || has_blank(&profile.non_conclusions) {
+        examples.push(generic_validation_example(
+            &profile.profile_id,
+            "nonConclusions",
+            "spectrum profile must keep non-conclusions explicit",
+        ));
+    }
+    for required in REQUIRED_SPECTRUM_PROFILE_NON_CONCLUSIONS {
+        if !present_non_conclusions.contains(required) {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                required,
+                "missing required spectrum profile non-conclusion",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "law-policy-spectrum-measurement-profile",
+        "LawPolicy keeps spectrum measurement recipes separate from the selected law universe",
         examples,
         "fail",
     )
@@ -994,6 +1221,39 @@ mod tests {
         assert_eq!(report.summary.result, "fail");
         assert!(report.checks.iter().any(|check| {
             check.id == "law-policy-monodromy-measurement-policy" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn invalid_spectrum_measurement_profile_fails() {
+        let mut policy = static_law_policy();
+        let profile = policy
+            .spectrum_measurement_profile
+            .as_mut()
+            .expect("fixture declares a spectrum profile");
+        profile.selected_axis_refs = vec!["axis:missing".to_string()];
+        profile.measured_witness_rule_refs = vec!["witness:missing".to_string()];
+        profile.coverage_requirement_refs.clear();
+        profile.non_conclusions.clear();
+
+        let report = validate_law_policy_report(&policy, "bad-law-policy.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "law-policy-spectrum-measurement-profile" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn absent_spectrum_measurement_profile_is_valid() {
+        let mut policy = static_law_policy();
+        policy.spectrum_measurement_profile = None;
+
+        let report = validate_law_policy_report(&policy, "law-policy-without-spectrum.json");
+
+        assert_eq!(report.summary.result, "pass");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "law-policy-spectrum-measurement-profile" && check.result == "pass"
         }));
     }
 

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -445,6 +445,8 @@ pub struct LawPolicyDocumentV0 {
     pub obstruction_circuit_definitions: Vec<LawPolicyObstructionCircuitDefinitionV0>,
     pub signature_axis_definitions: Vec<LawPolicySignatureAxisDefinitionV0>,
     pub measurement_policy: LawPolicyMeasurementPolicyV0,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spectrum_measurement_profile: Option<LawPolicySpectrumMeasurementProfileV0>,
     pub exactness_assumptions: Vec<String>,
     pub coverage_requirements: Vec<LawPolicyCoverageRequirementV0>,
     #[serde(default)]
@@ -468,6 +470,40 @@ pub struct LawPolicyMeasurementPolicyV0 {
     pub exactness_assumption_refs: Vec<String>,
     #[serde(default)]
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicySpectrumMeasurementProfileV0 {
+    pub profile_id: String,
+    #[serde(default)]
+    pub selected_axis_refs: Vec<String>,
+    #[serde(default)]
+    pub measured_witness_rule_refs: Vec<String>,
+    #[serde(default)]
+    pub distance_kinds: Vec<LawPolicySpectrumDistanceKindV0>,
+    pub weight_policy: String,
+    pub support_projection_rule: String,
+    pub transfer_edge_rule: String,
+    #[serde(default)]
+    pub clustering_ranking_options: Vec<String>,
+    #[serde(default)]
+    pub report_focus_options: Vec<String>,
+    #[serde(default)]
+    pub coverage_requirement_refs: Vec<String>,
+    pub coverage_boundary: String,
+    #[serde(default)]
+    pub exactness_assumption_refs: Vec<String>,
+    pub measurement_boundary: String,
+    #[serde(default)]
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicySpectrumDistanceKindV0 {
+    pub axis_ref: String,
+    pub distance_kind: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -55,10 +55,11 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                     "docs/tool/llm_native_archmap_archsig_prd.md",
                     "docs/tool/README.md",
                 ],
-                "The law-policy-v0 JSON contract is used as an interpretation profile: it selects laws, witness rules, molecule patterns, obstruction definitions, signature axes, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations. It is not the center of ArchSig output.",
+                "The law-policy-v0 JSON contract is used as an interpretation profile: it selects laws, witness rules, molecule patterns, obstruction definitions, signature axes, measurement policy, optional spectrum measurement profile, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations. It is not the center of ArchSig output.",
                 vec![
                     "Interpretation profile is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
                     "Adding a law family must preserve missing coverage as distinct from measured zero.",
+                    "Changing a spectrum measurement profile changes a measurement recipe, not the selected law universe.",
                 ],
             ),
             artifact(
@@ -68,7 +69,7 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "primary",
                 "LLM Atom ArchMap",
                 vec!["docs/tool/llm_native_archmap_archsig_prd.md"],
-                "LawPolicy validation checks schema support, identity, id uniqueness, law/witness/axis references, coverage, exactness, and non-conclusion guardrails.",
+                "LawPolicy validation checks schema support, identity, id uniqueness, law/witness/axis references, measurement policy, optional spectrum measurement profile refs, coverage, exactness, and non-conclusion guardrails.",
                 vec![
                     "Validation pass does not imply architecture lawfulness, certified atom truth, zero curvature, or Lean theorem discharge.",
                     "Policy validation is not a semantic-preservation theorem.",

--- a/tools/archsig/tests/fixtures/minimal/law_policy.json
+++ b/tools/archsig/tests/fixtures/minimal/law_policy.json
@@ -296,6 +296,52 @@
       "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
     ]
   },
+  "spectrumMeasurementProfile": {
+    "profileId": "spectrum-profile:curvature-transfer-default",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "measuredWitnessRuleRefs": [
+      "witness:layer-violation",
+      "witness:semantic-contract-mismatch"
+    ],
+    "distanceKinds": [
+      {
+        "axisRef": "axis:layer-violation",
+        "distanceKind": "boolean-mismatch"
+      },
+      {
+        "axisRef": "axis:semantic-inconsistency",
+        "distanceKind": "semantic-witness-mismatch-count"
+      }
+    ],
+    "weightPolicy": "unit weights until repo-specific calibration is declared",
+    "supportProjectionRule": "project witness support to observed Atom refs and selected axis ids",
+    "transferEdgeRule": "construct transfer edges only from measured witness support overlap under selected axes",
+    "clusteringRankingOptions": [
+      "rank top curvature modes by weighted measured curvature",
+      "rank recurrent modes only inside the selected measured support x axis state space"
+    ],
+    "reportFocusOptions": [
+      "surface top modes with witness refs, source refs, coverage gaps, and non-conclusions"
+    ],
+    "coverageRequirementRefs": [
+      "coverage:layer-atoms",
+      "coverage:semantic-contract-atoms"
+    ],
+    "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "measurementBoundary": "curvature-transfer spectrum readings are bounded ArchSig diagnostics, not theorem discharge",
+    "nonConclusions": [
+      "spectrum measurement profile is a measurement recipe, not a law universe",
+      "profile differences are not law universe differences",
+      "unmeasured axes are not zero",
+      "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -73,7 +73,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "The law-policy-v0 JSON contract is used as an interpretation profile: it selects laws, witness rules, molecule patterns, obstruction definitions, signature axes, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations. It is not the center of ArchSig output.",
+        "fieldMappingPolicy": "The law-policy-v0 JSON contract is used as an interpretation profile: it selects laws, witness rules, molecule patterns, obstruction definitions, signature axes, measurement policy, optional spectrum measurement profile, exactness assumptions, coverage requirements, excluded readings, and non-conclusions separately from ArchMap observations. It is not the center of ArchSig output.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",
@@ -84,7 +84,8 @@
         ],
         "nonConclusions": [
           "Interpretation profile is selected analysis policy, not AAT itself, architecture lawfulness, atom truth, or Lean theorem discharge.",
-          "Adding a law family must preserve missing coverage as distinct from measured zero."
+          "Adding a law family must preserve missing coverage as distinct from measured zero.",
+          "Changing a spectrum measurement profile changes a measurement recipe, not the selected law universe."
         ]
       }
     },
@@ -100,7 +101,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "LawPolicy validation checks schema support, identity, id uniqueness, law/witness/axis references, coverage, exactness, and non-conclusion guardrails.",
+        "fieldMappingPolicy": "LawPolicy validation checks schema support, identity, id uniqueness, law/witness/axis references, measurement policy, optional spectrum measurement profile refs, coverage, exactness, and non-conclusion guardrails.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",


### PR DESCRIPTION
## 概要

Closes #1505

- `law-policy-v0` に optional な `spectrumMeasurementProfile` を追加し、ACTS 向けの距離・重み・support projection・transfer edge・ranking・coverage / exactness 境界を LawPolicy 側で表現できるようにしました。
- profile refs / coverage boundary / non-conclusions を検証する validation を追加し、profile 差分を law universe 差分として扱わない境界を docs と schema catalog に明記しました。
- ArchMap には law-relative field を追加していません。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/law_policy.md`
- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（変更ファイル対象、該当なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `defined only` / tooling schema として扱っている
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない