### PR TITLE
ArchSig axis continuation distanceを評価器化

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -388,11 +388,16 @@ The builder:
   evidence instead of synthesizing a `:continuation` operation.
 - `pathContinuationTraces` records the selected continuation trace for each
   candidate path and axis family: static, contract, semantic, state, effect,
-  authority, runtime, and projection. Unmeasured axes are retained as
-  `missingRefs` and must not be read as zero defect.
+  authority, runtime, and projection. Each axis trace carries a
+  `distanceEvaluatorKind`, source-backed `distanceInputRefs`, and
+  `comparableContinuationValues` used as the bounded input to
+  `d_x(Cont_x(p), Cont_x(q))`. Unmeasured axes are retained as `missingRefs`
+  and must not be read as zero defect.
 - `axisWiseMonodromyDefects` records `mu_x(sigma)` for each selected operation
-  square and axis. Each defect carries distance kind, measured support,
-  witness refs, source / observation / missing refs, coverage boundary,
+  square and axis. Each defect dispatches on the LawPolicy distance kind plus
+  axis family, then compares the p/q comparable continuation values rather than
+  using observation-ref symmetric difference alone. Defects carry measured
+  support, witness refs, source / observation / missing refs, coverage boundary,
   exactness assumption status, zero-reflection assumptions, and cancellation
   boundary.
 - `amiAggregateReadings` records `AMI_X(A)` as a bounded weighted aggregate for

--- a/tools/archsig/skills/archmap-creater/references/prompt-pack.md
+++ b/tools/archsig/skills/archmap-creater/references/prompt-pack.md
@@ -90,6 +90,12 @@ refs. Do not rely on a later ArchSig inferred candidate as measurement truth;
 inferred candidates are review cues, and missing endpoints should remain
 blocked.
 
+For semantic, effect, state, runtime, authority, projection, contract, or
+static continuation distance, preserve the source-backed observations that make
+the two paths comparable. ArchSig will derive comparable continuation values
+from the supplied operation sequences, endpoint refs, and selected axis evidence;
+it will not execute runtime semantics or treat missing comparable input as zero.
+
 If filler evidence is unavailable, record a targeted `observationGaps[]` entry
 whose `subjectRef` names the affected path rule, operation square, or loop
 candidate. Avoid global gaps that block unrelated measured loops. Never turn

--- a/tools/archsig/skills/law-policy-creater/references/schema-guide.md
+++ b/tools/archsig/skills/law-policy-creater/references/schema-guide.md
@@ -154,6 +154,11 @@ evidence. Use conservative defaults when evidence is absent:
   inferred review cues. A LawPolicy may say which supplied / inferred sources
   are eligible, but source-backed operation sequences and endpoints belong in
   ArchMap `operationSquareEvidence[]`, not in the policy.
+- `distanceKind` is dispatched by ArchSig together with the selected axis
+  family. Semantic and effect axes compare ordered continuation values; static,
+  contract, projection, authority, runtime, and state axes keep their own
+  bounded comparable values. Missing comparable values must remain unmeasured,
+  not zero.
 - ArchitectureHomotopyReport is not a single architecture quality score.
 
 Keep unresolved questions outside the JSON as delivery notes, and reflect their

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -294,8 +294,12 @@ pub fn build_archsig_analysis_packet(
         &stokes_style_readings,
     );
     let operation_square_candidates = build_operation_square_candidates(archmap, &operation_deltas);
