### PR TITLE
ArchSig skillsをArchitectureSpectrumReportに対応

### DIFF
--- a/tools/archsig/skills/archsig-reader/SKILL.md
+++ b/tools/archsig/skills/archsig-reader/SKILL.md
@@ -115,6 +115,10 @@ Read in this order:
    - Treat coverage gaps as unknown remainder, not measured zero.
 
 4. Dominant pressure
+   - Read `architectureSpectrumReport` before building the review queue when present.
+   - Prioritize `topHotspots[]`, `recurrentObstructions[]`, `topWitnessClusters[]`, `coverageGaps[]`, `measuredBoundary`, and `recommendedReviewFocus[]`.
+   - Treat the report as a codebase-inspection surface over current ArchSig measurements, not a quality score, forecast, or repair proof.
+   - Preserve report-level `nonConclusions[]` when summarizing.
    - Read top `workflowRiskReadings[]` by `riskScore`.
    - Read `spectralAnalysisReadings[]`, especially dominant workflow row, dominant axis column, molecule overlap hub, obstruction curvature, and operation delta coupling.
    - If workflow risk or spectral readings are empty, do not force a risk narrative. Shift to `signatureAxes[]`, `obstructionCircuits[]`, `repairOperationCandidates[]`, `operationDeltas[]`, and coverage gaps.
@@ -139,6 +143,9 @@ Read in this order:
 Always compare high-priority readings against real source evidence before proposing changes.
 
 1. Select a small review queue:
+   - top ArchitectureSpectrumReport hotspots with witness refs and coverage gaps
+   - recurrent obstruction entries with transfer edge refs
+   - top witness clusters that connect several axes or support refs
    - top 2-4 workflow risk molecules
    - transfer bridge edges with high `reviewRisk`
    - low split-readiness molecules
@@ -186,6 +193,7 @@ Avoid:
 - "The architecture score is..."
 - "No risk exists because the axis is zero"
 - "ArchSig recommends this refactor automatically"
+- treating `ArchitectureSpectrumReport` as FieldSig forecast, future incident prediction, empirical cost amplification, or repair safety evidence
 
 ## Maintainer Validation
 

--- a/tools/archsig/skills/archsig-reader/agents/openai.yaml
+++ b/tools/archsig/skills/archsig-reader/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ArchSig Reader"
-  short_description: "Run ArchMap through ArchSig and interpret results"
-  default_prompt: "Use $archsig-reader to run an ArchMap through ArchSig, read the analysis packet, compare findings with source code, and propose improvements."
+  short_description: "Run ArchMap through ArchSig and read ArchitectureSpectrumReport"
+  default_prompt: "Use $archsig-reader to run an ArchMap through ArchSig, read ArchitectureSpectrumReport and other analysis packet surfaces, compare findings with source code, and propose bounded improvements."

--- a/tools/archsig/skills/archsig-reader/references/default_law_policy.json
+++ b/tools/archsig/skills/archsig-reader/references/default_law_policy.json
@@ -268,6 +268,80 @@
       ]
     }
   ],
+  "measurementPolicy": {
+    "policyId": "measurement:archsig-reader-default",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "distanceKind": "witness-mismatch-count",
+    "weightPolicy": "unit weights for bundled smoke-test baseline only",
+    "coveragePolicy": "coverage gaps block signature-zero and spectrum-zero reflection",
+    "archMapStoreRefKinds": [
+      "archmap-delta",
+      "archmap-commit",
+      "archmap-snapshot",
+      "archmap-index"
+    ],
+    "measurementBoundary": "finite ArchSig measurement over observed ArchMap atoms and bundled baseline axes, not project-specific architecture diagnosis",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "nonConclusions": [
+      "law policy is selected analysis policy, not AAT itself",
+      "law policy validation does not prove architecture lawfulness",
+      "law policy validation does not certify atom truth",
+      "missing coverage is not measured zero",
+      "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+    ]
+  },
+  "spectrumMeasurementProfile": {
+    "profileId": "spectrum-profile:archsig-reader-default",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "measuredWitnessRuleRefs": [
+      "witness:layer-violation",
+      "witness:semantic-contract-mismatch"
+    ],
+    "distanceKinds": [
+      {
+        "axisRef": "axis:layer-violation",
+        "distanceKind": "boolean-mismatch"
+      },
+      {
+        "axisRef": "axis:semantic-inconsistency",
+        "distanceKind": "semantic-witness-mismatch-count"
+      }
+    ],
+    "weightPolicy": "unit weights for bundled smoke-test baseline only",
+    "supportProjectionRule": "project measured witness support to observed Atom refs and selected axis ids",
+    "transferEdgeRule": "construct transfer edges only from measured witness support overlap under selected axes",
+    "clusteringRankingOptions": [
+      "rank top curvature modes by weighted measured curvature",
+      "rank recurrent modes only inside the selected measured support x axis state space"
+    ],
+    "reportFocusOptions": [
+      "surface top modes with witness refs, source refs, coverage gaps, measured boundary, and non-conclusions"
+    ],
+    "coverageRequirementRefs": [
+      "coverage:layer-atoms",
+      "coverage:semantic-contract-atoms"
+    ],
+    "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "measurementBoundary": "curvature-transfer spectrum readings are bounded ArchSig smoke-test diagnostics, not project-specific theorem discharge",
+    "nonConclusions": [
+      "spectrum measurement profile is a measurement recipe, not a law universe",
+      "profile differences are not law universe differences",
+      "ArchitectureSpectrumReport is not a single architecture quality score",
+      "unmeasured axes are not zero",
+      "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"

--- a/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
+++ b/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
@@ -11,6 +11,7 @@ Use this reference when deciding what to read first in an `archsig-analysis-pack
 | `signatureAxes[]` | Gives axis-local support refs, missing evidence, exactness assumptions, and excluded readings. |
 | `workflowRiskReadings[]` | Prioritizes molecule-local review pressure such as permission, LLM mediation, state/effect reconciliation, and domain cohesion. |
 | `spectralAnalysisReadings[]` | Shows dominant rows/columns and coupling surfaces across workflows, molecules, obstructions, and operation deltas. |
+| `architectureSpectrumReport` | Primary ACTS codebase-inspection surface: top hotspots, bounded mode data, witness clusters, recurrent obstruction entries, coverage gaps, measured boundary, review focus, and report non-conclusions. |
 | `transferBridgeReadings[]` | Connects repair transfer axes, molecule overlap paths, bridge edge source refs, review focus, and boundary preparation. |
 | `splitReadinessReadings[]` | Shows which molecules are blocked by bridge edges or need boundary preparation before feature extraction or refactoring. |
 | `structuralReadingReviewSurface` | Summarizes AAT structural review surfaces across representation, curvature, projection, state algebra, Galois, and split readiness. |
@@ -22,6 +23,11 @@ Use this reference when deciding what to read first in an `archsig-analysis-pack
 Do not treat LawPolicy as a harmless default. It defines the selected law universe, witness rules, signature axes, exactness assumptions, and coverage requirements. Changing LawPolicy changes what ArchSig can read as obstruction, nonzero axis, flatness pressure, repair candidate, or non-conclusion.
 
 Use a project-specific LawPolicy for real analysis. If only the bundled `default_law_policy.json` is available, use it only as an explicit generic baseline / smoke test and label the result that way. A bundled baseline run can show that the toolchain and packet-reading workflow work; it should not be presented as the repository's intended architecture law analysis.
+
+For ACTS readings, confirm that the selected LawPolicy contains
+`spectrumMeasurementProfile`. If it is absent, report that
+`ArchitectureSpectrumReport` may be absent and do not infer spectrum hotspots
+from generic spectral fields.
 
 ## Interpreting Status
 
@@ -57,6 +63,9 @@ For source comparison in this variant, build the review queue from nonzero axes,
 | `sourceBackedDomainCohesion` | domain identity, source relations, contracts | explicit interface / model relationship audit |
 | high molecule overlap | shared atom refs and source refs | split only after boundary preparation |
 | nonzero operation transfer | operation delta touches non-target axes | avoid local repair that transfers complexity |
+| `architectureSpectrumReport.topHotspots[]` | hotspot witness refs, support refs, coverage gaps | review current-state hotspot before repair planning |
+| `architectureSpectrumReport.recurrentObstructions[]` | transfer edge refs and witness support | inspect recurrence as bounded current-state diagnostic |
+| `architectureSpectrumReport.coverageGaps[]` | missing docs, traces, tests, or source refs | collect evidence before reading absent support as zero |
 
 ## Source Comparison Checklist
 

--- a/tools/archsig/skills/law-policy-creater/SKILL.md
+++ b/tools/archsig/skills/law-policy-creater/SKILL.md
@@ -28,6 +28,8 @@ Collect:
 - ArchMap path if available
 - repository docs or coding convention files
 - user goal: strict review, baseline diagnosis, release gate, migration planning, subsystem-specific analysis, or exploratory research
+- human intent for ACTS readings: what architectural pressure should be measured, which review decision the spectrum report should support, and which claims must be excluded
+- repository evidence for ACTS: source refs, docs, tests, traces, ArchMap observations, selected axes, witness rules, and known coverage gaps
 
 If no output path is supplied, prefer `.archsig/<scope>/law_policy.json` next to the ArchMap.
 
@@ -52,6 +54,16 @@ Classify evidence:
 - **Missing**: no repo evidence.
 
 Only normative or explicitly user-approved conventions should become selected laws. Conventional or observed-only evidence can become coverage requirements, review assumptions, or question prompts.
+
+For ACTS / spectrum work, do not ask the user to hand-author a large JSON profile. Build the profile from:
+
+- human intent: which review decision the report should support
+- repository evidence: docs, source refs, tests, traces, and ArchMap observations
+- selected laws and axes: only repo/user-approved rules become law obligations
+- inferred measurement fields: selected axis refs, measured witness rule refs, distance kinds, weight policy, support projection, transfer edge rule, clustering/ranking, report focus
+- unresolved questions: missing law approval, missing source evidence, missing runtime traces, uncalibrated weights, or ambiguous zero-reflection assumptions
+
+Keep these as explicit authoring notes in the delivery, and encode them in the LawPolicy fields that carry scope, descriptions, coverage boundaries, exactness assumptions, excluded readings, and non-conclusions. Do not add ad hoc top-level JSON fields outside `law-policy-v0`.
 
 ## Ask When Docs Are Missing
 
@@ -97,10 +109,22 @@ Record user answers as source evidence in the LawPolicy scope or in an accompany
    - Missing coverage must report a gap and block zero-reflection.
    - Add exactness assumptions that limit witness completeness.
 
-7. Add non-conclusions.
+7. Define measurement policy and ACTS spectrum profile.
+   - `measurementPolicy` selects the axis set, distance kind, weight policy, ArchMapStore ref kinds, measurement boundary, exactness assumptions, and non-conclusions for general ArchSig readings.
+   - Add `spectrumMeasurementProfile` when the user wants Architecture Curvature Transfer Spectrum / ArchitectureSpectrumReport readings.
+   - Select `selectedAxisRefs` from LawPolicy axes, not from a desired finding.
+   - Select `measuredWitnessRuleRefs` from witness rules that are backed by repo/user-approved laws.
+   - Choose `distanceKinds[]` per axis, such as boolean mismatch, witness mismatch count, support overlap, or project-specific calibrated distance.
+   - Keep `weightPolicy` conservative unless calibration evidence exists. Prefer unit weights or explicitly bounded weights over invented severity scores.
+   - Use `supportProjectionRule` to explain how witness support is projected to Atom refs and selected axes.
+   - Use `transferEdgeRule` to explain when transfer edges may be constructed. Do not use source proximity alone as transfer evidence unless the user/repo selected that rule.
+   - Use `clusteringRankingOptions` and `reportFocusOptions` to state how ArchSig should surface top modes, witness clusters, coverage gaps, and review focus.
+   - Preserve unmeasured axes and missing evidence as coverage gaps. Do not treat absent support as zero.
+
+8. Add non-conclusions.
    - Preserve these boundaries: LawPolicy is selected analysis policy, not AAT itself; validation does not prove architecture lawfulness or atom truth; missing coverage is not measured zero; signature zero requires ArchSig analysis with coverage and exactness assumptions.
 
-8. Validate.
+9. Validate.
    - Run `archsig law-policy`.
    - Treat ArchSig validation as the authoritative schema, reference, uniqueness, coverage, exactness, and non-conclusion check.
 
@@ -131,11 +155,14 @@ When delivering a LawPolicy, include:
 
 1. LawPolicy path
 2. Evidence summary: docs read, conventions found, user answers used
-3. Selected laws and why they are in scope
-4. Signature axes and zero-reading boundaries
-5. Coverage requirements and exactness assumptions
-6. Open questions / unresolved policy decisions
-7. Validation result
+3. Intent summary: review decision, ACTS measurement goal, and excluded claims
+4. Selected laws and why they are in scope
+5. Signature axes and zero-reading boundaries
+6. `spectrumMeasurementProfile`: selected axes, witness rules, distance kinds, support projection, transfer edge rule, ranking/report focus, coverage boundary
+7. Inferred fields and evidence used for each inference
+8. Coverage requirements and exactness assumptions
+9. Open questions / unresolved policy decisions
+10. Validation result
 
 Use concise Japanese when working in this repository.
 
@@ -143,6 +170,7 @@ Avoid:
 
 - using a generic policy as project analysis
 - turning current code shape into law without docs or user approval
+- inventing selected laws, selected axes, distance kinds, weights, or transfer rules without repo evidence, ArchMap evidence, or explicit user intent
 - treating LawPolicy validation as architecture lawfulness
 - treating absent evidence as measured zero
 - mixing FieldSig forecast / governance claims into ArchSig LawPolicy

--- a/tools/archsig/skills/law-policy-creater/agents/openai.yaml
+++ b/tools/archsig/skills/law-policy-creater/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LawPolicy Creater"
-  short_description: "Create ArchSig LawPolicy artifacts"
-  default_prompt: "Use $law-policy-creater to derive a law-policy-v0 artifact from repository conventions, ask for missing architecture decisions, and validate the result."
+  short_description: "Create ArchSig LawPolicy and ACTS spectrum profiles"
+  default_prompt: "Use $law-policy-creater to derive a law-policy-v0 artifact and optional spectrumMeasurementProfile from repository conventions, human intent, ArchMap evidence, unresolved questions, and non-conclusions; validate the result."

--- a/tools/archsig/skills/law-policy-creater/references/question-bank.md
+++ b/tools/archsig/skills/law-policy-creater/references/question-bank.md
@@ -44,3 +44,14 @@ Ask only the questions needed for the target scope. Prefer 3-6 high-signal quest
 - What evidence is required for zero-reading to be meaningful?
 - Which evidence is unavailable and must remain an observation gap?
 - Which claims must the policy explicitly exclude?
+
+## ACTS / Spectrum Profile
+
+- Which review decision should `ArchitectureSpectrumReport` support: hotspot triage, split planning, migration planning, release review, or evidence-gap discovery?
+- Which selected axes should enter `spectrumMeasurementProfile.selectedAxisRefs`, and what repo/user-approved law justifies each axis?
+- Which witness rules are measured, and what ArchMap atom families or source refs support those witnesses?
+- Which distance kinds are defensible for each axis: boolean mismatch, witness mismatch count, support overlap, calibrated severity, or another project-defined distance?
+- Are weights unit weights, bounded ordinal weights, or calibrated from repository evidence?
+- What should count as transfer evidence: shared witness support, shared Atom refs, shared molecule support, runtime trace overlap, or an explicitly documented dependency relation?
+- What should the report rank first: nonzero hotspots, recurrent obstruction modes, witness clusters, coverage gaps, or boundary-preparation actions?
+- Which missing docs, tests, traces, logs, or source refs should block zero-reflection and remain unresolved questions?

--- a/tools/archsig/skills/law-policy-creater/references/schema-guide.md
+++ b/tools/archsig/skills/law-policy-creater/references/schema-guide.md
@@ -16,6 +16,8 @@ Use this guide when authoring `law-policy-v0`.
 - `moleculePatterns[]`
 - `obstructionCircuitDefinitions[]`
 - `signatureAxisDefinitions[]`
+- `measurementPolicy`
+- `spectrumMeasurementProfile` when ACTS / ArchitectureSpectrumReport readings are requested
 - `exactnessAssumptions[]`
 - `coverageRequirements[]`
 - `excludedReadings[]`
@@ -33,6 +35,66 @@ Use this guide when authoring `law-policy-v0`.
 - `signatureAxisDefinitions[].lawRef` must resolve to `selectedLaws[].lawId`.
 - `signatureAxisDefinitions[].axisRef` must resolve to an axis id.
 - `coverageRequirements[].appliesToLawRefs[]` must resolve to `selectedLaws[].lawId`.
+- `measurementPolicy.selectedAxisRefs[]` must resolve to axis ids.
+- `spectrumMeasurementProfile.selectedAxisRefs[]` must resolve to axis ids.
+- `spectrumMeasurementProfile.measuredWitnessRuleRefs[]` must resolve to `witnessRules[].witnessRuleId`.
+- `spectrumMeasurementProfile.distanceKinds[].axisRef` must resolve to an axis id.
+- `spectrumMeasurementProfile.coverageRequirementRefs[]` must resolve to `coverageRequirements[].coverageRequirementId`.
+
+## Measurement Policy
+
+`measurementPolicy` is the general finite measurement policy used by ArchSig.
+It is not an empirical calibration claim.
+
+Required fields:
+
+- `policyId`
+- `selectedAxisRefs[]`
+- `distanceKind`
+- `weightPolicy`
+- `coveragePolicy`
+- `archMapStoreRefKinds[]`
+- `measurementBoundary`
+- `exactnessAssumptionRefs[]`
+- `nonConclusions[]`
+
+Keep `selectedAxisRefs[]` aligned with selected law-backed axes. Use optional
+axes only when the user explicitly wants auxiliary review surfaces.
+
+## Spectrum Measurement Profile
+
+Use `spectrumMeasurementProfile` for ACTS / ArchitectureSpectrumReport.
+The profile is a measurement recipe over selected LawPolicy axes and witness
+rules; it is not a second law universe and not a quality score.
+
+Required fields:
+
+- `profileId`
+- `selectedAxisRefs[]`
+- `measuredWitnessRuleRefs[]`
+- `distanceKinds[]`: each item has `axisRef` and `distanceKind`
+- `weightPolicy`
+- `supportProjectionRule`
+- `transferEdgeRule`
+- `clusteringRankingOptions[]`
+- `reportFocusOptions[]`
+- `coverageRequirementRefs[]`
+- `coverageBoundary`
+- `exactnessAssumptionRefs[]`
+- `measurementBoundary`
+- `nonConclusions[]`
+
+Author the profile from human intent, repository evidence, and ArchMap
+evidence. Use conservative defaults when evidence is absent:
+
+- unit weights until project calibration is declared
+- witness mismatch counts before severity scores
+- transfer edges from measured witness support overlap, not source proximity alone
+- report focus on top modes, witness refs, source refs, coverage gaps, and non-conclusions
+
+Keep unresolved questions outside the JSON as delivery notes, and reflect their
+effect inside `coverageBoundary`, `exactnessAssumptionRefs`, `excludedReadings`,
+or `nonConclusions`.
 
 ## Common Law Families
 
@@ -75,5 +137,9 @@ Keep these ideas in every policy:
 - LawPolicy validation does not certify atom truth.
 - Missing coverage is not measured zero.
 - Signature zero requires ArchSig analysis with declared coverage and exactness assumptions.
+- Spectrum measurement profile is a measurement recipe, not a selected law universe.
+- Profile differences are not law universe differences.
+- ArchitectureSpectrumReport is not a single architecture quality score.
+- Unmeasured axes are not zero.
 
 Exact wording may vary, but the boundaries must remain clear.

--- a/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
+++ b/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
@@ -137,6 +137,72 @@
       ]
     }
   ],
