### PR TITLE
ArchSigのanalytic graph engineを実計算にする

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -308,11 +308,13 @@ The builder:
   observation refs, distance kind and inputs, soundness boundary, and coverage
   status. Missing support is `blockedByCoverageGap`, not zero.
 - curvature transfer readings build a finite nonnegative transfer operator over
-  measured curvature support rows. They report row/column support refs, sparse
-  matrix entries, source-backed transfer edges, a `rho(T^kappa)` proxy, and
-  self-loop or multi-row recurrent obstruction modes only as bounded
-  current-state diagnostics. They do not conclude future incidents, empirical
-  cost increase, amplification, repair safety, or FieldSig forecast truth.
+  measured curvature support rows. Transfer entries are backed by selected
+  relation-graph evidence or shared selected-axis support, and report row/column
+  support refs, sparse matrix entries, source-backed transfer edges, a
+  `rho(T^kappa)` reading, and self-loop or multi-row recurrent obstruction modes
+  only as bounded current-state diagnostics. They do not conclude future
+  incidents, empirical cost increase, amplification, repair safety, or FieldSig
+  forecast truth.
 - `architectureSpectrumReport` summarizes the ACTS surface for human and LLM
   review: top hotspots, top bounded mode data, witness clusters, recurrent
   obstruction entries, coverage gaps, measured boundary, and recommended next
@@ -473,7 +475,16 @@ The builder:
 - analytic representations include weighted adjacency, walk count, reachable
   cone size, nilpotence boundary, selected subgraph spectrum, propagation depth,
   spectral radius, curvature valuation, state algebra boundary, and
-  zero-reflecting aggregate boundary
+  zero-reflecting aggregate boundary. The graph and matrix readings expose
+  selected graph nodes, source-backed relation edges, sparse matrix entries, and
+  bounded walk witnesses; spectral radius is a bounded finite-matrix estimate
+  over that selected relation graph, not a global architecture score.
+- spectral analysis readings now include
+  `relationAtomWeightedAdjacencyMatrix`, which constructs a finite weighted
+  adjacency matrix directly from selected relation atom endpoints and reports
+  row/column pressure, Frobenius norm, and a bounded `spectralRadius` estimate.
+  The older workflow / molecule / obstruction / operation matrices remain
+  bounded review representations over their own measured surfaces.
 - emits repair operation candidates with preserved invariants, preconditions,
   transfer risks, evidence boundaries, and non-conclusions
 - emits operation deltas and path / homotopy / diagram readings for repair

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -9,7 +9,8 @@ use crate::{
     ArchSigAmiAggregateReadingV0, ArchSigAmiTopContributorV0, ArchSigAnalysisArtifactRefV0,
     ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationInputV0,
     ArchSigAnalysisPacketValidationReportV0, ArchSigAnalysisPacketValidationSummaryV0,
-    ArchSigAnalyticRepresentationV0, ArchSigArchMapStoreRefsV0, ArchSigArchitecturalHoleReadingV0,
+    ArchSigAnalyticGraphEdgeV0, ArchSigAnalyticMatrixEntryV0, ArchSigAnalyticRepresentationV0,
+    ArchSigArchMapStoreRefsV0, ArchSigArchitecturalHoleReadingV0,
     ArchSigArchitectureHomotopyReportV0, ArchSigArchitectureObjectProjectionV0,
     ArchSigArchitectureSpectrumHotspotV0, ArchSigArchitectureSpectrumModeV0,
     ArchSigArchitectureSpectrumRecurrentObstructionV0, ArchSigArchitectureSpectrumReportV0,
@@ -157,7 +158,7 @@ pub fn build_archsig_analysis_packet(
         &signature_axes,
     );
     let curvature_transfer_readings =
-        build_curvature_transfer_readings(&curvature_support_readings);
+        build_curvature_transfer_readings(archmap, &curvature_support_readings);
     let architecture_spectrum_report = build_architecture_spectrum_report(
         &curvature_support_readings,
         &curvature_transfer_readings,
@@ -3056,107 +3057,120 @@ fn build_analytic_representations(
     signature_axes: &[ArchSigSignatureAxisReadingV0],
     obstruction_circuits: &[ArchSigObstructionCircuitV0],
 ) -> Vec<ArchSigAnalyticRepresentationV0> {
-    let relation_count = archmap
-        .atom_observations
-        .iter()
-        .filter(|atom| atom.atom_family.to_ascii_lowercase().contains("relation"))
-        .count();
-    let node_count = unique_strings(
-        archmap
-            .atom_observations
-            .iter()
-            .flat_map(|atom| atom.object_refs.clone()),
-    )
-    .len()
-    .max(archmap.atom_observations.len());
-    let reachable_cone_size = node_count + relation_count;
-    let walk_count = relation_count + archmap.molecule_observations.len();
-    let propagation_depth = if relation_count == 0 { 0 } else { 1 };
-    let nilpotence_boundary = if archmap.observation_gaps.is_empty() {
+    let graph = selected_relation_graph(archmap);
+    let node_count = graph.nodes.len();
+    let edge_count = graph.edges.len();
+    let reachable_cone_size = graph.reachable_pairs.len();
+    let walk_count = graph.walk_count_len_le_3;
+    let propagation_depth = graph.max_shortest_path_len;
+    let nilpotence_boundary = if graph.cycle_refs.is_empty() && archmap.observation_gaps.is_empty()
+    {
         "candidateNilpotentForSelectedStaticGraph"
+    } else if !graph.cycle_refs.is_empty() {
+        "cycleObservedInSelectedRelationGraph"
     } else {
         "blockedByCoverageGap"
     };
-    let spectral_proxy = if node_count == 0 {
+    let spectral_radius = graph.spectral_radius_estimate;
+    let spectral_value = if node_count == 0 {
         "unavailable".to_string()
     } else {
-        format!("{:.3}", relation_count as f64 / node_count as f64)
+        format!("{spectral_radius:.3}")
     };
+    let graph_scope_refs = graph
+        .edges
+        .iter()
+        .map(|edge| edge.relation_atom_ref.clone())
+        .collect::<Vec<_>>();
+    let mut weighted_adjacency = analytic_representation(
+        "analytic:weighted-adjacency",
+        "weightedAdjacencyMatrix",
+        "measured",
+        "matrixShape",
+        &format!("{node_count}x{node_count}; edgeCount={edge_count}"),
+        graph_scope_refs.clone(),
+        signature_axes,
+        "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
+    );
+    attach_relation_graph(&mut weighted_adjacency, &graph);
+    let mut reachable = analytic_representation(
+        "analytic:reachable-cone-size",
+        "reachableConeSize",
+        "measured",
+        "nat",
+        &reachable_cone_size.to_string(),
+        graph_scope_refs.clone(),
+        signature_axes,
+        "reachable cone is computed by finite graph traversal over selected relation atoms",
+    );
+    attach_relation_graph(&mut reachable, &graph);
+    let mut walks = analytic_representation(
+        "analytic:walk-count",
+        "walkCount",
+        "measured",
+        "nat",
+        &walk_count.to_string(),
+        graph_scope_refs.clone(),
+        signature_axes,
+        "walk count enumerates selected relation-graph walks up to length 3",
+    );
+    attach_relation_graph(&mut walks, &graph);
+    let mut nilpotence = analytic_representation(
+        "analytic:nilpotence-boundary",
+        "nilpotenceBoundary",
+        "needsReview",
+        "boundaryStatus",
+        nilpotence_boundary,
+        graph.cycle_refs.clone(),
+        signature_axes,
+        "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
+    );
+    attach_relation_graph(&mut nilpotence, &graph);
+    let mut spectrum = analytic_representation(
+        "analytic:selected-subgraph-spectrum",
+        "selectedSubgraphSpectrum",
+        "measured",
+        "vector",
+        &format!("[{spectral_value}]"),
+        graph_scope_refs.clone(),
+        signature_axes,
+        "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
+    );
+    attach_relation_graph(&mut spectrum, &graph);
+    let mut propagation = analytic_representation(
+        "analytic:propagation-depth",
+        "propagationDepth",
+        "measured",
+        "nat",
+        &propagation_depth.to_string(),
+        graph_scope_refs.clone(),
+        signature_axes,
+        "propagation depth is computed over observed relation atoms only",
+    );
+    attach_relation_graph(&mut propagation, &graph);
+    let mut spectral_radius_repr = analytic_representation(
+        "analytic:spectral-radius",
+        "spectralRadius",
+        if spectral_value == "unavailable" {
+            "unavailable"
+        } else {
+            "measured"
+        },
+        "float",
+        &spectral_value,
+        graph_scope_refs.clone(),
+        signature_axes,
+        "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
+    );
+    attach_relation_graph(&mut spectral_radius_repr, &graph);
     vec![
-        analytic_representation(
-            "analytic:weighted-adjacency",
-            "weightedAdjacencyMatrix",
-            "measured",
-            "matrixShape",
-            &format!("{node_count}x{node_count}; edgeCount={relation_count}"),
-            all_atom_refs(archmap),
-            signature_axes,
-            "selected relation atoms induce a bounded weighted adjacency representation",
-        ),
-        analytic_representation(
-            "analytic:reachable-cone-size",
-            "reachableConeSize",
-            "measured",
-            "nat",
-            &reachable_cone_size.to_string(),
-            all_atom_refs(archmap),
-            signature_axes,
-            "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
-        ),
-        analytic_representation(
-            "analytic:walk-count",
-            "walkCount",
-            "measured",
-            "nat",
-            &walk_count.to_string(),
-            all_atom_refs(archmap),
-            signature_axes,
-            "walk count is a bounded proxy from observed relation atoms and molecule paths",
-        ),
-        analytic_representation(
-            "analytic:nilpotence-boundary",
-            "nilpotenceBoundary",
-            "needsReview",
-            "boundaryStatus",
-            nilpotence_boundary,
-            all_atom_refs(archmap),
-            signature_axes,
-            "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
-        ),
-        analytic_representation(
-            "analytic:selected-subgraph-spectrum",
-            "selectedSubgraphSpectrum",
-            "measured",
-            "vector",
-            &format!("[{spectral_proxy}]"),
-            all_atom_refs(archmap),
-            signature_axes,
-            "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
-        ),
-        analytic_representation(
-            "analytic:propagation-depth",
-            "propagationDepth",
-            "measured",
-            "nat",
-            &propagation_depth.to_string(),
-            all_atom_refs(archmap),
-            signature_axes,
-            "propagation depth is computed over observed relation atoms only",
-        ),
-        analytic_representation(
-            "analytic:spectral-radius-proxy",
-            "spectralRadius",
-            if spectral_proxy == "unavailable" {
-                "unavailable"
-            } else {
-                "measured"
-            },
-            "float",
-            &spectral_proxy,
-            all_atom_refs(archmap),
-            signature_axes,
-            "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
-        ),
+        weighted_adjacency,
+        reachable,
+        walks,
+        nilpotence,
+        spectrum,
+        propagation,
+        spectral_radius_repr,
         analytic_representation(
             "analytic:curvature-valuation",
             "curvatureValuation",
@@ -3225,6 +3239,10 @@ fn analytic_representation(
         status: status.to_string(),
         value_type: value_type.to_string(),
         value: value.to_string(),
+        selected_graph_nodes: Vec::new(),
+        selected_graph_edges: Vec::new(),
+        sparse_matrix_entries: Vec::new(),
+        walk_witness_refs: Vec::new(),
         graph_scope_refs,
         axis_refs: signature_axes
             .iter()
@@ -3239,6 +3257,229 @@ fn analytic_representation(
                 .to_string(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
+}
+
+#[derive(Debug, Clone)]
+struct SelectedRelationGraph {
+    nodes: Vec<String>,
+    edges: Vec<ArchSigAnalyticGraphEdgeV0>,
+    matrix_entries: Vec<ArchSigAnalyticMatrixEntryV0>,
+    reachable_pairs: Vec<String>,
+    walk_witness_refs: Vec<String>,
+    cycle_refs: Vec<String>,
+    walk_count_len_le_3: usize,
+    max_shortest_path_len: usize,
+    spectral_radius_estimate: f64,
+}
+
+fn selected_relation_graph(archmap: &ArchMapDocumentV0) -> SelectedRelationGraph {
+    let relation_atoms = archmap
+        .atom_observations
+        .iter()
+        .filter(|atom| atom.atom_family.to_ascii_lowercase().contains("relation"))
+        .collect::<Vec<_>>();
+    let mut nodes = BTreeSet::<String>::new();
+    let mut edge_weights = BTreeMap::<(String, String), (i64, Vec<String>, Vec<String>)>::new();
+    let mut edges = Vec::new();
+    for atom in relation_atoms {
+        let source = if atom.object_refs.len() >= 2 {
+            atom.object_refs[0].clone()
+        } else if atom.subject_ref.trim().is_empty() {
+            continue;
+        } else {
+            atom.subject_ref.clone()
+        };
+        nodes.insert(source.clone());
+        let targets = if atom.object_refs.len() >= 2 {
+            atom.object_refs.iter().skip(1).cloned().collect::<Vec<_>>()
+        } else if atom.object_refs.len() == 1 {
+            atom.object_refs.clone()
+        } else {
+            Vec::new()
+        };
+        for target in targets {
+            nodes.insert(target.clone());
+            let source_refs = atom
+                .source_refs
+                .iter()
+                .map(source_ref_label)
+                .collect::<Vec<_>>();
+            edges.push(ArchSigAnalyticGraphEdgeV0 {
+                edge_ref: format!(
+                    "relation-edge:{}:{}:{}",
+                    stable_id(&atom.atom_observation_id),
+                    stable_id(&source),
+                    stable_id(&target)
+                ),
+                source_ref: source.clone(),
+                target_ref: target.clone(),
+                weight: 1,
+                relation_atom_ref: atom.atom_observation_id.clone(),
+                source_refs: source_refs.clone(),
+            });
+            let entry = edge_weights
+                .entry((source.clone(), target.clone()))
+                .or_insert_with(|| (0, Vec::new(), Vec::new()));
+            entry.0 += 1;
+            entry.1.push(atom.atom_observation_id.clone());
+            entry.2.extend(source_refs);
+        }
+    }
+    let nodes = nodes.into_iter().collect::<Vec<_>>();
+    let matrix_entries = edge_weights
+        .iter()
+        .map(|((source, target), (weight, evidence_refs, source_refs))| {
+            let evidence_refs =
+                unique_strings(evidence_refs.iter().chain(source_refs.iter()).cloned());
+            ArchSigAnalyticMatrixEntryV0 {
+                row_ref: source.clone(),
+                column_ref: target.clone(),
+                value: *weight,
+                evidence_refs,
+            }
+        })
+        .collect::<Vec<_>>();
+    let adjacency = matrix_entries
+        .iter()
+        .map(|entry| {
+            (
+                (entry.row_ref.as_str(), entry.column_ref.as_str()),
+                entry.value,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut reachable_pairs = BTreeSet::<String>::new();
+    let mut walk_witness_refs = Vec::new();
+    let mut cycle_refs = BTreeSet::<String>::new();
+    let mut walk_count_len_le_3 = 0_usize;
+    let mut max_shortest_path_len = 0_usize;
+    for start in &nodes {
+        let mut frontier = BTreeSet::from([start.as_str()]);
+        let mut seen = BTreeSet::from([start.as_str()]);
+        for depth in 1..=3 {
+            let mut next = BTreeSet::new();
+            for node in &frontier {
+                for target in nodes.iter().map(String::as_str) {
+                    if let Some(weight) = adjacency.get(&(*node, target)) {
+                        walk_count_len_le_3 += *weight as usize;
+                        next.insert(target);
+                        walk_witness_refs.push(format!(
+                            "walk:{}:{}:{}",
+                            stable_id(start),
+                            depth,
+                            stable_id(target)
+                        ));
+                        reachable_pairs.insert(format!("{start}->{target}"));
+                        if target == start.as_str() {
+                            cycle_refs.insert(format!("cycle:{start}:length-{depth}"));
+                        }
+                        if seen.insert(target) {
+                            max_shortest_path_len = max_shortest_path_len.max(depth);
+                        }
+                    }
+                }
+            }
+            frontier = next;
+            if frontier.is_empty() {
+                break;
+            }
+        }
+    }
+    let spectral_radius_estimate = spectral_radius_power_iteration(&matrix_entries);
+    SelectedRelationGraph {
+        nodes,
+        edges,
+        matrix_entries,
+        reachable_pairs: reachable_pairs.into_iter().collect(),
+        walk_witness_refs: unique_strings(walk_witness_refs.into_iter()),
+        cycle_refs: cycle_refs.into_iter().collect(),
+        walk_count_len_le_3,
+        max_shortest_path_len,
+        spectral_radius_estimate,
+    }
+}
+
+fn attach_relation_graph(
+    representation: &mut ArchSigAnalyticRepresentationV0,
+    graph: &SelectedRelationGraph,
+) {
+    representation.selected_graph_nodes = graph.nodes.clone();
+    representation.selected_graph_edges = graph.edges.clone();
+    representation.sparse_matrix_entries = graph.matrix_entries.clone();
+    representation.walk_witness_refs = graph.walk_witness_refs.clone();
+}
+
+fn relation_graph_evidence_between(
+    graph: &SelectedRelationGraph,
+    source_support_refs: &[String],
+    target_support_refs: &[String],
+) -> Vec<String> {
+    let source_refs = source_support_refs
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let target_refs = target_support_refs
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    graph
+        .edges
+        .iter()
+        .filter(|edge| {
+            let source_matches = source_refs.contains(edge.source_ref.as_str())
+                || source_refs.contains(edge.relation_atom_ref.as_str());
+            let target_matches = target_refs.contains(edge.target_ref.as_str())
+                || target_refs.contains(edge.relation_atom_ref.as_str());
+            source_matches && target_matches
+        })
+        .flat_map(|edge| {
+            std::iter::once(edge.edge_ref.clone())
+                .chain(std::iter::once(edge.relation_atom_ref.clone()))
+                .chain(edge.source_refs.iter().cloned())
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn spectral_radius_power_iteration(entries: &[ArchSigAnalyticMatrixEntryV0]) -> f64 {
+    let nodes = entries
+        .iter()
+        .flat_map(|entry| [entry.row_ref.clone(), entry.column_ref.clone()])
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if nodes.is_empty() {
+        return 0.0;
+    }
+    let index = nodes
+        .iter()
+        .enumerate()
+        .map(|(idx, node)| (node.as_str(), idx))
+        .collect::<BTreeMap<_, _>>();
+    let mut vector = vec![1.0 / nodes.len() as f64; nodes.len()];
+    let mut lambda = 0.0;
+    for _ in 0..16 {
+        let mut next = vec![0.0; nodes.len()];
+        for entry in entries {
+            if let (Some(row), Some(column)) = (
+                index.get(entry.row_ref.as_str()),
+                index.get(entry.column_ref.as_str()),
+            ) {
+                next[*column] += vector[*row] * entry.value as f64;
+            }
+        }
+        let norm = next.iter().copied().fold(0.0_f64, f64::max);
+        if norm == 0.0 {
+            return 0.0;
+        }
+        lambda = norm;
+        for value in &mut next {
+            *value /= norm;
+        }
+        vector = next;
+    }
+    lambda
 }
 
 fn build_coupling_cohesion_readings(
@@ -3770,11 +4011,94 @@ fn build_spectral_analysis_readings(
     operation_deltas: &[ArchSigOperationDeltaReadingV0],
 ) -> Vec<ArchSigSpectralAnalysisReadingV0> {
     vec![
+        relation_atom_adjacency_spectrum(archmap),
         workflow_risk_axis_pressure_spectrum(workflow_risk_readings),
         molecule_atom_overlap_spectrum(archmap),
         obstruction_axis_curvature_spectrum(obstruction_circuits, signature_axes),
         operation_signature_delta_spectrum(operation_deltas, signature_axes),
     ]
+}
+
+fn relation_atom_adjacency_spectrum(
+    archmap: &ArchMapDocumentV0,
+) -> ArchSigSpectralAnalysisReadingV0 {
+    let graph = selected_relation_graph(archmap);
+    let mut row_sums = BTreeMap::<String, i64>::new();
+    let mut col_sums = BTreeMap::<String, i64>::new();
+    let mut squared_sum = 0_f64;
+    for entry in &graph.matrix_entries {
+        *row_sums.entry(entry.row_ref.clone()).or_default() += entry.value;
+        *col_sums.entry(entry.column_ref.clone()).or_default() += entry.value;
+        squared_sum += (entry.value as f64).powi(2);
+    }
+    let max_row = row_sums.values().copied().max().unwrap_or_default();
+    let max_col = col_sums.values().copied().max().unwrap_or_default();
+    let mut dominant_components = Vec::new();
+    if let Some((node, value)) = row_sums
+        .iter()
+        .max_by(|left, right| left.1.cmp(right.1).then(left.0.cmp(right.0)))
+    {
+        dominant_components.push(spectral_component(
+            node,
+            "relationGraphSourceNode",
+            value.to_string(),
+            "largest outgoing weighted adjacency row in the selected relation graph",
+        ));
+    }
+    if let Some((node, value)) = col_sums
+        .iter()
+        .max_by(|left, right| left.1.cmp(right.1).then(left.0.cmp(right.0)))
+    {
+        dominant_components.push(spectral_component(
+            node,
+            "relationGraphTargetNode",
+            value.to_string(),
+            "largest incoming weighted adjacency column in the selected relation graph",
+        ));
+    }
+
+    spectral_reading(
+        "spectral:relation-atom-adjacency",
+        "relationAtomWeightedAdjacencyMatrix",
+        spectral_status(
+            graph.matrix_entries.len(),
+            !archmap.observation_gaps.is_empty(),
+        ),
+        spectral_shape(
+            "selectedRelationGraphNodes",
+            "selectedRelationGraphNodes",
+            graph.nodes.len(),
+            graph.nodes.len(),
+            graph.matrix_entries.len(),
+        ),
+        "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+        vec![
+            spectral_value("maxRowSum", max_row, "largest outgoing relation weight"),
+            spectral_value("maxColumnSum", max_col, "largest incoming relation weight"),
+            spectral_float_value(
+                "frobeniusNorm",
+                squared_sum.sqrt(),
+                "finite weighted adjacency matrix norm over selected relation atoms",
+            ),
+            spectral_float_value(
+                "spectralRadius",
+                graph.spectral_radius_estimate,
+                "power-iteration estimate over the finite nonnegative relation adjacency matrix",
+            ),
+        ],
+        dominant_components,
+        graph
+            .edges
+            .iter()
+            .map(|edge| edge.relation_atom_ref.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+        "observation gaps block measured-zero interpretation for absent relation edges",
+        "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+        "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+    )
 }
 
 fn workflow_risk_axis_pressure_spectrum(
@@ -4370,7 +4694,7 @@ fn build_curvature_support_readings(
         boundary_or_no_missing_evidence(archmap_gap_missing_evidence(archmap), &profile.profile_id);
     let reading_boundary = measurement_boundary_from_policy_or_fallback(
         &profile.reading_boundary,
-        "boundedMeasuredWithProxyTransfer",
+        "boundedMeasuredWithFiniteTransfer",
         &profile.coverage_requirement_refs,
         "zero spectrum reflects only selected measured witness rows with declared coverage; transfer recurrence remains bounded review telemetry",
     );
@@ -4672,8 +4996,10 @@ fn build_curvature_witness_clusters(
 }
 
 fn build_curvature_transfer_readings(
+    archmap: &ArchMapDocumentV0,
     curvature_support_readings: &[ArchSigCurvatureSupportReadingV0],
 ) -> Vec<ArchSigCurvatureTransferReadingV0> {
+    let relation_graph = selected_relation_graph(archmap);
     curvature_support_readings
         .iter()
         .map(|support_reading| {
@@ -4682,10 +5008,10 @@ fn build_curvature_transfer_readings(
                 .iter()
                 .filter(|support| support.curvature_value > 0)
                 .collect::<Vec<_>>();
-            let transfer_edges = build_curvature_transfer_edges(&positive_supports);
-            let spectral_radius_proxy = recurrent_transfer_weight_bound(&transfer_edges);
+            let transfer_edges = build_curvature_transfer_edges(&positive_supports, &relation_graph);
+            let spectral_radius = recurrent_transfer_spectral_radius(&transfer_edges);
             let recurrent_obstruction_modes =
-                build_recurrent_obstruction_modes(&transfer_edges, spectral_radius_proxy);
+                build_recurrent_obstruction_modes(&transfer_edges, spectral_radius);
             let status = if recurrent_obstruction_modes.is_empty() {
                 "nonConclusion"
             } else {
@@ -4699,7 +5025,7 @@ fn build_curvature_transfer_readings(
                 reading_id: reading_id.clone(),
                 profile_ref: support_reading.profile_ref.clone(),
                 status: status.to_string(),
-                measurement_status: "proxy".to_string(),
+                measurement_status: "measured".to_string(),
                 reading_boundary: support_reading.reading_boundary.clone(),
                 transfer_operator: ArchSigCurvatureTransferOperatorV0 {
                     operator_id: format!("transfer-operator:{}", stable_id(&reading_id)),
@@ -4727,7 +5053,7 @@ fn build_curvature_transfer_readings(
                     column_count: positive_supports.len(),
                     nonzero_edge_count: transfer_edges.len(),
                     entry_rule:
-                        "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence"
+                        "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence"
                             .to_string(),
                     spectral_radius_kind:
                         "finiteNonnegativeOperatorBoundedClosedWalkRadius".to_string(),
@@ -4737,10 +5063,10 @@ fn build_curvature_transfer_readings(
                 },
                 transfer_edges,
                 recurrent_obstruction_modes,
-                spectral_radius_reading: spectral_value(
-                    "rho(T^kappa)Proxy",
-                    spectral_radius_proxy,
-                    "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability",
+                spectral_radius_reading: spectral_float_value(
+                    "rho(T^kappa)",
+                    spectral_radius,
+                    "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability",
                 ),
                 coverage_boundary: support_reading.coverage_boundary.clone(),
                 evidence_boundary:
@@ -4761,6 +5087,7 @@ fn build_curvature_transfer_readings(
 
 fn build_curvature_transfer_edges(
     positive_supports: &[&ArchSigCurvatureWitnessSupportV0],
+    relation_graph: &SelectedRelationGraph,
 ) -> Vec<ArchSigCurvatureTransferEdgeV0> {
     let mut edges = Vec::new();
     for source in positive_supports {
@@ -4769,8 +5096,13 @@ fn build_curvature_transfer_edges(
                 .support_refs
                 .iter()
                 .any(|support_ref| target.support_refs.contains(support_ref));
+            let graph_evidence = relation_graph_evidence_between(
+                relation_graph,
+                &source.support_refs,
+                &target.support_refs,
+            );
             let same_axis = source.selected_axis_ref == target.selected_axis_ref;
-            if !same_axis && !shared_support {
+            if !same_axis && !shared_support && graph_evidence.is_empty() {
                 continue;
             }
             let weight = if source.witness_support_id == target.witness_support_id {
@@ -4806,11 +5138,14 @@ fn build_curvature_transfer_edges(
                         .support_refs
                         .iter()
                         .chain(target.support_refs.iter())
+                        .chain(graph_evidence.iter())
                         .chain(source.observation_refs.iter())
                         .chain(target.observation_refs.iter())
                         .cloned(),
                 ),
-                extraction_rule: if same_axis {
+                extraction_rule: if !graph_evidence.is_empty() {
+                    "selected-relation-graph"
+                } else if same_axis {
                     "same-selected-axis"
                 } else {
                     "shared-source-backed-support"
@@ -4828,6 +5163,9 @@ fn build_curvature_transfer_edges(
                 } else if same_axis {
                     "same-axis transfer edge records repeated curvature support along a selected axis"
                         .to_string()
+                } else if !graph_evidence.is_empty() {
+                    "relation-graph transfer edge records source-backed finite graph connectivity between supports"
+                        .to_string()
                 } else {
                     "shared-support transfer edge records cross-axis review pressure over observed support"
                         .to_string()
@@ -4840,9 +5178,9 @@ fn build_curvature_transfer_edges(
 
 fn build_recurrent_obstruction_modes(
     transfer_edges: &[ArchSigCurvatureTransferEdgeV0],
-    spectral_radius_proxy: i64,
+    spectral_radius: f64,
 ) -> Vec<ArchSigRecurrentObstructionModeV0> {
-    if spectral_radius_proxy <= 0 {
+    if spectral_radius <= 0.0 {
         return Vec::new();
     }
     let reciprocal_pairs = transfer_edges
@@ -4873,7 +5211,7 @@ fn build_recurrent_obstruction_modes(
             ),
             cycle_weight: edge.weight.min(reverse.weight).max(1),
             spectral_radius_reading: format!(
-                "rho(T^kappa) proxy bounded closed-walk radius {spectral_radius_proxy} over the finite ArchSig transfer operator"
+                "rho(T^kappa) finite-matrix estimate {spectral_radius:.3} over the finite ArchSig transfer operator"
             ),
             recurrent_obstruction_reading:
                 "positive multi-node closed walk is reported as recurrent obstruction support only"
@@ -4901,7 +5239,7 @@ fn build_recurrent_obstruction_modes(
             witness_refs: edge.witness_refs.clone(),
             cycle_weight: edge.weight,
             spectral_radius_reading: format!(
-                "rho(T^kappa) proxy bounded closed-walk radius {spectral_radius_proxy} > 0 over the finite ArchSig transfer operator"
+                "rho(T^kappa) finite-matrix estimate {spectral_radius:.3} > 0 over the finite ArchSig transfer operator"
             ),
             recurrent_obstruction_reading:
                 "positive closed walk is reported as recurrent obstruction support only"
@@ -4920,26 +5258,17 @@ fn build_recurrent_obstruction_modes(
         .collect()
 }
 
-fn recurrent_transfer_weight_bound(transfer_edges: &[ArchSigCurvatureTransferEdgeV0]) -> i64 {
-    let self_loop_weight = transfer_edges
+fn recurrent_transfer_spectral_radius(transfer_edges: &[ArchSigCurvatureTransferEdgeV0]) -> f64 {
+    let entries = transfer_edges
         .iter()
-        .filter(|edge| edge.source_support_ref == edge.target_support_ref)
-        .map(|edge| edge.weight)
-        .max()
-        .unwrap_or_default();
-    let reciprocal_weight = transfer_edges
-        .iter()
-        .filter(|edge| edge.source_support_ref != edge.target_support_ref)
-        .filter_map(|edge| {
-            let reverse = transfer_edges.iter().find(|candidate| {
-                candidate.source_support_ref == edge.target_support_ref
-                    && candidate.target_support_ref == edge.source_support_ref
-            })?;
-            Some(edge.weight.min(reverse.weight))
+        .map(|edge| ArchSigAnalyticMatrixEntryV0 {
+            row_ref: edge.source_support_ref.clone(),
+            column_ref: edge.target_support_ref.clone(),
+            value: edge.weight,
+            evidence_refs: edge.evidence_refs.clone(),
         })
-        .max()
-        .unwrap_or_default();
-    self_loop_weight.max(reciprocal_weight)
+        .collect::<Vec<_>>();
+    spectral_radius_power_iteration(&entries)
 }
 
 fn build_architecture_spectrum_report(
@@ -6116,6 +6445,8 @@ fn build_representation_strength_readings(
             non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
         })
         .chain(spectral_analysis_readings.iter().map(|reading| {
+            let is_relation_adjacency =
+                reading.representation_family == "relationAtomWeightedAdjacencyMatrix";
             ArchSigRepresentationStrengthReadingV0 {
                 reading_id: format!(
                     "representation-strength:{}",
@@ -6123,7 +6454,11 @@ fn build_representation_strength_readings(
                 ),
                 source_reading_ref: reading.spectral_reading_id.clone(),
                 representation_family: reading.representation_family.clone(),
-                zero_preserving: "boundedProxy".to_string(),
+                zero_preserving: if is_relation_adjacency {
+                    "supported".to_string()
+                } else {
+                    "boundedProxy".to_string()
+                },
                 zero_reflecting: if blockers.is_empty() {
                     "assumptionRelative".to_string()
                 } else {
@@ -6135,15 +6470,30 @@ fn build_representation_strength_readings(
                     "supported".to_string()
                 },
                 obstruction_reflecting: "notAnEigenvalueTheorem".to_string(),
-                aggregate_zero_safety: "proxyOnly".to_string(),
-                cancellation_risk: "boundedProxyMayHideLocalComponents".to_string(),
+                aggregate_zero_safety: if is_relation_adjacency {
+                    "notAggregate".to_string()
+                } else {
+                    "proxyOnly".to_string()
+                },
+                cancellation_risk: if is_relation_adjacency {
+                    "finiteMatrixMayHideUnobservedComponents".to_string()
+                } else {
+                    "boundedProxyMayHideLocalComponents".to_string()
+                },
                 required_assumptions: required_assumptions.clone(),
                 blocked_by: blockers.clone(),
                 blocked_reflection_or_preservation_reasons: blocked_reasons.clone(),
-                reading: format!(
-                    "{} is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
-                    reading.representation_family
-                ),
+                reading: if is_relation_adjacency {
+                    format!(
+                        "{} is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+                        reading.representation_family
+                    )
+                } else {
+                    format!(
+                        "{} is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
+                        reading.representation_family
+                    )
+                },
                 evidence_boundary: reading.coverage_boundary.clone(),
                 non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
             }
@@ -12133,7 +12483,7 @@ fn check_spectral_analysis_surface(packet: &ArchSigAnalysisPacketV0) -> Validati
     }
     check_from_examples(
         "archsig-analysis-packet-spectral-analysis-surface",
-        "packet exposes AAT spectral readings as bounded finite-representation proxies",
+        "packet exposes AAT spectral readings as bounded finite relation and measurement representations",
         examples,
         "fail",
     )
@@ -13001,14 +13351,14 @@ fn check_curvature_transfer_surface(packet: &ArchSigAnalysisPacketV0) -> Validat
         if reading
             .spectral_radius_reading
             .value
-            .parse::<i64>()
-            .is_ok_and(|value| value > 0)
+            .parse::<f64>()
+            .is_ok_and(|value| value > 0.0)
             && reading.recurrent_obstruction_modes.is_empty()
         {
             examples.push(generic_validation_example(
                 &reading.reading_id,
                 "recurrentObstructionModes",
-                "positive rho(T^kappa) proxy must be limited to recurrent obstruction modes",
+                "positive rho(T^kappa) finite transfer reading must be limited to recurrent obstruction modes",
             ));
         }
     }
@@ -16821,6 +17171,139 @@ fn strings(values: &[&str]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn relation_atom(
+        atom_observation_id: &str,
+        source_ref: &str,
+        target_ref: &str,
+    ) -> crate::ArchMapAtomObservationV0 {
+        crate::ArchMapAtomObservationV0 {
+            atom_observation_id: atom_observation_id.to_string(),
+            atom_family: "relation".to_string(),
+            predicate: format!("{source_ref} relates to {target_ref}"),
+            subject_ref: format!("{source_ref}->{target_ref}"),
+            object_refs: vec![source_ref.to_string(), target_ref.to_string()],
+            source_refs: vec![crate::ArchMapSourceRef {
+                artifact_id: Some(format!("fixture:{atom_observation_id}")),
+                kind: "fixture".to_string(),
+                path: Some("tests/fixtures/analytic_graph.json".to_string()),
+                symbol: Some(atom_observation_id.to_string()),
+                line: Some(1),
+                section: None,
+            }],
+            observation_status: "observed".to_string(),
+            evidence_boundary: "testFixture".to_string(),
+            confidence: "high".to_string(),
+            uncertainty: Vec::new(),
+            projection_refs: Vec::new(),
+            non_conclusions: vec![
+                "relation graph fixture is not runtime dependency proof".to_string(),
+            ],
+        }
+    }
+
+    fn curvature_support(
+        witness_support_id: &str,
+        axis_ref: &str,
+        weight: i64,
+    ) -> ArchSigCurvatureWitnessSupportV0 {
+        ArchSigCurvatureWitnessSupportV0 {
+            witness_support_id: witness_support_id.to_string(),
+            witness_rule_ref: format!("witness:{witness_support_id}"),
+            selected_axis_ref: axis_ref.to_string(),
+            signature_axis_ref: axis_ref.to_string(),
+            measurement_status: "measured".to_string(),
+            reading_boundary: ArchSigMeasurementReadingBoundaryV0::default(),
+            local_curvature_ref: String::new(),
+            diagram_ref: String::new(),
+            lhs_observation_refs: Vec::new(),
+            rhs_observation_refs: Vec::new(),
+            distance_kind: "fixture".to_string(),
+            distance_input_refs: vec![witness_support_id.to_string()],
+            soundness_boundary: "test fixture".to_string(),
+            coverage_status: "measured".to_string(),
+            curvature_value: 1,
+            weight,
+            support_refs: vec![witness_support_id.to_string()],
+            source_refs: vec![format!("source:{witness_support_id}")],
+            observation_refs: vec![format!("observation:{witness_support_id}")],
+            missing_evidence: Vec::new(),
+            reading: "fixture curvature support".to_string(),
+        }
+    }
+
+    #[test]
+    fn selected_relation_graph_acyclic_fixture_computes_walks_without_cycle() {
+        let mut archmap: ArchMapDocumentV0 =
+            serde_json::from_str(include_str!("../tests/fixtures/minimal/archmap.json"))
+                .expect("ArchMap fixture parses");
+        archmap.observation_gaps.clear();
+        archmap.atom_observations = vec![
+            relation_atom("atom:relation:a-b", "A", "B"),
+            relation_atom("atom:relation:b-c", "B", "C"),
+        ];
+
+        let graph = selected_relation_graph(&archmap);
+
+        assert_eq!(graph.nodes, vec!["A", "B", "C"]);
+        assert_eq!(graph.matrix_entries.len(), 2);
+        assert_eq!(graph.reachable_pairs.len(), 3);
+        assert_eq!(graph.max_shortest_path_len, 2);
+        assert!(graph.cycle_refs.is_empty());
+        assert_eq!(graph.spectral_radius_estimate, 0.0);
+    }
+
+    #[test]
+    fn selected_relation_graph_multi_node_cycle_fixture_detects_cycle_and_radius() {
+        let mut archmap: ArchMapDocumentV0 =
+            serde_json::from_str(include_str!("../tests/fixtures/minimal/archmap.json"))
+                .expect("ArchMap fixture parses");
+        archmap.observation_gaps.clear();
+        archmap.atom_observations = vec![
+            relation_atom("atom:relation:a-b", "A", "B"),
+            relation_atom("atom:relation:b-a", "B", "A"),
+        ];
+
+        let graph = selected_relation_graph(&archmap);
+
+        assert_eq!(graph.matrix_entries.len(), 2);
+        assert!(
+            graph
+                .cycle_refs
+                .iter()
+                .any(|cycle| cycle.contains("length-2")),
+            "{:?}",
+            graph.cycle_refs
+        );
+        assert!((graph.spectral_radius_estimate - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn curvature_transfer_weighted_fixture_uses_finite_matrix_radius() {
+        let first = curvature_support("support:a", "axis:semantic", 2);
+        let second = curvature_support("support:b", "axis:semantic", 3);
+        let supports = vec![&first, &second];
+        let graph = SelectedRelationGraph {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            matrix_entries: Vec::new(),
+            reachable_pairs: Vec::new(),
+            walk_witness_refs: Vec::new(),
+            cycle_refs: Vec::new(),
+            walk_count_len_le_3: 0,
+            max_shortest_path_len: 0,
+            spectral_radius_estimate: 0.0,
+        };
+
+        let transfer_edges = build_curvature_transfer_edges(&supports, &graph);
+        let radius = recurrent_transfer_spectral_radius(&transfer_edges);
+
+        assert_eq!(transfer_edges.len(), 4);
+        assert!(
+            radius > 4.0,
+            "finite matrix radius should exceed the old max-self-loop bound: {radius}"
+        );
+    }
 
     #[test]
     fn static_archsig_analysis_packet_validates() {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -1414,12 +1414,40 @@ pub struct ArchSigAnalyticRepresentationV0 {
     pub status: String,
     pub value_type: String,
     pub value: String,
+    #[serde(default)]
+    pub selected_graph_nodes: Vec<String>,
+    #[serde(default)]
+    pub selected_graph_edges: Vec<ArchSigAnalyticGraphEdgeV0>,
+    #[serde(default)]
+    pub sparse_matrix_entries: Vec<ArchSigAnalyticMatrixEntryV0>,
+    #[serde(default)]
+    pub walk_witness_refs: Vec<String>,
     pub graph_scope_refs: Vec<String>,
     pub axis_refs: Vec<String>,
     pub reading: String,
     pub coverage_boundary: String,
     pub zero_reflecting_boundary: String,
     pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAnalyticGraphEdgeV0 {
+    pub edge_ref: String,
+    pub source_ref: String,
+    pub target_ref: String,
+    pub weight: i64,
+    pub relation_atom_ref: String,
+    pub source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAnalyticMatrixEntryV0 {
+    pub row_ref: String,
+    pub column_ref: String,
+    pub value: i64,
+    pub evidence_refs: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1180,9 +1180,9 @@ fn acts_spectrum_fixture_manifest_locks_golden_validation() {
                             mode["transferEdgeRefs"]
                                 .as_array()
                                 .is_some_and(|refs| !refs.is_empty())
-                                && mode["spectralRadiusReading"]
-                                    .as_str()
-                                    .is_some_and(|text| text.contains("rho(T^kappa) proxy"))
+                                && mode["spectralRadiusReading"].as_str().is_some_and(|text| {
+                                    text.contains("rho(T^kappa) finite-matrix estimate")
+                                })
                         }),
                     "transfer cycle must surface as recurrent obstruction support"
                 );
@@ -2122,6 +2122,34 @@ fn assert_north_star_packet_surfaces(json: &Value) {
             "North Star packet must expose analytic representation {family}"
         );
     }
+    let weighted_adjacency = json["analyticRepresentations"]
+        .as_array()
+        .expect("analytic representations are array")
+        .iter()
+        .find(|entry| entry["representationFamily"] == "weightedAdjacencyMatrix")
+        .expect("weighted adjacency representation exists");
+    assert!(
+        weighted_adjacency["selectedGraphNodes"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+            && weighted_adjacency["selectedGraphEdges"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+            && weighted_adjacency["sparseMatrixEntries"]
+                .as_array()
+                .is_some_and(|items| {
+                    !items.is_empty()
+                        && items.iter().all(|entry| {
+                            entry["rowRef"].as_str().is_some()
+                                && entry["columnRef"].as_str().is_some()
+                                && entry["value"].as_i64().is_some_and(|value| value > 0)
+                                && entry["evidenceRefs"]
+                                    .as_array()
+                                    .is_some_and(|refs| !refs.is_empty())
+                        })
+                }),
+        "weighted adjacency must expose source-backed selected graph nodes, edges, and sparse matrix entries"
+    );
     for principle in [
         "InformationHiding",
         "Encapsulation",
@@ -2179,6 +2207,7 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "North Star packet must expose spectral analysis readings"
     );
     for family in [
+        "relationAtomWeightedAdjacencyMatrix",
         "workflowRiskAxisPressureMatrix",
         "moleculeAtomOverlapCouplingMatrix",
         "obstructionAxisCurvatureMatrix",

--- a/tools/archsig/tests/fixtures/acts_spectrum/coupon_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/coupon_validation.json
@@ -2,7 +2,7 @@
   "schemaVersion": "archsig-analysis-packet-validation-report-v0",
   "input": {
     "schemaVersion": "archsig-analysis-packet-v0",
-    "path": "archsig-analysis-packet",
+    "path": "/private/tmp/archsig1599-coupon-final/archsig-analysis-packet.json",
     "analysisId": "archsig-analysis:coupon-tax-rounding-archmap:llm-native-aat-law-policy-fixture",
     "archMapRef": "coupon-tax-rounding-archmap",
     "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture"
@@ -383,7 +383,7 @@
           "analytic:nilpotence-boundary",
           "analytic:selected-subgraph-spectrum",
           "analytic:propagation-depth",
-          "analytic:spectral-radius-proxy",
+          "analytic:spectral-radius",
           "analytic:curvature-valuation",
           "analytic:state-algebra-boundary",
           "analytic:zero-reflecting-aggregate-boundary"
@@ -715,17 +715,17 @@
         "representationFamily": "weightedAdjacencyMatrix",
         "status": "measured",
         "valueType": "matrixShape",
-        "value": "7x7; edgeCount=0",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "value": "0x0; edgeCount=0",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+        "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -743,17 +743,17 @@
         "representationFamily": "reachableConeSize",
         "status": "measured",
         "valueType": "nat",
-        "value": "7",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "value": "0",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+        "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -771,17 +771,17 @@
         "representationFamily": "walkCount",
         "status": "measured",
         "valueType": "nat",
-        "value": "1",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "value": "0",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+        "reading": "walk count enumerates selected relation-graph walks up to length 3",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -800,16 +800,16 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "blockedByCoverageGap",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+        "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -827,17 +827,17 @@
         "representationFamily": "selectedSubgraphSpectrum",
         "status": "measured",
         "valueType": "vector",
-        "value": "[0.000]",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "value": "[unavailable]",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+        "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -856,11 +856,11 @@
         "status": "measured",
         "valueType": "nat",
         "value": "0",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
@@ -879,21 +879,21 @@
         ]
       },
       {
-        "representationId": "analytic:spectral-radius-proxy",
+        "representationId": "analytic:spectral-radius",
         "representationFamily": "spectralRadius",
-        "status": "measured",
+        "status": "unavailable",
         "valueType": "float",
-        "value": "0.000",
-        "graphScopeRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
-        ],
+        "value": "unavailable",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+        "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -912,6 +912,10 @@
         "status": "measured",
         "valueType": "nat",
         "value": "1",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "obstruction:semantic-contract-mismatch:computed"
         ],
@@ -938,6 +942,10 @@
         "status": "unmeasured",
         "valueType": "boundaryStatus",
         "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
           "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
@@ -966,6 +974,10 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "blockedByObservationGaps",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "gap:coupon-runtime-payment-trace"
         ],
@@ -1242,6 +1254,57 @@
     ],
     "spectralAnalysisReadings": [
       {
+        "spectralReadingId": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "status": "nonConclusion",
+        "matrixShape": {
+          "rowDomain": "selectedRelationGraphNodes",
+          "columnDomain": "selectedRelationGraphNodes",
+          "rowCount": 0,
+          "columnCount": 0,
+          "nonzeroEntryCount": 0
+        },
+        "entryRule": "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "0",
+            "interpretation": "largest outgoing relation weight"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "0",
+            "interpretation": "largest incoming relation weight"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "0.000",
+            "interpretation": "finite weighted adjacency matrix norm over selected relation atoms"
+          },
+          {
+            "name": "spectralRadius",
+            "value": "0.000",
+            "interpretation": "power-iteration estimate over the finite nonnegative relation adjacency matrix"
+          }
+        ],
+        "dominantComponents": [],
+        "supportRefs": [],
+        "reading": "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+        "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+        "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+        "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
         "spectralReadingId": "spectral:workflow-risk-axis-pressure",
         "representationFamily": "workflowRiskAxisPressureMatrix",
         "status": "needsReview",
@@ -1497,6 +1560,42 @@
     ],
     "spectralModeReadings": [
       {
+        "spectralModeId": "spectral-mode:spectral-relation-atom-adjacency",
+        "sourceSpectralReadingRef": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "status": "nonConclusion",
+        "modeKind": "boundedSpectralMode",
+        "modeComponents": [],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "0.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "0.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.000",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is delocalized or dense; treat the concern as architecture-wide coupling before attempting local repair",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
         "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
         "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
         "representationFamily": "workflowRiskAxisPressureMatrix",
@@ -1699,6 +1798,7 @@
         "drilldownId": "spectral-drilldown:coupon-tax-rounding-archmap",
         "status": "needsReview",
         "sourceSpectralModeRefs": [
+          "spectral-mode:spectral-relation-atom-adjacency",
           "spectral-mode:spectral-workflow-risk-axis-pressure",
           "spectral-mode:spectral-molecule-atom-overlap-coupling",
           "spectral-mode:spectral-obstruction-axis-curvature",
@@ -2162,7 +2262,7 @@
         "readingId": "curvature-transfer-reading:spectrum-profile-curvature-transfer-default",
         "profileRef": "spectrum-profile:curvature-transfer-default",
         "status": "needsReview",
-        "measurementStatus": "proxy",
+        "measurementStatus": "measured",
         "readingBoundary": {
           "readingStrength": "boundedMeasuredWithProxyTransfer",
           "zeroReflectionAssumptions": [
@@ -2209,7 +2309,7 @@
           "rowCount": 1,
           "columnCount": 1,
           "nonzeroEdgeCount": 1,
-          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence",
           "spectralRadiusKind": "finiteNonnegativeOperatorBoundedClosedWalkRadius",
           "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
         },
@@ -2255,7 +2355,7 @@
               "witness:semantic-contract-mismatch"
             ],
             "cycleWeight": 1,
-            "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+            "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
             "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
             "reviewFocus": [
               "inspect the witness support behind the positive transfer self-loop",
@@ -2269,9 +2369,9 @@
           }
         ],
         "spectralRadiusReading": {
-          "name": "rho(T^kappa)Proxy",
-          "value": "1",
-          "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+          "name": "rho(T^kappa)",
+          "value": "1.000",
+          "interpretation": "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability"
         },
         "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
         "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
@@ -2501,7 +2601,7 @@
       "recurrentObstructions": [
         {
           "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
-          "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+          "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
           "transferEdgeRefs": [
             "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
           ],
@@ -2916,7 +3016,9 @@
         "featureLocalObstructionRefs": [
           "obstruction:semantic-contract-mismatch:computed"
         ],
-        "interactionObstructionRefs": [],
+        "interactionObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
         "liftingFailureRefs": [
           "split-readiness:molecule-coupon-operation-contract"
         ],
@@ -2924,10 +3026,76 @@
           "obstruction:semantic-contract-mismatch:computed"
         ],
         "complexityTransferRefs": [
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          "repair:obstruction-semantic-contract-mismatch-computed"
         ],
         "residualCoverageGapRefs": [
           "gap:coupon-runtime-payment-trace"
+        ],
+        "witnessBasis": [
+          {
+            "witnessRef": "gap:coupon-runtime-payment-trace",
+            "labels": [
+              "residualCoverageGap"
+            ],
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+            "labels": [
+              "featureLocalObstruction",
+              "fillingFailure",
+              "inheritedCoreObstruction",
+              "interactionObstruction"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+            "labels": [
+              "complexityTransfer"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "semantic:coupon-tax-rounding-paths"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "split-readiness:molecule-coupon-operation-contract",
+            "labels": [
+              "liftingFailure"
+            ],
+            "observationRefs": [
+              "molecule:coupon-operation-contract",
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          }
         ],
         "classificationSummary": [
           {
@@ -2948,8 +3116,10 @@
           },
           {
             "axis": "interactionObstruction",
-            "status": "unmeasuredOrAbsent",
-            "refs": [],
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
             "reading": "interactionObstruction is classified as a current-state extension coordinate"
           },
           {
@@ -2972,7 +3142,7 @@
             "axis": "complexityTransfer",
             "status": "observed",
             "refs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+              "repair:obstruction-semantic-contract-mismatch-computed"
             ],
             "reading": "complexityTransfer is classified as a current-state extension coordinate"
           },
@@ -2985,7 +3155,7 @@
             "reading": "residualCoverageGap is classified as a current-state extension coordinate"
           }
         ],
-        "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "evidenceBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -3002,15 +3172,15 @@
         "readingId": "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
         "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
         "operationKind": "repair-semanticmismatchcircuit",
-        "compositionStatus": "assumptionRelative",
-        "associativityUnderObservationStatus": "selectedObservationOnly",
-        "refinementAbstractionCompatibility": "blockedByMissingEvidence",
+        "compositionStatus": "observed",
+        "associativityUnderObservationStatus": "observed",
+        "refinementAbstractionCompatibility": "blocked",
         "replacementEquivalence": "unmeasured",
         "protectionIdempotence": "notApplicable",
-        "runtimeLocalization": "blockedByCoverageGap",
+        "runtimeLocalization": "blocked",
         "migrationCompatibility": "notApplicable",
         "reverseInvolution": "unmeasured",
-        "repairMonotonicity": "selectedAxisOnly",
+        "repairMonotonicity": "blockedByTransferRisk",
         "synthesisNoSolutionBoundary": "notASynthesisCertificate",
         "preconditionRefs": [
           "human review selects a repair operation",
@@ -3019,6 +3189,169 @@
         "evidenceRefs": [
           "obstruction:semantic-contract-mismatch:computed",
           "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "lawEvidence": [
+          {
+            "lawAxis": "composition",
+            "status": "observed",
+            "requiredEvidenceRefs": [
+              "operation support refs",
+              "operation precondition refs"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation",
+              "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+            ],
+            "blockedReasonRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "composition is observed under selected operation evidence"
+          },
+          {
+            "lawAxis": "associativityUnderObservation",
+            "status": "observed",
+            "requiredEvidenceRefs": [
+              "operation delta support"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "associativityUnderObservation is observed under selected operation evidence"
+          },
+          {
+            "lawAxis": "refinementAbstractionCompatibility",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "preserved invariant refs"
+            ],
+            "observedEvidenceRefs": [
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "refinementAbstractionCompatibility is blocked under selected operation evidence"
+          },
+          {
+            "lawAxis": "replacementEquivalence",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "before/after equivalence witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "blockedReasonRefs": [
+              "replacement-equivalence:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:replacement-equivalence"
+            ],
+            "reading": "replacementEquivalence is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "protectionIdempotence",
+            "status": "notApplicable",
+            "requiredEvidenceRefs": [
+              "repeat protection witness"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "protectionIdempotence is notApplicable under selected operation evidence"
+          },
+          {
+            "lawAxis": "runtimeLocalization",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "runtime/effect localization witness"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+            ],
+            "blockedReasonRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "runtimeLocalization is blocked under selected operation evidence"
+          },
+          {
+            "lawAxis": "migrationCompatibility",
+            "status": "notApplicable",
+            "requiredEvidenceRefs": [
+              "migration compatibility witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "migrationCompatibility is notApplicable under selected operation evidence"
+          },
+          {
+            "lawAxis": "reverseInvolution",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "reverse operation witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [
+              "reverse-involution:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:reverse-operation"
+            ],
+            "reading": "reverseInvolution is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "repairMonotonicity",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "selected obstruction valuation",
+              "transfer risk refs"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "sig-axis:semantic-inconsistency"
+            ],
+            "blockedReasonRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:selected-axis-only"
+            ],
+            "reading": "repairMonotonicity is blocked under selected operation evidence"
+          }
         ],
         "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
         "nonConclusions": [
@@ -3176,6 +3509,230 @@
         ],
         "coverageBoundary": "projection reflection is read only under explicit axis preservation and witness completeness assumptions",
         "evidenceBoundary": "axis-forgetting risk is current-state ArchSig telemetry; it is not a proof that every projection loses information",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "observationProjectionFidelityReadings": [
+      {
+        "readingId": "observation-projection-fidelity:observation-projection-coupon-tax-rounding-archmap",
+        "sourceProjectionRef": "observation-projection:coupon-tax-rounding-archmap",
+        "sourceAxisForgettingRef": "axis-forgetting-risk:selected-projection",
+        "fidelityStatus": "projectionLossObserved",
+        "observedAtomFamilyCount": 3,
+        "forgottenCoordinateCount": 1,
+        "observationCollisionCount": 0,
+        "collapsedAtomFamilyCandidateCount": 1,
+        "hiddenAtomFamilyHintCount": 1,
+        "projectionLostAtomFamilyRefs": [
+          "pricing.checkoutTotal -> contractSpecification,semanticInterpretation",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture"
+        ],
+        "projectionLossAxes": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "measurementBoundary": "projection loss is separated from zero/lawfulness; missing coordinates are not measured absent atoms",
+        "recommendedNextAction": "review projection-lost families and forgotten coordinates before treating the ArchMap as a faithful Atom observation",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomOriginClosureDebtReadings": [
+      {
+        "readingId": "atom-origin-closure-debt:coupon-tax-rounding-archmap",
+        "sourceBackedAtomCount": 3,
+        "derivedOrInferredAtomCount": 0,
+        "expectedMissingAtomCount": 1,
+        "sourceBackedAtomFamilyRefs": [
+          "contractSpecification",
+          "effect",
+          "semanticInterpretation"
+        ],
+        "derivedOrInferredRefs": [],
+        "missingExpectedAtomRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "closureStatus": "originClosureDebtObserved",
+        "weakensZeroOrRepairClaims": [
+          "zero readings need source-backed Atom closure or explicit coverage boundary",
+          "repair and synthesis candidates remain bounded when expected atoms are missing",
+          "derived or inferred atoms must not be promoted to source-backed evidence"
+        ],
+        "evidenceBoundary": "Atom origin closure debt is read from sourceRefs and observation gaps; it is not complete source extraction validation",
+        "recommendedNextAction": "separate source-backed, derived/inferred, and expected-missing Atom evidence before using the packet for repair or synthesis claims",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "effectRelationAlgebraReadings": [
+      {
+        "readingId": "effect-relation-algebra:coupon-tax-rounding-archmap",
+        "generatorRefs": [
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+        ],
+        "effectAtomRefs": [
+          "atom:effect:receipt-boundary"
+        ],
+        "relationAtomRefs": [
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
+        ],
+        "externalBoundaryRefs": [],
+        "requiredEffectRelations": [
+          "effect ordering",
+          "replay or roundtrip stability",
+          "compensation/finalization relation",
+          "handler and external provider boundary ownership"
+        ],
+        "unresolvedEffectRelations": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "effectOrderingPressure": "effectRelationPressureObserved",
+        "stateTransitionRef": "state-transition-algebra:coupon-tax-rounding-archmap",
+        "evidenceBoundary": "effect relation algebra is kept separate from state transition pressure and only reads observed effect/relation/runtime evidence",
+        "recommendedNextAction": "review async job, provider, event handler, replay, roundtrip, and compensation relations before approving state/effect repairs",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "synthesisBlockageReadings": [
+      {
+        "readingId": "synthesis-blockage:coupon-tax-rounding-archmap",
+        "targetConstructionRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed",
+          "feature-extension-formula:coupon-tax-rounding-archmap"
+        ],
+        "requiredAtomRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
+        "constraintRefs": [
+          "obstruction:semantic-contract-mismatch:computed",
+          "obstruction:semantic-contract-mismatch:computed",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-coupon-operation-contract",
+          "obstruction:semantic-contract-mismatch:computed",
+          "gap:coupon-runtime-payment-trace",
+          "diagram filling is LawPolicy-relative and requires selected witness completeness"
+        ],
+        "missingEvidenceRefs": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero",
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "decisionBoundaryRefs": [
+          "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "candidateSolutionRefs": [],
+        "blockageStatus": "synthesisBlockedByMissingEvidenceOrConstraints",
+        "noSolutionCertificateStatus": "notASolverAndNotAbsenceProof",
+        "synthesisBoundary": "candidate absence, missing evidence, and no-solution certificates are distinct; ArchSig does not run a synthesis solver",
+        "recommendedNextAction": "resolve Atom, constraint, evidence, and decision-boundary blockers before reading a repair candidate as constructible",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationPreconditionReadinessReadings": [
+      {
+        "readingId": "operation-precondition-readiness:repair-obstruction-semantic-contract-mismatch-computed",
+        "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "readinessStatus": "blockedByMissingPreconditionEvidence",
+        "preconditionRefs": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+        ],
+        "missingPreconditionRefs": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "replacement-equivalence:witness-not-supplied",
+          "reverse-involution:witness-not-supplied",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "coverageGapRefs": [
+          "gap:coupon-runtime-payment-trace",
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "exactnessGapRefs": [
+          "gap:coupon-runtime-payment-trace",
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "witnessGapRefs": [
+          "witness:layer-violation",
+          "witness:semantic-contract-mismatch"
+        ],
+        "candidateBoundary": "repair/split/migration/protection candidates are review cues until precondition evidence is observed",
+        "recommendedNextAction": "supply coverage, exactness, witness, and runtime precondition evidence before treating the operation as safe",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathMultiplicityLossReadings": [
+      {
+        "readingId": "path-multiplicity-loss:coupon-tax-rounding-archmap",
+        "scopeRef": "coupon-tax-rounding-archmap",
+        "pathReadingRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "observedPathCount": 1,
+        "alternatePathPressure": 8,
+        "maxWalkLengthProxy": 3,
+        "reachabilityForgottenRefs": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "fanInBoundaryRefs": [],
+        "multiplicityLossStatus": "reachabilityMultiplicityLossObserved",
+        "homotopyBoundary": "path multiplicity is a reachability and homotopy review signal, not proof of all paths",
+        "evidenceBoundary": "alternate-path pressure is bounded by observed operation trajectories, homotopy sensitivity, workflow risk, and gaps",
+        "recommendedNextAction": "inspect high fan-in and alternate path boundaries before treating one observed path as complete reachability",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -4900,44 +5457,60 @@
     },
     "operationSquareCandidates": [
       {
-        "candidateId": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "candidateSource": "inferred",
-        "suppliedPairRef": null,
+        "candidateId": "operation-square:operation-square-evidence-coupon-tax-rounding",
+        "candidateSource": "supplied",
+        "suppliedPairRef": "operation-square-evidence:coupon-tax-rounding",
         "candidateBasis": [
-          "effectFamily",
-          "contractAtom",
-          "semanticAtom",
-          "runtimeInteraction",
-          "projectionSurface"
+          "sourceBackedOperationPair",
+          "suppliedPathPair",
+          "sharedEndpoint",
+          "generatorCandidate",
+          "atomSupport",
+          "semanticSupport",
+          "projectionSupport"
         ],
-        "leftOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-        "rightOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
-        "pPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-        "qPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "candidateBasisRefs": [
+          "PaymentAmount",
+          "ReceiptAmount",
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "molecule:coupon-operation-contract",
+          "projection:coupon-payment-receipt",
+          "semantic:coupon-tax-rounding-paths",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "leftOperationRef": "operation:discount",
+        "rightOperationRef": "operation:tax-round",
+        "pPathRef": "operation:round . operation:tax . operation:discount",
+        "qPathRef": "operation:round . operation:discount . operation:tax",
         "pOperationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:discount",
+          "operation:tax",
+          "operation:round"
         ],
         "qOperationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+          "operation:tax",
+          "operation:discount",
+          "operation:round"
         ],
         "endpointObjectRefs": [
-          "PaymentAmount / ReceiptAmount"
+          "PaymentAmount",
+          "ReceiptAmount"
         ],
         "generatorCandidateRefs": [
           "generator:independent-square",
-          "generator:same-contract-replacement",
-          "generator:repair-filler",
-          "generator:identity-insertion-deletion",
-          "generator:associativity-reassociation"
+          "generator:same-contract-replacement"
         ],
-        "sharedAtomSupportRefs": [],
+        "sharedAtomSupportRefs": [
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "atom:effect:receipt-boundary"
+        ],
         "stateRefs": [],
         "effectRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:effect:receipt-boundary"
         ],
         "contractRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
@@ -4946,9 +5519,7 @@
           "semantic:coupon-tax-rounding-paths"
         ],
         "authorityRefs": [],
-        "runtimeRefs": [
-          "gap:coupon-runtime-payment-trace"
-        ],
+        "runtimeRefs": [],
         "projectionRefs": [
           "projection:coupon-payment-receipt"
         ],
@@ -4958,15 +5529,14 @@
         ],
         "observationRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "gap:coupon-runtime-payment-trace",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "molecule:coupon-operation-contract",
           "projection:coupon-payment-receipt",
           "semantic:coupon-tax-rounding-paths"
         ],
-        "missingRefs": [
-          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
-          "no state observation supplied for operation square candidate"
-        ],
-        "evidenceBoundary": "inferred operation square candidate is a review cue over observed ArchMap support, not operation truth",
+        "missingRefs": [],
+        "evidenceBoundary": "supplied operation square evidence is first-class ArchMap input with p/q paths, endpoints, and source-backed basis refs: fixture supplies p/q operation sequences and shared payment/receipt endpoints for AAT operation square measurement",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -4980,54 +5550,85 @@
     ],
     "pathContinuationTraces": [
       {
-        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "traceId": "path-continuation-trace:operation-square-operation-square-evidence-coupon-tax-rounding:p",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+        "pathRef": "operation-square:operation-square-evidence-coupon-tax-rounding:p",
         "pathRole": "p",
-        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "pathExpression": "operation:round . operation:tax . operation:discount",
         "operationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:discount",
+          "operation:tax",
+          "operation:round"
         ],
         "endpointObjectRefs": [
-          "PaymentAmount / ReceiptAmount"
+          "PaymentAmount",
+          "ReceiptAmount"
         ],
         "continuationStepRefs": [
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p:endpoint"
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:p:operation-discount",
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:p:operation-tax",
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:p:operation-round",
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:p:endpoint"
         ],
         "axisTraces": [
           {
             "axisFamily": "static",
             "axisRef": "static dependency / support axis",
-            "traceStatus": "unmeasured",
-            "continuationSummary": "static continuation is unmeasured under current ArchMap evidence",
+            "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
+            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_static[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_static[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_static[endpoint]=p; endpointRefs=1"
+              "Cont_static[0]=operation:discount; comparableValues=2",
+              "Cont_static[1]=operation:tax; comparableValues=2",
+              "Cont_static[2]=operation:round; comparableValues=2",
+              "Cont_static[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
             ],
-            "distanceInputRefs": [],
-            "observationRefs": [],
-            "sourceRefs": [],
-            "missingRefs": [
-              "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            "comparableContinuationValues": [
+              "static:endpoints:PaymentAmount|ReceiptAmount",
+              "static:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding|atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation|atom-effect-receipt-boundary"
             ],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount",
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:effect:receipt-boundary",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "atom:effect:receipt-boundary"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "contract",
             "axisRef": "contract axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
             "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_contract[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_contract[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_contract[endpoint]=p; endpointRefs=1"
+              "Cont_contract[0]=operation:discount; comparableValues=2",
+              "Cont_contract[1]=operation:tax; comparableValues=2",
+              "Cont_contract[2]=operation:round; comparableValues=2",
+              "Cont_contract[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "contract:endpoints:PaymentAmount|ReceiptAmount",
+              "contract:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
             ],
             "distanceInputRefs": [
-              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+              "PaymentAmount",
+              "ReceiptAmount",
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "test-coupon-rounding"
             ],
             "observationRefs": [
               "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
@@ -5042,19 +5643,26 @@
             "axisFamily": "semantic",
             "axisRef": "semantic axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "semantic continuation reads 2 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
+            "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_semantic[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=2",
-              "Cont_semantic[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=2",
-              "Cont_semantic[endpoint]=p; endpointRefs=1"
+              "Cont_semantic[0]=operation:discount; comparableValues=2",
+              "Cont_semantic[1]=operation:tax; comparableValues=2",
+              "Cont_semantic[2]=operation:round; comparableValues=2",
+              "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "semantic:path:p:operation:discount -> operation:tax -> operation:round",
+              "semantic:endpoints:PaymentAmount|ReceiptAmount"
             ],
             "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount",
               "semantic:coupon-tax-rounding-paths",
-              "derived-semantic-order:p=round(tax(discount(subtotal)))"
+              "test-coupon-rounding"
             ],
             "observationRefs": [
-              "semantic:coupon-tax-rounding-paths",
-              "derived-semantic-order:p=round(tax(discount(subtotal)))"
+              "semantic:coupon-tax-rounding-paths"
             ],
             "sourceRefs": [
               "test-coupon-rounding"
@@ -5066,17 +5674,23 @@
             "axisFamily": "state",
             "axisRef": "state transition axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
             "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_state[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_state[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_state[endpoint]=p; endpointRefs=1"
+              "Cont_state[0]=operation:discount; comparableValues=0",
+              "Cont_state[1]=operation:tax; comparableValues=0",
+              "Cont_state[2]=operation:round; comparableValues=0",
+              "Cont_state[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
@@ -5084,64 +5698,26 @@
             "axisFamily": "effect",
             "axisRef": "effect ordering / replay / compensation axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+            "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_effect[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=4",
-              "Cont_effect[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=4",
-              "Cont_effect[endpoint]=p; endpointRefs=1"
+              "Cont_effect[0]=operation:discount; comparableValues=2",
+              "Cont_effect[1]=operation:tax; comparableValues=2",
+              "Cont_effect[2]=operation:round; comparableValues=2",
+              "Cont_effect[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "effect:path:p:operation:discount -> operation:tax -> operation:round",
+              "effect:endpoints:PaymentAmount|ReceiptAmount"
             ],
             "distanceInputRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+              "PaymentAmount",
+              "ReceiptAmount",
+              "atom:effect:receipt-boundary",
+              "src-pricing-checkout"
             ],
             "observationRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
-            ],
-            "sourceRefs": [
-              "src-pricing-checkout",
-              "test-coupon-rounding"
-            ],
-            "missingRefs": [],
-            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
-          },
-          {
-            "axisFamily": "authority",
-            "axisRef": "authority / trust boundary axis",
-            "traceStatus": "unmeasured",
-            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
-            "continuationStates": [
-              "Cont_authority[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_authority[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_authority[endpoint]=p; endpointRefs=1"
-            ],
-            "distanceInputRefs": [],
-            "observationRefs": [],
-            "sourceRefs": [],
-            "missingRefs": [
-              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-            ],
-            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
-          },
-          {
-            "axisFamily": "runtime",
-            "axisRef": "runtime interaction axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
-            "continuationStates": [
-              "Cont_runtime[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_runtime[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_runtime[endpoint]=p; endpointRefs=1"
-            ],
-            "distanceInputRefs": [
-              "gap:coupon-runtime-payment-trace"
-            ],
-            "observationRefs": [
-              "gap:coupon-runtime-payment-trace"
+              "atom:effect:receipt-boundary"
             ],
             "sourceRefs": [
               "src-pricing-checkout"
@@ -5150,17 +5726,74 @@
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
+            "axisFamily": "authority",
+            "axisRef": "authority / trust boundary axis",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
+            "continuationStates": [
+              "Cont_authority[0]=operation:discount; comparableValues=0",
+              "Cont_authority[1]=operation:tax; comparableValues=0",
+              "Cont_authority[2]=operation:round; comparableValues=0",
+              "Cont_authority[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
+            ],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount"
+            ],
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "runtime",
+            "axisRef": "runtime interaction axis",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
+            "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
+            "continuationStates": [
+              "Cont_runtime[0]=operation:discount; comparableValues=0",
+              "Cont_runtime[1]=operation:tax; comparableValues=0",
+              "Cont_runtime[2]=operation:round; comparableValues=0",
+              "Cont_runtime[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
+            ],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount"
+            ],
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
             "axisFamily": "projection",
             "axisRef": "projection / representation axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
             "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_projection[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_projection[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_projection[endpoint]=p; endpointRefs=1"
+              "Cont_projection[0]=operation:discount; comparableValues=2",
+              "Cont_projection[1]=operation:tax; comparableValues=2",
+              "Cont_projection[2]=operation:round; comparableValues=2",
+              "Cont_projection[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "projection:endpoints:PaymentAmount|ReceiptAmount",
+              "projection:support:projection-coupon-payment-receipt"
             ],
             "distanceInputRefs": [
-              "projection:coupon-payment-receipt"
+              "PaymentAmount",
+              "ReceiptAmount",
+              "projection:coupon-payment-receipt",
+              "semantic:coupon-tax-rounding-paths"
             ],
             "observationRefs": [
               "projection:coupon-payment-receipt"
@@ -5174,7 +5807,9 @@
         ],
         "observationRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "gap:coupon-runtime-payment-trace",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "molecule:coupon-operation-contract",
           "projection:coupon-payment-receipt",
           "semantic:coupon-tax-rounding-paths"
         ],
@@ -5182,10 +5817,7 @@
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
-        "missingRefs": [
-          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
-          "no state observation supplied for operation square candidate"
-        ],
+        "missingRefs": [],
         "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
@@ -5198,54 +5830,85 @@
         ]
       },
       {
-        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+        "traceId": "path-continuation-trace:operation-square-operation-square-evidence-coupon-tax-rounding:q",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+        "pathRef": "operation-square:operation-square-evidence-coupon-tax-rounding:q",
         "pathRole": "q",
-        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "pathExpression": "operation:round . operation:discount . operation:tax",
         "operationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+          "operation:tax",
+          "operation:discount",
+          "operation:round"
         ],
         "endpointObjectRefs": [
-          "PaymentAmount / ReceiptAmount"
+          "PaymentAmount",
+          "ReceiptAmount"
         ],
         "continuationStepRefs": [
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q:endpoint"
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:q:operation-tax",
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:q:operation-discount",
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:q:operation-round",
+          "cont-step:operation-square-operation-square-evidence-coupon-tax-rounding:q:endpoint"
         ],
         "axisTraces": [
           {
             "axisFamily": "static",
             "axisRef": "static dependency / support axis",
-            "traceStatus": "unmeasured",
-            "continuationSummary": "static continuation is unmeasured under current ArchMap evidence",
+            "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
+            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_static[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_static[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_static[endpoint]=q; endpointRefs=1"
+              "Cont_static[0]=operation:tax; comparableValues=2",
+              "Cont_static[1]=operation:discount; comparableValues=2",
+              "Cont_static[2]=operation:round; comparableValues=2",
+              "Cont_static[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
             ],
-            "distanceInputRefs": [],
-            "observationRefs": [],
-            "sourceRefs": [],
-            "missingRefs": [
-              "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            "comparableContinuationValues": [
+              "static:endpoints:PaymentAmount|ReceiptAmount",
+              "static:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding|atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation|atom-effect-receipt-boundary"
             ],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount",
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:effect:receipt-boundary",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "atom:effect:receipt-boundary"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "contract",
             "axisRef": "contract axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
             "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_contract[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_contract[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_contract[endpoint]=q; endpointRefs=1"
+              "Cont_contract[0]=operation:tax; comparableValues=2",
+              "Cont_contract[1]=operation:discount; comparableValues=2",
+              "Cont_contract[2]=operation:round; comparableValues=2",
+              "Cont_contract[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "contract:endpoints:PaymentAmount|ReceiptAmount",
+              "contract:support:atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
             ],
             "distanceInputRefs": [
-              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+              "PaymentAmount",
+              "ReceiptAmount",
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "test-coupon-rounding"
             ],
             "observationRefs": [
               "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
@@ -5260,19 +5923,26 @@
             "axisFamily": "semantic",
             "axisRef": "semantic axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "semantic continuation reads 2 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
+            "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_semantic[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=2",
-              "Cont_semantic[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=2",
-              "Cont_semantic[endpoint]=q; endpointRefs=1"
+              "Cont_semantic[0]=operation:tax; comparableValues=2",
+              "Cont_semantic[1]=operation:discount; comparableValues=2",
+              "Cont_semantic[2]=operation:round; comparableValues=2",
+              "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "semantic:path:q:operation:tax -> operation:discount -> operation:round",
+              "semantic:endpoints:PaymentAmount|ReceiptAmount"
             ],
             "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount",
               "semantic:coupon-tax-rounding-paths",
-              "derived-semantic-order:q=round(discount(tax(subtotal)))"
+              "test-coupon-rounding"
             ],
             "observationRefs": [
-              "semantic:coupon-tax-rounding-paths",
-              "derived-semantic-order:q=round(discount(tax(subtotal)))"
+              "semantic:coupon-tax-rounding-paths"
             ],
             "sourceRefs": [
               "test-coupon-rounding"
@@ -5284,17 +5954,23 @@
             "axisFamily": "state",
             "axisRef": "state transition axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
             "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_state[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_state[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_state[endpoint]=q; endpointRefs=1"
+              "Cont_state[0]=operation:tax; comparableValues=0",
+              "Cont_state[1]=operation:discount; comparableValues=0",
+              "Cont_state[2]=operation:round; comparableValues=0",
+              "Cont_state[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
@@ -5302,64 +5978,26 @@
             "axisFamily": "effect",
             "axisRef": "effect ordering / replay / compensation axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+            "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_effect[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=4",
-              "Cont_effect[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=4",
-              "Cont_effect[endpoint]=q; endpointRefs=1"
+              "Cont_effect[0]=operation:tax; comparableValues=2",
+              "Cont_effect[1]=operation:discount; comparableValues=2",
+              "Cont_effect[2]=operation:round; comparableValues=2",
+              "Cont_effect[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "effect:path:q:operation:tax -> operation:discount -> operation:round",
+              "effect:endpoints:PaymentAmount|ReceiptAmount"
             ],
             "distanceInputRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "PaymentAmount",
+              "ReceiptAmount",
+              "atom:effect:receipt-boundary",
+              "src-pricing-checkout"
             ],
             "observationRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-            ],
-            "sourceRefs": [
-              "src-pricing-checkout",
-              "test-coupon-rounding"
-            ],
-            "missingRefs": [],
-            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
-          },
-          {
-            "axisFamily": "authority",
-            "axisRef": "authority / trust boundary axis",
-            "traceStatus": "unmeasured",
-            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
-            "continuationStates": [
-              "Cont_authority[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_authority[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_authority[endpoint]=q; endpointRefs=1"
-            ],
-            "distanceInputRefs": [],
-            "observationRefs": [],
-            "sourceRefs": [],
-            "missingRefs": [
-              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-            ],
-            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
-          },
-          {
-            "axisFamily": "runtime",
-            "axisRef": "runtime interaction axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
-            "continuationStates": [
-              "Cont_runtime[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_runtime[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_runtime[endpoint]=q; endpointRefs=1"
-            ],
-            "distanceInputRefs": [
-              "gap:coupon-runtime-payment-trace"
-            ],
-            "observationRefs": [
-              "gap:coupon-runtime-payment-trace"
+              "atom:effect:receipt-boundary"
             ],
             "sourceRefs": [
               "src-pricing-checkout"
@@ -5368,17 +6006,74 @@
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
+            "axisFamily": "authority",
+            "axisRef": "authority / trust boundary axis",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
+            "continuationStates": [
+              "Cont_authority[0]=operation:tax; comparableValues=0",
+              "Cont_authority[1]=operation:discount; comparableValues=0",
+              "Cont_authority[2]=operation:round; comparableValues=0",
+              "Cont_authority[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
+            ],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount"
+            ],
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
+            "axisFamily": "runtime",
+            "axisRef": "runtime interaction axis",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
+            "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
+            "continuationStates": [
+              "Cont_runtime[0]=operation:tax; comparableValues=0",
+              "Cont_runtime[1]=operation:discount; comparableValues=0",
+              "Cont_runtime[2]=operation:round; comparableValues=0",
+              "Cont_runtime[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
+            ],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "PaymentAmount",
+              "ReceiptAmount"
+            ],
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            ],
+            "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
+          },
+          {
             "axisFamily": "projection",
             "axisRef": "projection / representation axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
             "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_projection[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_projection[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_projection[endpoint]=q; endpointRefs=1"
+              "Cont_projection[0]=operation:tax; comparableValues=2",
+              "Cont_projection[1]=operation:discount; comparableValues=2",
+              "Cont_projection[2]=operation:round; comparableValues=2",
+              "Cont_projection[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "projection:endpoints:PaymentAmount|ReceiptAmount",
+              "projection:support:projection-coupon-payment-receipt"
             ],
             "distanceInputRefs": [
-              "projection:coupon-payment-receipt"
+              "PaymentAmount",
+              "ReceiptAmount",
+              "projection:coupon-payment-receipt",
+              "semantic:coupon-tax-rounding-paths"
             ],
             "observationRefs": [
               "projection:coupon-payment-receipt"
@@ -5392,7 +6087,9 @@
         ],
         "observationRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "gap:coupon-runtime-payment-trace",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "molecule:coupon-operation-contract",
           "projection:coupon-payment-receipt",
           "semantic:coupon-tax-rounding-paths"
         ],
@@ -5400,10 +6097,7 @@
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
-        "missingRefs": [
-          "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
-          "no state observation supplied for operation square candidate"
-        ],
+        "missingRefs": [],
         "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
@@ -5418,21 +6112,26 @@
     ],
     "axisWiseMonodromyDefects": [
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:authority",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "axisFamily": "authority",
         "axisRef": "authority / trust boundary axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:authority-boundary-value-mismatch",
         "pContinuationRef": "Cont_authority(p):authority / trust boundary axis",
         "qContinuationRef": "Cont_authority(q):authority / trust boundary axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "distanceInputRefs": [
+          "PaymentAmount",
+          "ReceiptAmount"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 0,
         "measurementStatus": "unmeasured",
         "distanceValue": null,
         "measuredSupportRefs": [],
         "witnessRefs": [
-          "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          "missing-evidence:missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+          "missing-evidence:missing comparable p continuation value for authority",
+          "missing-evidence:missing comparable q continuation value for authority"
         ],
         "sourceRefs": [
           "src-pricing-checkout",
@@ -5440,9 +6139,11 @@
         ],
         "observationRefs": [],
         "missingRefs": [
-          "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+          "missing comparable p continuation value for authority",
+          "missing comparable q continuation value for authority"
         ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5455,7 +6156,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5467,17 +6168,20 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "axisFamily": "contract",
         "axisRef": "contract axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:contract-obligation-value-mismatch",
         "pContinuationRef": "Cont_contract(p):contract axis",
         "qContinuationRef": "Cont_contract(q):contract axis",
         "distanceInputRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+          "PaymentAmount",
+          "ReceiptAmount",
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "test-coupon-rounding"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
@@ -5485,7 +6189,11 @@
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
         ],
         "witnessRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "p-value:contract-endpoints-paymentamount-receiptamount",
+          "p-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding",
+          "q-value:contract-endpoints-paymentamount-receiptamount",
+          "q-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
         ],
         "sourceRefs": [
           "src-pricing-checkout",
@@ -5495,7 +6203,7 @@
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5508,7 +6216,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5520,51 +6228,42 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "axisFamily": "effect",
         "axisRef": "effect ordering / replay / compensation axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:effect-replay-order-mismatch",
         "pContinuationRef": "Cont_effect(p):effect ordering / replay / compensation axis",
         "qContinuationRef": "Cont_effect(q):effect ordering / replay / compensation axis",
         "distanceInputRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "PaymentAmount",
+          "ReceiptAmount",
+          "atom:effect:receipt-boundary",
+          "src-pricing-checkout"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
-        "distanceValue": 2,
+        "distanceValue": 1,
         "measuredSupportRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:effect:receipt-boundary"
         ],
         "witnessRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:effect:receipt-boundary",
+          "p-value:effect-endpoints-paymentamount-receiptamount",
+          "p-value:effect-path-p-operation-discount-operation-tax-operation-round",
+          "q-value:effect-endpoints-paymentamount-receiptamount",
+          "q-value:effect-path-q-operation-tax-operation-discount-operation-round"
         ],
         "sourceRefs": [
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:effect:receipt-boundary"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5577,7 +6276,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5589,17 +6288,20 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:projection",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "axisFamily": "projection",
         "axisRef": "projection / representation axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:projection-target-value-mismatch",
         "pContinuationRef": "Cont_projection(p):projection / representation axis",
         "qContinuationRef": "Cont_projection(q):projection / representation axis",
         "distanceInputRefs": [
-          "projection:coupon-payment-receipt"
+          "PaymentAmount",
+          "ReceiptAmount",
+          "projection:coupon-payment-receipt",
+          "semantic:coupon-tax-rounding-paths"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
@@ -5607,7 +6309,11 @@
           "projection:coupon-payment-receipt"
         ],
         "witnessRefs": [
-          "projection:coupon-payment-receipt"
+          "p-value:projection-endpoints-paymentamount-receiptamount",
+          "p-value:projection-support-projection-coupon-payment-receipt",
+          "projection:coupon-payment-receipt",
+          "q-value:projection-endpoints-paymentamount-receiptamount",
+          "q-value:projection-support-projection-coupon-payment-receipt"
         ],
         "sourceRefs": [
           "src-pricing-checkout",
@@ -5617,7 +6323,7 @@
           "projection:coupon-payment-receipt"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5630,7 +6336,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5642,35 +6348,223 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:runtime",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "axisFamily": "runtime",
         "axisRef": "runtime interaction axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
         "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
         "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
         "distanceInputRefs": [
-          "gap:coupon-runtime-payment-trace"
+          "PaymentAmount",
+          "ReceiptAmount"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 0,
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing comparable p continuation value for runtime",
+          "missing-evidence:missing comparable q continuation value for runtime",
+          "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing comparable p continuation value for runtime",
+          "missing comparable q continuation value for runtime",
+          "missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+        ],
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "distanceKind": "weighted-axis-l1:semantic-sequence-mismatch",
+        "pContinuationRef": "Cont_semantic(p):semantic axis",
+        "qContinuationRef": "Cont_semantic(q):semantic axis",
+        "distanceInputRefs": [
+          "PaymentAmount",
+          "ReceiptAmount",
+          "semantic:coupon-tax-rounding-paths",
+          "test-coupon-rounding"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 1,
+        "measurementStatus": "measured",
+        "distanceValue": 1,
+        "measuredSupportRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "witnessRefs": [
+          "p-value:semantic-endpoints-paymentamount-receiptamount",
+          "p-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+          "q-value:semantic-endpoints-paymentamount-receiptamount",
+          "q-value:semantic-path-q-operation-tax-operation-discount-operation-round",
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [
+          "semantic:coupon-tax-rounding-paths"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:state",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+        "axisFamily": "state",
+        "axisRef": "state transition axis",
+        "distanceKind": "weighted-axis-l1:state-transition-value-mismatch",
+        "pContinuationRef": "Cont_state(p):state transition axis",
+        "qContinuationRef": "Cont_state(q):state transition axis",
+        "distanceInputRefs": [
+          "PaymentAmount",
+          "ReceiptAmount"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 0,
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing comparable p continuation value for state",
+          "missing-evidence:missing comparable q continuation value for state",
+          "missing-evidence:missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+        ],
+        "sourceRefs": [
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing comparable p continuation value for state",
+          "missing comparable q continuation value for state",
+          "missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+        ],
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:static",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+        "axisFamily": "static",
+        "axisRef": "static dependency / support axis",
+        "distanceKind": "weighted-axis-l1:static-support-value-mismatch",
+        "pContinuationRef": "Cont_static(p):static dependency / support axis",
+        "qContinuationRef": "Cont_static(q):static dependency / support axis",
+        "distanceInputRefs": [
+          "PaymentAmount",
+          "ReceiptAmount",
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
         "measuredSupportRefs": [
-          "gap:coupon-runtime-payment-trace"
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
         ],
         "witnessRefs": [
-          "gap:coupon-runtime-payment-trace"
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+          "p-value:static-endpoints-paymentamount-receiptamount",
+          "p-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary",
+          "q-value:static-endpoints-paymentamount-receiptamount",
+          "q-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary"
         ],
         "sourceRefs": [
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "gap:coupon-runtime-payment-trace"
+          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+          "atom:effect:receipt-boundary",
+          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5683,166 +6577,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "semantic",
-        "axisRef": "semantic axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_semantic(p):semantic axis",
-        "qContinuationRef": "Cont_semantic(q):semantic axis",
-        "distanceInputRefs": [
-          "derived-semantic-order:p=round(tax(discount(subtotal)))",
-          "derived-semantic-order:q=round(discount(tax(subtotal)))",
-          "semantic:coupon-tax-rounding-paths"
-        ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 2,
-        "measuredSupportRefs": [
-          "derived-semantic-order:p=round(tax(discount(subtotal)))",
-          "derived-semantic-order:q=round(discount(tax(subtotal)))",
-          "semantic:coupon-tax-rounding-paths"
-        ],
-        "witnessRefs": [
-          "derived-semantic-order:p=round(tax(discount(subtotal)))",
-          "derived-semantic-order:q=round(discount(tax(subtotal)))",
-          "semantic:coupon-tax-rounding-paths"
-        ],
-        "sourceRefs": [
-          "src-pricing-checkout",
-          "test-coupon-rounding"
-        ],
-        "observationRefs": [
-          "derived-semantic-order:p=round(tax(discount(subtotal)))",
-          "derived-semantic-order:q=round(discount(tax(subtotal)))",
-          "semantic:coupon-tax-rounding-paths"
-        ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "state",
-        "axisRef": "state transition axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_state(p):state transition axis",
-        "qContinuationRef": "Cont_state(q):state transition axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 0,
-        "measurementStatus": "unmeasured",
-        "distanceValue": null,
-        "measuredSupportRefs": [],
-        "witnessRefs": [
-          "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-        ],
-        "sourceRefs": [
-          "src-pricing-checkout",
-          "test-coupon-rounding"
-        ],
-        "observationRefs": [],
-        "missingRefs": [
-          "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-        ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "static",
-        "axisRef": "static dependency / support axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_static(p):static dependency / support axis",
-        "qContinuationRef": "Cont_static(q):static dependency / support axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 0,
-        "measurementStatus": "unmeasured",
-        "distanceValue": null,
-        "measuredSupportRefs": [],
-        "witnessRefs": [
-          "missing-evidence:missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-        ],
-        "sourceRefs": [
-          "src-pricing-checkout",
-          "test-coupon-rounding"
-        ],
-        "observationRefs": [],
-        "missingRefs": [
-          "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-        ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5869,133 +6604,155 @@
           "static"
         ],
         "selectedMeasuredSquareRefs": [
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+          "square-family-entry:mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
+          "square-family-entry:mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+          "square-family-entry:mu:operation-square-operation-square-evidence-coupon-tax-rounding:projection",
+          "square-family-entry:mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+          "square-family-entry:mu:operation-square-operation-square-evidence-coupon-tax-rounding:static"
         ],
         "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
         "distanceKind": "weighted-axis-l1",
         "measurementStatus": "partial",
-        "aggregateValue": 4,
+        "aggregateValue": 2,
         "measuredDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:projection",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:static"
         ],
         "unmeasuredDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:authority",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:runtime",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:state"
         ],
         "positiveWeightDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:projection",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:static"
         ],
         "zeroWeightDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:authority",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:runtime",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:state"
         ],
         "topContributors": [
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:authority",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
             "axisFamily": "authority",
             "contributionWeight": 1,
             "contributionValue": null,
             "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
             "witnessRefs": [
-              "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing-evidence:missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+              "missing-evidence:missing comparable p continuation value for authority",
+              "missing-evidence:missing comparable q continuation value for authority"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:runtime",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+            "axisFamily": "runtime",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing runtime trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing comparable p continuation value for runtime",
+              "missing-evidence:missing comparable q continuation value for runtime",
+              "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:state",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
             "axisFamily": "state",
             "contributionWeight": 1,
             "contributionValue": null,
             "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
             "witnessRefs": [
-              "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing-evidence:missing comparable p continuation value for state",
+              "missing-evidence:missing comparable q continuation value for state",
+              "missing-evidence:missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-            "axisFamily": "static",
-            "contributionWeight": 1,
-            "contributionValue": null,
-            "reviewFocus": "supply missing static trace evidence before interpreting AMI as zero",
-            "witnessRefs": [
-              "missing-evidence:missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-            ]
-          },
-          {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
             "axisFamily": "effect",
             "contributionWeight": 1,
-            "contributionValue": 2,
+            "contributionValue": 1,
             "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction"
+              "atom:effect:receipt-boundary",
+              "p-value:effect-endpoints-paymentamount-receiptamount",
+              "p-value:effect-path-p-operation-discount-operation-tax-operation-round",
+              "q-value:effect-endpoints-paymentamount-receiptamount",
+              "q-value:effect-path-q-operation-tax-operation-discount-operation-round"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
             "axisFamily": "semantic",
             "contributionWeight": 1,
-            "contributionValue": 2,
+            "contributionValue": 1,
             "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "derived-semantic-order:p=round(tax(discount(subtotal)))",
-              "derived-semantic-order:q=round(discount(tax(subtotal)))",
+              "p-value:semantic-endpoints-paymentamount-receiptamount",
+              "p-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+              "q-value:semantic-endpoints-paymentamount-receiptamount",
+              "q-value:semantic-path-q-operation-tax-operation-discount-operation-round",
               "semantic:coupon-tax-rounding-paths"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
             "axisFamily": "contract",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding"
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "p-value:contract-endpoints-paymentamount-receiptamount",
+              "p-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding",
+              "q-value:contract-endpoints-paymentamount-receiptamount",
+              "q-value:contract-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:projection",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
             "axisFamily": "projection",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "projection:coupon-payment-receipt"
+              "p-value:projection-endpoints-paymentamount-receiptamount",
+              "p-value:projection-support-projection-coupon-payment-receipt",
+              "projection:coupon-payment-receipt",
+              "q-value:projection-endpoints-paymentamount-receiptamount",
+              "q-value:projection-support-projection-coupon-payment-receipt"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-            "axisFamily": "runtime",
+            "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:static",
+            "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
+            "axisFamily": "static",
             "contributionWeight": 1,
             "contributionValue": 0,
-            "reviewFocus": "review runtime trace mismatch before treating aggregate value as local agreement",
+            "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "gap:coupon-runtime-payment-trace"
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:effect:receipt-boundary",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "p-value:static-endpoints-paymentamount-receiptamount",
+              "p-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary",
+              "q-value:static-endpoints-paymentamount-receiptamount",
+              "q-value:static-support-atom-contract-paymentamount-receiptamount-coupon-tax-rounding-atom-semantic-paymentamount-receiptamount-coupon-tax-rounding-noncommutation-atom-effect-receipt-boundary"
             ]
           }
         ],
@@ -6022,30 +6779,26 @@
     ],
     "nonzeroMonodromyWitnesses": [
       {
-        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
-        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-effect",
+        "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "operationPair": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:discount",
+          "operation:tax-round"
         ],
         "pathPair": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:round . operation:tax . operation:discount",
+          "operation:round . operation:discount . operation:tax"
         ],
         "axisFamily": "effect",
         "axisRef": "effect ordering / replay / compensation axis",
-        "defectValue": 2,
+        "defectValue": 1,
         "comparedTraceSummary": [
-          "p: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0",
-          "q: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0"
+          "p: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+          "q: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
         ],
         "affectedAtomRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:effect:receipt-boundary"
         ],
         "lawRefs": [
           "law:layer-respecting",
@@ -6060,14 +6813,10 @@
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:effect:receipt-boundary"
         ],
         "missingEvidence": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "suggestedFillerEvidence": [
           "supply filler evidence for effect axis trace disagreement",
           "record whether the two continuation paths preserve selected observations"
@@ -6079,7 +6828,7 @@
           "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
         ],
         "recommendedReviewFocus": [
-          "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
+          "compare operation:round . operation:tax . operation:discount and operation:round . operation:discount . operation:tax before treating the operation pair as order-insensitive",
           "review effect axis witness refs and missing evidence"
         ],
         "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
@@ -6094,27 +6843,25 @@
         ]
       },
       {
-        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-semantic",
-        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-semantic",
+        "defectRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+        "candidateRef": "operation-square:operation-square-evidence-coupon-tax-rounding",
         "operationPair": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:discount",
+          "operation:tax-round"
         ],
         "pathPair": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:round . operation:tax . operation:discount",
+          "operation:round . operation:discount . operation:tax"
         ],
         "axisFamily": "semantic",
         "axisRef": "semantic axis",
-        "defectValue": 2,
+        "defectValue": 1,
         "comparedTraceSummary": [
-          "p: semantic continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0",
-          "q: semantic continuation reads 2 observation ref(s) across 1 operation delta(s) refs=2 missing=0"
+          "p: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+          "q: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
         ],
         "affectedAtomRefs": [
-          "derived-semantic-order:p=round(tax(discount(subtotal)))",
-          "derived-semantic-order:q=round(discount(tax(subtotal)))",
           "semantic:coupon-tax-rounding-paths"
         ],
         "lawRefs": [
@@ -6130,12 +6877,10 @@
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "derived-semantic-order:p=round(tax(discount(subtotal)))",
-          "derived-semantic-order:q=round(discount(tax(subtotal)))",
           "semantic:coupon-tax-rounding-paths"
         ],
         "missingEvidence": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "suggestedFillerEvidence": [
           "supply filler evidence for semantic axis trace disagreement",
           "record whether the two continuation paths preserve selected observations"
@@ -6147,7 +6892,7 @@
           "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
         ],
         "recommendedReviewFocus": [
-          "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
+          "compare operation:round . operation:tax . operation:discount and operation:round . operation:discount . operation:tax before treating the operation pair as order-insensitive",
           "review semantic axis witness refs and missing evidence"
         ],
         "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
@@ -6172,8 +6917,8 @@
         "featureScopeRef": "coupon-tax-rounding-archmap:feature",
         "mixedSubconfigurationRefs": [
           "gap:coupon-runtime-payment-trace",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
           "obstruction:semantic-contract-mismatch:computed",
+          "repair:obstruction-semantic-contract-mismatch-computed",
           "split-readiness:molecule-coupon-operation-contract"
         ],
         "coreLocalReadingRefs": [
@@ -6184,26 +6929,23 @@
         ],
         "boundarySupportRefs": [
           "gap:coupon-runtime-payment-trace",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
           "obstruction:semantic-contract-mismatch:computed",
+          "repair:obstruction-semantic-contract-mismatch-computed",
           "split-readiness:molecule-coupon-operation-contract"
         ],
         "holonomyAxes": [
           {
             "holonomyAxisRef": "Hol_static",
             "axisFamily": "static",
-            "status": "coverageBlocked",
+            "status": "coveredZeroResidual",
             "residualValue": 0,
             "measuredDefectRefs": [],
             "supportRefs": [
-              "gap:coupon-runtime-payment-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-              "obstruction:semantic-contract-mismatch:computed",
-              "split-readiness:molecule-coupon-operation-contract"
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:effect:receipt-boundary",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation"
             ],
-            "missingEvidence": [
-              "missing static observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
-            ],
+            "missingEvidence": [],
             "reading": "Hol_static records boundary-local residual obstruction on the static axis"
           },
           {
@@ -6222,13 +6964,11 @@
             "holonomyAxisRef": "Hol_semantic",
             "axisFamily": "semantic",
             "status": "measuredResidual",
-            "residualValue": 2,
+            "residualValue": 1,
             "measuredDefectRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
             ],
             "supportRefs": [
-              "derived-semantic-order:p=round(tax(discount(subtotal)))",
-              "derived-semantic-order:q=round(discount(tax(subtotal)))",
               "semantic:coupon-tax-rounding-paths"
             ],
             "missingEvidence": [],
@@ -6242,12 +6982,14 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "gap:coupon-runtime-payment-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
               "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
               "split-readiness:molecule-coupon-operation-contract"
             ],
             "missingEvidence": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing comparable p continuation value for state",
+              "missing comparable q continuation value for state",
+              "missing state observation for operation-square:operation-square-evidence-coupon-tax-rounding"
             ],
             "reading": "Hol_state records boundary-local residual obstruction on the state axis"
           },
@@ -6255,16 +6997,12 @@
             "holonomyAxisRef": "Hol_effect",
             "axisFamily": "effect",
             "status": "measuredResidual",
-            "residualValue": 2,
+            "residualValue": 1,
             "measuredDefectRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect"
             ],
             "supportRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction"
+              "atom:effect:receipt-boundary"
             ],
             "missingEvidence": [],
             "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
@@ -6277,25 +7015,34 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "gap:coupon-runtime-payment-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
               "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
               "split-readiness:molecule-coupon-operation-contract"
             ],
             "missingEvidence": [
-              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing authority observation for operation-square:operation-square-evidence-coupon-tax-rounding",
+              "missing comparable p continuation value for authority",
+              "missing comparable q continuation value for authority"
             ],
             "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
           },
           {
             "holonomyAxisRef": "Hol_runtime",
             "axisFamily": "runtime",
-            "status": "coveredZeroResidual",
+            "status": "coverageBlocked",
             "residualValue": 0,
             "measuredDefectRefs": [],
             "supportRefs": [
-              "gap:coupon-runtime-payment-trace"
+              "gap:coupon-runtime-payment-trace",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-coupon-operation-contract"
             ],
-            "missingEvidence": [],
+            "missingEvidence": [
+              "missing comparable p continuation value for runtime",
+              "missing comparable q continuation value for runtime",
+              "missing runtime observation for operation-square:operation-square-evidence-coupon-tax-rounding"
+            ],
             "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
           },
           {
@@ -6313,10 +7060,10 @@
         ],
         "residualObstructionRefs": [
           "gap:coupon-runtime-payment-trace",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
           "obstruction:semantic-contract-mismatch:computed",
+          "repair:obstruction-semantic-contract-mismatch-computed",
           "split-readiness:molecule-coupon-operation-contract"
         ],
         "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
@@ -6329,7 +7076,7 @@
           "ArchMapStore compaction boundary"
         ],
         "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
-        "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "coverageBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
         "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
         "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
         "nonConclusions": [
@@ -6373,10 +7120,10 @@
             "refs": [
               "feature-boundary-residual:coupon-tax-rounding-archmap",
               "gap:coupon-runtime-payment-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
               "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
               "split-readiness:molecule-coupon-operation-contract"
             ],
             "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
@@ -6401,7 +7148,7 @@
             "axis": "complexityTransfer",
             "status": "observed",
             "refs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+              "repair:obstruction-semantic-contract-mismatch-computed"
             ],
             "reading": "complexityTransfer is classified as a current-state extension coordinate"
           },
@@ -6420,6 +7167,17 @@
             "labels": [
               "boundaryHolonomy"
             ],
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
@@ -6437,6 +7195,17 @@
               "boundaryHolonomy",
               "residualCoverageGap"
             ],
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
@@ -6451,55 +7220,58 @@
             "reading": "gap:coupon-runtime-payment-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
           },
           {
-            "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-            "labels": [
-              "boundaryHolonomy",
-              "complexityTransfer"
-            ],
-            "inheritedCoreRefs": [],
-            "featureLocalRefs": [],
-            "boundaryHolonomyRefs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-            ],
-            "liftingFailureRefs": [],
-            "fillingFailureRefs": [],
-            "complexityTransferRefs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-            ],
-            "residualCoverageGapRefs": [],
-            "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
-          },
-          {
-            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "witnessRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
             "labels": [
               "boundaryHolonomy"
             ],
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect"
             ],
             "liftingFailureRefs": [],
             "fillingFailureRefs": [],
             "complexityTransferRefs": [],
             "residualCoverageGapRefs": [],
-            "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+            "reading": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
           },
           {
-            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
+            "witnessRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
             "labels": [
               "boundaryHolonomy"
+            ],
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
             ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic"
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
             ],
             "liftingFailureRefs": [],
             "fillingFailureRefs": [],
             "complexityTransferRefs": [],
             "residualCoverageGapRefs": [],
-            "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+            "reading": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
           },
           {
             "witnessRef": "obstruction:semantic-contract-mismatch:computed",
@@ -6508,6 +7280,22 @@
               "featureLocalObstruction",
               "fillingFailure",
               "inheritedCoreObstruction"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "gap:coupon-runtime-payment-trace",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "semantic:coupon-tax-rounding-paths",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
             ],
             "inheritedCoreRefs": [
               "obstruction:semantic-contract-mismatch:computed"
@@ -6527,10 +7315,57 @@
             "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
           },
           {
+            "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+            "labels": [
+              "boundaryHolonomy",
+              "complexityTransfer"
+            ],
+            "observationRefs": [
+              "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+              "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+              "gap:coupon-runtime-payment-trace",
+              "molecule-reading:molecule-coupon-operation-contract",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "semantic:coupon-tax-rounding-paths",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout",
+              "test-coupon-rounding"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "repair:obstruction-semantic-contract-mismatch-computed"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [
+              "repair:obstruction-semantic-contract-mismatch-computed"
+            ],
+            "residualCoverageGapRefs": [],
+            "reading": "repair:obstruction-semantic-contract-mismatch-computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+          },
+          {
             "witnessRef": "split-readiness:molecule-coupon-operation-contract",
             "labels": [
               "boundaryHolonomy",
               "liftingFailure"
+            ],
+            "observationRefs": [
+              "gap:coupon-runtime-payment-trace",
+              "molecule:coupon-operation-contract",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+              "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-coupon-operation-contract"
+            ],
+            "sourceRefs": [
+              "src-pricing-checkout"
             ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
@@ -6556,7 +7391,7 @@
           "obstruction:semantic-contract-mismatch:computed"
         ],
         "complexityTransferRefs": [
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          "repair:obstruction-semantic-contract-mismatch-computed"
         ],
         "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
         "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
@@ -6574,7 +7409,11 @@
     ],
     "monodromyReadingFamily": {
       "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-      "status": "schemaFoundationOnly",
+      "status": "partial",
+      "measuredAxisCount": 5,
+      "unmeasuredAxisCount": 3,
+      "positiveWitnessCount": 2,
+      "coverageBlockerCount": 9,
       "archMapStoreRefSetRef": "archmap-store-refs:coupon-tax-rounding-archmap",
       "selectedAxisRefs": [
         "axis:layer-violation",
@@ -6584,21 +7423,21 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
       "operationSquareCandidateRefs": [
-        "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        "operation-square:operation-square-evidence-coupon-tax-rounding"
       ],
       "pathContinuationTraceRefs": [
-        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
-        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q"
+        "path-continuation-trace:operation-square-operation-square-evidence-coupon-tax-rounding:p",
+        "path-continuation-trace:operation-square-operation-square-evidence-coupon-tax-rounding:q"
       ],
       "axisWiseDefectRefs": [
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:authority",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:contract",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:projection",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:runtime",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:state",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:static"
       ],
       "amiAggregateReadingRefs": [
         "ami:measurement-policy-monodromy-boundary-holonomy"
@@ -6618,7 +7457,11 @@
     },
     "boundaryHolonomyReadingFamily": {
       "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-      "status": "schemaFoundationOnly",
+      "status": "partial",
+      "measuredAxisCount": 5,
+      "unmeasuredAxisCount": 3,
+      "positiveWitnessCount": 4,
+      "coverageBlockerCount": 10,
       "archMapStoreRefSetRef": "archmap-store-refs:coupon-tax-rounding-archmap",
       "selectedAxisRefs": [
         "axis:layer-violation",
@@ -6628,8 +7471,8 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
       "nonzeroMonodromyWitnessRefs": [
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-semantic"
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-effect",
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-semantic"
       ],
       "featureBoundaryResidualRefs": [
         "feature-boundary-residual:coupon-tax-rounding-archmap"
@@ -6850,10 +7693,10 @@
         ]
       },
       {
-        "readingId": "representation-strength:analytic-spectral-radius-proxy",
-        "sourceReadingRef": "analytic:spectral-radius-proxy",
+        "readingId": "representation-strength:analytic-spectral-radius",
+        "sourceReadingRef": "analytic:spectral-radius",
         "representationFamily": "spectralRadius",
-        "zeroPreserving": "supported",
+        "zeroPreserving": "bounded",
         "zeroReflecting": "blockedByCoverageGap",
         "obstructionPreserving": "supported",
         "obstructionReflecting": "blockedByCoverageGap",
@@ -6971,6 +7814,39 @@
         ],
         "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
         "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-relation-atom-adjacency",
+        "sourceReadingRef": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "weak",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "finiteMatrixMayHideUnobservedComponents",
+        "requiredAssumptions": [
+          "gap:coupon-runtime-payment-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:coupon-runtime-payment-trace"
+        ],
+        "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+        "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -7330,7 +8206,7 @@
     "structuralReadingReviewSurface": {
       "surfaceId": "aat-structural-reading-review-surface",
       "status": "needsReview",
-      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1",
+      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
       "connectedReadingRefs": [
         "representationStrength:weightedAdjacencyMatrix",
         "representationStrength:reachableConeSize",
@@ -7354,6 +8230,12 @@
         "homotopy-order-sensitivity:selected-operations",
         "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed",
         "axis-forgetting-risk:selected-projection",
+        "observation-projection-fidelity:observation-projection-coupon-tax-rounding-archmap",
+        "atom-origin-closure-debt:coupon-tax-rounding-archmap",
+        "effect-relation-algebra:coupon-tax-rounding-archmap",
+        "synthesis-blockage:coupon-tax-rounding-archmap",
+        "operation-precondition-readiness:repair-obstruction-semantic-contract-mismatch-computed",
+        "path-multiplicity-loss:coupon-tax-rounding-archmap",
         "signature-trajectory-homotopy-refutation:selected-trajectory",
         "bridge-split-obstruction-transfer:split-readiness-molecule-coupon-operation-contract"
       ],
@@ -7362,6 +8244,10 @@
         "read LawUniverse coverage and witness exactness before treating absence as measured zero",
         "read feature extension, operation law, trajectory, homotopy, and diagram-fillability axes as current-state coordinates, not PR evolution claims",
         "read axis-forgetting risk before treating a coarse projection as zero-reflecting or obstruction-reflecting",
+        "read projection fidelity and Atom origin closure before using summaries for zero, repair, or synthesis claims",
+        "read effect relation algebra separately from state transition pressure before approving replay, provider, event, or handler boundaries",
+        "read synthesis blockage and operation precondition readiness before treating candidates as constructible or safe",
+        "read path multiplicity loss before treating one observed route as complete reachability",
         "read selected trajectory disagreement before treating same-endpoint operations as homotopic",
         "read bridge split transfer before treating a boundary operation as obstruction removal",
         "read representation-strength blockers before treating zero or obstruction absence as exact",
@@ -8316,24 +9202,26 @@
         "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
       ],
       "analyticReadingsSummary": [
-        "weightedAdjacencyMatrix=7x7; edgeCount=0 (measured)",
-        "reachableConeSize=7 (measured)",
-        "walkCount=1 (measured)",
+        "weightedAdjacencyMatrix=0x0; edgeCount=0 (measured)",
+        "reachableConeSize=0 (measured)",
+        "walkCount=0 (measured)",
         "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
-        "selectedSubgraphSpectrum=[0.000] (measured)",
+        "selectedSubgraphSpectrum=[unavailable] (measured)",
         "propagationDepth=0 (measured)",
-        "spectralRadius=0.000 (measured)",
+        "spectralRadius=unavailable (unavailable)",
         "curvatureValuation=1 (measured)",
         "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
         "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
       ],
       "spectralReadingsSummary": [
+        "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=0x0 (nonConclusion)",
         "workflowRiskAxisPressureMatrix upperBound=9.220 shape=1x5 (needsReview)",
         "moleculeAtomOverlapCouplingMatrix upperBound=3.000 shape=1x1 (needsReview)",
         "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
         "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
       ],
       "spectralModeSummary": [
+        "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=0.000 localization=0.000 density=0.000 (nonConclusion)",
         "workflowRiskAxisPressureMatrix distributedPressureMode gap=8.185 localization=1.000 density=1.000 (needsReview)",
         "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=3.000 localization=1.000 density=1.000 (needsReview)",
         "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
@@ -8346,7 +9234,7 @@
         "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
       ],
       "curvatureTransferSummary": [
-        "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1 (needsReview)"
+        "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1.000 (needsReview)"
       ],
       "architectureSpectrumReportSummary": [
         "architecture-spectrum-report:spectrum-profile-curvature-transfer-default hotspots=4 recurrent=1 clusters=2 (needsReview)",
@@ -8357,7 +9245,7 @@
       ],
       "transferBridgeEdgeSummary": [],
       "measurementExpansionSummary": [
-        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 2 nonzero monodromy witnesses"
+        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 2 nonzero monodromy witnesses"
       ],
       "atomSupportAxisSummary": [
         "coupon-tax-rounding-archmap support=2 concentration=maxAxisShare=1/3 pressure=mixedAxisPressurePresent",
@@ -8370,10 +9258,10 @@
         "llm-native-aat-law-policy-fixture required=2 unmeasured=1 blockedWitnesses=2"
       ],
       "featureExtensionFormulaSummary": [
-        "feature-extension-formula:coupon-tax-rounding-archmap status=measured inherited=1 featureLocal=1 interaction=0 residualGaps=1"
+        "feature-extension-formula:coupon-tax-rounding-archmap status=measured inherited=1 featureLocal=1 interaction=1 residualGaps=1"
       ],
       "operationCalculusLawSummary": [
-        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
+        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=observed repairMonotonicity=blockedByTransferRisk boundary=notASynthesisCertificate"
       ],
       "pathSignatureTrajectorySummary": [
         "operation-delta:repair-obstruction-semantic-contract-mismatch-computed status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=1 transferred=1"
@@ -8387,6 +9275,24 @@
       "axisForgettingRiskSummary": [
         "observation-projection:coupon-tax-rounding-archmap kind=selectedAxisOrWitnessLoss zeroReflection=blockedWithoutAxisPreservationAndWitnessCompleteness obstructionReflection=blockedWithoutAxisPreservationAndWitnessCompleteness mixedScopes=2"
       ],
+      "observationProjectionFidelitySummary": [
+        "observation-projection:coupon-tax-rounding-archmap status=projectionLossObserved forgotten=1 collisions=0 reflection=blockedWithoutAxisPreservationAndWitnessCompleteness"
+      ],
+      "atomOriginClosureDebtSummary": [
+        "atom-origin-closure-debt:coupon-tax-rounding-archmap status=originClosureDebtObserved sourceBacked=3 inferred=0 missingExpected=1"
+      ],
+      "effectRelationAlgebraSummary": [
+        "effect-relation-algebra:coupon-tax-rounding-archmap pressure=effectRelationPressureObserved generators=2 unresolved=1 externalBoundaries=0"
+      ],
+      "synthesisBlockageSummary": [
+        "synthesis-blockage:coupon-tax-rounding-archmap status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=7 missing=5 noSolution=notASolverAndNotAbsenceProof"
+      ],
+      "operationPreconditionReadinessSummary": [
+        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit status=blockedByMissingPreconditionEvidence missing=7 witnesses=2"
+      ],
+      "pathMultiplicityLossSummary": [
+        "coupon-tax-rounding-archmap status=reachabilityMultiplicityLossObserved paths=1 alternatePressure=8 fanIn=0 forgotten=1"
+      ],
       "signatureTrajectoryHomotopyRefutationSummary": [
         "homotopy-order-sensitivity:selected-operations equivalence=selectedTrajectoryDisagreementObserved refutation=refutationCandidate disagreements=1"
       ],
@@ -8394,8 +9300,8 @@
         "split-readiness:molecule-coupon-operation-contract transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
       ],
       "nonzeroMonodromyWitnessSummary": [
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2",
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-semantic axis=semantic defect=2 affectedAtoms=3 missingEvidence=0 focus=2"
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-effect axis=effect defect=1 affectedAtoms=1 missingEvidence=0 focus=2",
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-coupon-tax-rounding-semantic axis=semantic defect=1 affectedAtoms=1 missingEvidence=0 focus=2"
       ],
       "featureBoundaryResidualSummary": [
         "feature-boundary-residual:coupon-tax-rounding-archmap boundary=Boundary(coupon-tax-rounding-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=6"
@@ -8414,6 +9320,7 @@
         "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
         "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
         "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "relationAtomWeightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
@@ -8438,8 +9345,8 @@
         "molecule:coupon-operation-contract status=needsReview score=92 boundaryOp=interface"
       ],
       "structuralReadingReviewSummary": [
-        "aat-structural-reading-review-surface status=needsReview refs=24 focus=12",
-        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1"
+        "aat-structural-reading-review-surface status=needsReview refs=30 focus=16",
+        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
       ],
       "currentStateEvolutionBoundarySummary": [
         "ArchSig computes current AAT structural state from ArchMap coupon-tax-rounding-archmap and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
@@ -8512,8 +9419,8 @@
     "analyticRepresentationCount": 10,
     "couplingCohesionReadingCount": 4,
     "workflowRiskReadingCount": 1,
-    "spectralAnalysisReadingCount": 4,
-    "spectralModeReadingCount": 4,
+    "spectralAnalysisReadingCount": 5,
+    "spectralModeReadingCount": 5,
     "spectralDrilldownReadingCount": 1,
     "curvatureSupportReadingCount": 1,
     "curvatureTransferReadingCount": 1,
@@ -8527,9 +9434,15 @@
     "homotopyOrderSensitivityReadingCount": 1,
     "diagramFillabilityReadingCount": 1,
     "axisForgettingRiskReadingCount": 1,
+    "observationProjectionFidelityReadingCount": 1,
+    "atomOriginClosureDebtReadingCount": 1,
+    "effectRelationAlgebraReadingCount": 1,
+    "synthesisBlockageReadingCount": 1,
+    "operationPreconditionReadinessReadingCount": 1,
+    "pathMultiplicityLossReadingCount": 1,
     "signatureTrajectoryHomotopyRefutationReadingCount": 1,
     "bridgeSplitObstructionTransferReadingCount": 1,
-    "representationStrengthReadingCount": 14,
+    "representationStrengthReadingCount": 15,
     "localCurvatureDiagramReadingCount": 1,
     "threeLayerFlatnessReadingCount": 1,
     "observationProjectionReadingCount": 1,
@@ -8605,7 +9518,7 @@
     },
     {
       "id": "archsig-analysis-packet-spectral-analysis-surface",
-      "title": "packet exposes AAT spectral readings as bounded finite-representation proxies",
+      "title": "packet exposes AAT spectral readings as bounded finite relation and measurement representations",
       "result": "pass",
       "count": 0
     },

--- a/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
@@ -2,7 +2,7 @@
   "schemaVersion": "archsig-analysis-packet-validation-report-v0",
   "input": {
     "schemaVersion": "archsig-analysis-packet-v0",
-    "path": "archsig-analysis-packet",
+    "path": "/private/tmp/archsig1599-minimal-final/archsig-analysis-packet.json",
     "analysisId": "archsig-analysis:fixture-archmap-atom-observation:llm-native-aat-law-policy-fixture",
     "archMapRef": "fixture-archmap-atom-observation",
     "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture"
@@ -388,7 +388,7 @@
           "analytic:nilpotence-boundary",
           "analytic:selected-subgraph-spectrum",
           "analytic:propagation-depth",
-          "analytic:spectral-radius-proxy",
+          "analytic:spectral-radius",
           "analytic:curvature-valuation",
           "analytic:state-algebra-boundary",
           "analytic:zero-reflecting-aggregate-boundary"
@@ -760,18 +760,47 @@
         "representationFamily": "weightedAdjacencyMatrix",
         "status": "measured",
         "valueType": "matrixShape",
-        "value": "4x4; edgeCount=1",
+        "value": "2x2; edgeCount=1",
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
         "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:relation:route-service"
         ],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+        "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -789,18 +818,47 @@
         "representationFamily": "reachableConeSize",
         "status": "measured",
         "valueType": "nat",
-        "value": "5",
+        "value": "1",
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
         "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:relation:route-service"
         ],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+        "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -818,18 +876,47 @@
         "representationFamily": "walkCount",
         "status": "measured",
         "valueType": "nat",
-        "value": "2",
+        "value": "1",
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
         "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:relation:route-service"
         ],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+        "reading": "walk count enumerates selected relation-graph walks up to length 3",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -848,17 +935,44 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "blockedByCoverageGap",
-        "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
         ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+        "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -876,18 +990,47 @@
         "representationFamily": "selectedSubgraphSpectrum",
         "status": "measured",
         "valueType": "vector",
-        "value": "[0.250]",
+        "value": "[0.000]",
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
         "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:relation:route-service"
         ],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+        "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -906,11 +1049,40 @@
         "status": "measured",
         "valueType": "nat",
         "value": "1",
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
         "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:relation:route-service"
         ],
         "axisRefs": [
           "sig-axis:layer-violation",
@@ -930,22 +1102,51 @@
         ]
       },
       {
-        "representationId": "analytic:spectral-radius-proxy",
+        "representationId": "analytic:spectral-radius",
         "representationFamily": "spectralRadius",
         "status": "measured",
         "valueType": "float",
-        "value": "0.250",
+        "value": "0.000",
+        "selectedGraphNodes": [
+          "route.users",
+          "service.user"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+            "sourceRef": "route.users",
+            "targetRef": "service.user",
+            "weight": 1,
+            "relationAtomRef": "atom:relation:route-service",
+            "sourceRefs": [
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "route.users",
+            "columnRef": "service.user",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:relation:route-service",
+              "src-route-users",
+              "src-service-user"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:route-users:1:service-user"
+        ],
         "graphScopeRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:relation:route-service"
         ],
         "axisRefs": [
           "sig-axis:layer-violation",
           "sig-axis:semantic-inconsistency"
         ],
-        "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+        "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -964,6 +1165,10 @@
         "status": "measured",
         "valueType": "nat",
         "value": "1",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "obstruction:semantic-contract-mismatch:computed"
         ],
@@ -990,6 +1195,10 @@
         "status": "unmeasured",
         "valueType": "boundaryStatus",
         "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "atom:component:route-users",
           "atom:component:service-user",
@@ -1019,6 +1228,10 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "blockedByObservationGaps",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "gap-runtime-user-db-trace"
         ],
@@ -1302,6 +1515,72 @@
     ],
     "spectralAnalysisReadings": [
       {
+        "spectralReadingId": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "status": "needsReview",
+        "matrixShape": {
+          "rowDomain": "selectedRelationGraphNodes",
+          "columnDomain": "selectedRelationGraphNodes",
+          "rowCount": 2,
+          "columnCount": 2,
+          "nonzeroEntryCount": 1
+        },
+        "entryRule": "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "1",
+            "interpretation": "largest outgoing relation weight"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "1",
+            "interpretation": "largest incoming relation weight"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "1.000",
+            "interpretation": "finite weighted adjacency matrix norm over selected relation atoms"
+          },
+          {
+            "name": "spectralRadius",
+            "value": "0.000",
+            "interpretation": "power-iteration estimate over the finite nonnegative relation adjacency matrix"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "route.users",
+            "componentKind": "relationGraphSourceNode",
+            "value": "1",
+            "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+          },
+          {
+            "componentRef": "service.user",
+            "componentKind": "relationGraphTargetNode",
+            "value": "1",
+            "reading": "largest incoming weighted adjacency column in the selected relation graph"
+          }
+        ],
+        "supportRefs": [
+          "atom:relation:route-service"
+        ],
+        "reading": "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+        "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+        "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+        "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
         "spectralReadingId": "spectral:workflow-risk-axis-pressure",
         "representationFamily": "workflowRiskAxisPressureMatrix",
         "status": "needsReview",
@@ -1557,6 +1836,57 @@
     ],
     "spectralModeReadings": [
       {
+        "spectralModeId": "spectral-mode:spectral-relation-atom-adjacency",
+        "sourceSpectralReadingRef": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "status": "needsReview",
+        "modeKind": "boundedSpectralMode",
+        "modeComponents": [
+          {
+            "componentRef": "route.users",
+            "componentKind": "relationGraphSourceNode",
+            "weight": "1",
+            "role": "primaryDominantComponent",
+            "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+          },
+          {
+            "componentRef": "service.user",
+            "componentKind": "relationGraphTargetNode",
+            "weight": "1",
+            "role": "coupledDominantComponent",
+            "reading": "largest incoming weighted adjacency column in the selected relation graph"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "1.000",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.250",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is relatively localized; decomposition or targeted repair may be reviewable as a local operation",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
         "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
         "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
         "representationFamily": "workflowRiskAxisPressureMatrix",
@@ -1759,6 +2089,7 @@
         "drilldownId": "spectral-drilldown:fixture-archmap-atom-observation",
         "status": "needsReview",
         "sourceSpectralModeRefs": [
+          "spectral-mode:spectral-relation-atom-adjacency",
           "spectral-mode:spectral-workflow-risk-axis-pressure",
           "spectral-mode:spectral-molecule-atom-overlap-coupling",
           "spectral-mode:spectral-obstruction-axis-curvature",
@@ -2208,7 +2539,7 @@
         "readingId": "curvature-transfer-reading:spectrum-profile-curvature-transfer-default",
         "profileRef": "spectrum-profile:curvature-transfer-default",
         "status": "needsReview",
-        "measurementStatus": "proxy",
+        "measurementStatus": "measured",
         "readingBoundary": {
           "readingStrength": "boundedMeasuredWithProxyTransfer",
           "zeroReflectionAssumptions": [
@@ -2253,7 +2584,7 @@
           "rowCount": 1,
           "columnCount": 1,
           "nonzeroEdgeCount": 1,
-          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence",
           "spectralRadiusKind": "finiteNonnegativeOperatorBoundedClosedWalkRadius",
           "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
         },
@@ -2296,7 +2627,7 @@
               "witness:semantic-contract-mismatch"
             ],
             "cycleWeight": 1,
-            "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+            "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
             "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
             "reviewFocus": [
               "inspect the witness support behind the positive transfer self-loop",
@@ -2310,9 +2641,9 @@
           }
         ],
         "spectralRadiusReading": {
-          "name": "rho(T^kappa)Proxy",
-          "value": "1",
-          "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+          "name": "rho(T^kappa)",
+          "value": "1.000",
+          "interpretation": "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability"
         },
         "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
         "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
@@ -2534,7 +2865,7 @@
       "recurrentObstructions": [
         {
           "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
-          "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+          "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
           "transferEdgeRefs": [
             "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
           ],
@@ -2979,7 +3310,9 @@
         "featureLocalObstructionRefs": [
           "obstruction:semantic-contract-mismatch:computed"
         ],
-        "interactionObstructionRefs": [],
+        "interactionObstructionRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
         "liftingFailureRefs": [
           "split-readiness:molecule-user-request-responsibility"
         ],
@@ -2987,10 +3320,70 @@
           "obstruction:semantic-contract-mismatch:computed"
         ],
         "complexityTransferRefs": [
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          "repair:obstruction-semantic-contract-mismatch-computed"
         ],
         "residualCoverageGapRefs": [
           "gap-runtime-user-db-trace"
+        ],
+        "witnessBasis": [
+          {
+            "witnessRef": "gap-runtime-user-db-trace",
+            "labels": [
+              "residualCoverageGap"
+            ],
+            "observationRefs": [
+              "gap-runtime-user-db-trace"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+            "labels": [
+              "featureLocalObstruction",
+              "fillingFailure",
+              "inheritedCoreObstruction",
+              "interactionObstruction"
+            ],
+            "observationRefs": [
+              "atom:contract:create-user",
+              "molecule-reading:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+            "labels": [
+              "complexityTransfer"
+            ],
+            "observationRefs": [
+              "atom:contract:create-user",
+              "molecule-reading:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "split-readiness:molecule-user-request-responsibility",
+            "labels": [
+              "liftingFailure"
+            ],
+            "observationRefs": [
+              "molecule:user-request-responsibility",
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "sourceRefs": [
+              "doc-architecture"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          }
         ],
         "classificationSummary": [
           {
@@ -3011,8 +3404,10 @@
           },
           {
             "axis": "interactionObstruction",
-            "status": "unmeasuredOrAbsent",
-            "refs": [],
+            "status": "observed",
+            "refs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
             "reading": "interactionObstruction is classified as a current-state extension coordinate"
           },
           {
@@ -3035,7 +3430,7 @@
             "axis": "complexityTransfer",
             "status": "observed",
             "refs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+              "repair:obstruction-semantic-contract-mismatch-computed"
             ],
             "reading": "complexityTransfer is classified as a current-state extension coordinate"
           },
@@ -3048,7 +3443,7 @@
             "reading": "residualCoverageGap is classified as a current-state extension coordinate"
           }
         ],
-        "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "evidenceBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -3065,15 +3460,15 @@
         "readingId": "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
         "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
         "operationKind": "repair-semanticmismatchcircuit",
-        "compositionStatus": "assumptionRelative",
-        "associativityUnderObservationStatus": "selectedObservationOnly",
-        "refinementAbstractionCompatibility": "blockedByMissingEvidence",
+        "compositionStatus": "observed",
+        "associativityUnderObservationStatus": "observed",
+        "refinementAbstractionCompatibility": "blocked",
         "replacementEquivalence": "unmeasured",
         "protectionIdempotence": "notApplicable",
-        "runtimeLocalization": "blockedByCoverageGap",
+        "runtimeLocalization": "blocked",
         "migrationCompatibility": "notApplicable",
         "reverseInvolution": "unmeasured",
-        "repairMonotonicity": "selectedAxisOnly",
+        "repairMonotonicity": "blockedByTransferRisk",
         "synthesisNoSolutionBoundary": "notASynthesisCertificate",
         "preconditionRefs": [
           "human review selects a repair operation",
@@ -3082,6 +3477,169 @@
         "evidenceRefs": [
           "obstruction:semantic-contract-mismatch:computed",
           "preserve zero reading for sig-axis:layer-violation"
+        ],
+        "lawEvidence": [
+          {
+            "lawAxis": "composition",
+            "status": "observed",
+            "requiredEvidenceRefs": [
+              "operation support refs",
+              "operation precondition refs"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation",
+              "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+            ],
+            "blockedReasonRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "composition is observed under selected operation evidence"
+          },
+          {
+            "lawAxis": "associativityUnderObservation",
+            "status": "observed",
+            "requiredEvidenceRefs": [
+              "operation delta support"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "associativityUnderObservation is observed under selected operation evidence"
+          },
+          {
+            "lawAxis": "refinementAbstractionCompatibility",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "preserved invariant refs"
+            ],
+            "observedEvidenceRefs": [
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "refinementAbstractionCompatibility is blocked under selected operation evidence"
+          },
+          {
+            "lawAxis": "replacementEquivalence",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "before/after equivalence witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed"
+            ],
+            "blockedReasonRefs": [
+              "replacement-equivalence:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:replacement-equivalence"
+            ],
+            "reading": "replacementEquivalence is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "protectionIdempotence",
+            "status": "notApplicable",
+            "requiredEvidenceRefs": [
+              "repeat protection witness"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "protectionIdempotence is notApplicable under selected operation evidence"
+          },
+          {
+            "lawAxis": "runtimeLocalization",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "runtime/effect localization witness"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+            ],
+            "blockedReasonRefs": [
+              "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+              "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "runtimeLocalization is blocked under selected operation evidence"
+          },
+          {
+            "lawAxis": "migrationCompatibility",
+            "status": "notApplicable",
+            "requiredEvidenceRefs": [
+              "migration compatibility witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "migrationCompatibility is notApplicable under selected operation evidence"
+          },
+          {
+            "lawAxis": "reverseInvolution",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "reverse operation witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "preserve zero reading for sig-axis:layer-violation"
+            ],
+            "blockedReasonRefs": [
+              "reverse-involution:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:reverse-operation"
+            ],
+            "reading": "reverseInvolution is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "repairMonotonicity",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "selected obstruction valuation",
+              "transfer risk refs"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:semantic-contract-mismatch:computed",
+              "sig-axis:semantic-inconsistency"
+            ],
+            "blockedReasonRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:selected-axis-only"
+            ],
+            "reading": "repairMonotonicity is blocked under selected operation evidence"
+          }
         ],
         "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
         "nonConclusions": [
@@ -3237,6 +3795,227 @@
         ],
         "coverageBoundary": "projection reflection is read only under explicit axis preservation and witness completeness assumptions",
         "evidenceBoundary": "axis-forgetting risk is current-state ArchSig telemetry; it is not a proof that every projection loses information",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "observationProjectionFidelityReadings": [
+      {
+        "readingId": "observation-projection-fidelity:observation-projection-fixture-archmap-atom-observation",
+        "sourceProjectionRef": "observation-projection:fixture-archmap-atom-observation",
+        "sourceAxisForgettingRef": "axis-forgetting-risk:selected-projection",
+        "fidelityStatus": "projectionLossObserved",
+        "observedAtomFamilyCount": 3,
+        "forgottenCoordinateCount": 1,
+        "observationCollisionCount": 0,
+        "collapsedAtomFamilyCandidateCount": 0,
+        "hiddenAtomFamilyHintCount": 1,
+        "projectionLostAtomFamilyRefs": [
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+        ],
+        "projectionLossAxes": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "measurementBoundary": "projection loss is separated from zero/lawfulness; missing coordinates are not measured absent atoms",
+        "recommendedNextAction": "review projection-lost families and forgotten coordinates before treating the ArchMap as a faithful Atom observation",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomOriginClosureDebtReadings": [
+      {
+        "readingId": "atom-origin-closure-debt:fixture-archmap-atom-observation",
+        "sourceBackedAtomCount": 4,
+        "derivedOrInferredAtomCount": 0,
+        "expectedMissingAtomCount": 1,
+        "sourceBackedAtomFamilyRefs": [
+          "contractSpecification",
+          "existence",
+          "relation"
+        ],
+        "derivedOrInferredRefs": [],
+        "missingExpectedAtomRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "closureStatus": "originClosureDebtObserved",
+        "weakensZeroOrRepairClaims": [
+          "zero readings need source-backed Atom closure or explicit coverage boundary",
+          "repair and synthesis candidates remain bounded when expected atoms are missing",
+          "derived or inferred atoms must not be promoted to source-backed evidence"
+        ],
+        "evidenceBoundary": "Atom origin closure debt is read from sourceRefs and observation gaps; it is not complete source extraction validation",
+        "recommendedNextAction": "separate source-backed, derived/inferred, and expected-missing Atom evidence before using the packet for repair or synthesis claims",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "effectRelationAlgebraReadings": [
+      {
+        "readingId": "effect-relation-algebra:fixture-archmap-atom-observation",
+        "generatorRefs": [
+          "atom:relation:route-service"
+        ],
+        "effectAtomRefs": [],
+        "relationAtomRefs": [
+          "atom:relation:route-service"
+        ],
+        "externalBoundaryRefs": [],
+        "requiredEffectRelations": [
+          "effect ordering",
+          "replay or roundtrip stability",
+          "compensation/finalization relation",
+          "handler and external provider boundary ownership"
+        ],
+        "unresolvedEffectRelations": [
+          "gap-runtime-user-db-trace"
+        ],
+        "effectOrderingPressure": "effectRelationPressureObserved",
+        "stateTransitionRef": "state-transition-algebra:fixture-archmap-atom-observation",
+        "evidenceBoundary": "effect relation algebra is kept separate from state transition pressure and only reads observed effect/relation/runtime evidence",
+        "recommendedNextAction": "review async job, provider, event handler, replay, roundtrip, and compensation relations before approving state/effect repairs",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "synthesisBlockageReadings": [
+      {
+        "readingId": "synthesis-blockage:fixture-archmap-atom-observation",
+        "targetConstructionRefs": [
+          "repair:obstruction-semantic-contract-mismatch-computed",
+          "feature-extension-formula:fixture-archmap-atom-observation"
+        ],
+        "requiredAtomRefs": [
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:relation:route-service",
+          "atom:contract:create-user"
+        ],
+        "constraintRefs": [
+          "obstruction:semantic-contract-mismatch:computed",
+          "obstruction:semantic-contract-mismatch:computed",
+          "obstruction:semantic-contract-mismatch:computed",
+          "split-readiness:molecule-user-request-responsibility",
+          "obstruction:semantic-contract-mismatch:computed",
+          "gap-runtime-user-db-trace",
+          "diagram filling is LawPolicy-relative and requires selected witness completeness"
+        ],
+        "missingEvidenceRefs": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero",
+          "gap-runtime-user-db-trace"
+        ],
+        "decisionBoundaryRefs": [
+          "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "candidateSolutionRefs": [],
+        "blockageStatus": "synthesisBlockedByMissingEvidenceOrConstraints",
+        "noSolutionCertificateStatus": "notASolverAndNotAbsenceProof",
+        "synthesisBoundary": "candidate absence, missing evidence, and no-solution certificates are distinct; ArchSig does not run a synthesis solver",
+        "recommendedNextAction": "resolve Atom, constraint, evidence, and decision-boundary blockers before reading a repair candidate as constructible",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationPreconditionReadinessReadings": [
+      {
+        "readingId": "operation-precondition-readiness:repair-obstruction-semantic-contract-mismatch-computed",
+        "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
+        "operationKind": "repair-semanticmismatchcircuit",
+        "readinessStatus": "blockedByMissingPreconditionEvidence",
+        "preconditionRefs": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap-runtime-user-db-trace"
+        ],
+        "missingPreconditionRefs": [
+          "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "replacement-equivalence:witness-not-supplied",
+          "reverse-involution:witness-not-supplied",
+          "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+        ],
+        "coverageGapRefs": [
+          "gap-runtime-user-db-trace",
+          "gap-runtime-user-db-trace"
+        ],
+        "exactnessGapRefs": [
+          "gap-runtime-user-db-trace",
+          "gap-runtime-user-db-trace"
+        ],
+        "witnessGapRefs": [
+          "witness:layer-violation",
+          "witness:semantic-contract-mismatch"
+        ],
+        "candidateBoundary": "repair/split/migration/protection candidates are review cues until precondition evidence is observed",
+        "recommendedNextAction": "supply coverage, exactness, witness, and runtime precondition evidence before treating the operation as safe",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathMultiplicityLossReadings": [
+      {
+        "readingId": "path-multiplicity-loss:fixture-archmap-atom-observation",
+        "scopeRef": "fixture-archmap-atom-observation",
+        "pathReadingRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "observedPathCount": 1,
+        "alternatePathPressure": 8,
+        "maxWalkLengthProxy": 3,
+        "reachabilityForgottenRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "fanInBoundaryRefs": [],
+        "multiplicityLossStatus": "reachabilityMultiplicityLossObserved",
+        "homotopyBoundary": "path multiplicity is a reachability and homotopy review signal, not proof of all paths",
+        "evidenceBoundary": "alternate-path pressure is bounded by observed operation trajectories, homotopy sensitivity, workflow risk, and gaps",
+        "recommendedNextAction": "inspect high fan-in and alternate path boundaries before treating one observed path as complete reachability",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5066,54 +5845,56 @@
     },
     "operationSquareCandidates": [
       {
-        "candidateId": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "candidateSource": "inferred",
-        "suppliedPairRef": null,
+        "candidateId": "operation-square:operation-square-evidence-create-user-route-service",
+        "candidateSource": "supplied",
+        "suppliedPairRef": "operation-square-evidence:create-user-route-service",
         "candidateBasis": [
-          "sharedAtomSupport",
-          "effectFamily",
-          "contractAtom",
-          "semanticAtom",
-          "runtimeInteraction",
-          "projectionSurface"
+          "sourceBackedOperationPair",
+          "suppliedPathPair",
+          "sharedEndpoint",
+          "generatorCandidate",
+          "atomSupport",
+          "semanticSupport",
+          "projectionSupport"
         ],
-        "leftOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-        "rightOperationRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
-        "pPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-        "qPathRef": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "candidateBasisRefs": [
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "molecule:user-request-responsibility",
+          "projection:aat:route-service",
+          "projection:sft:create-user",
+          "semantic:create-user-flow",
+          "service.user",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "leftOperationRef": "operation:route-create-user",
+        "rightOperationRef": "operation:service-create-user",
+        "pPathRef": "operation:service-create-user . operation:route-create-user",
+        "qPathRef": "operation:route-create-user . operation:service-create-user",
         "pOperationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:route-create-user",
+          "operation:service-create-user"
         ],
         "qOperationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+          "operation:service-create-user",
+          "operation:route-create-user"
         ],
         "endpointObjectRefs": [
-          "aat:object:route.users",
-          "aat:relation:route.users->service.user",
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "sft:observation:create-user-flow"
+          "route.users",
+          "service.user"
         ],
         "generatorCandidateRefs": [
-          "generator:independent-square",
           "generator:same-contract-replacement",
-          "generator:repair-filler",
-          "generator:identity-insertion-deletion",
-          "generator:associativity-reassociation"
+          "generator:repair-filler"
         ],
         "sharedAtomSupportRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service"
+          "atom:relation:route-service",
+          "atom:contract:create-user"
         ],
         "stateRefs": [],
-        "effectRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
-        ],
+        "effectRefs": [],
         "contractRefs": [
           "atom:contract:create-user"
         ],
@@ -5121,37 +5902,26 @@
           "semantic:create-user-flow"
         ],
         "authorityRefs": [],
-        "runtimeRefs": [
-          "gap-runtime-user-db-trace"
-        ],
+        "runtimeRefs": [],
         "projectionRefs": [
-          "projection:aat:route-users",
           "projection:aat:route-service",
           "projection:sft:create-user"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
           "atom:contract:create-user",
           "atom:relation:route-service",
-          "gap-runtime-user-db-trace",
+          "molecule:user-request-responsibility",
           "projection:aat:route-service",
-          "projection:aat:route-users",
           "projection:sft:create-user",
           "semantic:create-user-flow"
         ],
-        "missingRefs": [
-          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-          "no state observation supplied for operation square candidate"
-        ],
-        "evidenceBoundary": "inferred operation square candidate is a review cue over observed ArchMap support, not operation truth",
+        "missingRefs": [],
+        "evidenceBoundary": "supplied operation square evidence is first-class ArchMap input with p/q paths, endpoints, and source-backed basis refs: fixture supplies p/q route-service operation sequences and service endpoint for operation square analysis",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5165,51 +5935,57 @@
     ],
     "pathContinuationTraces": [
       {
-        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
+        "traceId": "path-continuation-trace:operation-square-operation-square-evidence-create-user-route-service:p",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "pathRef": "operation-square:operation-square-evidence-create-user-route-service:p",
         "pathRole": "p",
-        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
+        "pathExpression": "operation:service-create-user . operation:route-create-user",
         "operationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:route-create-user",
+          "operation:service-create-user"
         ],
         "endpointObjectRefs": [
-          "aat:object:route.users",
-          "aat:relation:route.users->service.user",
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "sft:observation:create-user-flow"
+          "route.users",
+          "service.user"
         ],
         "continuationStepRefs": [
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p:endpoint"
+          "cont-step:operation-square-operation-square-evidence-create-user-route-service:p:operation-route-create-user",
+          "cont-step:operation-square-operation-square-evidence-create-user-route-service:p:operation-service-create-user",
+          "cont-step:operation-square-operation-square-evidence-create-user-route-service:p:endpoint"
         ],
         "axisTraces": [
           {
             "axisFamily": "static",
             "axisRef": "static dependency / support axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
+            "continuationSummary": "static continuation reads 2 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_static[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=3",
-              "Cont_static[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=3",
-              "Cont_static[endpoint]=p; endpointRefs=5"
+              "Cont_static[0]=operation:route-create-user; comparableValues=2",
+              "Cont_static[1]=operation:service-create-user; comparableValues=2",
+              "Cont_static[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "static:endpoints:route.users|service.user",
+              "static:support:atom-relation-route-service|atom-contract-create-user"
             ],
             "distanceInputRefs": [
-              "atom:component:route-users",
-              "atom:component:service-user",
-              "atom:relation:route-service"
+              "atom:contract:create-user",
+              "atom:relation:route-service",
+              "route.users",
+              "service.user",
+              "src-route-users",
+              "src-service-user",
+              "test-user-contract"
             ],
             "observationRefs": [
-              "atom:component:route-users",
-              "atom:component:service-user",
-              "atom:relation:route-service"
+              "atom:relation:route-service",
+              "atom:contract:create-user"
             ],
             "sourceRefs": [
               "src-route-users",
-              "src-service-user"
+              "src-service-user",
+              "test-user-contract"
             ],
             "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
@@ -5218,14 +5994,22 @@
             "axisFamily": "contract",
             "axisRef": "contract axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
             "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_contract[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_contract[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_contract[endpoint]=p; endpointRefs=5"
+              "Cont_contract[0]=operation:route-create-user; comparableValues=2",
+              "Cont_contract[1]=operation:service-create-user; comparableValues=2",
+              "Cont_contract[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "contract:endpoints:route.users|service.user",
+              "contract:support:atom-contract-create-user"
             ],
             "distanceInputRefs": [
-              "atom:contract:create-user"
+              "atom:contract:create-user",
+              "route.users",
+              "service.user",
+              "test-user-contract"
             ],
             "observationRefs": [
               "atom:contract:create-user"
@@ -5240,14 +6024,23 @@
             "axisFamily": "semantic",
             "axisRef": "semantic axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
             "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_semantic[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_semantic[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_semantic[endpoint]=p; endpointRefs=5"
+              "Cont_semantic[0]=operation:route-create-user; comparableValues=2",
+              "Cont_semantic[1]=operation:service-create-user; comparableValues=2",
+              "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "semantic:path:p:operation:route-create-user -> operation:service-create-user",
+              "semantic:endpoints:route.users|service.user"
             ],
             "distanceInputRefs": [
-              "semantic:create-user-flow"
+              "doc-architecture",
+              "route.users",
+              "semantic:create-user-flow",
+              "service.user",
+              "test-user-contract"
             ],
             "observationRefs": [
               "semantic:create-user-flow"
@@ -5263,114 +6056,122 @@
             "axisFamily": "state",
             "axisRef": "state transition axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
             "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_state[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_state[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_state[endpoint]=p; endpointRefs=5"
+              "Cont_state[0]=operation:route-create-user; comparableValues=0",
+              "Cont_state[1]=operation:service-create-user; comparableValues=0",
+              "Cont_state[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "route.users",
+              "service.user"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing state observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "effect",
             "axisRef": "effect ordering / replay / compensation axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+            "continuationSummary": "effect continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_effect[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=4",
-              "Cont_effect[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=4",
-              "Cont_effect[endpoint]=p; endpointRefs=5"
+              "Cont_effect[0]=operation:route-create-user; comparableValues=0",
+              "Cont_effect[1]=operation:service-create-user; comparableValues=0",
+              "Cont_effect[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+              "route.users",
+              "service.user"
             ],
-            "observationRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
-            "sourceRefs": [
-              ".lake/runtime-trace.json",
-              "doc-architecture",
-              "src-route-users",
-              "src-service-user",
-              "test-user-contract"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "authority",
             "axisRef": "authority / trust boundary axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
             "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_authority[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_authority[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_authority[endpoint]=p; endpointRefs=5"
+              "Cont_authority[0]=operation:route-create-user; comparableValues=0",
+              "Cont_authority[1]=operation:service-create-user; comparableValues=0",
+              "Cont_authority[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "route.users",
+              "service.user"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing authority observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "runtime",
             "axisRef": "runtime interaction axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
+            "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_runtime[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_runtime[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_runtime[endpoint]=p; endpointRefs=5"
+              "Cont_runtime[0]=operation:route-create-user; comparableValues=0",
+              "Cont_runtime[1]=operation:service-create-user; comparableValues=0",
+              "Cont_runtime[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "gap-runtime-user-db-trace"
+              "route.users",
+              "service.user"
             ],
-            "observationRefs": [
-              "gap-runtime-user-db-trace"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
-            "sourceRefs": [
-              ".lake/runtime-trace.json"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "projection",
             "axisRef": "projection / representation axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "projection continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
+            "continuationSummary": "projection continuation reads 2 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_projection[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=3",
-              "Cont_projection[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=3",
-              "Cont_projection[endpoint]=p; endpointRefs=5"
+              "Cont_projection[0]=operation:route-create-user; comparableValues=2",
+              "Cont_projection[1]=operation:service-create-user; comparableValues=2",
+              "Cont_projection[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "projection:endpoints:route.users|service.user",
+              "projection:support:projection-aat-route-service|projection-sft-create-user"
             ],
             "distanceInputRefs": [
-              "projection:aat:route-users",
+              "atom:relation:route-service",
               "projection:aat:route-service",
-              "projection:sft:create-user"
+              "projection:sft:create-user",
+              "route.users",
+              "semantic:create-user-flow",
+              "service.user"
             ],
             "observationRefs": [
-              "projection:aat:route-users",
               "projection:aat:route-service",
               "projection:sft:create-user"
             ],
             "sourceRefs": [
-              "atom:component:route-users",
               "atom:relation:route-service",
               "semantic:create-user-flow"
             ],
@@ -5379,27 +6180,19 @@
           }
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
           "atom:contract:create-user",
           "atom:relation:route-service",
-          "gap-runtime-user-db-trace",
+          "molecule:user-request-responsibility",
           "projection:aat:route-service",
-          "projection:aat:route-users",
           "projection:sft:create-user",
           "semantic:create-user-flow"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
-        "missingRefs": [
-          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-          "no state observation supplied for operation square candidate"
-        ],
+        "missingRefs": [],
         "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
@@ -5412,51 +6205,57 @@
         ]
       },
       {
-        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "pathRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q",
+        "traceId": "path-continuation-trace:operation-square-operation-square-evidence-create-user-route-service:q",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "pathRef": "operation-square:operation-square-evidence-create-user-route-service:q",
         "pathRole": "q",
-        "pathExpression": "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
+        "pathExpression": "operation:route-create-user . operation:service-create-user",
         "operationSequence": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+          "operation:service-create-user",
+          "operation:route-create-user"
         ],
         "endpointObjectRefs": [
-          "aat:object:route.users",
-          "aat:relation:route.users->service.user",
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "sft:observation:create-user-flow"
+          "route.users",
+          "service.user"
         ],
         "continuationStepRefs": [
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "cont-step:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q:endpoint"
+          "cont-step:operation-square-operation-square-evidence-create-user-route-service:q:operation-service-create-user",
+          "cont-step:operation-square-operation-square-evidence-create-user-route-service:q:operation-route-create-user",
+          "cont-step:operation-square-operation-square-evidence-create-user-route-service:q:endpoint"
         ],
         "axisTraces": [
           {
             "axisFamily": "static",
             "axisRef": "static dependency / support axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:static-support-value-mismatch",
+            "continuationSummary": "static continuation reads 2 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_static[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=3",
-              "Cont_static[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=3",
-              "Cont_static[endpoint]=q; endpointRefs=5"
+              "Cont_static[0]=operation:service-create-user; comparableValues=2",
+              "Cont_static[1]=operation:route-create-user; comparableValues=2",
+              "Cont_static[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:static-support-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "static:endpoints:route.users|service.user",
+              "static:support:atom-relation-route-service|atom-contract-create-user"
             ],
             "distanceInputRefs": [
-              "atom:component:route-users",
-              "atom:component:service-user",
-              "atom:relation:route-service"
+              "atom:contract:create-user",
+              "atom:relation:route-service",
+              "route.users",
+              "service.user",
+              "src-route-users",
+              "src-service-user",
+              "test-user-contract"
             ],
             "observationRefs": [
-              "atom:component:route-users",
-              "atom:component:service-user",
-              "atom:relation:route-service"
+              "atom:relation:route-service",
+              "atom:contract:create-user"
             ],
             "sourceRefs": [
               "src-route-users",
-              "src-service-user"
+              "src-service-user",
+              "test-user-contract"
             ],
             "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
@@ -5465,14 +6264,22 @@
             "axisFamily": "contract",
             "axisRef": "contract axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:contract-obligation-value-mismatch",
             "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_contract[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_contract[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_contract[endpoint]=q; endpointRefs=5"
+              "Cont_contract[0]=operation:service-create-user; comparableValues=2",
+              "Cont_contract[1]=operation:route-create-user; comparableValues=2",
+              "Cont_contract[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:contract-obligation-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "contract:endpoints:route.users|service.user",
+              "contract:support:atom-contract-create-user"
             ],
             "distanceInputRefs": [
-              "atom:contract:create-user"
+              "atom:contract:create-user",
+              "route.users",
+              "service.user",
+              "test-user-contract"
             ],
             "observationRefs": [
               "atom:contract:create-user"
@@ -5487,14 +6294,23 @@
             "axisFamily": "semantic",
             "axisRef": "semantic axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "weighted-axis-l1:semantic-sequence-mismatch",
             "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_semantic[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_semantic[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_semantic[endpoint]=q; endpointRefs=5"
+              "Cont_semantic[0]=operation:service-create-user; comparableValues=2",
+              "Cont_semantic[1]=operation:route-create-user; comparableValues=2",
+              "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "semantic:path:q:operation:service-create-user -> operation:route-create-user",
+              "semantic:endpoints:route.users|service.user"
             ],
             "distanceInputRefs": [
-              "semantic:create-user-flow"
+              "doc-architecture",
+              "route.users",
+              "semantic:create-user-flow",
+              "service.user",
+              "test-user-contract"
             ],
             "observationRefs": [
               "semantic:create-user-flow"
@@ -5510,114 +6326,122 @@
             "axisFamily": "state",
             "axisRef": "state transition axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:state-transition-value-mismatch",
             "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_state[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_state[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_state[endpoint]=q; endpointRefs=5"
+              "Cont_state[0]=operation:service-create-user; comparableValues=0",
+              "Cont_state[1]=operation:route-create-user; comparableValues=0",
+              "Cont_state[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:state-transition-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "route.users",
+              "service.user"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing state observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "effect",
             "axisRef": "effect ordering / replay / compensation axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:effect-replay-order-mismatch",
+            "continuationSummary": "effect continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_effect[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=4",
-              "Cont_effect[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=4",
-              "Cont_effect[endpoint]=q; endpointRefs=5"
+              "Cont_effect[0]=operation:service-create-user; comparableValues=0",
+              "Cont_effect[1]=operation:route-create-user; comparableValues=0",
+              "Cont_effect[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:effect-replay-order-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "route.users",
+              "service.user"
             ],
-            "observationRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
-            "sourceRefs": [
-              ".lake/runtime-trace.json",
-              "doc-architecture",
-              "src-route-users",
-              "src-service-user",
-              "test-user-contract"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "authority",
             "axisRef": "authority / trust boundary axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:authority-boundary-value-mismatch",
             "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_authority[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=0",
-              "Cont_authority[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=0",
-              "Cont_authority[endpoint]=q; endpointRefs=5"
+              "Cont_authority[0]=operation:service-create-user; comparableValues=0",
+              "Cont_authority[1]=operation:route-create-user; comparableValues=0",
+              "Cont_authority[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:authority-boundary-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "route.users",
+              "service.user"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing authority observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "runtime",
             "axisRef": "runtime interaction axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "runtime continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
+            "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_runtime[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=1",
-              "Cont_runtime[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=1",
-              "Cont_runtime[endpoint]=q; endpointRefs=5"
+              "Cont_runtime[0]=operation:service-create-user; comparableValues=0",
+              "Cont_runtime[1]=operation:route-create-user; comparableValues=0",
+              "Cont_runtime[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:runtime-interaction-value-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "gap-runtime-user-db-trace"
+              "route.users",
+              "service.user"
             ],
-            "observationRefs": [
-              "gap-runtime-user-db-trace"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
-            "sourceRefs": [
-              ".lake/runtime-trace.json"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "projection",
             "axisRef": "projection / representation axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "projection continuation reads 3 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "weighted-axis-l1:projection-target-value-mismatch",
+            "continuationSummary": "projection continuation reads 2 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_projection[0]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation; refs=3",
-              "Cont_projection[1]=operation-delta:repair-obstruction-semantic-contract-mismatch-computed; refs=3",
-              "Cont_projection[endpoint]=q; endpointRefs=5"
+              "Cont_projection[0]=operation:service-create-user; comparableValues=2",
+              "Cont_projection[1]=operation:route-create-user; comparableValues=2",
+              "Cont_projection[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:projection-target-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "projection:endpoints:route.users|service.user",
+              "projection:support:projection-aat-route-service|projection-sft-create-user"
             ],
             "distanceInputRefs": [
-              "projection:aat:route-users",
+              "atom:relation:route-service",
               "projection:aat:route-service",
-              "projection:sft:create-user"
+              "projection:sft:create-user",
+              "route.users",
+              "semantic:create-user-flow",
+              "service.user"
             ],
             "observationRefs": [
-              "projection:aat:route-users",
               "projection:aat:route-service",
               "projection:sft:create-user"
             ],
             "sourceRefs": [
-              "atom:component:route-users",
               "atom:relation:route-service",
               "semantic:create-user-flow"
             ],
@@ -5626,27 +6450,19 @@
           }
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
           "atom:contract:create-user",
           "atom:relation:route-service",
-          "gap-runtime-user-db-trace",
+          "molecule:user-request-responsibility",
           "projection:aat:route-service",
-          "projection:aat:route-users",
           "projection:sft:create-user",
           "semantic:create-user-flow"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
-        "missingRefs": [
-          "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-          "no state observation supplied for operation square candidate"
-        ],
+        "missingRefs": [],
         "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
@@ -5661,34 +6477,39 @@
     ],
     "axisWiseMonodromyDefects": [
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
         "axisFamily": "authority",
         "axisRef": "authority / trust boundary axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:authority-boundary-value-mismatch",
         "pContinuationRef": "Cont_authority(p):authority / trust boundary axis",
         "qContinuationRef": "Cont_authority(q):authority / trust boundary axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "distanceInputRefs": [
+          "route.users",
+          "service.user"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 0,
         "measurementStatus": "unmeasured",
         "distanceValue": null,
         "measuredSupportRefs": [],
         "witnessRefs": [
-          "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          "missing-evidence:missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+          "missing-evidence:missing comparable p continuation value for authority",
+          "missing-evidence:missing comparable q continuation value for authority"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [],
         "missingRefs": [
-          "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          "missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+          "missing comparable p continuation value for authority",
+          "missing comparable q continuation value for authority"
         ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5701,7 +6522,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5713,17 +6534,20 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
         "axisFamily": "contract",
         "axisRef": "contract axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:contract-obligation-value-mismatch",
         "pContinuationRef": "Cont_contract(p):contract axis",
         "qContinuationRef": "Cont_contract(q):contract axis",
         "distanceInputRefs": [
-          "atom:contract:create-user"
+          "atom:contract:create-user",
+          "route.users",
+          "service.user",
+          "test-user-contract"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
@@ -5731,11 +6555,13 @@
           "atom:contract:create-user"
         ],
         "witnessRefs": [
-          "atom:contract:create-user"
+          "atom:contract:create-user",
+          "p-value:contract-endpoints-route-users-service-user",
+          "p-value:contract-support-atom-contract-create-user",
+          "q-value:contract-endpoints-route-users-service-user",
+          "q-value:contract-support-atom-contract-create-user"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
@@ -5744,7 +6570,7 @@
           "atom:contract:create-user"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -5757,7 +6583,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -5769,282 +6595,39 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
         "axisFamily": "effect",
         "axisRef": "effect ordering / replay / compensation axis",
-        "distanceKind": "weighted-axis-l1",
+        "distanceKind": "weighted-axis-l1:effect-replay-order-mismatch",
         "pContinuationRef": "Cont_effect(p):effect ordering / replay / compensation axis",
         "qContinuationRef": "Cont_effect(q):effect ordering / replay / compensation axis",
         "distanceInputRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "route.users",
+          "service.user"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 2,
-        "measuredSupportRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
-        ],
-        "witnessRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
-        ],
-        "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
-          "src-route-users",
-          "src-service-user",
-          "test-user-contract"
-        ],
-        "observationRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
-        ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "projection",
-        "axisRef": "projection / representation axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_projection(p):projection / representation axis",
-        "qContinuationRef": "Cont_projection(q):projection / representation axis",
-        "distanceInputRefs": [
-          "projection:aat:route-service",
-          "projection:aat:route-users",
-          "projection:sft:create-user"
-        ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 0,
-        "measuredSupportRefs": [
-          "projection:aat:route-service",
-          "projection:aat:route-users",
-          "projection:sft:create-user"
-        ],
-        "witnessRefs": [
-          "projection:aat:route-service",
-          "projection:aat:route-users",
-          "projection:sft:create-user"
-        ],
-        "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
-          "src-route-users",
-          "src-service-user",
-          "test-user-contract"
-        ],
-        "observationRefs": [
-          "projection:aat:route-service",
-          "projection:aat:route-users",
-          "projection:sft:create-user"
-        ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "runtime",
-        "axisRef": "runtime interaction axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
-        "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
-        "distanceInputRefs": [
-          "gap-runtime-user-db-trace"
-        ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 0,
-        "measuredSupportRefs": [
-          "gap-runtime-user-db-trace"
-        ],
-        "witnessRefs": [
-          "gap-runtime-user-db-trace"
-        ],
-        "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
-          "src-route-users",
-          "src-service-user",
-          "test-user-contract"
-        ],
-        "observationRefs": [
-          "gap-runtime-user-db-trace"
-        ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "semantic",
-        "axisRef": "semantic axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_semantic(p):semantic axis",
-        "qContinuationRef": "Cont_semantic(q):semantic axis",
-        "distanceInputRefs": [
-          "semantic:create-user-flow"
-        ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 0,
-        "measuredSupportRefs": [
-          "semantic:create-user-flow"
-        ],
-        "witnessRefs": [
-          "semantic:create-user-flow"
-        ],
-        "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
-          "src-route-users",
-          "src-service-user",
-          "test-user-contract"
-        ],
-        "observationRefs": [
-          "semantic:create-user-flow"
-        ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
-        "exactnessAssumptionStatus": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary"
-        ],
-        "zeroReflectionAssumptions": [
-          "selected LawPolicy exactness assumptions",
-          "ArchMapStore compaction boundary",
-          "all selected operation square candidates and axis traces are measured",
-          "weighted aggregate has no cancellation of local defects",
-          "zero aggregate is not global path flatness"
-        ],
-        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
-        "nonConclusions": [
-          "ArchSig analysis packet is not a Lean theorem proof",
-          "ArchSig analysis packet is not global architecture truth",
-          "ArchSig analysis packet does not prove source extraction completeness",
-          "signature axes are law-policy-relative, not universal quality scores",
-          "flatness reading is blocked by coverage gaps and exactness assumptions",
-          "repair operation candidates are not automatic safe refactorings",
-          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
-        ]
-      },
-      {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "state",
-        "axisRef": "state transition axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_state(p):state transition axis",
-        "qContinuationRef": "Cont_state(q):state transition axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 0,
         "measurementStatus": "unmeasured",
         "distanceValue": null,
         "measuredSupportRefs": [],
         "witnessRefs": [
-          "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          "missing-evidence:missing comparable p continuation value for effect",
+          "missing-evidence:missing comparable q continuation value for effect",
+          "missing-evidence:missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [],
         "missingRefs": [
-          "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+          "missing comparable p continuation value for effect",
+          "missing comparable q continuation value for effect",
+          "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
         ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -6057,7 +6640,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6069,46 +6652,48 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-        "axisFamily": "static",
-        "axisRef": "static dependency / support axis",
-        "distanceKind": "weighted-axis-l1",
-        "pContinuationRef": "Cont_static(p):static dependency / support axis",
-        "qContinuationRef": "Cont_static(q):static dependency / support axis",
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "axisFamily": "projection",
+        "axisRef": "projection / representation axis",
+        "distanceKind": "weighted-axis-l1:projection-target-value-mismatch",
+        "pContinuationRef": "Cont_projection(p):projection / representation axis",
+        "qContinuationRef": "Cont_projection(q):projection / representation axis",
         "distanceInputRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service"
+          "atom:relation:route-service",
+          "projection:aat:route-service",
+          "projection:sft:create-user",
+          "route.users",
+          "semantic:create-user-flow",
+          "service.user"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
         "measuredSupportRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service"
+          "projection:aat:route-service",
+          "projection:sft:create-user"
         ],
         "witnessRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service"
+          "p-value:projection-endpoints-route-users-service-user",
+          "p-value:projection-support-projection-aat-route-service-projection-sft-create-user",
+          "projection:aat:route-service",
+          "projection:sft:create-user",
+          "q-value:projection-endpoints-route-users-service-user",
+          "q-value:projection-support-projection-aat-route-service-projection-sft-create-user"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service"
+          "projection:aat:route-service",
+          "projection:sft:create-user"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions",
           "ArchMapStore compaction boundary"
@@ -6121,7 +6706,250 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "axisFamily": "runtime",
+        "axisRef": "runtime interaction axis",
+        "distanceKind": "weighted-axis-l1:runtime-interaction-value-mismatch",
+        "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
+        "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
+        "distanceInputRefs": [
+          "route.users",
+          "service.user"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 0,
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing comparable p continuation value for runtime",
+          "missing-evidence:missing comparable q continuation value for runtime",
+          "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing comparable p continuation value for runtime",
+          "missing comparable q continuation value for runtime",
+          "missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
+        ],
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "distanceKind": "weighted-axis-l1:semantic-sequence-mismatch",
+        "pContinuationRef": "Cont_semantic(p):semantic axis",
+        "qContinuationRef": "Cont_semantic(q):semantic axis",
+        "distanceInputRefs": [
+          "doc-architecture",
+          "route.users",
+          "semantic:create-user-flow",
+          "service.user",
+          "test-user-contract"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 1,
+        "measurementStatus": "measured",
+        "distanceValue": 1,
+        "measuredSupportRefs": [
+          "semantic:create-user-flow"
+        ],
+        "witnessRefs": [
+          "p-value:semantic-endpoints-route-users-service-user",
+          "p-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+          "q-value:semantic-endpoints-route-users-service-user",
+          "q-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+          "semantic:create-user-flow"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "semantic:create-user-flow"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:state",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "axisFamily": "state",
+        "axisRef": "state transition axis",
+        "distanceKind": "weighted-axis-l1:state-transition-value-mismatch",
+        "pContinuationRef": "Cont_state(p):state transition axis",
+        "qContinuationRef": "Cont_state(q):state transition axis",
+        "distanceInputRefs": [
+          "route.users",
+          "service.user"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 0,
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
+        "witnessRefs": [
+          "missing-evidence:missing comparable p continuation value for state",
+          "missing-evidence:missing comparable q continuation value for state",
+          "missing-evidence:missing state observation for operation-square:operation-square-evidence-create-user-route-service"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [],
+        "missingRefs": [
+          "missing comparable p continuation value for state",
+          "missing comparable q continuation value for state",
+          "missing state observation for operation-square:operation-square-evidence-create-user-route-service"
+        ],
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "defectId": "mu:operation-square-operation-square-evidence-create-user-route-service:static",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+        "axisFamily": "static",
+        "axisRef": "static dependency / support axis",
+        "distanceKind": "weighted-axis-l1:static-support-value-mismatch",
+        "pContinuationRef": "Cont_static(p):static dependency / support axis",
+        "qContinuationRef": "Cont_static(q):static dependency / support axis",
+        "distanceInputRefs": [
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "route.users",
+          "service.user",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 1,
+        "measurementStatus": "measured",
+        "distanceValue": 0,
+        "measuredSupportRefs": [
+          "atom:contract:create-user",
+          "atom:relation:route-service"
+        ],
+        "witnessRefs": [
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "p-value:static-endpoints-route-users-service-user",
+          "p-value:static-support-atom-relation-route-service-atom-contract-create-user",
+          "q-value:static-endpoints-route-users-service-user",
+          "q-value:static-support-atom-relation-route-service-atom-contract-create-user"
+        ],
+        "sourceRefs": [
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
+        ],
+        "observationRefs": [
+          "atom:contract:create-user",
+          "atom:relation:route-service"
+        ],
+        "missingRefs": [],
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
+        "exactnessAssumptionStatus": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary"
+        ],
+        "zeroReflectionAssumptions": [
+          "selected LawPolicy exactness assumptions",
+          "ArchMapStore compaction boundary",
+          "all selected operation square candidates and axis traces are measured",
+          "weighted aggregate has no cancellation of local defects",
+          "zero aggregate is not global path flatness"
+        ],
+        "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6148,136 +6976,152 @@
           "static"
         ],
         "selectedMeasuredSquareRefs": [
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+          "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:contract",
+          "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:projection",
+          "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+          "square-family-entry:mu:operation-square-operation-square-evidence-create-user-route-service:static"
         ],
         "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
         "distanceKind": "weighted-axis-l1",
         "measurementStatus": "partial",
-        "aggregateValue": 2,
+        "aggregateValue": 1,
         "measuredDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+          "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:static"
         ],
         "unmeasuredDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state"
+          "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:state"
         ],
         "positiveWeightDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+          "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:static"
         ],
         "zeroWeightDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state"
+          "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:state"
         ],
         "topContributors": [
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
             "axisFamily": "authority",
             "contributionWeight": 1,
             "contributionValue": null,
             "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
             "witnessRefs": [
-              "missing-evidence:missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing-evidence:missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+              "missing-evidence:missing comparable p continuation value for authority",
+              "missing-evidence:missing comparable q continuation value for authority"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+            "axisFamily": "effect",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing effect trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing comparable p continuation value for effect",
+              "missing-evidence:missing comparable q continuation value for effect",
+              "missing-evidence:missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+            "axisFamily": "runtime",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing runtime trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing comparable p continuation value for runtime",
+              "missing-evidence:missing comparable q continuation value for runtime",
+              "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:state",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
             "axisFamily": "state",
             "contributionWeight": 1,
             "contributionValue": null,
             "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
             "witnessRefs": [
-              "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing-evidence:missing comparable p continuation value for state",
+              "missing-evidence:missing comparable q continuation value for state",
+              "missing-evidence:missing state observation for operation-square:operation-square-evidence-create-user-route-service"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-            "axisFamily": "effect",
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
+            "axisFamily": "semantic",
             "contributionWeight": 1,
-            "contributionValue": 2,
-            "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
+            "contributionValue": 1,
+            "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction"
+              "p-value:semantic-endpoints-route-users-service-user",
+              "p-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+              "q-value:semantic-endpoints-route-users-service-user",
+              "q-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+              "semantic:create-user-flow"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
             "axisFamily": "contract",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "atom:contract:create-user"
+              "atom:contract:create-user",
+              "p-value:contract-endpoints-route-users-service-user",
+              "p-value:contract-support-atom-contract-create-user",
+              "q-value:contract-endpoints-route-users-service-user",
+              "q-value:contract-support-atom-contract-create-user"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
             "axisFamily": "projection",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
+              "p-value:projection-endpoints-route-users-service-user",
+              "p-value:projection-support-projection-aat-route-service-projection-sft-create-user",
               "projection:aat:route-service",
-              "projection:aat:route-users",
-              "projection:sft:create-user"
+              "projection:sft:create-user",
+              "q-value:projection-endpoints-route-users-service-user",
+              "q-value:projection-support-projection-aat-route-service-projection-sft-create-user"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-            "axisFamily": "runtime",
-            "contributionWeight": 1,
-            "contributionValue": 0,
-            "reviewFocus": "review runtime trace mismatch before treating aggregate value as local agreement",
-            "witnessRefs": [
-              "gap-runtime-user-db-trace"
-            ]
-          },
-          {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-            "axisFamily": "semantic",
-            "contributionWeight": 1,
-            "contributionValue": 0,
-            "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
-            "witnessRefs": [
-              "semantic:create-user-flow"
-            ]
-          },
-          {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:static",
+            "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
             "axisFamily": "static",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "atom:component:route-users",
-              "atom:component:service-user",
-              "atom:relation:route-service"
+              "atom:contract:create-user",
+              "atom:relation:route-service",
+              "p-value:static-endpoints-route-users-service-user",
+              "p-value:static-support-atom-relation-route-service-atom-contract-create-user",
+              "q-value:static-endpoints-route-users-service-user",
+              "q-value:static-support-atom-relation-route-service-atom-contract-create-user"
             ]
           }
         ],
@@ -6304,30 +7148,26 @@
     ],
     "nonzeroMonodromyWitnesses": [
       {
-        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect",
-        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-semantic",
+        "defectRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+        "candidateRef": "operation-square:operation-square-evidence-create-user-route-service",
         "operationPair": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:route-create-user",
+          "operation:service-create-user"
         ],
         "pathPair": [
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed",
-          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation"
+          "operation:service-create-user . operation:route-create-user",
+          "operation:route-create-user . operation:service-create-user"
         ],
-        "axisFamily": "effect",
-        "axisRef": "effect ordering / replay / compensation axis",
-        "defectValue": 2,
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "defectValue": 1,
         "comparedTraceSummary": [
-          "p: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0",
-          "q: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0"
+          "p: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+          "q: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
         ],
         "affectedAtomRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "semantic:create-user-flow"
         ],
         "lawRefs": [
           "law:layer-respecting",
@@ -6338,23 +7178,17 @@
           "sig-axis:semantic-inconsistency"
         ],
         "sourceRefs": [
-          ".lake/runtime-trace.json",
-          "doc-architecture",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-          "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "semantic:create-user-flow"
         ],
         "missingEvidence": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "suggestedFillerEvidence": [
-          "supply filler evidence for effect axis trace disagreement",
+          "supply filler evidence for semantic axis trace disagreement",
           "record whether the two continuation paths preserve selected observations"
         ],
         "suggestedLiftingEvidence": [
@@ -6364,8 +7198,8 @@
           "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
         ],
         "recommendedReviewFocus": [
-          "compare operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation . operation-delta:repair-obstruction-semantic-contract-mismatch-computed and operation-delta:repair-obstruction-semantic-contract-mismatch-computed . operation-delta:repair-obstruction-semantic-contract-mismatch-computed:continuation before treating the operation pair as order-insensitive",
-          "review effect axis witness refs and missing evidence"
+          "compare operation:service-create-user . operation:route-create-user and operation:route-create-user . operation:service-create-user before treating the operation pair as order-insensitive",
+          "review semantic axis witness refs and missing evidence"
         ],
         "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
         "nonConclusions": [
@@ -6389,8 +7223,8 @@
         "featureScopeRef": "fixture-archmap-atom-observation:feature",
         "mixedSubconfigurationRefs": [
           "gap-runtime-user-db-trace",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
           "obstruction:semantic-contract-mismatch:computed",
+          "repair:obstruction-semantic-contract-mismatch-computed",
           "split-readiness:molecule-user-request-responsibility"
         ],
         "coreLocalReadingRefs": [
@@ -6401,8 +7235,8 @@
         ],
         "boundarySupportRefs": [
           "gap-runtime-user-db-trace",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
           "obstruction:semantic-contract-mismatch:computed",
+          "repair:obstruction-semantic-contract-mismatch-computed",
           "split-readiness:molecule-user-request-responsibility"
         ],
         "holonomyAxes": [
@@ -6413,8 +7247,7 @@
             "residualValue": 0,
             "measuredDefectRefs": [],
             "supportRefs": [
-              "atom:component:route-users",
-              "atom:component:service-user",
+              "atom:contract:create-user",
               "atom:relation:route-service"
             ],
             "missingEvidence": [],
@@ -6435,9 +7268,11 @@
           {
             "holonomyAxisRef": "Hol_semantic",
             "axisFamily": "semantic",
-            "status": "coveredZeroResidual",
-            "residualValue": 0,
-            "measuredDefectRefs": [],
+            "status": "measuredResidual",
+            "residualValue": 1,
+            "measuredDefectRefs": [
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
+            ],
             "supportRefs": [
               "semantic:create-user-flow"
             ],
@@ -6452,31 +7287,34 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "gap-runtime-user-db-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
               "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
               "split-readiness:molecule-user-request-responsibility"
             ],
             "missingEvidence": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing comparable p continuation value for state",
+              "missing comparable q continuation value for state",
+              "missing state observation for operation-square:operation-square-evidence-create-user-route-service"
             ],
             "reading": "Hol_state records boundary-local residual obstruction on the state axis"
           },
           {
             "holonomyAxisRef": "Hol_effect",
             "axisFamily": "effect",
-            "status": "measuredResidual",
-            "residualValue": 2,
-            "measuredDefectRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
-            ],
+            "status": "coverageBlocked",
+            "residualValue": 0,
+            "measuredDefectRefs": [],
             "supportRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "derived-effect-order:p:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-operation-delta-repair-obstruction-semantic-contract-mismatch-computed",
-              "derived-effect-order:q:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation",
-              "obstruction:semantic-contract-mismatch:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction"
+              "gap-runtime-user-db-trace",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
             ],
-            "missingEvidence": [],
+            "missingEvidence": [
+              "missing comparable p continuation value for effect",
+              "missing comparable q continuation value for effect",
+              "missing effect observation for operation-square:operation-square-evidence-create-user-route-service"
+            ],
             "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
           },
           {
@@ -6487,25 +7325,34 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "gap-runtime-user-db-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
               "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
               "split-readiness:molecule-user-request-responsibility"
             ],
             "missingEvidence": [
-              "missing authority observation for operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+              "missing authority observation for operation-square:operation-square-evidence-create-user-route-service",
+              "missing comparable p continuation value for authority",
+              "missing comparable q continuation value for authority"
             ],
             "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
           },
           {
             "holonomyAxisRef": "Hol_runtime",
             "axisFamily": "runtime",
-            "status": "coveredZeroResidual",
+            "status": "coverageBlocked",
             "residualValue": 0,
             "measuredDefectRefs": [],
             "supportRefs": [
-              "gap-runtime-user-db-trace"
+              "gap-runtime-user-db-trace",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
             ],
-            "missingEvidence": [],
+            "missingEvidence": [
+              "missing comparable p continuation value for runtime",
+              "missing comparable q continuation value for runtime",
+              "missing runtime observation for operation-square:operation-square-evidence-create-user-route-service"
+            ],
             "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
           },
           {
@@ -6516,7 +7363,6 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "projection:aat:route-service",
-              "projection:aat:route-users",
               "projection:sft:create-user"
             ],
             "missingEvidence": [],
@@ -6525,9 +7371,9 @@
         ],
         "residualObstructionRefs": [
           "gap-runtime-user-db-trace",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-          "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+          "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
           "obstruction:semantic-contract-mismatch:computed",
+          "repair:obstruction-semantic-contract-mismatch-computed",
           "split-readiness:molecule-user-request-responsibility"
         ],
         "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
@@ -6540,7 +7386,7 @@
           "ArchMapStore compaction boundary"
         ],
         "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
-        "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "coverageBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
         "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
         "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
         "nonConclusions": [
@@ -6584,9 +7430,9 @@
             "refs": [
               "feature-boundary-residual:fixture-archmap-atom-observation",
               "gap-runtime-user-db-trace",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
               "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
               "split-readiness:molecule-user-request-responsibility"
             ],
             "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
@@ -6611,7 +7457,7 @@
             "axis": "complexityTransfer",
             "status": "observed",
             "refs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+              "repair:obstruction-semantic-contract-mismatch-computed"
             ],
             "reading": "complexityTransfer is classified as a current-state extension coordinate"
           },
@@ -6630,6 +7476,16 @@
             "labels": [
               "boundaryHolonomy"
             ],
+            "observationRefs": [
+              "gap-runtime-user-db-trace",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
@@ -6647,6 +7503,16 @@
               "boundaryHolonomy",
               "residualCoverageGap"
             ],
+            "observationRefs": [
+              "gap-runtime-user-db-trace",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
@@ -6661,39 +7527,30 @@
             "reading": "gap-runtime-user-db-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
           },
           {
-            "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-            "labels": [
-              "boundaryHolonomy",
-              "complexityTransfer"
-            ],
-            "inheritedCoreRefs": [],
-            "featureLocalRefs": [],
-            "boundaryHolonomyRefs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-            ],
-            "liftingFailureRefs": [],
-            "fillingFailureRefs": [],
-            "complexityTransferRefs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-            ],
-            "residualCoverageGapRefs": [],
-            "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
-          },
-          {
-            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
+            "witnessRef": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
             "labels": [
               "boundaryHolonomy"
             ],
+            "observationRefs": [
+              "gap-runtime-user-db-trace",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              ".lake/runtime-trace.json"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect"
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
             ],
             "liftingFailureRefs": [],
             "fillingFailureRefs": [],
             "complexityTransferRefs": [],
             "residualCoverageGapRefs": [],
-            "reading": "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+            "reading": "mu:operation-square-operation-square-evidence-create-user-route-service:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
           },
           {
             "witnessRef": "obstruction:semantic-contract-mismatch:computed",
@@ -6702,6 +7559,18 @@
               "featureLocalObstruction",
               "fillingFailure",
               "inheritedCoreObstruction"
+            ],
+            "observationRefs": [
+              "atom:contract:create-user",
+              "gap-runtime-user-db-trace",
+              "molecule-reading:molecule-user-request-responsibility",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
             ],
             "inheritedCoreRefs": [
               "obstruction:semantic-contract-mismatch:computed"
@@ -6721,10 +7590,52 @@
             "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
           },
           {
+            "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+            "labels": [
+              "boundaryHolonomy",
+              "complexityTransfer"
+            ],
+            "observationRefs": [
+              "atom:contract:create-user",
+              "gap-runtime-user-db-trace",
+              "molecule-reading:molecule-user-request-responsibility",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              "test-user-contract"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "repair:obstruction-semantic-contract-mismatch-computed"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [
+              "repair:obstruction-semantic-contract-mismatch-computed"
+            ],
+            "residualCoverageGapRefs": [],
+            "reading": "repair:obstruction-semantic-contract-mismatch-computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+          },
+          {
             "witnessRef": "split-readiness:molecule-user-request-responsibility",
             "labels": [
               "boundaryHolonomy",
               "liftingFailure"
+            ],
+            "observationRefs": [
+              "gap-runtime-user-db-trace",
+              "molecule:user-request-responsibility",
+              "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+              "obstruction:semantic-contract-mismatch:computed",
+              "repair:obstruction-semantic-contract-mismatch-computed",
+              "split-readiness:molecule-user-request-responsibility"
+            ],
+            "sourceRefs": [
+              "doc-architecture"
             ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
@@ -6750,7 +7661,7 @@
           "obstruction:semantic-contract-mismatch:computed"
         ],
         "complexityTransferRefs": [
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          "repair:obstruction-semantic-contract-mismatch-computed"
         ],
         "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
         "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
@@ -6768,7 +7679,11 @@
     ],
     "monodromyReadingFamily": {
       "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-      "status": "schemaFoundationOnly",
+      "status": "partial",
+      "measuredAxisCount": 4,
+      "unmeasuredAxisCount": 4,
+      "positiveWitnessCount": 1,
+      "coverageBlockerCount": 12,
       "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
       "selectedAxisRefs": [
         "axis:layer-violation",
@@ -6778,21 +7693,21 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
       "operationSquareCandidateRefs": [
-        "operation-square:operation-delta-repair-obstruction-semantic-contract-mismatch-computed:operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation"
+        "operation-square:operation-square-evidence-create-user-route-service"
       ],
       "pathContinuationTraceRefs": [
-        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:p",
-        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:q"
+        "path-continuation-trace:operation-square-operation-square-evidence-create-user-route-service:p",
+        "path-continuation-trace:operation-square-operation-square-evidence-create-user-route-service:q"
       ],
       "axisWiseDefectRefs": [
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:authority",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:contract",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:effect",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:projection",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:runtime",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:semantic",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:state",
-        "mu:operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation:static"
+        "mu:operation-square-operation-square-evidence-create-user-route-service:authority",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:contract",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:effect",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:projection",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:runtime",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:state",
+        "mu:operation-square-operation-square-evidence-create-user-route-service:static"
       ],
       "amiAggregateReadingRefs": [
         "ami:measurement-policy-monodromy-boundary-holonomy"
@@ -6812,7 +7727,11 @@
     },
     "boundaryHolonomyReadingFamily": {
       "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-      "status": "schemaFoundationOnly",
+      "status": "partial",
+      "measuredAxisCount": 4,
+      "unmeasuredAxisCount": 4,
+      "positiveWitnessCount": 2,
+      "coverageBlockerCount": 13,
       "archMapStoreRefSetRef": "archmap-store-refs:fixture-archmap-atom-observation",
       "selectedAxisRefs": [
         "axis:layer-violation",
@@ -6822,7 +7741,7 @@
       "weightPolicy": "unit weights until repo-specific calibration is declared in a future policy",
       "coveragePolicy": "measure only selected axes with declared coverage; missing coverage remains blocked, not zero",
       "nonzeroMonodromyWitnessRefs": [
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect"
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-semantic"
       ],
       "featureBoundaryResidualRefs": [
         "feature-boundary-residual:fixture-archmap-atom-observation"
@@ -7043,8 +7962,8 @@
         ]
       },
       {
-        "readingId": "representation-strength:analytic-spectral-radius-proxy",
-        "sourceReadingRef": "analytic:spectral-radius-proxy",
+        "readingId": "representation-strength:analytic-spectral-radius",
+        "sourceReadingRef": "analytic:spectral-radius",
         "representationFamily": "spectralRadius",
         "zeroPreserving": "supported",
         "zeroReflecting": "blockedByCoverageGap",
@@ -7164,6 +8083,39 @@
         ],
         "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
         "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-relation-atom-adjacency",
+        "sourceReadingRef": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "finiteMatrixMayHideUnobservedComponents",
+        "requiredAssumptions": [
+          "gap-runtime-user-db-trace",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap-runtime-user-db-trace"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap-runtime-user-db-trace"
+        ],
+        "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+        "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -7520,7 +8472,7 @@
     "structuralReadingReviewSurface": {
       "surfaceId": "aat-structural-reading-review-surface",
       "status": "needsReview",
-      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1",
+      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
       "connectedReadingRefs": [
         "representationStrength:weightedAdjacencyMatrix",
         "representationStrength:reachableConeSize",
@@ -7544,6 +8496,12 @@
         "homotopy-order-sensitivity:selected-operations",
         "diagram-fillability:local-curvature-obstruction-semantic-contract-mismatch-computed",
         "axis-forgetting-risk:selected-projection",
+        "observation-projection-fidelity:observation-projection-fixture-archmap-atom-observation",
+        "atom-origin-closure-debt:fixture-archmap-atom-observation",
+        "effect-relation-algebra:fixture-archmap-atom-observation",
+        "synthesis-blockage:fixture-archmap-atom-observation",
+        "operation-precondition-readiness:repair-obstruction-semantic-contract-mismatch-computed",
+        "path-multiplicity-loss:fixture-archmap-atom-observation",
         "signature-trajectory-homotopy-refutation:selected-trajectory",
         "bridge-split-obstruction-transfer:split-readiness-molecule-user-request-responsibility"
       ],
@@ -7552,6 +8510,10 @@
         "read LawUniverse coverage and witness exactness before treating absence as measured zero",
         "read feature extension, operation law, trajectory, homotopy, and diagram-fillability axes as current-state coordinates, not PR evolution claims",
         "read axis-forgetting risk before treating a coarse projection as zero-reflecting or obstruction-reflecting",
+        "read projection fidelity and Atom origin closure before using summaries for zero, repair, or synthesis claims",
+        "read effect relation algebra separately from state transition pressure before approving replay, provider, event, or handler boundaries",
+        "read synthesis blockage and operation precondition readiness before treating candidates as constructible or safe",
+        "read path multiplicity loss before treating one observed route as complete reachability",
         "read selected trajectory disagreement before treating same-endpoint operations as homotopic",
         "read bridge split transfer before treating a boundary operation as obstruction removal",
         "read representation-strength blockers before treating zero or obstruction absence as exact",
@@ -8526,24 +9488,26 @@
         "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
       ],
       "analyticReadingsSummary": [
-        "weightedAdjacencyMatrix=4x4; edgeCount=1 (measured)",
-        "reachableConeSize=5 (measured)",
-        "walkCount=2 (measured)",
+        "weightedAdjacencyMatrix=2x2; edgeCount=1 (measured)",
+        "reachableConeSize=1 (measured)",
+        "walkCount=1 (measured)",
         "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
-        "selectedSubgraphSpectrum=[0.250] (measured)",
+        "selectedSubgraphSpectrum=[0.000] (measured)",
         "propagationDepth=1 (measured)",
-        "spectralRadius=0.250 (measured)",
+        "spectralRadius=0.000 (measured)",
         "curvatureValuation=1 (measured)",
         "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
         "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
       ],
       "spectralReadingsSummary": [
+        "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=2x2 (needsReview)",
         "workflowRiskAxisPressureMatrix upperBound=10.677 shape=1x5 (needsReview)",
         "moleculeAtomOverlapCouplingMatrix upperBound=4.000 shape=1x1 (needsReview)",
         "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
         "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
       ],
       "spectralModeSummary": [
+        "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=1.000 localization=1.000 density=0.250 (needsReview)",
         "workflowRiskAxisPressureMatrix distributedPressureMode gap=9.434 localization=1.000 density=1.000 (needsReview)",
         "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=4.000 localization=1.000 density=1.000 (needsReview)",
         "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
@@ -8556,7 +9520,7 @@
         "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
       ],
       "curvatureTransferSummary": [
-        "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1 (needsReview)"
+        "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1.000 (needsReview)"
       ],
       "architectureSpectrumReportSummary": [
         "architecture-spectrum-report:spectrum-profile-curvature-transfer-default hotspots=4 recurrent=1 clusters=2 (needsReview)",
@@ -8567,7 +9531,7 @@
       ],
       "transferBridgeEdgeSummary": [],
       "measurementExpansionSummary": [
-        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
+        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
       ],
       "atomSupportAxisSummary": [
         "fixture-archmap-atom-observation support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent",
@@ -8580,10 +9544,10 @@
         "llm-native-aat-law-policy-fixture required=2 unmeasured=2 blockedWitnesses=2"
       ],
       "featureExtensionFormulaSummary": [
-        "feature-extension-formula:fixture-archmap-atom-observation status=measured inherited=1 featureLocal=1 interaction=0 residualGaps=1"
+        "feature-extension-formula:fixture-archmap-atom-observation status=measured inherited=1 featureLocal=1 interaction=1 residualGaps=1"
       ],
       "operationCalculusLawSummary": [
-        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
+        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=observed repairMonotonicity=blockedByTransferRisk boundary=notASynthesisCertificate"
       ],
       "pathSignatureTrajectorySummary": [
         "operation-delta:repair-obstruction-semantic-contract-mismatch-computed status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=1 transferred=1"
@@ -8597,6 +9561,24 @@
       "axisForgettingRiskSummary": [
         "observation-projection:fixture-archmap-atom-observation kind=selectedAxisOrWitnessLoss zeroReflection=blockedWithoutAxisPreservationAndWitnessCompleteness obstructionReflection=blockedWithoutAxisPreservationAndWitnessCompleteness mixedScopes=2"
       ],
+      "observationProjectionFidelitySummary": [
+        "observation-projection:fixture-archmap-atom-observation status=projectionLossObserved forgotten=1 collisions=0 reflection=blockedWithoutAxisPreservationAndWitnessCompleteness"
+      ],
+      "atomOriginClosureDebtSummary": [
+        "atom-origin-closure-debt:fixture-archmap-atom-observation status=originClosureDebtObserved sourceBacked=4 inferred=0 missingExpected=1"
+      ],
+      "effectRelationAlgebraSummary": [
+        "effect-relation-algebra:fixture-archmap-atom-observation pressure=effectRelationPressureObserved generators=1 unresolved=1 externalBoundaries=0"
+      ],
+      "synthesisBlockageSummary": [
+        "synthesis-blockage:fixture-archmap-atom-observation status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=7 missing=5 noSolution=notASolverAndNotAbsenceProof"
+      ],
+      "operationPreconditionReadinessSummary": [
+        "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit status=blockedByMissingPreconditionEvidence missing=7 witnesses=2"
+      ],
+      "pathMultiplicityLossSummary": [
+        "fixture-archmap-atom-observation status=reachabilityMultiplicityLossObserved paths=1 alternatePressure=8 fanIn=0 forgotten=1"
+      ],
       "signatureTrajectoryHomotopyRefutationSummary": [
         "homotopy-order-sensitivity:selected-operations equivalence=selectedTrajectoryDisagreementObserved refutation=refutationCandidate disagreements=1"
       ],
@@ -8604,7 +9586,7 @@
         "split-readiness:molecule-user-request-responsibility transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
       ],
       "nonzeroMonodromyWitnessSummary": [
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-operation-delta-repair-obstruction-semantic-contract-mismatch-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2"
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-create-user-route-service-semantic axis=semantic defect=1 affectedAtoms=1 missingEvidence=0 focus=2"
       ],
       "featureBoundaryResidualSummary": [
         "feature-boundary-residual:fixture-archmap-atom-observation boundary=Boundary(fixture-archmap-atom-observation, feature-extension) status=measuredResidual axes=8 residualRefs=5"
@@ -8623,6 +9605,7 @@
         "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
         "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
         "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "relationAtomWeightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
@@ -8647,8 +9630,8 @@
         "molecule:user-request-responsibility status=needsReview score=92 boundaryOp=interface"
       ],
       "structuralReadingReviewSummary": [
-        "aat-structural-reading-review-surface status=needsReview refs=24 focus=12",
-        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1"
+        "aat-structural-reading-review-surface status=needsReview refs=30 focus=16",
+        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
       ],
       "currentStateEvolutionBoundarySummary": [
         "ArchSig computes current AAT structural state from ArchMap fixture-archmap-atom-observation and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
@@ -8721,8 +9704,8 @@
     "analyticRepresentationCount": 10,
     "couplingCohesionReadingCount": 4,
     "workflowRiskReadingCount": 1,
-    "spectralAnalysisReadingCount": 4,
-    "spectralModeReadingCount": 4,
+    "spectralAnalysisReadingCount": 5,
+    "spectralModeReadingCount": 5,
     "spectralDrilldownReadingCount": 1,
     "curvatureSupportReadingCount": 1,
     "curvatureTransferReadingCount": 1,
@@ -8736,9 +9719,15 @@
     "homotopyOrderSensitivityReadingCount": 1,
     "diagramFillabilityReadingCount": 1,
     "axisForgettingRiskReadingCount": 1,
+    "observationProjectionFidelityReadingCount": 1,
+    "atomOriginClosureDebtReadingCount": 1,
+    "effectRelationAlgebraReadingCount": 1,
+    "synthesisBlockageReadingCount": 1,
+    "operationPreconditionReadinessReadingCount": 1,
+    "pathMultiplicityLossReadingCount": 1,
     "signatureTrajectoryHomotopyRefutationReadingCount": 1,
     "bridgeSplitObstructionTransferReadingCount": 1,
-    "representationStrengthReadingCount": 14,
+    "representationStrengthReadingCount": 15,
     "localCurvatureDiagramReadingCount": 1,
     "threeLayerFlatnessReadingCount": 1,
     "observationProjectionReadingCount": 1,
@@ -8814,7 +9803,7 @@
     },
     {
       "id": "archsig-analysis-packet-spectral-analysis-surface",
-      "title": "packet exposes AAT spectral readings as bounded finite-representation proxies",
+      "title": "packet exposes AAT spectral readings as bounded finite relation and measurement representations",
       "result": "pass",
       "count": 0
     },

--- a/tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json
@@ -374,7 +374,7 @@
         "analytic:nilpotence-boundary",
         "analytic:selected-subgraph-spectrum",
         "analytic:propagation-depth",
-        "analytic:spectral-radius-proxy",
+        "analytic:spectral-radius",
         "analytic:curvature-valuation",
         "analytic:state-algebra-boundary",
         "analytic:zero-reflecting-aggregate-boundary"
@@ -706,17 +706,17 @@
       "representationFamily": "weightedAdjacencyMatrix",
       "status": "measured",
       "valueType": "matrixShape",
-      "value": "7x7; edgeCount=0",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "value": "0x0; edgeCount=0",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+      "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -734,17 +734,17 @@
       "representationFamily": "reachableConeSize",
       "status": "measured",
       "valueType": "nat",
-      "value": "7",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "value": "0",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+      "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -762,17 +762,17 @@
       "representationFamily": "walkCount",
       "status": "measured",
       "valueType": "nat",
-      "value": "1",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "value": "0",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+      "reading": "walk count enumerates selected relation-graph walks up to length 3",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -791,16 +791,16 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "blockedByCoverageGap",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+      "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -818,17 +818,17 @@
       "representationFamily": "selectedSubgraphSpectrum",
       "status": "measured",
       "valueType": "vector",
-      "value": "[0.000]",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "value": "[unavailable]",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+      "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -847,11 +847,11 @@
       "status": "measured",
       "valueType": "nat",
       "value": "0",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
@@ -870,21 +870,21 @@
       ]
     },
     {
-      "representationId": "analytic:spectral-radius-proxy",
+      "representationId": "analytic:spectral-radius",
       "representationFamily": "spectralRadius",
-      "status": "measured",
+      "status": "unavailable",
       "valueType": "float",
-      "value": "0.000",
-      "graphScopeRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
-      ],
+      "value": "unavailable",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+      "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -903,6 +903,10 @@
       "status": "measured",
       "valueType": "nat",
       "value": "1",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "obstruction:semantic-contract-mismatch:computed"
       ],
@@ -929,6 +933,10 @@
       "status": "unmeasured",
       "valueType": "boundaryStatus",
       "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
         "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
@@ -957,6 +965,10 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "blockedByObservationGaps",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "gap:coupon-runtime-payment-trace"
       ],
@@ -1233,6 +1245,57 @@
   ],
   "spectralAnalysisReadings": [
     {
+      "spectralReadingId": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "status": "nonConclusion",
+      "matrixShape": {
+        "rowDomain": "selectedRelationGraphNodes",
+        "columnDomain": "selectedRelationGraphNodes",
+        "rowCount": 0,
+        "columnCount": 0,
+        "nonzeroEntryCount": 0
+      },
+      "entryRule": "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+      "valueType": "boundedSpectralProxy",
+      "values": [
+        {
+          "name": "maxRowSum",
+          "value": "0",
+          "interpretation": "largest outgoing relation weight"
+        },
+        {
+          "name": "maxColumnSum",
+          "value": "0",
+          "interpretation": "largest incoming relation weight"
+        },
+        {
+          "name": "frobeniusNorm",
+          "value": "0.000",
+          "interpretation": "finite weighted adjacency matrix norm over selected relation atoms"
+        },
+        {
+          "name": "spectralRadius",
+          "value": "0.000",
+          "interpretation": "power-iteration estimate over the finite nonnegative relation adjacency matrix"
+        }
+      ],
+      "dominantComponents": [],
+      "supportRefs": [],
+      "reading": "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+      "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+      "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+      "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
       "spectralReadingId": "spectral:workflow-risk-axis-pressure",
       "representationFamily": "workflowRiskAxisPressureMatrix",
       "status": "needsReview",
@@ -1488,6 +1551,42 @@
   ],
   "spectralModeReadings": [
     {
+      "spectralModeId": "spectral-mode:spectral-relation-atom-adjacency",
+      "sourceSpectralReadingRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "status": "nonConclusion",
+      "modeKind": "boundedSpectralMode",
+      "modeComponents": [],
+      "spectralGapProxy": {
+        "name": "dominantResidualGapProxy",
+        "value": "0.000",
+        "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+      },
+      "localizationIndex": {
+        "name": "dominantFrobeniusLocalization",
+        "value": "0.000",
+        "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+      },
+      "matrixDensity": {
+        "name": "nonzeroMatrixDensity",
+        "value": "0.000",
+        "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+      },
+      "decomposabilityReading": "mode is delocalized or dense; treat the concern as architecture-wide coupling before attempting local repair",
+      "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+      "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+      "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
       "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
       "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
       "representationFamily": "workflowRiskAxisPressureMatrix",
@@ -1690,6 +1789,7 @@
       "drilldownId": "spectral-drilldown:coupon-tax-rounding-archmap",
       "status": "needsReview",
       "sourceSpectralModeRefs": [
+        "spectral-mode:spectral-relation-atom-adjacency",
         "spectral-mode:spectral-workflow-risk-axis-pressure",
         "spectral-mode:spectral-molecule-atom-overlap-coupling",
         "spectral-mode:spectral-obstruction-axis-curvature",
@@ -2153,7 +2253,7 @@
       "readingId": "curvature-transfer-reading:spectrum-profile-curvature-transfer-default",
       "profileRef": "spectrum-profile:curvature-transfer-default",
       "status": "needsReview",
-      "measurementStatus": "proxy",
+      "measurementStatus": "measured",
       "readingBoundary": {
         "readingStrength": "boundedMeasuredWithProxyTransfer",
         "zeroReflectionAssumptions": [
@@ -2200,7 +2300,7 @@
         "rowCount": 1,
         "columnCount": 1,
         "nonzeroEdgeCount": 1,
-        "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+        "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence",
         "spectralRadiusKind": "finiteNonnegativeOperatorBoundedClosedWalkRadius",
         "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
       },
@@ -2246,7 +2346,7 @@
             "witness:semantic-contract-mismatch"
           ],
           "cycleWeight": 1,
-          "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+          "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
           "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
           "reviewFocus": [
             "inspect the witness support behind the positive transfer self-loop",
@@ -2260,9 +2360,9 @@
         }
       ],
       "spectralRadiusReading": {
-        "name": "rho(T^kappa)Proxy",
-        "value": "1",
-        "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+        "name": "rho(T^kappa)",
+        "value": "1.000",
+        "interpretation": "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability"
       },
       "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
       "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
@@ -2492,7 +2592,7 @@
     "recurrentObstructions": [
       {
         "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
-        "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+        "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
         "transferEdgeRefs": [
           "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
         ],
@@ -2907,7 +3007,9 @@
       "featureLocalObstructionRefs": [
         "obstruction:semantic-contract-mismatch:computed"
       ],
-      "interactionObstructionRefs": [],
+      "interactionObstructionRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
       "liftingFailureRefs": [
         "split-readiness:molecule-coupon-operation-contract"
       ],
@@ -2915,10 +3017,76 @@
         "obstruction:semantic-contract-mismatch:computed"
       ],
       "complexityTransferRefs": [
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "residualCoverageGapRefs": [
         "gap:coupon-runtime-payment-trace"
+      ],
+      "witnessBasis": [
+        {
+          "witnessRef": "gap:coupon-runtime-payment-trace",
+          "labels": [
+            "residualCoverageGap"
+          ],
+          "observationRefs": [
+            "gap:coupon-runtime-payment-trace"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "obstruction:semantic-contract-mismatch:computed",
+          "labels": [
+            "featureLocalObstruction",
+            "fillingFailure",
+            "inheritedCoreObstruction",
+            "interactionObstruction"
+          ],
+          "observationRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "semantic:coupon-tax-rounding-paths"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout",
+            "test-coupon-rounding"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+          "labels": [
+            "complexityTransfer"
+          ],
+          "observationRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "semantic:coupon-tax-rounding-paths"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout",
+            "test-coupon-rounding"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        },
+        {
+          "witnessRef": "split-readiness:molecule-coupon-operation-contract",
+          "labels": [
+            "liftingFailure"
+          ],
+          "observationRefs": [
+            "molecule:coupon-operation-contract",
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
+          ],
+          "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+        }
       ],
       "classificationSummary": [
         {
@@ -2939,8 +3107,10 @@
         },
         {
           "axis": "interactionObstruction",
-          "status": "unmeasuredOrAbsent",
-          "refs": [],
+          "status": "observed",
+          "refs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
           "reading": "interactionObstruction is classified as a current-state extension coordinate"
         },
         {
@@ -2963,7 +3133,7 @@
           "axis": "complexityTransfer",
           "status": "observed",
           "refs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            "repair:obstruction-semantic-contract-mismatch-computed"
           ],
           "reading": "complexityTransfer is classified as a current-state extension coordinate"
         },
@@ -2976,7 +3146,7 @@
           "reading": "residualCoverageGap is classified as a current-state extension coordinate"
         }
       ],
-      "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "evidenceBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -2993,15 +3163,15 @@
       "readingId": "operation-calculus-law:repair-obstruction-semantic-contract-mismatch-computed",
       "operationRef": "repair:obstruction-semantic-contract-mismatch-computed",
       "operationKind": "repair-semanticmismatchcircuit",
-      "compositionStatus": "assumptionRelative",
-      "associativityUnderObservationStatus": "selectedObservationOnly",
-      "refinementAbstractionCompatibility": "blockedByMissingEvidence",
+      "compositionStatus": "observed",
+      "associativityUnderObservationStatus": "observed",
+      "refinementAbstractionCompatibility": "blocked",
       "replacementEquivalence": "unmeasured",
       "protectionIdempotence": "notApplicable",
-      "runtimeLocalization": "blockedByCoverageGap",
+      "runtimeLocalization": "blocked",
       "migrationCompatibility": "notApplicable",
       "reverseInvolution": "unmeasured",
-      "repairMonotonicity": "selectedAxisOnly",
+      "repairMonotonicity": "blockedByTransferRisk",
       "synthesisNoSolutionBoundary": "notASynthesisCertificate",
       "preconditionRefs": [
         "human review selects a repair operation",
@@ -3010,6 +3180,169 @@
       "evidenceRefs": [
         "obstruction:semantic-contract-mismatch:computed",
         "preserve zero reading for sig-axis:layer-violation"
+      ],
+      "lawEvidence": [
+        {
+          "lawAxis": "composition",
+          "status": "observed",
+          "requiredEvidenceRefs": [
+            "operation support refs",
+            "operation precondition refs"
+          ],
+          "observedEvidenceRefs": [
+            "human review selects a repair operation",
+            "obstruction:semantic-contract-mismatch:computed",
+            "preserve zero reading for sig-axis:layer-violation",
+            "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+          ],
+          "blockedReasonRefs": [
+            "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+            "implementation patch and verification evidence are not supplied by ArchSig analysis",
+            "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+          ],
+          "exactnessAssumptionRefs": [
+            "exactness:operation-preconditions-observed"
+          ],
+          "reading": "composition is observed under selected operation evidence"
+        },
+        {
+          "lawAxis": "associativityUnderObservation",
+          "status": "observed",
+          "requiredEvidenceRefs": [
+            "operation delta support"
+          ],
+          "observedEvidenceRefs": [
+            "obstruction:semantic-contract-mismatch:computed",
+            "preserve zero reading for sig-axis:layer-violation"
+          ],
+          "blockedReasonRefs": [],
+          "exactnessAssumptionRefs": [],
+          "reading": "associativityUnderObservation is observed under selected operation evidence"
+        },
+        {
+          "lawAxis": "refinementAbstractionCompatibility",
+          "status": "blocked",
+          "requiredEvidenceRefs": [
+            "preserved invariant refs"
+          ],
+          "observedEvidenceRefs": [
+            "preserve zero reading for sig-axis:layer-violation"
+          ],
+          "blockedReasonRefs": [
+            "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+            "implementation patch and verification evidence are not supplied by ArchSig analysis",
+            "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+          ],
+          "exactnessAssumptionRefs": [
+            "exactness:operation-preconditions-observed"
+          ],
+          "reading": "refinementAbstractionCompatibility is blocked under selected operation evidence"
+        },
+        {
+          "lawAxis": "replacementEquivalence",
+          "status": "unmeasured",
+          "requiredEvidenceRefs": [
+            "before/after equivalence witness"
+          ],
+          "observedEvidenceRefs": [
+            "obstruction:semantic-contract-mismatch:computed"
+          ],
+          "blockedReasonRefs": [
+            "replacement-equivalence:witness-not-supplied"
+          ],
+          "exactnessAssumptionRefs": [
+            "exactness:replacement-equivalence"
+          ],
+          "reading": "replacementEquivalence is unmeasured under selected operation evidence"
+        },
+        {
+          "lawAxis": "protectionIdempotence",
+          "status": "notApplicable",
+          "requiredEvidenceRefs": [
+            "repeat protection witness"
+          ],
+          "observedEvidenceRefs": [
+            "human review selects a repair operation",
+            "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+          ],
+          "blockedReasonRefs": [],
+          "exactnessAssumptionRefs": [],
+          "reading": "protectionIdempotence is notApplicable under selected operation evidence"
+        },
+        {
+          "lawAxis": "runtimeLocalization",
+          "status": "blocked",
+          "requiredEvidenceRefs": [
+            "runtime/effect localization witness"
+          ],
+          "observedEvidenceRefs": [
+            "human review selects a repair operation",
+            "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+          ],
+          "blockedReasonRefs": [
+            "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+            "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
+            "implementation patch and verification evidence are not supplied by ArchSig analysis",
+            "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
+          ],
+          "exactnessAssumptionRefs": [
+            "exactness:operation-preconditions-observed"
+          ],
+          "reading": "runtimeLocalization is blocked under selected operation evidence"
+        },
+        {
+          "lawAxis": "migrationCompatibility",
+          "status": "notApplicable",
+          "requiredEvidenceRefs": [
+            "migration compatibility witness"
+          ],
+          "observedEvidenceRefs": [
+            "obstruction:semantic-contract-mismatch:computed",
+            "preserve zero reading for sig-axis:layer-violation"
+          ],
+          "blockedReasonRefs": [],
+          "exactnessAssumptionRefs": [],
+          "reading": "migrationCompatibility is notApplicable under selected operation evidence"
+        },
+        {
+          "lawAxis": "reverseInvolution",
+          "status": "unmeasured",
+          "requiredEvidenceRefs": [
+            "reverse operation witness"
+          ],
+          "observedEvidenceRefs": [
+            "obstruction:semantic-contract-mismatch:computed",
+            "preserve zero reading for sig-axis:layer-violation"
+          ],
+          "blockedReasonRefs": [
+            "reverse-involution:witness-not-supplied"
+          ],
+          "exactnessAssumptionRefs": [
+            "exactness:reverse-operation"
+          ],
+          "reading": "reverseInvolution is unmeasured under selected operation evidence"
+        },
+        {
+          "lawAxis": "repairMonotonicity",
+          "status": "blocked",
+          "requiredEvidenceRefs": [
+            "selected obstruction valuation",
+            "transfer risk refs"
+          ],
+          "observedEvidenceRefs": [
+            "obstruction:semantic-contract-mismatch:computed",
+            "sig-axis:semantic-inconsistency"
+          ],
+          "blockedReasonRefs": [
+            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          ],
+          "exactnessAssumptionRefs": [
+            "exactness:selected-axis-only"
+          ],
+          "reading": "repairMonotonicity is blocked under selected operation evidence"
+        }
       ],
       "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
       "nonConclusions": [
@@ -3297,6 +3630,7 @@
       "constraintRefs": [
         "obstruction:semantic-contract-mismatch:computed",
         "obstruction:semantic-contract-mismatch:computed",
+        "obstruction:semantic-contract-mismatch:computed",
         "split-readiness:molecule-coupon-operation-contract",
         "obstruction:semantic-contract-mismatch:computed",
         "gap:coupon-runtime-payment-trace",
@@ -3342,8 +3676,10 @@
         "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
         "gap:coupon-runtime-payment-trace: payment processor and receipt reconciliation traces are not included in the fixture",
         "implementation patch and verification evidence are not supplied by ArchSig analysis",
-        "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero",
-        "resolve or explicitly accept coverage gap gap:coupon-runtime-payment-trace"
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+        "replacement-equivalence:witness-not-supplied",
+        "reverse-involution:witness-not-supplied",
+        "witness:semantic-contract-mismatch: report observation gap; do not infer measured zero"
       ],
       "coverageGapRefs": [
         "gap:coupon-runtime-payment-trace",
@@ -6572,8 +6908,8 @@
       "featureScopeRef": "coupon-tax-rounding-archmap:feature",
       "mixedSubconfigurationRefs": [
         "gap:coupon-runtime-payment-trace",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "obstruction:semantic-contract-mismatch:computed",
+        "repair:obstruction-semantic-contract-mismatch-computed",
         "split-readiness:molecule-coupon-operation-contract"
       ],
       "coreLocalReadingRefs": [
@@ -6584,8 +6920,8 @@
       ],
       "boundarySupportRefs": [
         "gap:coupon-runtime-payment-trace",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "obstruction:semantic-contract-mismatch:computed",
+        "repair:obstruction-semantic-contract-mismatch-computed",
         "split-readiness:molecule-coupon-operation-contract"
       ],
       "holonomyAxes": [
@@ -6637,8 +6973,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:coupon-runtime-payment-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "missingEvidence": [
@@ -6670,8 +7006,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:coupon-runtime-payment-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "missingEvidence": [
@@ -6689,8 +7025,8 @@
           "measuredDefectRefs": [],
           "supportRefs": [
             "gap:coupon-runtime-payment-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "missingEvidence": [
@@ -6715,10 +7051,10 @@
       ],
       "residualObstructionRefs": [
         "gap:coupon-runtime-payment-trace",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
         "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
         "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
         "obstruction:semantic-contract-mismatch:computed",
+        "repair:obstruction-semantic-contract-mismatch-computed",
         "split-readiness:molecule-coupon-operation-contract"
       ],
       "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
@@ -6731,7 +7067,7 @@
         "ArchMapStore compaction boundary"
       ],
       "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
-      "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+      "coverageBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
       "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
       "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
       "nonConclusions": [
@@ -6775,10 +7111,10 @@
           "refs": [
             "feature-boundary-residual:coupon-tax-rounding-archmap",
             "gap:coupon-runtime-payment-trace",
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
             "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
             "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
             "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
             "split-readiness:molecule-coupon-operation-contract"
           ],
           "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
@@ -6803,7 +7139,7 @@
           "axis": "complexityTransfer",
           "status": "observed",
           "refs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            "repair:obstruction-semantic-contract-mismatch-computed"
           ],
           "reading": "complexityTransfer is classified as a current-state extension coordinate"
         },
@@ -6822,6 +7158,17 @@
           "labels": [
             "boundaryHolonomy"
           ],
+          "observationRefs": [
+            "gap:coupon-runtime-payment-trace",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -6839,6 +7186,17 @@
             "boundaryHolonomy",
             "residualCoverageGap"
           ],
+          "observationRefs": [
+            "gap:coupon-runtime-payment-trace",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
+          ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
           "boundaryHolonomyRefs": [
@@ -6853,28 +7211,20 @@
           "reading": "gap:coupon-runtime-payment-trace carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
         },
         {
-          "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-          "labels": [
-            "boundaryHolonomy",
-            "complexityTransfer"
-          ],
-          "inheritedCoreRefs": [],
-          "featureLocalRefs": [],
-          "boundaryHolonomyRefs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-          ],
-          "liftingFailureRefs": [],
-          "fillingFailureRefs": [],
-          "complexityTransferRefs": [
-            "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-          ],
-          "residualCoverageGapRefs": [],
-          "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
-        },
-        {
           "witnessRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
           "labels": [
             "boundaryHolonomy"
+          ],
+          "observationRefs": [
+            "gap:coupon-runtime-payment-trace",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -6891,6 +7241,17 @@
           "witnessRef": "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
           "labels": [
             "boundaryHolonomy"
+          ],
+          "observationRefs": [
+            "gap:coupon-runtime-payment-trace",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -6911,6 +7272,22 @@
             "fillingFailure",
             "inheritedCoreObstruction"
           ],
+          "observationRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "gap:coupon-runtime-payment-trace",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "semantic:coupon-tax-rounding-paths",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout",
+            "test-coupon-rounding"
+          ],
           "inheritedCoreRefs": [
             "obstruction:semantic-contract-mismatch:computed"
           ],
@@ -6929,10 +7306,57 @@
           "reading": "obstruction:semantic-contract-mismatch:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
         },
         {
+          "witnessRef": "repair:obstruction-semantic-contract-mismatch-computed",
+          "labels": [
+            "boundaryHolonomy",
+            "complexityTransfer"
+          ],
+          "observationRefs": [
+            "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
+            "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
+            "gap:coupon-runtime-payment-trace",
+            "molecule-reading:molecule-coupon-operation-contract",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "semantic:coupon-tax-rounding-paths",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout",
+            "test-coupon-rounding"
+          ],
+          "inheritedCoreRefs": [],
+          "featureLocalRefs": [],
+          "boundaryHolonomyRefs": [
+            "repair:obstruction-semantic-contract-mismatch-computed"
+          ],
+          "liftingFailureRefs": [],
+          "fillingFailureRefs": [],
+          "complexityTransferRefs": [
+            "repair:obstruction-semantic-contract-mismatch-computed"
+          ],
+          "residualCoverageGapRefs": [],
+          "reading": "repair:obstruction-semantic-contract-mismatch-computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
+        },
+        {
           "witnessRef": "split-readiness:molecule-coupon-operation-contract",
           "labels": [
             "boundaryHolonomy",
             "liftingFailure"
+          ],
+          "observationRefs": [
+            "gap:coupon-runtime-payment-trace",
+            "molecule:coupon-operation-contract",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+            "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic",
+            "obstruction:semantic-contract-mismatch:computed",
+            "repair:obstruction-semantic-contract-mismatch-computed",
+            "split-readiness:molecule-coupon-operation-contract"
+          ],
+          "sourceRefs": [
+            "src-pricing-checkout"
           ],
           "inheritedCoreRefs": [],
           "featureLocalRefs": [],
@@ -6958,7 +7382,7 @@
         "obstruction:semantic-contract-mismatch:computed"
       ],
       "complexityTransferRefs": [
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+        "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
       "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
@@ -6976,7 +7400,11 @@
   ],
   "monodromyReadingFamily": {
     "readingFamilyId": "monodromy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-    "status": "schemaFoundationOnly",
+    "status": "partial",
+    "measuredAxisCount": 5,
+    "unmeasuredAxisCount": 3,
+    "positiveWitnessCount": 2,
+    "coverageBlockerCount": 9,
     "archMapStoreRefSetRef": "archmap-store-refs:coupon-tax-rounding-archmap",
     "selectedAxisRefs": [
       "axis:layer-violation",
@@ -7020,7 +7448,11 @@
   },
   "boundaryHolonomyReadingFamily": {
     "readingFamilyId": "boundary-holonomy-reading-family:measurement-policy-monodromy-boundary-holonomy",
-    "status": "schemaFoundationOnly",
+    "status": "partial",
+    "measuredAxisCount": 5,
+    "unmeasuredAxisCount": 3,
+    "positiveWitnessCount": 4,
+    "coverageBlockerCount": 10,
     "archMapStoreRefSetRef": "archmap-store-refs:coupon-tax-rounding-archmap",
     "selectedAxisRefs": [
       "axis:layer-violation",
@@ -7252,10 +7684,10 @@
       ]
     },
     {
-      "readingId": "representation-strength:analytic-spectral-radius-proxy",
-      "sourceReadingRef": "analytic:spectral-radius-proxy",
+      "readingId": "representation-strength:analytic-spectral-radius",
+      "sourceReadingRef": "analytic:spectral-radius",
       "representationFamily": "spectralRadius",
-      "zeroPreserving": "supported",
+      "zeroPreserving": "bounded",
       "zeroReflecting": "blockedByCoverageGap",
       "obstructionPreserving": "supported",
       "obstructionReflecting": "blockedByCoverageGap",
@@ -7373,6 +7805,39 @@
       ],
       "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "readingId": "representation-strength:spectral-relation-atom-adjacency",
+      "sourceReadingRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "zeroPreserving": "supported",
+      "zeroReflecting": "blockedByCoverageGap",
+      "obstructionPreserving": "weak",
+      "obstructionReflecting": "notAnEigenvalueTheorem",
+      "aggregateZeroSafety": "notAggregate",
+      "cancellationRisk": "finiteMatrixMayHideUnobservedComponents",
+      "requiredAssumptions": [
+        "gap:coupon-runtime-payment-trace",
+        "witness completeness for selected LawPolicy",
+        "signature axis exactness for selected readings"
+      ],
+      "blockedBy": [
+        "gap:coupon-runtime-payment-trace"
+      ],
+      "blockedReflectionOrPreservationReasons": [
+        "gap:coupon-runtime-payment-trace"
+      ],
+      "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+      "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7732,7 +8197,7 @@
   "structuralReadingReviewSurface": {
     "surfaceId": "aat-structural-reading-review-surface",
     "status": "needsReview",
-    "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
+    "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
     "connectedReadingRefs": [
       "representationStrength:weightedAdjacencyMatrix",
       "representationStrength:reachableConeSize",
@@ -8728,24 +9193,26 @@
       "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
     ],
     "analyticReadingsSummary": [
-      "weightedAdjacencyMatrix=7x7; edgeCount=0 (measured)",
-      "reachableConeSize=7 (measured)",
-      "walkCount=1 (measured)",
+      "weightedAdjacencyMatrix=0x0; edgeCount=0 (measured)",
+      "reachableConeSize=0 (measured)",
+      "walkCount=0 (measured)",
       "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
-      "selectedSubgraphSpectrum=[0.000] (measured)",
+      "selectedSubgraphSpectrum=[unavailable] (measured)",
       "propagationDepth=0 (measured)",
-      "spectralRadius=0.000 (measured)",
+      "spectralRadius=unavailable (unavailable)",
       "curvatureValuation=1 (measured)",
       "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
       "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
     ],
     "spectralReadingsSummary": [
+      "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=0x0 (nonConclusion)",
       "workflowRiskAxisPressureMatrix upperBound=9.220 shape=1x5 (needsReview)",
       "moleculeAtomOverlapCouplingMatrix upperBound=3.000 shape=1x1 (needsReview)",
       "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
       "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
     ],
     "spectralModeSummary": [
+      "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=0.000 localization=0.000 density=0.000 (nonConclusion)",
       "workflowRiskAxisPressureMatrix distributedPressureMode gap=8.185 localization=1.000 density=1.000 (needsReview)",
       "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=3.000 localization=1.000 density=1.000 (needsReview)",
       "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
@@ -8758,7 +9225,7 @@
       "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
     ],
     "curvatureTransferSummary": [
-      "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1 (needsReview)"
+      "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1.000 (needsReview)"
     ],
     "architectureSpectrumReportSummary": [
       "architecture-spectrum-report:spectrum-profile-curvature-transfer-default hotspots=4 recurrent=1 clusters=2 (needsReview)",
@@ -8782,10 +9249,10 @@
       "llm-native-aat-law-policy-fixture required=2 unmeasured=1 blockedWitnesses=2"
     ],
     "featureExtensionFormulaSummary": [
-      "feature-extension-formula:coupon-tax-rounding-archmap status=measured inherited=1 featureLocal=1 interaction=0 residualGaps=1"
+      "feature-extension-formula:coupon-tax-rounding-archmap status=measured inherited=1 featureLocal=1 interaction=1 residualGaps=1"
     ],
     "operationCalculusLawSummary": [
-      "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
+      "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit composition=observed repairMonotonicity=blockedByTransferRisk boundary=notASynthesisCertificate"
     ],
     "pathSignatureTrajectorySummary": [
       "operation-delta:repair-obstruction-semantic-contract-mismatch-computed status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=1 transferred=1"
@@ -8809,10 +9276,10 @@
       "effect-relation-algebra:coupon-tax-rounding-archmap pressure=effectRelationPressureObserved generators=2 unresolved=1 externalBoundaries=0"
     ],
     "synthesisBlockageSummary": [
-      "synthesis-blockage:coupon-tax-rounding-archmap status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=6 missing=5 noSolution=notASolverAndNotAbsenceProof"
+      "synthesis-blockage:coupon-tax-rounding-archmap status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=7 missing=5 noSolution=notASolverAndNotAbsenceProof"
     ],
     "operationPreconditionReadinessSummary": [
-      "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit status=blockedByMissingPreconditionEvidence missing=5 witnesses=2"
+      "repair:obstruction-semantic-contract-mismatch-computed kind=repair-semanticmismatchcircuit status=blockedByMissingPreconditionEvidence missing=7 witnesses=2"
     ],
     "pathMultiplicityLossSummary": [
       "coupon-tax-rounding-archmap status=reachabilityMultiplicityLossObserved paths=1 alternatePressure=8 fanIn=0 forgotten=1"
@@ -8844,6 +9311,7 @@
       "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
       "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
       "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+      "relationAtomWeightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
@@ -8869,7 +9337,7 @@
     ],
     "structuralReadingReviewSummary": [
       "aat-structural-reading-review-surface status=needsReview refs=30 focus=16",
-      "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
+      "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=1, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
     ],
     "currentStateEvolutionBoundarySummary": [
       "ArchSig computes current AAT structural state from ArchMap coupon-tax-rounding-archmap and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",

--- a/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
@@ -386,7 +386,7 @@
         "analytic:nilpotence-boundary",
         "analytic:selected-subgraph-spectrum",
         "analytic:propagation-depth",
-        "analytic:spectral-radius-proxy",
+        "analytic:spectral-radius",
         "analytic:curvature-valuation",
         "analytic:state-algebra-boundary",
         "analytic:zero-reflecting-aggregate-boundary"
@@ -656,19 +656,66 @@
       "representationFamily": "weightedAdjacencyMatrix",
       "status": "measured",
       "valueType": "matrixShape",
-      "value": "9x9; edgeCount=2",
+      "value": "3x3; edgeCount=2",
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
       "graphScopeRefs": [
         "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read"
       ],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
       ],
-      "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+      "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -686,19 +733,66 @@
       "representationFamily": "reachableConeSize",
       "status": "measured",
       "valueType": "nat",
-      "value": "11",
+      "value": "2",
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
       "graphScopeRefs": [
         "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read"
       ],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
       ],
-      "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+      "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -716,19 +810,66 @@
       "representationFamily": "walkCount",
       "status": "measured",
       "valueType": "nat",
-      "value": "3",
+      "value": "2",
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
       "graphScopeRefs": [
         "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read"
       ],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
       ],
-      "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+      "reading": "walk count enumerates selected relation-graph walks up to length 3",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -747,18 +888,62 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "blockedByCoverageGap",
-      "graphScopeRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
       ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
       ],
-      "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+      "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -776,19 +961,66 @@
       "representationFamily": "selectedSubgraphSpectrum",
       "status": "measured",
       "valueType": "vector",
-      "value": "[0.222]",
+      "value": "[0.000]",
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
       "graphScopeRefs": [
         "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read"
       ],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
       ],
-      "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+      "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -807,13 +1039,60 @@
       "status": "measured",
       "valueType": "nat",
       "value": "1",
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
       "graphScopeRefs": [
         "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read"
       ],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
@@ -832,23 +1111,70 @@
       ]
     },
     {
-      "representationId": "analytic:spectral-radius-proxy",
+      "representationId": "analytic:spectral-radius",
       "representationFamily": "spectralRadius",
       "status": "measured",
       "valueType": "float",
-      "value": "0.222",
+      "value": "0.000",
+      "selectedGraphNodes": [
+        "CacheOrder",
+        "OrderView",
+        "RepositoryOrder"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+          "sourceRef": "CacheOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:cache-read",
+          "sourceRefs": [
+            "src-cache-read"
+          ]
+        },
+        {
+          "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+          "sourceRef": "RepositoryOrder",
+          "targetRef": "OrderView",
+          "weight": 1,
+          "relationAtomRef": "atom:repository-read",
+          "sourceRefs": [
+            "src-repository-read"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "CacheOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:cache-read",
+            "src-cache-read"
+          ]
+        },
+        {
+          "rowRef": "RepositoryOrder",
+          "columnRef": "OrderView",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:repository-read",
+            "src-repository-read"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:cacheorder:1:orderview",
+        "walk:repositoryorder:1:orderview"
+      ],
       "graphScopeRefs": [
         "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read"
       ],
       "axisRefs": [
         "sig-axis:homotopy-report-fixture"
       ],
-      "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+      "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -867,6 +1193,10 @@
       "status": "measured",
       "valueType": "nat",
       "value": "1",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "obstruction:homotopy-report-fixture:computed"
       ],
@@ -892,6 +1222,10 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "atom:cache-read",
         "atom:repository-read",
@@ -922,6 +1256,10 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "blockedByObservationGaps",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "gap:path-rule:authorization-bypass-hole:missing-policy-test"
       ],
@@ -1224,6 +1562,73 @@
   ],
   "spectralAnalysisReadings": [
     {
+      "spectralReadingId": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "status": "needsReview",
+      "matrixShape": {
+        "rowDomain": "selectedRelationGraphNodes",
+        "columnDomain": "selectedRelationGraphNodes",
+        "rowCount": 3,
+        "columnCount": 3,
+        "nonzeroEntryCount": 2
+      },
+      "entryRule": "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+      "valueType": "boundedSpectralProxy",
+      "values": [
+        {
+          "name": "maxRowSum",
+          "value": "1",
+          "interpretation": "largest outgoing relation weight"
+        },
+        {
+          "name": "maxColumnSum",
+          "value": "2",
+          "interpretation": "largest incoming relation weight"
+        },
+        {
+          "name": "frobeniusNorm",
+          "value": "1.414",
+          "interpretation": "finite weighted adjacency matrix norm over selected relation atoms"
+        },
+        {
+          "name": "spectralRadius",
+          "value": "0.000",
+          "interpretation": "power-iteration estimate over the finite nonnegative relation adjacency matrix"
+        }
+      ],
+      "dominantComponents": [
+        {
+          "componentRef": "RepositoryOrder",
+          "componentKind": "relationGraphSourceNode",
+          "value": "1",
+          "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+        },
+        {
+          "componentRef": "OrderView",
+          "componentKind": "relationGraphTargetNode",
+          "value": "2",
+          "reading": "largest incoming weighted adjacency column in the selected relation graph"
+        }
+      ],
+      "supportRefs": [
+        "atom:cache-read",
+        "atom:repository-read"
+      ],
+      "reading": "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+      "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+      "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+      "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
       "spectralReadingId": "spectral:workflow-risk-axis-pressure",
       "representationFamily": "workflowRiskAxisPressureMatrix",
       "status": "needsReview",
@@ -1479,6 +1884,57 @@
   ],
   "spectralModeReadings": [
     {
+      "spectralModeId": "spectral-mode:spectral-relation-atom-adjacency",
+      "sourceSpectralReadingRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "status": "needsReview",
+      "modeKind": "boundedSpectralMode",
+      "modeComponents": [
+        {
+          "componentRef": "RepositoryOrder",
+          "componentKind": "relationGraphSourceNode",
+          "weight": "1",
+          "role": "primaryDominantComponent",
+          "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+        },
+        {
+          "componentRef": "OrderView",
+          "componentKind": "relationGraphTargetNode",
+          "weight": "2",
+          "role": "coupledDominantComponent",
+          "reading": "largest incoming weighted adjacency column in the selected relation graph"
+        }
+      ],
+      "spectralGapProxy": {
+        "name": "dominantResidualGapProxy",
+        "value": "0.000",
+        "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+      },
+      "localizationIndex": {
+        "name": "dominantFrobeniusLocalization",
+        "value": "0.707",
+        "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+      },
+      "matrixDensity": {
+        "name": "nonzeroMatrixDensity",
+        "value": "0.222",
+        "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+      },
+      "decomposabilityReading": "mode is relatively localized; decomposition or targeted repair may be reviewable as a local operation",
+      "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+      "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+      "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
       "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
       "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
       "representationFamily": "workflowRiskAxisPressureMatrix",
@@ -1681,6 +2137,7 @@
       "drilldownId": "spectral-drilldown:homotopy-report-fixture-archmap",
       "status": "needsReview",
       "sourceSpectralModeRefs": [
+        "spectral-mode:spectral-relation-atom-adjacency",
         "spectral-mode:spectral-workflow-risk-axis-pressure",
         "spectral-mode:spectral-molecule-atom-overlap-coupling",
         "spectral-mode:spectral-obstruction-axis-curvature",
@@ -1953,7 +2410,7 @@
       "readingId": "curvature-transfer-reading:spectrum-profile-homotopy-report-fixture",
       "profileRef": "spectrum-profile:homotopy-report-fixture",
       "status": "needsReview",
-      "measurementStatus": "proxy",
+      "measurementStatus": "measured",
       "readingBoundary": {
         "readingStrength": "boundedMeasuredWithProxyTransfer",
         "zeroReflectionAssumptions": [
@@ -1991,14 +2448,18 @@
               "atom:cache-read",
               "atom:coupon-tax-rounding",
               "atom:repository-read",
-              "molecule-reading:molecule-homotopy-report-fixture"
+              "molecule-reading:molecule-homotopy-report-fixture",
+              "relation-edge:atom-cache-read:cacheorder:orderview",
+              "relation-edge:atom-repository-read:repositoryorder:orderview",
+              "src-cache-read",
+              "src-repository-read"
             ]
           }
         ],
         "rowCount": 1,
         "columnCount": 1,
         "nonzeroEdgeCount": 1,
-        "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+        "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence",
         "spectralRadiusKind": "finiteNonnegativeOperatorBoundedClosedWalkRadius",
         "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
       },
@@ -2025,9 +2486,13 @@
             "atom:cache-read",
             "atom:coupon-tax-rounding",
             "atom:repository-read",
-            "molecule-reading:molecule-homotopy-report-fixture"
+            "molecule-reading:molecule-homotopy-report-fixture",
+            "relation-edge:atom-cache-read:cacheorder:orderview",
+            "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "src-cache-read",
+            "src-repository-read"
           ],
-          "extractionRule": "same-selected-axis",
+          "extractionRule": "selected-relation-graph",
           "closedWalkKind": "selfLoop",
           "reading": "positive self-loop records a closed walk in the finite transfer operator"
         }
@@ -2046,7 +2511,7 @@
             "witness:homotopy-report-fixture"
           ],
           "cycleWeight": 1,
-          "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+          "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
           "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
           "reviewFocus": [
             "inspect the witness support behind the positive transfer self-loop",
@@ -2060,9 +2525,9 @@
         }
       ],
       "spectralRadiusReading": {
-        "name": "rho(T^kappa)Proxy",
-        "value": "1",
-        "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+        "name": "rho(T^kappa)",
+        "value": "1.000",
+        "interpretation": "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability"
       },
       "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
       "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
@@ -2181,7 +2646,7 @@
     "recurrentObstructions": [
       {
         "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture-curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture",
-        "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+        "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
         "transferEdgeRefs": [
           "curvature-transfer-edge:curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture:curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture"
         ],
@@ -8677,8 +9142,8 @@
       ]
     },
     {
-      "readingId": "representation-strength:analytic-spectral-radius-proxy",
-      "sourceReadingRef": "analytic:spectral-radius-proxy",
+      "readingId": "representation-strength:analytic-spectral-radius",
+      "sourceReadingRef": "analytic:spectral-radius",
       "representationFamily": "spectralRadius",
       "zeroPreserving": "supported",
       "zeroReflecting": "blockedByCoverageGap",
@@ -8798,6 +9263,39 @@
       ],
       "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "readingId": "representation-strength:spectral-relation-atom-adjacency",
+      "sourceReadingRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "zeroPreserving": "supported",
+      "zeroReflecting": "blockedByCoverageGap",
+      "obstructionPreserving": "supported",
+      "obstructionReflecting": "notAnEigenvalueTheorem",
+      "aggregateZeroSafety": "notAggregate",
+      "cancellationRisk": "finiteMatrixMayHideUnobservedComponents",
+      "requiredAssumptions": [
+        "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+        "witness completeness for selected LawPolicy",
+        "signature axis exactness for selected readings"
+      ],
+      "blockedBy": [
+        "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+      ],
+      "blockedReflectionOrPreservationReasons": [
+        "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+      ],
+      "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+      "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9167,7 +9665,7 @@
   "structuralReadingReviewSurface": {
     "surfaceId": "aat-structural-reading-review-surface",
     "status": "needsReview",
-    "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
+    "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
     "connectedReadingRefs": [
       "representationStrength:weightedAdjacencyMatrix",
       "representationStrength:reachableConeSize",
@@ -10196,24 +10694,26 @@
       "sig-axis:homotopy-report-fixture=1 (coverage-gap-preserved)"
     ],
     "analyticReadingsSummary": [
-      "weightedAdjacencyMatrix=9x9; edgeCount=2 (measured)",
-      "reachableConeSize=11 (measured)",
-      "walkCount=3 (measured)",
+      "weightedAdjacencyMatrix=3x3; edgeCount=2 (measured)",
+      "reachableConeSize=2 (measured)",
+      "walkCount=2 (measured)",
       "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
-      "selectedSubgraphSpectrum=[0.222] (measured)",
+      "selectedSubgraphSpectrum=[0.000] (measured)",
       "propagationDepth=1 (measured)",
-      "spectralRadius=0.222 (measured)",
+      "spectralRadius=0.000 (measured)",
       "curvatureValuation=1 (measured)",
       "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (needsReview)",
       "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
     ],
     "spectralReadingsSummary": [
+      "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=3x3 (needsReview)",
       "workflowRiskAxisPressureMatrix upperBound=26.458 shape=1x5 (needsReview)",
       "moleculeAtomOverlapCouplingMatrix upperBound=6.000 shape=1x1 (needsReview)",
       "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x1 (actionable)",
       "operationSignatureDeltaMatrix upperBound=1.000 shape=1x1 (actionable)"
     ],
     "spectralModeSummary": [
+      "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=0.000 localization=0.707 density=0.222 (needsReview)",
       "workflowRiskAxisPressureMatrix distributedPressureMode gap=23.195 localization=1.000 density=1.000 (needsReview)",
       "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=6.000 localization=1.000 density=1.000 (needsReview)",
       "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=1.000 (needsReview)",
@@ -10226,7 +10726,7 @@
       "curvature-support-reading:spectrum-profile-homotopy-report-fixture supports=1 topModes=1 clusters=1 measuredAxes=1 unmeasuredAxes=0 (needsReview)"
     ],
     "curvatureTransferSummary": [
-      "curvature-transfer-reading:spectrum-profile-homotopy-report-fixture edges=1 recurrentModes=1 rho=1 (needsReview)"
+      "curvature-transfer-reading:spectrum-profile-homotopy-report-fixture edges=1 recurrentModes=1 rho=1.000 (needsReview)"
     ],
     "architectureSpectrumReportSummary": [
       "architecture-spectrum-report:spectrum-profile-homotopy-report-fixture hotspots=1 recurrent=1 clusters=1 (needsReview)",
@@ -10312,6 +10812,7 @@
       "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
       "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
       "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+      "relationAtomWeightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
@@ -10337,7 +10838,7 @@
     ],
     "structuralReadingReviewSummary": [
       "aat-structural-reading-review-surface status=needsReview refs=30 focus=16",
-      "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
+      "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
     ],
     "currentStateEvolutionBoundarySummary": [
       "ArchSig computes current AAT structural state from ArchMap homotopy-report-fixture-archmap and LawPolicy homotopy-report-fixture-policy; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",

--- a/tools/archsig/tests/fixtures/homotopy_report/validation.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/validation.json
@@ -2,7 +2,7 @@
   "schemaVersion": "archsig-analysis-packet-validation-report-v0",
   "input": {
     "schemaVersion": "archsig-analysis-packet-v0",
-    "path": "archsig-analysis-packet",
+    "path": "/private/tmp/archsig1599-homotopy-final/archsig-analysis-packet.json",
     "analysisId": "archsig-analysis:homotopy-report-fixture-archmap:homotopy-report-fixture-policy",
     "archMapRef": "homotopy-report-fixture-archmap",
     "selectedLawPolicyRef": "homotopy-report-fixture-policy"
@@ -395,7 +395,7 @@
           "analytic:nilpotence-boundary",
           "analytic:selected-subgraph-spectrum",
           "analytic:propagation-depth",
-          "analytic:spectral-radius-proxy",
+          "analytic:spectral-radius",
           "analytic:curvature-valuation",
           "analytic:state-algebra-boundary",
           "analytic:zero-reflecting-aggregate-boundary"
@@ -665,19 +665,66 @@
         "representationFamily": "weightedAdjacencyMatrix",
         "status": "measured",
         "valueType": "matrixShape",
-        "value": "9x9; edgeCount=2",
+        "value": "3x3; edgeCount=2",
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
         "graphScopeRefs": [
           "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read"
         ],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
         ],
-        "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+        "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -695,19 +742,66 @@
         "representationFamily": "reachableConeSize",
         "status": "measured",
         "valueType": "nat",
-        "value": "11",
+        "value": "2",
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
         "graphScopeRefs": [
           "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read"
         ],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
         ],
-        "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+        "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -725,19 +819,66 @@
         "representationFamily": "walkCount",
         "status": "measured",
         "valueType": "nat",
-        "value": "3",
+        "value": "2",
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
         "graphScopeRefs": [
           "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read"
         ],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
         ],
-        "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+        "reading": "walk count enumerates selected relation-graph walks up to length 3",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -756,18 +897,62 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "blockedByCoverageGap",
-        "graphScopeRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
         ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
+        "graphScopeRefs": [],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
         ],
-        "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+        "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -785,19 +970,66 @@
         "representationFamily": "selectedSubgraphSpectrum",
         "status": "measured",
         "valueType": "vector",
-        "value": "[0.222]",
+        "value": "[0.000]",
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
         "graphScopeRefs": [
           "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read"
         ],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
         ],
-        "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+        "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -816,13 +1048,60 @@
         "status": "measured",
         "valueType": "nat",
         "value": "1",
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
         "graphScopeRefs": [
           "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read"
         ],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
@@ -841,23 +1120,70 @@
         ]
       },
       {
-        "representationId": "analytic:spectral-radius-proxy",
+        "representationId": "analytic:spectral-radius",
         "representationFamily": "spectralRadius",
         "status": "measured",
         "valueType": "float",
-        "value": "0.222",
+        "value": "0.000",
+        "selectedGraphNodes": [
+          "CacheOrder",
+          "OrderView",
+          "RepositoryOrder"
+        ],
+        "selectedGraphEdges": [
+          {
+            "edgeRef": "relation-edge:atom-cache-read:cacheorder:orderview",
+            "sourceRef": "CacheOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:cache-read",
+            "sourceRefs": [
+              "src-cache-read"
+            ]
+          },
+          {
+            "edgeRef": "relation-edge:atom-repository-read:repositoryorder:orderview",
+            "sourceRef": "RepositoryOrder",
+            "targetRef": "OrderView",
+            "weight": 1,
+            "relationAtomRef": "atom:repository-read",
+            "sourceRefs": [
+              "src-repository-read"
+            ]
+          }
+        ],
+        "sparseMatrixEntries": [
+          {
+            "rowRef": "CacheOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:cache-read",
+              "src-cache-read"
+            ]
+          },
+          {
+            "rowRef": "RepositoryOrder",
+            "columnRef": "OrderView",
+            "value": 1,
+            "evidenceRefs": [
+              "atom:repository-read",
+              "src-repository-read"
+            ]
+          }
+        ],
+        "walkWitnessRefs": [
+          "walk:cacheorder:1:orderview",
+          "walk:repositoryorder:1:orderview"
+        ],
         "graphScopeRefs": [
           "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read"
         ],
         "axisRefs": [
           "sig-axis:homotopy-report-fixture"
         ],
-        "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+        "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
         "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
         "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
         "nonConclusions": [
@@ -876,6 +1202,10 @@
         "status": "measured",
         "valueType": "nat",
         "value": "1",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "obstruction:homotopy-report-fixture:computed"
         ],
@@ -901,6 +1231,10 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "atom:cache-read",
           "atom:repository-read",
@@ -931,6 +1265,10 @@
         "status": "needsReview",
         "valueType": "boundaryStatus",
         "value": "blockedByObservationGaps",
+        "selectedGraphNodes": [],
+        "selectedGraphEdges": [],
+        "sparseMatrixEntries": [],
+        "walkWitnessRefs": [],
         "graphScopeRefs": [
           "gap:path-rule:authorization-bypass-hole:missing-policy-test"
         ],
@@ -1233,6 +1571,73 @@
     ],
     "spectralAnalysisReadings": [
       {
+        "spectralReadingId": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "status": "needsReview",
+        "matrixShape": {
+          "rowDomain": "selectedRelationGraphNodes",
+          "columnDomain": "selectedRelationGraphNodes",
+          "rowCount": 3,
+          "columnCount": 3,
+          "nonzeroEntryCount": 2
+        },
+        "entryRule": "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+        "valueType": "boundedSpectralProxy",
+        "values": [
+          {
+            "name": "maxRowSum",
+            "value": "1",
+            "interpretation": "largest outgoing relation weight"
+          },
+          {
+            "name": "maxColumnSum",
+            "value": "2",
+            "interpretation": "largest incoming relation weight"
+          },
+          {
+            "name": "frobeniusNorm",
+            "value": "1.414",
+            "interpretation": "finite weighted adjacency matrix norm over selected relation atoms"
+          },
+          {
+            "name": "spectralRadius",
+            "value": "0.000",
+            "interpretation": "power-iteration estimate over the finite nonnegative relation adjacency matrix"
+          }
+        ],
+        "dominantComponents": [
+          {
+            "componentRef": "RepositoryOrder",
+            "componentKind": "relationGraphSourceNode",
+            "value": "1",
+            "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+          },
+          {
+            "componentRef": "OrderView",
+            "componentKind": "relationGraphTargetNode",
+            "value": "2",
+            "reading": "largest incoming weighted adjacency column in the selected relation graph"
+          }
+        ],
+        "supportRefs": [
+          "atom:cache-read",
+          "atom:repository-read"
+        ],
+        "reading": "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+        "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+        "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+        "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
         "spectralReadingId": "spectral:workflow-risk-axis-pressure",
         "representationFamily": "workflowRiskAxisPressureMatrix",
         "status": "needsReview",
@@ -1488,6 +1893,57 @@
     ],
     "spectralModeReadings": [
       {
+        "spectralModeId": "spectral-mode:spectral-relation-atom-adjacency",
+        "sourceSpectralReadingRef": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "status": "needsReview",
+        "modeKind": "boundedSpectralMode",
+        "modeComponents": [
+          {
+            "componentRef": "RepositoryOrder",
+            "componentKind": "relationGraphSourceNode",
+            "weight": "1",
+            "role": "primaryDominantComponent",
+            "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+          },
+          {
+            "componentRef": "OrderView",
+            "componentKind": "relationGraphTargetNode",
+            "weight": "2",
+            "role": "coupledDominantComponent",
+            "reading": "largest incoming weighted adjacency column in the selected relation graph"
+          }
+        ],
+        "spectralGapProxy": {
+          "name": "dominantResidualGapProxy",
+          "value": "0.000",
+          "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+        },
+        "localizationIndex": {
+          "name": "dominantFrobeniusLocalization",
+          "value": "0.707",
+          "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+        },
+        "matrixDensity": {
+          "name": "nonzeroMatrixDensity",
+          "value": "0.222",
+          "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+        },
+        "decomposabilityReading": "mode is relatively localized; decomposition or targeted repair may be reviewable as a local operation",
+        "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+        "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+        "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
         "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
         "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
         "representationFamily": "workflowRiskAxisPressureMatrix",
@@ -1690,6 +2146,7 @@
         "drilldownId": "spectral-drilldown:homotopy-report-fixture-archmap",
         "status": "needsReview",
         "sourceSpectralModeRefs": [
+          "spectral-mode:spectral-relation-atom-adjacency",
           "spectral-mode:spectral-workflow-risk-axis-pressure",
           "spectral-mode:spectral-molecule-atom-overlap-coupling",
           "spectral-mode:spectral-obstruction-axis-curvature",
@@ -1962,7 +2419,7 @@
         "readingId": "curvature-transfer-reading:spectrum-profile-homotopy-report-fixture",
         "profileRef": "spectrum-profile:homotopy-report-fixture",
         "status": "needsReview",
-        "measurementStatus": "proxy",
+        "measurementStatus": "measured",
         "readingBoundary": {
           "readingStrength": "boundedMeasuredWithProxyTransfer",
           "zeroReflectionAssumptions": [
@@ -2000,14 +2457,18 @@
                 "atom:cache-read",
                 "atom:coupon-tax-rounding",
                 "atom:repository-read",
-                "molecule-reading:molecule-homotopy-report-fixture"
+                "molecule-reading:molecule-homotopy-report-fixture",
+                "relation-edge:atom-cache-read:cacheorder:orderview",
+                "relation-edge:atom-repository-read:repositoryorder:orderview",
+                "src-cache-read",
+                "src-repository-read"
               ]
             }
           ],
           "rowCount": 1,
           "columnCount": 1,
           "nonzeroEdgeCount": 1,
-          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+          "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence",
           "spectralRadiusKind": "finiteNonnegativeOperatorBoundedClosedWalkRadius",
           "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
         },
@@ -2034,9 +2495,13 @@
               "atom:cache-read",
               "atom:coupon-tax-rounding",
               "atom:repository-read",
-              "molecule-reading:molecule-homotopy-report-fixture"
+              "molecule-reading:molecule-homotopy-report-fixture",
+              "relation-edge:atom-cache-read:cacheorder:orderview",
+              "relation-edge:atom-repository-read:repositoryorder:orderview",
+              "src-cache-read",
+              "src-repository-read"
             ],
-            "extractionRule": "same-selected-axis",
+            "extractionRule": "selected-relation-graph",
             "closedWalkKind": "selfLoop",
             "reading": "positive self-loop records a closed walk in the finite transfer operator"
           }
@@ -2055,7 +2520,7 @@
               "witness:homotopy-report-fixture"
             ],
             "cycleWeight": 1,
-            "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+            "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
             "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
             "reviewFocus": [
               "inspect the witness support behind the positive transfer self-loop",
@@ -2069,9 +2534,9 @@
           }
         ],
         "spectralRadiusReading": {
-          "name": "rho(T^kappa)Proxy",
-          "value": "1",
-          "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+          "name": "rho(T^kappa)",
+          "value": "1.000",
+          "interpretation": "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability"
         },
         "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
         "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
@@ -2190,7 +2655,7 @@
       "recurrentObstructions": [
         {
           "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture-curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture",
-          "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+          "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
           "transferEdgeRefs": [
             "curvature-transfer-edge:curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture:curvature-support-witness-homotopy-report-fixture-axis-homotopy-report-fixture"
           ],
@@ -2626,8 +3091,12 @@
         "inheritedCoreObstructionRefs": [
           "obstruction:homotopy-report-fixture:computed"
         ],
-        "featureLocalObstructionRefs": [],
-        "interactionObstructionRefs": [],
+        "featureLocalObstructionRefs": [
+          "obstruction:homotopy-report-fixture:computed"
+        ],
+        "interactionObstructionRefs": [
+          "obstruction:homotopy-report-fixture:computed"
+        ],
         "liftingFailureRefs": [
           "split-readiness:molecule-homotopy-report-fixture"
         ],
@@ -2635,10 +3104,82 @@
           "obstruction:homotopy-report-fixture:computed"
         ],
         "complexityTransferRefs": [
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          "repair:obstruction-homotopy-report-fixture-computed"
         ],
         "residualCoverageGapRefs": [
           "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "witnessBasis": [
+          {
+            "witnessRef": "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+            "labels": [
+              "residualCoverageGap"
+            ],
+            "observationRefs": [
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+            ],
+            "sourceRefs": [
+              "doc-auth-policy"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "obstruction:homotopy-report-fixture:computed",
+            "labels": [
+              "featureLocalObstruction",
+              "fillingFailure",
+              "inheritedCoreObstruction",
+              "interactionObstruction"
+            ],
+            "observationRefs": [
+              "atom:authorization-bypass",
+              "atom:cache-read",
+              "atom:coupon-tax-rounding",
+              "atom:repository-read",
+              "molecule-reading:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "src-auth-bypass",
+              "src-cache-read",
+              "src-pricing-checkout",
+              "src-repository-read"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "repair:obstruction-homotopy-report-fixture-computed",
+            "labels": [
+              "complexityTransfer"
+            ],
+            "observationRefs": [
+              "atom:authorization-bypass",
+              "atom:cache-read",
+              "atom:coupon-tax-rounding",
+              "atom:repository-read",
+              "molecule-reading:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "src-auth-bypass",
+              "src-cache-read",
+              "src-pricing-checkout",
+              "src-repository-read"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          },
+          {
+            "witnessRef": "split-readiness:molecule-homotopy-report-fixture",
+            "labels": [
+              "liftingFailure"
+            ],
+            "observationRefs": [
+              "molecule:homotopy-report-fixture",
+              "obstruction:homotopy-report-fixture:computed"
+            ],
+            "sourceRefs": [
+              "test-homotopy-fillers"
+            ],
+            "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
+          }
         ],
         "classificationSummary": [
           {
@@ -2651,14 +3192,18 @@
           },
           {
             "axis": "featureLocalObstruction",
-            "status": "unmeasuredOrAbsent",
-            "refs": [],
+            "status": "observed",
+            "refs": [
+              "obstruction:homotopy-report-fixture:computed"
+            ],
             "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
           },
           {
             "axis": "interactionObstruction",
-            "status": "unmeasuredOrAbsent",
-            "refs": [],
+            "status": "observed",
+            "refs": [
+              "obstruction:homotopy-report-fixture:computed"
+            ],
             "reading": "interactionObstruction is classified as a current-state extension coordinate"
           },
           {
@@ -2681,7 +3226,7 @@
             "axis": "complexityTransfer",
             "status": "observed",
             "refs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+              "repair:obstruction-homotopy-report-fixture-computed"
             ],
             "reading": "complexityTransfer is classified as a current-state extension coordinate"
           },
@@ -2694,7 +3239,7 @@
             "reading": "residualCoverageGap is classified as a current-state extension coordinate"
           }
         ],
-        "evidenceBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "evidenceBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -2711,15 +3256,15 @@
         "readingId": "operation-calculus-law:repair-obstruction-homotopy-report-fixture-computed",
         "operationRef": "repair:obstruction-homotopy-report-fixture-computed",
         "operationKind": "repair-homotopyreportfixturecircuit",
-        "compositionStatus": "assumptionRelative",
-        "associativityUnderObservationStatus": "selectedObservationOnly",
-        "refinementAbstractionCompatibility": "blockedByMissingEvidence",
+        "compositionStatus": "observed",
+        "associativityUnderObservationStatus": "observed",
+        "refinementAbstractionCompatibility": "blocked",
         "replacementEquivalence": "unmeasured",
         "protectionIdempotence": "notApplicable",
         "runtimeLocalization": "unmeasured",
         "migrationCompatibility": "notApplicable",
         "reverseInvolution": "unmeasured",
-        "repairMonotonicity": "selectedAxisOnly",
+        "repairMonotonicity": "blockedByTransferRisk",
         "synthesisNoSolutionBoundary": "notASynthesisCertificate",
         "preconditionRefs": [
           "human review selects a repair operation",
@@ -2728,6 +3273,166 @@
         "evidenceRefs": [
           "obstruction:homotopy-report-fixture:computed",
           "preserve existing observed atom configuration boundaries"
+        ],
+        "lawEvidence": [
+          {
+            "lawAxis": "composition",
+            "status": "observed",
+            "requiredEvidenceRefs": [
+              "operation support refs",
+              "operation precondition refs"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "obstruction:homotopy-report-fixture:computed",
+              "preserve existing observed atom configuration boundaries",
+              "resolve or explicitly accept coverage gap gap:path-rule:authorization-bypass-hole:missing-policy-test"
+            ],
+            "blockedReasonRefs": [
+              "coverage:homotopy-report-fixture: report observation gap and block signature-zero reflection",
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:homotopy-report-fixture: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "composition is observed under selected operation evidence"
+          },
+          {
+            "lawAxis": "associativityUnderObservation",
+            "status": "observed",
+            "requiredEvidenceRefs": [
+              "operation delta support"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:homotopy-report-fixture:computed",
+              "preserve existing observed atom configuration boundaries"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "associativityUnderObservation is observed under selected operation evidence"
+          },
+          {
+            "lawAxis": "refinementAbstractionCompatibility",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "preserved invariant refs"
+            ],
+            "observedEvidenceRefs": [
+              "preserve existing observed atom configuration boundaries"
+            ],
+            "blockedReasonRefs": [
+              "coverage:homotopy-report-fixture: report observation gap and block signature-zero reflection",
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
+              "implementation patch and verification evidence are not supplied by ArchSig analysis",
+              "witness:homotopy-report-fixture: report observation gap; do not infer measured zero"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "refinementAbstractionCompatibility is blocked under selected operation evidence"
+          },
+          {
+            "lawAxis": "replacementEquivalence",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "before/after equivalence witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:homotopy-report-fixture:computed"
+            ],
+            "blockedReasonRefs": [
+              "replacement-equivalence:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:replacement-equivalence"
+            ],
+            "reading": "replacementEquivalence is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "protectionIdempotence",
+            "status": "notApplicable",
+            "requiredEvidenceRefs": [
+              "repeat protection witness"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "resolve or explicitly accept coverage gap gap:path-rule:authorization-bypass-hole:missing-policy-test"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "protectionIdempotence is notApplicable under selected operation evidence"
+          },
+          {
+            "lawAxis": "runtimeLocalization",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "runtime/effect localization witness"
+            ],
+            "observedEvidenceRefs": [
+              "human review selects a repair operation",
+              "resolve or explicitly accept coverage gap gap:path-rule:authorization-bypass-hole:missing-policy-test"
+            ],
+            "blockedReasonRefs": [
+              "runtime-localization:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:operation-preconditions-observed"
+            ],
+            "reading": "runtimeLocalization is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "migrationCompatibility",
+            "status": "notApplicable",
+            "requiredEvidenceRefs": [
+              "migration compatibility witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:homotopy-report-fixture:computed",
+              "preserve existing observed atom configuration boundaries"
+            ],
+            "blockedReasonRefs": [],
+            "exactnessAssumptionRefs": [],
+            "reading": "migrationCompatibility is notApplicable under selected operation evidence"
+          },
+          {
+            "lawAxis": "reverseInvolution",
+            "status": "unmeasured",
+            "requiredEvidenceRefs": [
+              "reverse operation witness"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:homotopy-report-fixture:computed",
+              "preserve existing observed atom configuration boundaries"
+            ],
+            "blockedReasonRefs": [
+              "reverse-involution:witness-not-supplied"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:reverse-operation"
+            ],
+            "reading": "reverseInvolution is unmeasured under selected operation evidence"
+          },
+          {
+            "lawAxis": "repairMonotonicity",
+            "status": "blocked",
+            "requiredEvidenceRefs": [
+              "selected obstruction valuation",
+              "transfer risk refs"
+            ],
+            "observedEvidenceRefs": [
+              "obstruction:homotopy-report-fixture:computed",
+              "sig-axis:homotopy-report-fixture"
+            ],
+            "blockedReasonRefs": [
+              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+            ],
+            "exactnessAssumptionRefs": [
+              "exactness:selected-axis-only"
+            ],
+            "reading": "repairMonotonicity is blocked under selected operation evidence"
+          }
         ],
         "evidenceBoundary": "repair candidate is derived from ArchSig packet evidence, not an automatic patch",
         "nonConclusions": [
@@ -2878,6 +3583,238 @@
         ],
         "coverageBoundary": "projection reflection is read only under explicit axis preservation and witness completeness assumptions",
         "evidenceBoundary": "axis-forgetting risk is current-state ArchSig telemetry; it is not a proof that every projection loses information",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "observationProjectionFidelityReadings": [
+      {
+        "readingId": "observation-projection-fidelity:observation-projection-homotopy-report-fixture-archmap",
+        "sourceProjectionRef": "observation-projection:homotopy-report-fixture-archmap",
+        "sourceAxisForgettingRef": "axis-forgetting-risk:selected-projection",
+        "fidelityStatus": "projectionLossObserved",
+        "observedAtomFamilyCount": 4,
+        "forgottenCoordinateCount": 1,
+        "observationCollisionCount": 0,
+        "collapsedAtomFamilyCandidateCount": 0,
+        "hiddenAtomFamilyHintCount": 1,
+        "projectionLostAtomFamilyRefs": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence"
+        ],
+        "projectionLossAxes": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "reflectionStatus": "blockedWithoutAxisPreservationAndWitnessCompleteness",
+        "measurementBoundary": "projection loss is separated from zero/lawfulness; missing coordinates are not measured absent atoms",
+        "recommendedNextAction": "review projection-lost families and forgotten coordinates before treating the ArchMap as a faithful Atom observation",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "atomOriginClosureDebtReadings": [
+      {
+        "readingId": "atom-origin-closure-debt:homotopy-report-fixture-archmap",
+        "sourceBackedAtomCount": 6,
+        "derivedOrInferredAtomCount": 0,
+        "expectedMissingAtomCount": 1,
+        "sourceBackedAtomFamilyRefs": [
+          "authority",
+          "contractSpecification",
+          "effect",
+          "relation"
+        ],
+        "derivedOrInferredRefs": [],
+        "missingExpectedAtomRefs": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "closureStatus": "originClosureDebtObserved",
+        "weakensZeroOrRepairClaims": [
+          "zero readings need source-backed Atom closure or explicit coverage boundary",
+          "repair and synthesis candidates remain bounded when expected atoms are missing",
+          "derived or inferred atoms must not be promoted to source-backed evidence"
+        ],
+        "evidenceBoundary": "Atom origin closure debt is read from sourceRefs and observation gaps; it is not complete source extraction validation",
+        "recommendedNextAction": "separate source-backed, derived/inferred, and expected-missing Atom evidence before using the packet for repair or synthesis claims",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "effectRelationAlgebraReadings": [
+      {
+        "readingId": "effect-relation-algebra:homotopy-report-fixture-archmap",
+        "generatorRefs": [
+          "atom:cache-read",
+          "atom:event-projection",
+          "atom:repository-read",
+          "atom:retry-idempotency"
+        ],
+        "effectAtomRefs": [
+          "atom:event-projection",
+          "atom:retry-idempotency"
+        ],
+        "relationAtomRefs": [
+          "atom:cache-read",
+          "atom:repository-read",
+          "atom:event-projection"
+        ],
+        "externalBoundaryRefs": [],
+        "requiredEffectRelations": [
+          "effect ordering",
+          "replay or roundtrip stability",
+          "compensation/finalization relation",
+          "handler and external provider boundary ownership"
+        ],
+        "unresolvedEffectRelations": [],
+        "effectOrderingPressure": "effectRelationPressureObserved",
+        "stateTransitionRef": "state-transition-algebra:homotopy-report-fixture-archmap",
+        "evidenceBoundary": "effect relation algebra is kept separate from state transition pressure and only reads observed effect/relation/runtime evidence",
+        "recommendedNextAction": "review async job, provider, event handler, replay, roundtrip, and compensation relations before approving state/effect repairs",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "synthesisBlockageReadings": [
+      {
+        "readingId": "synthesis-blockage:homotopy-report-fixture-archmap",
+        "targetConstructionRefs": [
+          "repair:obstruction-homotopy-report-fixture-computed",
+          "feature-extension-formula:homotopy-report-fixture-archmap"
+        ],
+        "requiredAtomRefs": [
+          "atom:cache-read",
+          "atom:repository-read",
+          "atom:event-projection",
+          "atom:retry-idempotency",
+          "atom:authorization-bypass",
+          "atom:coupon-tax-rounding"
+        ],
+        "constraintRefs": [
+          "obstruction:homotopy-report-fixture:computed",
+          "obstruction:homotopy-report-fixture:computed",
+          "obstruction:homotopy-report-fixture:computed",
+          "split-readiness:molecule-homotopy-report-fixture",
+          "obstruction:homotopy-report-fixture:computed",
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+          "diagram filling is LawPolicy-relative and requires selected witness completeness"
+        ],
+        "missingEvidenceRefs": [
+          "coverage:homotopy-report-fixture: report observation gap and block signature-zero reflection",
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "witness:homotopy-report-fixture: report observation gap; do not infer measured zero",
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "decisionBoundaryRefs": [
+          "diagram-fillability:local-curvature-obstruction-homotopy-report-fixture-computed"
+        ],
+        "candidateSolutionRefs": [],
+        "blockageStatus": "synthesisBlockedByMissingEvidenceOrConstraints",
+        "noSolutionCertificateStatus": "notASolverAndNotAbsenceProof",
+        "synthesisBoundary": "candidate absence, missing evidence, and no-solution certificates are distinct; ArchSig does not run a synthesis solver",
+        "recommendedNextAction": "resolve Atom, constraint, evidence, and decision-boundary blockers before reading a repair candidate as constructible",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "operationPreconditionReadinessReadings": [
+      {
+        "readingId": "operation-precondition-readiness:repair-obstruction-homotopy-report-fixture-computed",
+        "operationRef": "repair:obstruction-homotopy-report-fixture-computed",
+        "operationKind": "repair-homotopyreportfixturecircuit",
+        "readinessStatus": "blockedByMissingPreconditionEvidence",
+        "preconditionRefs": [
+          "human review selects a repair operation",
+          "resolve or explicitly accept coverage gap gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "missingPreconditionRefs": [
+          "coverage:homotopy-report-fixture: report observation gap and block signature-zero reflection",
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
+          "implementation patch and verification evidence are not supplied by ArchSig analysis",
+          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
+          "replacement-equivalence:witness-not-supplied",
+          "reverse-involution:witness-not-supplied",
+          "runtime-localization:witness-not-supplied",
+          "witness:homotopy-report-fixture: report observation gap; do not infer measured zero"
+        ],
+        "coverageGapRefs": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "exactnessGapRefs": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "witnessGapRefs": [
+          "witness:homotopy-report-fixture"
+        ],
+        "candidateBoundary": "repair/split/migration/protection candidates are review cues until precondition evidence is observed",
+        "recommendedNextAction": "supply coverage, exactness, witness, and runtime precondition evidence before treating the operation as safe",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      }
+    ],
+    "pathMultiplicityLossReadings": [
+      {
+        "readingId": "path-multiplicity-loss:homotopy-report-fixture-archmap",
+        "scopeRef": "homotopy-report-fixture-archmap",
+        "pathReadingRefs": [
+          "path-signature-trajectory:operation-delta-repair-obstruction-homotopy-report-fixture-computed"
+        ],
+        "observedPathCount": 1,
+        "alternatePathPressure": 8,
+        "maxWalkLengthProxy": 3,
+        "reachabilityForgottenRefs": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "fanInBoundaryRefs": [
+          "molecule:homotopy-report-fixture"
+        ],
+        "multiplicityLossStatus": "reachabilityMultiplicityLossObserved",
+        "homotopyBoundary": "path multiplicity is a reachability and homotopy review signal, not proof of all paths",
+        "evidenceBoundary": "alternate-path pressure is bounded by observed operation trajectories, homotopy sensitivity, workflow risk, and gaps",
+        "recommendedNextAction": "inspect high fan-in and alternate path boundaries before treating one observed path as complete reachability",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6043,96 +6980,82 @@
     },
     "operationSquareCandidates": [
       {
-        "candidateId": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-        "candidateSource": "inferred",
-        "suppliedPairRef": null,
+        "candidateId": "operation-square:operation-square-evidence-cache-repository-read",
+        "candidateSource": "supplied",
+        "suppliedPairRef": "operation-square-evidence:cache-repository-read",
         "candidateBasis": [
-          "sharedAtomSupport",
-          "effectFamily",
-          "contractAtom",
-          "semanticAtom",
-          "authorityBoundary",
-          "projectionSurface"
+          "sourceBackedOperationPair",
+          "suppliedPathPair",
+          "sharedEndpoint",
+          "generatorCandidate",
+          "atomSupport",
+          "semanticSupport",
+          "projectionSupport"
         ],
-        "leftOperationRef": "operation-delta:repair-obstruction-homotopy-report-fixture-computed",
-        "rightOperationRef": "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation",
-        "pPathRef": "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation . operation-delta:repair-obstruction-homotopy-report-fixture-computed",
-        "qPathRef": "operation-delta:repair-obstruction-homotopy-report-fixture-computed . operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation",
+        "candidateBasisRefs": [
+          "OrderView",
+          "atom:cache-read",
+          "atom:event-projection",
+          "atom:repository-read",
+          "molecule:homotopy-report-fixture",
+          "projection:homotopy-report-fixture",
+          "semantic:path-rule:cache-repository-semantic-loop",
+          "src-cache-read",
+          "src-repository-read",
+          "test-homotopy-fillers"
+        ],
+        "leftOperationRef": "operation:read-through-cache",
+        "rightOperationRef": "operation:read-from-repository",
+        "pPathRef": "operation:project-order-event . operation:read-through-cache",
+        "qPathRef": "operation:project-order-event . operation:read-from-repository",
         "pOperationSequence": [
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed",
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation"
+          "operation:read-through-cache",
+          "operation:project-order-event"
         ],
         "qOperationSequence": [
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation",
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed"
+          "operation:read-from-repository",
+          "operation:project-order-event"
         ],
         "endpointObjectRefs": [
-          "aat:homotopy:fixture",
-          "atom:cache-read",
-          "atom:repository-read"
+          "OrderView"
         ],
         "generatorCandidateRefs": [
-          "generator:independent-square",
-          "generator:same-contract-replacement",
-          "generator:repair-filler",
-          "generator:identity-insertion-deletion",
-          "generator:associativity-reassociation"
+          "generator:contract-filler",
+          "generator:runtime-filler"
         ],
         "sharedAtomSupportRefs": [
           "atom:cache-read",
-          "atom:repository-read"
+          "atom:repository-read",
+          "atom:event-projection"
         ],
         "stateRefs": [],
         "effectRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:event-projection"
         ],
-        "contractRefs": [
-          "atom:coupon-tax-rounding"
-        ],
+        "contractRefs": [],
         "semanticRefs": [
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:retry-idempotency-effect",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop"
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
-        "authorityRefs": [
-          "atom:authorization-bypass"
-        ],
+        "authorityRefs": [],
         "runtimeRefs": [],
         "projectionRefs": [
           "projection:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:authorization-bypass",
           "atom:cache-read",
-          "atom:coupon-tax-rounding",
+          "atom:event-projection",
           "atom:repository-read",
+          "molecule:homotopy-report-fixture",
           "projection:homotopy-report-fixture",
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
-        "missingRefs": [
-          "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
-          "no state observation supplied for operation square candidate"
-        ],
-        "evidenceBoundary": "inferred operation square candidate is a review cue over observed ArchMap support, not operation truth",
+        "missingRefs": [],
+        "evidenceBoundary": "supplied operation square evidence is first-class ArchMap input with p/q paths, endpoints, and source-backed basis refs: fixture supplies p/q read-model operation sequences and OrderView endpoint for homotopy continuation measurement",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6146,46 +7069,56 @@
     ],
     "pathContinuationTraces": [
       {
-        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:p",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-        "pathRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:p",
+        "traceId": "path-continuation-trace:operation-square-operation-square-evidence-cache-repository-read:p",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+        "pathRef": "operation-square:operation-square-evidence-cache-repository-read:p",
         "pathRole": "p",
-        "pathExpression": "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation . operation-delta:repair-obstruction-homotopy-report-fixture-computed",
+        "pathExpression": "operation:project-order-event . operation:read-through-cache",
         "operationSequence": [
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed",
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation"
+          "operation:read-through-cache",
+          "operation:project-order-event"
         ],
         "endpointObjectRefs": [
-          "aat:homotopy:fixture",
-          "atom:cache-read",
-          "atom:repository-read"
+          "OrderView"
         ],
         "continuationStepRefs": [
-          "cont-step:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "cont-step:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "cont-step:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:p:endpoint"
+          "cont-step:operation-square-operation-square-evidence-cache-repository-read:p:operation-read-through-cache",
+          "cont-step:operation-square-operation-square-evidence-cache-repository-read:p:operation-project-order-event",
+          "cont-step:operation-square-operation-square-evidence-cache-repository-read:p:endpoint"
         ],
         "axisTraces": [
           {
             "axisFamily": "static",
             "axisRef": "static dependency / support axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "static continuation reads 2 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "witness-mismatch-count:static-support-value-mismatch",
+            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_static[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=2",
-              "Cont_static[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=2",
-              "Cont_static[endpoint]=p; endpointRefs=3"
+              "Cont_static[0]=operation:read-through-cache; comparableValues=2",
+              "Cont_static[1]=operation:project-order-event; comparableValues=2",
+              "Cont_static[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:static-support-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "static:endpoints:OrderView",
+              "static:support:atom-cache-read|atom-repository-read|atom-event-projection"
             ],
             "distanceInputRefs": [
+              "OrderView",
               "atom:cache-read",
-              "atom:repository-read"
+              "atom:event-projection",
+              "atom:repository-read",
+              "src-cache-read",
+              "src-event-projection",
+              "src-repository-read"
             ],
             "observationRefs": [
               "atom:cache-read",
-              "atom:repository-read"
+              "atom:repository-read",
+              "atom:event-projection"
             ],
             "sourceRefs": [
               "src-cache-read",
+              "src-event-projection",
               "src-repository-read"
             ],
             "missingRefs": [],
@@ -6194,55 +7127,50 @@
           {
             "axisFamily": "contract",
             "axisRef": "contract axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:contract-obligation-value-mismatch",
+            "continuationSummary": "contract continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_contract[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=1",
-              "Cont_contract[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=1",
-              "Cont_contract[endpoint]=p; endpointRefs=3"
+              "Cont_contract[0]=operation:read-through-cache; comparableValues=0",
+              "Cont_contract[1]=operation:project-order-event; comparableValues=0",
+              "Cont_contract[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:contract-obligation-value-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "atom:coupon-tax-rounding"
+              "OrderView"
             ],
-            "observationRefs": [
-              "atom:coupon-tax-rounding"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
-            "sourceRefs": [
-              "src-pricing-checkout"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "semantic",
             "axisRef": "semantic axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "semantic continuation reads 5 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "witness-mismatch-count:semantic-sequence-mismatch",
+            "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_semantic[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=5",
-              "Cont_semantic[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=5",
-              "Cont_semantic[endpoint]=p; endpointRefs=3"
+              "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+              "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+              "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "semantic:path:p:operation:read-through-cache -> operation:project-order-event",
+              "semantic:endpoints:OrderView"
             ],
             "distanceInputRefs": [
-              "semantic:path-rule:nonzero-holonomy-filled-loop",
+              "OrderView",
               "semantic:path-rule:cache-repository-semantic-loop",
-              "semantic:path-rule:event-projection-direct-read",
-              "semantic:path-rule:retry-idempotency-effect",
-              "semantic:path-rule:coupon-tax-rounding-semantic-loop"
+              "src-cache-read"
             ],
             "observationRefs": [
-              "semantic:path-rule:nonzero-holonomy-filled-loop",
-              "semantic:path-rule:cache-repository-semantic-loop",
-              "semantic:path-rule:event-projection-direct-read",
-              "semantic:path-rule:retry-idempotency-effect",
-              "semantic:path-rule:coupon-tax-rounding-semantic-loop"
+              "semantic:path-rule:cache-repository-semantic-loop"
             ],
             "sourceRefs": [
-              "src-cache-read",
-              "src-direct-read",
-              "src-event-projection",
-              "src-pricing-checkout",
-              "src-retry-effect"
+              "src-cache-read"
             ],
             "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
@@ -6251,17 +7179,21 @@
             "axisFamily": "state",
             "axisRef": "state transition axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:state-transition-value-mismatch",
             "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_state[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=0",
-              "Cont_state[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=0",
-              "Cont_state[endpoint]=p; endpointRefs=3"
+              "Cont_state[0]=operation:read-through-cache; comparableValues=0",
+              "Cont_state[1]=operation:project-order-event; comparableValues=0",
+              "Cont_state[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:state-transition-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "OrderView"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing state observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
@@ -6269,34 +7201,27 @@
             "axisFamily": "effect",
             "axisRef": "effect ordering / replay / compensation axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "witness-mismatch-count:effect-replay-order-mismatch",
+            "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_effect[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=4",
-              "Cont_effect[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=4",
-              "Cont_effect[endpoint]=p; endpointRefs=3"
+              "Cont_effect[0]=operation:read-through-cache; comparableValues=2",
+              "Cont_effect[1]=operation:project-order-event; comparableValues=2",
+              "Cont_effect[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:effect-replay-order-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "effect:path:p:operation:read-through-cache -> operation:project-order-event",
+              "effect:endpoints:OrderView"
             ],
             "distanceInputRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed"
+              "OrderView",
+              "atom:event-projection",
+              "src-event-projection"
             ],
             "observationRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed"
+              "atom:event-projection"
             ],
             "sourceRefs": [
-              "doc-auth-policy",
-              "src-auth-bypass",
-              "src-cache-read",
-              "src-direct-read",
-              "src-event-projection",
-              "src-pricing-checkout",
-              "src-repository-read",
-              "src-retry-effect",
-              "test-homotopy-fillers"
+              "src-event-projection"
             ],
             "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
@@ -6304,40 +7229,44 @@
           {
             "axisFamily": "authority",
             "axisRef": "authority / trust boundary axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "authority continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:authority-boundary-value-mismatch",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_authority[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=1",
-              "Cont_authority[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=1",
-              "Cont_authority[endpoint]=p; endpointRefs=3"
+              "Cont_authority[0]=operation:read-through-cache; comparableValues=0",
+              "Cont_authority[1]=operation:project-order-event; comparableValues=0",
+              "Cont_authority[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:authority-boundary-value-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "atom:authorization-bypass"
+              "OrderView"
             ],
-            "observationRefs": [
-              "atom:authorization-bypass"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
-            "sourceRefs": [
-              "src-auth-bypass"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "runtime",
             "axisRef": "runtime interaction axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:runtime-interaction-value-mismatch",
             "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_runtime[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=0",
-              "Cont_runtime[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=0",
-              "Cont_runtime[endpoint]=p; endpointRefs=3"
+              "Cont_runtime[0]=operation:read-through-cache; comparableValues=0",
+              "Cont_runtime[1]=operation:project-order-event; comparableValues=0",
+              "Cont_runtime[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:runtime-interaction-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "OrderView"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing runtime observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
@@ -6345,13 +7274,20 @@
             "axisFamily": "projection",
             "axisRef": "projection / representation axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "witness-mismatch-count:projection-target-value-mismatch",
             "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_projection[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=1",
-              "Cont_projection[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=1",
-              "Cont_projection[endpoint]=p; endpointRefs=3"
+              "Cont_projection[0]=operation:read-through-cache; comparableValues=2",
+              "Cont_projection[1]=operation:project-order-event; comparableValues=2",
+              "Cont_projection[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:projection-target-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "projection:endpoints:OrderView",
+              "projection:support:projection-homotopy-report-fixture"
             ],
             "distanceInputRefs": [
+              "OrderView",
+              "molecule:homotopy-report-fixture",
               "projection:homotopy-report-fixture"
             ],
             "observationRefs": [
@@ -6365,32 +7301,19 @@
           }
         ],
         "observationRefs": [
-          "atom:authorization-bypass",
           "atom:cache-read",
-          "atom:coupon-tax-rounding",
+          "atom:event-projection",
           "atom:repository-read",
+          "molecule:homotopy-report-fixture",
           "projection:homotopy-report-fixture",
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
-        "missingRefs": [
-          "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
-          "no state observation supplied for operation square candidate"
-        ],
+        "missingRefs": [],
         "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
@@ -6403,46 +7326,56 @@
         ]
       },
       {
-        "traceId": "path-continuation-trace:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:q",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-        "pathRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:q",
+        "traceId": "path-continuation-trace:operation-square-operation-square-evidence-cache-repository-read:q",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+        "pathRef": "operation-square:operation-square-evidence-cache-repository-read:q",
         "pathRole": "q",
-        "pathExpression": "operation-delta:repair-obstruction-homotopy-report-fixture-computed . operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation",
+        "pathExpression": "operation:project-order-event . operation:read-from-repository",
         "operationSequence": [
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation",
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed"
+          "operation:read-from-repository",
+          "operation:project-order-event"
         ],
         "endpointObjectRefs": [
-          "aat:homotopy:fixture",
-          "atom:cache-read",
-          "atom:repository-read"
+          "OrderView"
         ],
         "continuationStepRefs": [
-          "cont-step:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "cont-step:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "cont-step:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:q:endpoint"
+          "cont-step:operation-square-operation-square-evidence-cache-repository-read:q:operation-read-from-repository",
+          "cont-step:operation-square-operation-square-evidence-cache-repository-read:q:operation-project-order-event",
+          "cont-step:operation-square-operation-square-evidence-cache-repository-read:q:endpoint"
         ],
         "axisTraces": [
           {
             "axisFamily": "static",
             "axisRef": "static dependency / support axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "static continuation reads 2 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "witness-mismatch-count:static-support-value-mismatch",
+            "continuationSummary": "static continuation reads 3 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_static[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=2",
-              "Cont_static[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=2",
-              "Cont_static[endpoint]=q; endpointRefs=3"
+              "Cont_static[0]=operation:read-from-repository; comparableValues=2",
+              "Cont_static[1]=operation:project-order-event; comparableValues=2",
+              "Cont_static[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:static-support-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "static:endpoints:OrderView",
+              "static:support:atom-cache-read|atom-repository-read|atom-event-projection"
             ],
             "distanceInputRefs": [
+              "OrderView",
               "atom:cache-read",
-              "atom:repository-read"
+              "atom:event-projection",
+              "atom:repository-read",
+              "src-cache-read",
+              "src-event-projection",
+              "src-repository-read"
             ],
             "observationRefs": [
               "atom:cache-read",
-              "atom:repository-read"
+              "atom:repository-read",
+              "atom:event-projection"
             ],
             "sourceRefs": [
               "src-cache-read",
+              "src-event-projection",
               "src-repository-read"
             ],
             "missingRefs": [],
@@ -6451,55 +7384,50 @@
           {
             "axisFamily": "contract",
             "axisRef": "contract axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "contract continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:contract-obligation-value-mismatch",
+            "continuationSummary": "contract continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_contract[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=1",
-              "Cont_contract[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=1",
-              "Cont_contract[endpoint]=q; endpointRefs=3"
+              "Cont_contract[0]=operation:read-from-repository; comparableValues=0",
+              "Cont_contract[1]=operation:project-order-event; comparableValues=0",
+              "Cont_contract[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:contract-obligation-value-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "atom:coupon-tax-rounding"
+              "OrderView"
             ],
-            "observationRefs": [
-              "atom:coupon-tax-rounding"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
-            "sourceRefs": [
-              "src-pricing-checkout"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "semantic",
             "axisRef": "semantic axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "semantic continuation reads 5 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "witness-mismatch-count:semantic-sequence-mismatch",
+            "continuationSummary": "semantic continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_semantic[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=5",
-              "Cont_semantic[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=5",
-              "Cont_semantic[endpoint]=q; endpointRefs=3"
+              "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+              "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+              "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "semantic:path:q:operation:read-from-repository -> operation:project-order-event",
+              "semantic:endpoints:OrderView"
             ],
             "distanceInputRefs": [
-              "semantic:path-rule:nonzero-holonomy-filled-loop",
+              "OrderView",
               "semantic:path-rule:cache-repository-semantic-loop",
-              "semantic:path-rule:event-projection-direct-read",
-              "semantic:path-rule:retry-idempotency-effect",
-              "semantic:path-rule:coupon-tax-rounding-semantic-loop"
+              "src-cache-read"
             ],
             "observationRefs": [
-              "semantic:path-rule:nonzero-holonomy-filled-loop",
-              "semantic:path-rule:cache-repository-semantic-loop",
-              "semantic:path-rule:event-projection-direct-read",
-              "semantic:path-rule:retry-idempotency-effect",
-              "semantic:path-rule:coupon-tax-rounding-semantic-loop"
+              "semantic:path-rule:cache-repository-semantic-loop"
             ],
             "sourceRefs": [
-              "src-cache-read",
-              "src-direct-read",
-              "src-event-projection",
-              "src-pricing-checkout",
-              "src-retry-effect"
+              "src-cache-read"
             ],
             "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
@@ -6508,17 +7436,21 @@
             "axisFamily": "state",
             "axisRef": "state transition axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:state-transition-value-mismatch",
             "continuationSummary": "state continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_state[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=0",
-              "Cont_state[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=0",
-              "Cont_state[endpoint]=q; endpointRefs=3"
+              "Cont_state[0]=operation:read-from-repository; comparableValues=0",
+              "Cont_state[1]=operation:project-order-event; comparableValues=0",
+              "Cont_state[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:state-transition-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "OrderView"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing state observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
@@ -6526,34 +7458,27 @@
             "axisFamily": "effect",
             "axisRef": "effect ordering / replay / compensation axis",
             "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "effect continuation reads 4 observation ref(s) across 1 operation delta(s)",
+            "distanceEvaluatorKind": "witness-mismatch-count:effect-replay-order-mismatch",
+            "continuationSummary": "effect continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_effect[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=4",
-              "Cont_effect[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=4",
-              "Cont_effect[endpoint]=q; endpointRefs=3"
+              "Cont_effect[0]=operation:read-from-repository; comparableValues=2",
+              "Cont_effect[1]=operation:project-order-event; comparableValues=2",
+              "Cont_effect[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:effect-replay-order-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "effect:path:q:operation:read-from-repository -> operation:project-order-event",
+              "effect:endpoints:OrderView"
             ],
             "distanceInputRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "OrderView",
+              "atom:event-projection",
+              "src-event-projection"
             ],
             "observationRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction",
-              "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "atom:event-projection"
             ],
             "sourceRefs": [
-              "doc-auth-policy",
-              "src-auth-bypass",
-              "src-cache-read",
-              "src-direct-read",
-              "src-event-projection",
-              "src-pricing-checkout",
-              "src-repository-read",
-              "src-retry-effect",
-              "test-homotopy-fillers"
+              "src-event-projection"
             ],
             "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
@@ -6561,40 +7486,44 @@
           {
             "axisFamily": "authority",
             "axisRef": "authority / trust boundary axis",
-            "traceStatus": "boundedObservationTrace",
-            "continuationSummary": "authority continuation reads 1 observation ref(s) across 1 operation delta(s)",
+            "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:authority-boundary-value-mismatch",
+            "continuationSummary": "authority continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_authority[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=1",
-              "Cont_authority[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=1",
-              "Cont_authority[endpoint]=q; endpointRefs=3"
+              "Cont_authority[0]=operation:read-from-repository; comparableValues=0",
+              "Cont_authority[1]=operation:project-order-event; comparableValues=0",
+              "Cont_authority[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:authority-boundary-value-mismatch"
             ],
+            "comparableContinuationValues": [],
             "distanceInputRefs": [
-              "atom:authorization-bypass"
+              "OrderView"
             ],
-            "observationRefs": [
-              "atom:authorization-bypass"
+            "observationRefs": [],
+            "sourceRefs": [],
+            "missingRefs": [
+              "missing authority observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
-            "sourceRefs": [
-              "src-auth-bypass"
-            ],
-            "missingRefs": [],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
           {
             "axisFamily": "runtime",
             "axisRef": "runtime interaction axis",
             "traceStatus": "unmeasured",
+            "distanceEvaluatorKind": "witness-mismatch-count:runtime-interaction-value-mismatch",
             "continuationSummary": "runtime continuation is unmeasured under current ArchMap evidence",
             "continuationStates": [
-              "Cont_runtime[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=0",
-              "Cont_runtime[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=0",
-              "Cont_runtime[endpoint]=q; endpointRefs=3"
+              "Cont_runtime[0]=operation:read-from-repository; comparableValues=0",
+              "Cont_runtime[1]=operation:project-order-event; comparableValues=0",
+              "Cont_runtime[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:runtime-interaction-value-mismatch"
             ],
-            "distanceInputRefs": [],
+            "comparableContinuationValues": [],
+            "distanceInputRefs": [
+              "OrderView"
+            ],
             "observationRefs": [],
             "sourceRefs": [],
             "missingRefs": [
-              "missing runtime observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
             "unmeasuredBoundary": "unmeasured axis is retained as missing evidence and is not interpreted as zero defect"
           },
@@ -6602,13 +7531,20 @@
             "axisFamily": "projection",
             "axisRef": "projection / representation axis",
             "traceStatus": "boundedObservationTrace",
+            "distanceEvaluatorKind": "witness-mismatch-count:projection-target-value-mismatch",
             "continuationSummary": "projection continuation reads 1 observation ref(s) across 1 operation delta(s)",
             "continuationStates": [
-              "Cont_projection[0]=operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation; refs=1",
-              "Cont_projection[1]=operation-delta:repair-obstruction-homotopy-report-fixture-computed; refs=1",
-              "Cont_projection[endpoint]=q; endpointRefs=3"
+              "Cont_projection[0]=operation:read-from-repository; comparableValues=2",
+              "Cont_projection[1]=operation:project-order-event; comparableValues=2",
+              "Cont_projection[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:projection-target-value-mismatch"
+            ],
+            "comparableContinuationValues": [
+              "projection:endpoints:OrderView",
+              "projection:support:projection-homotopy-report-fixture"
             ],
             "distanceInputRefs": [
+              "OrderView",
+              "molecule:homotopy-report-fixture",
               "projection:homotopy-report-fixture"
             ],
             "observationRefs": [
@@ -6622,32 +7558,19 @@
           }
         ],
         "observationRefs": [
-          "atom:authorization-bypass",
           "atom:cache-read",
-          "atom:coupon-tax-rounding",
+          "atom:event-projection",
           "atom:repository-read",
+          "molecule:homotopy-report-fixture",
           "projection:homotopy-report-fixture",
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
-        "missingRefs": [
-          "gap:path-rule:authorization-bypass-hole:missing-policy-test: authorization bypass path lacks policy or test filler evidence",
-          "no state observation supplied for operation square candidate"
-        ],
+        "missingRefs": [],
         "evidenceBoundary": "continuation trace is bounded by selected ArchMap observations and does not execute the operations",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
@@ -6662,42 +7585,38 @@
     ],
     "axisWiseMonodromyDefects": [
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:authority",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:authority",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "authority",
         "axisRef": "authority / trust boundary axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:authority-boundary-value-mismatch",
         "pContinuationRef": "Cont_authority(p):authority / trust boundary axis",
         "qContinuationRef": "Cont_authority(q):authority / trust boundary axis",
         "distanceInputRefs": [
-          "atom:authorization-bypass"
+          "OrderView"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 0,
-        "measuredSupportRefs": [
-          "atom:authorization-bypass"
-        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 0,
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
         "witnessRefs": [
-          "atom:authorization-bypass"
+          "missing-evidence:missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+          "missing-evidence:missing comparable p continuation value for authority",
+          "missing-evidence:missing comparable q continuation value for authority"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
-        "observationRefs": [
-          "atom:authorization-bypass"
+        "observationRefs": [],
+        "missingRefs": [
+          "missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+          "missing comparable p continuation value for authority",
+          "missing comparable q continuation value for authority"
         ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -6708,7 +7627,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6720,42 +7639,38 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:contract",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:contract",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "contract",
         "axisRef": "contract axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:contract-obligation-value-mismatch",
         "pContinuationRef": "Cont_contract(p):contract axis",
         "qContinuationRef": "Cont_contract(q):contract axis",
         "distanceInputRefs": [
-          "atom:coupon-tax-rounding"
+          "OrderView"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
-        "weight": 1,
-        "measurementStatus": "measured",
-        "distanceValue": 0,
-        "measuredSupportRefs": [
-          "atom:coupon-tax-rounding"
-        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
+        "weight": 0,
+        "measurementStatus": "unmeasured",
+        "distanceValue": null,
+        "measuredSupportRefs": [],
         "witnessRefs": [
-          "atom:coupon-tax-rounding"
+          "missing-evidence:missing comparable p continuation value for contract",
+          "missing-evidence:missing comparable q continuation value for contract",
+          "missing-evidence:missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
-        "observationRefs": [
-          "atom:coupon-tax-rounding"
+        "observationRefs": [],
+        "missingRefs": [
+          "missing comparable p continuation value for contract",
+          "missing comparable q continuation value for contract",
+          "missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
         ],
-        "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -6766,7 +7681,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6778,58 +7693,42 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "effect",
         "axisRef": "effect ordering / replay / compensation axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:effect-replay-order-mismatch",
         "pContinuationRef": "Cont_effect(p):effect ordering / replay / compensation axis",
         "qContinuationRef": "Cont_effect(q):effect ordering / replay / compensation axis",
         "distanceInputRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "OrderView",
+          "atom:event-projection",
+          "src-event-projection"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
-        "distanceValue": 2,
+        "distanceValue": 1,
         "measuredSupportRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:event-projection"
         ],
         "witnessRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:event-projection",
+          "p-value:effect-endpoints-orderview",
+          "p-value:effect-path-p-operation-read-through-cache-operation-project-order-event",
+          "q-value:effect-endpoints-orderview",
+          "q-value:effect-path-q-operation-read-from-repository-operation-project-order-event"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:event-projection"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -6840,7 +7739,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6852,17 +7751,19 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:projection",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:projection",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "projection",
         "axisRef": "projection / representation axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:projection-target-value-mismatch",
         "pContinuationRef": "Cont_projection(p):projection / representation axis",
         "qContinuationRef": "Cont_projection(q):projection / representation axis",
         "distanceInputRefs": [
+          "OrderView",
+          "molecule:homotopy-report-fixture",
           "projection:homotopy-report-fixture"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
@@ -6870,24 +7771,22 @@
           "projection:homotopy-report-fixture"
         ],
         "witnessRefs": [
-          "projection:homotopy-report-fixture"
+          "p-value:projection-endpoints-orderview",
+          "p-value:projection-support-projection-homotopy-report-fixture",
+          "projection:homotopy-report-fixture",
+          "q-value:projection-endpoints-orderview",
+          "q-value:projection-support-projection-homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
           "projection:homotopy-report-fixture"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -6898,7 +7797,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6910,38 +7809,38 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:runtime",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:runtime",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "runtime",
         "axisRef": "runtime interaction axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:runtime-interaction-value-mismatch",
         "pContinuationRef": "Cont_runtime(p):runtime interaction axis",
         "qContinuationRef": "Cont_runtime(q):runtime interaction axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "distanceInputRefs": [
+          "OrderView"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 0,
         "measurementStatus": "unmeasured",
         "distanceValue": null,
         "measuredSupportRefs": [],
         "witnessRefs": [
-          "missing-evidence:missing runtime observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+          "missing-evidence:missing comparable p continuation value for runtime",
+          "missing-evidence:missing comparable q continuation value for runtime",
+          "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [],
         "missingRefs": [
-          "missing runtime observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+          "missing comparable p continuation value for runtime",
+          "missing comparable q continuation value for runtime",
+          "missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
         ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -6952,7 +7851,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -6964,58 +7863,42 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:semantic",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "semantic",
         "axisRef": "semantic axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:semantic-sequence-mismatch",
         "pContinuationRef": "Cont_semantic(p):semantic axis",
         "qContinuationRef": "Cont_semantic(q):semantic axis",
         "distanceInputRefs": [
+          "OrderView",
           "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "src-cache-read"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
-        "distanceValue": 0,
+        "distanceValue": 1,
         "measuredSupportRefs": [
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "witnessRefs": [
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "p-value:semantic-endpoints-orderview",
+          "p-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "q-value:semantic-endpoints-orderview",
+          "q-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "semantic:path-rule:cache-repository-semantic-loop",
-          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-          "semantic:path-rule:event-projection-direct-read",
-          "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -7026,7 +7909,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -7038,38 +7921,38 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:state",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:state",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "state",
         "axisRef": "state transition axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:state-transition-value-mismatch",
         "pContinuationRef": "Cont_state(p):state transition axis",
         "qContinuationRef": "Cont_state(q):state transition axis",
-        "distanceInputRefs": [],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "distanceInputRefs": [
+          "OrderView"
+        ],
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 0,
         "measurementStatus": "unmeasured",
         "distanceValue": null,
         "measuredSupportRefs": [],
         "witnessRefs": [
-          "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+          "missing-evidence:missing comparable p continuation value for state",
+          "missing-evidence:missing comparable q continuation value for state",
+          "missing-evidence:missing state observation for operation-square:operation-square-evidence-cache-repository-read"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [],
         "missingRefs": [
-          "missing state observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+          "missing comparable p continuation value for state",
+          "missing comparable q continuation value for state",
+          "missing state observation for operation-square:operation-square-evidence-cache-repository-read"
         ],
-        "coverageBoundary": "coverage gap preserved; unmeasured axis is not zero defect",
+        "coverageBoundary": "coverage gap or missing comparable continuation input preserved; unmeasured axis is not zero defect",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -7080,7 +7963,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -7092,46 +7975,52 @@
         ]
       },
       {
-        "defectId": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:static",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "defectId": "mu:operation-square-operation-square-evidence-cache-repository-read:static",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "axisFamily": "static",
         "axisRef": "static dependency / support axis",
-        "distanceKind": "witness-mismatch-count",
+        "distanceKind": "witness-mismatch-count:static-support-value-mismatch",
         "pContinuationRef": "Cont_static(p):static dependency / support axis",
         "qContinuationRef": "Cont_static(q):static dependency / support axis",
         "distanceInputRefs": [
+          "OrderView",
           "atom:cache-read",
-          "atom:repository-read"
+          "atom:event-projection",
+          "atom:repository-read",
+          "src-cache-read",
+          "src-event-projection",
+          "src-repository-read"
         ],
-        "positiveWitnessBoundary": "mu_x > 0 is read only as selected continuation observation difference with source-backed p/q trace inputs",
+        "positiveWitnessBoundary": "mu_x > 0 is read by an axis-specific distance evaluator over comparable continuation values with source-backed p/q trace inputs",
         "weight": 1,
         "measurementStatus": "measured",
         "distanceValue": 0,
         "measuredSupportRefs": [
           "atom:cache-read",
+          "atom:event-projection",
           "atom:repository-read"
         ],
         "witnessRefs": [
           "atom:cache-read",
-          "atom:repository-read"
+          "atom:event-projection",
+          "atom:repository-read",
+          "p-value:static-endpoints-orderview",
+          "p-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection",
+          "q-value:static-endpoints-orderview",
+          "q-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
           "atom:cache-read",
+          "atom:event-projection",
           "atom:repository-read"
         ],
         "missingRefs": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "exactnessAssumptionStatus": [
           "selected LawPolicy exactness assumptions"
         ],
@@ -7142,7 +8031,7 @@
           "zero aggregate is not global path flatness"
         ],
         "cancellationBoundary": "axis-wise defect avoids aggregate cancellation; AMI zero can reflect local zero only under recorded zero-reflection assumptions",
-        "evidenceBoundary": "mu_x(sigma) is a bounded distance between selected continuation traces, not a theorem about path equality",
+        "evidenceBoundary": "mu_x(sigma) is a bounded axis-distance evaluation between selected continuation values, not a theorem about path equality",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -7169,137 +8058,152 @@
           "static"
         ],
         "selectedMeasuredSquareRefs": [
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:authority",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:contract",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:projection",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:semantic",
-          "square-family-entry:mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:static"
+          "square-family-entry:mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+          "square-family-entry:mu:operation-square-operation-square-evidence-cache-repository-read:projection",
+          "square-family-entry:mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+          "square-family-entry:mu:operation-square-operation-square-evidence-cache-repository-read:static"
         ],
         "weightPolicy": "unit weights until project-specific calibration is declared",
         "distanceKind": "witness-mismatch-count",
         "measurementStatus": "partial",
         "aggregateValue": 2,
         "measuredDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:authority",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:contract",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:projection",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:semantic",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:static"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:projection",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:static"
         ],
         "unmeasuredDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:runtime",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:state"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:authority",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:contract",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:runtime",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:state"
         ],
         "positiveWeightDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:authority",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:contract",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:projection",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:semantic",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:static"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:projection",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:static"
         ],
         "zeroWeightDefectRefs": [
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:runtime",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:state"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:authority",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:contract",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:runtime",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:state"
         ],
         "topContributors": [
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:runtime",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:authority",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+            "axisFamily": "authority",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing authority trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+              "missing-evidence:missing comparable p continuation value for authority",
+              "missing-evidence:missing comparable q continuation value for authority"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:contract",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+            "axisFamily": "contract",
+            "contributionWeight": 1,
+            "contributionValue": null,
+            "reviewFocus": "supply missing contract trace evidence before interpreting AMI as zero",
+            "witnessRefs": [
+              "missing-evidence:missing comparable p continuation value for contract",
+              "missing-evidence:missing comparable q continuation value for contract",
+              "missing-evidence:missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
+            ]
+          },
+          {
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:runtime",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
             "axisFamily": "runtime",
             "contributionWeight": 1,
             "contributionValue": null,
             "reviewFocus": "supply missing runtime trace evidence before interpreting AMI as zero",
             "witnessRefs": [
-              "missing-evidence:missing runtime observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing-evidence:missing comparable p continuation value for runtime",
+              "missing-evidence:missing comparable q continuation value for runtime",
+              "missing-evidence:missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:state",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:state",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
             "axisFamily": "state",
             "contributionWeight": 1,
             "contributionValue": null,
             "reviewFocus": "supply missing state trace evidence before interpreting AMI as zero",
             "witnessRefs": [
-              "missing-evidence:missing state observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing-evidence:missing comparable p continuation value for state",
+              "missing-evidence:missing comparable q continuation value for state",
+              "missing-evidence:missing state observation for operation-square:operation-square-evidence-cache-repository-read"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
             "axisFamily": "effect",
             "contributionWeight": 1,
-            "contributionValue": 2,
+            "contributionValue": 1,
             "reviewFocus": "review effect trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-              "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-              "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction"
+              "atom:event-projection",
+              "p-value:effect-endpoints-orderview",
+              "p-value:effect-path-p-operation-read-through-cache-operation-project-order-event",
+              "q-value:effect-endpoints-orderview",
+              "q-value:effect-path-q-operation-read-from-repository-operation-project-order-event"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:authority",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-            "axisFamily": "authority",
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+            "axisFamily": "semantic",
             "contributionWeight": 1,
-            "contributionValue": 0,
-            "reviewFocus": "review authority trace mismatch before treating aggregate value as local agreement",
+            "contributionValue": 1,
+            "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "atom:authorization-bypass"
+              "p-value:semantic-endpoints-orderview",
+              "p-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+              "q-value:semantic-endpoints-orderview",
+              "q-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+              "semantic:path-rule:cache-repository-semantic-loop"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:contract",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-            "axisFamily": "contract",
-            "contributionWeight": 1,
-            "contributionValue": 0,
-            "reviewFocus": "review contract trace mismatch before treating aggregate value as local agreement",
-            "witnessRefs": [
-              "atom:coupon-tax-rounding"
-            ]
-          },
-          {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:projection",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:projection",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
             "axisFamily": "projection",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review projection trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
-              "projection:homotopy-report-fixture"
+              "p-value:projection-endpoints-orderview",
+              "p-value:projection-support-projection-homotopy-report-fixture",
+              "projection:homotopy-report-fixture",
+              "q-value:projection-endpoints-orderview",
+              "q-value:projection-support-projection-homotopy-report-fixture"
             ]
           },
           {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:semantic",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-            "axisFamily": "semantic",
-            "contributionWeight": 1,
-            "contributionValue": 0,
-            "reviewFocus": "review semantic trace mismatch before treating aggregate value as local agreement",
-            "witnessRefs": [
-              "semantic:path-rule:cache-repository-semantic-loop",
-              "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-              "semantic:path-rule:event-projection-direct-read",
-              "semantic:path-rule:nonzero-holonomy-filled-loop",
-              "semantic:path-rule:retry-idempotency-effect"
-            ]
-          },
-          {
-            "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:static",
-            "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+            "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:static",
+            "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
             "axisFamily": "static",
             "contributionWeight": 1,
             "contributionValue": 0,
             "reviewFocus": "review static trace mismatch before treating aggregate value as local agreement",
             "witnessRefs": [
               "atom:cache-read",
-              "atom:repository-read"
+              "atom:event-projection",
+              "atom:repository-read",
+              "p-value:static-endpoints-orderview",
+              "p-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection",
+              "q-value:static-endpoints-orderview",
+              "q-value:static-support-atom-cache-read-atom-repository-read-atom-event-projection"
             ]
           }
         ],
@@ -7325,30 +8229,26 @@
     ],
     "nonzeroMonodromyWitnesses": [
       {
-        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-effect",
-        "defectRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-        "candidateRef": "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect",
+        "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
         "operationPair": [
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed",
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation"
+          "operation:read-through-cache",
+          "operation:read-from-repository"
         ],
         "pathPair": [
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation . operation-delta:repair-obstruction-homotopy-report-fixture-computed",
-          "operation-delta:repair-obstruction-homotopy-report-fixture-computed . operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation"
+          "operation:project-order-event . operation:read-through-cache",
+          "operation:project-order-event . operation:read-from-repository"
         ],
         "axisFamily": "effect",
         "axisRef": "effect ordering / replay / compensation axis",
-        "defectValue": 2,
+        "defectValue": 1,
         "comparedTraceSummary": [
-          "p: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0",
-          "q: effect continuation reads 4 observation ref(s) across 1 operation delta(s) refs=4 missing=0"
+          "p: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+          "q: effect continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
         ],
         "affectedAtomRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:event-projection"
         ],
         "lawRefs": [
           "law:homotopy-report-fixture"
@@ -7357,25 +8257,15 @@
           "sig-axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "add observed compensation / authority / effect atoms only after source review",
-          "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-          "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-          "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-          "split or enrich atoms that currently support the target obstruction"
+          "atom:event-projection"
         ],
         "missingEvidence": [],
-        "coverageBoundary": "covered for selected trace refs; not complete execution semantics",
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
         "suggestedFillerEvidence": [
           "supply filler evidence for effect axis trace disagreement",
           "record whether the two continuation paths preserve selected observations"
@@ -7387,8 +8277,71 @@
           "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
         ],
         "recommendedReviewFocus": [
-          "compare operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation . operation-delta:repair-obstruction-homotopy-report-fixture-computed and operation-delta:repair-obstruction-homotopy-report-fixture-computed . operation-delta:repair-obstruction-homotopy-report-fixture-computed:continuation before treating the operation pair as order-insensitive",
+          "compare operation:project-order-event . operation:read-through-cache and operation:project-order-event . operation:read-from-repository before treating the operation pair as order-insensitive",
           "review effect axis witness refs and missing evidence"
+        ],
+        "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "witnessId": "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-semantic",
+        "defectRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+        "candidateRef": "operation-square:operation-square-evidence-cache-repository-read",
+        "operationPair": [
+          "operation:read-through-cache",
+          "operation:read-from-repository"
+        ],
+        "pathPair": [
+          "operation:project-order-event . operation:read-through-cache",
+          "operation:project-order-event . operation:read-from-repository"
+        ],
+        "axisFamily": "semantic",
+        "axisRef": "semantic axis",
+        "defectValue": 1,
+        "comparedTraceSummary": [
+          "p: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0",
+          "q: semantic continuation reads 1 observation ref(s) across 1 operation delta(s) refs=1 missing=0"
+        ],
+        "affectedAtomRefs": [
+          "semantic:path-rule:cache-repository-semantic-loop"
+        ],
+        "lawRefs": [
+          "law:homotopy-report-fixture"
+        ],
+        "signatureAxisRefs": [
+          "sig-axis:homotopy-report-fixture"
+        ],
+        "sourceRefs": [
+          "src-cache-read",
+          "src-repository-read",
+          "test-homotopy-fillers"
+        ],
+        "observationRefs": [
+          "semantic:path-rule:cache-repository-semantic-loop"
+        ],
+        "missingEvidence": [],
+        "coverageBoundary": "covered for selected comparable continuation values; not complete execution semantics",
+        "suggestedFillerEvidence": [
+          "supply filler evidence for semantic axis trace disagreement",
+          "record whether the two continuation paths preserve selected observations"
+        ],
+        "suggestedLiftingEvidence": [
+          "check whether the local witness lifts from ArchMap observation refs to the intended boundary operation"
+        ],
+        "suggestedBoundaryEvidence": [
+          "identify the boundary, adapter, authority, or effect surface where the order-sensitive witness appears"
+        ],
+        "recommendedReviewFocus": [
+          "compare operation:project-order-event . operation:read-through-cache and operation:project-order-event . operation:read-from-repository before treating the operation pair as order-insensitive",
+          "review semantic axis witness refs and missing evidence"
         ],
         "evidenceBoundary": "nonzero monodromy witness is a measured review cue; it is not automatic repair safety or merge safety",
         "nonConclusions": [
@@ -7412,18 +8365,20 @@
         "featureScopeRef": "homotopy-report-fixture-archmap:feature",
         "mixedSubconfigurationRefs": [
           "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
           "obstruction:homotopy-report-fixture:computed",
+          "repair:obstruction-homotopy-report-fixture-computed",
           "split-readiness:molecule-homotopy-report-fixture"
         ],
         "coreLocalReadingRefs": [
           "obstruction:homotopy-report-fixture:computed"
         ],
-        "featureLocalReadingRefs": [],
+        "featureLocalReadingRefs": [
+          "obstruction:homotopy-report-fixture:computed"
+        ],
         "boundarySupportRefs": [
           "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
           "obstruction:homotopy-report-fixture:computed",
+          "repair:obstruction-homotopy-report-fixture-computed",
           "split-readiness:molecule-homotopy-report-fixture"
         ],
         "holonomyAxes": [
@@ -7435,6 +8390,7 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "atom:cache-read",
+              "atom:event-projection",
               "atom:repository-read"
             ],
             "missingEvidence": [],
@@ -7443,27 +8399,32 @@
           {
             "holonomyAxisRef": "Hol_contract",
             "axisFamily": "contract",
-            "status": "coveredZeroResidual",
+            "status": "coverageBlocked",
             "residualValue": 0,
             "measuredDefectRefs": [],
             "supportRefs": [
-              "atom:coupon-tax-rounding"
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
             ],
-            "missingEvidence": [],
+            "missingEvidence": [
+              "missing comparable p continuation value for contract",
+              "missing comparable q continuation value for contract",
+              "missing contract observation for operation-square:operation-square-evidence-cache-repository-read"
+            ],
             "reading": "Hol_contract records boundary-local residual obstruction on the contract axis"
           },
           {
             "holonomyAxisRef": "Hol_semantic",
             "axisFamily": "semantic",
-            "status": "coveredZeroResidual",
-            "residualValue": 0,
-            "measuredDefectRefs": [],
+            "status": "measuredResidual",
+            "residualValue": 1,
+            "measuredDefectRefs": [
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
+            ],
             "supportRefs": [
-              "semantic:path-rule:cache-repository-semantic-loop",
-              "semantic:path-rule:coupon-tax-rounding-semantic-loop",
-              "semantic:path-rule:event-projection-direct-read",
-              "semantic:path-rule:nonzero-holonomy-filled-loop",
-              "semantic:path-rule:retry-idempotency-effect"
+              "semantic:path-rule:cache-repository-semantic-loop"
             ],
             "missingEvidence": [],
             "reading": "Hol_semantic records boundary-local residual obstruction on the semantic axis"
@@ -7476,12 +8437,14 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
               "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
               "split-readiness:molecule-homotopy-report-fixture"
             ],
             "missingEvidence": [
-              "missing state observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing comparable p continuation value for state",
+              "missing comparable q continuation value for state",
+              "missing state observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
             "reading": "Hol_state records boundary-local residual obstruction on the state axis"
           },
@@ -7489,16 +8452,12 @@
             "holonomyAxisRef": "Hol_effect",
             "axisFamily": "effect",
             "status": "measuredResidual",
-            "residualValue": 2,
+            "residualValue": 1,
             "measuredDefectRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect"
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
             ],
             "supportRefs": [
-              "add observed compensation / authority / effect atoms only after source review",
-              "derived-effect-order:p:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-operation-delta-repair-obstruction-homotopy-report-fixture-computed",
-              "derived-effect-order:q:operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation",
-              "obstruction:homotopy-report-fixture:computed may decrease or move to a runtime/state/effect axis",
-              "split or enrich atoms that currently support the target obstruction"
+              "atom:event-projection"
             ],
             "missingEvidence": [],
             "reading": "Hol_effect records boundary-local residual obstruction on the effect axis"
@@ -7506,13 +8465,20 @@
           {
             "holonomyAxisRef": "Hol_authority",
             "axisFamily": "authority",
-            "status": "coveredZeroResidual",
+            "status": "coverageBlocked",
             "residualValue": 0,
             "measuredDefectRefs": [],
             "supportRefs": [
-              "atom:authorization-bypass"
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
             ],
-            "missingEvidence": [],
+            "missingEvidence": [
+              "missing authority observation for operation-square:operation-square-evidence-cache-repository-read",
+              "missing comparable p continuation value for authority",
+              "missing comparable q continuation value for authority"
+            ],
             "reading": "Hol_authority records boundary-local residual obstruction on the authority axis"
           },
           {
@@ -7523,12 +8489,14 @@
             "measuredDefectRefs": [],
             "supportRefs": [
               "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
               "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
               "split-readiness:molecule-homotopy-report-fixture"
             ],
             "missingEvidence": [
-              "missing runtime observation for operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+              "missing comparable p continuation value for runtime",
+              "missing comparable q continuation value for runtime",
+              "missing runtime observation for operation-square:operation-square-evidence-cache-repository-read"
             ],
             "reading": "Hol_runtime records boundary-local residual obstruction on the runtime axis"
           },
@@ -7547,9 +8515,10 @@
         ],
         "residualObstructionRefs": [
           "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-          "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
           "obstruction:homotopy-report-fixture:computed",
+          "repair:obstruction-homotopy-report-fixture-computed",
           "split-readiness:molecule-homotopy-report-fixture"
         ],
         "supportSeparationPolicy": "core-local, feature-local, and mixed boundary support are separated as review attribution surfaces, not as a proved direct-sum decomposition",
@@ -7561,7 +8530,7 @@
           "selected LawPolicy exactness assumptions"
         ],
         "attributionPolicy": "multi-label attribution may name core, feature, boundary, law, and coverage contributors without selecting a single cause",
-        "coverageBoundary": "extension formula is computed over current ArchMap state, not an actual PR diff",
+        "coverageBoundary": "extension formula is computed from witness refs over current ArchMap state, not text matching or an actual PR diff",
         "exactnessBoundary": "Boundary(A,f) residual is measured over current ArchMap evidence and does not prove Ob(B)=Ob(A)+Ob(f)+Hol(Boundary(A,f))",
         "evidenceBoundary": "feature boundary residual is a bounded ArchSig review reading, not a theorem about feature safety or danger",
         "nonConclusions": [
@@ -7593,8 +8562,10 @@
           },
           {
             "axis": "featureLocalObstruction",
-            "status": "unmeasuredOrAbsent",
-            "refs": [],
+            "status": "observed",
+            "refs": [
+              "obstruction:homotopy-report-fixture:computed"
+            ],
             "reading": "featureLocalObstruction is classified as a current-state extension coordinate"
           },
           {
@@ -7603,9 +8574,10 @@
             "refs": [
               "feature-boundary-residual:homotopy-report-fixture-archmap",
               "gap:path-rule:authorization-bypass-hole:missing-policy-test",
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-              "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
               "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
               "split-readiness:molecule-homotopy-report-fixture"
             ],
             "reading": "boundaryHolonomy is classified as a current-state extension coordinate"
@@ -7630,7 +8602,7 @@
             "axis": "complexityTransfer",
             "status": "observed",
             "refs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+              "repair:obstruction-homotopy-report-fixture-computed"
             ],
             "reading": "complexityTransfer is classified as a current-state extension coordinate"
           },
@@ -7649,6 +8621,17 @@
             "labels": [
               "boundaryHolonomy"
             ],
+            "observationRefs": [
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "doc-auth-policy"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
@@ -7666,6 +8649,17 @@
               "boundaryHolonomy",
               "residualCoverageGap"
             ],
+            "observationRefs": [
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "doc-auth-policy"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
@@ -7680,51 +8674,92 @@
             "reading": "gap:path-rule:authorization-bypass-hole:missing-policy-test carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"residualCoverageGap\"]"
           },
           {
-            "witnessRef": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-            "labels": [
-              "boundaryHolonomy",
-              "complexityTransfer"
-            ],
-            "inheritedCoreRefs": [],
-            "featureLocalRefs": [],
-            "boundaryHolonomyRefs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-            ],
-            "liftingFailureRefs": [],
-            "fillingFailureRefs": [],
-            "complexityTransferRefs": [
-              "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
-            ],
-            "residualCoverageGapRefs": [],
-            "reading": "may transfer obstruction into runtime behavior, ownership, or idempotency boundary carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
-          },
-          {
-            "witnessRef": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
+            "witnessRef": "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
             "labels": [
               "boundaryHolonomy"
             ],
+            "observationRefs": [
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "doc-auth-policy"
+            ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
             "boundaryHolonomyRefs": [
-              "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect"
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
             ],
             "liftingFailureRefs": [],
             "fillingFailureRefs": [],
             "complexityTransferRefs": [],
             "residualCoverageGapRefs": [],
-            "reading": "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+            "reading": "mu:operation-square-operation-square-evidence-cache-repository-read:effect carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
+          },
+          {
+            "witnessRef": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+            "labels": [
+              "boundaryHolonomy"
+            ],
+            "observationRefs": [
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "doc-auth-policy"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [],
+            "residualCoverageGapRefs": [],
+            "reading": "mu:operation-square-operation-square-evidence-cache-repository-read:semantic carries non-disjoint feature-extension labels [\"boundaryHolonomy\"]"
           },
           {
             "witnessRef": "obstruction:homotopy-report-fixture:computed",
             "labels": [
               "boundaryHolonomy",
+              "featureLocalObstruction",
               "fillingFailure",
               "inheritedCoreObstruction"
+            ],
+            "observationRefs": [
+              "atom:authorization-bypass",
+              "atom:cache-read",
+              "atom:coupon-tax-rounding",
+              "atom:repository-read",
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "molecule-reading:molecule-homotopy-report-fixture",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "src-auth-bypass",
+              "src-cache-read",
+              "src-pricing-checkout",
+              "src-repository-read"
             ],
             "inheritedCoreRefs": [
               "obstruction:homotopy-report-fixture:computed"
             ],
-            "featureLocalRefs": [],
+            "featureLocalRefs": [
+              "obstruction:homotopy-report-fixture:computed"
+            ],
             "boundaryHolonomyRefs": [
               "obstruction:homotopy-report-fixture:computed"
             ],
@@ -7734,13 +8769,63 @@
             ],
             "complexityTransferRefs": [],
             "residualCoverageGapRefs": [],
-            "reading": "obstruction:homotopy-report-fixture:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+            "reading": "obstruction:homotopy-report-fixture:computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"featureLocalObstruction\", \"fillingFailure\", \"inheritedCoreObstruction\"]"
+          },
+          {
+            "witnessRef": "repair:obstruction-homotopy-report-fixture-computed",
+            "labels": [
+              "boundaryHolonomy",
+              "complexityTransfer"
+            ],
+            "observationRefs": [
+              "atom:authorization-bypass",
+              "atom:cache-read",
+              "atom:coupon-tax-rounding",
+              "atom:repository-read",
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "molecule-reading:molecule-homotopy-report-fixture",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "src-auth-bypass",
+              "src-cache-read",
+              "src-pricing-checkout",
+              "src-repository-read"
+            ],
+            "inheritedCoreRefs": [],
+            "featureLocalRefs": [],
+            "boundaryHolonomyRefs": [
+              "repair:obstruction-homotopy-report-fixture-computed"
+            ],
+            "liftingFailureRefs": [],
+            "fillingFailureRefs": [],
+            "complexityTransferRefs": [
+              "repair:obstruction-homotopy-report-fixture-computed"
+            ],
+            "residualCoverageGapRefs": [],
+            "reading": "repair:obstruction-homotopy-report-fixture-computed carries non-disjoint feature-extension labels [\"boundaryHolonomy\", \"complexityTransfer\"]"
           },
           {
             "witnessRef": "split-readiness:molecule-homotopy-report-fixture",
             "labels": [
               "boundaryHolonomy",
               "liftingFailure"
+            ],
+            "observationRefs": [
+              "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+              "molecule:homotopy-report-fixture",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+              "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+              "obstruction:homotopy-report-fixture:computed",
+              "repair:obstruction-homotopy-report-fixture-computed",
+              "split-readiness:molecule-homotopy-report-fixture"
+            ],
+            "sourceRefs": [
+              "test-homotopy-fillers"
             ],
             "inheritedCoreRefs": [],
             "featureLocalRefs": [],
@@ -7766,7 +8851,7 @@
           "obstruction:homotopy-report-fixture:computed"
         ],
         "complexityTransferRefs": [
-          "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+          "repair:obstruction-homotopy-report-fixture-computed"
         ],
         "classificationBoundary": "feature-extension labels are intentionally non-disjoint; the same witness may carry inherited-core, feature-local, boundary-holonomy, lifting, filling, complexity-transfer, and coverage-gap labels",
         "fieldsigBoundary": "ArchSig reports current-state feature-extension attribution; FieldSig owns longitudinal evolution quality analysis",
@@ -7784,7 +8869,11 @@
     ],
     "monodromyReadingFamily": {
       "readingFamilyId": "monodromy-reading-family:measurement-homotopy-report-fixture",
-      "status": "schemaFoundationOnly",
+      "status": "partial",
+      "measuredAxisCount": 4,
+      "unmeasuredAxisCount": 4,
+      "positiveWitnessCount": 2,
+      "coverageBlockerCount": 12,
       "archMapStoreRefSetRef": "archmap-store-refs:homotopy-report-fixture-archmap",
       "selectedAxisRefs": [
         "axis:homotopy-report-fixture"
@@ -7793,21 +8882,21 @@
       "weightPolicy": "unit weights until project-specific calibration is declared",
       "coveragePolicy": "coverage gaps block signature-zero and spectrum-zero reflection",
       "operationSquareCandidateRefs": [
-        "operation-square:operation-delta-repair-obstruction-homotopy-report-fixture-computed:operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation"
+        "operation-square:operation-square-evidence-cache-repository-read"
       ],
       "pathContinuationTraceRefs": [
-        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:p",
-        "path-continuation-trace:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:q"
+        "path-continuation-trace:operation-square-operation-square-evidence-cache-repository-read:p",
+        "path-continuation-trace:operation-square-operation-square-evidence-cache-repository-read:q"
       ],
       "axisWiseDefectRefs": [
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:authority",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:contract",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:effect",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:projection",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:runtime",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:semantic",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:state",
-        "mu:operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation:static"
+        "mu:operation-square-operation-square-evidence-cache-repository-read:authority",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:contract",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:projection",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:runtime",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:semantic",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:state",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:static"
       ],
       "amiAggregateReadingRefs": [
         "ami:measurement-homotopy-report-fixture"
@@ -7827,7 +8916,11 @@
     },
     "boundaryHolonomyReadingFamily": {
       "readingFamilyId": "boundary-holonomy-reading-family:measurement-homotopy-report-fixture",
-      "status": "schemaFoundationOnly",
+      "status": "partial",
+      "measuredAxisCount": 4,
+      "unmeasuredAxisCount": 4,
+      "positiveWitnessCount": 4,
+      "coverageBlockerCount": 13,
       "archMapStoreRefSetRef": "archmap-store-refs:homotopy-report-fixture-archmap",
       "selectedAxisRefs": [
         "axis:homotopy-report-fixture"
@@ -7836,7 +8929,8 @@
       "weightPolicy": "unit weights until project-specific calibration is declared",
       "coveragePolicy": "coverage gaps block signature-zero and spectrum-zero reflection",
       "nonzeroMonodromyWitnessRefs": [
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-effect"
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect",
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-semantic"
       ],
       "featureBoundaryResidualRefs": [
         "feature-boundary-residual:homotopy-report-fixture-archmap"
@@ -8057,8 +9151,8 @@
         ]
       },
       {
-        "readingId": "representation-strength:analytic-spectral-radius-proxy",
-        "sourceReadingRef": "analytic:spectral-radius-proxy",
+        "readingId": "representation-strength:analytic-spectral-radius",
+        "sourceReadingRef": "analytic:spectral-radius",
         "representationFamily": "spectralRadius",
         "zeroPreserving": "supported",
         "zeroReflecting": "blockedByCoverageGap",
@@ -8178,6 +9272,39 @@
         ],
         "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
         "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+        "nonConclusions": [
+          "ArchSig analysis packet is not a Lean theorem proof",
+          "ArchSig analysis packet is not global architecture truth",
+          "ArchSig analysis packet does not prove source extraction completeness",
+          "signature axes are law-policy-relative, not universal quality scores",
+          "flatness reading is blocked by coverage gaps and exactness assumptions",
+          "repair operation candidates are not automatic safe refactorings",
+          "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+        ]
+      },
+      {
+        "readingId": "representation-strength:spectral-relation-atom-adjacency",
+        "sourceReadingRef": "spectral:relation-atom-adjacency",
+        "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+        "zeroPreserving": "supported",
+        "zeroReflecting": "blockedByCoverageGap",
+        "obstructionPreserving": "supported",
+        "obstructionReflecting": "notAnEigenvalueTheorem",
+        "aggregateZeroSafety": "notAggregate",
+        "cancellationRisk": "finiteMatrixMayHideUnobservedComponents",
+        "requiredAssumptions": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test",
+          "witness completeness for selected LawPolicy",
+          "signature axis exactness for selected readings"
+        ],
+        "blockedBy": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "blockedReflectionOrPreservationReasons": [
+          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        ],
+        "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+        "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -8547,7 +9674,7 @@
     "structuralReadingReviewSurface": {
       "surfaceId": "aat-structural-reading-review-surface",
       "status": "needsReview",
-      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1",
+      "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
       "connectedReadingRefs": [
         "representationStrength:weightedAdjacencyMatrix",
         "representationStrength:reachableConeSize",
@@ -8571,6 +9698,12 @@
         "homotopy-order-sensitivity:selected-operations",
         "diagram-fillability:local-curvature-obstruction-homotopy-report-fixture-computed",
         "axis-forgetting-risk:selected-projection",
+        "observation-projection-fidelity:observation-projection-homotopy-report-fixture-archmap",
+        "atom-origin-closure-debt:homotopy-report-fixture-archmap",
+        "effect-relation-algebra:homotopy-report-fixture-archmap",
+        "synthesis-blockage:homotopy-report-fixture-archmap",
+        "operation-precondition-readiness:repair-obstruction-homotopy-report-fixture-computed",
+        "path-multiplicity-loss:homotopy-report-fixture-archmap",
         "signature-trajectory-homotopy-refutation:selected-trajectory",
         "bridge-split-obstruction-transfer:split-readiness-molecule-homotopy-report-fixture"
       ],
@@ -8579,6 +9712,10 @@
         "read LawUniverse coverage and witness exactness before treating absence as measured zero",
         "read feature extension, operation law, trajectory, homotopy, and diagram-fillability axes as current-state coordinates, not PR evolution claims",
         "read axis-forgetting risk before treating a coarse projection as zero-reflecting or obstruction-reflecting",
+        "read projection fidelity and Atom origin closure before using summaries for zero, repair, or synthesis claims",
+        "read effect relation algebra separately from state transition pressure before approving replay, provider, event, or handler boundaries",
+        "read synthesis blockage and operation precondition readiness before treating candidates as constructible or safe",
+        "read path multiplicity loss before treating one observed route as complete reachability",
         "read selected trajectory disagreement before treating same-endpoint operations as homotopic",
         "read bridge split transfer before treating a boundary operation as obstruction removal",
         "read representation-strength blockers before treating zero or obstruction absence as exact",
@@ -9566,24 +10703,26 @@
         "sig-axis:homotopy-report-fixture=1 (coverage-gap-preserved)"
       ],
       "analyticReadingsSummary": [
-        "weightedAdjacencyMatrix=9x9; edgeCount=2 (measured)",
-        "reachableConeSize=11 (measured)",
-        "walkCount=3 (measured)",
+        "weightedAdjacencyMatrix=3x3; edgeCount=2 (measured)",
+        "reachableConeSize=2 (measured)",
+        "walkCount=2 (measured)",
         "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
-        "selectedSubgraphSpectrum=[0.222] (measured)",
+        "selectedSubgraphSpectrum=[0.000] (measured)",
         "propagationDepth=1 (measured)",
-        "spectralRadius=0.222 (measured)",
+        "spectralRadius=0.000 (measured)",
         "curvatureValuation=1 (measured)",
         "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (needsReview)",
         "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
       ],
       "spectralReadingsSummary": [
+        "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=3x3 (needsReview)",
         "workflowRiskAxisPressureMatrix upperBound=26.458 shape=1x5 (needsReview)",
         "moleculeAtomOverlapCouplingMatrix upperBound=6.000 shape=1x1 (needsReview)",
         "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x1 (actionable)",
         "operationSignatureDeltaMatrix upperBound=1.000 shape=1x1 (actionable)"
       ],
       "spectralModeSummary": [
+        "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=0.000 localization=0.707 density=0.222 (needsReview)",
         "workflowRiskAxisPressureMatrix distributedPressureMode gap=23.195 localization=1.000 density=1.000 (needsReview)",
         "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=6.000 localization=1.000 density=1.000 (needsReview)",
         "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=1.000 (needsReview)",
@@ -9596,7 +10735,7 @@
         "curvature-support-reading:spectrum-profile-homotopy-report-fixture supports=1 topModes=1 clusters=1 measuredAxes=1 unmeasuredAxes=0 (needsReview)"
       ],
       "curvatureTransferSummary": [
-        "curvature-transfer-reading:spectrum-profile-homotopy-report-fixture edges=1 recurrentModes=1 rho=1 (needsReview)"
+        "curvature-transfer-reading:spectrum-profile-homotopy-report-fixture edges=1 recurrentModes=1 rho=1.000 (needsReview)"
       ],
       "architectureSpectrumReportSummary": [
         "architecture-spectrum-report:spectrum-profile-homotopy-report-fixture hotspots=1 recurrent=1 clusters=1 (needsReview)",
@@ -9607,7 +10746,7 @@
       ],
       "transferBridgeEdgeSummary": [],
       "measurementExpansionSummary": [
-        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
+        "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 2 nonzero monodromy witnesses"
       ],
       "atomSupportAxisSummary": [
         "homotopy-report-fixture-archmap support=5 concentration=maxAxisShare=2/6 pressure=mixedAxisPressurePresent",
@@ -9620,10 +10759,10 @@
         "homotopy-report-fixture-policy required=1 unmeasured=0 blockedWitnesses=1"
       ],
       "featureExtensionFormulaSummary": [
-        "feature-extension-formula:homotopy-report-fixture-archmap status=measured inherited=1 featureLocal=0 interaction=0 residualGaps=1"
+        "feature-extension-formula:homotopy-report-fixture-archmap status=measured inherited=1 featureLocal=1 interaction=1 residualGaps=1"
       ],
       "operationCalculusLawSummary": [
-        "repair:obstruction-homotopy-report-fixture-computed kind=repair-homotopyreportfixturecircuit composition=assumptionRelative repairMonotonicity=selectedAxisOnly boundary=notASynthesisCertificate"
+        "repair:obstruction-homotopy-report-fixture-computed kind=repair-homotopyreportfixturecircuit composition=observed repairMonotonicity=blockedByTransferRisk boundary=notASynthesisCertificate"
       ],
       "pathSignatureTrajectorySummary": [
         "operation-delta:repair-obstruction-homotopy-report-fixture-computed status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=1 transferred=1"
@@ -9637,6 +10776,24 @@
       "axisForgettingRiskSummary": [
         "observation-projection:homotopy-report-fixture-archmap kind=selectedAxisOrWitnessLoss zeroReflection=blockedWithoutAxisPreservationAndWitnessCompleteness obstructionReflection=blockedWithoutAxisPreservationAndWitnessCompleteness mixedScopes=2"
       ],
+      "observationProjectionFidelitySummary": [
+        "observation-projection:homotopy-report-fixture-archmap status=projectionLossObserved forgotten=1 collisions=0 reflection=blockedWithoutAxisPreservationAndWitnessCompleteness"
+      ],
+      "atomOriginClosureDebtSummary": [
+        "atom-origin-closure-debt:homotopy-report-fixture-archmap status=originClosureDebtObserved sourceBacked=6 inferred=0 missingExpected=1"
+      ],
+      "effectRelationAlgebraSummary": [
+        "effect-relation-algebra:homotopy-report-fixture-archmap pressure=effectRelationPressureObserved generators=4 unresolved=0 externalBoundaries=0"
+      ],
+      "synthesisBlockageSummary": [
+        "synthesis-blockage:homotopy-report-fixture-archmap status=synthesisBlockedByMissingEvidenceOrConstraints targets=2 constraints=7 missing=5 noSolution=notASolverAndNotAbsenceProof"
+      ],
+      "operationPreconditionReadinessSummary": [
+        "repair:obstruction-homotopy-report-fixture-computed kind=repair-homotopyreportfixturecircuit status=blockedByMissingPreconditionEvidence missing=8 witnesses=1"
+      ],
+      "pathMultiplicityLossSummary": [
+        "homotopy-report-fixture-archmap status=reachabilityMultiplicityLossObserved paths=1 alternatePressure=8 fanIn=1 forgotten=1"
+      ],
       "signatureTrajectoryHomotopyRefutationSummary": [
         "homotopy-order-sensitivity:selected-operations equivalence=selectedTrajectoryDisagreementObserved refutation=refutationCandidate disagreements=1"
       ],
@@ -9644,13 +10801,14 @@
         "split-readiness:molecule-homotopy-report-fixture transferRisk=needsObstructionSupportReview bridgeEdges=0 obstructions=1 boundaryOps=1"
       ],
       "nonzeroMonodromyWitnessSummary": [
-        "nonzero-monodromy-witness:mu-operation-square-operation-delta-repair-obstruction-homotopy-report-fixture-computed-operation-delta-repair-obstruction-homotopy-report-fixture-computed-continuation-effect axis=effect defect=2 affectedAtoms=5 missingEvidence=0 focus=2"
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-effect axis=effect defect=1 affectedAtoms=1 missingEvidence=0 focus=2",
+        "nonzero-monodromy-witness:mu-operation-square-operation-square-evidence-cache-repository-read-semantic axis=semantic defect=1 affectedAtoms=1 missingEvidence=0 focus=2"
       ],
       "featureBoundaryResidualSummary": [
-        "feature-boundary-residual:homotopy-report-fixture-archmap boundary=Boundary(homotopy-report-fixture-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=5"
+        "feature-boundary-residual:homotopy-report-fixture-archmap boundary=Boundary(homotopy-report-fixture-archmap, feature-extension) status=measuredResidual axes=8 residualRefs=6"
       ],
       "featureExtensionDiagnosisSummary": [
-        "feature-extension-diagnosis:feature-extension-formula-homotopy-report-fixture-archmap status=multiLabelAttributed attributions=6 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
+        "feature-extension-diagnosis:feature-extension-formula-homotopy-report-fixture-archmap status=multiLabelAttributed attributions=7 multiLabel=4 coverageGaps=1 lifting=1 filling=1 complexity=1"
       ],
       "representationStrengthSummary": [
         "weightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
@@ -9663,6 +10821,7 @@
         "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
         "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
         "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+        "relationAtomWeightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
         "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
@@ -9687,8 +10846,8 @@
         "molecule:homotopy-report-fixture status=needsReview score=92 boundaryOp=interface"
       ],
       "structuralReadingReviewSummary": [
-        "aat-structural-reading-review-surface status=needsReview refs=24 focus=12",
-        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting risk, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, homotopyRefutations=1, bridgeTransfers=1"
+        "aat-structural-reading-review-surface status=needsReview refs=30 focus=16",
+        "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=0, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
       ],
       "currentStateEvolutionBoundarySummary": [
         "ArchSig computes current AAT structural state from ArchMap homotopy-report-fixture-archmap and LawPolicy homotopy-report-fixture-policy; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",
@@ -9760,8 +10919,8 @@
     "analyticRepresentationCount": 10,
     "couplingCohesionReadingCount": 4,
     "workflowRiskReadingCount": 1,
-    "spectralAnalysisReadingCount": 4,
-    "spectralModeReadingCount": 4,
+    "spectralAnalysisReadingCount": 5,
+    "spectralModeReadingCount": 5,
     "spectralDrilldownReadingCount": 1,
     "curvatureSupportReadingCount": 1,
     "curvatureTransferReadingCount": 1,
@@ -9775,9 +10934,15 @@
     "homotopyOrderSensitivityReadingCount": 1,
     "diagramFillabilityReadingCount": 1,
     "axisForgettingRiskReadingCount": 1,
+    "observationProjectionFidelityReadingCount": 1,
+    "atomOriginClosureDebtReadingCount": 1,
+    "effectRelationAlgebraReadingCount": 1,
+    "synthesisBlockageReadingCount": 1,
+    "operationPreconditionReadinessReadingCount": 1,
+    "pathMultiplicityLossReadingCount": 1,
     "signatureTrajectoryHomotopyRefutationReadingCount": 1,
     "bridgeSplitObstructionTransferReadingCount": 1,
-    "representationStrengthReadingCount": 14,
+    "representationStrengthReadingCount": 15,
     "localCurvatureDiagramReadingCount": 1,
     "threeLayerFlatnessReadingCount": 1,
     "observationProjectionReadingCount": 1,
@@ -9853,7 +11018,7 @@
     },
     {
       "id": "archsig-analysis-packet-spectral-analysis-surface",
-      "title": "packet exposes AAT spectral readings as bounded finite-representation proxies",
+      "title": "packet exposes AAT spectral readings as bounded finite relation and measurement representations",
       "result": "pass",
       "count": 0
     },

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -379,7 +379,7 @@
         "analytic:nilpotence-boundary",
         "analytic:selected-subgraph-spectrum",
         "analytic:propagation-depth",
-        "analytic:spectral-radius-proxy",
+        "analytic:spectral-radius",
         "analytic:curvature-valuation",
         "analytic:state-algebra-boundary",
         "analytic:zero-reflecting-aggregate-boundary"
@@ -751,18 +751,47 @@
       "representationFamily": "weightedAdjacencyMatrix",
       "status": "measured",
       "valueType": "matrixShape",
-      "value": "4x4; edgeCount=1",
+      "value": "2x2; edgeCount=1",
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
       "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:relation:route-service"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "selected relation atoms induce a bounded weighted adjacency representation",
+      "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -780,18 +809,47 @@
       "representationFamily": "reachableConeSize",
       "status": "measured",
       "valueType": "nat",
-      "value": "5",
+      "value": "1",
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
       "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:relation:route-service"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "reachable cone is a bounded graph proxy over observed object refs and relation atoms",
+      "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -809,18 +867,47 @@
       "representationFamily": "walkCount",
       "status": "measured",
       "valueType": "nat",
-      "value": "2",
+      "value": "1",
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
       "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:relation:route-service"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "walk count is a bounded proxy from observed relation atoms and molecule paths",
+      "reading": "walk count enumerates selected relation-graph walks up to length 3",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -839,17 +926,44 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "blockedByCoverageGap",
-      "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
       ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
+      "graphScopeRefs": [],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "nilpotence is represented as a boundary condition, not folded into Decomposable or global acyclicity",
+      "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -867,18 +981,47 @@
       "representationFamily": "selectedSubgraphSpectrum",
       "status": "measured",
       "valueType": "vector",
-      "value": "[0.250]",
+      "value": "[0.000]",
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
       "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:relation:route-service"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "selected subgraph spectrum records the bounded spectrum vector for the observed relation subgraph",
+      "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -897,11 +1040,40 @@
       "status": "measured",
       "valueType": "nat",
       "value": "1",
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
       "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:relation:route-service"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
@@ -921,22 +1093,51 @@
       ]
     },
     {
-      "representationId": "analytic:spectral-radius-proxy",
+      "representationId": "analytic:spectral-radius",
       "representationFamily": "spectralRadius",
       "status": "measured",
       "valueType": "float",
-      "value": "0.250",
+      "value": "0.000",
+      "selectedGraphNodes": [
+        "route.users",
+        "service.user"
+      ],
+      "selectedGraphEdges": [
+        {
+          "edgeRef": "relation-edge:atom-relation-route-service:route-users:service-user",
+          "sourceRef": "route.users",
+          "targetRef": "service.user",
+          "weight": 1,
+          "relationAtomRef": "atom:relation:route-service",
+          "sourceRefs": [
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "sparseMatrixEntries": [
+        {
+          "rowRef": "route.users",
+          "columnRef": "service.user",
+          "value": 1,
+          "evidenceRefs": [
+            "atom:relation:route-service",
+            "src-route-users",
+            "src-service-user"
+          ]
+        }
+      ],
+      "walkWitnessRefs": [
+        "walk:route-users:1:service-user"
+      ],
       "graphScopeRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:relation:route-service"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "reading": "spectral radius is represented as a bounded proxy until full matrix extraction is supplied",
+      "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
       "nonConclusions": [
@@ -955,6 +1156,10 @@
       "status": "measured",
       "valueType": "nat",
       "value": "1",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "obstruction:semantic-contract-mismatch:computed"
       ],
@@ -981,6 +1186,10 @@
       "status": "unmeasured",
       "valueType": "boundaryStatus",
       "value": "state/effect algebra requires explicit state transition and runtime/effect atoms",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
@@ -1010,6 +1219,10 @@
       "status": "needsReview",
       "valueType": "boundaryStatus",
       "value": "blockedByObservationGaps",
+      "selectedGraphNodes": [],
+      "selectedGraphEdges": [],
+      "sparseMatrixEntries": [],
+      "walkWitnessRefs": [],
       "graphScopeRefs": [
         "gap-runtime-user-db-trace"
       ],
@@ -1293,6 +1506,72 @@
   ],
   "spectralAnalysisReadings": [
     {
+      "spectralReadingId": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "status": "needsReview",
+      "matrixShape": {
+        "rowDomain": "selectedRelationGraphNodes",
+        "columnDomain": "selectedRelationGraphNodes",
+        "rowCount": 2,
+        "columnCount": 2,
+        "nonzeroEntryCount": 1
+      },
+      "entryRule": "entry(i,j) is the number of selected relation atom endpoints from node i to node j",
+      "valueType": "boundedSpectralProxy",
+      "values": [
+        {
+          "name": "maxRowSum",
+          "value": "1",
+          "interpretation": "largest outgoing relation weight"
+        },
+        {
+          "name": "maxColumnSum",
+          "value": "1",
+          "interpretation": "largest incoming relation weight"
+        },
+        {
+          "name": "frobeniusNorm",
+          "value": "1.000",
+          "interpretation": "finite weighted adjacency matrix norm over selected relation atoms"
+        },
+        {
+          "name": "spectralRadius",
+          "value": "0.000",
+          "interpretation": "power-iteration estimate over the finite nonnegative relation adjacency matrix"
+        }
+      ],
+      "dominantComponents": [
+        {
+          "componentRef": "route.users",
+          "componentKind": "relationGraphSourceNode",
+          "value": "1",
+          "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+        },
+        {
+          "componentRef": "service.user",
+          "componentKind": "relationGraphTargetNode",
+          "value": "1",
+          "reading": "largest incoming weighted adjacency column in the selected relation graph"
+        }
+      ],
+      "supportRefs": [
+        "atom:relation:route-service"
+      ],
+      "reading": "AAT analytic graph reading is computed from selected relation atom endpoints as a finite weighted adjacency matrix",
+      "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+      "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
+      "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
       "spectralReadingId": "spectral:workflow-risk-axis-pressure",
       "representationFamily": "workflowRiskAxisPressureMatrix",
       "status": "needsReview",
@@ -1548,6 +1827,57 @@
   ],
   "spectralModeReadings": [
     {
+      "spectralModeId": "spectral-mode:spectral-relation-atom-adjacency",
+      "sourceSpectralReadingRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "status": "needsReview",
+      "modeKind": "boundedSpectralMode",
+      "modeComponents": [
+        {
+          "componentRef": "route.users",
+          "componentKind": "relationGraphSourceNode",
+          "weight": "1",
+          "role": "primaryDominantComponent",
+          "reading": "largest outgoing weighted adjacency row in the selected relation graph"
+        },
+        {
+          "componentRef": "service.user",
+          "componentKind": "relationGraphTargetNode",
+          "weight": "1",
+          "role": "coupledDominantComponent",
+          "reading": "largest incoming weighted adjacency column in the selected relation graph"
+        }
+      ],
+      "spectralGapProxy": {
+        "name": "dominantResidualGapProxy",
+        "value": "1.000",
+        "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
+      },
+      "localizationIndex": {
+        "name": "dominantFrobeniusLocalization",
+        "value": "1.000",
+        "interpretation": "dominant component magnitude divided by Frobenius norm; higher means pressure is more localized"
+      },
+      "matrixDensity": {
+        "name": "nonzeroMatrixDensity",
+        "value": "0.250",
+        "interpretation": "nonzero entries divided by finite matrix capacity; higher means more distributed coupling"
+      },
+      "decomposabilityReading": "mode is relatively localized; decomposition or targeted repair may be reviewable as a local operation",
+      "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
+      "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
+      "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
       "spectralModeId": "spectral-mode:spectral-workflow-risk-axis-pressure",
       "sourceSpectralReadingRef": "spectral:workflow-risk-axis-pressure",
       "representationFamily": "workflowRiskAxisPressureMatrix",
@@ -1750,6 +2080,7 @@
       "drilldownId": "spectral-drilldown:fixture-archmap-atom-observation",
       "status": "needsReview",
       "sourceSpectralModeRefs": [
+        "spectral-mode:spectral-relation-atom-adjacency",
         "spectral-mode:spectral-workflow-risk-axis-pressure",
         "spectral-mode:spectral-molecule-atom-overlap-coupling",
         "spectral-mode:spectral-obstruction-axis-curvature",
@@ -2199,7 +2530,7 @@
       "readingId": "curvature-transfer-reading:spectrum-profile-curvature-transfer-default",
       "profileRef": "spectrum-profile:curvature-transfer-default",
       "status": "needsReview",
-      "measurementStatus": "proxy",
+      "measurementStatus": "measured",
       "readingBoundary": {
         "readingStrength": "boundedMeasuredWithProxyTransfer",
         "zeroReflectionAssumptions": [
@@ -2244,7 +2575,7 @@
         "rowCount": 1,
         "columnCount": 1,
         "nonzeroEdgeCount": 1,
-        "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j under shared selected-axis or shared support evidence",
+        "entryRule": "entry(i,j) is positive when measured curvature support i can transfer review pressure to support j through selected relation-graph evidence or shared selected-axis evidence",
         "spectralRadiusKind": "finiteNonnegativeOperatorBoundedClosedWalkRadius",
         "reading": "finite nonnegative transfer operator over measured curvature supports; absent edges are unmeasured, not proof of independence"
       },
@@ -2287,7 +2618,7 @@
             "witness:semantic-contract-mismatch"
           ],
           "cycleWeight": 1,
-          "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+          "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
           "recurrentObstructionReading": "positive closed walk is reported as recurrent obstruction support only",
           "reviewFocus": [
             "inspect the witness support behind the positive transfer self-loop",
@@ -2301,9 +2632,9 @@
         }
       ],
       "spectralRadiusReading": {
-        "name": "rho(T^kappa)Proxy",
-        "value": "1",
-        "interpretation": "positive proxy is read only as recurrent obstruction support in the finite ArchSig transfer operator, not future incident probability"
+        "name": "rho(T^kappa)",
+        "value": "1.000",
+        "interpretation": "positive value is computed from the finite ArchSig transfer operator and read only as recurrent obstruction support, not future incident probability"
       },
       "coverageBoundary": "missing coverage blocks spectrum zero reflection and remains a report gap",
       "evidenceBoundary": "transfer operator is computed from measured curvature support rows and does not forecast future cost, safety, or amplification",
@@ -2525,7 +2856,7 @@
     "recurrentObstructions": [
       {
         "modeRef": "recurrent-obstruction:curvature-transfer-edge-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency-curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency",
-        "spectralRadiusReading": "rho(T^kappa) proxy bounded closed-walk radius 1 > 0 over the finite ArchSig transfer operator",
+        "spectralRadiusReading": "rho(T^kappa) finite-matrix estimate 1.000 > 0 over the finite ArchSig transfer operator",
         "transferEdgeRefs": [
           "curvature-transfer-edge:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency:curvature-support-witness-semantic-contract-mismatch-axis-semantic-inconsistency"
         ],
@@ -7622,8 +7953,8 @@
       ]
     },
     {
-      "readingId": "representation-strength:analytic-spectral-radius-proxy",
-      "sourceReadingRef": "analytic:spectral-radius-proxy",
+      "readingId": "representation-strength:analytic-spectral-radius",
+      "sourceReadingRef": "analytic:spectral-radius",
       "representationFamily": "spectralRadius",
       "zeroPreserving": "supported",
       "zeroReflecting": "blockedByCoverageGap",
@@ -7743,6 +8074,39 @@
       ],
       "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "readingId": "representation-strength:spectral-relation-atom-adjacency",
+      "sourceReadingRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "zeroPreserving": "supported",
+      "zeroReflecting": "blockedByCoverageGap",
+      "obstructionPreserving": "supported",
+      "obstructionReflecting": "notAnEigenvalueTheorem",
+      "aggregateZeroSafety": "notAggregate",
+      "cancellationRisk": "finiteMatrixMayHideUnobservedComponents",
+      "requiredAssumptions": [
+        "gap-runtime-user-db-trace",
+        "witness completeness for selected LawPolicy",
+        "signature axis exactness for selected readings"
+      ],
+      "blockedBy": [
+        "gap-runtime-user-db-trace"
+      ],
+      "blockedReflectionOrPreservationReasons": [
+        "gap-runtime-user-db-trace"
+      ],
+      "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
+      "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -8099,7 +8463,7 @@
   "structuralReadingReviewSurface": {
     "surfaceId": "aat-structural-reading-review-surface",
     "status": "needsReview",
-    "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
+    "currentStateReading": "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1",
     "connectedReadingRefs": [
       "representationStrength:weightedAdjacencyMatrix",
       "representationStrength:reachableConeSize",
@@ -9115,24 +9479,26 @@
       "sig-axis:semantic-inconsistency=1 (coverage-gap-preserved)"
     ],
     "analyticReadingsSummary": [
-      "weightedAdjacencyMatrix=4x4; edgeCount=1 (measured)",
-      "reachableConeSize=5 (measured)",
-      "walkCount=2 (measured)",
+      "weightedAdjacencyMatrix=2x2; edgeCount=1 (measured)",
+      "reachableConeSize=1 (measured)",
+      "walkCount=1 (measured)",
       "nilpotenceBoundary=blockedByCoverageGap (needsReview)",
-      "selectedSubgraphSpectrum=[0.250] (measured)",
+      "selectedSubgraphSpectrum=[0.000] (measured)",
       "propagationDepth=1 (measured)",
-      "spectralRadius=0.250 (measured)",
+      "spectralRadius=0.000 (measured)",
       "curvatureValuation=1 (measured)",
       "stateAlgebra=state/effect algebra requires explicit state transition and runtime/effect atoms (unmeasured)",
       "zeroReflectingAggregateBoundary=blockedByObservationGaps (needsReview)"
     ],
     "spectralReadingsSummary": [
+      "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=2x2 (needsReview)",
       "workflowRiskAxisPressureMatrix upperBound=10.677 shape=1x5 (needsReview)",
       "moleculeAtomOverlapCouplingMatrix upperBound=4.000 shape=1x1 (needsReview)",
       "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
       "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
     ],
     "spectralModeSummary": [
+      "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=1.000 localization=1.000 density=0.250 (needsReview)",
       "workflowRiskAxisPressureMatrix distributedPressureMode gap=9.434 localization=1.000 density=1.000 (needsReview)",
       "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=4.000 localization=1.000 density=1.000 (needsReview)",
       "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
@@ -9145,7 +9511,7 @@
       "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
     ],
     "curvatureTransferSummary": [
-      "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1 (needsReview)"
+      "curvature-transfer-reading:spectrum-profile-curvature-transfer-default edges=1 recurrentModes=1 rho=1.000 (needsReview)"
     ],
     "architectureSpectrumReportSummary": [
       "architecture-spectrum-report:spectrum-profile-curvature-transfer-default hotspots=4 recurrent=1 clusters=2 (needsReview)",
@@ -9230,6 +9596,7 @@
       "curvatureValuation zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
       "stateAlgebra zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
       "zeroReflectingAggregateBoundary zeroReflecting=blockedByCoverageGap obstructionReflecting=blockedByCoverageGap blockedBy=1",
+      "relationAtomWeightedAdjacencyMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "workflowRiskAxisPressureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "moleculeAtomOverlapCouplingMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
       "obstructionAxisCurvatureMatrix zeroReflecting=blockedByCoverageGap obstructionReflecting=notAnEigenvalueTheorem blockedBy=1",
@@ -9255,7 +9622,7 @@
     ],
     "structuralReadingReviewSummary": [
       "aat-structural-reading-review-surface status=needsReview refs=30 focus=16",
-      "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=14, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
+      "ArchSig reads current architecture state across Atom support and compatibility, LawUniverse coverage, feature extension coordinates, operation calculus laws, path signature trajectory, homotopy order sensitivity, diagram fillability, axis forgetting/projection fidelity, Atom origin closure, effect relation algebra, synthesis blockage, operation preconditions, path multiplicity, trajectory homotopy refutation, bridge split transfer, representation strength, local curvature, three-layer flatness, observation projection, state transition algebra, operation-invariant constraints, and split readiness; blockedRepresentations=15, curvatures=1, blockedOperations=1, splitBlockers=1, atomConflicts=0, unmeasuredRequiredLaws=2, blockedDiagrams=1, axisForgetting=1, projectionLoss=1, atomOriginDebt=1, effectRelationPressure=1, synthesisBlockage=1, operationPreconditionBlockers=1, pathMultiplicityLoss=1, homotopyRefutations=1, bridgeTransfers=1"
     ],
     "currentStateEvolutionBoundarySummary": [
       "ArchSig computes current AAT structural state from ArchMap fixture-archmap-atom-observation and LawPolicy llm-native-aat-law-policy-fixture; it reads atoms, molecules, laws, obstructions, bridge pressure, structural readings, and bounded review focus",


### PR DESCRIPTION
## 概要

Closes #1599

- relation atom の endpoint から selected relation graph を構成し、weighted adjacency / sparse matrix / walk / reachable cone / cycle / propagation depth / spectral radius を実計算するようにした
- `build_spectral_analysis_readings` に `relationAtomWeightedAdjacencyMatrix` を追加し、source-backed relation adjacency の row / column / Frobenius / spectral radius reading を出すようにした
- curvature transfer の `rho(T^kappa)` を self-loop 最大値 proxy ではなく finite nonnegative matrix の power iteration で計算し、transfer edge に selected relation graph evidence を接続した
- minimal / coupon / homotopy / ACTS validation fixtures を更新し、acyclic graph / multi-node cycle / weighted transfer の回帰テストを追加した

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling implementation / docs tracking.