-    let path_continuation_traces =
-        build_path_continuation_traces(archmap, &operation_square_candidates, &operation_deltas);
+    let path_continuation_traces = build_path_continuation_traces(
+        archmap,
+        law_policy,
+        &operation_square_candidates,
+        &operation_deltas,
+    );
     let axis_wise_monodromy_defects = build_axis_wise_monodromy_defects(
         law_policy,
         &operation_square_candidates,
@@ -991,6 +995,7 @@ fn blocked_operation_square_candidate(
 
 fn build_path_continuation_traces(
     archmap: &ArchMapDocumentV0,
+    law_policy: &LawPolicyDocumentV0,
     operation_square_candidates: &[ArchSigOperationSquareCandidateV0],
     operation_deltas: &[ArchSigOperationDeltaReadingV0],
 ) -> Vec<ArchSigPathContinuationTraceV0> {
@@ -1041,6 +1046,7 @@ fn build_path_continuation_traces(
                     endpoint_object_refs: candidate.endpoint_object_refs.clone(),
                     axis_traces: build_axis_continuation_traces(
                         archmap,
+                        law_policy,
                         candidate,
                         operation_deltas,
                         path_role,
@@ -1060,6 +1066,7 @@ fn build_path_continuation_traces(
 
 fn build_axis_continuation_traces(
     archmap: &ArchMapDocumentV0,
+    law_policy: &LawPolicyDocumentV0,
     candidate: &ArchSigOperationSquareCandidateV0,
     operation_deltas: &[ArchSigOperationDeltaReadingV0],
     path_role: &str,
@@ -1071,27 +1078,13 @@ fn build_axis_continuation_traces(
             candidate.shared_atom_support_refs.clone(),
         ),
         ("contract", "contract axis", candidate.contract_refs.clone()),
-        ("semantic", "semantic axis", {
-            let mut refs = candidate.semantic_refs.clone();
-            if let Some(marker) = semantic_path_order_marker(archmap, path_role) {
-                refs.push(marker);
-            }
-            refs
-        }),
+        ("semantic", "semantic axis", candidate.semantic_refs.clone()),
         ("state", "state transition axis", candidate.state_refs.clone()),
-        ("effect", "effect ordering / replay / compensation axis", {
-            let mut refs = candidate.effect_refs.clone();
-            refs.push(format!(
-                "derived-effect-order:{}:{}",
-                path_role,
-                stable_id(if path_role == "p" {
-                    &candidate.p_path_ref
-                } else {
-                    &candidate.q_path_ref
-                })
-            ));
-            refs
-        }),
+        (
+            "effect",
+            "effect ordering / replay / compensation axis",
+            candidate.effect_refs.clone(),
+        ),
         (
             "authority",
             "authority / trust boundary axis",
@@ -1110,6 +1103,10 @@ fn build_axis_continuation_traces(
     ]
     .into_iter()
     .map(|(axis_family, axis_ref, observation_refs)| {
+        let distance_evaluator_kind = axis_distance_evaluator_kind(
+            &law_policy.measurement_policy.distance_kind,
+            axis_family,
+        );
         let trace_status = if observation_refs.is_empty() {
             "unmeasured"
         } else {
@@ -1132,32 +1129,49 @@ fn build_axis_continuation_traces(
         } else {
             &candidate.q_operation_sequence
         };
+        let comparable_continuation_values = comparable_continuation_values(
+            axis_family,
+            path_role,
+            operation_sequence,
+            &observation_refs,
+            candidate,
+        );
         let continuation_states = operation_sequence
             .iter()
             .enumerate()
             .map(|(index, operation_ref)| {
                 format!(
-                    "Cont_{axis_family}[{index}]={operation_ref}; refs={}",
-                    observation_refs.len()
+                    "Cont_{axis_family}[{index}]={operation_ref}; comparableValues={}",
+                    comparable_continuation_values.len()
                 )
             })
             .chain(std::iter::once(format!(
-                "Cont_{axis_family}[endpoint]={}; endpointRefs={}",
+                "Cont_{axis_family}[endpoint]={}; endpointRefs={}; evaluator={}",
                 path_role,
-                candidate.endpoint_object_refs.len()
+                candidate.endpoint_object_refs.len(),
+                distance_evaluator_kind
             )))
             .collect::<Vec<_>>();
+        let distance_input_refs = unique_strings(
+            observation_refs
+                .iter()
+                .chain(source_refs.iter())
+                .chain(candidate.endpoint_object_refs.iter())
+                .cloned(),
+        );
         ArchSigAxisContinuationTraceV0 {
             axis_family: axis_family.to_string(),
             axis_ref: axis_ref.to_string(),
             trace_status: trace_status.to_string(),
+            distance_evaluator_kind,
             continuation_summary: axis_continuation_summary(
                 axis_family,
                 &observation_refs,
                 operation_deltas,
             ),
             continuation_states,
-            distance_input_refs: observation_refs.clone(),
+            comparable_continuation_values,
+            distance_input_refs,
             source_refs,
             observation_refs,
             missing_refs,
@@ -1169,25 +1183,53 @@ fn build_axis_continuation_traces(
         .collect()
 }
 
-fn has_path_order_semantic_evidence(archmap: &ArchMapDocumentV0) -> bool {
-    archmap.semantic_observations.iter().any(|semantic| {
-        let text = format!(
-            "{} {} {}",
-            semantic.semantic_family, semantic.subject_ref, semantic.predicate
-        )
-        .to_ascii_lowercase();
-        text.contains("round(tax(discount")
-            || text.contains("round(discount(tax")
-            || (text.contains("noncommut") && text.contains("coupon") && text.contains("tax"))
-    })
+fn axis_distance_evaluator_kind(distance_kind: &str, axis_family: &str) -> String {
+    match axis_family {
+        "semantic" => format!("{distance_kind}:semantic-sequence-mismatch"),
+        "effect" => format!("{distance_kind}:effect-replay-order-mismatch"),
+        "state" => format!("{distance_kind}:state-transition-value-mismatch"),
+        "authority" => format!("{distance_kind}:authority-boundary-value-mismatch"),
+        "runtime" => format!("{distance_kind}:runtime-interaction-value-mismatch"),
+        "projection" => format!("{distance_kind}:projection-target-value-mismatch"),
+        "contract" => format!("{distance_kind}:contract-obligation-value-mismatch"),
+        "static" => format!("{distance_kind}:static-support-value-mismatch"),
+        other => format!("{distance_kind}:{other}-value-mismatch"),
+    }
 }
 
-fn semantic_path_order_marker(archmap: &ArchMapDocumentV0, path_role: &str) -> Option<String> {
-    has_path_order_semantic_evidence(archmap).then(|| match path_role {
-        "p" => "derived-semantic-order:p=round(tax(discount(subtotal)))".to_string(),
-        "q" => "derived-semantic-order:q=round(discount(tax(subtotal)))".to_string(),
-        other => format!("derived-semantic-order:{other}"),
-    })
+fn comparable_continuation_values(
+    axis_family: &str,
+    path_role: &str,
+    operation_sequence: &[String],
+    observation_refs: &[String],
+    candidate: &ArchSigOperationSquareCandidateV0,
+) -> Vec<String> {
+    if observation_refs.is_empty() {
+        return Vec::new();
+    }
+    let path_value = format!(
+        "{axis_family}:path:{path_role}:{}",
+        operation_sequence.join(" -> ")
+    );
+    let endpoint_value = format!(
+        "{axis_family}:endpoints:{}",
+        candidate.endpoint_object_refs.join("|")
+    );
+    match axis_family {
+        "semantic" | "effect" | "state" | "runtime" => vec![path_value, endpoint_value],
+        "authority" | "contract" | "projection" | "static" => {
+            let support_value = format!(
+                "{axis_family}:support:{}",
+                observation_refs
+                    .iter()
+                    .map(|value| stable_id(value))
+                    .collect::<Vec<_>>()
+                    .join("|")
+            );
+            vec![endpoint_value, support_value]
+        }
+        _ => vec![path_value, endpoint_value],
+    }
 }
 
 fn build_axis_wise_monodromy_defects(
@@ -1260,21 +1302,61 @@ fn axis_wise_monodromy_defect(
         .unwrap_or_else(|| vec![format!("missing q trace for {axis_family}")]);
     let missing_refs = unique_strings(p_missing.into_iter().chain(q_missing));
     let measured_support_refs = unique_strings(p_refs.iter().chain(q_refs.iter()).cloned());
+    let p_values = p_axis
+        .map(|axis| axis.comparable_continuation_values.clone())
+        .unwrap_or_default();
+    let q_values = q_axis
+        .map(|axis| axis.comparable_continuation_values.clone())
+        .unwrap_or_default();
+    let comparable_missing_refs = comparable_value_missing_refs(axis_family, &p_values, &q_values);
+    let missing_refs = unique_strings(missing_refs.into_iter().chain(comparable_missing_refs));
+    let evaluator_kind = p_axis
+        .or(q_axis)
+        .map(|axis| axis.distance_evaluator_kind.clone())
+        .unwrap_or_else(|| {
+            axis_distance_evaluator_kind(&law_policy.measurement_policy.distance_kind, axis_family)
+        });
     let witness_refs = unique_strings(
-        measured_support_refs.iter().cloned().chain(
-            missing_refs
-                .iter()
-                .map(|missing| format!("missing-evidence:{missing}")),
-        ),
+        measured_support_refs
+            .iter()
+            .cloned()
+            .chain(
+                p_values
+                    .iter()
+                    .map(|value| format!("p-value:{}", stable_id(value))),
+            )
+            .chain(
+                q_values
+                    .iter()
+                    .map(|value| format!("q-value:{}", stable_id(value))),
+            )
+            .chain(
+                missing_refs
+                    .iter()
+                    .map(|missing| format!("missing-evidence:{missing}")),
+            ),
     );
     let both_measured = p_axis.is_some_and(|axis| axis.trace_status != "unmeasured")
-        && q_axis.is_some_and(|axis| axis.trace_status != "unmeasured");
-    let distance_value = both_measured.then(|| symmetric_difference_size(&p_refs, &q_refs) as i64);
+        && q_axis.is_some_and(|axis| axis.trace_status != "unmeasured")
+        && !p_values.is_empty()
+        && !q_values.is_empty();
+    let distance_value =
+        both_measured.then(|| evaluate_axis_distance(&evaluator_kind, &p_values, &q_values));
     let axis_ref = p_axis
         .or(q_axis)
         .map(|axis| axis.axis_ref.clone())
         .unwrap_or_else(|| axis_family.to_string());
-    let distance_input_refs = unique_strings(p_refs.iter().chain(q_refs.iter()).cloned());
+    let distance_input_refs = unique_strings(
+        p_axis
+            .into_iter()
+            .flat_map(|axis| axis.distance_input_refs.iter())
+            .chain(
+                q_axis
+                    .into_iter()
+                    .flat_map(|axis| axis.distance_input_refs.iter()),
+            )
+            .cloned(),
+    );
 
     ArchSigAxisWiseMonodromyDefectV0 {
         defect_id: format!(
@@ -1285,7 +1367,7 @@ fn axis_wise_monodromy_defect(
         candidate_ref: candidate.candidate_id.clone(),
         axis_family: axis_family.to_string(),
         axis_ref,
-        distance_kind: law_policy.measurement_policy.distance_kind.clone(),
+        distance_kind: evaluator_kind,
         p_continuation_ref: p_axis
             .map(|axis| format!("Cont_{}(p):{}", axis.axis_family, axis.axis_ref))
             .unwrap_or_else(|| format!("Cont_{axis_family}(p):missing")),
@@ -1294,7 +1376,7 @@ fn axis_wise_monodromy_defect(
             .unwrap_or_else(|| format!("Cont_{axis_family}(q):missing")),
         distance_input_refs,
         positive_witness_boundary:
-            "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs"
+            "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs"
                 .to_string(),
         weight: if both_measured { 1 } else { 0 },
         measurement_status: if both_measured {
@@ -1309,9 +1391,10 @@ fn axis_wise_monodromy_defect(
         observation_refs: measured_support_refs,
         missing_refs,
         coverage_boundary: if both_measured {
-            "covered for selected trace refs; not complete execution semantics".to_string()
+            "covered for selected comparable continuation values; not complete execution semantics"
+                .to_string()
         } else {
-            "coverage gap preserved; unmeasured axis is not zero defect".to_string()
+            "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect".to_string()
         },
         exactness_assumption_status: law_policy
             .measurement_policy
@@ -1322,10 +1405,47 @@ fn axis_wise_monodromy_defect(
             "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions"
                 .to_string(),
         evidence_boundary:
-            "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality"
+            "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality"
                 .to_string(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
+}
+
+fn comparable_value_missing_refs(
+    axis_family: &str,
+    p_values: &[String],
+    q_values: &[String],
+) -> Vec<String> {
+    let mut missing = Vec::new();
+    if p_values.is_empty() {
+        missing.push(format!(
+            "missing comparable p continuation value for {axis_family}"
+        ));
+    }
+    if q_values.is_empty() {
+        missing.push(format!(
+            "missing comparable q continuation value for {axis_family}"
+        ));
+    }
+    missing
+}
+
+fn evaluate_axis_distance(evaluator_kind: &str, p_values: &[String], q_values: &[String]) -> i64 {
+    if evaluator_kind.contains("sequence-mismatch")
+        || evaluator_kind.contains("replay-order-mismatch")
+        || evaluator_kind.contains("transition-value-mismatch")
+        || evaluator_kind.contains("interaction-value-mismatch")
+    {
+        return ordered_value_mismatch_count(p_values, q_values) as i64;
+    }
+    symmetric_difference_size(p_values, q_values) as i64
+}
+
+fn ordered_value_mismatch_count(left: &[String], right: &[String]) -> usize {
+    let max_len = left.len().max(right.len());
+    (0..max_len)
+        .filter(|index| left.get(*index) != right.get(*index))
+        .count()
 }
 
 fn build_ami_aggregate_readings(
@@ -13999,6 +14119,11 @@ fn check_operation_square_trace_surface(packet: &ArchSigAnalysisPacketV0) -> Val
             );
             push_blank(
                 &mut examples,
+                &format!("{} distanceEvaluatorKind", trace.trace_id),
+                &axis.distance_evaluator_kind,
+            );
+            push_blank(
+                &mut examples,
                 &format!("{} continuationSummary", trace.trace_id),
                 &axis.continuation_summary,
             );
@@ -14009,6 +14134,13 @@ fn check_operation_square_trace_surface(packet: &ArchSigAnalysisPacketV0) -> Val
                     &trace.trace_id,
                     &axis.axis_family,
                     "measured continuation axes must carry continuation states and distance input refs",
+                ));
+            }
+            if axis.trace_status != "unmeasured" && axis.comparable_continuation_values.is_empty() {
+                examples.push(generic_validation_example(
+                    &trace.trace_id,
+                    &axis.axis_family,
+                    "measured continuation axes must carry comparable continuation values for d_x(Cont_x(p), Cont_x(q))",
                 ));
             }
             if axis.trace_status == "unmeasured" && axis.missing_refs.is_empty() {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -965,9 +965,13 @@ pub struct ArchSigAxisContinuationTraceV0 {
     pub axis_family: String,
     pub axis_ref: String,
     pub trace_status: String,
+    #[serde(default)]
+    pub distance_evaluator_kind: String,
     pub continuation_summary: String,
     #[serde(default)]
     pub continuation_states: Vec<String>,
+    #[serde(default)]
+    pub comparable_continuation_values: Vec<String>,
     #[serde(default)]
     pub distance_input_refs: Vec<String>,
     pub observation_refs: Vec<String>,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -935,13 +935,27 @@ fn coupon_tax_rounding_fixture_locks_semantic_monodromy() {
                     && defect["distanceValue"]
                         .as_i64()
                         .is_some_and(|value| value > 0)
+                    && defect["distanceKind"]
+                        .as_str()
+                        .is_some_and(|kind| kind.contains("semantic-sequence-mismatch"))
                     && defect["observationRefs"].as_array().is_some_and(|refs| {
                         refs.iter().any(|value| {
-                            value.as_str()
-                                == Some("derived-semantic-order:p=round(tax(discount(subtotal)))")
+                            value.as_str() == Some("semantic:coupon-tax-rounding-paths")
+                        }) && refs.iter().all(|value| {
+                            value
+                                .as_str()
+                                .is_none_or(|text| !text.contains("derived-semantic-order"))
+                        })
+                    })
+                    && defect["witnessRefs"].as_array().is_some_and(|refs| {
+                        refs.iter().any(|value| {
+                            value.as_str().is_some_and(|text| {
+                                text.contains("semantic-path-p-operation-discount")
+                            })
                         }) && refs.iter().any(|value| {
-                            value.as_str()
-                                == Some("derived-semantic-order:q=round(discount(tax(subtotal)))")
+                            value
+                                .as_str()
+                                .is_some_and(|text| text.contains("semantic-path-q-operation-tax"))
                         })
                     })
             }))
@@ -955,6 +969,31 @@ fn coupon_tax_rounding_fixture_locks_semantic_monodromy() {
                         .as_i64()
                         .is_some_and(|value| value > 0)
             }))
+    );
+    assert!(
+        golden["axisWiseMonodromyDefects"]
+            .as_array()
+            .is_some_and(|defects| defects.iter().any(|defect| {
+                defect["axisFamily"] == "effect"
+                    && defect["distanceKind"]
+                        .as_str()
+                        .is_some_and(|kind| kind.contains("effect-replay-order-mismatch"))
+                    && defect["distanceValue"]
+                        .as_i64()
+                        .is_some_and(|value| value > 0)
+                    && defect["witnessRefs"].as_array().is_some_and(|refs| {
+                        refs.iter().any(|value| {
+                            value.as_str().is_some_and(|text| {
+                                text.contains("effect-path-p-operation-discount")
+                            })
+                        }) && refs.iter().any(|value| {
+                            value
+                                .as_str()
+                                .is_some_and(|text| text.contains("effect-path-q-operation-tax"))
+                        })
+                    })
+            })),
+        "coupon fixture must lock effect replay mismatch through comparable continuation values"
     );
     assert!(
         golden["featureBoundaryResidualReadings"]

--- a/tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json
@@ -5230,17 +5230,26 @@
           "axisFamily": "static",
           "axisRef": "static dependency / support axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
           "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_static[0]=operation:discount; refs=3",
-            "Cont_static[1]=operation:tax; refs=3",
-            "Cont_static[2]=operation:round; refs=3",
-            "Cont_static[endpoint]=p; endpointRefs=2"
+            "Cont_static[0]=operation:discount; comparableValues=2",
+            "Cont_static[1]=operation:tax; comparableValues=2",
+            "Cont_static[2]=operation:round; comparableValues=2",
+            "Cont_static[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "static:endpoints:PaymentAmount|ReceiptAmount",
+            "static:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding|atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation|atom-effect-receipt-boundary"
           ],
           "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount",
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:effect:receipt-boundary",
             "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-            "atom:effect:receipt-boundary"
+            "src-pricing-checkout",
+            "test-coupon-rounding"
           ],
           "observationRefs": [
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
@@ -5258,15 +5267,23 @@
           "axisFamily": "contract",
           "axisRef": "contract axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
           "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_contract[0]=operation:discount; refs=1",
-            "Cont_contract[1]=operation:tax; refs=1",
-            "Cont_contract[2]=operation:round; refs=1",
-            "Cont_contract[endpoint]=p; endpointRefs=2"
+            "Cont_contract[0]=operation:discount; comparableValues=2",
+            "Cont_contract[1]=operation:tax; comparableValues=2",
+            "Cont_contract[2]=operation:round; comparableValues=2",
+            "Cont_contract[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "contract:endpoints:PaymentAmount|ReceiptAmount",
+            "contract:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
           ],
           "distanceInputRefs": [
-            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            "PaymentAmount",
+            "ReceiptAmount",
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "test-coupon-rounding"
           ],
           "observationRefs": [
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
@@ -5281,20 +5298,26 @@
           "axisFamily": "semantic",
           "axisRef": "semantic axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "semantic continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
+          "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_semantic[0]=operation:discount; refs=2",
-            "Cont_semantic[1]=operation:tax; refs=2",
-            "Cont_semantic[2]=operation:round; refs=2",
-            "Cont_semantic[endpoint]=p; endpointRefs=2"
+            "Cont_semantic[0]=operation:discount; comparableValues=2",
+            "Cont_semantic[1]=operation:tax; comparableValues=2",
+            "Cont_semantic[2]=operation:round; comparableValues=2",
+            "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "semantic:path:p:operation:discount -> operation:tax -> operation:round",
+            "semantic:endpoints:PaymentAmount|ReceiptAmount"
           ],
           "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount",
             "semantic:coupon-tax-rounding-paths",
-            "derived-semantic-order:p=round(tax(discount(subtotal)))"
+            "test-coupon-rounding"
           ],
           "observationRefs": [
-            "semantic:coupon-tax-rounding-paths",
-            "derived-semantic-order:p=round(tax(discount(subtotal)))"
+            "semantic:coupon-tax-rounding-paths"
           ],
           "sourceRefs": [
             "test-coupon-rounding"
@@ -5306,14 +5329,19 @@
           "axisFamily": "state",
           "axisRef": "state transition axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
           "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_state[0]=operation:discount; refs=0",
-            "Cont_state[1]=operation:tax; refs=0",
-            "Cont_state[2]=operation:round; refs=0",
-            "Cont_state[endpoint]=p; endpointRefs=2"
+            "Cont_state[0]=operation:discount; comparableValues=0",
+            "Cont_state[1]=operation:tax; comparableValues=0",
+            "Cont_state[2]=operation:round; comparableValues=0",
+            "Cont_state[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5325,20 +5353,26 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+          "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_effect[0]=operation:discount; refs=2",
-            "Cont_effect[1]=operation:tax; refs=2",
-            "Cont_effect[2]=operation:round; refs=2",
-            "Cont_effect[endpoint]=p; endpointRefs=2"
+            "Cont_effect[0]=operation:discount; comparableValues=2",
+            "Cont_effect[1]=operation:tax; comparableValues=2",
+            "Cont_effect[2]=operation:round; comparableValues=2",
+            "Cont_effect[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "effect:path:p:operation:discount -> operation:tax -> operation:round",
+            "effect:endpoints:PaymentAmount|ReceiptAmount"
           ],
           "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount",
             "atom:effect:receipt-boundary",
-            "derived-effect-order:p:operation-round-operation-tax-operation-discount"
+            "src-pricing-checkout"
           ],
           "observationRefs": [
-            "atom:effect:receipt-boundary",
-            "derived-effect-order:p:operation-round-operation-tax-operation-discount"
+            "atom:effect:receipt-boundary"
           ],
           "sourceRefs": [
             "src-pricing-checkout"
@@ -5350,14 +5384,19 @@
           "axisFamily": "authority",
           "axisRef": "authority / trust boundary axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
           "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_authority[0]=operation:discount; refs=0",
-            "Cont_authority[1]=operation:tax; refs=0",
-            "Cont_authority[2]=operation:round; refs=0",
-            "Cont_authority[endpoint]=p; endpointRefs=2"
+            "Cont_authority[0]=operation:discount; comparableValues=0",
+            "Cont_authority[1]=operation:tax; comparableValues=0",
+            "Cont_authority[2]=operation:round; comparableValues=0",
+            "Cont_authority[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5369,14 +5408,19 @@
           "axisFamily": "runtime",
           "axisRef": "runtime interaction axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
           "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_runtime[0]=operation:discount; refs=0",
-            "Cont_runtime[1]=operation:tax; refs=0",
-            "Cont_runtime[2]=operation:round; refs=0",
-            "Cont_runtime[endpoint]=p; endpointRefs=2"
+            "Cont_runtime[0]=operation:discount; comparableValues=0",
+            "Cont_runtime[1]=operation:tax; comparableValues=0",
+            "Cont_runtime[2]=operation:round; comparableValues=0",
+            "Cont_runtime[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5388,15 +5432,23 @@
           "axisFamily": "projection",
           "axisRef": "projection / representation axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
           "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_projection[0]=operation:discount; refs=1",
-            "Cont_projection[1]=operation:tax; refs=1",
-            "Cont_projection[2]=operation:round; refs=1",
-            "Cont_projection[endpoint]=p; endpointRefs=2"
+            "Cont_projection[0]=operation:discount; comparableValues=2",
+            "Cont_projection[1]=operation:tax; comparableValues=2",
+            "Cont_projection[2]=operation:round; comparableValues=2",
+            "Cont_projection[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "projection:endpoints:PaymentAmount|ReceiptAmount",
+            "projection:support:projection-coupon-payment-receipt"
           ],
           "distanceInputRefs": [
-            "projection:coupon-payment-receipt"
+            "PaymentAmount",
+            "ReceiptAmount",
+            "projection:coupon-payment-receipt",
+            "semantic:coupon-tax-rounding-paths"
           ],
           "observationRefs": [
             "projection:coupon-payment-receipt"
@@ -5458,17 +5510,26 @@
           "axisFamily": "static",
           "axisRef": "static dependency / support axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
           "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_static[0]=operation:tax; refs=3",
-            "Cont_static[1]=operation:discount; refs=3",
-            "Cont_static[2]=operation:round; refs=3",
-            "Cont_static[endpoint]=q; endpointRefs=2"
+            "Cont_static[0]=operation:tax; comparableValues=2",
+            "Cont_static[1]=operation:discount; comparableValues=2",
+            "Cont_static[2]=operation:round; comparableValues=2",
+            "Cont_static[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "static:endpoints:PaymentAmount|ReceiptAmount",
+            "static:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding|atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation|atom-effect-receipt-boundary"
           ],
           "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount",
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:effect:receipt-boundary",
             "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-            "atom:effect:receipt-boundary"
+            "src-pricing-checkout",
+            "test-coupon-rounding"
           ],
           "observationRefs": [
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
@@ -5486,15 +5547,23 @@
           "axisFamily": "contract",
           "axisRef": "contract axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
           "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_contract[0]=operation:tax; refs=1",
-            "Cont_contract[1]=operation:discount; refs=1",
-            "Cont_contract[2]=operation:round; refs=1",
-            "Cont_contract[endpoint]=q; endpointRefs=2"
+            "Cont_contract[0]=operation:tax; comparableValues=2",
+            "Cont_contract[1]=operation:discount; comparableValues=2",
+            "Cont_contract[2]=operation:round; comparableValues=2",
+            "Cont_contract[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "contract:endpoints:PaymentAmount|ReceiptAmount",
+            "contract:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
           ],
           "distanceInputRefs": [
-            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            "PaymentAmount",
+            "ReceiptAmount",
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "test-coupon-rounding"
           ],
           "observationRefs": [
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
@@ -5509,20 +5578,26 @@
           "axisFamily": "semantic",
           "axisRef": "semantic axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "semantic continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
+          "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_semantic[0]=operation:tax; refs=2",
-            "Cont_semantic[1]=operation:discount; refs=2",
-            "Cont_semantic[2]=operation:round; refs=2",
-            "Cont_semantic[endpoint]=q; endpointRefs=2"
+            "Cont_semantic[0]=operation:tax; comparableValues=2",
+            "Cont_semantic[1]=operation:discount; comparableValues=2",
+            "Cont_semantic[2]=operation:round; comparableValues=2",
+            "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "semantic:path:q:operation:tax -> operation:discount -> operation:round",
+            "semantic:endpoints:PaymentAmount|ReceiptAmount"
           ],
           "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount",
             "semantic:coupon-tax-rounding-paths",
-            "derived-semantic-order:q=round(discount(tax(subtotal)))"
+            "test-coupon-rounding"
           ],
           "observationRefs": [
-            "semantic:coupon-tax-rounding-paths",
-            "derived-semantic-order:q=round(discount(tax(subtotal)))"
+            "semantic:coupon-tax-rounding-paths"
           ],
           "sourceRefs": [
             "test-coupon-rounding"
@@ -5534,14 +5609,19 @@
           "axisFamily": "state",
           "axisRef": "state transition axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
           "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_state[0]=operation:tax; refs=0",
-            "Cont_state[1]=operation:discount; refs=0",
-            "Cont_state[2]=operation:round; refs=0",
-            "Cont_state[endpoint]=q; endpointRefs=2"
+            "Cont_state[0]=operation:tax; comparableValues=0",
+            "Cont_state[1]=operation:discount; comparableValues=0",
+            "Cont_state[2]=operation:round; comparableValues=0",
+            "Cont_state[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5553,20 +5633,26 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+          "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_effect[0]=operation:tax; refs=2",
-            "Cont_effect[1]=operation:discount; refs=2",
-            "Cont_effect[2]=operation:round; refs=2",
-            "Cont_effect[endpoint]=q; endpointRefs=2"
+            "Cont_effect[0]=operation:tax; comparableValues=2",
+            "Cont_effect[1]=operation:discount; comparableValues=2",
+            "Cont_effect[2]=operation:round; comparableValues=2",
+            "Cont_effect[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "effect:path:q:operation:tax -> operation:discount -> operation:round",
+            "effect:endpoints:PaymentAmount|ReceiptAmount"
           ],
           "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount",
             "atom:effect:receipt-boundary",
-            "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+            "src-pricing-checkout"
           ],
           "observationRefs": [
-            "atom:effect:receipt-boundary",
-            "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+            "atom:effect:receipt-boundary"
           ],
           "sourceRefs": [
             "src-pricing-checkout"
@@ -5578,14 +5664,19 @@
           "axisFamily": "authority",
           "axisRef": "authority / trust boundary axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
           "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_authority[0]=operation:tax; refs=0",
-            "Cont_authority[1]=operation:discount; refs=0",
-            "Cont_authority[2]=operation:round; refs=0",
-            "Cont_authority[endpoint]=q; endpointRefs=2"
+            "Cont_authority[0]=operation:tax; comparableValues=0",
+            "Cont_authority[1]=operation:discount; comparableValues=0",
+            "Cont_authority[2]=operation:round; comparableValues=0",
+            "Cont_authority[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5597,14 +5688,19 @@
           "axisFamily": "runtime",
           "axisRef": "runtime interaction axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
           "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_runtime[0]=operation:tax; refs=0",
-            "Cont_runtime[1]=operation:discount; refs=0",
-            "Cont_runtime[2]=operation:round; refs=0",
-            "Cont_runtime[endpoint]=q; endpointRefs=2"
+            "Cont_runtime[0]=operation:tax; comparableValues=0",
+            "Cont_runtime[1]=operation:discount; comparableValues=0",
+            "Cont_runtime[2]=operation:round; comparableValues=0",
+            "Cont_runtime[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "PaymentAmount",
+            "ReceiptAmount"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5616,15 +5712,23 @@
           "axisFamily": "projection",
           "axisRef": "projection / representation axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
           "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_projection[0]=operation:tax; refs=1",
-            "Cont_projection[1]=operation:discount; refs=1",
-            "Cont_projection[2]=operation:round; refs=1",
-            "Cont_projection[endpoint]=q; endpointRefs=2"
+            "Cont_projection[0]=operation:tax; comparableValues=2",
+            "Cont_projection[1]=operation:discount; comparableValues=2",
+            "Cont_projection[2]=operation:round; comparableValues=2",
+            "Cont_projection[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "projection:endpoints:PaymentAmount|ReceiptAmount",
+            "projection:support:projection-coupon-payment-receipt"
           ],
           "distanceInputRefs": [
-            "projection:coupon-payment-receipt"
+            "PaymentAmount",
+            "ReceiptAmount",
+            "projection:coupon-payment-receipt",
+            "semantic:coupon-tax-rounding-paths"
           ],
           "observationRefs": [
             "projection:coupon-payment-receipt"
@@ -5667,17 +5771,22 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "authority",
       "axisRef": "authority / trust boundary axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:authority-boundary-value-mismatch",
       "pContinuationRef": "Cont_authority(p):authority / trust boundary axis",
       "qContinuationRef": "Cont_authority(q):authority / trust boundary axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "PaymentAmount",
+        "ReceiptAmount"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+        "missing-evidence:missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+        "missing-evidence:missing comparable p continuation value for authority",
+        "missing-evidence:missing comparable q continuation value for authority"
       ],
       "sourceRefs": [
         "src-pricing-checkout",
@@ -5685,9 +5794,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+        "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+        "missing comparable p continuation value for authority",
+        "missing comparable q continuation value for authority"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5700,7 +5811,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5716,13 +5827,16 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "contract",
       "axisRef": "contract axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:contract-obligation-value-mismatch",
       "pContinuationRef": "Cont_contract(p):contract axis",
       "qContinuationRef": "Cont_contract(q):contract axis",
       "distanceInputRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+        "PaymentAmount",
+        "ReceiptAmount",
+        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+        "test-coupon-rounding"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -5730,7 +5844,11 @@
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
       ],
       "witnessRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+        "p-value:contract-endpoints-paymentamount-receiptamount",
+        "p-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding",
+        "q-value:contract-endpoints-paymentamount-receiptamount",
+        "q-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
       ],
       "sourceRefs": [
         "src-pricing-checkout",
@@ -5740,7 +5858,7 @@
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5753,7 +5871,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5769,39 +5887,38 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:effect-replay-order-mismatch",
       "pContinuationRef": "Cont_effect(p):effect ordering / replay / compensation axis",
       "qContinuationRef": "Cont_effect(q):effect ordering / replay / compensation axis",
       "distanceInputRefs": [
+        "PaymentAmount",
+        "ReceiptAmount",
         "atom:effect:receipt-boundary",
-        "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-        "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+        "src-pricing-checkout"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
-      "distanceValue": 2,
+      "distanceValue": 1,
       "measuredSupportRefs": [
-        "atom:effect:receipt-boundary",
-        "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-        "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+        "atom:effect:receipt-boundary"
       ],
       "witnessRefs": [
         "atom:effect:receipt-boundary",
-        "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-        "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+        "p-value:effect-endpoints-paymentamount-receiptamount",
+        "p-value:effect-path-p-operation-discount-operation-tax-operation-round",
+        "q-value:effect-endpoints-paymentamount-receiptamount",
+        "q-value:effect-path-q-operation-tax-operation-discount-operation-round"
       ],
       "sourceRefs": [
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:effect:receipt-boundary",
-        "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-        "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+        "atom:effect:receipt-boundary"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5814,7 +5931,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5830,13 +5947,16 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "projection",
       "axisRef": "projection / representation axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:projection-target-value-mismatch",
       "pContinuationRef": "Cont_projection(p):projection / representation axis",
       "qContinuationRef": "Cont_projection(q):projection / representation axis",
       "distanceInputRefs": [
-        "projection:coupon-payment-receipt"
+        "PaymentAmount",
+        "ReceiptAmount",
+        "projection:coupon-payment-receipt",
+        "semantic:coupon-tax-rounding-paths"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -5844,7 +5964,11 @@
         "projection:coupon-payment-receipt"
       ],
       "witnessRefs": [
-        "projection:coupon-payment-receipt"
+        "p-value:projection-endpoints-paymentamount-receiptamount",
+        "p-value:projection-support-projection-coupon-payment-receipt",
+        "projection:coupon-payment-receipt",
+        "q-value:projection-endpoints-paymentamount-receiptamount",
+        "q-value:projection-support-projection-coupon-payment-receipt"
       ],
       "sourceRefs": [
         "src-pricing-checkout",
@@ -5854,7 +5978,7 @@
         "projection:coupon-payment-receipt"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5867,7 +5991,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5883,16 +6007,21 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "runtime",
       "axisRef": "runtime interaction axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
       "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
       "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "PaymentAmount",
+        "ReceiptAmount"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for runtime",
+        "missing-evidence:missing comparable q continuation value for runtime",
         "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
       ],
       "sourceRefs": [
@@ -5901,9 +6030,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for runtime",
+        "missing comparable q continuation value for runtime",
         "missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5916,7 +6047,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5932,26 +6063,27 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "semantic",
       "axisRef": "semantic axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:semantic-sequence-mismatch",
       "pContinuationRef": "Cont_semantic(p):semantic axis",
       "qContinuationRef": "Cont_semantic(q):semantic axis",
       "distanceInputRefs": [
-        "derived-semantic-order:p=round(tax(discount(subtotal)))",
-        "derived-semantic-order:q=round(discount(tax(subtotal)))",
-        "semantic:coupon-tax-rounding-paths"
+        "PaymentAmount",
+        "ReceiptAmount",
+        "semantic:coupon-tax-rounding-paths",
+        "test-coupon-rounding"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
-      "distanceValue": 2,
+      "distanceValue": 1,
       "measuredSupportRefs": [
-        "derived-semantic-order:p=round(tax(discount(subtotal)))",
-        "derived-semantic-order:q=round(discount(tax(subtotal)))",
         "semantic:coupon-tax-rounding-paths"
       ],
       "witnessRefs": [
-        "derived-semantic-order:p=round(tax(discount(subtotal)))",
-        "derived-semantic-order:q=round(discount(tax(subtotal)))",
+        "p-value:semantic-endpoints-paymentamount-receiptamount",
+        "p-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+        "q-value:semantic-endpoints-paymentamount-receiptamount",
+        "q-value:semantic-path-q-operation-tax-operation-discount-operation-round",
         "semantic:coupon-tax-rounding-paths"
       ],
       "sourceRefs": [
@@ -5959,12 +6091,10 @@
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "derived-semantic-order:p=round(tax(discount(subtotal)))",
-        "derived-semantic-order:q=round(discount(tax(subtotal)))",
         "semantic:coupon-tax-rounding-paths"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5977,7 +6107,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5993,16 +6123,21 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "state",
       "axisRef": "state transition axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:state-transition-value-mismatch",
       "pContinuationRef": "Cont_state(p):state transition axis",
       "qContinuationRef": "Cont_state(q):state transition axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "PaymentAmount",
+        "ReceiptAmount"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for state",
+        "missing-evidence:missing comparable q continuation value for state",
         "missing-evidence:missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
       ],
       "sourceRefs": [
@@ -6011,9 +6146,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for state",
+        "missing comparable q continuation value for state",
         "missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6026,7 +6163,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6042,15 +6179,19 @@
       "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
       "axisFamily": "static",
       "axisRef": "static dependency / support axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:static-support-value-mismatch",
       "pContinuationRef": "Cont_static(p):static dependency / support axis",
       "qContinuationRef": "Cont_static(q):static dependency / support axis",
       "distanceInputRefs": [
+        "PaymentAmount",
+        "ReceiptAmount",
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
         "atom:effect:receipt-boundary",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -6062,7 +6203,11 @@
       "witnessRefs": [
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
         "atom:effect:receipt-boundary",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+        "p-value:static-endpoints-paymentamount-receiptamount",
+        "p-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary",
+        "q-value:static-endpoints-paymentamount-receiptamount",
+        "q-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary"
       ],
       "sourceRefs": [
         "src-pricing-checkout",
@@ -6074,7 +6219,7 @@
         "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6087,7 +6232,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6123,7 +6268,7 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "distanceKind": "weighted-axis-l1",
       "measurementStatus": "partial",
-      "aggregateValue": 4,
+      "aggregateValue": 2,
       "measuredDefectRefs": [
         "mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
         "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
@@ -6157,7 +6302,9 @@
           "contributionValue": null,
           "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            "missing-evidence:missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+            "missing-evidence:missing comparable p continuation value for authority",
+            "missing-evidence:missing comparable q continuation value for authority"
           ]
         },
         {
@@ -6168,6 +6315,8 @@
           "contributionValue": null,
           "reviewFocus": "supply missing runtime trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for runtime",
+            "missing-evidence:missing comparable q continuation value for runtime",
             "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
           ]
         },
@@ -6179,6 +6328,8 @@
           "contributionValue": null,
           "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for state",
+            "missing-evidence:missing comparable q continuation value for state",
             "missing-evidence:missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
           ]
         },
@@ -6187,12 +6338,14 @@
           "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
           "axisFamily": "effect",
           "contributionWeight": 1,
-          "contributionValue": 2,
+          "contributionValue": 1,
           "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
             "atom:effect:receipt-boundary",
-            "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-            "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+            "p-value:effect-endpoints-paymentamount-receiptamount",
+            "p-value:effect-path-p-operation-discount-operation-tax-operation-round",
+            "q-value:effect-endpoints-paymentamount-receiptamount",
+            "q-value:effect-path-q-operation-tax-operation-discount-operation-round"
           ]
         },
         {
@@ -6200,11 +6353,13 @@
           "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
           "axisFamily": "semantic",
           "contributionWeight": 1,
-          "contributionValue": 2,
+          "contributionValue": 1,
           "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
-            "derived-semantic-order:p=round(tax(discount(subtotal)))",
-            "derived-semantic-order:q=round(discount(tax(subtotal)))",
+            "p-value:semantic-endpoints-paymentamount-receiptamount",
+            "p-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+            "q-value:semantic-endpoints-paymentamount-receiptamount",
+            "q-value:semantic-path-q-operation-tax-operation-discount-operation-round",
             "semantic:coupon-tax-rounding-paths"
           ]
         },
@@ -6216,7 +6371,11 @@
           "contributionValue": 0,
           "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
-            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "p-value:contract-endpoints-paymentamount-receiptamount",
+            "p-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding",
+            "q-value:contract-endpoints-paymentamount-receiptamount",
+            "q-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
           ]
         },
         {
@@ -6227,7 +6386,11 @@
           "contributionValue": 0,
           "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
-            "projection:coupon-payment-receipt"
+            "p-value:projection-endpoints-paymentamount-receiptamount",
+            "p-value:projection-support-projection-coupon-payment-receipt",
+            "projection:coupon-payment-receipt",
+            "q-value:projection-endpoints-paymentamount-receiptamount",
+            "q-value:projection-support-projection-coupon-payment-receipt"
           ]
         },
         {
@@ -6240,7 +6403,11 @@
           "witnessRefs": [
             "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
             "atom:effect:receipt-boundary",
-            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "p-value:static-endpoints-paymentamount-receiptamount",
+            "p-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary",
+            "q-value:static-endpoints-paymentamount-receiptamount",
+            "q-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary"
           ]
         }
       ],
@@ -6280,15 +6447,13 @@
       ],
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
-      "defectValue": 2,
+      "defectValue": 1,
       "comparedTraceSummary": [
-        "p: effect continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0",
-        "q: effect continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0"
+        "p: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+        "q: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
       ],
       "affectedAtomRefs": [
-        "atom:effect:receipt-boundary",
-        "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-        "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+        "atom:effect:receipt-boundary"
       ],
       "lawRefs": [
         "law:layer-respecting",
@@ -6303,12 +6468,10 @@
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:effect:receipt-boundary",
-        "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-        "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+        "atom:effect:receipt-boundary"
       ],
       "missingEvidence": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "suggestedFillerEvidence": [
         "supply filler evidence for effect axis trace disagreement",
         "record whether the two continuation paths preserve selected observations"
@@ -6348,14 +6511,12 @@
       ],
       "axisFamily": "semantic",
       "axisRef": "semantic axis",
-      "defectValue": 2,
+      "defectValue": 1,
       "comparedTraceSummary": [
-        "p: semantic continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0",
-        "q: semantic continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0"
+        "p: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+        "q: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
       ],
       "affectedAtomRefs": [
-        "derived-semantic-order:p=round(tax(discount(subtotal)))",
-        "derived-semantic-order:q=round(discount(tax(subtotal)))",
         "semantic:coupon-tax-rounding-paths"
       ],
       "lawRefs": [
@@ -6371,12 +6532,10 @@
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "derived-semantic-order:p=round(tax(discount(subtotal)))",
-        "derived-semantic-order:q=round(discount(tax(subtotal)))",
         "semantic:coupon-tax-rounding-paths"
       ],
       "missingEvidence": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "suggestedFillerEvidence": [
         "supply filler evidence for semantic axis trace disagreement",
         "record whether the two continuation paths preserve selected observations"
@@ -6460,13 +6619,11 @@
           "holonomyAxisRef": "Hol_semantic",
           "axisFamily": "semantic",
           "status": "measuredResidual",
-          "residualValue": 2,
+          "residualValue": 1,
           "measuredDefectRefs": [
             "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
           ],
           "supportRefs": [
-            "derived-semantic-order:p=round(tax(discount(subtotal)))",
-            "derived-semantic-order:q=round(discount(tax(subtotal)))",
             "semantic:coupon-tax-rounding-paths"
           ],
           "missingEvidence": [],
@@ -6485,6 +6642,8 @@
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for state",
+            "missing comparable q continuation value for state",
             "missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
           ],
           "reading": "Hol_state records boundary-local residual obstruction on the state axis"
@@ -6493,14 +6652,12 @@
           "holonomyAxisRef": "Hol_effect",
           "axisFamily": "effect",
           "status": "measuredResidual",
-          "residualValue": 2,
+          "residualValue": 1,
           "measuredDefectRefs": [
             "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect"
           ],
           "supportRefs": [
-            "atom:effect:receipt-boundary",
-            "derived-effect-order:p:operation-round-operation-tax-operation-discount",
-            "derived-effect-order:q:operation-round-operation-discount-operation-tax"
+            "atom:effect:receipt-boundary"
           ],
           "missingEvidence": [],
           "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
@@ -6518,7 +6675,9 @@
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "missingEvidence": [
-            "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+            "missing comparable p continuation value for authority",
+            "missing comparable q continuation value for authority"
           ],
           "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
         },
@@ -6535,6 +6694,8 @@
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for runtime",
+            "missing comparable q continuation value for runtime",
             "missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
           ],
           "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
@@ -8663,8 +8824,8 @@
       "split-readiness:molecule-coupon-operation-contract transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
     ],
     "nonzeroMonodromyWitnessSummary": [
-      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-effect axis=effect defect=2 affectedAtoms=3 missingEvidence=0 focus=2",
-      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-semantic axis=semantic defect=2 affectedAtoms=3 missingEvidence=0 focus=2"
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-effect axis=effect defect=1 affectedAtoms=1 missingEvidence=0 focus=2",
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-semantic axis=semantic defect=1 affectedAtoms=1 missingEvidence=0 focus=2"
     ],
     "featureBoundaryResidualSummary": [
       "feature-boundary-residual:coupon-tax-rounding-archmap boundary=Boundary(coupon-tax-rounding-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=6"

--- a/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
@@ -6372,16 +6372,25 @@
           "axisFamily": "static",
           "axisRef": "static dependency / support axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "witness-mismatch-count:static-support-value-mismatch",
           "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_static[0]=operation:read-through-cache; refs=3",
-            "Cont_static[1]=operation:project-order-event; refs=3",
-            "Cont_static[endpoint]=p; endpointRefs=1"
+            "Cont_static[0]=operation:read-through-cache; comparableValues=2",
+            "Cont_static[1]=operation:project-order-event; comparableValues=2",
+            "Cont_static[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:static-support-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "static:endpoints:OrderView",
+            "static:support:atom-cache-read|atom-repository-read|atom-event-projection"
           ],
           "distanceInputRefs": [
+            "OrderView",
             "atom:cache-read",
+            "atom:event-projection",
             "atom:repository-read",
-            "atom:event-projection"
+            "src-cache-read",
+            "src-event-projection",
+            "src-repository-read"
           ],
           "observationRefs": [
             "atom:cache-read",
@@ -6400,13 +6409,17 @@
           "axisFamily": "contract",
           "axisRef": "contract axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:contract-obligation-value-mismatch",
           "continuationSummary": "contract continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_contract[0]=operation:read-through-cache; refs=0",
-            "Cont_contract[1]=operation:project-order-event; refs=0",
-            "Cont_contract[endpoint]=p; endpointRefs=1"
+            "Cont_contract[0]=operation:read-through-cache; comparableValues=0",
+            "Cont_contract[1]=operation:project-order-event; comparableValues=0",
+            "Cont_contract[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:contract-obligation-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6418,14 +6431,21 @@
           "axisFamily": "semantic",
           "axisRef": "semantic axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "witness-mismatch-count:semantic-sequence-mismatch",
           "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_semantic[0]=operation:read-through-cache; refs=1",
-            "Cont_semantic[1]=operation:project-order-event; refs=1",
-            "Cont_semantic[endpoint]=p; endpointRefs=1"
+            "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+            "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+            "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "semantic:path:p:operation:read-through-cache -> operation:project-order-event",
+            "semantic:endpoints:OrderView"
           ],
           "distanceInputRefs": [
-            "semantic:path-rule:cache-repository-semantic-loop"
+            "OrderView",
+            "semantic:path-rule:cache-repository-semantic-loop",
+            "src-cache-read"
           ],
           "observationRefs": [
             "semantic:path-rule:cache-repository-semantic-loop"
@@ -6440,13 +6460,17 @@
           "axisFamily": "state",
           "axisRef": "state transition axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:state-transition-value-mismatch",
           "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_state[0]=operation:read-through-cache; refs=0",
-            "Cont_state[1]=operation:project-order-event; refs=0",
-            "Cont_state[endpoint]=p; endpointRefs=1"
+            "Cont_state[0]=operation:read-through-cache; comparableValues=0",
+            "Cont_state[1]=operation:project-order-event; comparableValues=0",
+            "Cont_state[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:state-transition-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6458,19 +6482,24 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "distanceEvaluatorKind": "witness-mismatch-count:effect-replay-order-mismatch",
+          "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_effect[0]=operation:read-through-cache; refs=2",
-            "Cont_effect[1]=operation:project-order-event; refs=2",
-            "Cont_effect[endpoint]=p; endpointRefs=1"
+            "Cont_effect[0]=operation:read-through-cache; comparableValues=2",
+            "Cont_effect[1]=operation:project-order-event; comparableValues=2",
+            "Cont_effect[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:effect-replay-order-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "effect:path:p:operation:read-through-cache -> operation:project-order-event",
+            "effect:endpoints:OrderView"
           ],
           "distanceInputRefs": [
+            "OrderView",
             "atom:event-projection",
-            "derived-effect-order:p:operation-project-order-event-operation-read-through-cache"
+            "src-event-projection"
           ],
           "observationRefs": [
-            "atom:event-projection",
-            "derived-effect-order:p:operation-project-order-event-operation-read-through-cache"
+            "atom:event-projection"
           ],
           "sourceRefs": [
             "src-event-projection"
@@ -6482,13 +6511,17 @@
           "axisFamily": "authority",
           "axisRef": "authority / trust boundary axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:authority-boundary-value-mismatch",
           "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_authority[0]=operation:read-through-cache; refs=0",
-            "Cont_authority[1]=operation:project-order-event; refs=0",
-            "Cont_authority[endpoint]=p; endpointRefs=1"
+            "Cont_authority[0]=operation:read-through-cache; comparableValues=0",
+            "Cont_authority[1]=operation:project-order-event; comparableValues=0",
+            "Cont_authority[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:authority-boundary-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6500,13 +6533,17 @@
           "axisFamily": "runtime",
           "axisRef": "runtime interaction axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:runtime-interaction-value-mismatch",
           "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_runtime[0]=operation:read-through-cache; refs=0",
-            "Cont_runtime[1]=operation:project-order-event; refs=0",
-            "Cont_runtime[endpoint]=p; endpointRefs=1"
+            "Cont_runtime[0]=operation:read-through-cache; comparableValues=0",
+            "Cont_runtime[1]=operation:project-order-event; comparableValues=0",
+            "Cont_runtime[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:runtime-interaction-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6518,13 +6555,20 @@
           "axisFamily": "projection",
           "axisRef": "projection / representation axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "witness-mismatch-count:projection-target-value-mismatch",
           "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_projection[0]=operation:read-through-cache; refs=1",
-            "Cont_projection[1]=operation:project-order-event; refs=1",
-            "Cont_projection[endpoint]=p; endpointRefs=1"
+            "Cont_projection[0]=operation:read-through-cache; comparableValues=2",
+            "Cont_projection[1]=operation:project-order-event; comparableValues=2",
+            "Cont_projection[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:projection-target-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "projection:endpoints:OrderView",
+            "projection:support:projection-homotopy-report-fixture"
           ],
           "distanceInputRefs": [
+            "OrderView",
+            "molecule:homotopy-report-fixture",
             "projection:homotopy-report-fixture"
           ],
           "observationRefs": [
@@ -6585,16 +6629,25 @@
           "axisFamily": "static",
           "axisRef": "static dependency / support axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "witness-mismatch-count:static-support-value-mismatch",
           "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_static[0]=operation:read-from-repository; refs=3",
-            "Cont_static[1]=operation:project-order-event; refs=3",
-            "Cont_static[endpoint]=q; endpointRefs=1"
+            "Cont_static[0]=operation:read-from-repository; comparableValues=2",
+            "Cont_static[1]=operation:project-order-event; comparableValues=2",
+            "Cont_static[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:static-support-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "static:endpoints:OrderView",
+            "static:support:atom-cache-read|atom-repository-read|atom-event-projection"
           ],
           "distanceInputRefs": [
+            "OrderView",
             "atom:cache-read",
+            "atom:event-projection",
             "atom:repository-read",
-            "atom:event-projection"
+            "src-cache-read",
+            "src-event-projection",
+            "src-repository-read"
           ],
           "observationRefs": [
             "atom:cache-read",
@@ -6613,13 +6666,17 @@
           "axisFamily": "contract",
           "axisRef": "contract axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:contract-obligation-value-mismatch",
           "continuationSummary": "contract continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_contract[0]=operation:read-from-repository; refs=0",
-            "Cont_contract[1]=operation:project-order-event; refs=0",
-            "Cont_contract[endpoint]=q; endpointRefs=1"
+            "Cont_contract[0]=operation:read-from-repository; comparableValues=0",
+            "Cont_contract[1]=operation:project-order-event; comparableValues=0",
+            "Cont_contract[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:contract-obligation-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6631,14 +6688,21 @@
           "axisFamily": "semantic",
           "axisRef": "semantic axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "witness-mismatch-count:semantic-sequence-mismatch",
           "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_semantic[0]=operation:read-from-repository; refs=1",
-            "Cont_semantic[1]=operation:project-order-event; refs=1",
-            "Cont_semantic[endpoint]=q; endpointRefs=1"
+            "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+            "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+            "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "semantic:path:q:operation:read-from-repository -> operation:project-order-event",
+            "semantic:endpoints:OrderView"
           ],
           "distanceInputRefs": [
-            "semantic:path-rule:cache-repository-semantic-loop"
+            "OrderView",
+            "semantic:path-rule:cache-repository-semantic-loop",
+            "src-cache-read"
           ],
           "observationRefs": [
             "semantic:path-rule:cache-repository-semantic-loop"
@@ -6653,13 +6717,17 @@
           "axisFamily": "state",
           "axisRef": "state transition axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:state-transition-value-mismatch",
           "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_state[0]=operation:read-from-repository; refs=0",
-            "Cont_state[1]=operation:project-order-event; refs=0",
-            "Cont_state[endpoint]=q; endpointRefs=1"
+            "Cont_state[0]=operation:read-from-repository; comparableValues=0",
+            "Cont_state[1]=operation:project-order-event; comparableValues=0",
+            "Cont_state[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:state-transition-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6671,19 +6739,24 @@
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
           "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 2 observation ref(s) across 1 operation delta(s)",
+          "distanceEvaluatorKind": "witness-mismatch-count:effect-replay-order-mismatch",
+          "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_effect[0]=operation:read-from-repository; refs=2",
-            "Cont_effect[1]=operation:project-order-event; refs=2",
-            "Cont_effect[endpoint]=q; endpointRefs=1"
+            "Cont_effect[0]=operation:read-from-repository; comparableValues=2",
+            "Cont_effect[1]=operation:project-order-event; comparableValues=2",
+            "Cont_effect[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:effect-replay-order-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "effect:path:q:operation:read-from-repository -> operation:project-order-event",
+            "effect:endpoints:OrderView"
           ],
           "distanceInputRefs": [
+            "OrderView",
             "atom:event-projection",
-            "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+            "src-event-projection"
           ],
           "observationRefs": [
-            "atom:event-projection",
-            "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+            "atom:event-projection"
           ],
           "sourceRefs": [
             "src-event-projection"
@@ -6695,13 +6768,17 @@
           "axisFamily": "authority",
           "axisRef": "authority / trust boundary axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:authority-boundary-value-mismatch",
           "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_authority[0]=operation:read-from-repository; refs=0",
-            "Cont_authority[1]=operation:project-order-event; refs=0",
-            "Cont_authority[endpoint]=q; endpointRefs=1"
+            "Cont_authority[0]=operation:read-from-repository; comparableValues=0",
+            "Cont_authority[1]=operation:project-order-event; comparableValues=0",
+            "Cont_authority[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:authority-boundary-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6713,13 +6790,17 @@
           "axisFamily": "runtime",
           "axisRef": "runtime interaction axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "witness-mismatch-count:runtime-interaction-value-mismatch",
           "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_runtime[0]=operation:read-from-repository; refs=0",
-            "Cont_runtime[1]=operation:project-order-event; refs=0",
-            "Cont_runtime[endpoint]=q; endpointRefs=1"
+            "Cont_runtime[0]=operation:read-from-repository; comparableValues=0",
+            "Cont_runtime[1]=operation:project-order-event; comparableValues=0",
+            "Cont_runtime[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:runtime-interaction-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "OrderView"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -6731,13 +6812,20 @@
           "axisFamily": "projection",
           "axisRef": "projection / representation axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "witness-mismatch-count:projection-target-value-mismatch",
           "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_projection[0]=operation:read-from-repository; refs=1",
-            "Cont_projection[1]=operation:project-order-event; refs=1",
-            "Cont_projection[endpoint]=q; endpointRefs=1"
+            "Cont_projection[0]=operation:read-from-repository; comparableValues=2",
+            "Cont_projection[1]=operation:project-order-event; comparableValues=2",
+            "Cont_projection[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:projection-target-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "projection:endpoints:OrderView",
+            "projection:support:projection-homotopy-report-fixture"
           ],
           "distanceInputRefs": [
+            "OrderView",
+            "molecule:homotopy-report-fixture",
             "projection:homotopy-report-fixture"
           ],
           "observationRefs": [
@@ -6782,17 +6870,21 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "authority",
       "axisRef": "authority / trust boundary axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:authority-boundary-value-mismatch",
       "pContinuationRef": "Cont_authority(p):authority / trust boundary axis",
       "qContinuationRef": "Cont_authority(q):authority / trust boundary axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "OrderView"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing authority observation for operation-square:operation-square-evidence-cache-repository-read"
+        "missing-evidence:missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+        "missing-evidence:missing comparable p continuation value for authority",
+        "missing-evidence:missing comparable q continuation value for authority"
       ],
       "sourceRefs": [
         "src-cache-read",
@@ -6801,9 +6893,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing authority observation for operation-square:operation-square-evidence-cache-repository-read"
+        "missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+        "missing comparable p continuation value for authority",
+        "missing comparable q continuation value for authority"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -6814,7 +6908,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6830,16 +6924,20 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "contract",
       "axisRef": "contract axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:contract-obligation-value-mismatch",
       "pContinuationRef": "Cont_contract(p):contract axis",
       "qContinuationRef": "Cont_contract(q):contract axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "OrderView"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for contract",
+        "missing-evidence:missing comparable q continuation value for contract",
         "missing-evidence:missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
       ],
       "sourceRefs": [
@@ -6849,9 +6947,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for contract",
+        "missing comparable q continuation value for contract",
         "missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -6862,7 +6962,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6878,27 +6978,27 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:effect-replay-order-mismatch",
       "pContinuationRef": "Cont_effect(p):effect ordering / replay / compensation axis",
       "qContinuationRef": "Cont_effect(q):effect ordering / replay / compensation axis",
       "distanceInputRefs": [
+        "OrderView",
         "atom:event-projection",
-        "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-        "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+        "src-event-projection"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
-      "distanceValue": 2,
+      "distanceValue": 1,
       "measuredSupportRefs": [
-        "atom:event-projection",
-        "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-        "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+        "atom:event-projection"
       ],
       "witnessRefs": [
         "atom:event-projection",
-        "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-        "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+        "p-value:effect-endpoints-orderview",
+        "p-value:effect-path-p-operation-read-through-cache-operation-project-order-event",
+        "q-value:effect-endpoints-orderview",
+        "q-value:effect-path-q-operation-read-from-repository-operation-project-order-event"
       ],
       "sourceRefs": [
         "src-cache-read",
@@ -6906,12 +7006,10 @@
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:event-projection",
-        "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-        "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+        "atom:event-projection"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -6922,7 +7020,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6938,13 +7036,15 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "projection",
       "axisRef": "projection / representation axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:projection-target-value-mismatch",
       "pContinuationRef": "Cont_projection(p):projection / representation axis",
       "qContinuationRef": "Cont_projection(q):projection / representation axis",
       "distanceInputRefs": [
+        "OrderView",
+        "molecule:homotopy-report-fixture",
         "projection:homotopy-report-fixture"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -6952,7 +7052,11 @@
         "projection:homotopy-report-fixture"
       ],
       "witnessRefs": [
-        "projection:homotopy-report-fixture"
+        "p-value:projection-endpoints-orderview",
+        "p-value:projection-support-projection-homotopy-report-fixture",
+        "projection:homotopy-report-fixture",
+        "q-value:projection-endpoints-orderview",
+        "q-value:projection-support-projection-homotopy-report-fixture"
       ],
       "sourceRefs": [
         "src-cache-read",
@@ -6963,7 +7067,7 @@
         "projection:homotopy-report-fixture"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -6974,7 +7078,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6990,16 +7094,20 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "runtime",
       "axisRef": "runtime interaction axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:runtime-interaction-value-mismatch",
       "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
       "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "OrderView"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for runtime",
+        "missing-evidence:missing comparable q continuation value for runtime",
         "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
       ],
       "sourceRefs": [
@@ -7009,9 +7117,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for runtime",
+        "missing comparable q continuation value for runtime",
         "missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -7022,7 +7132,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7038,20 +7148,26 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "semantic",
       "axisRef": "semantic axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:semantic-sequence-mismatch",
       "pContinuationRef": "Cont_semantic(p):semantic axis",
       "qContinuationRef": "Cont_semantic(q):semantic axis",
       "distanceInputRefs": [
-        "semantic:path-rule:cache-repository-semantic-loop"
+        "OrderView",
+        "semantic:path-rule:cache-repository-semantic-loop",
+        "src-cache-read"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
-      "distanceValue": 0,
+      "distanceValue": 1,
       "measuredSupportRefs": [
         "semantic:path-rule:cache-repository-semantic-loop"
       ],
       "witnessRefs": [
+        "p-value:semantic-endpoints-orderview",
+        "p-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "q-value:semantic-endpoints-orderview",
+        "q-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
         "semantic:path-rule:cache-repository-semantic-loop"
       ],
       "sourceRefs": [
@@ -7063,7 +7179,7 @@
         "semantic:path-rule:cache-repository-semantic-loop"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -7074,7 +7190,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7090,16 +7206,20 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "state",
       "axisRef": "state transition axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:state-transition-value-mismatch",
       "pContinuationRef": "Cont_state(p):state transition axis",
       "qContinuationRef": "Cont_state(q):state transition axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "OrderView"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for state",
+        "missing-evidence:missing comparable q continuation value for state",
         "missing-evidence:missing state observation for operation-square:operation-square-evidence-cache-repository-read"
       ],
       "sourceRefs": [
@@ -7109,9 +7229,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for state",
+        "missing comparable q continuation value for state",
         "missing state observation for operation-square:operation-square-evidence-cache-repository-read"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -7122,7 +7244,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7138,15 +7260,19 @@
       "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
       "axisFamily": "static",
       "axisRef": "static dependency / support axis",
-      "distanceKind": "witness-mismatch-count",
+      "distanceKind": "witness-mismatch-count:static-support-value-mismatch",
       "pContinuationRef": "Cont_static(p):static dependency / support axis",
       "qContinuationRef": "Cont_static(q):static dependency / support axis",
       "distanceInputRefs": [
+        "OrderView",
         "atom:cache-read",
         "atom:event-projection",
-        "atom:repository-read"
+        "atom:repository-read",
+        "src-cache-read",
+        "src-event-projection",
+        "src-repository-read"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -7158,7 +7284,11 @@
       "witnessRefs": [
         "atom:cache-read",
         "atom:event-projection",
-        "atom:repository-read"
+        "atom:repository-read",
+        "p-value:static-endpoints-orderview",
+        "p-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection",
+        "q-value:static-endpoints-orderview",
+        "q-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection"
       ],
       "sourceRefs": [
         "src-cache-read",
@@ -7171,7 +7301,7 @@
         "atom:repository-read"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions"
       ],
@@ -7182,7 +7312,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7251,7 +7381,9 @@
           "contributionValue": null,
           "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing authority observation for operation-square:operation-square-evidence-cache-repository-read"
+            "missing-evidence:missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+            "missing-evidence:missing comparable p continuation value for authority",
+            "missing-evidence:missing comparable q continuation value for authority"
           ]
         },
         {
@@ -7262,6 +7394,8 @@
           "contributionValue": null,
           "reviewFocus": "supply missing contract trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for contract",
+            "missing-evidence:missing comparable q continuation value for contract",
             "missing-evidence:missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
           ]
         },
@@ -7273,6 +7407,8 @@
           "contributionValue": null,
           "reviewFocus": "supply missing runtime trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for runtime",
+            "missing-evidence:missing comparable q continuation value for runtime",
             "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
           ]
         },
@@ -7284,6 +7420,8 @@
           "contributionValue": null,
           "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for state",
+            "missing-evidence:missing comparable q continuation value for state",
             "missing-evidence:missing state observation for operation-square:operation-square-evidence-cache-repository-read"
           ]
         },
@@ -7292,12 +7430,29 @@
           "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
           "axisFamily": "effect",
           "contributionWeight": 1,
-          "contributionValue": 2,
+          "contributionValue": 1,
           "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
             "atom:event-projection",
-            "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-            "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+            "p-value:effect-endpoints-orderview",
+            "p-value:effect-path-p-operation-read-through-cache-operation-project-order-event",
+            "q-value:effect-endpoints-orderview",
+            "q-value:effect-path-q-operation-read-from-repository-operation-project-order-event"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+          "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+          "axisFamily": "semantic",
+          "contributionWeight": 1,
+          "contributionValue": 1,
+          "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
+          "witnessRefs": [
+            "p-value:semantic-endpoints-orderview",
+            "p-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+            "q-value:semantic-endpoints-orderview",
+            "q-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+            "semantic:path-rule:cache-repository-semantic-loop"
           ]
         },
         {
@@ -7308,18 +7463,11 @@
           "contributionValue": 0,
           "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
-            "projection:homotopy-report-fixture"
-          ]
-        },
-        {
-          "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
-          "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
-          "axisFamily": "semantic",
-          "contributionWeight": 1,
-          "contributionValue": 0,
-          "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
-          "witnessRefs": [
-            "semantic:path-rule:cache-repository-semantic-loop"
+            "p-value:projection-endpoints-orderview",
+            "p-value:projection-support-projection-homotopy-report-fixture",
+            "projection:homotopy-report-fixture",
+            "q-value:projection-endpoints-orderview",
+            "q-value:projection-support-projection-homotopy-report-fixture"
           ]
         },
         {
@@ -7332,7 +7480,11 @@
           "witnessRefs": [
             "atom:cache-read",
             "atom:event-projection",
-            "atom:repository-read"
+            "atom:repository-read",
+            "p-value:static-endpoints-orderview",
+            "p-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection",
+            "q-value:static-endpoints-orderview",
+            "q-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection"
           ]
         }
       ],
