### PR TITLE
Feature Extensionをwitness attribution化

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -419,13 +419,15 @@ The builder:
   machine-readable non-conclusions. It does not claim an unconditional
   `Ob(B) = Ob(A) + Ob(f) + Hol(Boundary(A,f))` theorem or decide feature
   safety.
-- `featureExtensionDiagnosisReadings` classifies feature-extension witnesses
-  with non-disjoint multi-label attribution. The seven labels are inherited core
-  obstruction, feature-local obstruction, boundary holonomy, lifting failure,
-  filling failure, complexity transfer, and residual coverage gap. A single
-  witness can carry multiple labels; the classifier records this as review
-  attribution, not as a mutually disjoint decomposition, and keeps the ArchSig /
-  FieldSig boundary explicit.
+- `featureExtensionFormulaReadings` and `featureExtensionDiagnosisReadings`
+  classify feature-extension witnesses with non-disjoint multi-label
+  attribution. The seven labels are inherited core obstruction, feature-local
+  obstruction, boundary holonomy, lifting failure, filling failure, complexity
+  transfer, and residual coverage gap. Formula readings retain `witnessBasis`
+  entries with observation and source refs; diagnosis records carry those refs
+  into witness-level attribution. The classifier records review attribution, not
+  a mutually disjoint decomposition, and keeps the ArchSig / FieldSig boundary
+  explicit.
 - axis-forgetting risk records when a coarse observation projection has
   forgotten selected axes or collapsed mixed-axis support. It blocks
   `ZeroReflecting` and `ObstructionReflecting` readings unless explicit axis

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -33,28 +33,28 @@ use crate::{
     ArchSigEvolutionRiskRankingV0, ArchSigFeatureBoundaryResidualReadingV0,
     ArchSigFeatureExtensionAxisSummaryV0, ArchSigFeatureExtensionDiagnosisReadingV0,
     ArchSigFeatureExtensionFormulaReadingV0, ArchSigFeatureExtensionWitnessAttributionV0,
-    ArchSigFillerCandidateReadingV0, ArchSigFlatnessReadingV0, ArchSigHighOverlapMoleculePairV0,
-    ArchSigHomotopyAggregateReadingV0, ArchSigHomotopyCellSummaryV0,
-    ArchSigHomotopyComplexSummaryV0, ArchSigHomotopyHolonomyReadingV0,
-    ArchSigHomotopyOrderSensitivityReadingV0, ArchSigInvariantFamilyReadingV0,
-    ArchSigLawUniverseCoverageReadingV0, ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0,
-    ArchSigLlmInterpretationPacketV0, ArchSigLocalCurvatureDiagramReadingV0,
-    ArchSigLoopCandidateV0, ArchSigMeasurementReadingBoundaryV0, ArchSigMoleculeReadingV0,
-    ArchSigMonodromyReadingFamilyV0, ArchSigNonzeroMonodromyWitnessV0,
-    ArchSigObservationProjectionFidelityReadingV0, ArchSigObservationProjectionReadingV0,
-    ArchSigObstructionCircuitV0, ArchSigOperationCalculusLawReadingV0,
-    ArchSigOperationDeltaReadingV0, ArchSigOperationInvariantGaloisReadingV0,
-    ArchSigOperationPreconditionReadinessReadingV0, ArchSigOperationSquareCandidateV0,
-    ArchSigPathContinuationTraceV0, ArchSigPathHomotopyDiagramReadingV0,
-    ArchSigPathMultiplicityLossReadingV0, ArchSigPathPairCandidateV0,
-    ArchSigPathSignatureTrajectoryReadingV0, ArchSigRecurrentObstructionModeV0,
-    ArchSigRepairAxisDeltaReadingV0, ArchSigRepairOperationCandidateV0,
-    ArchSigRepairTransferRiskRankV0, ArchSigRepresentationStrengthReadingV0,
-    ArchSigSignatureAxisReadingV0, ArchSigSignatureTrajectoryHomotopyRefutationReadingV0,
-    ArchSigSpectralAnalysisReadingV0, ArchSigSpectralDominantComponentV0,
-    ArchSigSpectralDrilldownReadingV0, ArchSigSpectralMatrixShapeV0,
-    ArchSigSpectralModeComponentV0, ArchSigSpectralModeReadingV0, ArchSigSpectralValueV0,
-    ArchSigSplitReadinessReadingV0, ArchSigStateTransitionAlgebraReadingV0,
+    ArchSigFeatureExtensionWitnessBasisV0, ArchSigFillerCandidateReadingV0,
+    ArchSigFlatnessReadingV0, ArchSigHighOverlapMoleculePairV0, ArchSigHomotopyAggregateReadingV0,
+    ArchSigHomotopyCellSummaryV0, ArchSigHomotopyComplexSummaryV0,
+    ArchSigHomotopyHolonomyReadingV0, ArchSigHomotopyOrderSensitivityReadingV0,
+    ArchSigInvariantFamilyReadingV0, ArchSigLawUniverseCoverageReadingV0,
+    ArchSigLawUniverseReadingV0, ArchSigLayerSplitV0, ArchSigLlmInterpretationPacketV0,
+    ArchSigLocalCurvatureDiagramReadingV0, ArchSigLoopCandidateV0,
+    ArchSigMeasurementReadingBoundaryV0, ArchSigMoleculeReadingV0, ArchSigMonodromyReadingFamilyV0,
+    ArchSigNonzeroMonodromyWitnessV0, ArchSigObservationProjectionFidelityReadingV0,
+    ArchSigObservationProjectionReadingV0, ArchSigObstructionCircuitV0,
+    ArchSigOperationCalculusLawReadingV0, ArchSigOperationDeltaReadingV0,
+    ArchSigOperationInvariantGaloisReadingV0, ArchSigOperationPreconditionReadinessReadingV0,
+    ArchSigOperationSquareCandidateV0, ArchSigPathContinuationTraceV0,
+    ArchSigPathHomotopyDiagramReadingV0, ArchSigPathMultiplicityLossReadingV0,
+    ArchSigPathPairCandidateV0, ArchSigPathSignatureTrajectoryReadingV0,
+    ArchSigRecurrentObstructionModeV0, ArchSigRepairAxisDeltaReadingV0,
+    ArchSigRepairOperationCandidateV0, ArchSigRepairTransferRiskRankV0,
+    ArchSigRepresentationStrengthReadingV0, ArchSigSignatureAxisReadingV0,
+    ArchSigSignatureTrajectoryHomotopyRefutationReadingV0, ArchSigSpectralAnalysisReadingV0,
+    ArchSigSpectralDominantComponentV0, ArchSigSpectralDrilldownReadingV0,
+    ArchSigSpectralMatrixShapeV0, ArchSigSpectralModeComponentV0, ArchSigSpectralModeReadingV0,
+    ArchSigSpectralValueV0, ArchSigSplitReadinessReadingV0, ArchSigStateTransitionAlgebraReadingV0,
     ArchSigStokesStyleReadingV0, ArchSigStructuralReadingReviewSurfaceV0,
     ArchSigSubjectFamilySpreadV0, ArchSigSynthesisBlockageReadingV0,
     ArchSigThreeLayerFlatnessReadingV0, ArchSigTransferBridgeReadingV0,
@@ -319,6 +319,7 @@ pub fn build_archsig_analysis_packet(
         &axis_wise_monodromy_defects,
     );
     let feature_extension_diagnosis_readings = build_feature_extension_diagnosis_readings(
+        archmap,
         &feature_extension_formula_readings,
         &feature_boundary_residual_readings,
     );
@@ -1918,6 +1919,7 @@ fn boundary_holonomy_axis_residuals(
 }
 
 fn build_feature_extension_diagnosis_readings(
+    archmap: &ArchMapDocumentV0,
     feature_extension_formula_readings: &[ArchSigFeatureExtensionFormulaReadingV0],
     feature_boundary_residual_readings: &[ArchSigFeatureBoundaryResidualReadingV0],
 ) -> Vec<ArchSigFeatureExtensionDiagnosisReadingV0> {
@@ -1927,6 +1929,11 @@ fn build_feature_extension_diagnosis_readings(
             let boundary_residual = feature_boundary_residual_readings
                 .iter()
                 .find(|reading| reading.feature_extension_ref == formula.reading_id);
+            let witness_basis = formula
+                .witness_basis
+                .iter()
+                .map(|basis| (basis.witness_ref.as_str(), basis))
+                .collect::<BTreeMap<_, _>>();
             let mut attributions = BTreeMap::<String, ArchSigFeatureExtensionWitnessAttributionV0>::new();
 
             for witness_ref in &formula.inherited_core_obstruction_refs {
@@ -1988,7 +1995,29 @@ fn build_feature_extension_diagnosis_readings(
 
             let mut attribution_records = attributions.into_values().collect::<Vec<_>>();
             for record in &mut attribution_records {
+                if let Some(basis) = witness_basis.get(record.witness_ref.as_str()) {
+                    record.observation_refs
+                        .extend(basis.observation_refs.iter().cloned());
+                    record.source_refs.extend(basis.source_refs.iter().cloned());
+                }
+                if let Some(boundary_residual) = boundary_residual {
+                    if record
+                        .boundary_holonomy_refs
+                        .iter()
+                        .any(|witness_ref| witness_ref == &record.witness_ref)
+                    {
+                        record
+                            .observation_refs
+                            .extend(boundary_residual.residual_obstruction_refs.iter().cloned());
+                    }
+                }
+                if record.source_refs.is_empty() && !record.observation_refs.is_empty() {
+                    record.source_refs =
+                        source_refs_for_observation_refs(archmap, &record.observation_refs);
+                }
                 record.labels = unique_strings(record.labels.drain(..));
+                record.observation_refs = unique_strings(record.observation_refs.drain(..));
+                record.source_refs = unique_strings(record.source_refs.drain(..));
                 record.inherited_core_refs = unique_strings(record.inherited_core_refs.drain(..));
                 record.feature_local_refs = unique_strings(record.feature_local_refs.drain(..));
                 record.boundary_holonomy_refs =
@@ -2058,6 +2087,8 @@ fn push_feature_extension_attribution(
         .or_insert_with(|| ArchSigFeatureExtensionWitnessAttributionV0 {
             witness_ref: witness_ref.to_string(),
             labels: Vec::new(),
+            observation_refs: Vec::new(),
+            source_refs: Vec::new(),
             inherited_core_refs: Vec::new(),
             feature_local_refs: Vec::new(),
             boundary_holonomy_refs: Vec::new(),
@@ -6928,49 +6959,185 @@ fn build_feature_extension_formula_readings(
     repair_candidates: &[ArchSigRepairOperationCandidateV0],
     split_readiness_readings: &[ArchSigSplitReadinessReadingV0],
 ) -> Vec<ArchSigFeatureExtensionFormulaReadingV0> {
+    let semantic_atom_refs = archmap
+        .semantic_observations
+        .iter()
+        .flat_map(|semantic| semantic.atom_observation_refs.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let obstruction_observation_refs_by_id = obstruction_circuits
+        .iter()
+        .map(|obstruction| {
+            let refs = unique_strings(
+                obstruction
+                    .atom_observation_refs
+                    .iter()
+                    .chain(obstruction.molecule_reading_refs.iter())
+                    .cloned(),
+            );
+            (obstruction.obstruction_circuit_id.clone(), refs)
+        })
+        .collect::<BTreeMap<_, _>>();
+    let obstruction_source_refs_by_id = obstruction_circuits
+        .iter()
+        .map(|obstruction| {
+            (
+                obstruction.obstruction_circuit_id.clone(),
+                source_refs_for_observation_refs(archmap, &obstruction.atom_observation_refs),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let interaction_obstruction_refs = split_readiness_readings
+        .iter()
+        .flat_map(|reading| reading.interaction_obstruction_refs.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let mut witness_basis = BTreeMap::<String, ArchSigFeatureExtensionWitnessBasisV0>::new();
     let obstruction_ids = obstruction_circuits
         .iter()
-        .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+        .map(|obstruction| {
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &obstruction.obstruction_circuit_id,
+                "inheritedCoreObstruction",
+                obstruction.atom_observation_refs.clone(),
+                source_refs_for_observation_refs(archmap, &obstruction.atom_observation_refs),
+            );
+            obstruction.obstruction_circuit_id.clone()
+        })
         .collect::<Vec<_>>();
     let feature_local = obstruction_circuits
         .iter()
         .filter(|obstruction| {
-            let text = format!("{} {}", obstruction.law_ref, obstruction.evidence_summary)
-                .to_ascii_lowercase();
-            text.contains("feature") || text.contains("extension") || text.contains("semantic")
+            obstruction
+                .atom_observation_refs
+                .iter()
+                .any(|atom_ref| semantic_atom_refs.contains(atom_ref))
         })
-        .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+        .map(|obstruction| {
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &obstruction.obstruction_circuit_id,
+                "featureLocalObstruction",
+                obstruction.atom_observation_refs.clone(),
+                source_refs_for_observation_refs(archmap, &obstruction.atom_observation_refs),
+            );
+            obstruction.obstruction_circuit_id.clone()
+        })
         .collect::<Vec<_>>();
     let interaction = obstruction_circuits
         .iter()
         .filter(|obstruction| {
-            let text = format!("{} {}", obstruction.law_ref, obstruction.evidence_summary)
-                .to_ascii_lowercase();
-            text.contains("interaction")
-                || text.contains("bridge")
-                || text.contains("runtime")
-                || text.contains("effect")
+            interaction_obstruction_refs.contains(&obstruction.obstruction_circuit_id)
+                || !obstruction.molecule_reading_refs.is_empty()
         })
-        .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+        .map(|obstruction| {
+            let observation_refs = unique_strings(
+                obstruction
+                    .atom_observation_refs
+                    .iter()
+                    .chain(obstruction.molecule_reading_refs.iter())
+                    .cloned(),
+            );
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &obstruction.obstruction_circuit_id,
+                "interactionObstruction",
+                observation_refs,
+                source_refs_for_observation_refs(archmap, &obstruction.atom_observation_refs),
+            );
+            obstruction.obstruction_circuit_id.clone()
+        })
         .collect::<Vec<_>>();
     let lifting_failure_refs = split_readiness_readings
         .iter()
-        .filter(|reading| reading.lifting_evidence_status != "observed")
-        .map(|reading| reading.reading_id.clone())
+        .filter(|reading| {
+            reading.core_embedding_status == "missingEvidence"
+                || reading.feature_view_section_status != "observed"
+                || reading.lifting_evidence_status == "blockedByBridgeEdge"
+        })
+        .map(|reading| {
+            let observation_refs = unique_strings(
+                std::iter::once(reading.molecule_ref.clone())
+                    .chain(reading.interaction_obstruction_refs.iter().cloned())
+                    .chain(reading.bridge_edge_refs.iter().cloned()),
+            );
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &reading.reading_id,
+                "liftingFailure",
+                observation_refs,
+                source_refs_for_observation_refs(
+                    archmap,
+                    std::slice::from_ref(&reading.molecule_ref),
+                ),
+            );
+            reading.reading_id.clone()
+        })
         .collect::<Vec<_>>();
     let complexity_transfer_refs = repair_candidates
         .iter()
-        .flat_map(|candidate| candidate.transfer_risks.clone())
+        .filter(|candidate| !candidate.transfer_risks.is_empty())
+        .map(|candidate| {
+            let observation_refs =
+                unique_strings(candidate.target_obstruction_refs.iter().flat_map(
+                    |obstruction_ref| {
+                        obstruction_observation_refs_by_id
+                            .get(obstruction_ref)
+                            .cloned()
+                            .unwrap_or_else(|| vec![obstruction_ref.clone()])
+                    },
+                ));
+            let source_refs = unique_strings(candidate.target_obstruction_refs.iter().flat_map(
+                |obstruction_ref| {
+                    obstruction_source_refs_by_id
+                        .get(obstruction_ref)
+                        .cloned()
+                        .unwrap_or_default()
+                },
+            ));
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &candidate.repair_operation_candidate_id,
+                "complexityTransfer",
+                observation_refs,
+                source_refs,
+            );
+            candidate.repair_operation_candidate_id.clone()
+        })
         .collect::<Vec<_>>();
     let residual_coverage_gap_refs = archmap
         .observation_gaps
         .iter()
-        .map(|gap| gap.gap_id.clone())
+        .map(|gap| {
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &gap.gap_id,
+                "residualCoverageGap",
+                vec![gap.gap_id.clone()],
+                gap.source_refs.iter().map(source_ref_label).collect(),
+            );
+            gap.gap_id.clone()
+        })
         .collect::<Vec<_>>();
     let filling_failure_refs = obstruction_circuits
         .iter()
         .filter(|obstruction| !obstruction.missing_evidence.is_empty())
-        .map(|obstruction| obstruction.obstruction_circuit_id.clone())
+        .map(|obstruction| {
+            push_feature_extension_witness_basis(
+                &mut witness_basis,
+                archmap,
+                &obstruction.obstruction_circuit_id,
+                "fillingFailure",
+                obstruction.atom_observation_refs.clone(),
+                source_refs_for_observation_refs(archmap, &obstruction.atom_observation_refs),
+            );
+            obstruction.obstruction_circuit_id.clone()
+        })
         .collect::<Vec<_>>();
     let classification_summary = vec![
         extension_axis_summary("inheritedCoreObstruction", &obstruction_ids),
@@ -6996,12 +7163,44 @@ fn build_feature_extension_formula_readings(
         filling_failure_refs,
         complexity_transfer_refs,
         residual_coverage_gap_refs,
+        witness_basis: witness_basis.into_values().collect(),
         classification_summary,
         evidence_boundary:
-            "extension formula is computed over current ArchMap state, not an actual PR diff"
+            "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff"
                 .to_string(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }]
+}
+
+fn push_feature_extension_witness_basis(
+    basis: &mut BTreeMap<String, ArchSigFeatureExtensionWitnessBasisV0>,
+    archmap: &ArchMapDocumentV0,
+    witness_ref: &str,
+    label: &str,
+    observation_refs: Vec<String>,
+    source_refs: Vec<String>,
+) {
+    let entry =
+        basis
+            .entry(witness_ref.to_string())
+            .or_insert_with(|| ArchSigFeatureExtensionWitnessBasisV0 {
+                witness_ref: witness_ref.to_string(),
+                labels: Vec::new(),
+                observation_refs: Vec::new(),
+                source_refs: Vec::new(),
+                basis_boundary:
+                    "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+                        .to_string(),
+            });
+    entry.labels.push(label.to_string());
+    entry.observation_refs.extend(observation_refs);
+    entry.source_refs.extend(source_refs);
+    if entry.source_refs.is_empty() && !entry.observation_refs.is_empty() {
+        entry.source_refs = source_refs_for_observation_refs(archmap, &entry.observation_refs);
+    }
+    entry.labels = unique_strings(entry.labels.drain(..));
+    entry.observation_refs = unique_strings(entry.observation_refs.drain(..));
+    entry.source_refs = unique_strings(entry.source_refs.drain(..));
 }
 
 fn extension_axis_summary(axis: &str, refs: &[String]) -> ArchSigFeatureExtensionAxisSummaryV0 {
@@ -13422,6 +13621,34 @@ fn check_aat_structural_reading_surfaces(packet: &ArchSigAnalysisPacketV0) -> Va
                 "feature extension formula must classify all required axes",
             ));
         }
+        if reading.witness_basis.is_empty() {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                "witnessBasis",
+                "feature extension formula must retain witness-driven attribution basis",
+            ));
+        }
+        for basis in &reading.witness_basis {
+            push_blank(
+                &mut examples,
+                &format!("{} witnessBasis.witnessRef", reading.reading_id),
+                &basis.witness_ref,
+            );
+            if basis.labels.is_empty() || has_blank(&basis.labels) {
+                examples.push(generic_validation_example(
+                    &reading.reading_id,
+                    &basis.witness_ref,
+                    "feature extension witness basis must carry labels",
+                ));
+            }
+            if basis.observation_refs.is_empty() && basis.source_refs.is_empty() {
+                examples.push(generic_validation_example(
+                    &reading.reading_id,
+                    &basis.witness_ref,
+                    "feature extension witness basis must connect to observation or source refs",
+                ));
+            }
+        }
         push_blank(
             &mut examples,
             &format!("{} evidenceBoundary", reading.reading_id),
@@ -15000,6 +15227,13 @@ fn check_feature_extension_diagnosis_surface(packet: &ArchSigAnalysisPacketV0) -
                     "witness attribution must carry one or more labels",
                 ));
             }
+            if record.observation_refs.is_empty() && record.source_refs.is_empty() {
+                examples.push(generic_validation_example(
+                    &reading.diagnosis_id,
+                    &record.witness_ref,
+                    "witness attribution must retain source or observation refs",
+                ));
+            }
             for label in &record.labels {
                 if !required_labels.contains(label.as_str()) {
                     examples.push(generic_validation_example(
@@ -16185,6 +16419,13 @@ fn source_refs_for_observation_refs(
         .flat_map(|atom| atom.source_refs.iter().map(source_ref_label))
         .chain(
             archmap
+                .molecule_observations
+                .iter()
+                .filter(|molecule| wanted.contains(molecule.molecule_observation_id.as_str()))
+                .flat_map(|molecule| molecule.source_refs.iter().map(source_ref_label)),
+        )
+        .chain(
+            archmap
                 .semantic_observations
                 .iter()
                 .filter(|semantic| wanted.contains(semantic.semantic_observation_id.as_str()))
@@ -16196,6 +16437,13 @@ fn source_refs_for_observation_refs(
                 .iter()
                 .filter(|gap| wanted.contains(gap.gap_id.as_str()))
                 .flat_map(|gap| gap.source_refs.iter().map(source_ref_label)),
+        )
+        .chain(
+            archmap
+                .operation_square_evidence
+                .iter()
+                .filter(|evidence| wanted.contains(evidence.operation_square_evidence_id.as_str()))
+                .flat_map(|evidence| evidence.source_refs.iter().map(source_ref_label)),
         )
         .chain(
             archmap

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -1141,6 +1141,10 @@ pub struct ArchSigFeatureExtensionDiagnosisReadingV0 {
 pub struct ArchSigFeatureExtensionWitnessAttributionV0 {
     pub witness_ref: String,
     pub labels: Vec<String>,
+    #[serde(default)]
+    pub observation_refs: Vec<String>,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
     pub inherited_core_refs: Vec<String>,
     pub feature_local_refs: Vec<String>,
     pub boundary_holonomy_refs: Vec<String>,
@@ -2099,9 +2103,21 @@ pub struct ArchSigFeatureExtensionFormulaReadingV0 {
     pub filling_failure_refs: Vec<String>,
     pub complexity_transfer_refs: Vec<String>,
     pub residual_coverage_gap_refs: Vec<String>,
+    #[serde(default)]
+    pub witness_basis: Vec<ArchSigFeatureExtensionWitnessBasisV0>,
     pub classification_summary: Vec<ArchSigFeatureExtensionAxisSummaryV0>,
     pub evidence_boundary: String,
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigFeatureExtensionWitnessBasisV0 {
+    pub witness_ref: String,
+    pub labels: Vec<String>,
+    pub observation_refs: Vec<String>,
+    pub source_refs: Vec<String>,
+    pub basis_boundary: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2647,9 +2647,23 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                     .as_array()
                     .is_some_and(|items| items.len() >= 7)
                     && reading["residualCoverageGapRefs"].as_array().is_some()
+                    && reading["witnessBasis"].as_array().is_some_and(|items| {
+                        !items.is_empty()
+                            && items.iter().all(|basis| {
+                                basis["labels"]
+                                    .as_array()
+                                    .is_some_and(|labels| !labels.is_empty())
+                                    && (basis["observationRefs"]
+                                        .as_array()
+                                        .is_some_and(|refs| !refs.is_empty())
+                                        || basis["sourceRefs"]
+                                            .as_array()
+                                            .is_some_and(|refs| !refs.is_empty()))
+                            })
+                    })
                     && reading["evidenceBoundary"].as_str().is_some()
             }),
-        "feature extension formula readings must carry required axes and boundary"
+        "feature extension formula readings must carry required axes, witness basis, and boundary"
     );
     assert!(
         json["operationCalculusLawReadings"]
@@ -3174,6 +3188,14 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                                                 .as_array()
                                                 .is_some_and(|labels| labels.len() > 1)
                                         })
+                                        && records.iter().all(|record| {
+                                            record["observationRefs"]
+                                                .as_array()
+                                                .is_some_and(|refs| !refs.is_empty())
+                                                || record["sourceRefs"]
+                                                    .as_array()
+                                                    .is_some_and(|refs| !refs.is_empty())
+                                        })
                                 })
                             && reading["residualCoverageGapRefs"].as_array().is_some()
                             && reading["liftingFailureRefs"].as_array().is_some()
@@ -3190,7 +3212,7 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                                 .is_some_and(|items| !items.is_empty())
                     })
             }),
-        "feature extension diagnosis readings must expose seven non-disjoint labels, witness attribution, separated failure refs, and FieldSig boundary"
+        "feature extension diagnosis readings must expose seven non-disjoint labels, witness-backed attribution refs, separated failure refs, and FieldSig boundary"
     );
     assert!(
         {

--- a/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
@@ -2617,8 +2617,12 @@
       "inheritedCoreObstructionRefs": [
         "obstruction:homotopy-report-fixture:computed"
       ],
-      "featureLocalObstructionRefs": [],
-      "interactionObstructionRefs": [],
+      "featureLocalObstructionRefs": [
+        "obstruction:homotopy-report-fixture:computed"
+      ],
+      "interactionObstructionRefs": [
+        "obstruction:homotopy-report-fixture:computed"
+      ],
       "liftingFailureRefs": [
         "split-readiness:molecule-homotopy-report-fixture"
       ],
@@ -2626,10 +2630,82 @@
         "obstruction:homotopy-report-fixture:computed"
       ],
       "complexityTransferRefs": [
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        "repair:obstruction-homotopy-report-fixture-computed"
       ],
       "residualCoverageGapRefs": [
         "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+      ],
+      "witnessBasis": [
+        {
+          "witnessRef": "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+          "labels": [
+            "residualCoverageGap"
+          ],
+          "observationRefs": [
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+          ],
+          "sourceRefs": [
+            "doc-auth-policy"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "obstruction:homotopy-report-fixture:computed",
+          "labels": [
+            "featureLocalObstruction",
+            "fillingFailure",
+            "inheritedCoreObstruction",
+            "interactionObstruction"
+          ],
+          "observationRefs": [
+            "atom:authorization-bypass",
+            "atom:cache-read",
+            "atom:coupon-tax-rounding",
+            "atom:repository-read",
+            "molecule-reading:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "src-auth-bypass",
+            "src-cache-read",
+            "src-pricing-checkout",
+            "src-repository-read"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "repair:obstruction-homotopy-report-fixture-computed",
+          "labels": [
+            "complexityTransfer"
+          ],
+          "observationRefs": [
+            "atom:authorization-bypass",
+            "atom:cache-read",
+            "atom:coupon-tax-rounding",
+            "atom:repository-read",
+            "molecule-reading:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "src-auth-bypass",
+            "src-cache-read",
+            "src-pricing-checkout",
+            "src-repository-read"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "split-readiness:molecule-homotopy-report-fixture",
+          "labels": [
+            "liftingFailure"
+          ],
+          "observationRefs": [
+            "molecule:homotopy-report-fixture",
+            "obstruction:homotopy-report-fixture:computed"
+          ],
+          "sourceRefs": [
+            "test-homotopy-fillers"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        }
       ],
       "classificationSummary": [
         {
@@ -2642,14 +2718,18 @@
         },
         {
           "axis": "featureLocalObstruction",
-          "status": "unmeasuredOrAbsent",
-          "refs": [],
+          "status": "observed",
+          "refs": [
+            "obstruction:homotopy-report-fixture:computed"
+          ],
           "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
         },
         {
           "axis": "interactionObstruction",
-          "status": "unmeasuredOrAbsent",
-          "refs": [],
+          "status": "observed",
+          "refs": [
+            "obstruction:homotopy-report-fixture:computed"
+          ],
           "reading": "interactionObstruction is classified as a current-state extension coordinate"
         },
         {
@@ -2672,7 +2752,7 @@
           "axis": "complexityTransfer",
           "status": "observed",
           "refs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            "repair:obstruction-homotopy-report-fixture-computed"
           ],
           "reading": "complexityTransfer is classified as a current-state extension coordinate"
         },
@@ -2685,7 +2765,7 @@
           "reading": "residualCoverageGap is classified as a current-state extension coordinate"
         }
       ],
-      "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "evidenceBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -3003,6 +3083,8 @@
         "atom:coupon-tax-rounding"
       ],
       "constraintRefs": [
+        "obstruction:homotopy-report-fixture:computed",
+        "obstruction:homotopy-report-fixture:computed",
         "obstruction:homotopy-report-fixture:computed",
         "split-readiness:molecule-homotopy-report-fixture",
         "obstruction:homotopy-report-fixture:computed",
@@ -7646,18 +7728,20 @@
       "featureScopeRef": "homotopy-report-fixture-archmap:feature",
       "mixedSubconfigurationRefs": [
         "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "obstruction:homotopy-report-fixture:computed",
+        "repair:obstruction-homotopy-report-fixture-computed",
         "split-readiness:molecule-homotopy-report-fixture"
       ],
       "coreLocalReadingRefs": [
         "obstruction:homotopy-report-fixture:computed"
       ],
-      "featureLocalReadingRefs": [],
+      "featureLocalReadingRefs": [
+        "obstruction:homotopy-report-fixture:computed"
+      ],
       "boundarySupportRefs": [
         "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "obstruction:homotopy-report-fixture:computed",
+        "repair:obstruction-homotopy-report-fixture-computed",
         "split-readiness:molecule-homotopy-report-fixture"
       ],
       "holonomyAxes": [
@@ -7683,8 +7767,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
@@ -7716,8 +7800,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
@@ -7749,8 +7833,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
@@ -7768,8 +7852,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "missingEvidence": [
@@ -7794,10 +7878,10 @@
       ],
       "residualObstructionRefs": [
         "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
         "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
         "obstruction:homotopy-report-fixture:computed",
+        "repair:obstruction-homotopy-report-fixture-computed",
         "split-readiness:molecule-homotopy-report-fixture"
       ],
       "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
@@ -7809,7 +7893,7 @@
         "selected LawPolicy exactness assumptions"
       ],
       "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
-      "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "coverageBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
       "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
       "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
       "nonConclusions": [
@@ -7841,8 +7925,10 @@
         },
         {
           "axis": "featureLocalObstruction",
-          "status": "unmeasuredOrAbsent",
-          "refs": [],
+          "status": "observed",
+          "refs": [
+            "obstruction:homotopy-report-fixture:computed"
+          ],
           "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
         },
         {
@@ -7851,10 +7937,10 @@
           "refs": [
             "feature-boundary-residual:homotopy-report-fixture-archmap",
             "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
             "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
             "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
             "split-readiness:molecule-homotopy-report-fixture"
           ],
           "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
@@ -7879,7 +7965,7 @@
           "axis": "complexityTransfer",
           "status": "observed",
           "refs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            "repair:obstruction-homotopy-report-fixture-computed"
           ],
           "reading": "complexityTransfer is classified as a current-state extension coordinate"
         },
@@ -7898,6 +7984,17 @@
           "labels": [
             "boundaryHolonomy"
           ],
+          "observationRefs": [
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "doc-auth-policy"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -7915,6 +8012,17 @@
             "boundaryHolonomy",
             "residualCoverageGap"
           ],
+          "observationRefs": [
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "doc-auth-policy"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -7929,28 +8037,20 @@
           "reading": "gap:path-rule:authorization-bypass-hole:missing-policy-test carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
         },
         {
-          "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-          "labels": [
-            "boundaryHolonomy",
-            "complexityTransfer"
-          ],
-          "inheritedCoreRefs": [],
-          "featureLocalRefs": [],
-          "boundaryHolonomyRefs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-          ],
-          "liftingFailureRefs": [],
-          "fillingFailureRefs": [],
-          "complexityTransferRefs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-          ],
-          "residualCoverageGapRefs": [],
-          "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
-        },
-        {
           "witnessRef": "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
           "labels": [
             "boundaryHolonomy"
+          ],
+          "observationRefs": [
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "doc-auth-policy"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -7968,6 +8068,17 @@
           "labels": [
             "boundaryHolonomy"
           ],
+          "observationRefs": [
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "doc-auth-policy"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -7983,13 +8094,35 @@
           "witnessRef": "obstruction:homotopy-report-fixture:computed",
           "labels": [
             "boundaryHolonomy",
+            "featureLocalObstruction",
             "fillingFailure",
             "inheritedCoreObstruction"
+          ],
+          "observationRefs": [
+            "atom:authorization-bypass",
+            "atom:cache-read",
+            "atom:coupon-tax-rounding",
+            "atom:repository-read",
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "molecule-reading:molecule-homotopy-report-fixture",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "src-auth-bypass",
+            "src-cache-read",
+            "src-pricing-checkout",
+            "src-repository-read"
           ],
           "inheritedCoreRefs": [
             "obstruction:homotopy-report-fixture:computed"
           ],
-          "featureLocalRefs": [],
+          "featureLocalRefs": [
+            "obstruction:homotopy-report-fixture:computed"
+          ],
           "boundaryHolonomyRefs": [
             "obstruction:homotopy-report-fixture:computed"
           ],
@@ -7999,13 +8132,63 @@
           ],
           "complexityTransferRefs": [],
           "residualCoverageGapRefs": [],
-          "reading": "obstruction:homotopy-report-fixture:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+          "reading": "obstruction:homotopy-report-fixture:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+        },
+        {
+          "witnessRef": "repair:obstruction-homotopy-report-fixture-computed",
+          "labels": [
+            "boundaryHolonomy",
+            "complexityTransfer"
+          ],
+          "observationRefs": [
+            "atom:authorization-bypass",
+            "atom:cache-read",
+            "atom:coupon-tax-rounding",
+            "atom:repository-read",
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "molecule-reading:molecule-homotopy-report-fixture",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "src-auth-bypass",
+            "src-cache-read",
+            "src-pricing-checkout",
+            "src-repository-read"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "repair:obstruction-homotopy-report-fixture-computed"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [
+            "repair:obstruction-homotopy-report-fixture-computed"
+          ],
+          "residualCoverageGapRefs": [],
+          "reading": "repair:obstruction-homotopy-report-fixture-computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
         },
         {
           "witnessRef": "split-readiness:molecule-homotopy-report-fixture",
           "labels": [
             "boundaryHolonomy",
             "liftingFailure"
+          ],
+          "observationRefs": [
+            "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "molecule:homotopy-report-fixture",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "obstruction:homotopy-report-fixture:computed",
+            "repair:obstruction-homotopy-report-fixture-computed",
+            "split-readiness:molecule-homotopy-report-fixture"
+          ],
+          "sourceRefs": [
+            "test-homotopy-fillers"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -8031,7 +8214,7 @@
         "obstruction:homotopy-report-fixture:computed"
       ],
       "complexityTransferRefs": [
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        "repair:obstruction-homotopy-report-fixture-computed"
       ],
       "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
       "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
@@ -9904,7 +10087,7 @@
       "homotopy-report-fixture-policy required=1 unmeasured=0 blockedWitnesses=1"
     ],
     "featureExtensionFormulaSummary": [
-      "feature-extension-formula:homotopy-report-fixture-archmap status=measured inherited=1 featureLocal=0 interaction=0 residualGaps=1"
+      "feature-extension-formula:homotopy-report-fixture-archmap status=measured inherited=1 featureLocal=1 interaction=1 residualGaps=1"
     ],
     "operationCalculusLawSummary": [
       "repair:obstruction-homotopy-report-fixture-computed kind=repair-homotopyreportfixturecircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
@@ -9931,7 +10114,7 @@
       "effect-relation-algebra:homotopy-report-fixture-archmap pressure=effectRelationPressureObserved generators=4 unresolved=0 externalBoundaries=0"
     ],
     "synthesisBlockageSummary": [
-      "synthesis-blockage:homotopy-report-fixture-archmap status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=5 missing=5 noSolution=notASolverAndNotAbsenceProof"
+      "synthesis-blockage:homotopy-report-fixture-archmap status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=7 missing=5 noSolution=notASolverAndNotAbsenceProof"
     ],
     "operationPreconditionReadinessSummary": [
       "repair:obstruction-homotopy-report-fixture-computed kind=repair-homotopyreportfixturecircuit status=blockedByMissingPreconditionEvidence missing=5 witnesses=1"

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -2970,7 +2970,9 @@
       "featureLocalObstructionRefs": [
         "obstruction:semantic-contract-mismatch:computed"
       ],
-      "interactionObstructionRefs": [],
+      "interactionObstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
       "liftingFailureRefs": [
         "split-readiness:molecule-user-request-responsibility"
       ],
@@ -2978,10 +2980,70 @@
         "obstruction:semantic-contract-mismatch:computed"
       ],
       "complexityTransferRefs": [
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "residualCoverageGapRefs": [
         "gap-runtime-user-db-trace"
+      ],
+      "witnessBasis": [
+        {
+          "witnessRef": "gap-runtime-user-db-trace",
+          "labels": [
+            "residualCoverageGap"
+          ],
+          "observationRefs": [
+            "gap-runtime-user-db-trace"
+          ],
+          "sourceRefs": [
+            ".lake/runtime-trace.json"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+          "labels": [
+            "featureLocalObstruction",
+            "fillingFailure",
+            "inheritedCoreObstruction",
+            "interactionObstruction"
+          ],
+          "observationRefs": [
+            "atom:contract:create-user",
+            "molecule-reading:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+          "labels": [
+            "complexityTransfer"
+          ],
+          "observationRefs": [
+            "atom:contract:create-user",
+            "molecule-reading:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "split-readiness:molecule-user-request-responsibility",
+          "labels": [
+            "liftingFailure"
+          ],
+          "observationRefs": [
+            "molecule:user-request-responsibility",
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "sourceRefs": [
+            "doc-architecture"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        }
       ],
       "classificationSummary": [
         {
@@ -3002,8 +3064,10 @@
         },
         {
           "axis": "interactionObstruction",
-          "status": "unmeasuredOrAbsent",
-          "refs": [],
+          "status": "observed",
+          "refs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
           "reading": "interactionObstruction is classified as a current-state extension coordinate"
         },
         {
@@ -3026,7 +3090,7 @@
           "axis": "complexityTransfer",
           "status": "observed",
           "refs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            "repair:obstruction-semantic-contract-mismatch-computed"
           ],
           "reading": "complexityTransfer is classified as a current-state extension coordinate"
         },
@@ -3039,7 +3103,7 @@
           "reading": "residualCoverageGap is classified as a current-state extension coordinate"
         }
       ],
-      "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "evidenceBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -3353,6 +3417,7 @@
         "atom:contract:create-user"
       ],
       "constraintRefs": [
+        "obstruction:semantic-contract-mismatch:computed",
         "obstruction:semantic-contract-mismatch:computed",
         "obstruction:semantic-contract-mismatch:computed",
         "split-readiness:molecule-user-request-responsibility",
@@ -6653,8 +6718,8 @@
       "featureScopeRef": "fixture-archmap-atom-observation:feature",
       "mixedSubconfigurationRefs": [
         "gap-runtime-user-db-trace",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "obstruction:semantic-contract-mismatch:computed",
+        "repair:obstruction-semantic-contract-mismatch-computed",
         "split-readiness:molecule-user-request-responsibility"
       ],
       "coreLocalReadingRefs": [
@@ -6665,8 +6730,8 @@
       ],
       "boundarySupportRefs": [
         "gap-runtime-user-db-trace",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "obstruction:semantic-contract-mismatch:computed",
+        "repair:obstruction-semantic-contract-mismatch-computed",
         "split-readiness:molecule-user-request-responsibility"
       ],
       "holonomyAxes": [
@@ -6717,8 +6782,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap-runtime-user-db-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
@@ -6736,8 +6801,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap-runtime-user-db-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
@@ -6755,8 +6820,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap-runtime-user-db-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
@@ -6774,8 +6839,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap-runtime-user-db-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "missingEvidence": [
@@ -6801,9 +6866,9 @@
       ],
       "residualObstructionRefs": [
         "gap-runtime-user-db-trace",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
         "obstruction:semantic-contract-mismatch:computed",
+        "repair:obstruction-semantic-contract-mismatch-computed",
         "split-readiness:molecule-user-request-responsibility"
       ],
       "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
@@ -6816,7 +6881,7 @@
         "ArchMapStore compaction boundary"
       ],
       "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
-      "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "coverageBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
       "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
       "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
       "nonConclusions": [
@@ -6860,9 +6925,9 @@
           "refs": [
             "feature-boundary-residual:fixture-archmap-atom-observation",
             "gap-runtime-user-db-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
@@ -6887,7 +6952,7 @@
           "axis": "complexityTransfer",
           "status": "observed",
           "refs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            "repair:obstruction-semantic-contract-mismatch-computed"
           ],
           "reading": "complexityTransfer is classified as a current-state extension coordinate"
         },
@@ -6906,6 +6971,16 @@
           "labels": [
             "boundaryHolonomy"
           ],
+          "observationRefs": [
+            "gap-runtime-user-db-trace",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            ".lake/runtime-trace.json"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -6923,6 +6998,16 @@
             "boundaryHolonomy",
             "residualCoverageGap"
           ],
+          "observationRefs": [
+            "gap-runtime-user-db-trace",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            ".lake/runtime-trace.json"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -6937,28 +7022,19 @@
           "reading": "gap-runtime-user-db-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
         },
         {
-          "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-          "labels": [
-            "boundaryHolonomy",
-            "complexityTransfer"
-          ],
-          "inheritedCoreRefs": [],
-          "featureLocalRefs": [],
-          "boundaryHolonomyRefs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-          ],
-          "liftingFailureRefs": [],
-          "fillingFailureRefs": [],
-          "complexityTransferRefs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-          ],
-          "residualCoverageGapRefs": [],
-          "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
-        },
-        {
           "witnessRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
           "labels": [
             "boundaryHolonomy"
+          ],
+          "observationRefs": [
+            "gap-runtime-user-db-trace",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            ".lake/runtime-trace.json"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -6979,6 +7055,18 @@
             "fillingFailure",
             "inheritedCoreObstruction"
           ],
+          "observationRefs": [
+            "atom:contract:create-user",
+            "gap-runtime-user-db-trace",
+            "molecule-reading:molecule-user-request-responsibility",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
           "inheritedCoreRefs": [
             "obstruction:semantic-contract-mismatch:computed"
           ],
@@ -6997,10 +7085,52 @@
           "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
         },
         {
+          "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+          "labels": [
+            "boundaryHolonomy",
+            "complexityTransfer"
+          ],
+          "observationRefs": [
+            "atom:contract:create-user",
+            "gap-runtime-user-db-trace",
+            "molecule-reading:molecule-user-request-responsibility",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "repair:obstruction-semantic-contract-mismatch-computed"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [
+            "repair:obstruction-semantic-contract-mismatch-computed"
+          ],
+          "residualCoverageGapRefs": [],
+          "reading": "repair:obstruction-semantic-contract-mismatch-computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+        },
+        {
           "witnessRef": "split-readiness:molecule-user-request-responsibility",
           "labels": [
             "boundaryHolonomy",
             "liftingFailure"
+          ],
+          "observationRefs": [
+            "gap-runtime-user-db-trace",
+            "molecule:user-request-responsibility",
+            "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-user-request-responsibility"
+          ],
+          "sourceRefs": [
+            "doc-architecture"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -7026,7 +7156,7 @@
         "obstruction:semantic-contract-mismatch:computed"
       ],
       "complexityTransferRefs": [
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
       "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
@@ -8874,7 +9004,7 @@
       "llm-native-aat-law-policy-fixture required=2 unmeasured=2 blockedWitnesses=2"
     ],
     "featureExtensionFormulaSummary": [
-      "feature-extension-formula:fixture-archmap-atom-observation status=measured inherited=1 featureLocal=1 interaction=0 residualGaps=1"
+      "feature-extension-formula:fixture-archmap-atom-observation status=measured inherited=1 featureLocal=1 interaction=1 residualGaps=1"
     ],
     "operationCalculusLawSummary": [
       "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
@@ -8901,7 +9031,7 @@
       "effect-relation-algebra:fixture-archmap-atom-observation pressure=effectRelationPressureObserved generators=1 unresolved=1 externalBoundaries=0"
     ],
     "synthesisBlockageSummary": [
-      "synthesis-blockage:fixture-archmap-atom-observation status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=6 missing=5 noSolution=notASolverAndNotAbsenceProof"
+      "synthesis-blockage:fixture-archmap-atom-observation status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=7 missing=5 noSolution=notASolverAndNotAbsenceProof"
     ],
     "operationPreconditionReadinessSummary": [
       "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit status=blockedByMissingPreconditionEvidence missing=5 witnesses=2"


### PR DESCRIPTION
## 概要

Closes #1597

Feature Extension Formula の feature-local / interaction / lifting / filling / transfer / coverage 分類を、`lawRef` や `evidenceSummary` の文字列 contains ではなく、ArchMap observation refs と ArchSig witness refs に基づく attribution に置き換えました。

- `featureExtensionFormulaReadings[].witnessBasis` を追加し、各 witness の labels、observation refs、source refs、basis boundary を保持
- `featureExtensionDiagnosisReadings[].attributionRecords[]` に observation refs / source refs を追加
- feature-local は semantic observation の atom support、interaction は split readiness / molecule linkage、lifting は split readiness status、transfer は repair candidate refs、coverage は observation gaps から導出
- validation / CLI assertion を witness basis と attribution refs 必須に強化
- minimal / homotopy_report fixture を再生成

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `tooling implementation / docs tracking` として扱った
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
