### PR TITLE
ArchSigスキルをHomotopyReport対応に更新

### DIFF
--- a/tools/archsig/skills/archsig-reader/SKILL.md
+++ b/tools/archsig/skills/archsig-reader/SKILL.md
@@ -119,6 +119,10 @@ Read in this order:
    - Prioritize `topHotspots[]`, `recurrentObstructions[]`, `topWitnessClusters[]`, `coverageGaps[]`, `measuredBoundary`, and `recommendedReviewFocus[]`.
    - Treat the report as a codebase-inspection surface over current ArchSig measurements, not a quality score, forecast, or repair proof.
    - Preserve report-level `nonConclusions[]` when summarizing.
+   - Read `architectureHomotopyReport` next when present.
+   - Prioritize `nonzeroHolonomyLoops[]`, `unfilledLoops[]`, `topLocalCurvatureCells[]`, `aggregateReadings[]`, `coverageGaps[]`, `measuredBoundary`, and `recommendedReviewFocus[]`.
+   - Treat filled/unfilled loops, hole readings, and Stokes-style readings as bounded review queues. Do not turn them into path truth, global homology, a quality score, or violation proof.
+   - Preserve report-level `nonConclusions[]` when summarizing.
    - Read top `workflowRiskReadings[]` by `riskScore`.
    - Read `spectralAnalysisReadings[]`, especially dominant workflow row, dominant axis column, molecule overlap hub, obstruction curvature, and operation delta coupling.
    - If workflow risk or spectral readings are empty, do not force a risk narrative. Shift to `signatureAxes[]`, `obstructionCircuits[]`, `repairOperationCandidates[]`, `operationDeltas[]`, and coverage gaps.
@@ -146,6 +150,7 @@ Always compare high-priority readings against real source evidence before propos
    - top ArchitectureSpectrumReport hotspots with witness refs and coverage gaps
    - recurrent obstruction entries with transfer edge refs
    - top witness clusters that connect several axes or support refs
+   - ArchitectureHomotopyReport nonzero holonomy loops, unfilled loops, missing filler evidence, local curvature cells, and recommended review focus
    - top 2-4 workflow risk molecules
    - transfer bridge edges with high `reviewRisk`
    - low split-readiness molecules
@@ -163,6 +168,7 @@ Always compare high-priority readings against real source evidence before propos
 
 4. Propose improvements:
    - Start with review actions that reduce uncertainty: route audit, runtime trace capture, provider log review, test evidence, model relationship audit.
+   - For homotopy readings, start by resolving source refs for path pairs, checking whether filler evidence exists, and deciding whether missing filler evidence should stay as a coverage gap or become a project law question.
    - Then propose architecture changes only where source evidence supports the pressure: policy boundary, transaction boundary, anti-corruption layer, interface contract, idempotency/retry/status finalization, provider output validation.
    - Keep proposals tied to source refs and ArchSig fields.
 
@@ -184,6 +190,7 @@ Recommended phrasing:
 - "ArchSig reads this as..."
 - "The packet marks this as `needsReview` because..."
 - "Source comparison supports / partially supports / does not yet support this reading..."
+- "This loop remains unfilled because the packet lacks declared filler evidence..."
 - "The next useful improvement is..."
 
 Avoid:
@@ -194,6 +201,7 @@ Avoid:
 - "No risk exists because the axis is zero"
 - "ArchSig recommends this refactor automatically"
 - treating `ArchitectureSpectrumReport` as FieldSig forecast, future incident prediction, empirical cost amplification, or repair safety evidence
+- treating `ArchitectureHomotopyReport` as path truth, global homology, automatic violation proof, a quality score, FieldSig forecast, or repair safety evidence
 
 ## Maintainer Validation
 

--- a/tools/archsig/skills/archsig-reader/references/default_law_policy.json
+++ b/tools/archsig/skills/archsig-reader/references/default_law_policy.json
@@ -342,6 +342,103 @@
       "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
     ]
   },
