### PR TITLE
ArchSig reading family statusを実測化

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -371,12 +371,11 @@ The builder:
   `archmap-index-v0`. It also records raw-diff and compaction boundaries so
   review readers can distinguish change-local evidence from snapshot-level
   current-state evidence.
-- `monodromyReadingFamily` and `boundaryHolonomyReadingFamily` are schema
-  foundation surfaces. They carry selected axes, distance kind, weight policy,
-  coverage policy, and the ArchMapStore ref set used by later operation-square,
-  axis-wise defect, AMI, boundary residual, and feature-extension attribution
-  readings. They define the shared measurement policy boundary while concrete
-  valuation fields live in the corresponding reading records.
+- `monodromyReadingFamily` and `boundaryHolonomyReadingFamily` carry
+  evidence-derived status, not just schema presence. Their `status` is derived
+  from measured axis count, unmeasured axis count, positive witness count, and
+  coverage blocker count. `schemaFoundationOnly` means the family has no
+  measurable inputs yet and must not be read as completed measurement.
 - `operationSquareCandidates` enumerates supplied, inferred, or blocked
   operation pairs as path pairs `p = g . f` and `q = f . g`. Supplied
   candidates are read from first-class ArchMap `operationSquareEvidence[]` and

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -625,12 +625,43 @@ fn build_monodromy_reading_family(
     axis_wise_monodromy_defects: &[ArchSigAxisWiseMonodromyDefectV0],
     ami_aggregate_readings: &[ArchSigAmiAggregateReadingV0],
 ) -> ArchSigMonodromyReadingFamilyV0 {
+    let measured_axis_count = axis_wise_monodromy_defects
+        .iter()
+        .filter(|defect| defect.measurement_status == "measured")
+        .count();
+    let unmeasured_axis_count = axis_wise_monodromy_defects
+        .iter()
+        .filter(|defect| defect.measurement_status != "measured")
+        .count();
+    let positive_witness_count = axis_wise_monodromy_defects
+        .iter()
+        .filter(|defect| defect.distance_value.is_some_and(|value| value > 0))
+        .count();
+    let coverage_blocker_count = axis_wise_monodromy_defects
+        .iter()
+        .map(|defect| defect.missing_refs.len())
+        .sum::<usize>()
+        + operation_square_candidates
+            .iter()
+            .filter(|candidate| candidate.candidate_source == "blocked")
+            .count();
+    let status = reading_family_status(
+        measured_axis_count,
+        unmeasured_axis_count,
+        positive_witness_count,
+        coverage_blocker_count,
+        !operation_square_candidates.is_empty() || !path_continuation_traces.is_empty(),
+    );
     ArchSigMonodromyReadingFamilyV0 {
         reading_family_id: format!(
             "monodromy-reading-family:{}",
             stable_id(&law_policy.measurement_policy.policy_id)
         ),
-        status: "schemaFoundationOnly".to_string(),
+        status,
+        measured_axis_count,
+        unmeasured_axis_count,
+        positive_witness_count,
+        coverage_blocker_count,
         arch_map_store_ref_set_ref: arch_map_store_refs.ref_set_id.clone(),
         selected_axis_refs: law_policy.measurement_policy.selected_axis_refs.clone(),
         distance_kind: law_policy.measurement_policy.distance_kind.clone(),
@@ -670,12 +701,49 @@ fn build_boundary_holonomy_reading_family(
     feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
     feature_extension_diagnosis_readings: &[ArchSigFeatureExtensionDiagnosisReadingV0],
 ) -> ArchSigBoundaryHolonomyReadingFamilyV0 {
+    let measured_axis_count = feature_boundary_residual_readings
+        .iter()
+        .flat_map(|reading| reading.holonomy_axes.iter())
+        .filter(|axis| axis.status != "coverageBlocked")
+        .count();
+    let unmeasured_axis_count = feature_boundary_residual_readings
+        .iter()
+        .flat_map(|reading| reading.holonomy_axes.iter())
+        .filter(|axis| axis.status == "coverageBlocked")
+        .count();
+    let positive_witness_count = nonzero_monodromy_witnesses.len()
+        + feature_boundary_residual_readings
+            .iter()
+            .flat_map(|reading| reading.holonomy_axes.iter())
+            .filter(|axis| axis.residual_value > 0)
+            .count();
+    let coverage_blocker_count = feature_boundary_residual_readings
+        .iter()
+        .flat_map(|reading| reading.holonomy_axes.iter())
+        .map(|axis| axis.missing_evidence.len())
+        .sum::<usize>()
+        + feature_extension_diagnosis_readings
+            .iter()
+            .map(|reading| reading.residual_coverage_gap_refs.len())
+            .sum::<usize>();
+    let status = reading_family_status(
+        measured_axis_count,
+        unmeasured_axis_count,
+        positive_witness_count,
+        coverage_blocker_count,
+        !feature_boundary_residual_readings.is_empty()
+            || !feature_extension_diagnosis_readings.is_empty(),
+    );
     ArchSigBoundaryHolonomyReadingFamilyV0 {
         reading_family_id: format!(
             "boundary-holonomy-reading-family:{}",
             stable_id(&law_policy.measurement_policy.policy_id)
         ),
-        status: "schemaFoundationOnly".to_string(),
+        status,
+        measured_axis_count,
+        unmeasured_axis_count,
+        positive_witness_count,
+        coverage_blocker_count,
         arch_map_store_ref_set_ref: arch_map_store_refs.ref_set_id.clone(),
         selected_axis_refs: law_policy.measurement_policy.selected_axis_refs.clone(),
         distance_kind: law_policy.measurement_policy.distance_kind.clone(),
@@ -704,6 +772,28 @@ fn build_boundary_holonomy_reading_family(
                 .to_string(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
+}
+
+fn reading_family_status(
+    measured_axis_count: usize,
+    unmeasured_axis_count: usize,
+    positive_witness_count: usize,
+    coverage_blocker_count: usize,
+    has_family_inputs: bool,
+) -> String {
+    if !has_family_inputs {
+        return "schemaFoundationOnly".to_string();
+    }
+    if measured_axis_count == 0 {
+        return "blockedByCoverageGap".to_string();
+    }
+    if coverage_blocker_count > 0 || unmeasured_axis_count > 0 {
+        return "partial".to_string();
+    }
+    if positive_witness_count > 0 {
+        return "measured".to_string();
+    }
+    "measuredZeroUnderSelectedAxes".to_string()
 }
 
 fn build_operation_square_candidates(
@@ -15034,6 +15124,10 @@ fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) 
         &packet.monodromy_reading_family.distance_kind,
         &packet.monodromy_reading_family.weight_policy,
         &packet.monodromy_reading_family.coverage_policy,
+        packet.monodromy_reading_family.measured_axis_count,
+        packet.monodromy_reading_family.unmeasured_axis_count,
+        packet.monodromy_reading_family.positive_witness_count,
+        packet.monodromy_reading_family.coverage_blocker_count,
         &packet.monodromy_reading_family.reading_boundary,
         &packet.monodromy_reading_family.evidence_boundary,
         &packet.monodromy_reading_family.non_conclusions,
@@ -15052,6 +15146,16 @@ fn check_monodromy_boundary_schema_foundation(packet: &ArchSigAnalysisPacketV0) 
         &packet.boundary_holonomy_reading_family.distance_kind,
         &packet.boundary_holonomy_reading_family.weight_policy,
         &packet.boundary_holonomy_reading_family.coverage_policy,
+        packet.boundary_holonomy_reading_family.measured_axis_count,
+        packet
+            .boundary_holonomy_reading_family
+            .unmeasured_axis_count,
+        packet
+            .boundary_holonomy_reading_family
+            .positive_witness_count,
+        packet
+            .boundary_holonomy_reading_family
+            .coverage_blocker_count,
         &packet.boundary_holonomy_reading_family.reading_boundary,
         &packet.boundary_holonomy_reading_family.evidence_boundary,
         &packet.boundary_holonomy_reading_family.non_conclusions,
@@ -15088,6 +15192,10 @@ fn check_monodromy_family(
     distance_kind: &str,
     weight_policy: &str,
     coverage_policy: &str,
+    measured_axis_count: usize,
+    unmeasured_axis_count: usize,
+    positive_witness_count: usize,
+    coverage_blocker_count: usize,
     reading_boundary: &str,
     evidence_boundary: &str,
     non_conclusions: &[String],
@@ -15101,6 +15209,44 @@ fn check_monodromy_family(
         reading_family_id,
     );
     push_blank(examples, &format!("{field}.status"), status);
+    if status == "schemaFoundationOnly" {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            status,
+            "reading family still has schema-only status; measured, partial, or blocked status must be derived from evidence counts",
+        ));
+    }
+    if !matches!(
+        status,
+        "measured" | "partial" | "blockedByCoverageGap" | "measuredZeroUnderSelectedAxes"
+    ) {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            status,
+            "reading family status must be evidence-derived",
+        ));
+    }
+    if measured_axis_count == 0 && status != "blockedByCoverageGap" {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            "measuredAxisCount",
+            "status must be blocked when no measured axes exist",
+        ));
+    }
+    if status == "measured" && (positive_witness_count == 0 || coverage_blocker_count > 0) {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            "positiveWitnessCount/coverageBlockerCount",
+            "measured status requires positive witnesses and no coverage blockers",
+        ));
+    }
+    if status == "partial" && unmeasured_axis_count == 0 && coverage_blocker_count == 0 {
+        examples.push(generic_validation_example(
+            reading_family_id,
+            "unmeasuredAxisCount/coverageBlockerCount",
+            "partial status must be backed by unmeasured axes or coverage blockers",
+        ));
+    }
     if arch_map_store_ref_set_ref != expected_ref_set_id {
         examples.push(generic_validation_example(
             reading_family_id,

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -674,6 +674,8 @@ fn build_codebase_inspection_report(
                 "operationIndexKeys": object_keys(index, "operationHintIndex", limit),
                 "operationSquareCandidateCount": array_len(packet, "operationSquareCandidates"),
                 "pathContinuationTraceCount": array_len(packet, "pathContinuationTraces"),
+                "monodromyFamilyStatus": reading_family_status_summary(packet, "monodromyReadingFamily"),
+                "boundaryHolonomyFamilyStatus": reading_family_status_summary(packet, "boundaryHolonomyReadingFamily"),
                 "summary": limited_array_field(llm_packet, "homotopyOrderSensitivitySummary", limit)
             },
             "topBoundaryHolonomy": top_boundary_holonomy(packet, limit),
@@ -2518,6 +2520,8 @@ fn measurement_basis(
             "analysis": validation_result(analysis_validation)
         },
         "coverageGaps": json_string_array(coverage_gap_refs(packet).iter()),
+        "monodromyFamily": reading_family_status_summary(packet, "monodromyReadingFamily"),
+        "boundaryHolonomyFamily": reading_family_status_summary(packet, "boundaryHolonomyReadingFamily"),
         "spectrumMeasuredBoundary": json_field(spectrum, "measuredBoundary"),
         "homotopyMeasuredBoundary": json_field(homotopy, "measuredBoundary"),
         "projectionFidelityBoundary": first_string_field(packet, "observationProjectionFidelityReadings", "measurementBoundary"),
@@ -2527,6 +2531,20 @@ fn measurement_basis(
         "operationPreconditionBoundary": first_string_field(packet, "operationPreconditionReadinessReadings", "candidateBoundary"),
         "pathMultiplicityBoundary": first_string_field(packet, "pathMultiplicityLossReadings", "homotopyBoundary"),
         "basisStatement": "conclusions are measured from the supplied ArchMap and selected LawPolicy"
+    })
+}
+
+fn reading_family_status_summary(
+    packet: &serde_json::Value,
+    family_key: &str,
+) -> serde_json::Value {
+    let family = packet.get(family_key).unwrap_or(&serde_json::Value::Null);
+    serde_json::json!({
+        "status": json_field(family, "status"),
+        "measuredAxisCount": json_field(family, "measuredAxisCount"),
+        "unmeasuredAxisCount": json_field(family, "unmeasuredAxisCount"),
+        "positiveWitnessCount": json_field(family, "positiveWitnessCount"),
+        "coverageBlockerCount": json_field(family, "coverageBlockerCount")
     })
 }
 

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -1170,6 +1170,14 @@ pub struct ArchSigArchMapStoreRefsV0 {
 pub struct ArchSigMonodromyReadingFamilyV0 {
     pub reading_family_id: String,
     pub status: String,
+    #[serde(default)]
+    pub measured_axis_count: usize,
+    #[serde(default)]
+    pub unmeasured_axis_count: usize,
+    #[serde(default)]
+    pub positive_witness_count: usize,
+    #[serde(default)]
+    pub coverage_blocker_count: usize,
     pub arch_map_store_ref_set_ref: String,
     pub selected_axis_refs: Vec<String>,
     pub distance_kind: String,
@@ -1190,6 +1198,14 @@ pub struct ArchSigMonodromyReadingFamilyV0 {
 pub struct ArchSigBoundaryHolonomyReadingFamilyV0 {
     pub reading_family_id: String,
     pub status: String,
+    #[serde(default)]
+    pub measured_axis_count: usize,
+    #[serde(default)]
+    pub unmeasured_axis_count: usize,
+    #[serde(default)]
+    pub positive_witness_count: usize,
+    #[serde(default)]
+    pub coverage_blocker_count: usize,
     pub arch_map_store_ref_set_ref: String,
     pub selected_axis_refs: Vec<String>,
     pub distance_kind: String,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2922,6 +2922,9 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "ArchMapStore refs must expose delta / commit / snapshot / index and raw-diff exclusion boundary"
     );
     for family in ["monodromyReadingFamily", "boundaryHolonomyReadingFamily"] {
+        let family_status = json[family]["status"].as_str();
+        let measured_axis_count = json[family]["measuredAxisCount"].as_u64();
+        let coverage_blocker_count = json[family]["coverageBlockerCount"].as_u64();
         assert!(
             json[family]["archMapStoreRefSetRef"] == json["archMapStoreRefs"]["refSetId"]
                 && json[family]["selectedAxisRefs"]
@@ -2930,8 +2933,16 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                 && json[family]["distanceKind"].as_str().is_some()
                 && json[family]["weightPolicy"].as_str().is_some()
                 && json[family]["coveragePolicy"].as_str().is_some()
+                && family_status.is_some_and(|status| status != "schemaFoundationOnly")
+                && measured_axis_count.is_some()
+                && json[family]["unmeasuredAxisCount"].as_u64().is_some()
+                && json[family]["positiveWitnessCount"].as_u64().is_some()
+                && coverage_blocker_count.is_some()
+                && (measured_axis_count.is_some_and(|count| count > 0)
+                    || (family_status == Some("blockedByCoverageGap")
+                        && coverage_blocker_count.is_some_and(|count| count > 0)))
                 && json[family]["evidenceBoundary"].as_str().is_some(),
-            "{family} must connect to ArchMapStore refs and carry measurement policy"
+            "{family} must connect to ArchMapStore refs and carry evidence-derived status counts"
         );
     }
     assert!(

--- a/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
@@ -8049,7 +8049,11 @@
   ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-homotopy-report-fixture",
-    "status": "schemaFoundationOnly",
+    "status": "partial",
+    "measuredAxisCount": 4,
+    "unmeasuredAxisCount": 4,
+    "positiveWitnessCount": 2,
+    "coverageBlockerCount": 12,
     "archMapStoreRefSetRef": "archmap-store-refs:homotopy-report-fixture-archmap",
     "selectedAxisRefs": [
       "axis:homotopy-report-fixture"
@@ -8092,7 +8096,11 @@
   },
   "boundaryHolonomyReadingFamily": {
     "readingFamilyId": "boundary-holonomy-reading-family:measurement-homotopy-report-fixture",
-    "status": "schemaFoundationOnly",
+    "status": "partial",
+    "measuredAxisCount": 4,
+    "unmeasuredAxisCount": 4,
+    "positiveWitnessCount": 4,
+    "coverageBlockerCount": 13,
     "archMapStoreRefSetRef": "archmap-store-refs:homotopy-report-fixture-archmap",
     "selectedAxisRefs": [
       "axis:homotopy-report-fixture"

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -7044,7 +7044,11 @@
   ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-    "status": "schemaFoundationOnly",
+    "status": "partial",
+    "measuredAxisCount": 4,
+    "unmeasuredAxisCount": 4,
+    "positiveWitnessCount": 1,
+    "coverageBlockerCount": 12,
     "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
     "selectedAxisRefs": [
       "axis:layer-violation",
@@ -7088,7 +7092,11 @@
   },
   "boundaryHolonomyReadingFamily": {
     "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-    "status": "schemaFoundationOnly",
+    "status": "partial",
+    "measuredAxisCount": 4,
+    "unmeasuredAxisCount": 4,
+    "positiveWitnessCount": 2,
+    "coverageBlockerCount": 13,
     "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
     "selectedAxisRefs": [
       "axis:layer-violation",


### PR DESCRIPTION
## 概要

Closes #1594

`monodromyReadingFamily` と `boundaryHolonomyReadingFamily` を、単なる `schemaFoundationOnly` surface ではなく、実測入力から `status` と根拠 count を導く reading family に更新しました。

- measured / unmeasured axis count、positive witness count、coverage blocker count を schema と builder に追加
- `schemaFoundationOnly` のままの family を validation で完了扱いにしない退行検出を追加
- analysis summary / codebase inspection summary に family status compact reading を追加
- minimal / homotopy_report fixture を再生成し、両方で `partial` status と根拠 count が出ることを確認

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `tooling implementation / docs tracking` として扱った
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