@@ -7371,15 +7523,13 @@
       ],
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
-      "defectValue": 2,
+      "defectValue": 1,
       "comparedTraceSummary": [
-        "p: effect continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0",
-        "q: effect continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0"
+        "p: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+        "q: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
       ],
       "affectedAtomRefs": [
-        "atom:event-projection",
-        "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-        "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+        "atom:event-projection"
       ],
       "lawRefs": [
         "law:homotopy-report-fixture"
@@ -7393,12 +7543,10 @@
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:event-projection",
-        "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-        "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+        "atom:event-projection"
       ],
       "missingEvidence": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "suggestedFillerEvidence": [
         "supply filler evidence for effect axis trace disagreement",
         "record whether the two continuation paths preserve selected observations"
@@ -7412,6 +7560,69 @@
       "recommendedReviewFocus": [
         "compare operation:project-order-event . operation:read-through-cache and operation:project-order-event . operation:read-from-repository before treating the operation pair as order-insensitive",
         "review effect axis witness refs and missing evidence"
+      ],
+      "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-semantic",
+      "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+      "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+      "operationPair": [
+        "operation:read-through-cache",
+        "operation:read-from-repository"
+      ],
+      "pathPair": [
+        "operation:project-order-event . operation:read-through-cache",
+        "operation:project-order-event . operation:read-from-repository"
+      ],
+      "axisFamily": "semantic",
+      "axisRef": "semantic axis",
+      "defectValue": 1,
+      "comparedTraceSummary": [
+        "p: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+        "q: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
+      ],
+      "affectedAtomRefs": [
+        "semantic:path-rule:cache-repository-semantic-loop"
+      ],
+      "lawRefs": [
+        "law:homotopy-report-fixture"
+      ],
+      "signatureAxisRefs": [
+        "sig-axis:homotopy-report-fixture"
+      ],
+      "sourceRefs": [
+        "src-cache-read",
+        "src-repository-read",
+        "test-homotopy-fillers"
+      ],
+      "observationRefs": [
+        "semantic:path-rule:cache-repository-semantic-loop"
+      ],
+      "missingEvidence": [],
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
+      "suggestedFillerEvidence": [
+        "supply filler evidence for semantic axis trace disagreement",
+        "record whether the two continuation paths preserve selected observations"
+      ],
+      "suggestedLiftingEvidence": [
+        "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+      ],
+      "suggestedBoundaryEvidence": [
+        "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+      ],
+      "recommendedReviewFocus": [
+        "compare operation:project-order-event . operation:read-through-cache and operation:project-order-event . operation:read-from-repository before treating the operation pair as order-insensitive",
+        "review semantic axis witness refs and missing evidence"
       ],
       "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
       "nonConclusions": [
@@ -7477,6 +7688,8 @@
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for contract",
+            "missing comparable q continuation value for contract",
             "missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
           ],
           "reading": "Hol_contract records boundary-local residual obstruction on the contract axis"
@@ -7484,9 +7697,11 @@
         {
           "holonomyAxisRef": "Hol_semantic",
           "axisFamily": "semantic",
-          "status": "coveredZeroResidual",
-          "residualValue": 0,
-          "measuredDefectRefs": [],
+          "status": "measuredResidual",
+          "residualValue": 1,
+          "measuredDefectRefs": [
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
+          ],
           "supportRefs": [
             "semantic:path-rule:cache-repository-semantic-loop"
           ],
@@ -7506,6 +7721,8 @@
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for state",
+            "missing comparable q continuation value for state",
             "missing state observation for operation-square:operation-square-evidence-cache-repository-read"
           ],
           "reading": "Hol_state records boundary-local residual obstruction on the state axis"
@@ -7514,14 +7731,12 @@
           "holonomyAxisRef": "Hol_effect",
           "axisFamily": "effect",
           "status": "measuredResidual",
-          "residualValue": 2,
+          "residualValue": 1,
           "measuredDefectRefs": [
             "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
           ],
           "supportRefs": [
-            "atom:event-projection",
-            "derived-effect-order:p:operation-project-order-event-operation-read-through-cache",
-            "derived-effect-order:q:operation-project-order-event-operation-read-from-repository"
+            "atom:event-projection"
           ],
           "missingEvidence": [],
           "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
@@ -7539,7 +7754,9 @@
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
-            "missing authority observation for operation-square:operation-square-evidence-cache-repository-read"
+            "missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+            "missing comparable p continuation value for authority",
+            "missing comparable q continuation value for authority"
           ],
           "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
         },
@@ -7556,6 +7773,8 @@
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for runtime",
+            "missing comparable q continuation value for runtime",
             "missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
           ],
           "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