+  "measurementPolicy": {
+    "policyId": "measurement:project-boundary-example",
+    "selectedAxisRefs": [
+      "axis:project-boundary-example"
+    ],
+    "distanceKind": "witness-mismatch-count",
+    "weightPolicy": "unit weights until project-specific calibration is declared",
+    "coveragePolicy": "coverage gaps block signature-zero and spectrum-zero reflection",
+    "archMapStoreRefKinds": [
+      "archmap-delta",
+      "archmap-commit",
+      "archmap-snapshot",
+      "archmap-index"
+    ],
+    "measurementBoundary": "finite ArchSig measurement over observed ArchMap atoms and selected LawPolicy axes, not theorem proof or empirical calibration",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "nonConclusions": [
+      "law policy is selected analysis policy, not AAT itself",
+      "law policy validation does not prove architecture lawfulness",
+      "law policy validation does not certify atom truth",
+      "missing coverage is not measured zero",
+      "signature zero requires ArchSig analysis with declared coverage and exactness assumptions"
+    ]
+  },
+  "spectrumMeasurementProfile": {
+    "profileId": "spectrum-profile:project-boundary-example",
+    "selectedAxisRefs": [
+      "axis:project-boundary-example"
+    ],
+    "measuredWitnessRuleRefs": [
+      "witness:project-boundary-example"
+    ],
+    "distanceKinds": [
+      {
+        "axisRef": "axis:project-boundary-example",
+        "distanceKind": "witness-mismatch-count"
+      }
+    ],
+    "weightPolicy": "unit weights until project-specific calibration is declared",
+    "supportProjectionRule": "project measured witness support to observed Atom refs and selected axis ids",
+    "transferEdgeRule": "construct transfer edges only from measured witness support overlap under selected axes",
+    "clusteringRankingOptions": [
+      "rank top curvature modes by weighted measured curvature",
+      "rank recurrent modes only inside the selected measured support x axis state space"
+    ],
+    "reportFocusOptions": [
+      "surface top modes with witness refs, source refs, coverage gaps, measured boundary, and non-conclusions"
+    ],
+    "coverageRequirementRefs": [
+      "coverage:project-boundary-example"
+    ],
+    "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "measurementBoundary": "curvature-transfer spectrum readings are bounded ArchSig diagnostics, not theorem discharge",
+    "nonConclusions": [
+      "spectrum measurement profile is a measurement recipe, not a law universe",
+      "profile differences are not law universe differences",
+      "ArchitectureSpectrumReport is not a single architecture quality score",
+      "unmeasured axes are not zero",
+      "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"


### PR DESCRIPTION
## 概要

Closes #1509

#1527 の ArchitectureSpectrumReport 実装に積む形で、LLM-native skill surface を更新しました。law-policy-creater は human intent / repository evidence / ArchMap evidence から ACTS 用の spectrumMeasurementProfile を構成する手順を持ち、archsig-reader は ArchitectureSpectrumReport を codebase-inspection の primary surface として読む導線を持ちます。

巨大 JSON の人間手書きを primary surface にせず、selected laws / axes / distance / weights / transfer rules を repo evidence、ArchMap evidence、または明示 user intent から構成する境界を明記しました。

## 証明した定理

- なし

## 編集したドキュメント

- tools/archsig/skills/law-policy-creater/SKILL.md
- tools/archsig/skills/law-policy-creater/references/schema-guide.md
- tools/archsig/skills/law-policy-creater/references/question-bank.md
- tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
- tools/archsig/skills/archsig-reader/SKILL.md
- tools/archsig/skills/archsig-reader/references/output-reading-guide.md
- tools/archsig/skills/archsig-reader/references/default_law_policy.json
- tools/archsig/skills/*/agents/openai.yaml

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [x] cargo test --manifest-path tools/archsig/Cargo.toml
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [x] axiom / admit / sorry / unsafe scan
- [x] cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy --input tools/archsig/skills/law-policy-creater/references/starter_law_policy.json --out /private/tmp/law-policy-creater-starter-validation.json
- [x] cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy --input tools/archsig/skills/archsig-reader/references/default_law_policy.json --out /private/tmp/archsig-reader-default-policy-validation.json
- [ ] skill-creator quick_validate.py（ローカル Python に PyYAML がなく ModuleNotFoundError: No module named 'yaml' のため未実施）

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を tooling skill guidance として扱っている
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## スタック

- base: codex/issue-1508-spectrum-report（#1527）