### PR TITLE
ACTS fixtureとgolden validationを追加

### DIFF
--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -17,6 +17,10 @@ fn coupon_rounding_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/coupon_rounding")
 }
 
+fn acts_spectrum_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/acts_spectrum")
+}
+
 fn inspection_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/inspection")
 }
@@ -615,6 +619,172 @@ fn coupon_tax_rounding_fixture_locks_semantic_monodromy() {
     );
     assert!(golden.to_string().contains("PaymentAmount"));
     assert!(golden.to_string().contains("ReceiptAmount"));
+}
+
+#[test]
+fn acts_spectrum_fixture_manifest_locks_golden_validation() {
+    let fixtures_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let manifest = read_json(&acts_spectrum_root().join("manifest.json"));
+    let cases = manifest["cases"]
+        .as_array()
+        .expect("ACTS fixture manifest has cases");
+
+    assert!(
+        manifest["nonConclusions"].as_array().is_some_and(|items| {
+            items.iter().any(|item| {
+                item.as_str()
+                    .is_some_and(|text| text.contains("not architecture lawfulness proof"))
+            })
+        }),
+        "ACTS fixture manifest must preserve fixture non-conclusions"
+    );
+
+    for case in cases {
+        let case_id = case["caseId"].as_str().expect("case id is present");
+        let packet = read_json(
+            &fixtures_root.join(case["packetPath"].as_str().expect("packet path is present")),
+        );
+        let validation = read_json(
+            &fixtures_root.join(
+                case["validationPath"]
+                    .as_str()
+                    .expect("validation path is present"),
+            ),
+        );
+
+        assert_eq!(
+            validation["summary"]["result"], "pass",
+            "{case_id} validation output must pass"
+        );
+        assert!(
+            validation["checks"]
+                .as_array()
+                .expect("validation checks are array")
+                .iter()
+                .any(|check| {
+                    check["id"] == "archsig-analysis-packet-architecture-spectrum-report-surface"
+                        && check["result"] == "pass"
+                }),
+            "{case_id} must lock ArchitectureSpectrumReport validation"
+        );
+
+        let report = &packet["architectureSpectrumReport"];
+        assert!(
+            report["nonConclusions"].as_array().is_some_and(|items| {
+                items.iter().any(|item| {
+                    item.as_str()
+                        .is_some_and(|text| text.contains("single architecture quality score"))
+                })
+            }),
+            "{case_id} must preserve report-level non-conclusions"
+        );
+
+        match case_id {
+            "zero-curvature-support" => {
+                let axis_ref = case["axisRef"].as_str().expect("axis ref is present");
+                let expected = case["expectedCurvatureValue"]
+                    .as_i64()
+                    .expect("expected curvature value is present");
+                let supports = packet["curvatureSupportReadings"][0]["witnessSupports"]
+                    .as_array()
+                    .expect("witness supports are array");
+                assert!(
+                    supports.iter().any(|support| {
+                        support["selectedAxisRef"] == axis_ref
+                            && support["curvatureValue"] == expected
+                            && support["missingEvidence"]
+                                .as_array()
+                                .is_some_and(|items| !items.is_empty())
+                    }),
+                    "zero curvature support must remain distinct from missing evidence"
+                );
+            }
+            "nonzero-semantic-curvature" => {
+                let axis_ref = case["axisRef"].as_str().expect("axis ref is present");
+                let minimum = case["minimumCurvatureValue"]
+                    .as_i64()
+                    .expect("minimum curvature value is present");
+                assert!(
+                    report["topHotspots"]
+                        .as_array()
+                        .expect("top hotspots are array")
+                        .iter()
+                        .any(|hotspot| {
+                            hotspot["axisRef"] == axis_ref
+                                && hotspot["curvatureValue"]
+                                    .as_i64()
+                                    .is_some_and(|value| value >= minimum)
+                                && hotspot["witnessRefs"]
+                                    .as_array()
+                                    .is_some_and(|refs| !refs.is_empty())
+                        }),
+                    "nonzero semantic curvature must be visible as hotspot"
+                );
+            }
+            "transfer-cycle" => {
+                assert!(
+                    packet["curvatureTransferReadings"][0]["transferEdges"]
+                        .as_array()
+                        .expect("transfer edges are array")
+                        .iter()
+                        .any(|edge| {
+                            edge["sourceSupportRef"] == edge["targetSupportRef"]
+                                && edge["weight"].as_i64().is_some_and(|value| value > 0)
+                        }),
+                    "transfer fixture must contain a positive closed transfer edge"
+                );
+                assert!(
+                    report["recurrentObstructions"]
+                        .as_array()
+                        .expect("recurrent obstructions are array")
+                        .iter()
+                        .any(|mode| {
+                            mode["transferEdgeRefs"]
+                                .as_array()
+                                .is_some_and(|refs| !refs.is_empty())
+                                && mode["spectralRadiusReading"]
+                                    .as_str()
+                                    .is_some_and(|text| text.contains("rho(T^kappa) proxy"))
+                        }),
+                    "transfer cycle must surface as recurrent obstruction support"
+                );
+            }
+            "coverage-gap-boundary" => {
+                let required_text = case["requiredText"]
+                    .as_str()
+                    .expect("required text is present");
+                assert!(
+                    report["coverageGaps"]
+                        .as_array()
+                        .expect("coverage gaps are array")
+                        .iter()
+                        .any(|gap| gap
+                            .as_str()
+                            .is_some_and(|text| text.contains(required_text))),
+                    "coverage gap must remain explicit in ArchitectureSpectrumReport"
+                );
+            }
+            "coupon-tax-rounding-acts" => {
+                let required_text = case["requiredText"]
+                    .as_str()
+                    .expect("required text is present");
+                assert!(
+                    packet.to_string().contains(required_text),
+                    "coupon/tax/rounding fixture must keep payment trace gap"
+                );
+                assert!(
+                    report["topHotspots"]
+                        .as_array()
+                        .is_some_and(|items| !items.is_empty())
+                        && report["recurrentObstructions"]
+                            .as_array()
+                            .is_some_and(|items| !items.is_empty()),
+                    "coupon/tax/rounding fixture must expose ACTS report surfaces"
+                );
+            }
+            other => panic!("unhandled ACTS fixture case {other}"),
+        }
+    }
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/acts_spectrum/coupon_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/coupon_validation.json
@@ -1,0 +1,6505 @@
+{
+  "schemaVersion": "archsig-analysis-packet-validation-report-v0",
+  "input": {
+    "schemaVersion": "archsig-analysis-packet-v0",
+    "path": "archsig-analysis-packet",
+    "analysisId": "archsig-analysis:coupon-tax-rounding-archmap:llm-native-aat-law-policy-fixture",
+    "archMapRef": "coupon-tax-rounding-archmap",
+    "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture"
+  },
+  "packet": {
+    "schemaVersion": "archsig-analysis-packet-v0",
+    "analysisId": "archsig-analysis:coupon-tax-rounding-archmap:llm-native-aat-law-policy-fixture",
+    "generatedAt": "2026-05-31T00:00:00Z",
+    "archMapRef": {
+      "artifactId": "coupon-tax-rounding-archmap",
+      "artifactKind": "archmap",
+      "schemaVersion": "archmap-observation-map-v0",
+      "path": "tools/archsig/tests/fixtures/coupon_rounding/archmap.json"
+    },
+    "interpretationProfileRef": {
+      "artifactId": "llm-native-aat-law-policy-fixture",
+      "artifactKind": "interpretation-profile",
+      "schemaVersion": "law-policy-v0",
+      "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
+    },
+    "selectedLawPolicyRef": {
+      "artifactId": "llm-native-aat-law-policy-fixture",
+      "artifactKind": "law-policy",
+      "schemaVersion": "law-policy-v0",
+      "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
+    },
+    "archMapStoreRefs": {
+      "refSetId": "archmap-store-refs:coupon-tax-rounding-archmap",
+      "archMapRef": "coupon-tax-rounding-archmap",
+      "deltaRef": {
+        "artifactId": "archmap-delta:coupon-tax-rounding-archmap:current",
+        "artifactKind": "archmap-delta",
+        "schemaVersion": "archmap-delta-v0"
+      },
+      "commitRef": {
+        "artifactId": "archmap-commit:coupon-tax-rounding-archmap:current",
+        "artifactKind": "archmap-commit",
+        "schemaVersion": "archmap-commit-v0"
+      },
+      "snapshotRef": {
+        "artifactId": "archmap-snapshot:coupon-tax-rounding-archmap:current",
+        "artifactKind": "archmap-snapshot",
+        "schemaVersion": "archmap-snapshot-v0"
+      },
+      "indexRef": {
+        "artifactId": "archmap-index:coupon-tax-rounding-archmap:current",
+        "artifactKind": "archmap-index",
+        "schemaVersion": "archmap-index-v0"
+      },
+      "rawDiffBoundary": "raw diffs are not ArchSig semantic inputs; upstream source readers must translate source changes into ArchMapStore delta / commit / snapshot / index refs",
+      "compactionBoundary": "snapshot and index compaction may lose per-change granularity; compaction loss remains explicit evidence boundary",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "architectureState": {
+      "stateId": "architecture-state:coupon-tax-rounding-fixture",
+      "reading": "coupon-tax-rounding-fixture is represented as 3 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
+      "atomFamilyRefs": [
+        "contractSpecification",
+        "effect",
+        "semanticInterpretation"
+      ],
+      "moleculeRefs": [
+        "molecule:coupon-operation-contract"
+      ],
+      "workflowRefs": [
+        "semantic:coupon-tax-rounding-paths"
+      ],
+      "boundaryRefs": [
+        "gap:coupon-runtime-payment-trace"
+      ],
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "coverageBoundary": "state is an ArchMap-relative architecture state, not a complete source reconstruction",
+      "recommendedNextAction": "review nonzero axes, stressed principles, and preserved observation gaps before planning repair",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "designPressure": [
+      {
+        "pressureId": "design-pressure:selected-atom-configuration",
+        "status": "actionable",
+        "reading": "1 selected obstruction circuit(s) and 1 coverage gap(s) define the current pressure surface",
+        "atomConfigurationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "coverageBoundary": "pressure is relative to the observed finite Atom configuration and selected profile",
+        "recommendedNextAction": "use bounded judgements to decide whether to inspect source refs, add evidence, or plan repair",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "changeImpact": {
+      "impactId": "change-impact:selected-repair-operations",
+      "operationScope": "repair, extension, migration, and refactor operations over observed ArchMap atoms",
+      "signatureDeltaSummary": [
+        "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+      ],
+      "affectedBoundaries": [
+        "sig-axis:layer-violation: coverage-gap-preserved",
+        "sig-axis:semantic-inconsistency: coverage-gap-preserved"
+      ],
+      "complexityTransferNotes": [
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "coverageBoundary": "impact is a pre-change operation reading; it is not evidence that a future patch is safe",
+      "recommendedNextAction": "compare operation deltas before and after the patch and keep transferred obstruction notes",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "aatConceptSurfaces": [
+      {
+        "concept": "Atom",
+        "status": "observedOrRepresented",
+        "reading": "Atom is represented with 3 bounded packet record(s)",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Configuration",
+        "status": "observedOrRepresented",
+        "reading": "Configuration is represented with 4 bounded packet record(s)",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "ArchitectureObject",
+        "status": "observedOrRepresented",
+        "reading": "ArchitectureObject is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "projection:coupon-payment-receipt"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Invariant",
+        "status": "observedOrRepresented",
+        "reading": "Invariant is represented with 2 bounded packet record(s)",
+        "evidenceRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "LawUniverse",
+        "status": "observedOrRepresented",
+        "reading": "LawUniverse is represented with 2 bounded packet record(s)",
+        "evidenceRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "ObstructionCircuit",
+        "status": "observedOrRepresented",
+        "reading": "ObstructionCircuit is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "ArchitectureSignature",
+        "status": "observedOrRepresented",
+        "reading": "ArchitectureSignature is represented with 2 bounded packet record(s)",
+        "evidenceRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Operation",
+        "status": "observedOrRepresented",
+        "reading": "Operation is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Path",
+        "status": "observedOrRepresented",
+        "reading": "Path is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "molecule:coupon-operation-contract"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Homotopy",
+        "status": "observedOrRepresented",
+        "reading": "Homotopy is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Diagram",
+        "status": "observedOrRepresented",
+        "reading": "Diagram is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "AnalyticRepresentation",
+        "status": "observedOrRepresented",
+        "reading": "AnalyticRepresentation is represented with 10 bounded packet record(s)",
+        "evidenceRefs": [
+          "analytic:weighted-adjacency",
+          "analytic:reachable-cone-size",
+          "analytic:walk-count",
+          "analytic:nilpotence-boundary",
+          "analytic:selected-subgraph-spectrum",
+          "analytic:propagation-depth",
+          "analytic:spectral-radius-proxy",
+          "analytic:curvature-valuation",
+          "analytic:state-algebra-boundary",
+          "analytic:zero-reflecting-aggregate-boundary"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomConfigurationSummary": {
+      "atomObservationCount": 3,
+      "moleculeObservationCount": 1,
+      "semanticObservationCount": 1,
+      "observationGapCount": 1,
+      "concernHintCount": 1,
+      "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
+      "coverageSummary": [
+        "3 atom observations",
+        "1 molecule observations",
+        "1 semantic observations",
+        "1 observation gaps preserved as gaps"
+      ],
+      "sourceRefs": [
+        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+        "atom:effect:receipt-boundary",
+        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+        "gap:coupon-runtime-payment-trace"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "architectureObjectProjections": [
+      {
+        "projectionId": "projection:coupon-payment-receipt",
+        "projectionFamily": "paymentReceiptProjection",
+        "atomRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "moleculeRefs": [],
+        "semanticRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "reading": "coupon path projection keeps payment and receipt amount surfaces visible",
+        "projectionBoundary": "fixture projection is not a complete payment ledger",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "invariantFamilyReadings": [
+      {
+        "invariantId": "invariant:law-layer-respecting",
+        "invariantFamily": "dependency-direction",
+        "status": "preservedForConstructedWitnesses",
+        "lawRefs": [
+          "law:layer-respecting"
+        ],
+        "atomRefs": [],
+        "obstructionRefs": [],
+        "reading": "Dependencies must respect the selected layer order. is read as an invariant family selected by the interpretation profile",
+        "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "invariantId": "invariant:law-semantic-contract-alignment",
+        "invariantFamily": "semantic-contract",
+        "status": "stressed",
+        "lawRefs": [
+          "law:semantic-contract-alignment"
+        ],
+        "atomRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "reading": "Semantic observations and contract observations must agree on the selected operation meaning. is read as an invariant family selected by the interpretation profile",
+        "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "lawUniverseReading": {
+      "lawUniverseId": "law-universe:llm-native-aat-law-policy-fixture",
+      "profileRef": "llm-native-aat-law-policy-fixture",
+      "selectedLawRefs": [
+        "law:layer-respecting",
+        "law:semantic-contract-alignment"
+      ],
+      "witnessRuleRefs": [
+        "witness:layer-violation",
+        "witness:semantic-contract-mismatch"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "exactnessAssumptions": [
+        "the selected witness rules cover only policy-declared laws",
+        "zero readings are exact only for observed atoms and declared coverage requirements"
+      ],
+      "coverageRequirements": [
+        "coverage:layer-atoms",
+        "coverage:semantic-contract-atoms"
+      ],
+      "reading": "LawPolicy is interpreted as an analysis profile selecting a bounded LawUniverse, witnesses, axes, coverage, and exactness assumptions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "moleculeReadings": [
+      {
+        "moleculeReadingId": "molecule-reading:molecule-coupon-operation-contract",
+        "moleculeObservationRef": "molecule:coupon-operation-contract",
+        "lawRefs": [
+          "law:semantic-contract-alignment"
+        ],
+        "atomObservationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "reading": "molecule:coupon-operation-contract is read as a operation-contract molecule under selected LawPolicy",
+        "evidenceSummary": "molecule uses 3 atom observation refs and 1 source refs",
+        "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
+        "sourceRefs": [
+          "src-pricing-checkout"
+        ],
+        "interpretationNotesForLLM": [
+          "Explain molecule readings as grouped observed atoms before discussing laws."
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "obstructionCircuits": [
+      {
+        "obstructionCircuitId": "obstruction:semantic-contract-mismatch:computed",
+        "lawRef": "law:semantic-contract-alignment",
+        "witnessRuleRef": "witness:semantic-contract-mismatch",
+        "circuitKind": "SemanticMismatchCircuit",
+        "atomObservationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "moleculeReadingRefs": [
+          "molecule-reading:molecule-coupon-operation-contract"
+        ],
+        "concernHintRefs": [
+          "concern:coupon-semantic-monodromy"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+        "evidenceSummary": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
+        "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+        "missingEvidence": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "single architecture quality score"
+        ],
+        "interpretationNotesForLLM": [
+          "Explain this obstruction as selected LawPolicy-relative."
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "signatureAxes": [
+      {
+        "signatureAxisId": "sig-axis:layer-violation",
+        "lawRef": "law:layer-respecting",
+        "axisRef": "axis:layer-violation",
+        "valueType": "nat",
+        "value": 0,
+        "zeroReading": "zero means no axis:layer-violation witness was constructed under declared coverage",
+        "coverageStatus": "coverage-gap-preserved",
+        "exactnessAssumptions": [
+          "the selected witness rules cover only policy-declared laws",
+          "zero readings are exact only for observed atoms and declared coverage requirements"
+        ],
+        "evidenceSummary": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+        "sourceRefs": [
+          "sig-axis:layer-violation: no direct source refs under selected coverage"
+        ],
+        "missingEvidence": [
+          "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "sig-axis:layer-violation coverage boundary: coverage gaps remain observation gaps, not measured zero",
+          "single architecture quality score"
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "signatureAxisId": "sig-axis:semantic-inconsistency",
+        "lawRef": "law:semantic-contract-alignment",
+        "axisRef": "axis:semantic-inconsistency",
+        "valueType": "nat",
+        "value": 1,
+        "zeroReading": "nonzero means axis:semantic-inconsistency witness count is present under selected LawPolicy",
+        "coverageStatus": "coverage-gap-preserved",
+        "exactnessAssumptions": [
+          "the selected witness rules cover only policy-declared laws",
+          "zero readings are exact only for observed atoms and declared coverage requirements"
+        ],
+        "evidenceSummary": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
+        "sourceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "missingEvidence": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "sig-axis:semantic-inconsistency coverage boundary: coverage gaps remain observation gaps, not measured zero",
+          "single architecture quality score"
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "analyticRepresentations": [
+      {
+        "representationId": "analytic:weighted-adjacency",
+        "representationFamily": "weightedAdjacencyMatrix",
+        "status": "measured",
+        "valueType": "matrixShape",
+        "value": "7x7; edgeCount=0",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:reachable-cone-size",
+        "representationFamily": "reachableConeSize",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "7",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:walk-count",
+        "representationFamily": "walkCount",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "1",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:nilpotence-boundary",
+        "representationFamily": "nilpotenceBoundary",
+        "status": "needsReview",
+        "valueType": "boundaryStatus",
+        "value": "blockedByCoverageGap",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:selected-subgraph-spectrum",
+        "representationFamily": "selectedSubgraphSpectrum",
+        "status": "measured",
+        "valueType": "vector",
+        "value": "[0.000]",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:propagation-depth",
+        "representationFamily": "propagationDepth",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "0",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "propagation depth is computed over observed relation atoms only",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:spectral-radius-proxy",
+        "representationFamily": "spectralRadius",
+        "status": "measured",
+        "valueType": "float",
+        "value": "0.000",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:curvature-valuation",
+        "representationFamily": "curvatureValuation",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "1",
+        "graphScopeRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "curvature valuation counts constructed obstruction circuits under the selected profile",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:state-algebra-boundary",
+        "representationFamily": "stateAlgebra",
+        "status": "unmeasured",
+        "valueType": "boundaryStatus",
+        "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+        "graphScopeRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "state algebra is preserved as a first-class analytic boundary even when state evidence is unavailable",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:zero-reflecting-aggregate-boundary",
+        "representationFamily": "zeroReflectingAggregateBoundary",
+        "status": "needsReview",
+        "valueType": "boundaryStatus",
+        "value": "blockedByObservationGaps",
+        "graphScopeRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "zero-reflecting aggregate boundary says when zero axes may and may not be read as absence",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "couplingCohesionReadings": [
+      {
+        "readingId": "coupling:static-dependency",
+        "axis": "staticDependencyCoupling",
+        "status": "unmeasured",
+        "valueType": "boundedCount",
+        "value": "0",
+        "supportingRefs": [],
+        "stressedRefs": [],
+        "reading": "static relation atoms show direct source-level coupling",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "cohesion:semantic-contract",
+        "axis": "contractCohesion",
+        "status": "actionable",
+        "valueType": "boundedCount",
+        "value": "2",
+        "supportingRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "stressedRefs": [],
+        "reading": "contract and semantic observations give a semantic cohesion reading",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "coupling:state-effect",
+        "axis": "stateEffectCoupling",
+        "status": "needsReview",
+        "valueType": "boundedCount",
+        "value": "1",
+        "supportingRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "stressedRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "state/effect coupling remains stressed when runtime or effect evidence is unavailable",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "coupling:authority-trust",
+        "axis": "authorityTrustCoupling",
+        "status": "unmeasured",
+        "valueType": "boundedCount",
+        "value": "0",
+        "supportingRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "stressedRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "authority and trust coupling are unmeasured unless ArchMap records explicit authority/trust atoms",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "workflowRiskReadings": [
+      {
+        "workflowRiskId": "workflow-risk:molecule-coupon-operation-contract",
+        "moleculeObservationRef": "molecule:coupon-operation-contract",
+        "moleculeFamily": "operation-contract",
+        "roleName": "coupon / tax / rounding operation contract",
+        "status": "needsReview",
+        "riskScore": 17,
+        "riskTier": "low",
+        "atomCount": 3,
+        "atomFamilyCounts": [
+          {
+            "atomFamily": "contractSpecification",
+            "count": 1
+          },
+          {
+            "atomFamily": "effect",
+            "count": 1
+          },
+          {
+            "atomFamily": "semanticInterpretation",
+            "count": 1
+          }
+        ],
+        "semanticRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "concernRefs": [
+          "concern:coupon-semantic-monodromy"
+        ],
+        "topAxes": [
+          {
+            "axis": "llmOutputMediation",
+            "status": "needsReview",
+            "score": 5,
+            "familyScore": 4,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "prompt/context validation, LLM/provider output, filtering, and persistence gates concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "stateEffectReconciliation",
+            "status": "needsReview",
+            "score": 5,
+            "familyScore": 4,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "durable state, external effects, retry, and status-finalization pressure concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "authorityTrustBoundary",
+            "status": "needsReview",
+            "score": 3,
+            "familyScore": 2,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "authority labels, trust handoffs, provider output, and boundary checks concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "permissionCoverage",
+            "status": "actionable",
+            "score": 2,
+            "familyScore": 2,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [],
+            "reading": "route/session/admin authority coverage concentrates in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "sourceBackedDomainCohesion",
+            "status": "actionable",
+            "score": 2,
+            "familyScore": 2,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [],
+            "reading": "source-backed domain identity, relation, and contract cohesion concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          }
+        ],
+        "reviewFocus": [
+          "authority label, trust handoff, provider output, and boundary checks",
+          "prompt/context validation, LLM output filtering, persistence gate",
+          "retry / duplicate / partial failure / status finalization"
+        ],
+        "coverageGapRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "evidenceBoundary": "workflow risk is a molecule-local ArchMap reading for review prioritization, not a quality score or proof",
+        "recommendedNextAction": "review the top axes, source refs, concern hints, and coverage gaps before planning repair",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "spectralAnalysisReadings": [
+      {
+        "spectralReadingId": "spectral:workflow-risk-axis-pressure",
+        "representationFamily": "workflowRiskAxisPressureMatrix",
+        "status": "needsReview",
+        "matrixShape": {
+          "rowDomain": "workflowRiskReadings",
+          "columnDomain": "workflowRiskAxes",
+          "rowCount": 1,
+          "columnCount": 5,
+          "nonzeroEntryCount": 5
+        },
+        "entryRule": "entry(i,j) is the workflow risk axis score for workflow i and risk axis j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "17",
+            "interpretation": "largest molecule-local review pressure"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "5",
+            "interpretation": "largest accumulated axis pressure"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "8.185",
+            "interpretation": "global pressure magnitude of the observed finite matrix"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "9.220",
+            "interpretation": "nonnegative-matrix upper bound, not an exact eigen theorem"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "molecule:coupon-operation-contract",
+            "componentKind": "workflow",
+            "value": "17",
+            "reading": "dominant row pressure in the workflow-by-axis matrix"
+          },
+          {
+            "componentRef": "stateEffectReconciliation",
+            "componentKind": "workflowRiskAxis",
+            "value": "5",
+            "reading": "dominant column pressure accumulated across workflows"
+          }
+        ],
+        "supportRefs": [
+          "workflow-risk:molecule-coupon-operation-contract"
+        ],
+        "reading": "workflow risk pressure is concentrated by rows and axes; use the dominant row and column before treating local risk as isolated",
+        "coverageBoundary": "coverage gaps on workflow axes block measured-zero interpretation for absent entries",
+        "zeroReflectingBoundary": "zero entries mean no observed risk-axis evidence under current ArchMap and heuristics, not absence of architectural pressure",
+        "recommendedNextAction": "review the dominant workflow row, dominant axis column, and coverage gaps before selecting repair operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralReadingId": "spectral:molecule-atom-overlap-coupling",
+        "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+        "status": "needsReview",
+        "matrixShape": {
+          "rowDomain": "moleculeObservations",
+          "columnDomain": "moleculeObservations",
+          "rowCount": 1,
+          "columnCount": 1,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is exact atom overlap weighted with atom-family overlap; the diagonal records molecule atom-family mass",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "3",
+            "interpretation": "largest observed molecule overlap mass"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "3.000",
+            "interpretation": "observed overlap magnitude of the molecule coupling matrix"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "3.000",
+            "interpretation": "Gershgorin-style row-sum upper bound for this nonnegative matrix"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "molecule:coupon-operation-contract",
+            "componentKind": "molecule",
+            "value": "3",
+            "reading": "dominant molecule by atom/family overlap mass"
+          }
+        ],
+        "supportRefs": [
+          "molecule:coupon-operation-contract"
+        ],
+        "reading": "molecules sharing atom refs or atom families form an overlap coupling surface that is invisible to import-only static analysis",
+        "coverageBoundary": "missing atom families and observation gaps can make overlap coupling appear smaller than the source architecture actually is",
+        "zeroReflectingBoundary": "zero off-diagonal overlap means no shared observed atom/family evidence, not guaranteed independence",
+        "recommendedNextAction": "inspect the dominant molecule and any high-overlap neighbors before splitting or moving responsibilities",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralReadingId": "spectral:obstruction-axis-curvature",
+        "representationFamily": "obstructionAxisCurvatureMatrix",
+        "status": "actionable",
+        "matrixShape": {
+          "rowDomain": "obstructionCircuits",
+          "columnDomain": "signatureAxes",
+          "rowCount": 1,
+          "columnCount": 2,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is 1 when obstruction circuit i contributes to signature axis j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "1",
+            "interpretation": "widest obstruction-to-axis curvature row"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "1",
+            "interpretation": "most repeated obstruction axis"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "1.000",
+            "interpretation": "curvature incidence magnitude over constructed obstruction circuits"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "1.000",
+            "interpretation": "incidence-matrix upper bound, not a global flatness proof"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "obstruction:semantic-contract-mismatch:computed",
+            "componentKind": "obstructionCircuit",
+            "value": "1",
+            "reading": "dominant obstruction row by connected signature axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "value": "1",
+            "reading": "dominant curvature column across obstruction circuits"
+          }
+        ],
+        "supportRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "reading": "obstruction circuits distribute curvature onto signature axes; repeated columns indicate axes where local failures accumulate",
+        "coverageBoundary": "only constructed obstruction circuits are represented; concern hints that lack witness rules remain outside this matrix",
+        "zeroReflectingBoundary": "zero incidence means no constructed obstruction-to-axis edge, not proof of zero curvature",
+        "recommendedNextAction": "review the dominant obstruction row and repeated axis column before treating a signature axis as local",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralReadingId": "spectral:operation-signature-delta",
+        "representationFamily": "operationSignatureDeltaMatrix",
+        "status": "actionable",
+        "matrixShape": {
+          "rowDomain": "operationDeltas",
+          "columnDomain": "signatureAxes",
+          "rowCount": 1,
+          "columnCount": 2,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is 1 when operation delta i declares or mentions a change to signature axis j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "1",
+            "interpretation": "widest operation-to-signature delta row"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "1",
+            "interpretation": "signature axis touched by most operations"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "1.000",
+            "interpretation": "operation delta incidence magnitude"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "1.000",
+            "interpretation": "operation-transition upper bound, not repair correctness"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+            "componentKind": "operationDelta",
+            "value": "1",
+            "reading": "dominant operation row by declared decreased axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "value": "1",
+            "reading": "dominant signature axis touched by operation deltas"
+          }
+        ],
+        "supportRefs": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "reading": "operation deltas show which signature axes would move together under candidate repairs or evidence enrichment",
+        "coverageBoundary": "candidate operations are bounded review artifacts; absent delta entries are not proof that an operation preserves an axis",
+        "zeroReflectingBoundary": "zero delta incidence means no declared or text-mentioned axis movement under current candidates, not repair safety",
+        "recommendedNextAction": "review the dominant operation row and repeated axis column before converting a repair candidate into code changes",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "spectralModeReadings": [
+      {
+        "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
+        "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
+        "representationFamily": "workflowRiskAxisPressureMatrix",
+        "status": "needsReview",
+        "modeKind": "distributedPressureMode",
+        "modeComponents": [
+          {
+            "componentRef": "molecule:coupon-operation-contract",
+            "componentKind": "workflow",
+            "weight": "17",
+            "role": "primaryDominantComponent",
+            "reading": "dominant row pressure in the workflow-by-axis matrix"
+          },
+          {
+            "componentRef": "stateEffectReconciliation",
+            "componentKind": "workflowRiskAxis",
+            "weight": "5",
+            "role": "coupledDominantComponent",
+            "reading": "dominant column pressure accumulated across workflows"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "8.185",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "1.000",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is delocalized or dense; treat the concern as architecture-wide coupling before attempting local repair",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "start review from the dominant workflow and dominant risk axis, then verify coverage gaps",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralModeId": "spectral-mode:spectral-molecule-atom-overlap-coupling",
+        "sourceSpectralReadingRef": "spectral:molecule-atom-overlap-coupling",
+        "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+        "status": "needsReview",
+        "modeKind": "delocalizedCouplingMode",
+        "modeComponents": [
+          {
+            "componentRef": "molecule:coupon-operation-contract",
+            "componentKind": "molecule",
+            "weight": "3",
+            "role": "primaryDominantComponent",
+            "reading": "dominant molecule by atom/family overlap mass"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "3.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "1.000",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is delocalized or dense; treat the concern as architecture-wide coupling before attempting local repair",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "map shared atom families across the dense molecule cluster before splitting boundaries",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralModeId": "spectral-mode:spectral-obstruction-axis-curvature",
+        "sourceSpectralReadingRef": "spectral:obstruction-axis-curvature",
+        "representationFamily": "obstructionAxisCurvatureMatrix",
+        "status": "actionable",
+        "modeKind": "curvatureMode",
+        "modeComponents": [
+          {
+            "componentRef": "obstruction:semantic-contract-mismatch:computed",
+            "componentKind": "obstructionCircuit",
+            "weight": "1",
+            "role": "primaryDominantComponent",
+            "reading": "dominant obstruction row by connected signature axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "weight": "1",
+            "role": "coupledDominantComponent",
+            "reading": "dominant curvature column across obstruction circuits"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.500",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is mixed; local repair may work, but review nearby coupled components and transferred axes",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "review whether repeated obstruction-axis curvature is local, transferred, or a law-policy coverage gap",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralModeId": "spectral-mode:spectral-operation-signature-delta",
+        "sourceSpectralReadingRef": "spectral:operation-signature-delta",
+        "representationFamily": "operationSignatureDeltaMatrix",
+        "status": "actionable",
+        "modeKind": "localizedPerturbationMode",
+        "modeComponents": [
+          {
+            "componentRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+            "componentKind": "operationDelta",
+            "weight": "1",
+            "role": "primaryDominantComponent",
+            "reading": "dominant operation row by declared decreased axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "weight": "1",
+            "role": "coupledDominantComponent",
+            "reading": "dominant signature axis touched by operation deltas"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.500",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is mixed; local repair may work, but review nearby coupled components and transferred axes",
+        "repairPerturbationReading": "candidate operations have a dominant perturbation mode; review the leading operation before broad refactoring",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "compare the perturbation mode against candidate repair preconditions before changing code",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "spectralDrilldownReadings": [
+      {
+        "drilldownId": "spectral-drilldown:coupon-tax-rounding-archmap",
+        "status": "needsReview",
+        "sourceSpectralModeRefs": [
+          "spectral-mode:spectral-workflow-risk-axis-pressure",
+          "spectral-mode:spectral-molecule-atom-overlap-coupling",
+          "spectral-mode:spectral-obstruction-axis-curvature",
+          "spectral-mode:spectral-operation-signature-delta"
+        ],
+        "dominantAtomFamilyComposition": [
+          {
+            "sourceComponentRef": "molecule:coupon-operation-contract",
+            "sourceComponentKind": "workflow",
+            "atomFamily": "contractSpecification",
+            "count": 1,
+            "atomObservationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ],
+            "reading": "molecule:coupon-operation-contract contributes 1 observed contractSpecification atom(s) to the dominant spectral mode"
+          },
+          {
+            "sourceComponentRef": "molecule:coupon-operation-contract",
+            "sourceComponentKind": "workflow",
+            "atomFamily": "effect",
+            "count": 1,
+            "atomObservationRefs": [
+              "atom:effect:receipt-boundary"
+            ],
+            "reading": "molecule:coupon-operation-contract contributes 1 observed effect atom(s) to the dominant spectral mode"
+          },
+          {
+            "sourceComponentRef": "molecule:coupon-operation-contract",
+            "sourceComponentKind": "workflow",
+            "atomFamily": "semanticInterpretation",
+            "count": 1,
+            "atomObservationRefs": [
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+            ],
+            "reading": "molecule:coupon-operation-contract contributes 1 observed semanticInterpretation atom(s) to the dominant spectral mode"
+          }
+        ],
+        "highOverlapMoleculePairs": [],
+        "repairAxisDeltaReadings": [
+          {
+            "operationDeltaRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+            "operationKind": "repair-semanticmismatchcircuit",
+            "positiveDeltaAxes": [
+              "sig-axis:semantic-inconsistency"
+            ],
+            "negativeDeltaAxes": [],
+            "neutralOrUnknownAxes": [
+              "sig-axis:layer-violation"
+            ],
+            "transferRiskRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "reading": "operation has bounded positive axes and leaves some axes neutral or unknown under current evidence",
+            "evidenceBoundary": "positive axes come from target obstruction support; negative axes are touched but not target axes; neutral axes are unmentioned under current operation delta evidence",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          }
+        ],
+        "reading": "spectral drilldown explains dominant modes with atom-family composition, molecule overlap pairs, and repair axis deltas",
+        "evidenceBoundary": "drilldown is derived from ArchMap atom/molecule observations and ArchSig spectral summaries; it is not exact eigendecomposition or repair correctness",
+        "recommendedNextAction": "review dominant atom families, high-overlap molecule pairs, and positive/negative repair delta axes before changing boundaries",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "curvatureSupportReadings": [
+      {
+        "readingId": "curvature-support-reading:spectrum-profile-curvature-transfer-default",
+        "profileRef": "spectrum-profile:curvature-transfer-default",
+        "status": "needsReview",
+        "measuredAxisRefs": [
+          "axis:semantic-inconsistency"
+        ],
+        "unmeasuredAxisRefs": [
+          "axis:layer-violation",
+          "axis:semantic-inconsistency"
+        ],
+        "witnessSupports": [
+          {
+            "witnessSupportId": "curvature-support:witness-layer-violation:axis-layer-violation",
+            "witnessRuleRef": "witness:layer-violation",
+            "selectedAxisRef": "axis:layer-violation",
+            "signatureAxisRef": "sig-axis:layer-violation",
+            "curvatureValue": 0,
+            "weight": 0,
+            "supportRefs": [],
+            "sourceRefs": [],
+            "observationRefs": [],
+            "missingEvidence": [
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+            ],
+            "reading": "unmeasured support is preserved as missing evidence, not measured zero"
+          },
+          {
+            "witnessSupportId": "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation",
+            "witnessRuleRef": "witness:semantic-contract-mismatch",
+            "selectedAxisRef": "axis:layer-violation",
+            "signatureAxisRef": "sig-axis:layer-violation",
+            "curvatureValue": 0,
+            "weight": 0,
+            "supportRefs": [],
+            "sourceRefs": [],
+            "observationRefs": [],
+            "missingEvidence": [
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+            ],
+            "reading": "unmeasured support is preserved as missing evidence, not measured zero"
+          },
+          {
+            "witnessSupportId": "curvature-support:witness-layer-violation:axis-semantic-inconsistency",
+            "witnessRuleRef": "witness:layer-violation",
+            "selectedAxisRef": "axis:semantic-inconsistency",
+            "signatureAxisRef": "sig-axis:semantic-inconsistency",
+            "curvatureValue": 0,
+            "weight": 0,
+            "supportRefs": [],
+            "sourceRefs": [],
+            "observationRefs": [],
+            "missingEvidence": [
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+            ],
+            "reading": "unmeasured support is preserved as missing evidence, not measured zero"
+          },
+          {
+            "witnessSupportId": "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
+            "witnessRuleRef": "witness:semantic-contract-mismatch",
+            "selectedAxisRef": "axis:semantic-inconsistency",
+            "signatureAxisRef": "sig-axis:semantic-inconsistency",
+            "curvatureValue": 1,
+            "weight": 1,
+            "supportRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "concern:coupon-semantic-monodromy",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "concern:coupon-semantic-monodromy",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "missingEvidence": [
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+            ],
+            "reading": "1 constructed witness support(s) contribute to axis:semantic-inconsistency under spectrum-profile:curvature-transfer-default"
+          }
+        ],
+        "topCurvatureModes": [
+          {
+            "modeId": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+            "rank": 1,
+            "axisRef": "axis:semantic-inconsistency",
+            "curvatureValue": 1,
+            "witnessRefs": [
+              "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+            ],
+            "supportRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "concern:coupon-semantic-monodromy",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "reading": "top measured curvature support mode with traceable witness and support refs"
+          },
+          {
+            "modeId": "curvature-mode:curvature-support-witness-layer-violation-axis-layer-violation",
+            "rank": 2,
+            "axisRef": "axis:layer-violation",
+            "curvatureValue": 0,
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-layer-violation"
+            ],
+            "supportRefs": [],
+            "reading": "unmeasured curvature support mode retained as coverage debt"
+          },
+          {
+            "modeId": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-layer-violation",
+            "rank": 3,
+            "axisRef": "axis:layer-violation",
+            "curvatureValue": 0,
+            "witnessRefs": [
+              "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+            ],
+            "supportRefs": [],
+            "reading": "unmeasured curvature support mode retained as coverage debt"
+          },
+          {
+            "modeId": "curvature-mode:curvature-support-witness-layer-violation-axis-semantic-inconsistency",
+            "rank": 4,
+            "axisRef": "axis:semantic-inconsistency",
+            "curvatureValue": 0,
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-semantic-inconsistency"
+            ],
+            "supportRefs": [],
+            "reading": "unmeasured curvature support mode retained as coverage debt"
+          }
+        ],
+        "witnessClusters": [
+          {
+            "clusterId": "curvature-cluster:axis-layer-violation",
+            "clusterKind": "axisWitnessSupportCluster",
+            "axisRefs": [
+              "axis:layer-violation"
+            ],
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-layer-violation",
+              "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+            ],
+            "supportRefs": [],
+            "clusterWeight": 0,
+            "reading": "cluster records unmeasured selected axis support as coverage debt"
+          },
+          {
+            "clusterId": "curvature-cluster:axis-semantic-inconsistency",
+            "clusterKind": "axisWitnessSupportCluster",
+            "axisRefs": [
+              "axis:semantic-inconsistency"
+            ],
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-semantic-inconsistency",
+              "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+            ],
+            "supportRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "concern:coupon-semantic-monodromy",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "clusterWeight": 1,
+            "reading": "cluster groups measured witness supports by selected axis for review ranking"
+          }
+        ],
+        "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+        "exactnessAssumptionRefs": [
+          "selected LawPolicy exactness assumptions"
+        ],
+        "measurementBoundary": "curvature-transfer spectrum readings are bounded ArchSig diagnostics, not theorem discharge",
+        "missingEvidence": [
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "nonConclusions": [
+          "spectrum measurement profile is a measurement recipe, not a law universe",
+          "profile differences are not law universe differences",
+          "unmeasured axes are not zero",
+          "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
+        ]
+      }
+    ],
+    "curvatureTransferReadings": [
+      {
+        "readingId": "curvature-transfer-reading:spectrum-profile-curvature-transfer-default",
+        "profileRef": "spectrum-profile:curvature-transfer-default",
+        "status": "needsReview",
+        "transferOperator": {
+          "operatorId": "transfer-operator:curvature-transfer-reading-spectrum-profile-curvature-transfer-default",
+          "rowDomain": "curvatureWitnessSupports",
+          "columnDomain": "curvatureWitnessSupports",
+          "rowCount": 1,
+          "columnCount": 1,
+          "nonzeroEdgeCount": 1,
+          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+          "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
+        },
+        "transferEdges": [
+          {
+            "edgeId": "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+            "sourceSupportRef": "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
+            "sourceAxisRef": "axis:semantic-inconsistency",
+            "targetSupportRef": "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
+            "targetAxisRef": "axis:semantic-inconsistency",
+            "witnessRefs": [
+              "witness:semantic-contract-mismatch"
+            ],
+            "defectValue": 2,
+            "weight": 1,
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "reading": "positive self-loop records a closed walk in the finite transfer operator"
+          }
+        ],
+        "recurrentObstructionModes": [
+          {
+            "modeId": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+            "transferEdgeRefs": [
+              "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
+            ],
+            "supportRefs": [
+              "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+            ],
+            "witnessRefs": [
+              "witness:semantic-contract-mismatch"
+            ],
+            "spectralRadiusReading": "rho(T^kappa) proxy 1 > 0 over the finite ArchSig transfer operator",
+            "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
+            "reviewFocus": [
+              "inspect the witness support behind the positive transfer self-loop",
+              "check whether coverage gaps or exactness limits block zero-reflection"
+            ],
+            "nonConclusions": [
+              "recurrent obstruction mode is not future incident prediction",
+              "recurrent obstruction mode is not empirical cost amplification",
+              "recurrent obstruction mode is not repair safety evidence"
+            ]
+          }
+        ],
+        "spectralRadiusReading": {
+          "name": "rho(T^kappa)Proxy",
+          "value": "1",
+          "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+        },
+        "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+        "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
+        "nonConclusions": [
+          "rho(T^kappa) > 0 is only a bounded recurrent obstruction reading",
+          "transfer operator reading does not predict future incidents or empirical cost increase",
+          "transfer operator reading does not replace FieldSig forecast",
+          "absence of transfer edges is not proof of future safety"
+        ]
+      }
+    ],
+    "architectureSpectrumReport": {
+      "reportId": "architecture-spectrum-report:spectrum-profile-curvature-transfer-default",
+      "profileRef": "spectrum-profile:curvature-transfer-default",
+      "status": "needsReview",
+      "topHotspots": [
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 1,
+          "supportRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "concern:coupon-semantic-monodromy",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "semantic:coupon-tax-rounding-paths"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "coverageGapRefs": [
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+          ],
+          "recommendedNextAction": "review witness support, selected axis coverage, and transfer recurrence before repair planning"
+        },
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-layer-violation-axis-layer-violation",
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-layer-violation"
+          ],
+          "coverageGapRefs": [
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+          ],
+          "recommendedNextAction": "resolve coverage and exactness gaps before treating this axis as zero"
+        },
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-semantic-contract-mismatch-axis-layer-violation",
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+          ],
+          "coverageGapRefs": [
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+          ],
+          "recommendedNextAction": "resolve coverage and exactness gaps before treating this axis as zero"
+        },
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-layer-violation-axis-semantic-inconsistency",
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-semantic-inconsistency"
+          ],
+          "coverageGapRefs": [
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+          ],
+          "recommendedNextAction": "resolve coverage and exactness gaps before treating this axis as zero"
+        }
+      ],
+      "topEigenmodes": [
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+          "rank": 1,
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 1,
+          "supportRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "concern:coupon-semantic-monodromy",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "semantic:coupon-tax-rounding-paths"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "reading": "top measured curvature support mode with traceable witness and support refs"
+        },
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-layer-violation-axis-layer-violation",
+          "rank": 2,
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-layer-violation"
+          ],
+          "reading": "unmeasured curvature support mode retained as coverage debt"
+        },
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-layer-violation",
+          "rank": 3,
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+          ],
+          "reading": "unmeasured curvature support mode retained as coverage debt"
+        },
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-layer-violation-axis-semantic-inconsistency",
+          "rank": 4,
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-semantic-inconsistency"
+          ],
+          "reading": "unmeasured curvature support mode retained as coverage debt"
+        }
+      ],
+      "topWitnessClusters": [
+        {
+          "clusterRef": "curvature-cluster:axis-layer-violation",
+          "axisRefs": [
+            "axis:layer-violation"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-layer-violation",
+            "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+          ],
+          "supportRefs": [],
+          "clusterWeight": 0,
+          "reading": "cluster records unmeasured selected axis support as coverage debt"
+        },
+        {
+          "clusterRef": "curvature-cluster:axis-semantic-inconsistency",
+          "axisRefs": [
+            "axis:semantic-inconsistency"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-semantic-inconsistency",
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "supportRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "concern:coupon-semantic-monodromy",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "semantic:coupon-tax-rounding-paths"
+          ],
+          "clusterWeight": 1,
+          "reading": "cluster groups measured witness supports by selected axis for review ranking"
+        }
+      ],
+      "recurrentObstructions": [
+        {
+          "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+          "spectralRadiusReading": "rho(T^kappa) proxy 1 > 0 over the finite ArchSig transfer operator",
+          "transferEdgeRefs": [
+            "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
+          ],
+          "supportRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "witnessRefs": [
+            "witness:semantic-contract-mismatch"
+          ],
+          "reading": "positive closed walk is reported as recurrent obstruction support only"
+        }
+      ],
+      "coverageGaps": [
+        "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+      ],
+      "measuredBoundary": "report is measured from ArchSig curvature support and transfer readings under selected LawPolicy coverage and exactness assumptions",
+      "recommendedReviewFocus": [
+        "start from nonzero hotspots with traceable witness and support refs",
+        "review recurrent obstruction modes only as current-state bounded diagnostics",
+        "resolve coverage gaps before reading absent support as zero"
+      ],
+      "nonConclusions": [
+        "ArchitectureSpectrumReport is not a single architecture quality score",
+        "ArchitectureSpectrumReport does not prove global lawfulness or flatness",
+        "ArchitectureSpectrumReport does not predict future incidents or empirical cost increase",
+        "ArchitectureSpectrumReport does not replace FieldSig forecast or governance"
+      ]
+    },
+    "transferBridgeReadings": [
+      {
+        "transferBridgeId": "transfer-bridge:coupon-tax-rounding-archmap",
+        "status": "nonConclusion",
+        "transferMatrixEntries": [],
+        "bridgeAtomFamilies": [
+          {
+            "bridgeId": "bridge:molecule-coupon-operation-contract:molecule-coupon-operation-contract",
+            "sourceHubMoleculeRef": "molecule:coupon-operation-contract",
+            "targetHubMoleculeRef": "molecule:coupon-operation-contract",
+            "intermediateMoleculeRefs": [],
+            "bridgeAtomFamilies": [],
+            "bridgeScore": 0,
+            "pathPairRefs": [],
+            "edgeBreakdowns": [],
+            "sharedAxisRefs": [
+              "authorityTrustBoundary",
+              "llmOutputMediation",
+              "permissionCoverage",
+              "sourceBackedDomainCohesion",
+              "stateEffectReconciliation"
+            ],
+            "reviewRisk": "high",
+            "recommendedBoundaryPreparation": "review bridge atom families before assuming molecule:coupon-operation-contract and molecule:coupon-operation-contract are independent architecture hubs",
+            "evidenceBoundary": "bridge path is computed from high-overlap molecule pairs and shared atom families, not from direct source dependency proof",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          }
+        ],
+        "evolutionRiskRanking": {
+          "repairTransferRiskRanking": [
+            {
+              "rank": 1,
+              "operationDeltaRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+              "positiveAxisCount": 1,
+              "transferredAxisCount": 0,
+              "transferWeight": 1,
+              "reading": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed has 1 target-positive axis/axes and 0 transferred axis/axes"
+            }
+          ],
+          "boundaryPreparationRanking": [],
+          "reading": "evolution risk ranks repairs by transfer-axis pressure and molecule pairs by boundary-preparation need",
+          "nonConclusions": [
+            "ArchSig analysis packet is not a Lean theorem proof",
+            "ArchSig analysis packet is not global architecture truth",
+            "ArchSig analysis packet does not prove source extraction completeness",
+            "signature axes are law-policy-relative, not universal quality scores",
+            "flatness reading is blocked by coverage gaps and exactness assumptions",
+            "repair operation candidates are not automatic safe refactorings",
+            "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+          ]
+        },
+        "reading": "transfer bridge reading connects repair transfer axes, bridge atom families, and evolution risk ranking",
+        "evidenceBoundary": "transfer bridge is derived from ArchMap atom/molecule overlap and ArchSig repair delta summaries; it is not a repair correctness theorem",
+        "recommendedNextAction": "review bridge atom families and top transfer-risk repairs before applying local architecture changes",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomSupportAxisReadings": [
+      {
+        "readingId": "atom-support-axis:coupon-tax-rounding-archmap",
+        "scopeRef": "coupon-tax-rounding-archmap",
+        "scopeKind": "selectedSourceUniverse",
+        "supportSize": 2,
+        "subjectFamilySpread": [
+          {
+            "subjectRef": "pricing.checkoutTotal",
+            "atomCount": 2,
+            "atomFamilies": [
+              "contractSpecification",
+              "semanticInterpretation"
+            ]
+          },
+          {
+            "subjectRef": "pricing.receipt",
+            "atomCount": 1,
+            "atomFamilies": [
+              "effect"
+            ]
+          }
+        ],
+        "axisRestrictionCounts": [
+          {
+            "axis": "contractSpecification",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ]
+          },
+          {
+            "axis": "effect",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:effect:receipt-boundary"
+            ]
+          },
+          {
+            "axis": "semanticInterpretation",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+            ]
+          }
+        ],
+        "axisConcentration": "maxAxisShare=1/3",
+        "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
+        "highSupportRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "coverageBoundary": "support and axis restriction are computed from observed ArchMap atoms only",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "atom-support-axis:molecule-coupon-operation-contract",
+        "scopeRef": "molecule:coupon-operation-contract",
+        "scopeKind": "molecule",
+        "supportSize": 2,
+        "subjectFamilySpread": [
+          {
+            "subjectRef": "pricing.checkoutTotal",
+            "atomCount": 2,
+            "atomFamilies": [
+              "contractSpecification",
+              "semanticInterpretation"
+            ]
+          },
+          {
+            "subjectRef": "pricing.receipt",
+            "atomCount": 1,
+            "atomFamilies": [
+              "effect"
+            ]
+          }
+        ],
+        "axisRestrictionCounts": [
+          {
+            "axis": "contractSpecification",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ]
+          },
+          {
+            "axis": "effect",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:effect:receipt-boundary"
+            ]
+          },
+          {
+            "axis": "semanticInterpretation",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+            ]
+          }
+        ],
+        "axisConcentration": "maxAxisShare=1/3",
+        "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
+        "highSupportRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "coverageBoundary": "support and axis restriction are computed from observed ArchMap atoms only",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomCompatibilityReadings": [
+      {
+        "readingId": "atom-compatibility:coupon-tax-rounding-archmap",
+        "status": "compatibleWithinObservedSlots",
+        "sameSlotConflictCount": 0,
+        "conflicts": [],
+        "conflictingAtomObservationRefs": [],
+        "conflictingSemanticObservationRefs": [],
+        "payloadInconsistencyKinds": [
+          "familyDivergence",
+          "statusDivergence",
+          "semanticDivergence"
+        ],
+        "confidenceBoundary": "compatibility is checked over observed subject/predicate slots only",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "evidenceBoundary": "compatibility conflict is a review target, not proof of global semantic incorrectness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "lawUniverseCoverageReadings": [
+      {
+        "readingId": "law-universe-coverage:llm-native-aat-law-policy-fixture",
+        "lawUniverseRef": "llm-native-aat-law-policy-fixture",
+        "requiredLawCoverage": [
+          {
+            "refId": "law:layer-respecting",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [
+              "relation",
+              "boundaryAuthority"
+            ],
+            "blockerRefs": [
+              "relation",
+              "boundaryAuthority",
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          },
+          {
+            "refId": "law:semantic-contract-alignment",
+            "status": "coveredByObservedAtoms",
+            "evidenceRefs": [
+              "contractSpecification",
+              "semanticInterpretation"
+            ],
+            "blockerRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          }
+        ],
+        "optionalLawCoverage": [
+          {
+            "refId": "axis:observation-gap",
+            "status": "optionalAxis",
+            "evidenceRefs": [
+              "observation gap records"
+            ],
+            "blockerRefs": [],
+            "reading": "optional axis coverage is advisory"
+          }
+        ],
+        "witnessFamilyCoverage": [
+          {
+            "refId": "witness:layer-violation",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [
+              "relation",
+              "boundaryAuthority"
+            ],
+            "blockerRefs": [
+              "relation",
+              "boundaryAuthority",
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          },
+          {
+            "refId": "witness:semantic-contract-mismatch",
+            "status": "coveredByObservedAtoms",
+            "evidenceRefs": [
+              "contractSpecification",
+              "semanticInterpretation"
+            ],
+            "blockerRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          }
+        ],
+        "signatureAxisCoverage": [
+          {
+            "refId": "sig-axis:layer-violation",
+            "status": "coverage-gap-preserved",
+            "evidenceRefs": [
+              "sig-axis:layer-violation: no direct source refs under selected coverage"
+            ],
+            "blockerRefs": [
+              "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+            ],
+            "reading": "0 obstruction circuit(s) contribute to sig-axis:layer-violation"
+          },
+          {
+            "refId": "sig-axis:semantic-inconsistency",
+            "status": "coverage-gap-preserved",
+            "evidenceRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "blockerRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+            ],
+            "reading": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency"
+          }
+        ],
+        "exactnessAssumptionStatus": [
+          {
+            "refId": "the selected witness rules cover only policy-declared laws",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [],
+            "blockerRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "exactness assumption is not theorem discharge"
+          },
+          {
+            "refId": "zero readings are exact only for observed atoms and declared coverage requirements",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [],
+            "blockerRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "exactness assumption is not theorem discharge"
+          }
+        ],
+        "unmeasuredRequiredLawCount": 1,
+        "blockedWitnessRefs": [
+          "witness:layer-violation",
+          "witness:semantic-contract-mismatch"
+        ],
+        "lawWitnessAxisAlignment": "selected laws, witness rules, and signature axes are compared by refs only; alignment is profile-relative",
+        "coverageBoundary": "coverage measures selected profile visibility, not LawUniverse completeness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "featureExtensionFormulaReadings": [
+      {
+        "readingId": "feature-extension-formula:coupon-tax-rounding-archmap",
+        "scopeRef": "coupon-tax-rounding-archmap",
+        "status": "measured",
+        "inheritedCoreObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "featureLocalObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "interactionObstructionRefs": [],
+        "liftingFailureRefs": [
+          "split-readiness:molecule-coupon-operation-contract"
+        ],
+        "fillingFailureRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "complexityTransferRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "residualCoverageGapRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "classificationSummary": [
+          {
+            "axis": "inheritedCoreObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "inheritedCoreObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "featureLocalObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "interactionObstruction",
+            "status": "unmeasuredOrAbsent",
+            "refs": [],
+            "reading": "interactionObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "liftingFailure",
+            "status": "observed",
+            "refs": [
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "reading": "liftingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "fillingFailure",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "fillingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "complexityTransfer",
+            "status": "observed",
+            "refs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "reading": "complexityTransfer is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "residualCoverageGap",
+            "status": "observed",
+            "refs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "residualCoverageGap is classified as a current-state extension coordinate"
+          }
+        ],
+        "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationCalculusLawReadings": [
+      {
+        "readingId": "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
+        "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "compositionStatus": "assumptionRelative",
+        "associativityUnderObservationStatus": "selectedObservationOnly",
+        "refinementAbstractionCompatibility": "blockedByMissingEvidence",
+        "replacementEquivalence": "unmeasured",
+        "protectionIdempotence": "notApplicable",
+        "runtimeLocalization": "blockedByCoverageGap",
+        "migrationCompatibility": "notApplicable",
+        "reverseInvolution": "unmeasured",
+        "repairMonotonicity": "selectedAxisOnly",
+        "synthesisNoSolutionBoundary": "notASynthesisCertificate",
+        "preconditionRefs": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+        ],
+        "evidenceRefs": [
+          "obstruction:semantic-contract-mismatch:computed",
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathSignatureTrajectoryReadings": [
+      {
+        "readingId": "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "pathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "status": "candidateTrajectory",
+        "endpointSignatureDelta": [
+          "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+        ],
+        "maxAxisExcursion": [
+          {
+            "axisRef": "sig-axis:layer-violation",
+            "maxValue": 0,
+            "evidenceRefs": [
+              "sig-axis:layer-violation: no direct source refs under selected coverage"
+            ],
+            "reading": "max excursion is a current-state proxy, not future trajectory proof"
+          },
+          {
+            "axisRef": "sig-axis:semantic-inconsistency",
+            "maxValue": 1,
+            "evidenceRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "reading": "max excursion is a current-state proxy, not future trajectory proof"
+          }
+        ],
+        "nonMonotoneAxisRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "pathCostProxy": "support=1 transferred=1",
+        "preservedInvariantTrajectory": [
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "introducedObstructionTrajectory": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "trajectoryCoverageBoundary": "trajectory is built from candidate operation deltas, not repository evolution",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "homotopyOrderSensitivityReadings": [
+      {
+        "readingId": "homotopy-order-sensitivity:selected-operations",
+        "status": "sensitive",
+        "independentSquareCandidateRefs": [
+          "molecule-reading:molecule-coupon-operation-contract",
+          "molecule-reading:molecule-coupon-operation-contract"
+        ],
+        "sameContractReplacementRefs": [],
+        "repairFillerRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "operationOrderSensitivity": "blockedByTransferredObstructionOrMissingEvidence",
+        "homotopyBlockerRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "selectedObservationPreservationStatus": "selected observation only; same endpoint does not imply same trajectory",
+        "evidenceBoundary": "homotopy reading is generator-relative and does not prove operation commutativity",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "diagramFillabilityReadings": [
+      {
+        "readingId": "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed",
+        "diagramRef": "local-curvature:obstruction-semantic-contract-mismatch-computed",
+        "diagramFamily": "localCurvatureDiagram",
+        "status": "nonFillabilityWitnessed",
+        "missingFillerKind": "lawRelativeFiller",
+        "fillerCandidateRefs": [
+          "molecule-coupon-operation-contract",
+          "law-path:law-semantic-contract-alignment",
+          "witness-path:witness-semantic-contract-mismatch"
+        ],
+        "nonFillabilityWitnessRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "fillingBlockerRefs": [
+          "diagram filling is LawPolicy-relative and requires selected witness completeness"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "featureExtensionRefs": [
+          "feature-extension-formula:coupon-tax-rounding-archmap"
+        ],
+        "evidenceBoundary": "diagram fillability is selected-diagram-relative and not a theorem discharge",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "axisForgettingRiskReadings": [
+      {
+        "readingId": "axis-forgetting-risk:selected-projection",
+        "sourceProjectionRef": "observation-projection:coupon-tax-rounding-archmap",
+        "sourceAtomSupportRefs": [
+          "atom-support-axis:coupon-tax-rounding-archmap",
+          "atom-support-axis:molecule-coupon-operation-contract"
+        ],
+        "forgottenAxisRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "mixedAxisScopeRefs": [
+          "atom-support-axis:coupon-tax-rounding-archmap",
+          "atom-support-axis:molecule-coupon-operation-contract"
+        ],
+        "reflectionLossKind": "selectedAxisOrWitnessLoss",
+        "zeroReflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "obstructionReflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "requiredAssumptions": [
+          "selected axis preservation",
+          "witness completeness for forgotten coordinates",
+          "coverage boundary matching the selected LawPolicy"
+        ],
+        "coverageBoundary": "projection reflection is read only under explicit axis preservation and witness completeness assumptions",
+        "evidenceBoundary": "axis-forgetting risk is current-state ArchSig telemetry; it is not a proof that every projection loses information",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "signatureTrajectoryHomotopyRefutationReadings": [
+      {
+        "readingId": "signature-trajectory-homotopy-refutation:selected-trajectory",
+        "selectedHomotopyRef": "homotopy-order-sensitivity:selected-operations",
+        "trajectoryReadingRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "pathRefs": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "trajectoryDisagreementRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "trajectoryEquivalenceStatus": "selectedTrajectoryDisagreementObserved",
+        "homotopyRefutationStatus": "refutationCandidate",
+        "selectedEquivalenceBoundary": "trajectory disagreement refutes only homotopy that is selected-signature-preserving",
+        "evidenceBoundary": "endpoint delta and path trajectory are kept separate; this is not an operation-commutativity theorem",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "bridgeSplitObstructionTransferReadings": [
+      {
+        "readingId": "bridge-split-obstruction-transfer:split-readiness-molecule-coupon-operation-contract",
+        "splitReadinessRef": "split-readiness:molecule-coupon-operation-contract",
+        "bridgeEdgeRefs": [],
+        "moleculeRefs": [
+          "molecule:coupon-operation-contract"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "requiredBoundaryOperations": [
+          "interface"
+        ],
+        "fillerEvidenceStatus": "requiredOrUnmeasured",
+        "liftingEvidenceStatus": "notBlockedByObservedBridge",
+        "transferRiskStatus": "needsObstructionSupportReview",
+        "evidenceBoundary": "bridge-edge transfer is a split-readiness boundary reading, not proof of automatic obstruction removal",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationSquareCandidates": [
+      {
+        "candidateId": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "candidateSource": "inferred",
+        "suppliedPairRef": null,
+        "candidateBasis": [
+          "effectFamily",
+          "contractAtom",
+          "semanticAtom",
+          "runtimeInteraction",
+          "projectionSurface"
+        ],
+        "leftOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "rightOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "pPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "qPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "sharedAtomSupportRefs": [],
+        "stateRefs": [],
+        "effectRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "contractRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+        ],
+        "semanticRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "authorityRefs": [],
+        "runtimeRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "projectionRefs": [
+          "projection:coupon-payment-receipt"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "gap:coupon-runtime-payment-trace",
+          "projection:coupon-payment-receipt",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "missingRefs": [
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "no state observation supplied for operation square candidate"
+        ],
+        "evidenceBoundary": "inferred operation square candidate is a review cue over observed ArchMap support, not operation truth",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathContinuationTraces": [
+      {
+        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "pathRole": "p",
+        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "axisTraces": [
+          {
+            "axisFamily": "static",
+            "axisRef": "static dependency / support axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "static continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "contract",
+            "axisRef": "contract axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ],
+            "sourceRefs": [
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "semantic",
+            "axisRef": "semantic axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "semantic continuation reads 2 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "semantic:coupon-tax-rounding-paths",
+              "derived-semantic-order:p=round(tax(discount(subtotal)))"
+            ],
+            "sourceRefs": [
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "state",
+            "axisRef": "state transition axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "effect",
+            "axisRef": "effect ordering / replay / compensation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction",
+              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "authority",
+            "axisRef": "authority / trust boundary axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "runtime",
+            "axisRef": "runtime interaction axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "projection",
+            "axisRef": "projection / representation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "projection:coupon-payment-receipt"
+            ],
+            "sourceRefs": [
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          }
+        ],
+        "observationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "gap:coupon-runtime-payment-trace",
+          "projection:coupon-payment-receipt",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "missingRefs": [
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "no state observation supplied for operation square candidate"
+        ],
+        "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+        "pathRole": "q",
+        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "axisTraces": [
+          {
+            "axisFamily": "static",
+            "axisRef": "static dependency / support axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "static continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "contract",
+            "axisRef": "contract axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ],
+            "sourceRefs": [
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "semantic",
+            "axisRef": "semantic axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "semantic continuation reads 2 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "semantic:coupon-tax-rounding-paths",
+              "derived-semantic-order:q=round(discount(tax(subtotal)))"
+            ],
+            "sourceRefs": [
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "state",
+            "axisRef": "state transition axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "effect",
+            "axisRef": "effect ordering / replay / compensation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction",
+              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "authority",
+            "axisRef": "authority / trust boundary axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "runtime",
+            "axisRef": "runtime interaction axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "projection",
+            "axisRef": "projection / representation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "projection:coupon-payment-receipt"
+            ],
+            "sourceRefs": [
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          }
+        ],
+        "observationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "gap:coupon-runtime-payment-trace",
+          "projection:coupon-payment-receipt",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "missingRefs": [
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "no state observation supplied for operation square candidate"
+        ],
+        "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "axisWiseMonodromyDefects": [
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "authority",
+        "axisRef": "authority / trust boundary axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "contract",
+        "axisRef": "contract axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+        ],
+        "witnessRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "effect",
+        "axisRef": "effect ordering / replay / compensation axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 2,
+        "measuredSupportRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "witnessRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "projection",
+        "axisRef": "projection / representation axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "projection:coupon-payment-receipt"
+        ],
+        "witnessRefs": [
+          "projection:coupon-payment-receipt"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "projection:coupon-payment-receipt"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "runtime",
+        "axisRef": "runtime interaction axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "witnessRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 2,
+        "measuredSupportRefs": [
+          "derived-semantic-order:p=round(tax(discount(subtotal)))",
+          "derived-semantic-order:q=round(discount(tax(subtotal)))",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "witnessRefs": [
+          "derived-semantic-order:p=round(tax(discount(subtotal)))",
+          "derived-semantic-order:q=round(discount(tax(subtotal)))",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "derived-semantic-order:p=round(tax(discount(subtotal)))",
+          "derived-semantic-order:q=round(discount(tax(subtotal)))",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "state",
+        "axisRef": "state transition axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "static",
+        "axisRef": "static dependency / support axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "amiAggregateReadings": [
+      {
+        "aggregateId": "ami:measurement-policy-monodromy-boundary-holonomy",
+        "selectedSquareFamily": "operationSquareCandidates",
+        "selectedAxisFamily": [
+          "authority",
+          "contract",
+          "effect",
+          "projection",
+          "runtime",
+          "semantic",
+          "state",
+          "static"
+        ],
+        "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "partial",
+        "aggregateValue": 4,
+        "measuredDefectRefs": [
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+        ],
+        "unmeasuredDefectRefs": [
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+        ],
+        "topContributors": [
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "authority",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "state",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "static",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing static trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "effect",
+            "contributionWeight": 1,
+            "contributionValue": 2,
+            "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "semantic",
+            "contributionWeight": 1,
+            "contributionValue": 2,
+            "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "derived-semantic-order:p=round(tax(discount(subtotal)))",
+              "derived-semantic-order:q=round(discount(tax(subtotal)))",
+              "semantic:coupon-tax-rounding-paths"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "contract",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "projection",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "projection:coupon-payment-receipt"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "runtime",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review runtime trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ]
+          }
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "weighted aggregate is a review prioritization reading; cancellation can hide local defects, so top contributors remain authoritative",
+        "aggregateToLocalReadingBoundary": "AMI_X(A) summarizes selected local mu_x(sigma) readings and does not replace axis-wise defect review",
+        "reviewPriority": "reviewMissingEvidence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "nonzeroMonodromyWitnesses": [
+      {
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
+        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "operationPair": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+        ],
+        "pathPair": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+        ],
+        "axisFamily": "effect",
+        "axisRef": "effect ordering / replay / compensation axis",
+        "defectValue": 2,
+        "comparedTraceSummary": [
+          "p: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0",
+          "q: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0"
+        ],
+        "affectedAtomRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "lawRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "missingEvidence": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "suggestedFillerEvidence": [
+          "supply filler evidence for effect axis trace disagreement",
+          "record whether the two continuation paths preserve selected observations"
+        ],
+        "suggestedLiftingEvidence": [
+          "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+        ],
+        "suggestedBoundaryEvidence": [
+          "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+        ],
+        "recommendedReviewFocus": [
+          "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
+          "review effect axis witness refs and missing evidence"
+        ],
+        "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-semantic",
+        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "operationPair": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+        ],
+        "pathPair": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+        ],
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "defectValue": 2,
+        "comparedTraceSummary": [
+          "p: semantic continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0",
+          "q: semantic continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0"
+        ],
+        "affectedAtomRefs": [
+          "derived-semantic-order:p=round(tax(discount(subtotal)))",
+          "derived-semantic-order:q=round(discount(tax(subtotal)))",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "lawRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "derived-semantic-order:p=round(tax(discount(subtotal)))",
+          "derived-semantic-order:q=round(discount(tax(subtotal)))",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "missingEvidence": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "suggestedFillerEvidence": [
+          "supply filler evidence for semantic axis trace disagreement",
+          "record whether the two continuation paths preserve selected observations"
+        ],
+        "suggestedLiftingEvidence": [
+          "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+        ],
+        "suggestedBoundaryEvidence": [
+          "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+        ],
+        "recommendedReviewFocus": [
+          "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
+          "review semantic axis witness refs and missing evidence"
+        ],
+        "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "featureBoundaryResidualReadings": [
+      {
+        "readingId": "feature-boundary-residual:coupon-tax-rounding-archmap",
+        "boundaryRef": "Boundary(coupon-tax-rounding-archmap, feature-extension)",
+        "featureExtensionRef": "feature-extension-formula:coupon-tax-rounding-archmap",
+        "status": "measuredResidual",
+        "coreScopeRef": "coupon-tax-rounding-archmap:core",
+        "featureScopeRef": "coupon-tax-rounding-archmap:feature",
+        "mixedSubconfigurationRefs": [
+          "gap:coupon-runtime-payment-trace",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-coupon-operation-contract"
+        ],
+        "coreLocalReadingRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "featureLocalReadingRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "boundarySupportRefs": [
+          "gap:coupon-runtime-payment-trace",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-coupon-operation-contract"
+        ],
+        "holonomyAxes": [
+          {
+            "holonomyAxisRef": "Hol_static",
+            "axisFamily": "static",
+            "status": "coverageBlocked",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "missingEvidence": [
+              "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "reading": "Hol_static records boundary-local residual obstruction on the static axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_contract",
+            "axisFamily": "contract",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_contract records boundary-local residual obstruction on the contract axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_semantic",
+            "axisFamily": "semantic",
+            "status": "measuredResidual",
+            "residualValue": 2,
+            "measuredDefectRefs": [
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+            ],
+            "supportRefs": [
+              "derived-semantic-order:p=round(tax(discount(subtotal)))",
+              "derived-semantic-order:q=round(discount(tax(subtotal)))",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_semantic records boundary-local residual obstruction on the semantic axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_state",
+            "axisFamily": "state",
+            "status": "coverageBlocked",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "missingEvidence": [
+              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "reading": "Hol_state records boundary-local residual obstruction on the state axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_effect",
+            "axisFamily": "effect",
+            "status": "measuredResidual",
+            "residualValue": 2,
+            "measuredDefectRefs": [
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+            ],
+            "supportRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_authority",
+            "axisFamily": "authority",
+            "status": "coverageBlocked",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "missingEvidence": [
+              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_runtime",
+            "axisFamily": "runtime",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_projection",
+            "axisFamily": "projection",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "projection:coupon-payment-receipt"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_projection records boundary-local residual obstruction on the projection axis"
+          }
+        ],
+        "residualObstructionRefs": [
+          "gap:coupon-runtime-payment-trace",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-coupon-operation-contract"
+        ],
+        "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
+        "coverageAssumptions": [
+          "coveragePolicy=measure only selected axes with declared coverage; missing coverage remains blocked, not zero over selected axes [\"axis:layer-violation\", \"axis:semantic-inconsistency\"]",
+          "unmeasured boundary support remains residual coverage debt"
+        ],
+        "exactnessAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
+        "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
+        "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "featureExtensionDiagnosisReadings": [
+      {
+        "diagnosisId": "feature-extension-diagnosis:feature-extension-formula-coupon-tax-rounding-archmap",
+        "featureExtensionRef": "feature-extension-formula:coupon-tax-rounding-archmap",
+        "boundaryResidualRef": "feature-boundary-residual:coupon-tax-rounding-archmap",
+        "status": "multiLabelAttributed",
+        "classifierVersion": "feature-extension-diagnosis-classifier-v0",
+        "classificationSummary": [
+          {
+            "axis": "inheritedCoreObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "inheritedCoreObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "featureLocalObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "boundaryHolonomy",
+            "status": "observed",
+            "refs": [
+              "feature-boundary-residual:coupon-tax-rounding-archmap",
+              "gap:coupon-runtime-payment-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "liftingFailure",
+            "status": "observed",
+            "refs": [
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "reading": "liftingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "fillingFailure",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "fillingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "complexityTransfer",
+            "status": "observed",
+            "refs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "reading": "complexityTransfer is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "residualCoverageGap",
+            "status": "observed",
+            "refs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "residualCoverageGap is classified as a current-state extension coordinate"
+          }
+        ],
+        "attributionRecords": [
+          {
+            "witnessRef": "feature-boundary-residual:coupon-tax-rounding-archmap",
+            "labels": [
+              "boundaryHolonomy"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "feature-boundary-residual:coupon-tax-rounding-archmap"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "feature-boundary-residual:coupon-tax-rounding-archmap carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          },
+          {
+            "witnessRef": "gap:coupon-runtime-payment-trace",
+            "labels": [
+              "boundaryHolonomy",
+              "residualCoverageGap"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "reading": "gap:coupon-runtime-payment-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
+          },
+          {
+            "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+            "labels": [
+              "boundaryHolonomy",
+              "complexityTransfer"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "residualCoverageGapRefs": [],
+            "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+          },
+          {
+            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "labels": [
+              "boundaryHolonomy"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          },
+          {
+            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+            "labels": [
+              "boundaryHolonomy"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          },
+          {
+            "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+            "labels": [
+              "boundaryHolonomy",
+              "featureLocalObstruction",
+              "fillingFailure",
+              "inheritedCoreObstruction"
+            ],
+            "inheritedCoreRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "featureLocalRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "boundaryHolonomyRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+          },
+          {
+            "witnessRef": "split-readiness:molecule-coupon-operation-contract",
+            "labels": [
+              "boundaryHolonomy",
+              "liftingFailure"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "liftingFailureRefs": [
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "split-readiness:molecule-coupon-operation-contract carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"liftingFailure\"]"
+          }
+        ],
+        "residualCoverageGapRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "liftingFailureRefs": [
+          "split-readiness:molecule-coupon-operation-contract"
+        ],
+        "fillingFailureRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "complexityTransferRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
+        "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
+        "evidenceBoundary": "diagnosis is computed from ArchSig packet evidence and does not prove a mutually disjoint Architecture Extension Formula",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "monodromyReadingFamily": {
+      "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+      "status": "schemaFoundationOnly",
+      "archMapStoreRefSetRef": "archmap-store-refs:coupon-tax-rounding-archmap",
+      "selectedAxisRefs": [
+        "axis:layer-violation",
+        "axis:semantic-inconsistency"
+      ],
+      "distanceKind": "weighted-axis-l1",
+      "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+      "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+      "operationSquareCandidateRefs": [
+        "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+      ],
+      "pathContinuationTraceRefs": [
+        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q"
+      ],
+      "axisWiseDefectRefs": [
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+      ],
+      "amiAggregateReadingRefs": [
+        "ami:measurement-policy-monodromy-boundary-holonomy"
+      ],
+      "aggregateReadingKind": "ami-weighted-review-prioritization",
+      "readingBoundary": "records axis-wise defect and AMI aggregate readings as bounded review telemetry, not merge gates or global flatness theorems",
+      "evidenceBoundary": "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "boundaryHolonomyReadingFamily": {
+      "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+      "status": "schemaFoundationOnly",
+      "archMapStoreRefSetRef": "archmap-store-refs:coupon-tax-rounding-archmap",
+      "selectedAxisRefs": [
+        "axis:layer-violation",
+        "axis:semantic-inconsistency"
+      ],
+      "distanceKind": "weighted-axis-l1",
+      "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+      "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+      "nonzeroMonodromyWitnessRefs": [
+        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
+        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-semantic"
+      ],
+      "featureBoundaryResidualRefs": [
+        "feature-boundary-residual:coupon-tax-rounding-archmap"
+      ],
+      "extensionDiagnosisRefs": [
+        "feature-extension-diagnosis:feature-extension-formula-coupon-tax-rounding-archmap"
+      ],
+      "attributionBoundary": "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause",
+      "readingBoundary": "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues",
+      "evidenceBoundary": "boundary holonomy readings use ArchMapStore refs and LawPolicy axes; raw diff hunks are not ArchSig evidence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "representationStrengthReadings": [
+      {
+        "readingId": "representation-strength:analytic-weighted-adjacency",
+        "sourceReadingRef": "analytic:weighted-adjacency",
+        "representationFamily": "weightedAdjacencyMatrix",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "weightedAdjacencyMatrix is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-reachable-cone-size",
+        "sourceReadingRef": "analytic:reachable-cone-size",
+        "representationFamily": "reachableConeSize",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "reachableConeSize is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-walk-count",
+        "sourceReadingRef": "analytic:walk-count",
+        "representationFamily": "walkCount",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "walkCount is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-nilpotence-boundary",
+        "sourceReadingRef": "analytic:nilpotence-boundary",
+        "representationFamily": "nilpotenceBoundary",
+        "zeroPreserving": "bounded",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "nilpotenceBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-selected-subgraph-spectrum",
+        "sourceReadingRef": "analytic:selected-subgraph-spectrum",
+        "representationFamily": "selectedSubgraphSpectrum",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "selectedSubgraphSpectrum is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-propagation-depth",
+        "sourceReadingRef": "analytic:propagation-depth",
+        "representationFamily": "propagationDepth",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "propagationDepth is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-spectral-radius-proxy",
+        "sourceReadingRef": "analytic:spectral-radius-proxy",
+        "representationFamily": "spectralRadius",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "spectralRadius is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-curvature-valuation",
+        "sourceReadingRef": "analytic:curvature-valuation",
+        "representationFamily": "curvatureValuation",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "curvatureValuation is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-state-algebra-boundary",
+        "sourceReadingRef": "analytic:state-algebra-boundary",
+        "representationFamily": "stateAlgebra",
+        "zeroPreserving": "bounded",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "stateAlgebra is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-zero-reflecting-aggregate-boundary",
+        "sourceReadingRef": "analytic:zero-reflecting-aggregate-boundary",
+        "representationFamily": "zeroReflectingAggregateBoundary",
+        "zeroPreserving": "bounded",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-workflow-risk-axis-pressure",
+        "sourceReadingRef": "spectral:workflow-risk-axis-pressure",
+        "representationFamily": "workflowRiskAxisPressureMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "workflowRiskAxisPressureMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "coverage gaps on workflow axes block measured-zero interpretation for absent entries",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-molecule-atom-overlap-coupling",
+        "sourceReadingRef": "spectral:molecule-atom-overlap-coupling",
+        "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "moleculeAtomOverlapCouplingMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "missing atom families and observation gaps can make overlap coupling appear smaller than the source architecture actually is",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-obstruction-axis-curvature",
+        "sourceReadingRef": "spectral:obstruction-axis-curvature",
+        "representationFamily": "obstructionAxisCurvatureMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "obstructionAxisCurvatureMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "only constructed obstruction circuits are represented; concern hints that lack witness rules remain outside this matrix",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-operation-signature-delta",
+        "sourceReadingRef": "spectral:operation-signature-delta",
+        "representationFamily": "operationSignatureDeltaMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "operationSignatureDeltaMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "candidate operations are bounded review artifacts; absent delta entries are not proof that an operation preserves an axis",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "localCurvatureDiagramReadings": [
+      {
+        "diagramId": "local-curvature:obstruction-semantic-contract-mismatch-computed",
+        "lawRef": "law:semantic-contract-alignment",
+        "obstructionRef": "obstruction:semantic-contract-mismatch:computed",
+        "signatureAxisRefs": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "moleculeRefs": [
+          "molecule-coupon-operation-contract"
+        ],
+        "lhsPathRefs": [
+          "molecule-coupon-operation-contract"
+        ],
+        "rhsPathRefs": [
+          "law-path:law-semantic-contract-alignment",
+          "witness-path:witness-semantic-contract-mismatch"
+        ],
+        "curvatureValue": 1,
+        "curvatureStatus": "nonzero",
+        "diagramReading": "obstruction:semantic-contract-mismatch:computed is read as local curvature for law:semantic-contract-alignment",
+        "fillingBoundary": "diagram filling is LawPolicy-relative and requires selected witness completeness",
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "threeLayerFlatnessReadings": [
+      {
+        "readingId": "three-layer-flatness:coupon-tax-rounding-archmap",
+        "staticStatus": "unmeasured",
+        "runtimeStatus": "blockedByCoverageGap",
+        "semanticStatus": "stressed",
+        "staticObservationRefs": [],
+        "runtimeObservationRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "semanticObservationRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "crossLayerAtomRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:effect:receipt-boundary"
+        ],
+        "nonImplicationReading": "static flatness does not imply runtime or semantic flatness; cross-layer atoms must be reviewed separately",
+        "evidenceBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
+        "recommendedNextAction": "review cross-layer contract/state/effect/authority atoms before treating layer separation as flatness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "observationProjectionReadings": [
+      {
+        "readingId": "observation-projection:coupon-tax-rounding-archmap",
+        "observedAtomFamilies": [
+          "contractSpecification",
+          "effect",
+          "semanticInterpretation"
+        ],
+        "observedAtomFamilyCount": 3,
+        "forgottenCoordinates": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "observationCollisionPairs": [],
+        "collapsedAtomFamilyCandidates": [
+          "pricing.checkoutTotal -> contractSpecification,semanticInterpretation"
+        ],
+        "hiddenAtomFamilyHints": [
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "reconstructionRisk": "reconstructionLossPresent",
+        "coarseProjectionRisks": [
+          "coarse observation may merge distinct canonical atoms",
+          "unobserved source coordinates must not be read as absent atoms",
+          "LLM observation uncertainty is projection loss, not Atom non-uniqueness"
+        ],
+        "reconstructionBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout"
+        ],
+        "reading": "ArchMap is treated as an observation projection of a canonical source-derived Atom family",
+        "evidenceBoundary": "projection reading records lost coordinates and does not reconstruct the complete canonical Atom family",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "stateTransitionAlgebraReadings": [
+      {
+        "readingId": "state-transition-algebra:coupon-tax-rounding-archmap",
+        "generatorRefs": [
+          "atom:effect:receipt-boundary"
+        ],
+        "stateAtomRefs": [],
+        "effectAtomRefs": [
+          "atom:effect:receipt-boundary"
+        ],
+        "runtimeAtomRefs": [],
+        "requiredRelations": [
+          "idempotency",
+          "replay safety",
+          "state/effect ordering",
+          "compensation or finalization",
+          "transaction boundary ownership"
+        ],
+        "unresolvedRelations": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "obstructionRefs": [],
+        "reading": "state/effect/runtime atoms generate a bounded state transition algebra reading",
+        "evidenceBoundary": "transition algebra is derived from observed atoms only; runtime traces and tests remain required for reflecting laws",
+        "recommendedNextAction": "verify idempotency, replay, ordering, and transaction ownership before claiming state/effect flatness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationInvariantGaloisReadings": [
+      {
+        "readingId": "operation-invariant-galois:selected-law-policy",
+        "invariantFamilyRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "operationFamilyRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "opsOfInvariants": [
+          "repair:obstruction-semantic-contract-mismatch-computed is allowed only relative to preserved [\"preserve zero reading for sig-axis:layer-violation\"]"
+        ],
+        "invOfOperations": [
+          "invariant:law-layer-respecting must be preserved by selected operation families (preservedForConstructedWitnesses)",
+          "invariant:law-semantic-contract-alignment must be preserved by selected operation families (stressed)"
+        ],
+        "preservedInvariantRefs": [
+          "invariant:law-layer-respecting"
+        ],
+        "blockedOperationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "reading": "operation families and invariant families form an AAT Galois-style review reading",
+        "evidenceBoundary": "this reading classifies allowed operation families; it does not prove repair soundness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "splitReadinessReadings": [
+      {
+        "readingId": "split-readiness:molecule-coupon-operation-contract",
+        "moleculeRef": "molecule:coupon-operation-contract",
+        "status": "needsReview",
+        "readinessScore": 92,
+        "coreEmbeddingStatus": "observed",
+        "featureViewSectionStatus": "needsSemanticView",
+        "liftingEvidenceStatus": "notBlockedByObservedBridge",
+        "interactionObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "bridgeEdgeRefs": [],
+        "recommendedBoundaryOperation": "interface",
+        "reading": "molecule:coupon-operation-contract has split readiness score 92 under current ArchSig evidence",
+        "evidenceBoundary": "split readiness is a current-state architecture reading, not a feature-extension proof",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "structuralReadingReviewSurface": {
+      "surfaceId": "aat-structural-reading-review-surface",
+      "status": "needsReview",
+      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1",
+      "connectedReadingRefs": [
+        "representationStrength:weightedAdjacencyMatrix",
+        "representationStrength:reachableConeSize",
+        "representationStrength:walkCount",
+        "representationStrength:nilpotenceBoundary",
+        "representationStrength:selectedSubgraphSpectrum",
+        "representationStrength:propagationDepth",
+        "local-curvature:obstruction-semantic-contract-mismatch-computed",
+        "three-layer-flatness:coupon-tax-rounding-archmap",
+        "observation-projection:coupon-tax-rounding-archmap",
+        "state-transition-algebra:coupon-tax-rounding-archmap",
+        "operation-invariant-galois:selected-law-policy",
+        "split-readiness:molecule-coupon-operation-contract",
+        "atom-support-axis:coupon-tax-rounding-archmap",
+        "atom-support-axis:molecule-coupon-operation-contract",
+        "atom-compatibility:coupon-tax-rounding-archmap",
+        "law-universe-coverage:llm-native-aat-law-policy-fixture",
+        "feature-extension-formula:coupon-tax-rounding-archmap",
+        "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
+        "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "homotopy-order-sensitivity:selected-operations",
+        "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed",
+        "axis-forgetting-risk:selected-projection",
+        "signature-trajectory-homotopy-refutation:selected-trajectory",
+        "bridge-split-obstruction-transfer:split-readiness-molecule-coupon-operation-contract"
+      ],
+      "reviewFocus": [
+        "read Atom support and compatibility before collapsing mixed state, effect, contract, authority, semantic, or runtime axes",
+        "read LawUniverse coverage and witness exactness before treating absence as measured zero",
+        "read feature extension, operation law, trajectory, homotopy, and diagram-fillability axes as current-state coordinates, not PR evolution claims",
+        "read axis-forgetting risk before treating a coarse projection as zero-reflecting or obstruction-reflecting",
+        "read selected trajectory disagreement before treating same-endpoint operations as homotopic",
+        "read bridge split transfer before treating a boundary operation as obstruction removal",
+        "read representation-strength blockers before treating zero or obstruction absence as exact",
+        "read local-curvature diagrams as law-relative state pressure, not as generic lint failures",
+        "compare static, runtime, and semantic flatness before relying on source layout",
+        "treat observation projection gaps as lost coordinates that bound the reading",
+        "check state/effect algebra relations before approving local repairs",
+        "read split readiness and bridge edges before separating molecules"
+      ],
+      "evidenceBoundary": "structural readings are computed from the current ArchMap and selected LawPolicy; they are review telemetry, not proof of global architecture truth",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "currentStateEvolutionBoundary": {
+      "boundaryId": "archsig-fieldsig-current-state-evolution-boundary",
+      "archsigCurrentStateScope": "ArchSig computes current AAT structural state from ArchMap coupon-tax-rounding-archmap and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
+      "fieldsigEvolutionScope": "FieldSig consumes archsig-analysis-packet-v0 as bounded current AAT structural state and studies PR, diff, change-vector, forecast, governance, calibration, and operational evolution over that state",
+      "handoffArtifactRef": "archsig-analysis-packet-v0",
+      "forbiddenReadings": [
+        "ArchSig packet is not PR diff analysis",
+        "ArchSig packet is not forecast correctness or causal truth",
+        "raw ArchMap observations are not FieldSig forecast truth",
+        "FieldSig evolution readings must not be moved back into ArchMap"
+      ],
+      "evidenceBoundary": "handoff preserves bounded current-state evidence; evolution claims remain downstream FieldSig readings",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "designPrincipleReadings": [
+      {
+        "principleId": "principle:informationhiding",
+        "principle": "InformationHiding",
+        "status": "stressed",
+        "aatReading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:encapsulation",
+        "principle": "Encapsulation",
+        "status": "stressed",
+        "aatReading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:separationofconcerns",
+        "principle": "SeparationOfConcerns",
+        "status": "stressed",
+        "aatReading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:substitutability",
+        "principle": "Substitutability",
+        "status": "stressed",
+        "aatReading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:openclosedextension",
+        "principle": "OpenClosedExtension",
+        "status": "stressed",
+        "aatReading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:dependencyinversion",
+        "principle": "DependencyInversion",
+        "status": "stressed",
+        "aatReading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:representationindependence",
+        "principle": "RepresentationIndependence",
+        "status": "unmeasured",
+        "aatReading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "low",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:idempotencyandreplaysafety",
+        "principle": "IdempotencyAndReplaySafety",
+        "status": "unmeasured",
+        "aatReading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "low",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:authorityandtrustboundary",
+        "principle": "AuthorityAndTrustBoundary",
+        "status": "unmeasured",
+        "aatReading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "low",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "flatnessReading": {
+      "readingId": "flatness:llm-native-aat-law-policy-fixture",
+      "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture",
+      "status": "nonflatUnderSelectedPolicy",
+      "zeroSignatureAxisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "nonzeroSignatureAxisRefs": [
+        "sig-axis:semantic-inconsistency"
+      ],
+      "blockedByCoverageGaps": [
+        "gap:coupon-runtime-payment-trace"
+      ],
+      "evidenceBoundary": "flatness is relative to selected signature axes, coverage gaps, and exactness assumptions",
+      "interpretationNotesForLLM": [
+        "Do not turn zero signature axes into global lawfulness claims."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "staticRuntimeSemanticLayerSplit": {
+      "staticObservationRefs": [],
+      "runtimeObservationRefs": [
+        "gap:coupon-runtime-payment-trace"
+      ],
+      "semanticObservationRefs": [
+        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+        "semantic:coupon-tax-rounding-paths"
+      ],
+      "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "repairOperationCandidates": [
+      {
+        "repairOperationCandidateId": "repair:obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "targetObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "preservedInvariants": [
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "preconditions": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+        ],
+        "expectedSignatureAxisEffects": [
+          "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+        ],
+        "transferRisks": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
+        "missingEvidence": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "causal forecast correctness",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "merge approval",
+          "single architecture quality score"
+        ],
+        "interpretationNotesForLLM": [
+          "Explain preconditions and transfer risks before implementation advice."
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationDeltas": [
+      {
+        "operationDeltaId": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "supportRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "preconditions": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+        ],
+        "atomTransformations": [
+          "split or enrich atoms that currently support the target obstruction",
+          "add observed compensation / authority / effect atoms only after source review"
+        ],
+        "transitionRelation": "operation maps the current bounded Atom configuration to a candidate repaired configuration",
+        "invariantPreservationClaims": [
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "obstructionTransport": [
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis"
+        ],
+        "signatureDelta": [
+          "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+        ],
+        "decreasedAxes": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "transferredObstructions": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "causal forecast correctness",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "merge approval",
+          "single architecture quality score"
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathHomotopyDiagramReadings": [
+      {
+        "readingId": "path:semantic-operation-flow",
+        "surface": "Path",
+        "status": "observedOrRepresented",
+        "pathRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "homotopyRefs": [
+          "molecule-reading:molecule-coupon-operation-contract"
+        ],
+        "diagramRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "fillingBoundary": "path reading is a source-grounded semantic workflow proxy, not a free-category proof",
+        "reading": "semantic observations and molecules provide path candidates for review",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "diagram:obstruction-filling",
+        "surface": "Diagram",
+        "status": "actionable",
+        "pathRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "homotopyRefs": [
+          "molecule-reading:molecule-coupon-operation-contract"
+        ],
+        "diagramRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "fillingBoundary": "diagram filling is reported as obstruction / repair planning surface, not theorem discharge",
+        "reading": "constructed obstruction circuits identify diagrams whose filling requires review or repair",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "boundedJudgements": [
+      {
+        "judgementId": "judgement:architecture-state",
+        "status": "actionable",
+        "aatConcept": "ArchitectureObject",
+        "reading": "observed atoms, molecules, semantic records, gaps, and signature axes define a bounded architecture state",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "coverageBoundary": "bounded to supplied ArchMap and selected interpretation profile",
+        "exactnessBoundary": "not global architecture truth and not Lean theorem proof",
+        "recommendedNextAction": "review nonzero axes and stressed principle readings first",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:obstruction-semantic-contract-mismatch-computed",
+        "status": "actionable",
+        "aatConcept": "ObstructionCircuit",
+        "reading": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "semantic:coupon-tax-rounding-paths",
+          "molecule-reading:molecule-coupon-operation-contract",
+          "concern:coupon-semantic-monodromy"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "coverageBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+        "exactnessBoundary": "witness is selected-profile-relative",
+        "recommendedNextAction": "inspect source refs and repair operation preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:sig-axis-layer-violation",
+        "status": "needsReview",
+        "aatConcept": "ArchitectureSignature",
+        "reading": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+        "evidenceRefs": [
+          "sig-axis:layer-violation: no direct source refs under selected coverage"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "coverageBoundary": "coverage-gap-preserved",
+        "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+        "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:sig-axis-semantic-inconsistency",
+        "status": "actionable",
+        "aatConcept": "ArchitectureSignature",
+        "reading": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "coverageBoundary": "coverage-gap-preserved",
+        "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+        "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-informationhiding",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-encapsulation",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-separationofconcerns",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-substitutability",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-openclosedextension",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-dependencyinversion",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-representationindependence",
+        "status": "blocked",
+        "aatConcept": "Invariant",
+        "reading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-idempotencyandreplaysafety",
+        "status": "blocked",
+        "aatConcept": "Invariant",
+        "reading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-authorityandtrustboundary",
+        "status": "blocked",
+        "aatConcept": "Invariant",
+        "reading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+        "evidenceRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "llmInterpretationPacket": {
+      "packetId": "llm-interpretation:coupon-tax-rounding-archmap",
+      "shortDiagnosis": "9 actionable judgement(s), 1 design pressure reading(s), and 1 observation gap(s) require review",
+      "aatConceptMap": [
+        "Atom -> Configuration -> ArchitectureObject",
+        "InvariantFamily -> LawUniverse -> ObstructionCircuit -> ArchitectureSignature",
+        "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation"
+      ],
+      "observedAtomsSummary": [
+        "contractSpecification",
+        "effect",
+        "semanticInterpretation"
+      ],
+      "obstructionSummary": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "signatureAxesSummary": [
+        "sig-axis:layer-violation=0 (coverage-gap-preserved)",
+        "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
+      ],
+      "analyticReadingsSummary": [
+        "weightedAdjacencyMatrix=7x7; edgeCount=0 (measured)",
+        "reachableConeSize=7 (measured)",
+        "walkCount=1 (measured)",
+        "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
+        "selectedSubgraphSpectrum=[0.000] (measured)",
+        "propagationDepth=0 (measured)",
+        "spectralRadius=0.000 (measured)",
+        "curvatureValuation=1 (measured)",
+        "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
+        "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
+      ],
+      "spectralReadingsSummary": [
+        "workflowRiskAxisPressureMatrix upperBound=9.220 shape=1x5 (needsReview)",
+        "moleculeAtomOverlapCouplingMatrix upperBound=3.000 shape=1x1 (needsReview)",
+        "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
+        "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
+      ],
+      "spectralModeSummary": [
+        "workflowRiskAxisPressureMatrix distributedPressureMode gap=8.185 localization=1.000 density=1.000 (needsReview)",
+        "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=3.000 localization=1.000 density=1.000 (needsReview)",
+        "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
+        "operationSignatureDeltaMatrix localizedPerturbationMode gap=1.000 localization=1.000 density=0.500 (actionable)"
+      ],
+      "spectralDrilldownSummary": [
+        "spectral-drilldown:coupon-tax-rounding-archmap atomFamilies=3 overlapPairs=0 repairAxisDeltas=1 (needsReview)"
+      ],
+      "curvatureSupportSummary": [
+        "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
+      ],
+      "curvatureTransferSummary": [
+        "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1 (needsReview)"
+      ],
+      "architectureSpectrumReportSummary": [
+        "architecture-spectrum-report:spectrum-profile-curvature-transfer-default hotspots=4 recurrent=1 clusters=2 (needsReview)",
+        "report is measured from ArchSig curvature support and transfer readings under selected LawPolicy coverage and exactness assumptions"
+      ],
+      "transferBridgeSummary": [
+        "transfer-bridge:coupon-tax-rounding-archmap transfers=0 bridges=1 repairRanks=1 boundaryRanks=0 (nonConclusion)"
+      ],
+      "transferBridgeEdgeSummary": [],
+      "measurementExpansionSummary": [
+        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 2 nonzero monodromy witnesses"
+      ],
+      "atomSupportAxisSummary": [
+        "coupon-tax-rounding-archmap support=2 concentration=maxAxisShare=1/3 pressure=mixedAxisPressurePresent",
+        "molecule:coupon-operation-contract support=2 concentration=maxAxisShare=1/3 pressure=mixedAxisPressurePresent"
+      ],
+      "atomCompatibilitySummary": [
+        "atom-compatibility:coupon-tax-rounding-archmap status=compatibleWithinObservedSlots sameSlotConflicts=0 uncertainty=1"
+      ],
+      "lawUniverseCoverageSummary": [
+        "llm-native-aat-law-policy-fixture required=2 unmeasured=1 blockedWitnesses=2"
+      ],
+      "featureExtensionFormulaSummary": [
+        "feature-extension-formula:coupon-tax-rounding-archmap status=measured inherited=1 featureLocal=1 interaction=0 residualGaps=1"
+      ],
+      "operationCalculusLawSummary": [
+        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
+      ],
+      "pathSignatureTrajectorySummary": [
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=1 transferred=1"
+      ],
+      "homotopyOrderSensitivitySummary": [
+        "homotopy-order-sensitivity:selected-operations status=sensitive orderSensitivity=blockedByTransferredObstructionOrMissingEvidence blockers=5"
+      ],
+      "diagramFillabilitySummary": [
+        "local-curvature:obstruction-semantic-contract-mismatch-computed family=localCurvatureDiagram status=nonFillabilityWitnessed missingFiller=lawRelativeFiller blockers=1"
+      ],
+      "axisForgettingRiskSummary": [
+        "observation-projection:coupon-tax-rounding-archmap kind=selectedAxisOrWitnessLoss zeroReflection=blockedWithoutAxisPreservationAndWitnessCompleteness obstructionReflection=blockedWithoutAxisPreservationAndWitnessCompleteness mixedScopes=2"
+      ],
+      "signatureTrajectoryHomotopyRefutationSummary": [
+        "homotopy-order-sensitivity:selected-operations equivalence=selectedTrajectoryDisagreementObserved refutation=refutationCandidate disagreements=1"
+      ],
+      "bridgeSplitObstructionTransferSummary": [
+        "split-readiness:molecule-coupon-operation-contract transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
+      ],
+      "nonzeroMonodromyWitnessSummary": [
+        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2",
+        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-semantic axis=semantic defect=2 affectedAtoms=3 missingEvidence=0 focus=2"
+      ],
+      "featureBoundaryResidualSummary": [
+        "feature-boundary-residual:coupon-tax-rounding-archmap boundary=Boundary(coupon-tax-rounding-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=6"
+      ],
+      "featureExtensionDiagnosisSummary": [
+        "feature-extension-diagnosis:feature-extension-formula-coupon-tax-rounding-archmap status=multiLabelAttributed attributions=7 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
+      ],
+      "representationStrengthSummary": [
+        "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "reachableConeSize zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "walkCount zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "nilpotenceBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "selectedSubgraphSpectrum zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "propagationDepth zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "spectralRadius zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
+        "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
+        "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
+        "operationSignatureDeltaMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1"
+      ],
+      "localCurvatureDiagramSummary": [
+        "local-curvature:obstruction-semantic-contract-mismatch-computed law=law:semantic-contract-alignment curvature=1 axes=1"
+      ],
+      "threeLayerFlatnessSummary": [
+        "three-layer-flatness:coupon-tax-rounding-archmap static=unmeasured runtime=blockedByCoverageGap semantic=stressed crossLayerAtoms=2"
+      ],
+      "observationProjectionSummary": [
+        "observation-projection:coupon-tax-rounding-archmap families=3 forgotten=1 blockers=1"
+      ],
+      "stateTransitionAlgebraSummary": [
+        "state-transition-algebra:coupon-tax-rounding-archmap generators=1 unresolved=1 obstructions=0"
+      ],
+      "operationInvariantGaloisSummary": [
+        "operation-invariant-galois:selected-law-policy invariants=2 operations=1 blockedOps=1"
+      ],
+      "splitReadinessSummary": [
+        "molecule:coupon-operation-contract status=needsReview score=92 boundaryOp=interface"
+      ],
+      "structuralReadingReviewSummary": [
+        "aat-structural-reading-review-surface status=needsReview refs=24 focus=12",
+        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1"
+      ],
+      "currentStateEvolutionBoundarySummary": [
+        "ArchSig computes current AAT structural state from ArchMap coupon-tax-rounding-archmap and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
+        "FieldSig consumes archsig-analysis-packet-v0 as bounded current AAT structural state and studies PR, diff, change-vector, forecast, governance, calibration, and operational evolution over that state",
+        "handoff=archsig-analysis-packet-v0 forbiddenReadings=4"
+      ],
+      "repairOperationSummary": [
+        "repair:obstruction-semantic-contract-mismatch-computed targets [\"obstruction:semantic-contract-mismatch:computed\"]"
+      ],
+      "complexityTransferNotes": [
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+        "molecule:coupon-operation-contract: review low (llmOutputMediation, stateEffectReconciliation, authorityTrustBoundary)"
+      ],
+      "coverageGapsAndExactnessBlockers": [
+        "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ],
+      "recommendedHumanReviewFocus": [
+        "judgement:architecture-state: review nonzero axes and stressed principle readings first",
+        "judgement:obstruction-semantic-contract-mismatch-computed: inspect source refs and repair operation preconditions",
+        "judgement:sig-axis-layer-violation: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "judgement:sig-axis-semantic-inconsistency: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "judgement:principle-informationhiding: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-encapsulation: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-separationofconcerns: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-substitutability: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-openclosedextension: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-dependencyinversion: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-representationindependence: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-idempotencyandreplaysafety: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-authorityandtrustboundary: turn stressed readings into source review questions or repair preconditions"
+      ]
+    },
+    "evidenceBoundary": "computed from ArchMap coupon-tax-rounding-archmap and selected interpretation profile llm-native-aat-law-policy-fixture; concernHints are auxiliary cues only",
+    "interpretationNotesForLLM": [
+      "Lead with selected LawPolicy scope and evidence gaps.",
+      "Explain nonzero signature axes as law-relative ArchSig outputs.",
+      "Do not describe concernHints as obstruction circuits."
+    ],
+    "excludedReadings": [
+      "single architecture quality score",
+      "global architecture lawfulness",
+      "automatic repair safety",
+      "concern hint promoted without LawPolicy witness rule"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
+  "summary": {
+    "result": "pass",
+    "aatConceptSurfaceCount": 12,
+    "moleculeReadingCount": 1,
+    "obstructionCircuitCount": 1,
+    "signatureAxisCount": 2,
+    "analyticRepresentationCount": 10,
+    "couplingCohesionReadingCount": 4,
+    "workflowRiskReadingCount": 1,
+    "spectralAnalysisReadingCount": 4,
+    "spectralModeReadingCount": 4,
+    "spectralDrilldownReadingCount": 1,
+    "curvatureSupportReadingCount": 1,
+    "curvatureTransferReadingCount": 1,
+    "transferBridgeReadingCount": 1,
+    "atomSupportAxisReadingCount": 2,
+    "atomCompatibilityReadingCount": 1,
+    "lawUniverseCoverageReadingCount": 1,
+    "featureExtensionFormulaReadingCount": 1,
+    "operationCalculusLawReadingCount": 1,
+    "pathSignatureTrajectoryReadingCount": 1,
+    "homotopyOrderSensitivityReadingCount": 1,
+    "diagramFillabilityReadingCount": 1,
+    "axisForgettingRiskReadingCount": 1,
+    "signatureTrajectoryHomotopyRefutationReadingCount": 1,
+    "bridgeSplitObstructionTransferReadingCount": 1,
+    "representationStrengthReadingCount": 14,
+    "localCurvatureDiagramReadingCount": 1,
+    "threeLayerFlatnessReadingCount": 1,
+    "observationProjectionReadingCount": 1,
+    "stateTransitionAlgebraReadingCount": 1,
+    "operationInvariantGaloisReadingCount": 1,
+    "splitReadinessReadingCount": 1,
+    "designPrincipleReadingCount": 9,
+    "repairOperationCandidateCount": 1,
+    "operationDeltaCount": 1,
+    "boundedJudgementCount": 13,
+    "failedCheckCount": 0,
+    "warningCheckCount": 0
+  },
+  "checks": [
+    {
+      "id": "archsig-analysis-packet-schema-version-supported",
+      "title": "ArchSig analysis packet schema version is supported",
+      "result": "pass"
+    },
+    {
+      "id": "archsig-analysis-packet-refs-and-identity",
+      "title": "analysis identity and ArchMap / LawPolicy references are recorded",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-north-star-aat-surfaces",
+      "title": "packet represents all AAT concept surfaces required by the North Star PRD",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-bounded-judgement-surface",
+      "title": "packet makes non-conclusion usable through bounded judgement records",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-analytic-and-principle-surfaces",
+      "title": "packet exposes analytic axes, semantic coupling/cohesion, and static-hard design principle readings",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-workflow-risk-surface",
+      "title": "packet exposes workflow-local risk readings with review focus and bounded evidence boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-spectral-analysis-surface",
+      "title": "packet exposes AAT spectral readings as bounded finite-representation proxies",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-spectral-mode-surface",
+      "title": "packet exposes bounded spectral mode readings for localization, decomposability, and repair perturbation review",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-spectral-drilldown-surface",
+      "title": "packet explains spectral modes through atom families, overlap pairs, and repair axis deltas",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-curvature-support-surface",
+      "title": "packet exposes curvature support rows, top modes, witness clusters, and unmeasured boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-curvature-transfer-surface",
+      "title": "packet exposes finite transfer operator, recurrent obstruction modes, rho(T^kappa) reading, and forecast non-conclusions",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-architecture-spectrum-report-surface",
+      "title": "packet exposes ArchitectureSpectrumReport hotspots, recurrent obstructions, measured boundary, review focus, and non-conclusions",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-transfer-bridge-surface",
+      "title": "packet exposes transfer matrix, bridge atom families, and evolution risk ranking",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-aat-structural-readings",
+      "title": "packet exposes representation strength, curvature, layer flatness, projection, transition algebra, Galois, and split readiness readings",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-fieldsig-current-state-evolution-boundary",
+      "title": "packet preserves ArchSig current-state and FieldSig evolution responsibilities",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-operation-square-trace-surface",
+      "title": "packet enumerates inferred/supplied operation square candidates and axis-wise path continuation traces",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-axis-defect-ami-surface",
+      "title": "packet carries mu_x(sigma) axis-wise defects and AMI aggregate review readings without theorem or merge-gate conclusions",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-nonzero-monodromy-witness-surface",
+      "title": "packet surfaces positive measured mu_x(sigma) defects as reviewer-readable nonzero monodromy witnesses",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-feature-boundary-residual-surface",
+      "title": "packet surfaces Boundary(A,f) residual holonomy axes as bounded review telemetry",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-feature-extension-diagnosis-surface",
+      "title": "packet reports non-disjoint feature-extension multi-label attribution without replacing FieldSig evolution analysis",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-monodromy-boundary-foundation",
+      "title": "packet defines ArchMapStore refs and monodromy / boundary holonomy reading family policy surfaces",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-law-relative-obstructions",
+      "title": "obstruction circuits are LawPolicy-relative and cross-reference molecule and signature readings",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-signature-and-flatness",
+      "title": "signature axes and flatness reading preserve coverage and exactness boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-repair-operation-boundary",
+      "title": "repair operation candidates preserve invariant, precondition, transfer risk, and evidence boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-llm-interpretation-surface",
+      "title": "packet carries evidence boundary, excluded readings, and LLM interpretation notes",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-non-conclusion-boundary",
+      "title": "packet keeps theorem, global truth, completeness, score, flatness, and repair boundaries explicit",
+      "result": "pass",
+      "count": 0
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/acts_spectrum/manifest.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/manifest.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "archsig-acts-spectrum-fixture-manifest-v0",
+  "manifestId": "acts-spectrum-golden-fixtures",
+  "purpose": "Lock ACTS fixture coverage for ArchitectureSpectrumReport without treating fixtures as architecture lawfulness proof or empirical incident calibration.",
+  "cases": [
+    {
+      "caseId": "zero-curvature-support",
+      "description": "Minimal fixture preserves measured zero curvature support as distinct from coverage gaps.",
+      "packetPath": "minimal/archsig_analysis_packet.json",
+      "validationPath": "acts_spectrum/minimal_validation.json",
+      "expectedSurface": "curvatureSupportReadings",
+      "axisRef": "axis:layer-violation",
+      "expectedCurvatureValue": 0,
+      "requiresMissingEvidence": true
+    },
+    {
+      "caseId": "nonzero-semantic-curvature",
+      "description": "Minimal fixture exposes nonzero semantic curvature as a hotspot with witness refs.",
+      "packetPath": "minimal/archsig_analysis_packet.json",
+      "validationPath": "acts_spectrum/minimal_validation.json",
+      "expectedSurface": "architectureSpectrumReport.topHotspots",
+      "axisRef": "axis:semantic-inconsistency",
+      "minimumCurvatureValue": 1,
+      "requiresWitnessRefs": true
+    },
+    {
+      "caseId": "transfer-cycle",
+      "description": "Minimal fixture locks a positive closed transfer edge as recurrent obstruction support.",
+      "packetPath": "minimal/archsig_analysis_packet.json",
+      "validationPath": "acts_spectrum/minimal_validation.json",
+      "expectedSurface": "architectureSpectrumReport.recurrentObstructions",
+      "requiresTransferEdgeRefs": true,
+      "requiresSpectralRadiusReading": true
+    },
+    {
+      "caseId": "coverage-gap-boundary",
+      "description": "Minimal fixture keeps missing runtime trace evidence as report coverage gap.",
+      "packetPath": "minimal/archsig_analysis_packet.json",
+      "validationPath": "acts_spectrum/minimal_validation.json",
+      "expectedSurface": "architectureSpectrumReport.coverageGaps",
+      "requiredText": "runtime trace was requested but not supplied"
+    },
+    {
+      "caseId": "coupon-tax-rounding-acts",
+      "description": "Coupon/tax/rounding fixture exposes ACTS report and keeps payment trace coverage as a gap.",
+      "packetPath": "coupon_rounding/archsig_analysis_packet.json",
+      "validationPath": "acts_spectrum/coupon_validation.json",
+      "expectedSurface": "architectureSpectrumReport",
+      "requiredText": "coupon-runtime-payment-trace",
+      "requiresHotspots": true,
+      "requiresRecurrentObstructions": true
+    }
+  ],
+  "nonConclusions": [
+    "ACTS fixtures are not architecture lawfulness proof.",
+    "ACTS fixtures are not empirical incident calibration.",
+    "ArchitectureSpectrumReport is not a single architecture quality score.",
+    "Coverage gaps are not measured zero."
+  ]
+}

--- a/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
@@ -1,0 +1,6594 @@
+{
+  "schemaVersion": "archsig-analysis-packet-validation-report-v0",
+  "input": {
+    "schemaVersion": "archsig-analysis-packet-v0",
+    "path": "archsig-analysis-packet",
+    "analysisId": "archsig-analysis:fixture-archmap-atom-observation:llm-native-aat-law-policy-fixture",
+    "archMapRef": "fixture-archmap-atom-observation",
+    "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture"
+  },
+  "packet": {
+    "schemaVersion": "archsig-analysis-packet-v0",
+    "analysisId": "archsig-analysis:fixture-archmap-atom-observation:llm-native-aat-law-policy-fixture",
+    "generatedAt": "2026-05-23T00:00:00Z",
+    "archMapRef": {
+      "artifactId": "fixture-archmap-atom-observation",
+      "artifactKind": "archmap",
+      "schemaVersion": "archmap-observation-map-v0",
+      "path": "tools/archsig/tests/fixtures/minimal/archmap.json"
+    },
+    "interpretationProfileRef": {
+      "artifactId": "llm-native-aat-law-policy-fixture",
+      "artifactKind": "interpretation-profile",
+      "schemaVersion": "law-policy-v0",
+      "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
+    },
+    "selectedLawPolicyRef": {
+      "artifactId": "llm-native-aat-law-policy-fixture",
+      "artifactKind": "law-policy",
+      "schemaVersion": "law-policy-v0",
+      "path": "tools/archsig/tests/fixtures/minimal/law_policy.json"
+    },
+    "archMapStoreRefs": {
+      "refSetId": "archmap-store-refs:fixture-archmap-atom-observation",
+      "archMapRef": "fixture-archmap-atom-observation",
+      "deltaRef": {
+        "artifactId": "archmap-delta:fixture-archmap-atom-observation:current",
+        "artifactKind": "archmap-delta",
+        "schemaVersion": "archmap-delta-v0"
+      },
+      "commitRef": {
+        "artifactId": "archmap-commit:fixture-archmap-atom-observation:current",
+        "artifactKind": "archmap-commit",
+        "schemaVersion": "archmap-commit-v0"
+      },
+      "snapshotRef": {
+        "artifactId": "archmap-snapshot:fixture-archmap-atom-observation:current",
+        "artifactKind": "archmap-snapshot",
+        "schemaVersion": "archmap-snapshot-v0"
+      },
+      "indexRef": {
+        "artifactId": "archmap-index:fixture-archmap-atom-observation:current",
+        "artifactKind": "archmap-index",
+        "schemaVersion": "archmap-index-v0"
+      },
+      "rawDiffBoundary": "raw diffs are not ArchSig semantic inputs; upstream source readers must translate source changes into ArchMapStore delta / commit / snapshot / index refs",
+      "compactionBoundary": "snapshot and index compaction may lose per-change granularity; compaction loss remains explicit evidence boundary",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "architectureState": {
+      "stateId": "architecture-state:archmap-fixture-repo",
+      "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
+      "atomFamilyRefs": [
+        "contractSpecification",
+        "existence",
+        "relation"
+      ],
+      "moleculeRefs": [
+        "molecule:user-request-responsibility"
+      ],
+      "workflowRefs": [
+        "semantic:create-user-flow"
+      ],
+      "boundaryRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "invariantRefs": [
+        "invariant:law-layer-respecting",
+        "invariant:law-semantic-contract-alignment"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "coverageBoundary": "state is an ArchMap-relative architecture state, not a complete source reconstruction",
+      "recommendedNextAction": "review nonzero axes, stressed principles, and preserved observation gaps before planning repair",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "designPressure": [
+      {
+        "pressureId": "design-pressure:selected-atom-configuration",
+        "status": "actionable",
+        "reading": "1 selected obstruction circuit(s) and 1 coverage gap(s) define the current pressure surface",
+        "atomConfigurationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "coverageBoundary": "pressure is relative to the observed finite Atom configuration and selected profile",
+        "recommendedNextAction": "use bounded judgements to decide whether to inspect source refs, add evidence, or plan repair",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "changeImpact": {
+      "impactId": "change-impact:selected-repair-operations",
+      "operationScope": "repair, extension, migration, and refactor operations over observed ArchMap atoms",
+      "signatureDeltaSummary": [
+        "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+      ],
+      "affectedBoundaries": [
+        "sig-axis:layer-violation: coverage-gap-preserved",
+        "sig-axis:semantic-inconsistency: coverage-gap-preserved"
+      ],
+      "complexityTransferNotes": [
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "coverageBoundary": "impact is a pre-change operation reading; it is not evidence that a future patch is safe",
+      "recommendedNextAction": "compare operation deltas before and after the patch and keep transferred obstruction notes",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "aatConceptSurfaces": [
+      {
+        "concept": "Atom",
+        "status": "observedOrRepresented",
+        "reading": "Atom is represented with 4 bounded packet record(s)",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Configuration",
+        "status": "observedOrRepresented",
+        "reading": "Configuration is represented with 5 bounded packet record(s)",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "ArchitectureObject",
+        "status": "observedOrRepresented",
+        "reading": "ArchitectureObject is represented with 3 bounded packet record(s)",
+        "evidenceRefs": [
+          "projection:aat:route-users",
+          "projection:aat:route-service",
+          "projection:sft:create-user"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Invariant",
+        "status": "observedOrRepresented",
+        "reading": "Invariant is represented with 2 bounded packet record(s)",
+        "evidenceRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "LawUniverse",
+        "status": "observedOrRepresented",
+        "reading": "LawUniverse is represented with 2 bounded packet record(s)",
+        "evidenceRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "ObstructionCircuit",
+        "status": "observedOrRepresented",
+        "reading": "ObstructionCircuit is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "ArchitectureSignature",
+        "status": "observedOrRepresented",
+        "reading": "ArchitectureSignature is represented with 2 bounded packet record(s)",
+        "evidenceRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Operation",
+        "status": "observedOrRepresented",
+        "reading": "Operation is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Path",
+        "status": "observedOrRepresented",
+        "reading": "Path is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "molecule:user-request-responsibility"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Homotopy",
+        "status": "observedOrRepresented",
+        "reading": "Homotopy is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "semantic:create-user-flow"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "Diagram",
+        "status": "observedOrRepresented",
+        "reading": "Diagram is represented with 1 bounded packet record(s)",
+        "evidenceRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "concept": "AnalyticRepresentation",
+        "status": "observedOrRepresented",
+        "reading": "AnalyticRepresentation is represented with 10 bounded packet record(s)",
+        "evidenceRefs": [
+          "analytic:weighted-adjacency",
+          "analytic:reachable-cone-size",
+          "analytic:walk-count",
+          "analytic:nilpotence-boundary",
+          "analytic:selected-subgraph-spectrum",
+          "analytic:propagation-depth",
+          "analytic:spectral-radius-proxy",
+          "analytic:curvature-valuation",
+          "analytic:state-algebra-boundary",
+          "analytic:zero-reflecting-aggregate-boundary"
+        ],
+        "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
+        "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomConfigurationSummary": {
+      "atomObservationCount": 4,
+      "moleculeObservationCount": 1,
+      "semanticObservationCount": 1,
+      "observationGapCount": 1,
+      "concernHintCount": 1,
+      "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
+      "coverageSummary": [
+        "4 atom observations",
+        "1 molecule observations",
+        "1 semantic observations",
+        "1 observation gaps preserved as gaps"
+      ],
+      "sourceRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:contract:create-user",
+        "atom:relation:route-service",
+        "gap-runtime-user-db-trace"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "architectureObjectProjections": [
+      {
+        "projectionId": "projection:aat:route-users",
+        "projectionFamily": "object",
+        "atomRefs": [
+          "atom:component:route-users"
+        ],
+        "moleculeRefs": [],
+        "semanticRefs": [
+          "atom:component:route-users"
+        ],
+        "reading": "route.users is an observed component object",
+        "projectionBoundary": "derived from observed source atom; not primary ArchMap law claim",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "projectionId": "projection:aat:route-service",
+        "projectionFamily": "relation",
+        "atomRefs": [
+          "atom:relation:route-service"
+        ],
+        "moleculeRefs": [],
+        "semanticRefs": [
+          "atom:relation:route-service"
+        ],
+        "reading": "route.users to service.user is an observed relation",
+        "projectionBoundary": "derived from observed source atom; runtime frequency unmeasured",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "projectionId": "projection:sft:create-user",
+        "projectionFamily": "signatureAxis",
+        "atomRefs": [],
+        "moleculeRefs": [],
+        "semanticRefs": [
+          "semantic:create-user-flow"
+        ],
+        "reading": "semantic observation can be handed off as bounded SFT evidence",
+        "projectionBoundary": "SFT consequence analysis is not owned by ArchMap",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "invariantFamilyReadings": [
+      {
+        "invariantId": "invariant:law-layer-respecting",
+        "invariantFamily": "dependency-direction",
+        "status": "preservedForConstructedWitnesses",
+        "lawRefs": [
+          "law:layer-respecting"
+        ],
+        "atomRefs": [
+          "atom:relation:route-service"
+        ],
+        "obstructionRefs": [],
+        "reading": "Dependencies must respect the selected layer order. is read as an invariant family selected by the interpretation profile",
+        "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "invariantId": "invariant:law-semantic-contract-alignment",
+        "invariantFamily": "semantic-contract",
+        "status": "stressed",
+        "lawRefs": [
+          "law:semantic-contract-alignment"
+        ],
+        "atomRefs": [
+          "atom:contract:create-user"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "reading": "Semantic observations and contract observations must agree on the selected operation meaning. is read as an invariant family selected by the interpretation profile",
+        "evidenceBoundary": "ArchSig computes witnesses from observed Atom records; this policy does not prove lawfulness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "lawUniverseReading": {
+      "lawUniverseId": "law-universe:llm-native-aat-law-policy-fixture",
+      "profileRef": "llm-native-aat-law-policy-fixture",
+      "selectedLawRefs": [
+        "law:layer-respecting",
+        "law:semantic-contract-alignment"
+      ],
+      "witnessRuleRefs": [
+        "witness:layer-violation",
+        "witness:semantic-contract-mismatch"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:layer-violation",
+        "sig-axis:semantic-inconsistency"
+      ],
+      "exactnessAssumptions": [
+        "the selected witness rules cover only policy-declared laws",
+        "zero readings are exact only for observed atoms and declared coverage requirements"
+      ],
+      "coverageRequirements": [
+        "coverage:layer-atoms",
+        "coverage:semantic-contract-atoms"
+      ],
+      "reading": "LawPolicy is interpreted as an analysis profile selecting a bounded LawUniverse, witnesses, axes, coverage, and exactness assumptions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "moleculeReadings": [
+      {
+        "moleculeReadingId": "molecule-reading:molecule-user-request-responsibility",
+        "moleculeObservationRef": "molecule:user-request-responsibility",
+        "lawRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "atomObservationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "reading": "molecule:user-request-responsibility is read as a responsibility molecule under selected LawPolicy",
+        "evidenceSummary": "molecule uses 4 atom observation refs and 1 source refs",
+        "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
+        "sourceRefs": [
+          "doc-architecture"
+        ],
+        "interpretationNotesForLLM": [
+          "Explain molecule readings as grouped observed atoms before discussing laws."
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "obstructionCircuits": [
+      {
+        "obstructionCircuitId": "obstruction:semantic-contract-mismatch:computed",
+        "lawRef": "law:semantic-contract-alignment",
+        "witnessRuleRef": "witness:semantic-contract-mismatch",
+        "circuitKind": "SemanticMismatchCircuit",
+        "atomObservationRefs": [
+          "atom:contract:create-user"
+        ],
+        "moleculeReadingRefs": [
+          "molecule-reading:molecule-user-request-responsibility"
+        ],
+        "concernHintRefs": [
+          "concern:missing-compensation"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "minimalityReading": "minimality is evaluated within the selected observed Atom configuration and witness rule",
+        "evidenceSummary": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
+        "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+        "missingEvidence": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "single architecture quality score"
+        ],
+        "interpretationNotesForLLM": [
+          "Explain this obstruction as selected LawPolicy-relative."
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "signatureAxes": [
+      {
+        "signatureAxisId": "sig-axis:layer-violation",
+        "lawRef": "law:layer-respecting",
+        "axisRef": "axis:layer-violation",
+        "valueType": "nat",
+        "value": 0,
+        "zeroReading": "zero means no axis:layer-violation witness was constructed under declared coverage",
+        "coverageStatus": "coverage-gap-preserved",
+        "exactnessAssumptions": [
+          "the selected witness rules cover only policy-declared laws",
+          "zero readings are exact only for observed atoms and declared coverage requirements"
+        ],
+        "evidenceSummary": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+        "sourceRefs": [
+          "atom:relation:route-service"
+        ],
+        "missingEvidence": [
+          "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "sig-axis:layer-violation coverage boundary: coverage gaps remain observation gaps, not measured zero",
+          "single architecture quality score"
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "signatureAxisId": "sig-axis:semantic-inconsistency",
+        "lawRef": "law:semantic-contract-alignment",
+        "axisRef": "axis:semantic-inconsistency",
+        "valueType": "nat",
+        "value": 1,
+        "zeroReading": "nonzero means axis:semantic-inconsistency witness count is present under selected LawPolicy",
+        "coverageStatus": "coverage-gap-preserved",
+        "exactnessAssumptions": [
+          "the selected witness rules cover only policy-declared laws",
+          "zero readings are exact only for observed atoms and declared coverage requirements"
+        ],
+        "evidenceSummary": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
+        "sourceRefs": [
+          "atom:contract:create-user"
+        ],
+        "missingEvidence": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "sig-axis:semantic-inconsistency coverage boundary: coverage gaps remain observation gaps, not measured zero",
+          "single architecture quality score"
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "analyticRepresentations": [
+      {
+        "representationId": "analytic:weighted-adjacency",
+        "representationFamily": "weightedAdjacencyMatrix",
+        "status": "measured",
+        "valueType": "matrixShape",
+        "value": "4x4; edgeCount=1",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:reachable-cone-size",
+        "representationFamily": "reachableConeSize",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "5",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:walk-count",
+        "representationFamily": "walkCount",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "2",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:nilpotence-boundary",
+        "representationFamily": "nilpotenceBoundary",
+        "status": "needsReview",
+        "valueType": "boundaryStatus",
+        "value": "blockedByCoverageGap",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:selected-subgraph-spectrum",
+        "representationFamily": "selectedSubgraphSpectrum",
+        "status": "measured",
+        "valueType": "vector",
+        "value": "[0.250]",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:propagation-depth",
+        "representationFamily": "propagationDepth",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "1",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "propagation depth is computed over observed relation atoms only",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:spectral-radius-proxy",
+        "representationFamily": "spectralRadius",
+        "status": "measured",
+        "valueType": "float",
+        "value": "0.250",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:curvature-valuation",
+        "representationFamily": "curvatureValuation",
+        "status": "measured",
+        "valueType": "nat",
+        "value": "1",
+        "graphScopeRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "curvature valuation counts constructed obstruction circuits under the selected profile",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:state-algebra-boundary",
+        "representationFamily": "stateAlgebra",
+        "status": "unmeasured",
+        "valueType": "boundaryStatus",
+        "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+        "graphScopeRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "state algebra is preserved as a first-class analytic boundary even when state evidence is unavailable",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "representationId": "analytic:zero-reflecting-aggregate-boundary",
+        "representationFamily": "zeroReflectingAggregateBoundary",
+        "status": "needsReview",
+        "valueType": "boundaryStatus",
+        "value": "blockedByObservationGaps",
+        "graphScopeRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "axisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "reading": "zero-reflecting aggregate boundary says when zero axes may and may not be read as absence",
+        "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "couplingCohesionReadings": [
+      {
+        "readingId": "coupling:static-dependency",
+        "axis": "staticDependencyCoupling",
+        "status": "actionable",
+        "valueType": "boundedCount",
+        "value": "1",
+        "supportingRefs": [
+          "atom:relation:route-service"
+        ],
+        "stressedRefs": [],
+        "reading": "static relation atoms show direct source-level coupling",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "cohesion:semantic-contract",
+        "axis": "contractCohesion",
+        "status": "actionable",
+        "valueType": "boundedCount",
+        "value": "2",
+        "supportingRefs": [
+          "atom:contract:create-user",
+          "semantic:create-user-flow"
+        ],
+        "stressedRefs": [],
+        "reading": "contract and semantic observations give a semantic cohesion reading",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "coupling:state-effect",
+        "axis": "stateEffectCoupling",
+        "status": "needsReview",
+        "valueType": "boundedCount",
+        "value": "1",
+        "supportingRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "stressedRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "state/effect coupling remains stressed when runtime or effect evidence is unavailable",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "coupling:authority-trust",
+        "axis": "authorityTrustCoupling",
+        "status": "unmeasured",
+        "valueType": "boundedCount",
+        "value": "0",
+        "supportingRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "stressedRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "authority and trust coupling are unmeasured unless ArchMap records explicit authority/trust atoms",
+        "coverageBoundary": "coupling/cohesion is semantic ArchMap-relative evidence, not import-count truth",
+        "recommendedNextAction": "inspect supporting refs and add missing state/effect/authority evidence before treating zero as absence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "workflowRiskReadings": [
+      {
+        "workflowRiskId": "workflow-risk:molecule-user-request-responsibility",
+        "moleculeObservationRef": "molecule:user-request-responsibility",
+        "moleculeFamily": "responsibility",
+        "roleName": "user request orchestration",
+        "status": "needsReview",
+        "riskScore": 19,
+        "riskTier": "low",
+        "atomCount": 4,
+        "atomFamilyCounts": [
+          {
+            "atomFamily": "contractSpecification",
+            "count": 1
+          },
+          {
+            "atomFamily": "existence",
+            "count": 2
+          },
+          {
+            "atomFamily": "relation",
+            "count": 1
+          }
+        ],
+        "semanticRefs": [
+          "semantic:create-user-flow"
+        ],
+        "concernRefs": [
+          "concern:missing-compensation"
+        ],
+        "topAxes": [
+          {
+            "axis": "permissionCoverage",
+            "status": "actionable",
+            "score": 6,
+            "familyScore": 4,
+            "keywordHits": [
+              "route"
+            ],
+            "concernRefs": [],
+            "coverageGapRefs": [],
+            "reading": "route/session/admin authority coverage concentrates in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "sourceBackedDomainCohesion",
+            "status": "actionable",
+            "score": 6,
+            "familyScore": 4,
+            "keywordHits": [
+              "source"
+            ],
+            "concernRefs": [],
+            "coverageGapRefs": [],
+            "reading": "source-backed domain identity, relation, and contract cohesion concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "llmOutputMediation",
+            "status": "needsReview",
+            "score": 3,
+            "familyScore": 2,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "prompt/context validation, LLM/provider output, filtering, and persistence gates concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "authorityTrustBoundary",
+            "status": "needsReview",
+            "score": 2,
+            "familyScore": 1,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "authority labels, trust handoffs, provider output, and boundary checks concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          },
+          {
+            "axis": "stateEffectReconciliation",
+            "status": "needsReview",
+            "score": 2,
+            "familyScore": 1,
+            "keywordHits": [],
+            "concernRefs": [],
+            "coverageGapRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "durable state, external effects, retry, and status-finalization pressure concentrate in this workflow",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          }
+        ],
+        "reviewFocus": [
+          "Source-backed domain identity, relations, and contract cohesion",
+          "prompt/context validation, LLM output filtering, persistence gate",
+          "route-by-route permission dependency and tenant/workspace scope"
+        ],
+        "coverageGapRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "evidenceBoundary": "workflow risk is a molecule-local ArchMap reading for review prioritization, not a quality score or proof",
+        "recommendedNextAction": "review the top axes, source refs, concern hints, and coverage gaps before planning repair",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "spectralAnalysisReadings": [
+      {
+        "spectralReadingId": "spectral:workflow-risk-axis-pressure",
+        "representationFamily": "workflowRiskAxisPressureMatrix",
+        "status": "needsReview",
+        "matrixShape": {
+          "rowDomain": "workflowRiskReadings",
+          "columnDomain": "workflowRiskAxes",
+          "rowCount": 1,
+          "columnCount": 5,
+          "nonzeroEntryCount": 5
+        },
+        "entryRule": "entry(i,j) is the workflow risk axis score for workflow i and risk axis j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "19",
+            "interpretation": "largest molecule-local review pressure"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "6",
+            "interpretation": "largest accumulated axis pressure"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "9.434",
+            "interpretation": "global pressure magnitude of the observed finite matrix"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "10.677",
+            "interpretation": "nonnegative-matrix upper bound, not an exact eigen theorem"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "molecule:user-request-responsibility",
+            "componentKind": "workflow",
+            "value": "19",
+            "reading": "dominant row pressure in the workflow-by-axis matrix"
+          },
+          {
+            "componentRef": "sourceBackedDomainCohesion",
+            "componentKind": "workflowRiskAxis",
+            "value": "6",
+            "reading": "dominant column pressure accumulated across workflows"
+          }
+        ],
+        "supportRefs": [
+          "workflow-risk:molecule-user-request-responsibility"
+        ],
+        "reading": "workflow risk pressure is concentrated by rows and axes; use the dominant row and column before treating local risk as isolated",
+        "coverageBoundary": "coverage gaps on workflow axes block measured-zero interpretation for absent entries",
+        "zeroReflectingBoundary": "zero entries mean no observed risk-axis evidence under current ArchMap and heuristics, not absence of architectural pressure",
+        "recommendedNextAction": "review the dominant workflow row, dominant axis column, and coverage gaps before selecting repair operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralReadingId": "spectral:molecule-atom-overlap-coupling",
+        "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+        "status": "needsReview",
+        "matrixShape": {
+          "rowDomain": "moleculeObservations",
+          "columnDomain": "moleculeObservations",
+          "rowCount": 1,
+          "columnCount": 1,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is exact atom overlap weighted with atom-family overlap; the diagonal records molecule atom-family mass",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "4",
+            "interpretation": "largest observed molecule overlap mass"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "4.000",
+            "interpretation": "observed overlap magnitude of the molecule coupling matrix"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "4.000",
+            "interpretation": "Gershgorin-style row-sum upper bound for this nonnegative matrix"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "molecule:user-request-responsibility",
+            "componentKind": "molecule",
+            "value": "4",
+            "reading": "dominant molecule by atom/family overlap mass"
+          }
+        ],
+        "supportRefs": [
+          "molecule:user-request-responsibility"
+        ],
+        "reading": "molecules sharing atom refs or atom families form an overlap coupling surface that is invisible to import-only static analysis",
+        "coverageBoundary": "missing atom families and observation gaps can make overlap coupling appear smaller than the source architecture actually is",
+        "zeroReflectingBoundary": "zero off-diagonal overlap means no shared observed atom/family evidence, not guaranteed independence",
+        "recommendedNextAction": "inspect the dominant molecule and any high-overlap neighbors before splitting or moving responsibilities",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralReadingId": "spectral:obstruction-axis-curvature",
+        "representationFamily": "obstructionAxisCurvatureMatrix",
+        "status": "actionable",
+        "matrixShape": {
+          "rowDomain": "obstructionCircuits",
+          "columnDomain": "signatureAxes",
+          "rowCount": 1,
+          "columnCount": 2,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is 1 when obstruction circuit i contributes to signature axis j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "1",
+            "interpretation": "widest obstruction-to-axis curvature row"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "1",
+            "interpretation": "most repeated obstruction axis"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "1.000",
+            "interpretation": "curvature incidence magnitude over constructed obstruction circuits"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "1.000",
+            "interpretation": "incidence-matrix upper bound, not a global flatness proof"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "obstruction:semantic-contract-mismatch:computed",
+            "componentKind": "obstructionCircuit",
+            "value": "1",
+            "reading": "dominant obstruction row by connected signature axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "value": "1",
+            "reading": "dominant curvature column across obstruction circuits"
+          }
+        ],
+        "supportRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "reading": "obstruction circuits distribute curvature onto signature axes; repeated columns indicate axes where local failures accumulate",
+        "coverageBoundary": "only constructed obstruction circuits are represented; concern hints that lack witness rules remain outside this matrix",
+        "zeroReflectingBoundary": "zero incidence means no constructed obstruction-to-axis edge, not proof of zero curvature",
+        "recommendedNextAction": "review the dominant obstruction row and repeated axis column before treating a signature axis as local",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralReadingId": "spectral:operation-signature-delta",
+        "representationFamily": "operationSignatureDeltaMatrix",
+        "status": "actionable",
+        "matrixShape": {
+          "rowDomain": "operationDeltas",
+          "columnDomain": "signatureAxes",
+          "rowCount": 1,
+          "columnCount": 2,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is 1 when operation delta i declares or mentions a change to signature axis j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "1",
+            "interpretation": "widest operation-to-signature delta row"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "1",
+            "interpretation": "signature axis touched by most operations"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "1.000",
+            "interpretation": "operation delta incidence magnitude"
+          },
+          {
+            "name": "spectralRadiusUpperBound",
+            "value": "1.000",
+            "interpretation": "operation-transition upper bound, not repair correctness"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+            "componentKind": "operationDelta",
+            "value": "1",
+            "reading": "dominant operation row by declared decreased axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "value": "1",
+            "reading": "dominant signature axis touched by operation deltas"
+          }
+        ],
+        "supportRefs": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "reading": "operation deltas show which signature axes would move together under candidate repairs or evidence enrichment",
+        "coverageBoundary": "candidate operations are bounded review artifacts; absent delta entries are not proof that an operation preserves an axis",
+        "zeroReflectingBoundary": "zero delta incidence means no declared or text-mentioned axis movement under current candidates, not repair safety",
+        "recommendedNextAction": "review the dominant operation row and repeated axis column before converting a repair candidate into code changes",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "spectralModeReadings": [
+      {
+        "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
+        "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
+        "representationFamily": "workflowRiskAxisPressureMatrix",
+        "status": "needsReview",
+        "modeKind": "distributedPressureMode",
+        "modeComponents": [
+          {
+            "componentRef": "molecule:user-request-responsibility",
+            "componentKind": "workflow",
+            "weight": "19",
+            "role": "primaryDominantComponent",
+            "reading": "dominant row pressure in the workflow-by-axis matrix"
+          },
+          {
+            "componentRef": "sourceBackedDomainCohesion",
+            "componentKind": "workflowRiskAxis",
+            "weight": "6",
+            "role": "coupledDominantComponent",
+            "reading": "dominant column pressure accumulated across workflows"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "9.434",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "1.000",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is delocalized or dense; treat the concern as architecture-wide coupling before attempting local repair",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "start review from the dominant workflow and dominant risk axis, then verify coverage gaps",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralModeId": "spectral-mode:spectral-molecule-atom-overlap-coupling",
+        "sourceSpectralReadingRef": "spectral:molecule-atom-overlap-coupling",
+        "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+        "status": "needsReview",
+        "modeKind": "delocalizedCouplingMode",
+        "modeComponents": [
+          {
+            "componentRef": "molecule:user-request-responsibility",
+            "componentKind": "molecule",
+            "weight": "4",
+            "role": "primaryDominantComponent",
+            "reading": "dominant molecule by atom/family overlap mass"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "4.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "1.000",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is delocalized or dense; treat the concern as architecture-wide coupling before attempting local repair",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "map shared atom families across the dense molecule cluster before splitting boundaries",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralModeId": "spectral-mode:spectral-obstruction-axis-curvature",
+        "sourceSpectralReadingRef": "spectral:obstruction-axis-curvature",
+        "representationFamily": "obstructionAxisCurvatureMatrix",
+        "status": "actionable",
+        "modeKind": "curvatureMode",
+        "modeComponents": [
+          {
+            "componentRef": "obstruction:semantic-contract-mismatch:computed",
+            "componentKind": "obstructionCircuit",
+            "weight": "1",
+            "role": "primaryDominantComponent",
+            "reading": "dominant obstruction row by connected signature axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "weight": "1",
+            "role": "coupledDominantComponent",
+            "reading": "dominant curvature column across obstruction circuits"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.500",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is mixed; local repair may work, but review nearby coupled components and transferred axes",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "review whether repeated obstruction-axis curvature is local, transferred, or a law-policy coverage gap",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "spectralModeId": "spectral-mode:spectral-operation-signature-delta",
+        "sourceSpectralReadingRef": "spectral:operation-signature-delta",
+        "representationFamily": "operationSignatureDeltaMatrix",
+        "status": "actionable",
+        "modeKind": "localizedPerturbationMode",
+        "modeComponents": [
+          {
+            "componentRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+            "componentKind": "operationDelta",
+            "weight": "1",
+            "role": "primaryDominantComponent",
+            "reading": "dominant operation row by declared decreased axes"
+          },
+          {
+            "componentRef": "sig-axis:semantic-inconsistency",
+            "componentKind": "signatureAxis",
+            "weight": "1",
+            "role": "coupledDominantComponent",
+            "reading": "dominant signature axis touched by operation deltas"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.500",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is mixed; local repair may work, but review nearby coupled components and transferred axes",
+        "repairPerturbationReading": "candidate operations have a dominant perturbation mode; review the leading operation before broad refactoring",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "compare the perturbation mode against candidate repair preconditions before changing code",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "spectralDrilldownReadings": [
+      {
+        "drilldownId": "spectral-drilldown:fixture-archmap-atom-observation",
+        "status": "needsReview",
+        "sourceSpectralModeRefs": [
+          "spectral-mode:spectral-workflow-risk-axis-pressure",
+          "spectral-mode:spectral-molecule-atom-overlap-coupling",
+          "spectral-mode:spectral-obstruction-axis-curvature",
+          "spectral-mode:spectral-operation-signature-delta"
+        ],
+        "dominantAtomFamilyComposition": [
+          {
+            "sourceComponentRef": "molecule:user-request-responsibility",
+            "sourceComponentKind": "workflow",
+            "atomFamily": "existence",
+            "count": 2,
+            "atomObservationRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user"
+            ],
+            "reading": "molecule:user-request-responsibility contributes 2 observed existence atom(s) to the dominant spectral mode"
+          },
+          {
+            "sourceComponentRef": "molecule:user-request-responsibility",
+            "sourceComponentKind": "workflow",
+            "atomFamily": "contractSpecification",
+            "count": 1,
+            "atomObservationRefs": [
+              "atom:contract:create-user"
+            ],
+            "reading": "molecule:user-request-responsibility contributes 1 observed contractSpecification atom(s) to the dominant spectral mode"
+          },
+          {
+            "sourceComponentRef": "molecule:user-request-responsibility",
+            "sourceComponentKind": "workflow",
+            "atomFamily": "relation",
+            "count": 1,
+            "atomObservationRefs": [
+              "atom:relation:route-service"
+            ],
+            "reading": "molecule:user-request-responsibility contributes 1 observed relation atom(s) to the dominant spectral mode"
+          }
+        ],
+        "highOverlapMoleculePairs": [],
+        "repairAxisDeltaReadings": [
+          {
+            "operationDeltaRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+            "operationKind": "repair-semanticmismatchcircuit",
+            "positiveDeltaAxes": [
+              "sig-axis:semantic-inconsistency"
+            ],
+            "negativeDeltaAxes": [],
+            "neutralOrUnknownAxes": [
+              "sig-axis:layer-violation"
+            ],
+            "transferRiskRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "reading": "operation has bounded positive axes and leaves some axes neutral or unknown under current evidence",
+            "evidenceBoundary": "positive axes come from target obstruction support; negative axes are touched but not target axes; neutral axes are unmentioned under current operation delta evidence",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          }
+        ],
+        "reading": "spectral drilldown explains dominant modes with atom-family composition, molecule overlap pairs, and repair axis deltas",
+        "evidenceBoundary": "drilldown is derived from ArchMap atom/molecule observations and ArchSig spectral summaries; it is not exact eigendecomposition or repair correctness",
+        "recommendedNextAction": "review dominant atom families, high-overlap molecule pairs, and positive/negative repair delta axes before changing boundaries",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "curvatureSupportReadings": [
+      {
+        "readingId": "curvature-support-reading:spectrum-profile-curvature-transfer-default",
+        "profileRef": "spectrum-profile:curvature-transfer-default",
+        "status": "needsReview",
+        "measuredAxisRefs": [
+          "axis:semantic-inconsistency"
+        ],
+        "unmeasuredAxisRefs": [
+          "axis:layer-violation",
+          "axis:semantic-inconsistency"
+        ],
+        "witnessSupports": [
+          {
+            "witnessSupportId": "curvature-support:witness-layer-violation:axis-layer-violation",
+            "witnessRuleRef": "witness:layer-violation",
+            "selectedAxisRef": "axis:layer-violation",
+            "signatureAxisRef": "sig-axis:layer-violation",
+            "curvatureValue": 0,
+            "weight": 0,
+            "supportRefs": [],
+            "sourceRefs": [],
+            "observationRefs": [],
+            "missingEvidence": [
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+            ],
+            "reading": "unmeasured support is preserved as missing evidence, not measured zero"
+          },
+          {
+            "witnessSupportId": "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation",
+            "witnessRuleRef": "witness:semantic-contract-mismatch",
+            "selectedAxisRef": "axis:layer-violation",
+            "signatureAxisRef": "sig-axis:layer-violation",
+            "curvatureValue": 0,
+            "weight": 0,
+            "supportRefs": [],
+            "sourceRefs": [],
+            "observationRefs": [],
+            "missingEvidence": [
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+            ],
+            "reading": "unmeasured support is preserved as missing evidence, not measured zero"
+          },
+          {
+            "witnessSupportId": "curvature-support:witness-layer-violation:axis-semantic-inconsistency",
+            "witnessRuleRef": "witness:layer-violation",
+            "selectedAxisRef": "axis:semantic-inconsistency",
+            "signatureAxisRef": "sig-axis:semantic-inconsistency",
+            "curvatureValue": 0,
+            "weight": 0,
+            "supportRefs": [],
+            "sourceRefs": [],
+            "observationRefs": [],
+            "missingEvidence": [
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+            ],
+            "reading": "unmeasured support is preserved as missing evidence, not measured zero"
+          },
+          {
+            "witnessSupportId": "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
+            "witnessRuleRef": "witness:semantic-contract-mismatch",
+            "selectedAxisRef": "axis:semantic-inconsistency",
+            "signatureAxisRef": "sig-axis:semantic-inconsistency",
+            "curvatureValue": 1,
+            "weight": 1,
+            "supportRefs": [
+              "atom:contract:create-user",
+              "concern:missing-compensation",
+              "molecule-reading:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "observationRefs": [
+              "atom:contract:create-user",
+              "concern:missing-compensation",
+              "molecule-reading:molecule-user-request-responsibility"
+            ],
+            "missingEvidence": [
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+            ],
+            "reading": "1 constructed witness support(s) contribute to axis:semantic-inconsistency under spectrum-profile:curvature-transfer-default"
+          }
+        ],
+        "topCurvatureModes": [
+          {
+            "modeId": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+            "rank": 1,
+            "axisRef": "axis:semantic-inconsistency",
+            "curvatureValue": 1,
+            "witnessRefs": [
+              "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+            ],
+            "supportRefs": [
+              "atom:contract:create-user",
+              "concern:missing-compensation",
+              "molecule-reading:molecule-user-request-responsibility"
+            ],
+            "reading": "top measured curvature support mode with traceable witness and support refs"
+          },
+          {
+            "modeId": "curvature-mode:curvature-support-witness-layer-violation-axis-layer-violation",
+            "rank": 2,
+            "axisRef": "axis:layer-violation",
+            "curvatureValue": 0,
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-layer-violation"
+            ],
+            "supportRefs": [],
+            "reading": "unmeasured curvature support mode retained as coverage debt"
+          },
+          {
+            "modeId": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-layer-violation",
+            "rank": 3,
+            "axisRef": "axis:layer-violation",
+            "curvatureValue": 0,
+            "witnessRefs": [
+              "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+            ],
+            "supportRefs": [],
+            "reading": "unmeasured curvature support mode retained as coverage debt"
+          },
+          {
+            "modeId": "curvature-mode:curvature-support-witness-layer-violation-axis-semantic-inconsistency",
+            "rank": 4,
+            "axisRef": "axis:semantic-inconsistency",
+            "curvatureValue": 0,
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-semantic-inconsistency"
+            ],
+            "supportRefs": [],
+            "reading": "unmeasured curvature support mode retained as coverage debt"
+          }
+        ],
+        "witnessClusters": [
+          {
+            "clusterId": "curvature-cluster:axis-layer-violation",
+            "clusterKind": "axisWitnessSupportCluster",
+            "axisRefs": [
+              "axis:layer-violation"
+            ],
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-layer-violation",
+              "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+            ],
+            "supportRefs": [],
+            "clusterWeight": 0,
+            "reading": "cluster records unmeasured selected axis support as coverage debt"
+          },
+          {
+            "clusterId": "curvature-cluster:axis-semantic-inconsistency",
+            "clusterKind": "axisWitnessSupportCluster",
+            "axisRefs": [
+              "axis:semantic-inconsistency"
+            ],
+            "witnessRefs": [
+              "curvature-support:witness-layer-violation:axis-semantic-inconsistency",
+              "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+            ],
+            "supportRefs": [
+              "atom:contract:create-user",
+              "concern:missing-compensation",
+              "molecule-reading:molecule-user-request-responsibility"
+            ],
+            "clusterWeight": 1,
+            "reading": "cluster groups measured witness supports by selected axis for review ranking"
+          }
+        ],
+        "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+        "exactnessAssumptionRefs": [
+          "selected LawPolicy exactness assumptions"
+        ],
+        "measurementBoundary": "curvature-transfer spectrum readings are bounded ArchSig diagnostics, not theorem discharge",
+        "missingEvidence": [
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "nonConclusions": [
+          "spectrum measurement profile is a measurement recipe, not a law universe",
+          "profile differences are not law universe differences",
+          "unmeasured axes are not zero",
+          "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
+        ]
+      }
+    ],
+    "curvatureTransferReadings": [
+      {
+        "readingId": "curvature-transfer-reading:spectrum-profile-curvature-transfer-default",
+        "profileRef": "spectrum-profile:curvature-transfer-default",
+        "status": "needsReview",
+        "transferOperator": {
+          "operatorId": "transfer-operator:curvature-transfer-reading-spectrum-profile-curvature-transfer-default",
+          "rowDomain": "curvatureWitnessSupports",
+          "columnDomain": "curvatureWitnessSupports",
+          "rowCount": 1,
+          "columnCount": 1,
+          "nonzeroEdgeCount": 1,
+          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+          "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
+        },
+        "transferEdges": [
+          {
+            "edgeId": "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+            "sourceSupportRef": "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
+            "sourceAxisRef": "axis:semantic-inconsistency",
+            "targetSupportRef": "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
+            "targetAxisRef": "axis:semantic-inconsistency",
+            "witnessRefs": [
+              "witness:semantic-contract-mismatch"
+            ],
+            "defectValue": 2,
+            "weight": 1,
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "reading": "positive self-loop records a closed walk in the finite transfer operator"
+          }
+        ],
+        "recurrentObstructionModes": [
+          {
+            "modeId": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+            "transferEdgeRefs": [
+              "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
+            ],
+            "supportRefs": [
+              "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+            ],
+            "witnessRefs": [
+              "witness:semantic-contract-mismatch"
+            ],
+            "spectralRadiusReading": "rho(T^kappa) proxy 1 > 0 over the finite ArchSig transfer operator",
+            "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
+            "reviewFocus": [
+              "inspect the witness support behind the positive transfer self-loop",
+              "check whether coverage gaps or exactness limits block zero-reflection"
+            ],
+            "nonConclusions": [
+              "recurrent obstruction mode is not future incident prediction",
+              "recurrent obstruction mode is not empirical cost amplification",
+              "recurrent obstruction mode is not repair safety evidence"
+            ]
+          }
+        ],
+        "spectralRadiusReading": {
+          "name": "rho(T^kappa)Proxy",
+          "value": "1",
+          "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+        },
+        "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
+        "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
+        "nonConclusions": [
+          "rho(T^kappa) > 0 is only a bounded recurrent obstruction reading",
+          "transfer operator reading does not predict future incidents or empirical cost increase",
+          "transfer operator reading does not replace FieldSig forecast",
+          "absence of transfer edges is not proof of future safety"
+        ]
+      }
+    ],
+    "architectureSpectrumReport": {
+      "reportId": "architecture-spectrum-report:spectrum-profile-curvature-transfer-default",
+      "profileRef": "spectrum-profile:curvature-transfer-default",
+      "status": "needsReview",
+      "topHotspots": [
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 1,
+          "supportRefs": [
+            "atom:contract:create-user",
+            "concern:missing-compensation",
+            "molecule-reading:molecule-user-request-responsibility"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "coverageGapRefs": [
+            "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+          ],
+          "recommendedNextAction": "review witness support, selected axis coverage, and transfer recurrence before repair planning"
+        },
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-layer-violation-axis-layer-violation",
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-layer-violation"
+          ],
+          "coverageGapRefs": [
+            "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+          ],
+          "recommendedNextAction": "resolve coverage and exactness gaps before treating this axis as zero"
+        },
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-semantic-contract-mismatch-axis-layer-violation",
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+          ],
+          "coverageGapRefs": [
+            "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+          ],
+          "recommendedNextAction": "resolve coverage and exactness gaps before treating this axis as zero"
+        },
+        {
+          "hotspotId": "spectrum-hotspot:curvature-mode-curvature-support-witness-layer-violation-axis-semantic-inconsistency",
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-semantic-inconsistency"
+          ],
+          "coverageGapRefs": [
+            "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+          ],
+          "recommendedNextAction": "resolve coverage and exactness gaps before treating this axis as zero"
+        }
+      ],
+      "topEigenmodes": [
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+          "rank": 1,
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 1,
+          "supportRefs": [
+            "atom:contract:create-user",
+            "concern:missing-compensation",
+            "molecule-reading:molecule-user-request-responsibility"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "reading": "top measured curvature support mode with traceable witness and support refs"
+        },
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-layer-violation-axis-layer-violation",
+          "rank": 2,
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-layer-violation"
+          ],
+          "reading": "unmeasured curvature support mode retained as coverage debt"
+        },
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-semantic-contract-mismatch-axis-layer-violation",
+          "rank": 3,
+          "axisRef": "axis:layer-violation",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+          ],
+          "reading": "unmeasured curvature support mode retained as coverage debt"
+        },
+        {
+          "modeRef": "curvature-mode:curvature-support-witness-layer-violation-axis-semantic-inconsistency",
+          "rank": 4,
+          "axisRef": "axis:semantic-inconsistency",
+          "curvatureValue": 0,
+          "supportRefs": [],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-semantic-inconsistency"
+          ],
+          "reading": "unmeasured curvature support mode retained as coverage debt"
+        }
+      ],
+      "topWitnessClusters": [
+        {
+          "clusterRef": "curvature-cluster:axis-layer-violation",
+          "axisRefs": [
+            "axis:layer-violation"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-layer-violation",
+            "curvature-support:witness-semantic-contract-mismatch:axis-layer-violation"
+          ],
+          "supportRefs": [],
+          "clusterWeight": 0,
+          "reading": "cluster records unmeasured selected axis support as coverage debt"
+        },
+        {
+          "clusterRef": "curvature-cluster:axis-semantic-inconsistency",
+          "axisRefs": [
+            "axis:semantic-inconsistency"
+          ],
+          "witnessRefs": [
+            "curvature-support:witness-layer-violation:axis-semantic-inconsistency",
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "supportRefs": [
+            "atom:contract:create-user",
+            "concern:missing-compensation",
+            "molecule-reading:molecule-user-request-responsibility"
+          ],
+          "clusterWeight": 1,
+          "reading": "cluster groups measured witness supports by selected axis for review ranking"
+        }
+      ],
+      "recurrentObstructions": [
+        {
+          "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
+          "spectralRadiusReading": "rho(T^kappa) proxy 1 > 0 over the finite ArchSig transfer operator",
+          "transferEdgeRefs": [
+            "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
+          ],
+          "supportRefs": [
+            "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
+          ],
+          "witnessRefs": [
+            "witness:semantic-contract-mismatch"
+          ],
+          "reading": "positive closed walk is reported as recurrent obstruction support only"
+        }
+      ],
+      "coverageGaps": [
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "measuredBoundary": "report is measured from ArchSig curvature support and transfer readings under selected LawPolicy coverage and exactness assumptions",
+      "recommendedReviewFocus": [
+        "start from nonzero hotspots with traceable witness and support refs",
+        "review recurrent obstruction modes only as current-state bounded diagnostics",
+        "resolve coverage gaps before reading absent support as zero"
+      ],
+      "nonConclusions": [
+        "ArchitectureSpectrumReport is not a single architecture quality score",
+        "ArchitectureSpectrumReport does not prove global lawfulness or flatness",
+        "ArchitectureSpectrumReport does not predict future incidents or empirical cost increase",
+        "ArchitectureSpectrumReport does not replace FieldSig forecast or governance"
+      ]
+    },
+    "transferBridgeReadings": [
+      {
+        "transferBridgeId": "transfer-bridge:fixture-archmap-atom-observation",
+        "status": "nonConclusion",
+        "transferMatrixEntries": [],
+        "bridgeAtomFamilies": [
+          {
+            "bridgeId": "bridge:molecule-user-request-responsibility:molecule-user-request-responsibility",
+            "sourceHubMoleculeRef": "molecule:user-request-responsibility",
+            "targetHubMoleculeRef": "molecule:user-request-responsibility",
+            "intermediateMoleculeRefs": [],
+            "bridgeAtomFamilies": [],
+            "bridgeScore": 0,
+            "pathPairRefs": [],
+            "edgeBreakdowns": [],
+            "sharedAxisRefs": [
+              "authorityTrustBoundary",
+              "llmOutputMediation",
+              "permissionCoverage",
+              "sourceBackedDomainCohesion",
+              "stateEffectReconciliation"
+            ],
+            "reviewRisk": "high",
+            "recommendedBoundaryPreparation": "review bridge atom families before assuming molecule:user-request-responsibility and molecule:user-request-responsibility are independent architecture hubs",
+            "evidenceBoundary": "bridge path is computed from high-overlap molecule pairs and shared atom families, not from direct source dependency proof",
+            "nonConclusions": [
+              "ArchSig analysis packet is not a Lean theorem proof",
+              "ArchSig analysis packet is not global architecture truth",
+              "ArchSig analysis packet does not prove source extraction completeness",
+              "signature axes are law-policy-relative, not universal quality scores",
+              "flatness reading is blocked by coverage gaps and exactness assumptions",
+              "repair operation candidates are not automatic safe refactorings",
+              "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+            ]
+          }
+        ],
+        "evolutionRiskRanking": {
+          "repairTransferRiskRanking": [
+            {
+              "rank": 1,
+              "operationDeltaRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+              "positiveAxisCount": 1,
+              "transferredAxisCount": 0,
+              "transferWeight": 1,
+              "reading": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed has 1 target-positive axis/axes and 0 transferred axis/axes"
+            }
+          ],
+          "boundaryPreparationRanking": [],
+          "reading": "evolution risk ranks repairs by transfer-axis pressure and molecule pairs by boundary-preparation need",
+          "nonConclusions": [
+            "ArchSig analysis packet is not a Lean theorem proof",
+            "ArchSig analysis packet is not global architecture truth",
+            "ArchSig analysis packet does not prove source extraction completeness",
+            "signature axes are law-policy-relative, not universal quality scores",
+            "flatness reading is blocked by coverage gaps and exactness assumptions",
+            "repair operation candidates are not automatic safe refactorings",
+            "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+          ]
+        },
+        "reading": "transfer bridge reading connects repair transfer axes, bridge atom families, and evolution risk ranking",
+        "evidenceBoundary": "transfer bridge is derived from ArchMap atom/molecule overlap and ArchSig repair delta summaries; it is not a repair correctness theorem",
+        "recommendedNextAction": "review bridge atom families and top transfer-risk repairs before applying local architecture changes",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomSupportAxisReadings": [
+      {
+        "readingId": "atom-support-axis:fixture-archmap-atom-observation",
+        "scopeRef": "fixture-archmap-atom-observation",
+        "scopeKind": "selectedSourceUniverse",
+        "supportSize": 4,
+        "subjectFamilySpread": [
+          {
+            "subjectRef": "contract.createsUser",
+            "atomCount": 1,
+            "atomFamilies": [
+              "contractSpecification"
+            ]
+          },
+          {
+            "subjectRef": "route.users",
+            "atomCount": 1,
+            "atomFamilies": [
+              "existence"
+            ]
+          },
+          {
+            "subjectRef": "semantic.route.users->service.user",
+            "atomCount": 1,
+            "atomFamilies": [
+              "relation"
+            ]
+          },
+          {
+            "subjectRef": "service.user",
+            "atomCount": 1,
+            "atomFamilies": [
+              "existence"
+            ]
+          }
+        ],
+        "axisRestrictionCounts": [
+          {
+            "axis": "contractSpecification",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:contract:create-user"
+            ]
+          },
+          {
+            "axis": "existence",
+            "atomCount": 2,
+            "atomObservationRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user"
+            ]
+          },
+          {
+            "axis": "relation",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:relation:route-service"
+            ]
+          }
+        ],
+        "axisConcentration": "maxAxisShare=2/4",
+        "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
+        "highSupportRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "coverageBoundary": "support and axis restriction are computed from observed ArchMap atoms only",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "atom-support-axis:molecule-user-request-responsibility",
+        "scopeRef": "molecule:user-request-responsibility",
+        "scopeKind": "molecule",
+        "supportSize": 4,
+        "subjectFamilySpread": [
+          {
+            "subjectRef": "contract.createsUser",
+            "atomCount": 1,
+            "atomFamilies": [
+              "contractSpecification"
+            ]
+          },
+          {
+            "subjectRef": "route.users",
+            "atomCount": 1,
+            "atomFamilies": [
+              "existence"
+            ]
+          },
+          {
+            "subjectRef": "semantic.route.users->service.user",
+            "atomCount": 1,
+            "atomFamilies": [
+              "relation"
+            ]
+          },
+          {
+            "subjectRef": "service.user",
+            "atomCount": 1,
+            "atomFamilies": [
+              "existence"
+            ]
+          }
+        ],
+        "axisRestrictionCounts": [
+          {
+            "axis": "contractSpecification",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:contract:create-user"
+            ]
+          },
+          {
+            "axis": "existence",
+            "atomCount": 2,
+            "atomObservationRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user"
+            ]
+          },
+          {
+            "axis": "relation",
+            "atomCount": 1,
+            "atomObservationRefs": [
+              "atom:relation:route-service"
+            ]
+          }
+        ],
+        "axisConcentration": "maxAxisShare=2/4",
+        "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
+        "highSupportRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "coverageBoundary": "support and axis restriction are computed from observed ArchMap atoms only",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomCompatibilityReadings": [
+      {
+        "readingId": "atom-compatibility:fixture-archmap-atom-observation",
+        "status": "compatibleWithinObservedSlots",
+        "sameSlotConflictCount": 0,
+        "conflicts": [],
+        "conflictingAtomObservationRefs": [],
+        "conflictingSemanticObservationRefs": [],
+        "payloadInconsistencyKinds": [
+          "familyDivergence",
+          "statusDivergence",
+          "semanticDivergence"
+        ],
+        "confidenceBoundary": "compatibility is checked over observed subject/predicate slots only",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "evidenceBoundary": "compatibility conflict is a review target, not proof of global semantic incorrectness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "lawUniverseCoverageReadings": [
+      {
+        "readingId": "law-universe-coverage:llm-native-aat-law-policy-fixture",
+        "lawUniverseRef": "llm-native-aat-law-policy-fixture",
+        "requiredLawCoverage": [
+          {
+            "refId": "law:layer-respecting",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [
+              "relation",
+              "boundaryAuthority"
+            ],
+            "blockerRefs": [
+              "boundaryAuthority",
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          },
+          {
+            "refId": "law:semantic-contract-alignment",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [
+              "contractSpecification",
+              "semanticInterpretation"
+            ],
+            "blockerRefs": [
+              "semanticInterpretation",
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          }
+        ],
+        "optionalLawCoverage": [
+          {
+            "refId": "axis:observation-gap",
+            "status": "optionalAxis",
+            "evidenceRefs": [
+              "observation gap records"
+            ],
+            "blockerRefs": [],
+            "reading": "optional axis coverage is advisory"
+          }
+        ],
+        "witnessFamilyCoverage": [
+          {
+            "refId": "witness:layer-violation",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [
+              "relation",
+              "boundaryAuthority"
+            ],
+            "blockerRefs": [
+              "boundaryAuthority",
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          },
+          {
+            "refId": "witness:semantic-contract-mismatch",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [
+              "contractSpecification",
+              "semanticInterpretation"
+            ],
+            "blockerRefs": [
+              "semanticInterpretation",
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "coverage is selected-profile-relative and does not prove lawfulness"
+          }
+        ],
+        "signatureAxisCoverage": [
+          {
+            "refId": "sig-axis:layer-violation",
+            "status": "coverage-gap-preserved",
+            "evidenceRefs": [
+              "atom:relation:route-service"
+            ],
+            "blockerRefs": [
+              "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+            ],
+            "reading": "0 obstruction circuit(s) contribute to sig-axis:layer-violation"
+          },
+          {
+            "refId": "sig-axis:semantic-inconsistency",
+            "status": "coverage-gap-preserved",
+            "evidenceRefs": [
+              "atom:contract:create-user"
+            ],
+            "blockerRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+            ],
+            "reading": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency"
+          }
+        ],
+        "exactnessAssumptionStatus": [
+          {
+            "refId": "the selected witness rules cover only policy-declared laws",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [],
+            "blockerRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "exactness assumption is not theorem discharge"
+          },
+          {
+            "refId": "zero readings are exact only for observed atoms and declared coverage requirements",
+            "status": "blockedByCoverageGap",
+            "evidenceRefs": [],
+            "blockerRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "exactness assumption is not theorem discharge"
+          }
+        ],
+        "unmeasuredRequiredLawCount": 2,
+        "blockedWitnessRefs": [
+          "witness:layer-violation",
+          "witness:semantic-contract-mismatch"
+        ],
+        "lawWitnessAxisAlignment": "selected laws, witness rules, and signature axes are compared by refs only; alignment is profile-relative",
+        "coverageBoundary": "coverage measures selected profile visibility, not LawUniverse completeness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "featureExtensionFormulaReadings": [
+      {
+        "readingId": "feature-extension-formula:fixture-archmap-atom-observation",
+        "scopeRef": "fixture-archmap-atom-observation",
+        "status": "measured",
+        "inheritedCoreObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "featureLocalObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "interactionObstructionRefs": [],
+        "liftingFailureRefs": [
+          "split-readiness:molecule-user-request-responsibility"
+        ],
+        "fillingFailureRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "complexityTransferRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "residualCoverageGapRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "classificationSummary": [
+          {
+            "axis": "inheritedCoreObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "inheritedCoreObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "featureLocalObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "interactionObstruction",
+            "status": "unmeasuredOrAbsent",
+            "refs": [],
+            "reading": "interactionObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "liftingFailure",
+            "status": "observed",
+            "refs": [
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "reading": "liftingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "fillingFailure",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "fillingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "complexityTransfer",
+            "status": "observed",
+            "refs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "reading": "complexityTransfer is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "residualCoverageGap",
+            "status": "observed",
+            "refs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "residualCoverageGap is classified as a current-state extension coordinate"
+          }
+        ],
+        "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationCalculusLawReadings": [
+      {
+        "readingId": "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
+        "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "compositionStatus": "assumptionRelative",
+        "associativityUnderObservationStatus": "selectedObservationOnly",
+        "refinementAbstractionCompatibility": "blockedByMissingEvidence",
+        "replacementEquivalence": "unmeasured",
+        "protectionIdempotence": "notApplicable",
+        "runtimeLocalization": "blockedByCoverageGap",
+        "migrationCompatibility": "notApplicable",
+        "reverseInvolution": "unmeasured",
+        "repairMonotonicity": "selectedAxisOnly",
+        "synthesisNoSolutionBoundary": "notASynthesisCertificate",
+        "preconditionRefs": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+        ],
+        "evidenceRefs": [
+          "obstruction:semantic-contract-mismatch:computed",
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathSignatureTrajectoryReadings": [
+      {
+        "readingId": "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "pathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "status": "candidateTrajectory",
+        "endpointSignatureDelta": [
+          "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+        ],
+        "maxAxisExcursion": [
+          {
+            "axisRef": "sig-axis:layer-violation",
+            "maxValue": 0,
+            "evidenceRefs": [
+              "atom:relation:route-service"
+            ],
+            "reading": "max excursion is a current-state proxy, not future trajectory proof"
+          },
+          {
+            "axisRef": "sig-axis:semantic-inconsistency",
+            "maxValue": 1,
+            "evidenceRefs": [
+              "atom:contract:create-user"
+            ],
+            "reading": "max excursion is a current-state proxy, not future trajectory proof"
+          }
+        ],
+        "nonMonotoneAxisRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "pathCostProxy": "support=1 transferred=1",
+        "preservedInvariantTrajectory": [
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "introducedObstructionTrajectory": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "trajectoryCoverageBoundary": "trajectory is built from candidate operation deltas, not repository evolution",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "homotopyOrderSensitivityReadings": [
+      {
+        "readingId": "homotopy-order-sensitivity:selected-operations",
+        "status": "sensitive",
+        "independentSquareCandidateRefs": [
+          "molecule-reading:molecule-user-request-responsibility",
+          "molecule-reading:molecule-user-request-responsibility"
+        ],
+        "sameContractReplacementRefs": [],
+        "repairFillerRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "operationOrderSensitivity": "blockedByTransferredObstructionOrMissingEvidence",
+        "homotopyBlockerRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "selectedObservationPreservationStatus": "selected observation only; same endpoint does not imply same trajectory",
+        "evidenceBoundary": "homotopy reading is generator-relative and does not prove operation commutativity",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "diagramFillabilityReadings": [
+      {
+        "readingId": "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed",
+        "diagramRef": "local-curvature:obstruction-semantic-contract-mismatch-computed",
+        "diagramFamily": "localCurvatureDiagram",
+        "status": "nonFillabilityWitnessed",
+        "missingFillerKind": "lawRelativeFiller",
+        "fillerCandidateRefs": [
+          "molecule-user-request-responsibility",
+          "law-path:law-semantic-contract-alignment",
+          "witness-path:witness-semantic-contract-mismatch"
+        ],
+        "nonFillabilityWitnessRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "fillingBlockerRefs": [
+          "diagram filling is LawPolicy-relative and requires selected witness completeness"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "featureExtensionRefs": [
+          "feature-extension-formula:fixture-archmap-atom-observation"
+        ],
+        "evidenceBoundary": "diagram fillability is selected-diagram-relative and not a theorem discharge",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "axisForgettingRiskReadings": [
+      {
+        "readingId": "axis-forgetting-risk:selected-projection",
+        "sourceProjectionRef": "observation-projection:fixture-archmap-atom-observation",
+        "sourceAtomSupportRefs": [
+          "atom-support-axis:fixture-archmap-atom-observation",
+          "atom-support-axis:molecule-user-request-responsibility"
+        ],
+        "forgottenAxisRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "mixedAxisScopeRefs": [
+          "atom-support-axis:fixture-archmap-atom-observation",
+          "atom-support-axis:molecule-user-request-responsibility"
+        ],
+        "reflectionLossKind": "selectedAxisOrWitnessLoss",
+        "zeroReflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "obstructionReflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "requiredAssumptions": [
+          "selected axis preservation",
+          "witness completeness for forgotten coordinates",
+          "coverage boundary matching the selected LawPolicy"
+        ],
+        "coverageBoundary": "projection reflection is read only under explicit axis preservation and witness completeness assumptions",
+        "evidenceBoundary": "axis-forgetting risk is current-state ArchSig telemetry; it is not a proof that every projection loses information",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "signatureTrajectoryHomotopyRefutationReadings": [
+      {
+        "readingId": "signature-trajectory-homotopy-refutation:selected-trajectory",
+        "selectedHomotopyRef": "homotopy-order-sensitivity:selected-operations",
+        "trajectoryReadingRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "pathRefs": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "trajectoryDisagreementRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "trajectoryEquivalenceStatus": "selectedTrajectoryDisagreementObserved",
+        "homotopyRefutationStatus": "refutationCandidate",
+        "selectedEquivalenceBoundary": "trajectory disagreement refutes only homotopy that is selected-signature-preserving",
+        "evidenceBoundary": "endpoint delta and path trajectory are kept separate; this is not an operation-commutativity theorem",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "bridgeSplitObstructionTransferReadings": [
+      {
+        "readingId": "bridge-split-obstruction-transfer:split-readiness-molecule-user-request-responsibility",
+        "splitReadinessRef": "split-readiness:molecule-user-request-responsibility",
+        "bridgeEdgeRefs": [],
+        "moleculeRefs": [
+          "molecule:user-request-responsibility"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "requiredBoundaryOperations": [
+          "interface"
+        ],
+        "fillerEvidenceStatus": "requiredOrUnmeasured",
+        "liftingEvidenceStatus": "notBlockedByObservedBridge",
+        "transferRiskStatus": "needsObstructionSupportReview",
+        "evidenceBoundary": "bridge-edge transfer is a split-readiness boundary reading, not proof of automatic obstruction removal",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationSquareCandidates": [
+      {
+        "candidateId": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "candidateSource": "inferred",
+        "suppliedPairRef": null,
+        "candidateBasis": [
+          "sharedAtomSupport",
+          "effectFamily",
+          "contractAtom",
+          "semanticAtom",
+          "runtimeInteraction",
+          "projectionSurface"
+        ],
+        "leftOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "rightOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "pPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "qPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "sharedAtomSupportRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service"
+        ],
+        "stateRefs": [],
+        "effectRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "contractRefs": [
+          "atom:contract:create-user"
+        ],
+        "semanticRefs": [
+          "semantic:create-user-flow"
+        ],
+        "authorityRefs": [],
+        "runtimeRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "projectionRefs": [
+          "projection:aat:route-users",
+          "projection:aat:route-service",
+          "projection:sft:create-user"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "gap-runtime-user-db-trace",
+          "projection:aat:route-service",
+          "projection:aat:route-users",
+          "projection:sft:create-user",
+          "semantic:create-user-flow"
+        ],
+        "missingRefs": [
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "no state observation supplied for operation square candidate"
+        ],
+        "evidenceBoundary": "inferred operation square candidate is a review cue over observed ArchMap support, not operation truth",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathContinuationTraces": [
+      {
+        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "pathRole": "p",
+        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "axisTraces": [
+          {
+            "axisFamily": "static",
+            "axisRef": "static dependency / support axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user",
+              "atom:relation:route-service"
+            ],
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "contract",
+            "axisRef": "contract axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "atom:contract:create-user"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "semantic",
+            "axisRef": "semantic axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "semantic:create-user-flow"
+            ],
+            "sourceRefs": [
+              "doc-architecture",
+              "test-user-contract"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "state",
+            "axisRef": "state transition axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "effect",
+            "axisRef": "effect ordering / replay / compensation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction",
+              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json",
+              "doc-architecture",
+              "src-route-users",
+              "src-service-user",
+              "test-user-contract"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "authority",
+            "axisRef": "authority / trust boundary axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "runtime",
+            "axisRef": "runtime interaction axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "projection",
+            "axisRef": "projection / representation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "projection continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "projection:aat:route-users",
+              "projection:aat:route-service",
+              "projection:sft:create-user"
+            ],
+            "sourceRefs": [
+              "atom:component:route-users",
+              "atom:relation:route-service",
+              "semantic:create-user-flow"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          }
+        ],
+        "observationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "gap-runtime-user-db-trace",
+          "projection:aat:route-service",
+          "projection:aat:route-users",
+          "projection:sft:create-user",
+          "semantic:create-user-flow"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "missingRefs": [
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "no state observation supplied for operation square candidate"
+        ],
+        "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+        "pathRole": "q",
+        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "axisTraces": [
+          {
+            "axisFamily": "static",
+            "axisRef": "static dependency / support axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user",
+              "atom:relation:route-service"
+            ],
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "contract",
+            "axisRef": "contract axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "atom:contract:create-user"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "semantic",
+            "axisRef": "semantic axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "semantic:create-user-flow"
+            ],
+            "sourceRefs": [
+              "doc-architecture",
+              "test-user-contract"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "state",
+            "axisRef": "state transition axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "effect",
+            "axisRef": "effect ordering / replay / compensation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction",
+              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json",
+              "doc-architecture",
+              "src-route-users",
+              "src-service-user",
+              "test-user-contract"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "authority",
+            "axisRef": "authority / trust boundary axis",
+            "traceStatus": "unmeasured",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "runtime",
+            "axisRef": "runtime interaction axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "projection",
+            "axisRef": "projection / representation axis",
+            "traceStatus": "boundedObservationTrace",
+            "continuationSummary": "projection continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "observationRefs": [
+              "projection:aat:route-users",
+              "projection:aat:route-service",
+              "projection:sft:create-user"
+            ],
+            "sourceRefs": [
+              "atom:component:route-users",
+              "atom:relation:route-service",
+              "semantic:create-user-flow"
+            ],
+            "missingRefs": [],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          }
+        ],
+        "observationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "gap-runtime-user-db-trace",
+          "projection:aat:route-service",
+          "projection:aat:route-users",
+          "projection:sft:create-user",
+          "semantic:create-user-flow"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "missingRefs": [
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "no state observation supplied for operation square candidate"
+        ],
+        "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "axisWiseMonodromyDefects": [
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "authority",
+        "axisRef": "authority / trust boundary axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "contract",
+        "axisRef": "contract axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "atom:contract:create-user"
+        ],
+        "witnessRefs": [
+          "atom:contract:create-user"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "atom:contract:create-user"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "effect",
+        "axisRef": "effect ordering / replay / compensation axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 2,
+        "measuredSupportRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "witnessRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "projection",
+        "axisRef": "projection / representation axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "projection:aat:route-service",
+          "projection:aat:route-users",
+          "projection:sft:create-user"
+        ],
+        "witnessRefs": [
+          "projection:aat:route-service",
+          "projection:aat:route-users",
+          "projection:sft:create-user"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "projection:aat:route-service",
+          "projection:aat:route-users",
+          "projection:sft:create-user"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "runtime",
+        "axisRef": "runtime interaction axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "witnessRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "semantic:create-user-flow"
+        ],
+        "witnessRefs": [
+          "semantic:create-user-flow"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "semantic:create-user-flow"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "state",
+        "axisRef": "state transition axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        ],
+        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "axisFamily": "static",
+        "axisRef": "static dependency / support axis",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service"
+        ],
+        "witnessRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "amiAggregateReadings": [
+      {
+        "aggregateId": "ami:measurement-policy-monodromy-boundary-holonomy",
+        "selectedSquareFamily": "operationSquareCandidates",
+        "selectedAxisFamily": [
+          "authority",
+          "contract",
+          "effect",
+          "projection",
+          "runtime",
+          "semantic",
+          "state",
+          "static"
+        ],
+        "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+        "distanceKind": "weighted-axis-l1",
+        "measurementStatus": "partial",
+        "aggregateValue": 2,
+        "measuredDefectRefs": [
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+        ],
+        "unmeasuredDefectRefs": [
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state"
+        ],
+        "topContributors": [
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "authority",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "state",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "effect",
+            "contributionWeight": 1,
+            "contributionValue": 2,
+            "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "contract",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "atom:contract:create-user"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "projection",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "projection:aat:route-service",
+              "projection:aat:route-users",
+              "projection:sft:create-user"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "runtime",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review runtime trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "gap-runtime-user-db-trace"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "semantic",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "semantic:create-user-flow"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
+            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "axisFamily": "static",
+            "contributionWeight": 1,
+            "contributionValue": 0,
+            "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
+            "witnessRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user",
+              "atom:relation:route-service"
+            ]
+          }
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "weighted aggregate is a review prioritization reading; cancellation can hide local defects, so top contributors remain authoritative",
+        "aggregateToLocalReadingBoundary": "AMI_X(A) summarizes selected local mu_x(sigma) readings and does not replace axis-wise defect review",
+        "reviewPriority": "reviewMissingEvidence",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "nonzeroMonodromyWitnesses": [
+      {
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
+        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "operationPair": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+        ],
+        "pathPair": [
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+        ],
+        "axisFamily": "effect",
+        "axisRef": "effect ordering / replay / compensation axis",
+        "defectValue": 2,
+        "comparedTraceSummary": [
+          "p: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0",
+          "q: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0"
+        ],
+        "affectedAtomRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "lawRefs": [
+          "law:layer-respecting",
+          "law:semantic-contract-alignment"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:layer-violation",
+          "sig-axis:semantic-inconsistency"
+        ],
+        "sourceRefs": [
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "add observed compensation / authority / effect atoms only after source review",
+          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+          "split or enrich atoms that currently support the target obstruction"
+        ],
+        "missingEvidence": [],
+        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "suggestedFillerEvidence": [
+          "supply filler evidence for effect axis trace disagreement",
+          "record whether the two continuation paths preserve selected observations"
+        ],
+        "suggestedLiftingEvidence": [
+          "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+        ],
+        "suggestedBoundaryEvidence": [
+          "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+        ],
+        "recommendedReviewFocus": [
+          "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
+          "review effect axis witness refs and missing evidence"
+        ],
+        "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "featureBoundaryResidualReadings": [
+      {
+        "readingId": "feature-boundary-residual:fixture-archmap-atom-observation",
+        "boundaryRef": "Boundary(fixture-archmap-atom-observation, feature-extension)",
+        "featureExtensionRef": "feature-extension-formula:fixture-archmap-atom-observation",
+        "status": "measuredResidual",
+        "coreScopeRef": "fixture-archmap-atom-observation:core",
+        "featureScopeRef": "fixture-archmap-atom-observation:feature",
+        "mixedSubconfigurationRefs": [
+          "gap-runtime-user-db-trace",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-user-request-responsibility"
+        ],
+        "coreLocalReadingRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "featureLocalReadingRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "boundarySupportRefs": [
+          "gap-runtime-user-db-trace",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-user-request-responsibility"
+        ],
+        "holonomyAxes": [
+          {
+            "holonomyAxisRef": "Hol_static",
+            "axisFamily": "static",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "atom:component:route-users",
+              "atom:component:service-user",
+              "atom:relation:route-service"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_static records boundary-local residual obstruction on the static axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_contract",
+            "axisFamily": "contract",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "atom:contract:create-user"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_contract records boundary-local residual obstruction on the contract axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_semantic",
+            "axisFamily": "semantic",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "semantic:create-user-flow"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_semantic records boundary-local residual obstruction on the semantic axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_state",
+            "axisFamily": "state",
+            "status": "coverageBlocked",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap-runtime-user-db-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "missingEvidence": [
+              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "reading": "Hol_state records boundary-local residual obstruction on the state axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_effect",
+            "axisFamily": "effect",
+            "status": "measuredResidual",
+            "residualValue": 2,
+            "measuredDefectRefs": [
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+            ],
+            "supportRefs": [
+              "add observed compensation / authority / effect atoms only after source review",
+              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
+              "split or enrich atoms that currently support the target obstruction"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_authority",
+            "axisFamily": "authority",
+            "status": "coverageBlocked",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap-runtime-user-db-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "missingEvidence": [
+              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            ],
+            "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_runtime",
+            "axisFamily": "runtime",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
+          },
+          {
+            "holonomyAxisRef": "Hol_projection",
+            "axisFamily": "projection",
+            "status": "coveredZeroResidual",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
+            "supportRefs": [
+              "projection:aat:route-service",
+              "projection:aat:route-users",
+              "projection:sft:create-user"
+            ],
+            "missingEvidence": [],
+            "reading": "Hol_projection records boundary-local residual obstruction on the projection axis"
+          }
+        ],
+        "residualObstructionRefs": [
+          "gap-runtime-user-db-trace",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-user-request-responsibility"
+        ],
+        "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
+        "coverageAssumptions": [
+          "coveragePolicy=measure only selected axes with declared coverage; missing coverage remains blocked, not zero over selected axes [\"axis:layer-violation\", \"axis:semantic-inconsistency\"]",
+          "unmeasured boundary support remains residual coverage debt"
+        ],
+        "exactnessAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
+        "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
+        "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "featureExtensionDiagnosisReadings": [
+      {
+        "diagnosisId": "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation",
+        "featureExtensionRef": "feature-extension-formula:fixture-archmap-atom-observation",
+        "boundaryResidualRef": "feature-boundary-residual:fixture-archmap-atom-observation",
+        "status": "multiLabelAttributed",
+        "classifierVersion": "feature-extension-diagnosis-classifier-v0",
+        "classificationSummary": [
+          {
+            "axis": "inheritedCoreObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "inheritedCoreObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "featureLocalObstruction",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "boundaryHolonomy",
+            "status": "observed",
+            "refs": [
+              "feature-boundary-residual:fixture-archmap-atom-observation",
+              "gap-runtime-user-db-trace",
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+              "obstruction:semantic-contract-mismatch:computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "liftingFailure",
+            "status": "observed",
+            "refs": [
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "reading": "liftingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "fillingFailure",
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "reading": "fillingFailure is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "complexityTransfer",
+            "status": "observed",
+            "refs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "reading": "complexityTransfer is classified as a current-state extension coordinate"
+          },
+          {
+            "axis": "residualCoverageGap",
+            "status": "observed",
+            "refs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "residualCoverageGap is classified as a current-state extension coordinate"
+          }
+        ],
+        "attributionRecords": [
+          {
+            "witnessRef": "feature-boundary-residual:fixture-archmap-atom-observation",
+            "labels": [
+              "boundaryHolonomy"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "feature-boundary-residual:fixture-archmap-atom-observation"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "feature-boundary-residual:fixture-archmap-atom-observation carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          },
+          {
+            "witnessRef": "gap-runtime-user-db-trace",
+            "labels": [
+              "boundaryHolonomy",
+              "residualCoverageGap"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "reading": "gap-runtime-user-db-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
+          },
+          {
+            "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+            "labels": [
+              "boundaryHolonomy",
+              "complexityTransfer"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "residualCoverageGapRefs": [],
+            "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+          },
+          {
+            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "labels": [
+              "boundaryHolonomy"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          },
+          {
+            "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+            "labels": [
+              "boundaryHolonomy",
+              "featureLocalObstruction",
+              "fillingFailure",
+              "inheritedCoreObstruction"
+            ],
+            "inheritedCoreRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "featureLocalRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "boundaryHolonomyRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+          },
+          {
+            "witnessRef": "split-readiness:molecule-user-request-responsibility",
+            "labels": [
+              "boundaryHolonomy",
+              "liftingFailure"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "liftingFailureRefs": [
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "split-readiness:molecule-user-request-responsibility carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"liftingFailure\"]"
+          }
+        ],
+        "residualCoverageGapRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "liftingFailureRefs": [
+          "split-readiness:molecule-user-request-responsibility"
+        ],
+        "fillingFailureRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "complexityTransferRefs": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
+        "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
+        "evidenceBoundary": "diagnosis is computed from ArchSig packet evidence and does not prove a mutually disjoint Architecture Extension Formula",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "monodromyReadingFamily": {
+      "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+      "status": "schemaFoundationOnly",
+      "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
+      "selectedAxisRefs": [
+        "axis:layer-violation",
+        "axis:semantic-inconsistency"
+      ],
+      "distanceKind": "weighted-axis-l1",
+      "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+      "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+      "operationSquareCandidateRefs": [
+        "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+      ],
+      "pathContinuationTraceRefs": [
+        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q"
+      ],
+      "axisWiseDefectRefs": [
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
+        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+      ],
+      "amiAggregateReadingRefs": [
+        "ami:measurement-policy-monodromy-boundary-holonomy"
+      ],
+      "aggregateReadingKind": "ami-weighted-review-prioritization",
+      "readingBoundary": "records axis-wise defect and AMI aggregate readings as bounded review telemetry, not merge gates or global flatness theorems",
+      "evidenceBoundary": "monodromy is measured over ArchMapStore refs and selected LawPolicy axes, not over raw source diffs",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "boundaryHolonomyReadingFamily": {
+      "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
+      "status": "schemaFoundationOnly",
+      "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
+      "selectedAxisRefs": [
+        "axis:layer-violation",
+        "axis:semantic-inconsistency"
+      ],
+      "distanceKind": "weighted-axis-l1",
+      "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
+      "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
+      "nonzeroMonodromyWitnessRefs": [
+        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect"
+      ],
+      "featureBoundaryResidualRefs": [
+        "feature-boundary-residual:fixture-archmap-atom-observation"
+      ],
+      "extensionDiagnosisRefs": [
+        "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation"
+      ],
+      "attributionBoundary": "multi-label attribution can name feature, boundary, law, and coverage contributors without claiming a single cause",
+      "readingBoundary": "records the packet shape for boundary residual and feature-extension diagnosis; concrete attribution is introduced by later issues",
+      "evidenceBoundary": "boundary holonomy readings use ArchMapStore refs and LawPolicy axes; raw diff hunks are not ArchSig evidence",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "representationStrengthReadings": [
+      {
+        "readingId": "representation-strength:analytic-weighted-adjacency",
+        "sourceReadingRef": "analytic:weighted-adjacency",
+        "representationFamily": "weightedAdjacencyMatrix",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "weightedAdjacencyMatrix is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-reachable-cone-size",
+        "sourceReadingRef": "analytic:reachable-cone-size",
+        "representationFamily": "reachableConeSize",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "reachableConeSize is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-walk-count",
+        "sourceReadingRef": "analytic:walk-count",
+        "representationFamily": "walkCount",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "walkCount is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-nilpotence-boundary",
+        "sourceReadingRef": "analytic:nilpotence-boundary",
+        "representationFamily": "nilpotenceBoundary",
+        "zeroPreserving": "bounded",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "nilpotenceBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-selected-subgraph-spectrum",
+        "sourceReadingRef": "analytic:selected-subgraph-spectrum",
+        "representationFamily": "selectedSubgraphSpectrum",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "selectedSubgraphSpectrum is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-propagation-depth",
+        "sourceReadingRef": "analytic:propagation-depth",
+        "representationFamily": "propagationDepth",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "propagationDepth is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-spectral-radius-proxy",
+        "sourceReadingRef": "analytic:spectral-radius-proxy",
+        "representationFamily": "spectralRadius",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "spectralRadius is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-curvature-valuation",
+        "sourceReadingRef": "analytic:curvature-valuation",
+        "representationFamily": "curvatureValuation",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "curvatureValuation is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-state-algebra-boundary",
+        "sourceReadingRef": "analytic:state-algebra-boundary",
+        "representationFamily": "stateAlgebra",
+        "zeroPreserving": "bounded",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "stateAlgebra is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:analytic-zero-reflecting-aggregate-boundary",
+        "sourceReadingRef": "analytic:zero-reflecting-aggregate-boundary",
+        "representationFamily": "zeroReflectingAggregateBoundary",
+        "zeroPreserving": "bounded",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "blockedByCoverageGap",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "notApplicable",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
+        "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-workflow-risk-axis-pressure",
+        "sourceReadingRef": "spectral:workflow-risk-axis-pressure",
+        "representationFamily": "workflowRiskAxisPressureMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "workflowRiskAxisPressureMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "coverage gaps on workflow axes block measured-zero interpretation for absent entries",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-molecule-atom-overlap-coupling",
+        "sourceReadingRef": "spectral:molecule-atom-overlap-coupling",
+        "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "moleculeAtomOverlapCouplingMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "missing atom families and observation gaps can make overlap coupling appear smaller than the source architecture actually is",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-obstruction-axis-curvature",
+        "sourceReadingRef": "spectral:obstruction-axis-curvature",
+        "representationFamily": "obstructionAxisCurvatureMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "obstructionAxisCurvatureMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "only constructed obstruction circuits are represented; concern hints that lack witness rules remain outside this matrix",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-operation-signature-delta",
+        "sourceReadingRef": "spectral:operation-signature-delta",
+        "representationFamily": "operationSignatureDeltaMatrix",
+        "zeroPreserving": "boundedProxy",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "proxyOnly",
+        "cancellationRisk": "boundedProxyMayHideLocalComponents",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "operationSignatureDeltaMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+        "evidenceBoundary": "candidate operations are bounded review artifacts; absent delta entries are not proof that an operation preserves an axis",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "localCurvatureDiagramReadings": [
+      {
+        "diagramId": "local-curvature:obstruction-semantic-contract-mismatch-computed",
+        "lawRef": "law:semantic-contract-alignment",
+        "obstructionRef": "obstruction:semantic-contract-mismatch:computed",
+        "signatureAxisRefs": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "moleculeRefs": [
+          "molecule-user-request-responsibility"
+        ],
+        "lhsPathRefs": [
+          "molecule-user-request-responsibility"
+        ],
+        "rhsPathRefs": [
+          "law-path:law-semantic-contract-alignment",
+          "witness-path:witness-semantic-contract-mismatch"
+        ],
+        "curvatureValue": 1,
+        "curvatureStatus": "nonzero",
+        "diagramReading": "obstruction:semantic-contract-mismatch:computed is read as local curvature for law:semantic-contract-alignment",
+        "fillingBoundary": "diagram filling is LawPolicy-relative and requires selected witness completeness",
+        "sourceRefs": [
+          "test-user-contract"
+        ],
+        "evidenceBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "threeLayerFlatnessReadings": [
+      {
+        "readingId": "three-layer-flatness:fixture-archmap-atom-observation",
+        "staticStatus": "needsReview",
+        "runtimeStatus": "blockedByCoverageGap",
+        "semanticStatus": "stressed",
+        "staticObservationRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service"
+        ],
+        "runtimeObservationRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "semanticObservationRefs": [
+          "atom:contract:create-user",
+          "semantic:create-user-flow"
+        ],
+        "crossLayerAtomRefs": [
+          "atom:contract:create-user"
+        ],
+        "nonImplicationReading": "static flatness does not imply runtime or semantic flatness; cross-layer atoms must be reviewed separately",
+        "evidenceBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
+        "recommendedNextAction": "review cross-layer contract/state/effect/authority atoms before treating layer separation as flatness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "observationProjectionReadings": [
+      {
+        "readingId": "observation-projection:fixture-archmap-atom-observation",
+        "observedAtomFamilies": [
+          "contractSpecification",
+          "existence",
+          "relation"
+        ],
+        "observedAtomFamilyCount": 3,
+        "forgottenCoordinates": [
+          "gap-runtime-user-db-trace"
+        ],
+        "observationCollisionPairs": [],
+        "collapsedAtomFamilyCandidates": [],
+        "hiddenAtomFamilyHints": [
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "reconstructionRisk": "reconstructionLossPresent",
+        "coarseProjectionRisks": [
+          "coarse observation may merge distinct canonical atoms",
+          "unobserved source coordinates must not be read as absent atoms",
+          "LLM observation uncertainty is projection loss, not Atom non-uniqueness"
+        ],
+        "reconstructionBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user"
+        ],
+        "reading": "ArchMap is treated as an observation projection of a canonical source-derived Atom family",
+        "evidenceBoundary": "projection reading records lost coordinates and does not reconstruct the complete canonical Atom family",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "stateTransitionAlgebraReadings": [
+      {
+        "readingId": "state-transition-algebra:fixture-archmap-atom-observation",
+        "generatorRefs": [],
+        "stateAtomRefs": [],
+        "effectAtomRefs": [],
+        "runtimeAtomRefs": [],
+        "requiredRelations": [
+          "idempotency",
+          "replay safety",
+          "state/effect ordering",
+          "compensation or finalization",
+          "transaction boundary ownership"
+        ],
+        "unresolvedRelations": [
+          "gap-runtime-user-db-trace"
+        ],
+        "obstructionRefs": [],
+        "reading": "state/effect/runtime atoms generate a bounded state transition algebra reading",
+        "evidenceBoundary": "transition algebra is derived from observed atoms only; runtime traces and tests remain required for reflecting laws",
+        "recommendedNextAction": "verify idempotency, replay, ordering, and transaction ownership before claiming state/effect flatness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationInvariantGaloisReadings": [
+      {
+        "readingId": "operation-invariant-galois:selected-law-policy",
+        "invariantFamilyRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "operationFamilyRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "opsOfInvariants": [
+          "repair:obstruction-semantic-contract-mismatch-computed is allowed only relative to preserved [\"preserve zero reading for sig-axis:layer-violation\"]"
+        ],
+        "invOfOperations": [
+          "invariant:law-layer-respecting must be preserved by selected operation families (preservedForConstructedWitnesses)",
+          "invariant:law-semantic-contract-alignment must be preserved by selected operation families (stressed)"
+        ],
+        "preservedInvariantRefs": [
+          "invariant:law-layer-respecting"
+        ],
+        "blockedOperationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "reading": "operation families and invariant families form an AAT Galois-style review reading",
+        "evidenceBoundary": "this reading classifies allowed operation families; it does not prove repair soundness",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "splitReadinessReadings": [
+      {
+        "readingId": "split-readiness:molecule-user-request-responsibility",
+        "moleculeRef": "molecule:user-request-responsibility",
+        "status": "needsReview",
+        "readinessScore": 92,
+        "coreEmbeddingStatus": "observed",
+        "featureViewSectionStatus": "needsSemanticView",
+        "liftingEvidenceStatus": "notBlockedByObservedBridge",
+        "interactionObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "bridgeEdgeRefs": [],
+        "recommendedBoundaryOperation": "interface",
+        "reading": "molecule:user-request-responsibility has split readiness score 92 under current ArchSig evidence",
+        "evidenceBoundary": "split readiness is a current-state architecture reading, not a feature-extension proof",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "structuralReadingReviewSurface": {
+      "surfaceId": "aat-structural-reading-review-surface",
+      "status": "needsReview",
+      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1",
+      "connectedReadingRefs": [
+        "representationStrength:weightedAdjacencyMatrix",
+        "representationStrength:reachableConeSize",
+        "representationStrength:walkCount",
+        "representationStrength:nilpotenceBoundary",
+        "representationStrength:selectedSubgraphSpectrum",
+        "representationStrength:propagationDepth",
+        "local-curvature:obstruction-semantic-contract-mismatch-computed",
+        "three-layer-flatness:fixture-archmap-atom-observation",
+        "observation-projection:fixture-archmap-atom-observation",
+        "state-transition-algebra:fixture-archmap-atom-observation",
+        "operation-invariant-galois:selected-law-policy",
+        "split-readiness:molecule-user-request-responsibility",
+        "atom-support-axis:fixture-archmap-atom-observation",
+        "atom-support-axis:molecule-user-request-responsibility",
+        "atom-compatibility:fixture-archmap-atom-observation",
+        "law-universe-coverage:llm-native-aat-law-policy-fixture",
+        "feature-extension-formula:fixture-archmap-atom-observation",
+        "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
+        "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
+        "homotopy-order-sensitivity:selected-operations",
+        "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed",
+        "axis-forgetting-risk:selected-projection",
+        "signature-trajectory-homotopy-refutation:selected-trajectory",
+        "bridge-split-obstruction-transfer:split-readiness-molecule-user-request-responsibility"
+      ],
+      "reviewFocus": [
+        "read Atom support and compatibility before collapsing mixed state, effect, contract, authority, semantic, or runtime axes",
+        "read LawUniverse coverage and witness exactness before treating absence as measured zero",
+        "read feature extension, operation law, trajectory, homotopy, and diagram-fillability axes as current-state coordinates, not PR evolution claims",
+        "read axis-forgetting risk before treating a coarse projection as zero-reflecting or obstruction-reflecting",
+        "read selected trajectory disagreement before treating same-endpoint operations as homotopic",
+        "read bridge split transfer before treating a boundary operation as obstruction removal",
+        "read representation-strength blockers before treating zero or obstruction absence as exact",
+        "read local-curvature diagrams as law-relative state pressure, not as generic lint failures",
+        "compare static, runtime, and semantic flatness before relying on source layout",
+        "treat observation projection gaps as lost coordinates that bound the reading",
+        "check state/effect algebra relations before approving local repairs",
+        "read split readiness and bridge edges before separating molecules"
+      ],
+      "evidenceBoundary": "structural readings are computed from the current ArchMap and selected LawPolicy; they are review telemetry, not proof of global architecture truth",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "currentStateEvolutionBoundary": {
+      "boundaryId": "archsig-fieldsig-current-state-evolution-boundary",
+      "archsigCurrentStateScope": "ArchSig computes current AAT structural state from ArchMap fixture-archmap-atom-observation and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
+      "fieldsigEvolutionScope": "FieldSig consumes archsig-analysis-packet-v0 as bounded current AAT structural state and studies PR, diff, change-vector, forecast, governance, calibration, and operational evolution over that state",
+      "handoffArtifactRef": "archsig-analysis-packet-v0",
+      "forbiddenReadings": [
+        "ArchSig packet is not PR diff analysis",
+        "ArchSig packet is not forecast correctness or causal truth",
+        "raw ArchMap observations are not FieldSig forecast truth",
+        "FieldSig evolution readings must not be moved back into ArchMap"
+      ],
+      "evidenceBoundary": "handoff preserves bounded current-state evidence; evolution claims remain downstream FieldSig readings",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "designPrincipleReadings": [
+      {
+        "principleId": "principle:informationhiding",
+        "principle": "InformationHiding",
+        "status": "stressed",
+        "aatReading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:encapsulation",
+        "principle": "Encapsulation",
+        "status": "stressed",
+        "aatReading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:separationofconcerns",
+        "principle": "SeparationOfConcerns",
+        "status": "stressed",
+        "aatReading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:substitutability",
+        "principle": "Substitutability",
+        "status": "stressed",
+        "aatReading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:openclosedextension",
+        "principle": "OpenClosedExtension",
+        "status": "stressed",
+        "aatReading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:dependencyinversion",
+        "principle": "DependencyInversion",
+        "status": "stressed",
+        "aatReading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:representationindependence",
+        "principle": "RepresentationIndependence",
+        "status": "unmeasured",
+        "aatReading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "low",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:idempotencyandreplaysafety",
+        "principle": "IdempotencyAndReplaySafety",
+        "status": "unmeasured",
+        "aatReading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "low",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "principleId": "principle:authorityandtrustboundary",
+        "principle": "AuthorityAndTrustBoundary",
+        "status": "unmeasured",
+        "aatReading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+        "invariantRefs": [
+          "invariant:law-layer-respecting",
+          "invariant:law-semantic-contract-alignment"
+        ],
+        "obstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "operationRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "low",
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBlockers": [
+          "gap-runtime-user-db-trace"
+        ],
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "flatnessReading": {
+      "readingId": "flatness:llm-native-aat-law-policy-fixture",
+      "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture",
+      "status": "nonflatUnderSelectedPolicy",
+      "zeroSignatureAxisRefs": [
+        "sig-axis:layer-violation"
+      ],
+      "nonzeroSignatureAxisRefs": [
+        "sig-axis:semantic-inconsistency"
+      ],
+      "blockedByCoverageGaps": [
+        "gap-runtime-user-db-trace"
+      ],
+      "evidenceBoundary": "flatness is relative to selected signature axes, coverage gaps, and exactness assumptions",
+      "interpretationNotesForLLM": [
+        "Do not turn zero signature axes into global lawfulness claims."
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "staticRuntimeSemanticLayerSplit": {
+      "staticObservationRefs": [
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:relation:route-service"
+      ],
+      "runtimeObservationRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "semanticObservationRefs": [
+        "atom:contract:create-user",
+        "semantic:create-user-flow"
+      ],
+      "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    "repairOperationCandidates": [
+      {
+        "repairOperationCandidateId": "repair:obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "targetObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "preservedInvariants": [
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "preconditions": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+        ],
+        "expectedSignatureAxisEffects": [
+          "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+        ],
+        "transferRisks": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
+        "missingEvidence": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "causal forecast correctness",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "merge approval",
+          "single architecture quality score"
+        ],
+        "interpretationNotesForLLM": [
+          "Explain preconditions and transfer risks before implementation advice."
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationDeltas": [
+      {
+        "operationDeltaId": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "supportRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "preconditions": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+        ],
+        "atomTransformations": [
+          "split or enrich atoms that currently support the target obstruction",
+          "add observed compensation / authority / effect atoms only after source review"
+        ],
+        "transitionRelation": "operation maps the current bounded Atom configuration to a candidate repaired configuration",
+        "invariantPreservationClaims": [
+          "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "obstructionTransport": [
+          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis"
+        ],
+        "signatureDelta": [
+          "decrease sig-axis:semantic-inconsistency if the witness no longer constructs"
+        ],
+        "decreasedAxes": [
+          "sig-axis:semantic-inconsistency"
+        ],
+        "transferredObstructions": [
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        ],
+        "excludedReadings": [
+          "Lean theorem discharge",
+          "SFT forecast correctness",
+          "automatic repair safety",
+          "causal forecast correctness",
+          "exactness-limited: the selected witness rules cover only policy-declared laws",
+          "exactness-limited: zero readings are exact only for observed atoms and declared coverage requirements",
+          "global architecture lawfulness",
+          "global architecture truth",
+          "merge approval",
+          "single architecture quality score"
+        ],
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathHomotopyDiagramReadings": [
+      {
+        "readingId": "path:semantic-operation-flow",
+        "surface": "Path",
+        "status": "observedOrRepresented",
+        "pathRefs": [
+          "semantic:create-user-flow"
+        ],
+        "homotopyRefs": [
+          "molecule-reading:molecule-user-request-responsibility"
+        ],
+        "diagramRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "fillingBoundary": "path reading is a source-grounded semantic workflow proxy, not a free-category proof",
+        "reading": "semantic observations and molecules provide path candidates for review",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "diagram:obstruction-filling",
+        "surface": "Diagram",
+        "status": "actionable",
+        "pathRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "homotopyRefs": [
+          "molecule-reading:molecule-user-request-responsibility"
+        ],
+        "diagramRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "fillingBoundary": "diagram filling is reported as obstruction / repair planning surface, not theorem discharge",
+        "reading": "constructed obstruction circuits identify diagrams whose filling requires review or repair",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "boundedJudgements": [
+      {
+        "judgementId": "judgement:architecture-state",
+        "status": "actionable",
+        "aatConcept": "ArchitectureObject",
+        "reading": "observed atoms, molecules, semantic records, gaps, and signature axes define a bounded architecture state",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "runtime trace was requested but not supplied"
+        ],
+        "coverageBoundary": "bounded to supplied ArchMap and selected interpretation profile",
+        "exactnessBoundary": "not global architecture truth and not Lean theorem proof",
+        "recommendedNextAction": "review nonzero axes and stressed principle readings first",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:obstruction-semantic-contract-mismatch-computed",
+        "status": "actionable",
+        "aatConcept": "ObstructionCircuit",
+        "reading": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
+        "evidenceRefs": [
+          "atom:contract:create-user",
+          "molecule-reading:molecule-user-request-responsibility",
+          "concern:missing-compensation"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "coverageBoundary": "computed ArchSig witness under selected LawPolicy; concern hints are auxiliary evidence only",
+        "exactnessBoundary": "witness is selected-profile-relative",
+        "recommendedNextAction": "inspect source refs and repair operation preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:sig-axis-layer-violation",
+        "status": "needsReview",
+        "aatConcept": "ArchitectureSignature",
+        "reading": "0 obstruction circuit(s) contribute to sig-axis:layer-violation",
+        "evidenceRefs": [
+          "atom:relation:route-service"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "coverageBoundary": "coverage-gap-preserved",
+        "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+        "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:sig-axis-semantic-inconsistency",
+        "status": "actionable",
+        "aatConcept": "ArchitectureSignature",
+        "reading": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
+        "evidenceRefs": [
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "coverageBoundary": "coverage-gap-preserved",
+        "exactnessBoundary": "the selected witness rules cover only policy-declared laws; zero readings are exact only for observed atoms and declared coverage requirements",
+        "recommendedNextAction": "use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-informationhiding",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-encapsulation",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-separationofconcerns",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-substitutability",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-openclosedextension",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-dependencyinversion",
+        "status": "actionable",
+        "aatConcept": "Invariant",
+        "reading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "medium",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-representationindependence",
+        "status": "blocked",
+        "aatConcept": "Invariant",
+        "reading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-idempotencyandreplaysafety",
+        "status": "blocked",
+        "aatConcept": "Invariant",
+        "reading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "judgementId": "judgement:principle-authorityandtrustboundary",
+        "status": "blocked",
+        "aatConcept": "Invariant",
+        "reading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+        "evidenceRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "confidence": "low",
+        "uncertainty": [
+          "gap-runtime-user-db-trace"
+        ],
+        "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
+        "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
+        "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "llmInterpretationPacket": {
+      "packetId": "llm-interpretation:fixture-archmap-atom-observation",
+      "shortDiagnosis": "9 actionable judgement(s), 1 design pressure reading(s), and 1 observation gap(s) require review",
+      "aatConceptMap": [
+        "Atom -> Configuration -> ArchitectureObject",
+        "InvariantFamily -> LawUniverse -> ObstructionCircuit -> ArchitectureSignature",
+        "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation"
+      ],
+      "observedAtomsSummary": [
+        "contractSpecification",
+        "existence",
+        "relation"
+      ],
+      "obstructionSummary": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "signatureAxesSummary": [
+        "sig-axis:layer-violation=0 (coverage-gap-preserved)",
+        "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
+      ],
+      "analyticReadingsSummary": [
+        "weightedAdjacencyMatrix=4x4; edgeCount=1 (measured)",
+        "reachableConeSize=5 (measured)",
+        "walkCount=2 (measured)",
+        "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
+        "selectedSubgraphSpectrum=[0.250] (measured)",
+        "propagationDepth=1 (measured)",
+        "spectralRadius=0.250 (measured)",
+        "curvatureValuation=1 (measured)",
+        "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
+        "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
+      ],
+      "spectralReadingsSummary": [
+        "workflowRiskAxisPressureMatrix upperBound=10.677 shape=1x5 (needsReview)",
+        "moleculeAtomOverlapCouplingMatrix upperBound=4.000 shape=1x1 (needsReview)",
+        "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
+        "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
+      ],
+      "spectralModeSummary": [
+        "workflowRiskAxisPressureMatrix distributedPressureMode gap=9.434 localization=1.000 density=1.000 (needsReview)",
+        "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=4.000 localization=1.000 density=1.000 (needsReview)",
+        "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
+        "operationSignatureDeltaMatrix localizedPerturbationMode gap=1.000 localization=1.000 density=0.500 (actionable)"
+      ],
+      "spectralDrilldownSummary": [
+        "spectral-drilldown:fixture-archmap-atom-observation atomFamilies=3 overlapPairs=0 repairAxisDeltas=1 (needsReview)"
+      ],
+      "curvatureSupportSummary": [
+        "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
+      ],
+      "curvatureTransferSummary": [
+        "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1 (needsReview)"
+      ],
+      "architectureSpectrumReportSummary": [
+        "architecture-spectrum-report:spectrum-profile-curvature-transfer-default hotspots=4 recurrent=1 clusters=2 (needsReview)",
+        "report is measured from ArchSig curvature support and transfer readings under selected LawPolicy coverage and exactness assumptions"
+      ],
+      "transferBridgeSummary": [
+        "transfer-bridge:fixture-archmap-atom-observation transfers=0 bridges=1 repairRanks=1 boundaryRanks=0 (nonConclusion)"
+      ],
+      "transferBridgeEdgeSummary": [],
+      "measurementExpansionSummary": [
+        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
+      ],
+      "atomSupportAxisSummary": [
+        "fixture-archmap-atom-observation support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent",
+        "molecule:user-request-responsibility support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent"
+      ],
+      "atomCompatibilitySummary": [
+        "atom-compatibility:fixture-archmap-atom-observation status=compatibleWithinObservedSlots sameSlotConflicts=0 uncertainty=1"
+      ],
+      "lawUniverseCoverageSummary": [
+        "llm-native-aat-law-policy-fixture required=2 unmeasured=2 blockedWitnesses=2"
+      ],
+      "featureExtensionFormulaSummary": [
+        "feature-extension-formula:fixture-archmap-atom-observation status=measured inherited=1 featureLocal=1 interaction=0 residualGaps=1"
+      ],
+      "operationCalculusLawSummary": [
+        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
+      ],
+      "pathSignatureTrajectorySummary": [
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=1 transferred=1"
+      ],
+      "homotopyOrderSensitivitySummary": [
+        "homotopy-order-sensitivity:selected-operations status=sensitive orderSensitivity=blockedByTransferredObstructionOrMissingEvidence blockers=5"
+      ],
+      "diagramFillabilitySummary": [
+        "local-curvature:obstruction-semantic-contract-mismatch-computed family=localCurvatureDiagram status=nonFillabilityWitnessed missingFiller=lawRelativeFiller blockers=1"
+      ],
+      "axisForgettingRiskSummary": [
+        "observation-projection:fixture-archmap-atom-observation kind=selectedAxisOrWitnessLoss zeroReflection=blockedWithoutAxisPreservationAndWitnessCompleteness obstructionReflection=blockedWithoutAxisPreservationAndWitnessCompleteness mixedScopes=2"
+      ],
+      "signatureTrajectoryHomotopyRefutationSummary": [
+        "homotopy-order-sensitivity:selected-operations equivalence=selectedTrajectoryDisagreementObserved refutation=refutationCandidate disagreements=1"
+      ],
+      "bridgeSplitObstructionTransferSummary": [
+        "split-readiness:molecule-user-request-responsibility transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
+      ],
+      "nonzeroMonodromyWitnessSummary": [
+        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2"
+      ],
+      "featureBoundaryResidualSummary": [
+        "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=5"
+      ],
+      "featureExtensionDiagnosisSummary": [
+        "feature-extension-diagnosis:feature-extension-formula-fixture-archmap-atom-observation status=multiLabelAttributed attributions=6 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
+      ],
+      "representationStrengthSummary": [
+        "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "reachableConeSize zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "walkCount zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "nilpotenceBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "selectedSubgraphSpectrum zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "propagationDepth zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "spectralRadius zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
+        "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
+        "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
+        "operationSignatureDeltaMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1"
+      ],
+      "localCurvatureDiagramSummary": [
+        "local-curvature:obstruction-semantic-contract-mismatch-computed law=law:semantic-contract-alignment curvature=1 axes=1"
+      ],
+      "threeLayerFlatnessSummary": [
+        "three-layer-flatness:fixture-archmap-atom-observation static=needsReview runtime=blockedByCoverageGap semantic=stressed crossLayerAtoms=1"
+      ],
+      "observationProjectionSummary": [
+        "observation-projection:fixture-archmap-atom-observation families=3 forgotten=1 blockers=1"
+      ],
+      "stateTransitionAlgebraSummary": [
+        "state-transition-algebra:fixture-archmap-atom-observation generators=0 unresolved=1 obstructions=0"
+      ],
+      "operationInvariantGaloisSummary": [
+        "operation-invariant-galois:selected-law-policy invariants=2 operations=1 blockedOps=1"
+      ],
+      "splitReadinessSummary": [
+        "molecule:user-request-responsibility status=needsReview score=92 boundaryOp=interface"
+      ],
+      "structuralReadingReviewSummary": [
+        "aat-structural-reading-review-surface status=needsReview refs=24 focus=12",
+        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1"
+      ],
+      "currentStateEvolutionBoundarySummary": [
+        "ArchSig computes current AAT structural state from ArchMap fixture-archmap-atom-observation and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
+        "FieldSig consumes archsig-analysis-packet-v0 as bounded current AAT structural state and studies PR, diff, change-vector, forecast, governance, calibration, and operational evolution over that state",
+        "handoff=archsig-analysis-packet-v0 forbiddenReadings=4"
+      ],
+      "repairOperationSummary": [
+        "repair:obstruction-semantic-contract-mismatch-computed targets [\"obstruction:semantic-contract-mismatch:computed\"]"
+      ],
+      "complexityTransferNotes": [
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+        "molecule:user-request-responsibility: review low (permissionCoverage, sourceBackedDomainCohesion, llmOutputMediation)"
+      ],
+      "coverageGapsAndExactnessBlockers": [
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ],
+      "recommendedHumanReviewFocus": [
+        "judgement:architecture-state: review nonzero axes and stressed principle readings first",
+        "judgement:obstruction-semantic-contract-mismatch-computed: inspect source refs and repair operation preconditions",
+        "judgement:sig-axis-layer-violation: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "judgement:sig-axis-semantic-inconsistency: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
+        "judgement:principle-informationhiding: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-encapsulation: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-separationofconcerns: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-substitutability: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-openclosedextension: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-dependencyinversion: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-representationindependence: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-idempotencyandreplaysafety: turn stressed readings into source review questions or repair preconditions",
+        "judgement:principle-authorityandtrustboundary: turn stressed readings into source review questions or repair preconditions"
+      ]
+    },
+    "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected interpretation profile llm-native-aat-law-policy-fixture; concernHints are auxiliary cues only",
+    "interpretationNotesForLLM": [
+      "Lead with selected LawPolicy scope and evidence gaps.",
+      "Explain nonzero signature axes as law-relative ArchSig outputs.",
+      "Do not describe concernHints as obstruction circuits."
+    ],
+    "excludedReadings": [
+      "single architecture quality score",
+      "global architecture lawfulness",
+      "automatic repair safety",
+      "concern hint promoted without LawPolicy witness rule"
+    ],
+    "nonConclusions": [
+      "ArchSig analysis packet is not a Lean theorem proof",
+      "ArchSig analysis packet is not global architecture truth",
+      "ArchSig analysis packet does not prove source extraction completeness",
+      "signature axes are law-policy-relative, not universal quality scores",
+      "flatness reading is blocked by coverage gaps and exactness assumptions",
+      "repair operation candidates are not automatic safe refactorings",
+      "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+    ]
+  },
+  "summary": {
+    "result": "pass",
+    "aatConceptSurfaceCount": 12,
+    "moleculeReadingCount": 1,
+    "obstructionCircuitCount": 1,
+    "signatureAxisCount": 2,
+    "analyticRepresentationCount": 10,
+    "couplingCohesionReadingCount": 4,
+    "workflowRiskReadingCount": 1,
+    "spectralAnalysisReadingCount": 4,
+    "spectralModeReadingCount": 4,
+    "spectralDrilldownReadingCount": 1,
+    "curvatureSupportReadingCount": 1,
+    "curvatureTransferReadingCount": 1,
+    "transferBridgeReadingCount": 1,
+    "atomSupportAxisReadingCount": 2,
+    "atomCompatibilityReadingCount": 1,
+    "lawUniverseCoverageReadingCount": 1,
+    "featureExtensionFormulaReadingCount": 1,
+    "operationCalculusLawReadingCount": 1,
+    "pathSignatureTrajectoryReadingCount": 1,
+    "homotopyOrderSensitivityReadingCount": 1,
+    "diagramFillabilityReadingCount": 1,
+    "axisForgettingRiskReadingCount": 1,
+    "signatureTrajectoryHomotopyRefutationReadingCount": 1,
+    "bridgeSplitObstructionTransferReadingCount": 1,
+    "representationStrengthReadingCount": 14,
+    "localCurvatureDiagramReadingCount": 1,
+    "threeLayerFlatnessReadingCount": 1,
+    "observationProjectionReadingCount": 1,
+    "stateTransitionAlgebraReadingCount": 1,
+    "operationInvariantGaloisReadingCount": 1,
+    "splitReadinessReadingCount": 1,
+    "designPrincipleReadingCount": 9,
+    "repairOperationCandidateCount": 1,
+    "operationDeltaCount": 1,
+    "boundedJudgementCount": 13,
+    "failedCheckCount": 0,
+    "warningCheckCount": 0
+  },
+  "checks": [
+    {
+      "id": "archsig-analysis-packet-schema-version-supported",
+      "title": "ArchSig analysis packet schema version is supported",
+      "result": "pass"
+    },
+    {
+      "id": "archsig-analysis-packet-refs-and-identity",
+      "title": "analysis identity and ArchMap / LawPolicy references are recorded",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-north-star-aat-surfaces",
+      "title": "packet represents all AAT concept surfaces required by the North Star PRD",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-bounded-judgement-surface",
+      "title": "packet makes non-conclusion usable through bounded judgement records",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-analytic-and-principle-surfaces",
+      "title": "packet exposes analytic axes, semantic coupling/cohesion, and static-hard design principle readings",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-workflow-risk-surface",
+      "title": "packet exposes workflow-local risk readings with review focus and bounded evidence boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-spectral-analysis-surface",
+      "title": "packet exposes AAT spectral readings as bounded finite-representation proxies",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-spectral-mode-surface",
+      "title": "packet exposes bounded spectral mode readings for localization, decomposability, and repair perturbation review",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-spectral-drilldown-surface",
+      "title": "packet explains spectral modes through atom families, overlap pairs, and repair axis deltas",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-curvature-support-surface",
+      "title": "packet exposes curvature support rows, top modes, witness clusters, and unmeasured boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-curvature-transfer-surface",
+      "title": "packet exposes finite transfer operator, recurrent obstruction modes, rho(T^kappa) reading, and forecast non-conclusions",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-architecture-spectrum-report-surface",
+      "title": "packet exposes ArchitectureSpectrumReport hotspots, recurrent obstructions, measured boundary, review focus, and non-conclusions",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-transfer-bridge-surface",
+      "title": "packet exposes transfer matrix, bridge atom families, and evolution risk ranking",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-aat-structural-readings",
+      "title": "packet exposes representation strength, curvature, layer flatness, projection, transition algebra, Galois, and split readiness readings",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-fieldsig-current-state-evolution-boundary",
+      "title": "packet preserves ArchSig current-state and FieldSig evolution responsibilities",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-operation-square-trace-surface",
+      "title": "packet enumerates inferred/supplied operation square candidates and axis-wise path continuation traces",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-axis-defect-ami-surface",
+      "title": "packet carries mu_x(sigma) axis-wise defects and AMI aggregate review readings without theorem or merge-gate conclusions",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-nonzero-monodromy-witness-surface",
+      "title": "packet surfaces positive measured mu_x(sigma) defects as reviewer-readable nonzero monodromy witnesses",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-feature-boundary-residual-surface",
+      "title": "packet surfaces Boundary(A,f) residual holonomy axes as bounded review telemetry",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-feature-extension-diagnosis-surface",
+      "title": "packet reports non-disjoint feature-extension multi-label attribution without replacing FieldSig evolution analysis",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-monodromy-boundary-foundation",
+      "title": "packet defines ArchMapStore refs and monodromy / boundary holonomy reading family policy surfaces",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-law-relative-obstructions",
+      "title": "obstruction circuits are LawPolicy-relative and cross-reference molecule and signature readings",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-signature-and-flatness",
+      "title": "signature axes and flatness reading preserve coverage and exactness boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-repair-operation-boundary",
+      "title": "repair operation candidates preserve invariant, precondition, transfer risk, and evidence boundaries",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-llm-interpretation-surface",
+      "title": "packet carries evidence boundary, excluded readings, and LLM interpretation notes",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-non-conclusion-boundary",
+      "title": "packet keeps theorem, global truth, completeness, score, flatness, and repair boundaries explicit",
+      "result": "pass",
+      "count": 0
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1510

#1528 の LLM-native skill 更新に積む形で、ACTS 用 fixture manifest と golden validation output を追加しました。minimal / coupon_rounding の既存 packet を ACTS fixture set として明示し、zero curvature support、nonzero semantic curvature、transfer cycle、coverage gap、coupon / tax / rounding style fixture をテストで固定しています。

ArchitectureSpectrumReport の refs / coverage boundary / non-conclusions が validation output と CLI test で読めることを確認し、fixture を architecture lawfulness proof や empirical incident calibration として扱わない non-conclusions も manifest に残しています。

## 証明した定理

- なし

## 編集したドキュメント

- なし（fixture manifest / golden validation / CLI test のみ）

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [x] cargo test --manifest-path tools/archsig/Cargo.toml
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なしのため未実施）
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [x] axiom / admit / sorry / unsafe scan

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を tooling validation / empirical fixture として扱っている
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## スタック

- base: codex/issue-1509-spectrum-skills（#1528）