@@ -7577,6 +7796,7 @@
         "gap:path-rule:authorization-bypass-hole:missing-policy-test",
         "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
         "obstruction:homotopy-report-fixture:computed",
         "split-readiness:molecule-homotopy-report-fixture"
       ],
@@ -7633,6 +7853,7 @@
             "gap:path-rule:authorization-bypass-hole:missing-policy-test",
             "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
             "obstruction:homotopy-report-fixture:computed",
             "split-readiness:molecule-homotopy-report-fixture"
           ],
@@ -7741,6 +7962,22 @@
           "complexityTransferRefs": [],
           "residualCoverageGapRefs": [],
           "reading": "mu:operation-square-operation-square-evidence-cache-repository-read:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+        },
+        {
+          "witnessRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+          "labels": [
+            "boundaryHolonomy"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [],
+          "residualCoverageGapRefs": [],
+          "reading": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
         },
         {
           "witnessRef": "obstruction:homotopy-report-fixture:computed",
@@ -7864,7 +8101,8 @@
     "weightPolicy": "unit weights until project-specific calibration is declared",
     "coveragePolicy": "coverage gaps block signature-zero and spectrum-zero reflection",
     "nonzeroMonodromyWitnessRefs": [
-      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect"
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect",
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-semantic"
     ],
     "featureBoundaryResidualRefs": [
       "feature-boundary-residual:homotopy-report-fixture-archmap"
@@ -9645,7 +9883,7 @@
     ],
     "transferBridgeEdgeSummary": [],
     "measurementExpansionSummary": [
-      "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
+      "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 2 nonzero monodromy witnesses"
     ],
     "atomSupportAxisSummary": [
       "homotopy-report-fixture-archmap support=5 concentration=maxAxisShare=2/6 pressure=mixedAxisPressurePresent",
@@ -9700,13 +9938,14 @@
       "split-readiness:molecule-homotopy-report-fixture transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
     ],
     "nonzeroMonodromyWitnessSummary": [
-      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect axis=effect defect=2 affectedAtoms=3 missingEvidence=0 focus=2"
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect axis=effect defect=1 affectedAtoms=1 missingEvidence=0 focus=2",
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-semantic axis=semantic defect=1 affectedAtoms=1 missingEvidence=0 focus=2"
     ],
     "featureBoundaryResidualSummary": [
-      "feature-boundary-residual:homotopy-report-fixture-archmap boundary=Boundary(homotopy-report-fixture-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=5"
+      "feature-boundary-residual:homotopy-report-fixture-archmap boundary=Boundary(homotopy-report-fixture-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=6"
     ],
     "featureExtensionDiagnosisSummary": [
-      "feature-extension-diagnosis:feature-extension-formula-homotopy-report-fixture-archmap status=multiLabelAttributed attributions=6 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
+      "feature-extension-diagnosis:feature-extension-formula-homotopy-report-fixture-archmap status=multiLabelAttributed attributions=7 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
     ],
     "representationStrengthSummary": [
       "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -5388,15 +5388,25 @@
           "axisFamily": "static",
           "axisRef": "static dependency / support axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
           "continuationSummary": "static continuation reads 2 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_static[0]=operation:route-create-user; refs=2",
-            "Cont_static[1]=operation:service-create-user; refs=2",
-            "Cont_static[endpoint]=p; endpointRefs=2"
+            "Cont_static[0]=operation:route-create-user; comparableValues=2",
+            "Cont_static[1]=operation:service-create-user; comparableValues=2",
+            "Cont_static[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "static:endpoints:route.users|service.user",
+            "static:support:atom-relation-route-service|atom-contract-create-user"
           ],
           "distanceInputRefs": [
+            "atom:contract:create-user",
             "atom:relation:route-service",
-            "atom:contract:create-user"
+            "route.users",
+            "service.user",
+            "src-route-users",
+            "src-service-user",
+            "test-user-contract"
           ],
           "observationRefs": [
             "atom:relation:route-service",
@@ -5414,14 +5424,22 @@
           "axisFamily": "contract",
           "axisRef": "contract axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
           "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_contract[0]=operation:route-create-user; refs=1",
-            "Cont_contract[1]=operation:service-create-user; refs=1",
-            "Cont_contract[endpoint]=p; endpointRefs=2"
+            "Cont_contract[0]=operation:route-create-user; comparableValues=2",
+            "Cont_contract[1]=operation:service-create-user; comparableValues=2",
+            "Cont_contract[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "contract:endpoints:route.users|service.user",
+            "contract:support:atom-contract-create-user"
           ],
           "distanceInputRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "route.users",
+            "service.user",
+            "test-user-contract"
           ],
           "observationRefs": [
             "atom:contract:create-user"
@@ -5436,14 +5454,23 @@
           "axisFamily": "semantic",
           "axisRef": "semantic axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
           "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_semantic[0]=operation:route-create-user; refs=1",
-            "Cont_semantic[1]=operation:service-create-user; refs=1",
-            "Cont_semantic[endpoint]=p; endpointRefs=2"
+            "Cont_semantic[0]=operation:route-create-user; comparableValues=2",
+            "Cont_semantic[1]=operation:service-create-user; comparableValues=2",
+            "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "semantic:path:p:operation:route-create-user -> operation:service-create-user",
+            "semantic:endpoints:route.users|service.user"
           ],
           "distanceInputRefs": [
-            "semantic:create-user-flow"
+            "doc-architecture",
+            "route.users",
+            "semantic:create-user-flow",
+            "service.user",
+            "test-user-contract"
           ],
           "observationRefs": [
             "semantic:create-user-flow"
@@ -5459,13 +5486,18 @@
           "axisFamily": "state",
           "axisRef": "state transition axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
           "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_state[0]=operation:route-create-user; refs=0",
-            "Cont_state[1]=operation:service-create-user; refs=0",
-            "Cont_state[endpoint]=p; endpointRefs=2"
+            "Cont_state[0]=operation:route-create-user; comparableValues=0",
+            "Cont_state[1]=operation:service-create-user; comparableValues=0",
+            "Cont_state[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "route.users",
+            "service.user"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5476,38 +5508,42 @@
         {
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
-          "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
+          "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+          "continuationSummary": "effect continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_effect[0]=operation:route-create-user; refs=1",
-            "Cont_effect[1]=operation:service-create-user; refs=1",
-            "Cont_effect[endpoint]=p; endpointRefs=2"
+            "Cont_effect[0]=operation:route-create-user; comparableValues=0",
+            "Cont_effect[1]=operation:service-create-user; comparableValues=0",
+            "Cont_effect[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
           ],
+          "comparableContinuationValues": [],
           "distanceInputRefs": [
-            "derived-effect-order:p:operation-service-create-user-operation-route-create-user"
+            "route.users",
+            "service.user"
           ],
-          "observationRefs": [
-            "derived-effect-order:p:operation-service-create-user-operation-route-create-user"
+          "observationRefs": [],
+          "sourceRefs": [],
+          "missingRefs": [
+            "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
           ],
-          "sourceRefs": [
-            "src-route-users",
-            "src-service-user",
-            "test-user-contract"
-          ],
-          "missingRefs": [],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
         {
           "axisFamily": "authority",
           "axisRef": "authority / trust boundary axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
           "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_authority[0]=operation:route-create-user; refs=0",
-            "Cont_authority[1]=operation:service-create-user; refs=0",
-            "Cont_authority[endpoint]=p; endpointRefs=2"
+            "Cont_authority[0]=operation:route-create-user; comparableValues=0",
+            "Cont_authority[1]=operation:service-create-user; comparableValues=0",
+            "Cont_authority[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "route.users",
+            "service.user"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5519,13 +5555,18 @@
           "axisFamily": "runtime",
           "axisRef": "runtime interaction axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
           "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_runtime[0]=operation:route-create-user; refs=0",
-            "Cont_runtime[1]=operation:service-create-user; refs=0",
-            "Cont_runtime[endpoint]=p; endpointRefs=2"
+            "Cont_runtime[0]=operation:route-create-user; comparableValues=0",
+            "Cont_runtime[1]=operation:service-create-user; comparableValues=0",
+            "Cont_runtime[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "route.users",
+            "service.user"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5537,15 +5578,24 @@
           "axisFamily": "projection",
           "axisRef": "projection / representation axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
           "continuationSummary": "projection continuation reads 2 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_projection[0]=operation:route-create-user; refs=2",
-            "Cont_projection[1]=operation:service-create-user; refs=2",
-            "Cont_projection[endpoint]=p; endpointRefs=2"
+            "Cont_projection[0]=operation:route-create-user; comparableValues=2",
+            "Cont_projection[1]=operation:service-create-user; comparableValues=2",
+            "Cont_projection[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "projection:endpoints:route.users|service.user",
+            "projection:support:projection-aat-route-service|projection-sft-create-user"
           ],
           "distanceInputRefs": [
+            "atom:relation:route-service",
             "projection:aat:route-service",
-            "projection:sft:create-user"
+            "projection:sft:create-user",
+            "route.users",
+            "semantic:create-user-flow",
+            "service.user"
           ],
           "observationRefs": [
             "projection:aat:route-service",
@@ -5608,15 +5658,25 @@
           "axisFamily": "static",
           "axisRef": "static dependency / support axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
           "continuationSummary": "static continuation reads 2 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_static[0]=operation:service-create-user; refs=2",
-            "Cont_static[1]=operation:route-create-user; refs=2",
-            "Cont_static[endpoint]=q; endpointRefs=2"
+            "Cont_static[0]=operation:service-create-user; comparableValues=2",
+            "Cont_static[1]=operation:route-create-user; comparableValues=2",
+            "Cont_static[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "static:endpoints:route.users|service.user",
+            "static:support:atom-relation-route-service|atom-contract-create-user"
           ],
           "distanceInputRefs": [
+            "atom:contract:create-user",
             "atom:relation:route-service",
-            "atom:contract:create-user"
+            "route.users",
+            "service.user",
+            "src-route-users",
+            "src-service-user",
+            "test-user-contract"
           ],
           "observationRefs": [
             "atom:relation:route-service",
@@ -5634,14 +5694,22 @@
           "axisFamily": "contract",
           "axisRef": "contract axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
           "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_contract[0]=operation:service-create-user; refs=1",
-            "Cont_contract[1]=operation:route-create-user; refs=1",
-            "Cont_contract[endpoint]=q; endpointRefs=2"
+            "Cont_contract[0]=operation:service-create-user; comparableValues=2",
+            "Cont_contract[1]=operation:route-create-user; comparableValues=2",
+            "Cont_contract[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "contract:endpoints:route.users|service.user",
+            "contract:support:atom-contract-create-user"
           ],
           "distanceInputRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "route.users",
+            "service.user",
+            "test-user-contract"
           ],
           "observationRefs": [
             "atom:contract:create-user"
@@ -5656,14 +5724,23 @@
           "axisFamily": "semantic",
           "axisRef": "semantic axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
           "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_semantic[0]=operation:service-create-user; refs=1",
-            "Cont_semantic[1]=operation:route-create-user; refs=1",
-            "Cont_semantic[endpoint]=q; endpointRefs=2"
+            "Cont_semantic[0]=operation:service-create-user; comparableValues=2",
+            "Cont_semantic[1]=operation:route-create-user; comparableValues=2",
+            "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "semantic:path:q:operation:service-create-user -> operation:route-create-user",
+            "semantic:endpoints:route.users|service.user"
           ],
           "distanceInputRefs": [
-            "semantic:create-user-flow"
+            "doc-architecture",
+            "route.users",
+            "semantic:create-user-flow",
+            "service.user",
+            "test-user-contract"
           ],
           "observationRefs": [
             "semantic:create-user-flow"
@@ -5679,13 +5756,18 @@
           "axisFamily": "state",
           "axisRef": "state transition axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
           "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_state[0]=operation:service-create-user; refs=0",
-            "Cont_state[1]=operation:route-create-user; refs=0",
-            "Cont_state[endpoint]=q; endpointRefs=2"
+            "Cont_state[0]=operation:service-create-user; comparableValues=0",
+            "Cont_state[1]=operation:route-create-user; comparableValues=0",
+            "Cont_state[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "route.users",
+            "service.user"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5696,38 +5778,42 @@
         {
           "axisFamily": "effect",
           "axisRef": "effect ordering / replay / compensation axis",
-          "traceStatus": "boundedObservationTrace",
-          "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
+          "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+          "continuationSummary": "effect continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_effect[0]=operation:service-create-user; refs=1",
-            "Cont_effect[1]=operation:route-create-user; refs=1",
-            "Cont_effect[endpoint]=q; endpointRefs=2"
+            "Cont_effect[0]=operation:service-create-user; comparableValues=0",
+            "Cont_effect[1]=operation:route-create-user; comparableValues=0",
+            "Cont_effect[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
           ],
+          "comparableContinuationValues": [],
           "distanceInputRefs": [
-            "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+            "route.users",
+            "service.user"
           ],
-          "observationRefs": [
-            "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+          "observationRefs": [],
+          "sourceRefs": [],
+          "missingRefs": [
+            "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
           ],
-          "sourceRefs": [
-            "src-route-users",
-            "src-service-user",
-            "test-user-contract"
-          ],
-          "missingRefs": [],
           "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
         },
         {
           "axisFamily": "authority",
           "axisRef": "authority / trust boundary axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
           "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_authority[0]=operation:service-create-user; refs=0",
-            "Cont_authority[1]=operation:route-create-user; refs=0",
-            "Cont_authority[endpoint]=q; endpointRefs=2"
+            "Cont_authority[0]=operation:service-create-user; comparableValues=0",
+            "Cont_authority[1]=operation:route-create-user; comparableValues=0",
+            "Cont_authority[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "route.users",
+            "service.user"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5739,13 +5825,18 @@
           "axisFamily": "runtime",
           "axisRef": "runtime interaction axis",
           "traceStatus": "unmeasured",
+          "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
           "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
           "continuationStates": [
-            "Cont_runtime[0]=operation:service-create-user; refs=0",
-            "Cont_runtime[1]=operation:route-create-user; refs=0",
-            "Cont_runtime[endpoint]=q; endpointRefs=2"
+            "Cont_runtime[0]=operation:service-create-user; comparableValues=0",
+            "Cont_runtime[1]=operation:route-create-user; comparableValues=0",
+            "Cont_runtime[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
           ],
-          "distanceInputRefs": [],
+          "comparableContinuationValues": [],
+          "distanceInputRefs": [
+            "route.users",
+            "service.user"
+          ],
           "observationRefs": [],
           "sourceRefs": [],
           "missingRefs": [
@@ -5757,15 +5848,24 @@
           "axisFamily": "projection",
           "axisRef": "projection / representation axis",
           "traceStatus": "boundedObservationTrace",
+          "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
           "continuationSummary": "projection continuation reads 2 observation ref(s) across 1 operation delta(s)",
           "continuationStates": [
-            "Cont_projection[0]=operation:service-create-user; refs=2",
-            "Cont_projection[1]=operation:route-create-user; refs=2",
-            "Cont_projection[endpoint]=q; endpointRefs=2"
+            "Cont_projection[0]=operation:service-create-user; comparableValues=2",
+            "Cont_projection[1]=operation:route-create-user; comparableValues=2",
+            "Cont_projection[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+          ],
+          "comparableContinuationValues": [
+            "projection:endpoints:route.users|service.user",
+            "projection:support:projection-aat-route-service|projection-sft-create-user"
           ],
           "distanceInputRefs": [
+            "atom:relation:route-service",
             "projection:aat:route-service",
-            "projection:sft:create-user"
+            "projection:sft:create-user",
+            "route.users",
+            "semantic:create-user-flow",
+            "service.user"
           ],
           "observationRefs": [
             "projection:aat:route-service",
@@ -5811,17 +5911,22 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "authority",
       "axisRef": "authority / trust boundary axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:authority-boundary-value-mismatch",
       "pContinuationRef": "Cont_authority(p):authority / trust boundary axis",
       "qContinuationRef": "Cont_authority(q):authority / trust boundary axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "route.users",
+        "service.user"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
-        "missing-evidence:missing authority observation for operation-square:operation-square-evidence-create-user-route-service"
+        "missing-evidence:missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+        "missing-evidence:missing comparable p continuation value for authority",
+        "missing-evidence:missing comparable q continuation value for authority"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -5830,9 +5935,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
-        "missing authority observation for operation-square:operation-square-evidence-create-user-route-service"
+        "missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+        "missing comparable p continuation value for authority",
+        "missing comparable q continuation value for authority"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5845,7 +5952,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5861,13 +5968,16 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "contract",
       "axisRef": "contract axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:contract-obligation-value-mismatch",
       "pContinuationRef": "Cont_contract(p):contract axis",
       "qContinuationRef": "Cont_contract(q):contract axis",
       "distanceInputRefs": [
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "route.users",
+        "service.user",
+        "test-user-contract"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -5875,7 +5985,11 @@
         "atom:contract:create-user"
       ],
       "witnessRefs": [
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "p-value:contract-endpoints-route-users-service-user",
+        "p-value:contract-support-atom-contract-create-user",
+        "q-value:contract-endpoints-route-users-service-user",
+        "q-value:contract-support-atom-contract-create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -5886,7 +6000,7 @@
         "atom:contract:create-user"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5899,7 +6013,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5915,36 +6029,35 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "effect",
       "axisRef": "effect ordering / replay / compensation axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:effect-replay-order-mismatch",
       "pContinuationRef": "Cont_effect(p):effect ordering / replay / compensation axis",
       "qContinuationRef": "Cont_effect(q):effect ordering / replay / compensation axis",
       "distanceInputRefs": [
-        "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-        "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+        "route.users",
+        "service.user"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-      "weight": 1,
-      "measurementStatus": "measured",
-      "distanceValue": 2,
-      "measuredSupportRefs": [
-        "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-        "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
-      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+      "weight": 0,
+      "measurementStatus": "unmeasured",
+      "distanceValue": null,
+      "measuredSupportRefs": [],
       "witnessRefs": [
-        "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-        "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+        "missing-evidence:missing comparable p continuation value for effect",
+        "missing-evidence:missing comparable q continuation value for effect",
+        "missing-evidence:missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
       ],
       "sourceRefs": [
         "src-route-users",
         "src-service-user",
         "test-user-contract"
       ],
-      "observationRefs": [
-        "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-        "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+      "observationRefs": [],
+      "missingRefs": [
+        "missing comparable p continuation value for effect",
+        "missing comparable q continuation value for effect",
+        "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
       ],
-      "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -5957,7 +6070,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -5973,14 +6086,18 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "projection",
       "axisRef": "projection / representation axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:projection-target-value-mismatch",
       "pContinuationRef": "Cont_projection(p):projection / representation axis",
       "qContinuationRef": "Cont_projection(q):projection / representation axis",
       "distanceInputRefs": [
+        "atom:relation:route-service",
         "projection:aat:route-service",
-        "projection:sft:create-user"
+        "projection:sft:create-user",
+        "route.users",
+        "semantic:create-user-flow",
+        "service.user"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -5989,8 +6106,12 @@
         "projection:sft:create-user"
       ],
       "witnessRefs": [
+        "p-value:projection-endpoints-route-users-service-user",
+        "p-value:projection-support-projection-aat-route-service-projection-sft-create-user",
         "projection:aat:route-service",
-        "projection:sft:create-user"
+        "projection:sft:create-user",
+        "q-value:projection-endpoints-route-users-service-user",
+        "q-value:projection-support-projection-aat-route-service-projection-sft-create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -6002,7 +6123,7 @@
         "projection:sft:create-user"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6015,7 +6136,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6031,16 +6152,21 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "runtime",
       "axisRef": "runtime interaction axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
       "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
       "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "route.users",
+        "service.user"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for runtime",
+        "missing-evidence:missing comparable q continuation value for runtime",
         "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
       ],
       "sourceRefs": [
@@ -6050,9 +6176,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for runtime",
+        "missing comparable q continuation value for runtime",
         "missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6065,7 +6193,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6081,20 +6209,28 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "semantic",
       "axisRef": "semantic axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:semantic-sequence-mismatch",
       "pContinuationRef": "Cont_semantic(p):semantic axis",
       "qContinuationRef": "Cont_semantic(q):semantic axis",
       "distanceInputRefs": [
-        "semantic:create-user-flow"
+        "doc-architecture",
+        "route.users",
+        "semantic:create-user-flow",
+        "service.user",
+        "test-user-contract"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
-      "distanceValue": 0,
+      "distanceValue": 1,
       "measuredSupportRefs": [
         "semantic:create-user-flow"
       ],
       "witnessRefs": [
+        "p-value:semantic-endpoints-route-users-service-user",
+        "p-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+        "q-value:semantic-endpoints-route-users-service-user",
+        "q-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
         "semantic:create-user-flow"
       ],
       "sourceRefs": [
@@ -6106,7 +6242,7 @@
         "semantic:create-user-flow"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6119,7 +6255,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6135,16 +6271,21 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "state",
       "axisRef": "state transition axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:state-transition-value-mismatch",
       "pContinuationRef": "Cont_state(p):state transition axis",
       "qContinuationRef": "Cont_state(q):state transition axis",
-      "distanceInputRefs": [],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "distanceInputRefs": [
+        "route.users",
+        "service.user"
+      ],
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 0,
       "measurementStatus": "unmeasured",
       "distanceValue": null,
       "measuredSupportRefs": [],
       "witnessRefs": [
+        "missing-evidence:missing comparable p continuation value for state",
+        "missing-evidence:missing comparable q continuation value for state",
         "missing-evidence:missing state observation for operation-square:operation-square-evidence-create-user-route-service"
       ],
       "sourceRefs": [
@@ -6154,9 +6295,11 @@
       ],
       "observationRefs": [],
       "missingRefs": [
+        "missing comparable p continuation value for state",
+        "missing comparable q continuation value for state",
         "missing state observation for operation-square:operation-square-evidence-create-user-route-service"
       ],
-      "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+      "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6169,7 +6312,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6185,14 +6328,19 @@
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "axisFamily": "static",
       "axisRef": "static dependency / support axis",
-      "distanceKind": "weighted-axis-l1",
+      "distanceKind": "weighted-axis-l1:static-support-value-mismatch",
       "pContinuationRef": "Cont_static(p):static dependency / support axis",
       "qContinuationRef": "Cont_static(q):static dependency / support axis",
       "distanceInputRefs": [
         "atom:contract:create-user",
-        "atom:relation:route-service"
+        "atom:relation:route-service",
+        "route.users",
+        "service.user",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
-      "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+      "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
       "weight": 1,
       "measurementStatus": "measured",
       "distanceValue": 0,
@@ -6202,7 +6350,11 @@
       ],
       "witnessRefs": [
         "atom:contract:create-user",
-        "atom:relation:route-service"
+        "atom:relation:route-service",
+        "p-value:static-endpoints-route-users-service-user",
+        "p-value:static-support-atom-relation-route-service-atom-contract-create-user",
+        "q-value:static-endpoints-route-users-service-user",
+        "q-value:static-support-atom-relation-route-service-atom-contract-create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -6214,7 +6366,7 @@
         "atom:relation:route-service"
       ],
       "missingRefs": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "exactnessAssumptionStatus": [
         "selected LawPolicy exactness assumptions",
         "ArchMapStore compaction boundary"
@@ -6227,7 +6379,7 @@
         "zero aggregate is not global path flatness"
       ],
       "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-      "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+      "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6255,7 +6407,6 @@
       ],
       "selectedMeasuredSquareRefs": [
         "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:contract",
-        "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:effect",
         "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:projection",
         "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
         "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:static"
@@ -6263,28 +6414,28 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "distanceKind": "weighted-axis-l1",
       "measurementStatus": "partial",
-      "aggregateValue": 2,
+      "aggregateValue": 1,
       "measuredDefectRefs": [
         "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
-        "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
         "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
         "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
         "mu:operation-square-operation-square-evidence-create-user-route-service:static"
       ],
       "unmeasuredDefectRefs": [
         "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
         "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
         "mu:operation-square-operation-square-evidence-create-user-route-service:state"
       ],
       "positiveWeightDefectRefs": [
         "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
-        "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
         "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
         "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
         "mu:operation-square-operation-square-evidence-create-user-route-service:static"
       ],
       "zeroWeightDefectRefs": [
         "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
         "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
         "mu:operation-square-operation-square-evidence-create-user-route-service:state"
       ],
@@ -6297,7 +6448,22 @@
           "contributionValue": null,
           "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
           "witnessRefs": [
-            "missing-evidence:missing authority observation for operation-square:operation-square-evidence-create-user-route-service"
+            "missing-evidence:missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+            "missing-evidence:missing comparable p continuation value for authority",
+            "missing-evidence:missing comparable q continuation value for authority"
+          ]
+        },
+        {
+          "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+          "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+          "axisFamily": "effect",
+          "contributionWeight": 1,
+          "contributionValue": null,
+          "reviewFocus": "supply missing effect trace evidence before interpreting AMI as zero",
+          "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for effect",
+            "missing-evidence:missing comparable q continuation value for effect",
+            "missing-evidence:missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
           ]
         },
         {
@@ -6308,6 +6474,8 @@
           "contributionValue": null,
           "reviewFocus": "supply missing runtime trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for runtime",
+            "missing-evidence:missing comparable q continuation value for runtime",
             "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
           ]
         },
@@ -6319,19 +6487,24 @@
           "contributionValue": null,
           "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
           "witnessRefs": [
+            "missing-evidence:missing comparable p continuation value for state",
+            "missing-evidence:missing comparable q continuation value for state",
             "missing-evidence:missing state observation for operation-square:operation-square-evidence-create-user-route-service"
           ]
         },
         {
-          "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+          "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
           "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
-          "axisFamily": "effect",
+          "axisFamily": "semantic",
           "contributionWeight": 1,
-          "contributionValue": 2,
-          "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+          "contributionValue": 1,
+          "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
-            "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-            "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+            "p-value:semantic-endpoints-route-users-service-user",
+            "p-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+            "q-value:semantic-endpoints-route-users-service-user",
+            "q-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+            "semantic:create-user-flow"
           ]
         },
         {
@@ -6342,7 +6515,11 @@
           "contributionValue": 0,
           "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "p-value:contract-endpoints-route-users-service-user",
+            "p-value:contract-support-atom-contract-create-user",
+            "q-value:contract-endpoints-route-users-service-user",
+            "q-value:contract-support-atom-contract-create-user"
           ]
         },
         {
@@ -6353,19 +6530,12 @@
           "contributionValue": 0,
           "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
+            "p-value:projection-endpoints-route-users-service-user",
+            "p-value:projection-support-projection-aat-route-service-projection-sft-create-user",
             "projection:aat:route-service",
-            "projection:sft:create-user"
-          ]
-        },
-        {
-          "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
-          "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
-          "axisFamily": "semantic",
-          "contributionWeight": 1,
-          "contributionValue": 0,
-          "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
-          "witnessRefs": [
-            "semantic:create-user-flow"
+            "projection:sft:create-user",
+            "q-value:projection-endpoints-route-users-service-user",
+            "q-value:projection-support-projection-aat-route-service-projection-sft-create-user"
           ]
         },
         {
@@ -6377,7 +6547,11 @@
           "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
           "witnessRefs": [
             "atom:contract:create-user",
-            "atom:relation:route-service"
+            "atom:relation:route-service",
+            "p-value:static-endpoints-route-users-service-user",
+            "p-value:static-support-atom-relation-route-service-atom-contract-create-user",
+            "q-value:static-endpoints-route-users-service-user",
+            "q-value:static-support-atom-relation-route-service-atom-contract-create-user"
           ]
         }
       ],
@@ -6404,8 +6578,8 @@
   ],
   "nonzeroMonodromyWitnesses": [
     {
-      "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-effect",
-      "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+      "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-semantic",
+      "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
       "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
       "operationPair": [
         "operation:route-create-user",
@@ -6415,16 +6589,15 @@
         "operation:service-create-user . operation:route-create-user",
         "operation:route-create-user . operation:service-create-user"
       ],
-      "axisFamily": "effect",
-      "axisRef": "effect ordering / replay / compensation axis",
-      "defectValue": 2,
+      "axisFamily": "semantic",
+      "axisRef": "semantic axis",
+      "defectValue": 1,
       "comparedTraceSummary": [
-        "p: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
-        "q: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
+        "p: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+        "q: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
       ],
       "affectedAtomRefs": [
-        "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-        "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+        "semantic:create-user-flow"
       ],
       "lawRefs": [
         "law:layer-respecting",
@@ -6440,13 +6613,12 @@
         "test-user-contract"
       ],
       "observationRefs": [
-        "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-        "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+        "semantic:create-user-flow"
       ],
       "missingEvidence": [],
-      "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+      "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
       "suggestedFillerEvidence": [
-        "supply filler evidence for effect axis trace disagreement",
+        "supply filler evidence for semantic axis trace disagreement",
         "record whether the two continuation paths preserve selected observations"
       ],
       "suggestedLiftingEvidence": [
@@ -6457,7 +6629,7 @@
       ],
       "recommendedReviewFocus": [
         "compare operation:service-create-user . operation:route-create-user and operation:route-create-user . operation:service-create-user before treating the operation pair as order-insensitive",
-        "review effect axis witness refs and missing evidence"
+        "review semantic axis witness refs and missing evidence"
       ],
       "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
       "nonConclusions": [
@@ -6526,9 +6698,11 @@
         {
           "holonomyAxisRef": "Hol_semantic",
           "axisFamily": "semantic",
-          "status": "coveredZeroResidual",
-          "residualValue": 0,
-          "measuredDefectRefs": [],
+          "status": "measuredResidual",
+          "residualValue": 1,
+          "measuredDefectRefs": [
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
+          ],
           "supportRefs": [
             "semantic:create-user-flow"
           ],
@@ -6548,6 +6722,8 @@
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for state",
+            "missing comparable q continuation value for state",
             "missing state observation for operation-square:operation-square-evidence-create-user-route-service"
           ],
           "reading": "Hol_state records boundary-local residual obstruction on the state axis"
@@ -6555,16 +6731,20 @@
         {
           "holonomyAxisRef": "Hol_effect",
           "axisFamily": "effect",
-          "status": "measuredResidual",
-          "residualValue": 2,
-          "measuredDefectRefs": [
-            "mu:operation-square-operation-square-evidence-create-user-route-service:effect"
-          ],
+          "status": "coverageBlocked",
+          "residualValue": 0,
+          "measuredDefectRefs": [],
           "supportRefs": [
-            "derived-effect-order:p:operation-service-create-user-operation-route-create-user",
-            "derived-effect-order:q:operation-route-create-user-operation-service-create-user"
+            "gap-runtime-user-db-trace",
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+            "obstruction:semantic-contract-mismatch:computed",
+            "split-readiness:molecule-user-request-responsibility"
           ],
-          "missingEvidence": [],
+          "missingEvidence": [
+            "missing comparable p continuation value for effect",
+            "missing comparable q continuation value for effect",
+            "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
+          ],
           "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
         },
         {
@@ -6580,7 +6760,9 @@
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
-            "missing authority observation for operation-square:operation-square-evidence-create-user-route-service"
+            "missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+            "missing comparable p continuation value for authority",
+            "missing comparable q continuation value for authority"
           ],
           "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
         },
@@ -6597,6 +6779,8 @@
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
+            "missing comparable p continuation value for runtime",
+            "missing comparable q continuation value for runtime",
             "missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
           ],
           "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
@@ -6618,7 +6802,7 @@
       "residualObstructionRefs": [
         "gap-runtime-user-db-trace",
         "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-        "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
         "obstruction:semantic-contract-mismatch:computed",
         "split-readiness:molecule-user-request-responsibility"
       ],
@@ -6677,7 +6861,7 @@
             "feature-boundary-residual:fixture-archmap-atom-observation",
             "gap-runtime-user-db-trace",
             "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-            "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
             "obstruction:semantic-contract-mismatch:computed",
             "split-readiness:molecule-user-request-responsibility"
           ],
@@ -6772,20 +6956,20 @@
           "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
         },
         {
-          "witnessRef": "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+          "witnessRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
           "labels": [
             "boundaryHolonomy"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
-            "mu:operation-square-operation-square-evidence-create-user-route-service:effect"
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
           ],
           "liftingFailureRefs": [],
           "fillingFailureRefs": [],
           "complexityTransferRefs": [],
           "residualCoverageGapRefs": [],
-          "reading": "mu:operation-square-operation-square-evidence-create-user-route-service:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          "reading": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
         },
         {
           "witnessRef": "obstruction:semantic-contract-mismatch:computed",
@@ -6914,7 +7098,7 @@
     "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
     "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
     "nonzeroMonodromyWitnessRefs": [
-      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-effect"
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-semantic"
     ],
     "featureBoundaryResidualRefs": [
       "feature-boundary-residual:fixture-archmap-atom-observation"
@@ -8724,7 +8908,7 @@
       "split-readiness:molecule-user-request-responsibility transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
     ],
     "nonzeroMonodromyWitnessSummary": [
-      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-effect axis=effect defect=2 affectedAtoms=2 missingEvidence=0 focus=2"
+      "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-semantic axis=semantic defect=1 affectedAtoms=1 missingEvidence=0 focus=2"
     ],
     "featureBoundaryResidualSummary": [
       "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=5"


### PR DESCRIPTION
## 概要

Closes #1596

`Cont_x(p)` / `mu_x` を、coupon 専用 marker と observation ref symmetric difference から、axis family ごとの bounded distance evaluator に置き換えました。

- axis trace に `distanceEvaluatorKind` と `comparableContinuationValues` を追加
- LawPolicy の `distanceKind` と axis family から evaluator kind を dispatch
- semantic / effect / state / runtime は ordered continuation value を比較
- static / contract / authority / projection は endpoint/support comparable value を比較
- comparable input が欠ける場合は missing refs を残し、unmeasured として扱う
- coupon fixture は hard-coded `derived-semantic-order:*` なしで semantic / effect nonzero defect を出す

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`
- `tools/archsig/skills/archmap-creater/references/prompt-pack.md`
- `tools/archsig/skills/law-policy-creater/references/schema-guide.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `tooling implementation / docs tracking` として扱い、定理追加なしを明記した
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