+  "homotopyMeasurementProfile": {
+    "profileId": "homotopy-profile:archsig-reader-default",
+    "selectedAxisRefs": [
+      "axis:layer-violation",
+      "axis:semantic-inconsistency"
+    ],
+    "pathDiscoveryRules": [
+      {
+        "ruleId": "path-rule:interface-implementation",
+        "pathSourceKind": "interface-implementation-path",
+        "endpointPolicy": "compare candidate paths only when endpoints are supported by observed Atom refs",
+        "candidateSource": "bundled smoke-test candidates must cite source refs or remain unresolved",
+        "evidenceBoundary": "candidate paths are bounded review cues derived from supplied ArchMap evidence and the bundled baseline LawPolicy",
+        "nonConclusions": [
+          "homotopy measurement profile is a measurement recipe, not a law universe",
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "ArchitectureHomotopyReport is not a single architecture quality score"
+        ]
+      },
+      {
+        "ruleId": "path-rule:cache-repository",
+        "pathSourceKind": "cache-repository-path",
+        "endpointPolicy": "compare cache and repository paths only under declared semantic and state axes",
+        "candidateSource": "bundled smoke-test candidates must cite source refs, tests, runtime notes, or remain unresolved",
+        "evidenceBoundary": "absence of a candidate path is not proof that no architectural loop exists",
+        "nonConclusions": [
+          "homotopy measurement profile is a measurement recipe, not a law universe",
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "ArchitectureHomotopyReport is not a single architecture quality score"
+        ]
+      }
+    ],
+    "fillerRules": [
+      {
+        "ruleId": "filler-rule:contract-or-test",
+        "fillerKind": "contract-or-test-filler",
+        "requiredSourceRefKinds": [
+          "docSection",
+          "test",
+          "runtimeTrace"
+        ],
+        "missingFillerBehavior": "report architectural hole and missing filler evidence; do not promote to violation",
+        "evidenceBoundary": "filler evidence is bounded to supplied source refs, tests, runtime evidence, or user-confirmed policy",
+        "nonConclusions": [
+          "homotopy measurement profile is a measurement recipe, not a law universe",
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "ArchitectureHomotopyReport is not a single architecture quality score"
+        ]
+      }
+    ],
+    "loopMeasurementPolicy": {
+      "policyId": "loop-policy:selected-axis-holonomy",
+      "loopCandidateSources": [
+        "LLM-discovered candidate with source refs",
+        "LawPolicy-required candidate",
+        "ArchMap-supplied candidate",
+        "source-confirmed candidate",
+        "unresolved needsReview candidate"
+      ],
+      "filledLoopReading": "filled loops may localize nonzero holonomy to measured local curvature cells",
+      "unfilledLoopReading": "unfilled loops are architectural holes and missing evidence surfaces",
+      "holonomyDistanceKind": "selected-axis-continuation-distance",
+      "localCurvatureReadingBoundary": "local curvature is read only for measured fillings, not for unfilled loops",
+      "nonConclusions": [
+        "homotopy measurement profile is a measurement recipe, not a law universe",
+        "candidate paths and loops are review cues, not path truth",
+        "unfilled loops are architectural holes, not automatic violations",
+        "missing filler evidence is not measured zero",
+        "ArchitectureHomotopyReport is not a single architecture quality score"
+      ]
+    },
+    "continuationPolicy": "compare selected continuation traces only on axes declared in this profile",
+    "distancePolicy": "bounded distance over selected semantic, state, effect, authority, and runtime axes",
+    "coverageRequirementRefs": [
+      "coverage:layer-atoms",
+      "coverage:semantic-contract-atoms"
+    ],
+    "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "measurementBoundary": "homotopy / holonomy readings are bounded ArchSig smoke-test diagnostics, not project-specific theorem discharge",
+    "nonConclusions": [
+      "homotopy measurement profile is a measurement recipe, not a law universe",
+      "candidate paths and loops are review cues, not path truth",
+      "unfilled loops are architectural holes, not automatic violations",
+      "missing filler evidence is not measured zero",
+      "nonzero holonomy does not prove future incidents or repair unsafety",
+      "ArchitectureHomotopyReport is not a single architecture quality score"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"

--- a/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
+++ b/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
@@ -12,6 +12,7 @@ Use this reference when deciding what to read first in an `archsig-analysis-pack
 | `workflowRiskReadings[]` | Prioritizes molecule-local review pressure such as permission, LLM mediation, state/effect reconciliation, and domain cohesion. |
 | `spectralAnalysisReadings[]` | Shows dominant rows/columns and coupling surfaces across workflows, molecules, obstructions, and operation deltas. |
 | `architectureSpectrumReport` | Primary ACTS codebase-inspection surface: top hotspots, bounded mode data, witness clusters, recurrent obstruction entries, coverage gaps, measured boundary, review focus, and report non-conclusions. |
+| `architectureHomotopyReport` | Primary Homotopy / Holonomy / Stokes surface: filled loops, unfilled loops, nonzero holonomy loops, local curvature cells, bounded aggregate readings, coverage gaps, review focus, and report non-conclusions. |
 | `transferBridgeReadings[]` | Connects repair transfer axes, molecule overlap paths, bridge edge source refs, review focus, and boundary preparation. |
 | `splitReadinessReadings[]` | Shows which molecules are blocked by bridge edges or need boundary preparation before feature extraction or refactoring. |
 | `structuralReadingReviewSurface` | Summarizes AAT structural review surfaces across representation, curvature, projection, state algebra, Galois, and split readiness. |
@@ -28,6 +29,11 @@ For ACTS readings, confirm that the selected LawPolicy contains
 `spectrumMeasurementProfile`. If it is absent, report that
 `ArchitectureSpectrumReport` may be absent and do not infer spectrum hotspots
 from generic spectral fields.
+
+For Homotopy / Holonomy / Stokes readings, confirm that the selected LawPolicy
+contains `homotopyMeasurementProfile`. If it is absent, report that
+`ArchitectureHomotopyReport` may be absent and do not infer loop, filler,
+holonomy, or local-curvature readings from generic obstruction fields.
 
 ## Interpreting Status
 
@@ -66,6 +72,10 @@ For source comparison in this variant, build the review queue from nonzero axes,
 | `architectureSpectrumReport.topHotspots[]` | hotspot witness refs, support refs, coverage gaps | review current-state hotspot before repair planning |
 | `architectureSpectrumReport.recurrentObstructions[]` | transfer edge refs and witness support | inspect recurrence as bounded current-state diagnostic |
 | `architectureSpectrumReport.coverageGaps[]` | missing docs, traces, tests, or source refs | collect evidence before reading absent support as zero |
+| `architectureHomotopyReport.nonzeroHolonomyLoops[]` | loop refs, compared continuations, selected axes, source refs | inspect path differences as bounded current-state review queues |
+| `architectureHomotopyReport.unfilledLoops[]` | missing filler evidence, coverage gaps, next check refs | add or confirm contract/test/runtime/policy filler evidence before concluding |
+| `architectureHomotopyReport.topLocalCurvatureCells[]` | filled loop refs and local curvature cell candidates | review local curvature only inside measured fillings, not unfilled holes |
+| `architectureHomotopyReport.aggregateReadings[]` | selected measured complex boundary | use as prioritization counts, not quality score or global homology |
 
 ## Source Comparison Checklist
 
@@ -75,6 +85,10 @@ For source comparison in this variant, build the review queue from nonzero axes,
 - Preserve private/unavailable/runtime gaps; do not infer from missing files.
 - When a reading depends on route coverage, runtime traces, provider logs, or model relationships, report the missing evidence explicitly.
 - Tie every improvement proposal to a packet field and source ref.
+- For homotopy reports, resolve loop refs through `loopCandidates[]`,
+  `pathPairCandidates[]`, `architecturalHoleReadings[]`,
+  `homotopyHolonomyReadings[]`, and `stokesStyleReadings[]` before proposing
+  code or policy changes.
 
 ## Report Boundaries
 
@@ -85,3 +99,11 @@ Always include:
 - whether source comparison was performed
 - which source refs were confirmed, stale, missing, or not inspected
 - non-conclusions relevant to the user's decision
+
+For `ArchitectureHomotopyReport`, always preserve:
+
+- candidate paths and loops are review cues, not path truth
+- unfilled loops are architectural holes, not automatic violations
+- missing filler evidence is not measured zero
+- nonzero holonomy is not future incident prediction or repair-safety evidence
+- ArchitectureHomotopyReport is not a single architecture quality score

--- a/tools/archsig/skills/law-policy-creater/SKILL.md
+++ b/tools/archsig/skills/law-policy-creater/SKILL.md
@@ -30,6 +30,8 @@ Collect:
 - user goal: strict review, baseline diagnosis, release gate, migration planning, subsystem-specific analysis, or exploratory research
 - human intent for ACTS readings: what architectural pressure should be measured, which review decision the spectrum report should support, and which claims must be excluded
 - repository evidence for ACTS: source refs, docs, tests, traces, ArchMap observations, selected axes, witness rules, and known coverage gaps
+- human intent for homotopy readings: which path alternatives, missing fillers, loop evidence, or continuation differences should become review queues
+- repository evidence for homotopy readings: source refs for candidate paths, contract/test/runtime/policy filler evidence, known missing evidence, selected axes, witness rules, and coverage gaps
 
 If no output path is supplied, prefer `.archsig/<scope>/law_policy.json` next to the ArchMap.
 
@@ -64,6 +66,18 @@ For ACTS / spectrum work, do not ask the user to hand-author a large JSON profil
 - unresolved questions: missing law approval, missing source evidence, missing runtime traces, uncalibrated weights, or ambiguous zero-reflection assumptions
 
 Keep these as explicit authoring notes in the delivery, and encode them in the LawPolicy fields that carry scope, descriptions, coverage boundaries, exactness assumptions, excluded readings, and non-conclusions. Do not add ad hoc top-level JSON fields outside `law-policy-v0`.
+
+For Homotopy / Holonomy / Stokes work, also do not ask the user to author chain-complex or homology details. Build `homotopyMeasurementProfile` from:
+
+- human intent: which path differences, missing fillers, or local curvature review queues matter
+- repository evidence: source refs, docs, tests, traces, ArchMap observations, and explicit policy statements
+- selected laws and axes: only repo/user-approved laws become selected axes for continuation comparison
+- path discovery rules: how an LLM may propose path candidates, and which endpoint/source evidence is required
+- filler rules: which contract, test, runtime trace, policy, or user-confirmed evidence can fill a loop
+- loop measurement policy: how filled loops, unfilled loops, nonzero holonomy, and local curvature readings should be reported
+- unresolved questions: candidate paths without source refs, missing filler evidence, ambiguous endpoint policy, uncalibrated distances, or coverage gaps
+
+Encode the profile inside `homotopyMeasurementProfile`; keep open questions as delivery notes and reflect their effect through coverage boundaries, exactness assumptions, excluded readings, and non-conclusions.
 
 ## Ask When Docs Are Missing
 
@@ -121,10 +135,19 @@ Record user answers as source evidence in the LawPolicy scope or in an accompany
    - Use `clusteringRankingOptions` and `reportFocusOptions` to state how ArchSig should surface top modes, witness clusters, coverage gaps, and review focus.
    - Preserve unmeasured axes and missing evidence as coverage gaps. Do not treat absent support as zero.
 
-8. Add non-conclusions.
+8. Define homotopy measurement profile when requested.
+   - Add `homotopyMeasurementProfile` when the user wants Homotopy / Holonomy / Stokes readings or ArchitectureHomotopyReport.
+   - Select `selectedAxisRefs` from LawPolicy axes, not from desired path differences.
+   - Use `pathDiscoveryRules[]` to state how candidate paths may be proposed from human intent, ArchMap observations, source refs, docs, tests, traces, or explicit unresolved questions.
+   - Use `fillerRules[]` to state what counts as filler evidence: contracts, tests, runtime traces, policies, source refs, or user-confirmed architecture rules.
+   - Use `loopMeasurementPolicy` to preserve the difference between filled loops, unfilled loops, nonzero holonomy, local curvature readings, and missing filler evidence.
+   - Do not invent selected laws, path endpoints, or filler laws without repo evidence, ArchMap evidence, or explicit user intent.
+   - Missing filler evidence becomes an architectural hole / coverage gap, not a violation proof and not measured zero.
+
+9. Add non-conclusions.
    - Preserve these boundaries: LawPolicy is selected analysis policy, not AAT itself; validation does not prove architecture lawfulness or atom truth; missing coverage is not measured zero; signature zero requires ArchSig analysis with coverage and exactness assumptions.
 
-9. Validate.
+10. Validate.
    - Run `archsig law-policy`.
    - Treat ArchSig validation as the authoritative schema, reference, uniqueness, coverage, exactness, and non-conclusion check.
 
@@ -159,10 +182,11 @@ When delivering a LawPolicy, include:
 4. Selected laws and why they are in scope
 5. Signature axes and zero-reading boundaries
 6. `spectrumMeasurementProfile`: selected axes, witness rules, distance kinds, support projection, transfer edge rule, ranking/report focus, coverage boundary
-7. Inferred fields and evidence used for each inference
-8. Coverage requirements and exactness assumptions
-9. Open questions / unresolved policy decisions
-10. Validation result
+7. `homotopyMeasurementProfile` when requested: selected axes, path discovery rules, filler rules, loop measurement policy, coverage boundary, and non-conclusions
+8. Inferred fields and evidence used for each inference
+9. Coverage requirements and exactness assumptions
+10. Open questions / unresolved policy decisions
+11. Validation result
 
 Use concise Japanese when working in this repository.
 
@@ -171,8 +195,10 @@ Avoid:
 - using a generic policy as project analysis
 - turning current code shape into law without docs or user approval
 - inventing selected laws, selected axes, distance kinds, weights, or transfer rules without repo evidence, ArchMap evidence, or explicit user intent
+- inventing path candidates, selected path laws, or filler evidence without source refs, ArchMap observations, repository docs, runtime/test evidence, or explicit user intent
 - treating LawPolicy validation as architecture lawfulness
 - treating absent evidence as measured zero
+- treating unfilled loops as automatic violations
 - mixing FieldSig forecast / governance claims into ArchSig LawPolicy
 
 ## References

--- a/tools/archsig/skills/law-policy-creater/references/question-bank.md
+++ b/tools/archsig/skills/law-policy-creater/references/question-bank.md
@@ -55,3 +55,15 @@ Ask only the questions needed for the target scope. Prefer 3-6 high-signal quest
 - What should count as transfer evidence: shared witness support, shared Atom refs, shared molecule support, runtime trace overlap, or an explicitly documented dependency relation?
 - What should the report rank first: nonzero hotspots, recurrent obstruction modes, witness clusters, coverage gaps, or boundary-preparation actions?
 - Which missing docs, tests, traces, logs, or source refs should block zero-reflection and remain unresolved questions?
+
+## Homotopy / Holonomy / Stokes Profile
+
+- Which path alternatives should `ArchitectureHomotopyReport` compare: interface/implementation, cache/repository, policy/runtime, source/DTO, provider/domain, or another project-specific path pair?
+- Which selected axes justify comparing those paths, and what repo/user-approved law backs each axis?
+- What evidence is required before an LLM may propose a candidate path: ArchMap observations, source refs, docs, tests, runtime traces, or explicit user intent?
+- What endpoint policy should hold for candidate paths: shared source refs, shared Atom refs, same domain object, same operation, same API contract, or another bounded relation?
+- What counts as filler evidence: contract docs, tests, runtime traces, policy docs, source implementations, review notes, or explicit user confirmation?
+- Which missing filler evidence should become an architectural hole instead of a violation finding?
+- Which distance kind is defensible for holonomy: selected-axis continuation distance, boolean mismatch, semantic witness mismatch, state/effect mismatch, or project-defined distance?
+- Which coverage gaps should block zero and Stokes-style local-curvature readings: missing tests, missing runtime traces, missing policy docs, unresolved source refs, or ambiguous endpoints?
+- Which claims must be excluded: path truth, global homology, architecture score, automatic violation proof, future incident prediction, or repair-safety proof?

--- a/tools/archsig/skills/law-policy-creater/references/schema-guide.md
+++ b/tools/archsig/skills/law-policy-creater/references/schema-guide.md
@@ -18,6 +18,7 @@ Use this guide when authoring `law-policy-v0`.
 - `signatureAxisDefinitions[]`
 - `measurementPolicy`
 - `spectrumMeasurementProfile` when ACTS / ArchitectureSpectrumReport readings are requested
+- `homotopyMeasurementProfile` when Homotopy / Holonomy / Stokes readings or ArchitectureHomotopyReport are requested
 - `exactnessAssumptions[]`
 - `coverageRequirements[]`
 - `excludedReadings[]`
@@ -40,6 +41,8 @@ Use this guide when authoring `law-policy-v0`.
 - `spectrumMeasurementProfile.measuredWitnessRuleRefs[]` must resolve to `witnessRules[].witnessRuleId`.
 - `spectrumMeasurementProfile.distanceKinds[].axisRef` must resolve to an axis id.
 - `spectrumMeasurementProfile.coverageRequirementRefs[]` must resolve to `coverageRequirements[].coverageRequirementId`.
+- `homotopyMeasurementProfile.selectedAxisRefs[]` must resolve to axis ids.
+- `homotopyMeasurementProfile.coverageRequirementRefs[]` must resolve to `coverageRequirements[].coverageRequirementId`.
 
 ## Measurement Policy
 
@@ -96,6 +99,50 @@ Keep unresolved questions outside the JSON as delivery notes, and reflect their
 effect inside `coverageBoundary`, `exactnessAssumptionRefs`, `excludedReadings`,
 or `nonConclusions`.
 
+## Homotopy Measurement Profile
+
+Use `homotopyMeasurementProfile` for Homotopy / Holonomy / Stokes readings and
+ArchitectureHomotopyReport. The profile is a measurement recipe over selected
+LawPolicy axes. It is not a chain-complex proof object, not a second law
+universe, and not a requirement for humans to hand-author topology.
+
+Required fields:
+
+- `profileId`
+- `selectedAxisRefs[]`
+- `pathDiscoveryRules[]`: each item has `ruleId`, `pathSourceKind`,
+  `endpointPolicy`, `candidateSource`, `evidenceBoundary`, and
+  `nonConclusions[]`
+- `fillerRules[]`: each item has `ruleId`, `fillerKind`,
+  `requiredSourceRefKinds[]`, `missingFillerBehavior`, `evidenceBoundary`, and
+  `nonConclusions[]`
+- `loopMeasurementPolicy`: includes `policyId`, `loopCandidateSources[]`,
+  `filledLoopReading`, `unfilledLoopReading`, `holonomyDistanceKind`,
+  `localCurvatureReadingBoundary`, and `nonConclusions[]`
+- `continuationPolicy`
+- `distancePolicy`
+- `coverageRequirementRefs[]`
+- `coverageBoundary`
+- `exactnessAssumptionRefs[]`
+- `measurementBoundary`
+- `nonConclusions[]`
+
+Author the profile from human intent, repository evidence, and ArchMap
+evidence. Use conservative defaults when evidence is absent:
+
+- LLM-discovered path candidates must cite source refs or remain unresolved.
+- Filler laws come from contracts, tests, runtime traces, policies, source refs,
+  or explicit user approval.
+- Missing filler evidence becomes an architectural hole and coverage gap, not a
+  violation proof.
+- Nonzero holonomy is a bounded current-state review queue, not forecast,
+  incident prediction, or repair-safety evidence.
+- ArchitectureHomotopyReport is not a single architecture quality score.
+
+Keep unresolved questions outside the JSON as delivery notes, and reflect their
+effect inside `coverageBoundary`, `exactnessAssumptionRefs`, `excludedReadings`,
+or `nonConclusions`.
+
 ## Common Law Families
 
 Use project-specific names when needed, but common families include:
@@ -141,5 +188,10 @@ Keep these ideas in every policy:
 - Profile differences are not law universe differences.
 - ArchitectureSpectrumReport is not a single architecture quality score.
 - Unmeasured axes are not zero.
+- Homotopy measurement profile is a measurement recipe, not a law universe.
+- Candidate paths and loops are review cues, not path truth.
+- Unfilled loops are architectural holes, not automatic violations.
+- Missing filler evidence is not measured zero.
+- ArchitectureHomotopyReport is not a single architecture quality score.
 
 Exact wording may vary, but the boundaries must remain clear.

--- a/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
+++ b/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
@@ -203,6 +203,88 @@
       "spectrum zero requires coverage, exactness, and zero-reflection assumptions"
     ]
   },
+  "homotopyMeasurementProfile": {
+    "profileId": "homotopy-profile:project-boundary-example",
+    "selectedAxisRefs": [
+      "axis:project-boundary-example"
+    ],
+    "pathDiscoveryRules": [
+      {
+        "ruleId": "path-rule:project-boundary-example",
+        "pathSourceKind": "llm-discovered-source-backed-path",
+        "endpointPolicy": "compare candidate paths only when endpoints are supported by observed Atom refs or explicit user intent",
+        "candidateSource": "LLM-discovered candidates must cite source refs, docs, tests, runtime traces, or remain unresolved",
+        "evidenceBoundary": "candidate paths are bounded review cues derived from ArchMap evidence, repository evidence, and selected LawPolicy",
+        "nonConclusions": [
+          "homotopy measurement profile is a measurement recipe, not a law universe",
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "ArchitectureHomotopyReport is not a single architecture quality score"
+        ]
+      }
+    ],
+    "fillerRules": [
+      {
+        "ruleId": "filler-rule:project-boundary-example",
+        "fillerKind": "contract-test-runtime-or-policy-filler",
+        "requiredSourceRefKinds": [
+          "docSection",
+          "test",
+          "runtimeTrace",
+          "policy"
+        ],
+        "missingFillerBehavior": "report architectural hole and missing filler evidence; do not promote to violation",
+        "evidenceBoundary": "filler evidence is bounded to supplied source refs, tests, runtime evidence, policy docs, or user-confirmed rules",
+        "nonConclusions": [
+          "homotopy measurement profile is a measurement recipe, not a law universe",
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "ArchitectureHomotopyReport is not a single architecture quality score"
+        ]
+      }
+    ],
+    "loopMeasurementPolicy": {
+      "policyId": "loop-policy:project-boundary-example",
+      "loopCandidateSources": [
+        "LLM-discovered candidate with source refs",
+        "LawPolicy-required candidate",
+        "ArchMap-supplied candidate",
+        "source-confirmed candidate",
+        "unresolved needsReview candidate"
+      ],
+      "filledLoopReading": "filled loops may localize nonzero holonomy to measured local curvature cells",
+      "unfilledLoopReading": "unfilled loops are architectural holes and missing evidence surfaces",
+      "holonomyDistanceKind": "selected-axis-continuation-distance",
+      "localCurvatureReadingBoundary": "local curvature is read only for measured fillings, not for unfilled loops",
+      "nonConclusions": [
+        "homotopy measurement profile is a measurement recipe, not a law universe",
+        "candidate paths and loops are review cues, not path truth",
+        "unfilled loops are architectural holes, not automatic violations",
+        "missing filler evidence is not measured zero",
+        "ArchitectureHomotopyReport is not a single architecture quality score"
+      ]
+    },
+    "continuationPolicy": "compare selected continuation traces only on axes declared in this profile",
+    "distancePolicy": "bounded distance over selected axes; no calibrated severity without project evidence",
+    "coverageRequirementRefs": [
+      "coverage:project-boundary-example"
+    ],
+    "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
+    "exactnessAssumptionRefs": [
+      "selected LawPolicy exactness assumptions"
+    ],
+    "measurementBoundary": "homotopy / holonomy readings are bounded ArchSig diagnostics, not theorem discharge",
+    "nonConclusions": [
+      "homotopy measurement profile is a measurement recipe, not a law universe",
+      "candidate paths and loops are review cues, not path truth",
+      "unfilled loops are architectural holes, not automatic violations",
+      "missing filler evidence is not measured zero",
+      "nonzero holonomy does not prove future incidents or repair unsafety",
+      "ArchitectureHomotopyReport is not a single architecture quality score"
+    ]
+  },
   "exactnessAssumptions": [
     "the selected witness rules cover only policy-declared laws",
     "zero readings are exact only for observed atoms and declared coverage requirements"


### PR DESCRIPTION
## 概要

Closes #1519

`law-policy-creater` に `homotopyMeasurementProfile` を LLM-native に構成する手順を追加し、人間が chain complex / homology を手書きしなくても、human intent、repo evidence、ArchMap evidence、selected laws / axes、path discovery、filler rules、coverage gaps から profile を組み立てられるようにしました。

`archsig-reader` には `ArchitectureHomotopyReport` の読解優先順位、source comparison の確認順、unfilled loops / missing filler evidence / nonzero holonomy の non-conclusion boundary を追加しました。starter/default LawPolicy も smoke check 用に homotopy profile を持つよう更新しています。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/skills/law-policy-creater/SKILL.md`
- `tools/archsig/skills/law-policy-creater/references/schema-guide.md`
- `tools/archsig/skills/law-policy-creater/references/question-bank.md`
- `tools/archsig/skills/law-policy-creater/references/starter_law_policy.json`
- `tools/archsig/skills/archsig-reader/SKILL.md`
- `tools/archsig/skills/archsig-reader/references/output-reading-guide.md`
- `tools/archsig/skills/archsig-reader/references/default_law_policy.json`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy --input tools/archsig/skills/law-policy-creater/references/starter_law_policy.json --out .lake/law-policy-creater-starter-validation.json`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy --input tools/archsig/skills/archsig-reader/references/default_law_policy.json --out .lake/archsig-reader-default-law-policy-validation.json`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analysis-summary --packet tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json --out .lake/archsig-reader-summary-validation.json`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] skill metadata validation（この checkout では validator が見つからないため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `tooling skill guidance` として Issue 境界に合わせた
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない