### PR TITLE
ArchSigのhomotopy holonomyをsource-backed比較にする

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -345,14 +345,19 @@ The builder:
   `homotopyHolonomyReadings`, `stokesStyleReadings`, and
   `architectureHomotopyReport`. Path-pair and operation-square candidates carry
   first-class operation sequences, endpoint object refs, and generator
-  candidate refs. Continuation traces carry step refs and selected-axis
+  candidate refs. Holonomy value is computed from source-backed continuation
+  comparison inputs: exact path-rule semantic observations, supplied p/q
+  continuation traces, axis-wise `mu_x` defects, filler evidence, and explicit
+  missing filler refs. Path-pair id / path ref string containment is not the
+  value calculator. Continuation traces carry step refs and selected-axis
   continuation states. Axis-wise defects record `mu_x` distance inputs and
   positive witness boundaries, and AMI aggregates name the selected measured
   squares, positive contributors, and zero-weight defects. Filled nonzero
   holonomy loops point reviewers to measured local curvature cells; unfilled
   loops point reviewers to missing contract, test, runtime, policy, or semantic
-  filler evidence. Stokes-style local curvature is measured only when filler
-  evidence is present; holes preserve non-fillability witness refs instead.
+  filler evidence. Stokes-style local curvature is measured only when measured
+  filler evidence and measured nonzero holonomy are present; holes preserve
+  non-fillability witness refs instead.
   Neither case is a theorem discharge, architecture score, future forecast, or
   automatic violation proof.
 - ArchMapStore is the forward history boundary for PR and longitudinal

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -256,6 +256,18 @@ pub fn build_archsig_analysis_packet(
         );
     let bridge_split_obstruction_transfer_readings =
         build_bridge_split_obstruction_transfer_readings(&split_readiness_readings);
+    let operation_square_candidates = build_operation_square_candidates(archmap, &operation_deltas);
+    let path_continuation_traces = build_path_continuation_traces(
+        archmap,
+        law_policy,
+        &operation_square_candidates,
+        &operation_deltas,
+    );
+    let axis_wise_monodromy_defects = build_axis_wise_monodromy_defects(
+        law_policy,
+        &operation_square_candidates,
+        &path_continuation_traces,
+    );
     let homotopy_complex_summary = build_homotopy_complex_summary(archmap, law_policy);
     let path_pair_candidates = build_path_pair_candidates(
         archmap,
@@ -280,6 +292,8 @@ pub fn build_archsig_analysis_packet(
         &path_pair_candidates,
         &filler_candidate_readings,
         &architectural_hole_readings,
+        &path_continuation_traces,
+        &axis_wise_monodromy_defects,
     );
     let stokes_style_readings = build_stokes_style_readings(
         &homotopy_complex_summary,
@@ -294,18 +308,6 @@ pub fn build_archsig_analysis_packet(
         &architectural_hole_readings,
         &homotopy_holonomy_readings,
         &stokes_style_readings,
-    );
-    let operation_square_candidates = build_operation_square_candidates(archmap, &operation_deltas);
-    let path_continuation_traces = build_path_continuation_traces(
-        archmap,
-        law_policy,
-        &operation_square_candidates,
-        &operation_deltas,
-    );
-    let axis_wise_monodromy_defects = build_axis_wise_monodromy_defects(
-        law_policy,
-        &operation_square_candidates,
-        &path_continuation_traces,
     );
     let ami_aggregate_readings =
         build_ami_aggregate_readings(law_policy, &axis_wise_monodromy_defects);
@@ -9697,11 +9699,13 @@ fn build_path_pair_candidates(
 
     if let Some(profile) = law_policy.homotopy_measurement_profile.as_ref() {
         candidates.extend(profile.path_discovery_rules.iter().map(|rule| {
+            let rule_observation_refs = path_rule_observation_refs(archmap, &rule.rule_id);
+            let rule_source_refs =
+                source_refs_for_observation_refs(archmap, &rule_observation_refs);
             let has_rule_gap = archmap.observation_gaps.iter().any(|gap| {
-                text_contains_any(
-                    [&gap.gap_id, &gap.subject_ref, &gap.reason],
-                    [&rule.rule_id, &rule.path_source_kind],
-                )
+                gap.subject_ref == rule.rule_id
+                    || gap.gap_id == rule.rule_id
+                    || gap.subject_ref == rule.path_source_kind
             });
             ArchSigPathPairCandidateV0 {
                 candidate_id: format!("path-pair:{}", stable_id(&rule.rule_id)),
@@ -9741,8 +9745,16 @@ fn build_path_pair_candidates(
                     .map(|atom| atom.atom_observation_id.clone())
                     .collect(),
                 selected_axis_refs: complex.selected_axis_refs.clone(),
-                source_refs: all_archmap_source_ref_labels(archmap),
-                observation_refs: all_atom_refs(archmap),
+                source_refs: if rule_source_refs.is_empty() {
+                    all_archmap_source_ref_labels(archmap)
+                } else {
+                    rule_source_refs
+                },
+                observation_refs: if rule_observation_refs.is_empty() {
+                    vec![rule.rule_id.clone()]
+                } else {
+                    rule_observation_refs
+                },
                 coverage_boundary: profile.coverage_boundary.clone(),
                 evidence_boundary: rule.evidence_boundary.clone(),
                 non_conclusions: strings(&REQUIRED_HOMOTOPY_NON_CONCLUSIONS),
@@ -9750,6 +9762,20 @@ fn build_path_pair_candidates(
         }));
     }
     candidates
+}
+
+fn path_rule_observation_refs(archmap: &ArchMapDocumentV0, rule_id: &str) -> Vec<String> {
+    unique_strings(
+        archmap
+            .semantic_observations
+            .iter()
+            .filter(|semantic| semantic.subject_ref == rule_id)
+            .flat_map(|semantic| {
+                std::iter::once(semantic.semantic_observation_id.clone())
+                    .chain(semantic.atom_observation_refs.iter().cloned())
+                    .chain(semantic.molecule_observation_refs.iter().cloned())
+            }),
+    )
 }
 
 fn build_loop_candidates(
@@ -10022,6 +10048,8 @@ fn build_homotopy_holonomy_readings(
     path_pair_candidates: &[ArchSigPathPairCandidateV0],
     filler_candidate_readings: &[ArchSigFillerCandidateReadingV0],
     architectural_hole_readings: &[ArchSigArchitecturalHoleReadingV0],
+    path_continuation_traces: &[ArchSigPathContinuationTraceV0],
+    axis_wise_monodromy_defects: &[ArchSigAxisWiseMonodromyDefectV0],
 ) -> Vec<ArchSigHomotopyHolonomyReadingV0> {
     let distance_kind = law_policy
         .homotopy_measurement_profile
@@ -10076,6 +10104,17 @@ fn build_homotopy_holonomy_readings(
                     let path_pair_measured = path_pair
                         .map(|candidate| candidate.measurement_status == "measured")
                         .unwrap_or(false);
+                    let comparison = source_backed_continuation_comparison(
+                        archmap,
+                        path_pair,
+                        loop_candidate,
+                        &axis_ref,
+                        &distance_kind,
+                        &filler_refs,
+                        &missing_filler_refs,
+                        path_continuation_traces,
+                        axis_wise_monodromy_defects,
+                    );
                     ArchSigHomotopyHolonomyReadingV0 {
                         reading_id: format!(
                             "homotopy-holonomy:{}:{}",
@@ -10085,65 +10124,34 @@ fn build_homotopy_holonomy_readings(
                         path_pair_ref: loop_candidate.path_pair_ref.clone(),
                         loop_ref: loop_candidate.loop_id.clone(),
                         axis_ref: axis_ref.clone(),
-                        measurement_status: if missing_filler_refs.is_empty()
-                            && path_pair_measured
+                        measurement_status: if !comparison.missing_refs.is_empty()
+                            || !missing_filler_refs.is_empty()
+                        {
+                            "blockedByCoverageGap"
+                        } else if path_pair_measured
                             && loop_candidate.measurement_status == "measured"
+                            && comparison.has_source_backed_inputs
                         {
                             "measured"
-                        } else if missing_filler_refs.is_empty() {
-                            "unmeasured"
                         } else {
-                            "blockedByCoverageGap"
+                            "unmeasured"
                         }
                         .to_string(),
                         reading_boundary: loop_candidate.reading_boundary.clone(),
                         distance_kind: distance_kind.clone(),
-                        value: if missing_filler_refs.is_empty()
-                            && !semantic_observation_matches_path_pair(archmap, path_pair)
-                        {
-                            0
-                        } else {
-                            1
-                        },
-                        compared_continuation_summary: format!(
-                            "{} vs {} on {axis_ref}",
-                            path_pair
-                                .map(|candidate| candidate.p_path_ref.as_str())
-                                .unwrap_or("path:p"),
-                            path_pair
-                                .map(|candidate| candidate.q_path_ref.as_str())
-                                .unwrap_or("path:q")
-                        ),
-                        compared_continuation_refs: path_pair
-                            .map(|candidate| {
-                                vec![
-                                    format!("Cont_{axis_ref}({})", candidate.p_path_ref),
-                                    format!("Cont_{axis_ref}({})", candidate.q_path_ref),
-                                ]
-                            })
-                            .unwrap_or_default(),
-                        distance_input_refs: path_pair
-                            .map(|candidate| {
-                                unique_strings(
-                                    candidate
-                                        .observation_refs
-                                        .iter()
-                                        .chain(loop_candidate.missing_filler_evidence.iter())
-                                        .cloned(),
-                                )
-                            })
-                            .unwrap_or_default(),
-                        mu_defect_refs: vec![format!(
-                            "mu:{}:{}",
-                            stable_id(&loop_candidate.path_pair_ref),
-                            stable_id(&axis_ref)
-                        )],
-                        source_refs: loop_candidate.source_refs.clone(),
-                        observation_refs: path_pair
-                            .map(|candidate| candidate.observation_refs.clone())
-                            .unwrap_or_default(),
+                        value: comparison.value,
+                        compared_continuation_summary: comparison.summary,
+                        compared_continuation_refs: comparison.compared_continuation_refs,
+                        distance_input_refs: comparison.distance_input_refs,
+                        mu_defect_refs: comparison.mu_defect_refs,
+                        source_refs: comparison.source_refs,
+                        observation_refs: comparison.observation_refs,
                         filler_refs,
-                        missing_filler_refs,
+                        missing_filler_refs: unique_strings(
+                            missing_filler_refs
+                                .into_iter()
+                                .chain(comparison.missing_refs.into_iter()),
+                        ),
                         coverage_boundary: loop_candidate.coverage_boundary.clone(),
                         exactness_assumption_status:
                             "bounded selected-axis continuation comparison; not theorem exactness"
@@ -10156,25 +10164,209 @@ fn build_homotopy_holonomy_readings(
         .collect()
 }
 
-fn semantic_observation_matches_path_pair(
+#[derive(Debug, Clone)]
+struct HomotopyContinuationComparison {
+    value: i64,
+    summary: String,
+    compared_continuation_refs: Vec<String>,
+    distance_input_refs: Vec<String>,
+    mu_defect_refs: Vec<String>,
+    source_refs: Vec<String>,
+    observation_refs: Vec<String>,
+    missing_refs: Vec<String>,
+    has_source_backed_inputs: bool,
+}
+
+fn source_backed_continuation_comparison(
     archmap: &ArchMapDocumentV0,
     path_pair: Option<&ArchSigPathPairCandidateV0>,
-) -> bool {
+    loop_candidate: &ArchSigLoopCandidateV0,
+    axis_ref: &str,
+    distance_kind: &str,
+    filler_refs: &[String],
+    missing_filler_refs: &[String],
+    path_continuation_traces: &[ArchSigPathContinuationTraceV0],
+    axis_wise_monodromy_defects: &[ArchSigAxisWiseMonodromyDefectV0],
+) -> HomotopyContinuationComparison {
     let Some(path_pair) = path_pair else {
-        return false;
+        return HomotopyContinuationComparison {
+            value: 0,
+            summary: format!(
+                "missing path pair for {} on {axis_ref}",
+                loop_candidate.loop_id
+            ),
+            compared_continuation_refs: Vec::new(),
+            distance_input_refs: Vec::new(),
+            mu_defect_refs: Vec::new(),
+            source_refs: loop_candidate.source_refs.clone(),
+            observation_refs: Vec::new(),
+            missing_refs: vec![format!(
+                "missing path pair {}",
+                loop_candidate.path_pair_ref
+            )],
+            has_source_backed_inputs: false,
+        };
     };
-    archmap.semantic_observations.iter().any(|semantic| {
-        text_matches_candidate(
-            path_pair,
-            [
-                &semantic.semantic_observation_id,
-                &semantic.semantic_family,
-                &semantic.subject_ref,
-                &semantic.predicate,
-                &semantic.evidence_boundary,
-            ],
-        )
-    })
+
+    let semantic_observations = semantic_observations_for_path_pair(archmap, path_pair);
+    let semantic_refs = semantic_observations
+        .iter()
+        .map(|semantic| semantic.semantic_observation_id.clone())
+        .collect::<Vec<_>>();
+    let semantic_atom_refs = semantic_observations
+        .iter()
+        .flat_map(|semantic| semantic.atom_observation_refs.iter().cloned())
+        .collect::<Vec<_>>();
+    let semantic_source_refs = semantic_observations
+        .iter()
+        .flat_map(|semantic| semantic.source_refs.iter().map(source_ref_label))
+        .collect::<Vec<_>>();
+    let path_observation_set = path_pair
+        .observation_refs
+        .iter()
+        .chain(semantic_refs.iter())
+        .chain(semantic_atom_refs.iter())
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let related_trace_axes = path_continuation_traces
+        .iter()
+        .filter(|trace| {
+            trace
+                .observation_refs
+                .iter()
+                .any(|observation| path_observation_set.contains(observation.as_str()))
+        })
+        .flat_map(|trace| {
+            trace.axis_traces.iter().filter(|axis| {
+                axis.axis_ref == axis_ref
+                    || axis_ref.contains(&axis.axis_family)
+                    || axis.axis_family == "semantic"
+            })
+        })
+        .collect::<Vec<_>>();
+    let related_defects = axis_wise_monodromy_defects
+        .iter()
+        .filter(|defect| {
+            defect
+                .observation_refs
+                .iter()
+                .any(|observation| path_observation_set.contains(observation.as_str()))
+        })
+        .collect::<Vec<_>>();
+    let positive_defect_refs = related_defects
+        .iter()
+        .filter(|defect| defect.distance_value.unwrap_or_default() > 0)
+        .map(|defect| defect.defect_id.clone())
+        .collect::<Vec<_>>();
+    let trace_value_refs = related_trace_axes
+        .iter()
+        .flat_map(|axis| axis.comparable_continuation_values.iter().cloned())
+        .map(|value| format!("continuation-value:{}", stable_id(&value)))
+        .collect::<Vec<_>>();
+    let compared_continuation_refs = unique_strings(
+        [
+            format!("Cont_{axis_ref}({})", path_pair.p_path_ref),
+            format!("Cont_{axis_ref}({})", path_pair.q_path_ref),
+        ]
+        .into_iter()
+        .chain(
+            related_trace_axes
+                .iter()
+                .flat_map(|axis| axis.continuation_states.iter().cloned()),
+        ),
+    );
+    let observation_refs = unique_strings(
+        path_pair
+            .observation_refs
+            .iter()
+            .cloned()
+            .chain(semantic_refs.iter().cloned())
+            .chain(semantic_atom_refs.iter().cloned()),
+    );
+    let source_refs = unique_strings(
+        path_pair
+            .source_refs
+            .iter()
+            .cloned()
+            .chain(loop_candidate.source_refs.iter().cloned())
+            .chain(semantic_source_refs)
+            .chain(
+                related_trace_axes
+                    .iter()
+                    .flat_map(|axis| axis.source_refs.iter().cloned()),
+            )
+            .chain(filler_refs.iter().cloned()),
+    );
+    let distance_input_refs = unique_strings(
+        observation_refs
+            .iter()
+            .cloned()
+            .chain(source_refs.iter().cloned())
+            .chain(trace_value_refs)
+            .chain(filler_refs.iter().cloned()),
+    );
+    let missing_refs = if !missing_filler_refs.is_empty() {
+        missing_filler_refs.to_vec()
+    } else if source_refs.is_empty() && related_trace_axes.is_empty() {
+        vec![format!(
+            "missing source-backed continuation input for {}",
+            path_pair.candidate_id
+        )]
+    } else {
+        Vec::new()
+    };
+    let value = if !positive_defect_refs.is_empty() || !semantic_refs.is_empty() {
+        1
+    } else {
+        0
+    };
+    let mu_defect_refs = if positive_defect_refs.is_empty() {
+        vec![format!(
+            "mu:{}:{}",
+            stable_id(&loop_candidate.path_pair_ref),
+            stable_id(axis_ref)
+        )]
+    } else {
+        positive_defect_refs
+    };
+    let summary = format!(
+        "{} vs {} on {axis_ref}; distanceKind={distance_kind}; sourceRefs={}; semanticEvidence={}; traceAxes={}; missing={}",
+        path_pair.p_path_ref,
+        path_pair.q_path_ref,
+        source_refs.len(),
+        semantic_refs.len(),
+        related_trace_axes.len(),
+        missing_refs.len()
+    );
+    let has_source_backed_inputs = !distance_input_refs.is_empty();
+
+    HomotopyContinuationComparison {
+        value,
+        summary,
+        compared_continuation_refs,
+        distance_input_refs,
+        mu_defect_refs,
+        source_refs,
+        observation_refs,
+        missing_refs,
+        has_source_backed_inputs,
+    }
+}
+
+fn semantic_observations_for_path_pair<'a>(
+    archmap: &'a ArchMapDocumentV0,
+    path_pair: &ArchSigPathPairCandidateV0,
+) -> Vec<&'a ArchMapSemanticObservationV0> {
+    archmap
+        .semantic_observations
+        .iter()
+        .filter(|semantic| {
+            semantic.subject_ref == path_pair.p_path_ref
+                || path_pair
+                    .observation_refs
+                    .contains(&semantic.semantic_observation_id)
+        })
+        .collect()
 }
 
 fn text_matches_candidate<'a>(
@@ -10189,22 +10381,6 @@ fn text_matches_candidate<'a>(
     .into_iter()
     .map(|value| value.to_ascii_lowercase())
     .collect::<Vec<_>>();
-    values.into_iter().any(|value| {
-        let value = value.to_ascii_lowercase();
-        needles
-            .iter()
-            .any(|needle| !needle.is_empty() && value.contains(needle))
-    })
-}
-
-fn text_contains_any<'a, 'b>(
-    values: impl IntoIterator<Item = &'a String>,
-    needles: impl IntoIterator<Item = &'b String>,
-) -> bool {
-    let needles = needles
-        .into_iter()
-        .map(|value| value.to_ascii_lowercase())
-        .collect::<Vec<_>>();
     values.into_iter().any(|value| {
         let value = value.to_ascii_lowercase();
         needles
@@ -11883,6 +12059,11 @@ fn check_homotopy_holonomy_stokes_surface(packet: &ArchSigAnalysisPacketV0) -> V
         .iter()
         .map(|reading| reading.reading_id.as_str())
         .collect::<BTreeSet<_>>();
+    let holonomy_by_id = packet
+        .homotopy_holonomy_readings
+        .iter()
+        .map(|reading| (reading.reading_id.as_str(), reading))
+        .collect::<BTreeMap<_, _>>();
     let mut examples = Vec::new();
     if packet.homotopy_holonomy_readings.is_empty() {
         examples.push(generic_validation_example(
@@ -11953,6 +12134,15 @@ fn check_homotopy_holonomy_stokes_surface(packet: &ArchSigAnalysisPacketV0) -> V
                 "homotopy holonomy reading must record filler or missing filler refs",
             ));
         }
+        if reading.measurement_status == "measured"
+            && (reading.source_refs.is_empty() || reading.distance_input_refs.is_empty())
+        {
+            examples.push(generic_validation_example(
+                &reading.reading_id,
+                "sourceRefs/distanceInputRefs",
+                "measured holonomy must be computed from source-backed continuation comparison inputs",
+            ));
+        }
         if reading.non_conclusions.is_empty() || has_blank(&reading.non_conclusions) {
             examples.push(generic_validation_example(
                 &reading.reading_id,
@@ -12004,6 +12194,20 @@ fn check_homotopy_holonomy_stokes_surface(packet: &ArchSigAnalysisPacketV0) -> V
                 "localCurvatureCellCandidates",
                 "filled nonzero holonomy readings must provide a local curvature review queue",
             ));
+        }
+        if reading.status == "filledNonzeroHolonomyReview" {
+            let has_nonzero_holonomy = reading
+                .holonomy_reading_refs
+                .iter()
+                .filter_map(|holonomy_ref| holonomy_by_id.get(holonomy_ref.as_str()).copied())
+                .any(|holonomy| holonomy.value != 0 && holonomy.measurement_status == "measured");
+            if !has_nonzero_holonomy || reading.filling_evidence_refs.is_empty() {
+                examples.push(generic_validation_example(
+                    &reading.reading_id,
+                    "holonomyReadingRefs/fillingEvidenceRefs",
+                    "filled nonzero Stokes-style reading must be limited to measured filler plus measured nonzero holonomy",
+                ));
+            }
         }
         push_blank(
             &mut examples,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1280,12 +1280,37 @@ fn homotopy_report_fixture_manifest_locks_golden_validation() {
             .iter()
             .find(|reading| reading["loopRef"] == loop_ref)
             .unwrap_or_else(|| panic!("missing holonomy reading for {case_id}"));
+        assert!(
+            holonomy["distanceInputRefs"]
+                .as_array()
+                .is_some_and(|refs| !refs.is_empty())
+                && holonomy["sourceRefs"]
+                    .as_array()
+                    .is_some_and(|refs| !refs.is_empty()),
+            "{case_id} must compute holonomy from source-backed continuation inputs"
+        );
+        assert!(
+            holonomy["comparedContinuationSummary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("semanticEvidence=")
+                    && summary.contains("traceAxes=")
+                    && summary.contains("missing=")),
+            "{case_id} must expose measured continuation comparison basis"
+        );
 
         if let Some(expected) = case["expectedHolonomyValue"].as_i64() {
             assert_eq!(
                 holonomy["value"], expected,
                 "{case_id} must lock expected holonomy value"
             );
+            if expected == 0 {
+                assert!(
+                    holonomy["comparedContinuationSummary"]
+                        .as_str()
+                        .is_some_and(|summary| summary.contains("semanticEvidence=0")),
+                    "{case_id} zero holonomy must come from absent source-backed semantic defect, not text fallback"
+                );
+            }
         }
         if let Some(minimum) = case["minimumHolonomyValue"].as_i64() {
             assert!(
@@ -1294,12 +1319,32 @@ fn homotopy_report_fixture_manifest_locks_golden_validation() {
                     .is_some_and(|value| value >= minimum),
                 "{case_id} must expose nonzero holonomy"
             );
+            assert!(
+                holonomy["observationRefs"].as_array().is_some_and(|refs| {
+                    refs.iter().any(|item| {
+                        item.as_str()
+                            .is_some_and(|value| value.starts_with("semantic:"))
+                    })
+                }),
+                "{case_id} nonzero holonomy must be backed by semantic observation refs"
+            );
         }
         if let Some(expected_status) = case["expectedStokesStatus"].as_str() {
             assert_eq!(
                 stokes["status"], expected_status,
                 "{case_id} must lock Stokes status"
             );
+            if expected_status == "filledNonzeroHolonomyReview" {
+                assert!(
+                    stokes["fillingEvidenceRefs"]
+                        .as_array()
+                        .is_some_and(|refs| !refs.is_empty())
+                        && stokes["localCurvatureCellCandidates"]
+                            .as_array()
+                            .is_some_and(|refs| !refs.is_empty()),
+                    "{case_id} Stokes positive reading must require measured filler and local curvature cells"
+                );
+            }
         }
         if let Some(required_missing) = case["requiredMissingEvidence"].as_str() {
             assert!(

--- a/tools/archsig/tests/fixtures/acts_spectrum/coupon_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/coupon_validation.json
@@ -2,7 +2,7 @@
   "schemaVersion": "archsig-analysis-packet-validation-report-v0",
   "input": {
     "schemaVersion": "archsig-analysis-packet-v0",
-    "path": "/private/tmp/archsig1599-coupon-final/archsig-analysis-packet.json",
+    "path": "/private/tmp/archsig1600-coupon-final/archsig-analysis-packet.json",
     "analysisId": "archsig-analysis:coupon-tax-rounding-archmap:llm-native-aat-law-policy-fixture",
     "archMapRef": "coupon-tax-rounding-archmap",
     "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture"
@@ -4106,9 +4106,7 @@
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
+          "path-rule:interface-implementation"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "candidate paths are bounded review cues derived from ArchMap evidence and selected LawPolicy",
@@ -4171,9 +4169,7 @@
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
+          "path-rule:cache-repository"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "absence of a candidate path is not proof that no architectural loop exists",
@@ -4878,22 +4874,38 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:layer-violation",
+        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=1",
         "comparedContinuationRefs": [
+          "Cont_axis:layer-violation(molecule:coupon-operation-contract)",
           "Cont_axis:layer-violation(path:semantic-operation-flow)",
-          "Cont_axis:layer-violation(molecule:coupon-operation-contract)"
+          "Cont_semantic[0]=operation:discount; comparableValues=2",
+          "Cont_semantic[0]=operation:tax; comparableValues=2",
+          "Cont_semantic[1]=operation:discount; comparableValues=2",
+          "Cont_semantic[1]=operation:tax; comparableValues=2",
+          "Cont_semantic[2]=operation:round; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
           "atom:effect:receipt-boundary",
           "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "gap:coupon-runtime-payment-trace",
-          "semantic:coupon-tax-rounding-paths"
+          "continuation-value:semantic-endpoints-paymentamount-receiptamount",
+          "continuation-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+          "continuation-value:semantic-path-q-operation-tax-operation-discount-operation-round",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+          "semantic:coupon-tax-rounding-paths",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
         ],
         "muDefectRefs": [
-          "mu:path-pair-semantic-contract-loop:axis-layer-violation"
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
@@ -4945,22 +4957,38 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:semantic-inconsistency",
+        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=1",
         "comparedContinuationRefs": [
+          "Cont_axis:semantic-inconsistency(molecule:coupon-operation-contract)",
           "Cont_axis:semantic-inconsistency(path:semantic-operation-flow)",
-          "Cont_axis:semantic-inconsistency(molecule:coupon-operation-contract)"
+          "Cont_semantic[0]=operation:discount; comparableValues=2",
+          "Cont_semantic[0]=operation:tax; comparableValues=2",
+          "Cont_semantic[1]=operation:discount; comparableValues=2",
+          "Cont_semantic[1]=operation:tax; comparableValues=2",
+          "Cont_semantic[2]=operation:round; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
           "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
           "atom:effect:receipt-boundary",
           "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "gap:coupon-runtime-payment-trace",
-          "semantic:coupon-tax-rounding-paths"
+          "continuation-value:semantic-endpoints-paymentamount-receiptamount",
+          "continuation-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+          "continuation-value:semantic-path-q-operation-tax-operation-discount-operation-round",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+          "semantic:coupon-tax-rounding-paths",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
         ],
         "muDefectRefs": [
-          "mu:path-pair-semantic-contract-loop:axis-semantic-inconsistency"
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+          "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
@@ -5011,29 +5039,30 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:layer-violation(path-rule:interface-implementation)",
-          "Cont_axis:layer-violation(interface-implementation-path)"
+          "Cont_axis:layer-violation(interface-implementation-path)",
+          "Cont_axis:layer-violation(path-rule:interface-implementation)"
         ],
         "distanceInputRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:effect:receipt-boundary",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "gap:coupon-runtime-payment-trace"
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+          "path-rule:interface-implementation",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-interface-implementation:axis-layer-violation"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
+          "path-rule:interface-implementation"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5076,29 +5105,30 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)",
-          "Cont_axis:semantic-inconsistency(interface-implementation-path)"
+          "Cont_axis:semantic-inconsistency(interface-implementation-path)",
+          "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)"
         ],
         "distanceInputRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:effect:receipt-boundary",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "gap:coupon-runtime-payment-trace"
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+          "path-rule:interface-implementation",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-interface-implementation:axis-semantic-inconsistency"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
+          "path-rule:interface-implementation"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5141,29 +5171,30 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:layer-violation(path-rule:cache-repository)",
-          "Cont_axis:layer-violation(cache-repository-path)"
+          "Cont_axis:layer-violation(cache-repository-path)",
+          "Cont_axis:layer-violation(path-rule:cache-repository)"
         ],
         "distanceInputRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:effect:receipt-boundary",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "gap:coupon-runtime-payment-trace"
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+          "path-rule:cache-repository",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-cache-repository:axis-layer-violation"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
+          "path-rule:cache-repository"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5206,29 +5237,30 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:semantic-inconsistency(path-rule:cache-repository)",
-          "Cont_axis:semantic-inconsistency(cache-repository-path)"
+          "Cont_axis:semantic-inconsistency(cache-repository-path)",
+          "Cont_axis:semantic-inconsistency(path-rule:cache-repository)"
         ],
         "distanceInputRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:effect:receipt-boundary",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "gap:coupon-runtime-payment-trace"
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+          "path-rule:cache-repository",
+          "src-pricing-checkout",
+          "test-coupon-rounding"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-cache-repository:axis-semantic-inconsistency"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
           "src-pricing-checkout",
           "test-coupon-rounding"
         ],
         "observationRefs": [
-          "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-          "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-          "atom:effect:receipt-boundary"
+          "path-rule:cache-repository"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5414,8 +5446,6 @@
         "loop-candidate:path-pair-semantic-contract-loop-0"
       ],
       "nonzeroHolonomyLoops": [
-        "loop-candidate:path-pair-path-rule-cache-repository-2",
-        "loop-candidate:path-pair-path-rule-interface-implementation-1",
         "loop-candidate:path-pair-semantic-contract-loop-0"
       ],
       "topLocalCurvatureCells": [],
@@ -5428,7 +5458,7 @@
         },
         {
           "aggregateId": "hol-mass:nonzero-holonomy-loop-count",
-          "value": 3,
+          "value": 1,
           "reading": "bounded count of loops with nonzero selected-axis holonomy",
           "boundary": "not future incident or empirical cost prediction"
         },

--- a/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
@@ -2,7 +2,7 @@
   "schemaVersion": "archsig-analysis-packet-validation-report-v0",
   "input": {
     "schemaVersion": "archsig-analysis-packet-v0",
-    "path": "/private/tmp/archsig1599-minimal-final/archsig-analysis-packet.json",
+    "path": "/private/tmp/archsig1600-minimal-final/archsig-analysis-packet.json",
     "analysisId": "archsig-analysis:fixture-archmap-atom-observation:llm-native-aat-law-policy-fixture",
     "archMapRef": "fixture-archmap-atom-observation",
     "selectedLawPolicyRef": "llm-native-aat-law-policy-fixture"
@@ -4423,10 +4423,7 @@
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "path-rule:interface-implementation"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "candidate paths are bounded review cues derived from ArchMap evidence and selected LawPolicy",
@@ -4493,10 +4490,7 @@
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "path-rule:cache-repository"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "absence of a candidate path is not proof that no architectural loop exists",
@@ -5238,24 +5232,40 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation",
+        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=1",
         "comparedContinuationRefs": [
+          "Cont_axis:layer-violation(molecule:user-request-responsibility)",
           "Cont_axis:layer-violation(path:semantic-operation-flow)",
-          "Cont_axis:layer-violation(molecule:user-request-responsibility)"
+          "Cont_semantic[0]=operation:route-create-user; comparableValues=2",
+          "Cont_semantic[0]=operation:service-create-user; comparableValues=2",
+          "Cont_semantic[1]=operation:route-create-user; comparableValues=2",
+          "Cont_semantic[1]=operation:service-create-user; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
           "atom:component:route-users",
           "atom:component:service-user",
           "atom:contract:create-user",
           "atom:relation:route-service",
-          "gap-runtime-user-db-trace",
-          "semantic:create-user-flow"
+          "continuation-value:semantic-endpoints-route-users-service-user",
+          "continuation-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+          "continuation-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+          "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+          "semantic:create-user-flow",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
         ],
         "muDefectRefs": [
-          "mu:path-pair-semantic-contract-loop:axis-layer-violation"
+          "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
         ],
         "sourceRefs": [
           "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
@@ -5309,24 +5319,40 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:semantic-inconsistency",
+        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=1",
         "comparedContinuationRefs": [
+          "Cont_axis:semantic-inconsistency(molecule:user-request-responsibility)",
           "Cont_axis:semantic-inconsistency(path:semantic-operation-flow)",
-          "Cont_axis:semantic-inconsistency(molecule:user-request-responsibility)"
+          "Cont_semantic[0]=operation:route-create-user; comparableValues=2",
+          "Cont_semantic[0]=operation:service-create-user; comparableValues=2",
+          "Cont_semantic[1]=operation:route-create-user; comparableValues=2",
+          "Cont_semantic[1]=operation:service-create-user; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
           "atom:component:route-users",
           "atom:component:service-user",
           "atom:contract:create-user",
           "atom:relation:route-service",
-          "gap-runtime-user-db-trace",
-          "semantic:create-user-flow"
+          "continuation-value:semantic-endpoints-route-users-service-user",
+          "continuation-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+          "continuation-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+          "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+          "semantic:create-user-flow",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
         ],
         "muDefectRefs": [
-          "mu:path-pair-semantic-contract-loop:axis-semantic-inconsistency"
+          "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
         ],
         "sourceRefs": [
           "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
@@ -5379,18 +5405,21 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:layer-violation(path-rule:interface-implementation)",
-          "Cont_axis:layer-violation(interface-implementation-path)"
+          "Cont_axis:layer-violation(interface-implementation-path)",
+          "Cont_axis:layer-violation(path-rule:interface-implementation)"
         ],
         "distanceInputRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:contract:create-user",
-          "atom:relation:route-service",
-          "gap-runtime-user-db-trace"
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+          "path-rule:interface-implementation",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-interface-implementation:axis-layer-violation"
@@ -5398,15 +5427,14 @@
         "sourceRefs": [
           ".lake/runtime-trace.json",
           "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "path-rule:interface-implementation"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5449,18 +5477,21 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)",
-          "Cont_axis:semantic-inconsistency(interface-implementation-path)"
+          "Cont_axis:semantic-inconsistency(interface-implementation-path)",
+          "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)"
         ],
         "distanceInputRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:contract:create-user",
-          "atom:relation:route-service",
-          "gap-runtime-user-db-trace"
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+          "path-rule:interface-implementation",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-interface-implementation:axis-semantic-inconsistency"
@@ -5468,15 +5499,14 @@
         "sourceRefs": [
           ".lake/runtime-trace.json",
           "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "path-rule:interface-implementation"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5519,18 +5549,21 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:layer-violation(path-rule:cache-repository)",
-          "Cont_axis:layer-violation(cache-repository-path)"
+          "Cont_axis:layer-violation(cache-repository-path)",
+          "Cont_axis:layer-violation(path-rule:cache-repository)"
         ],
         "distanceInputRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:contract:create-user",
-          "atom:relation:route-service",
-          "gap-runtime-user-db-trace"
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+          "path-rule:cache-repository",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-cache-repository:axis-layer-violation"
@@ -5538,15 +5571,14 @@
         "sourceRefs": [
           ".lake/runtime-trace.json",
           "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "path-rule:cache-repository"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5589,18 +5621,21 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:semantic-inconsistency(path-rule:cache-repository)",
-          "Cont_axis:semantic-inconsistency(cache-repository-path)"
+          "Cont_axis:semantic-inconsistency(cache-repository-path)",
+          "Cont_axis:semantic-inconsistency(path-rule:cache-repository)"
         ],
         "distanceInputRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:contract:create-user",
-          "atom:relation:route-service",
-          "gap-runtime-user-db-trace"
+          ".lake/runtime-trace.json",
+          "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+          "path-rule:cache-repository",
+          "src-route-users",
+          "src-service-user",
+          "test-user-contract"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-cache-repository:axis-semantic-inconsistency"
@@ -5608,15 +5643,14 @@
         "sourceRefs": [
           ".lake/runtime-trace.json",
           "doc-architecture",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
           "src-route-users",
           "src-service-user",
           "test-user-contract"
         ],
         "observationRefs": [
-          "atom:component:route-users",
-          "atom:component:service-user",
-          "atom:relation:route-service",
-          "atom:contract:create-user"
+          "path-rule:cache-repository"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5802,8 +5836,6 @@
         "loop-candidate:path-pair-semantic-contract-loop-0"
       ],
       "nonzeroHolonomyLoops": [
-        "loop-candidate:path-pair-path-rule-cache-repository-2",
-        "loop-candidate:path-pair-path-rule-interface-implementation-1",
         "loop-candidate:path-pair-semantic-contract-loop-0"
       ],
       "topLocalCurvatureCells": [],
@@ -5816,7 +5848,7 @@
         },
         {
           "aggregateId": "hol-mass:nonzero-holonomy-loop-count",
-          "value": 3,
+          "value": 1,
           "reading": "bounded count of loops with nonzero selected-axis holonomy",
           "boundary": "not future incident or empirical cost prediction"
         },

--- a/tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/coupon_rounding/archsig_analysis_packet.json
@@ -4097,9 +4097,7 @@
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
+        "path-rule:interface-implementation"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "candidate paths are bounded review cues derived from ArchMap evidence and selected LawPolicy",
@@ -4162,9 +4160,7 @@
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
+        "path-rule:cache-repository"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "absence of a candidate path is not proof that no architectural loop exists",
@@ -4869,22 +4865,38 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:layer-violation",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
+        "Cont_axis:layer-violation(molecule:coupon-operation-contract)",
         "Cont_axis:layer-violation(path:semantic-operation-flow)",
-        "Cont_axis:layer-violation(molecule:coupon-operation-contract)"
+        "Cont_semantic[0]=operation:discount; comparableValues=2",
+        "Cont_semantic[0]=operation:tax; comparableValues=2",
+        "Cont_semantic[1]=operation:discount; comparableValues=2",
+        "Cont_semantic[1]=operation:tax; comparableValues=2",
+        "Cont_semantic[2]=operation:round; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
         "atom:effect:receipt-boundary",
         "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "gap:coupon-runtime-payment-trace",
-        "semantic:coupon-tax-rounding-paths"
+        "continuation-value:semantic-endpoints-paymentamount-receiptamount",
+        "continuation-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+        "continuation-value:semantic-path-q-operation-tax-operation-discount-operation-round",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+        "semantic:coupon-tax-rounding-paths",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
       "muDefectRefs": [
-        "mu:path-pair-semantic-contract-loop:axis-layer-violation"
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
@@ -4936,22 +4948,38 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:semantic-inconsistency",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:coupon-operation-contract on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
+        "Cont_axis:semantic-inconsistency(molecule:coupon-operation-contract)",
         "Cont_axis:semantic-inconsistency(path:semantic-operation-flow)",
-        "Cont_axis:semantic-inconsistency(molecule:coupon-operation-contract)"
+        "Cont_semantic[0]=operation:discount; comparableValues=2",
+        "Cont_semantic[0]=operation:tax; comparableValues=2",
+        "Cont_semantic[1]=operation:discount; comparableValues=2",
+        "Cont_semantic[1]=operation:tax; comparableValues=2",
+        "Cont_semantic[2]=operation:round; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
         "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
         "atom:effect:receipt-boundary",
         "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "gap:coupon-runtime-payment-trace",
-        "semantic:coupon-tax-rounding-paths"
+        "continuation-value:semantic-endpoints-paymentamount-receiptamount",
+        "continuation-value:semantic-path-p-operation-discount-operation-tax-operation-round",
+        "continuation-value:semantic-path-q-operation-tax-operation-discount-operation-round",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+        "semantic:coupon-tax-rounding-paths",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
       "muDefectRefs": [
-        "mu:path-pair-semantic-contract-loop:axis-semantic-inconsistency"
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:effect",
+        "mu:operation-square-operation-square-evidence-coupon-tax-rounding:semantic"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
@@ -5002,29 +5030,30 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:layer-violation(path-rule:interface-implementation)",
-        "Cont_axis:layer-violation(interface-implementation-path)"
+        "Cont_axis:layer-violation(interface-implementation-path)",
+        "Cont_axis:layer-violation(path-rule:interface-implementation)"
       ],
       "distanceInputRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:effect:receipt-boundary",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "gap:coupon-runtime-payment-trace"
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+        "path-rule:interface-implementation",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-interface-implementation:axis-layer-violation"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
+        "path-rule:interface-implementation"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5067,29 +5096,30 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)",
-        "Cont_axis:semantic-inconsistency(interface-implementation-path)"
+        "Cont_axis:semantic-inconsistency(interface-implementation-path)",
+        "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)"
       ],
       "distanceInputRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:effect:receipt-boundary",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "gap:coupon-runtime-payment-trace"
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+        "path-rule:interface-implementation",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-interface-implementation:axis-semantic-inconsistency"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
+        "path-rule:interface-implementation"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5132,29 +5162,30 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:layer-violation(path-rule:cache-repository)",
-        "Cont_axis:layer-violation(cache-repository-path)"
+        "Cont_axis:layer-violation(cache-repository-path)",
+        "Cont_axis:layer-violation(path-rule:cache-repository)"
       ],
       "distanceInputRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:effect:receipt-boundary",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "gap:coupon-runtime-payment-trace"
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+        "path-rule:cache-repository",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-cache-repository:axis-layer-violation"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
+        "path-rule:cache-repository"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5197,29 +5228,30 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:semantic-inconsistency(path-rule:cache-repository)",
-        "Cont_axis:semantic-inconsistency(cache-repository-path)"
+        "Cont_axis:semantic-inconsistency(cache-repository-path)",
+        "Cont_axis:semantic-inconsistency(path-rule:cache-repository)"
       ],
       "distanceInputRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:effect:receipt-boundary",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "gap:coupon-runtime-payment-trace"
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+        "path-rule:cache-repository",
+        "src-pricing-checkout",
+        "test-coupon-rounding"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-cache-repository:axis-semantic-inconsistency"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
         "src-pricing-checkout",
         "test-coupon-rounding"
       ],
       "observationRefs": [
-        "atom:contract:PaymentAmount-ReceiptAmount-coupon-tax-rounding",
-        "atom:semantic:PaymentAmount-ReceiptAmount-coupon-tax-rounding-noncommutation",
-        "atom:effect:receipt-boundary"
+        "path-rule:cache-repository"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5405,8 +5437,6 @@
       "loop-candidate:path-pair-semantic-contract-loop-0"
     ],
     "nonzeroHolonomyLoops": [
-      "loop-candidate:path-pair-path-rule-cache-repository-2",
-      "loop-candidate:path-pair-path-rule-interface-implementation-1",
       "loop-candidate:path-pair-semantic-contract-loop-0"
     ],
     "topLocalCurvatureCells": [],
@@ -5419,7 +5449,7 @@
       },
       {
         "aggregateId": "hol-mass:nonzero-holonomy-loop-count",
-        "value": 3,
+        "value": 1,
         "reading": "bounded count of loops with nonzero selected-axis holonomy",
         "boundary": "not future incident or empirical cost prediction"
       },

--- a/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/archsig_analysis_packet.json
@@ -4321,12 +4321,7 @@
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "path-rule:zero-holonomy-filled-loop"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "zero holonomy fixture path is a bounded review cue, not path truth",
@@ -4382,23 +4377,15 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
-        "src-direct-read",
         "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
         "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:nonzero-holonomy-filled-loop"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "nonzero holonomy fixture path is bounded to supplied semantic observation",
@@ -4454,23 +4441,15 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
         "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
         "atom:cache-read",
         "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:cache-repository-semantic-loop"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "cache / repository fixture path is bounded to source refs and selected law policy",
@@ -4526,23 +4505,16 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
         "src-direct-read",
         "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
         "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:event-projection-direct-read"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "event projection fixture path is bounded to supplied source refs",
@@ -4598,23 +4570,13 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
-        "src-pricing-checkout",
-        "src-repository-read",
         "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
         "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:retry-idempotency-effect"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "retry fixture path is bounded to supplied test and runtime trace expectations",
@@ -4681,12 +4643,7 @@
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "path-rule:authorization-bypass-hole"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "authorization bypass fixture path remains a hole until policy/test filler evidence is supplied",
@@ -4742,23 +4699,13 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
         "src-pricing-checkout",
-        "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:coupon-tax-rounding",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:coupon-tax-rounding-semantic-loop"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "coupon fixture path is bounded to selected examples, not global pricing correctness",
@@ -4918,14 +4865,8 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
-        "src-direct-read",
         "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -4974,14 +4915,8 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
         "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -5030,14 +4965,9 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
         "src-direct-read",
         "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -5086,13 +5016,6 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
-        "src-pricing-checkout",
-        "src-repository-read",
         "src-retry-effect",
         "test-homotopy-fillers"
       ],
@@ -5200,14 +5123,7 @@
         "axis:homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
-        "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
         "src-pricing-checkout",
-        "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -5899,11 +5815,16 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 0,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:homotopy-report-fixture on axis:homotopy-report-fixture",
+      "value": 1,
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:homotopy-report-fixture on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=8; semanticEvidence=5; traceAxes=2; missing=0",
       "comparedContinuationRefs": [
+        "Cont_axis:homotopy-report-fixture(molecule:homotopy-report-fixture)",
         "Cont_axis:homotopy-report-fixture(path:semantic-operation-flow)",
-        "Cont_axis:homotopy-report-fixture(molecule:homotopy-report-fixture)"
+        "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+        "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+        "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
         "atom:authorization-bypass",
@@ -5912,16 +5833,29 @@
         "atom:event-projection",
         "atom:repository-read",
         "atom:retry-idempotency",
+        "continuation-value:semantic-endpoints-orderview",
+        "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "semantic:path-rule:cache-repository-semantic-loop",
         "semantic:path-rule:coupon-tax-rounding-semantic-loop",
         "semantic:path-rule:event-projection-direct-read",
         "semantic:path-rule:nonzero-holonomy-filled-loop",
-        "semantic:path-rule:retry-idempotency-effect"
+        "semantic:path-rule:retry-idempotency-effect",
+        "src-auth-bypass",
+        "src-cache-read",
+        "src-direct-read",
+        "src-event-projection",
+        "src-pricing-checkout",
+        "src-repository-read",
+        "src-retry-effect"
       ],
       "muDefectRefs": [
-        "mu:path-pair-semantic-contract-loop:axis-homotopy-report-fixture"
+        "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+        "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
       ],
       "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "src-auth-bypass",
         "src-cache-read",
         "src-direct-read",
@@ -5980,24 +5914,30 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 0,
-      "comparedContinuationSummary": "path-rule:zero-holonomy-filled-loop vs zero-holonomy-filled-loop-path on axis:homotopy-report-fixture",
+      "comparedContinuationSummary": "path-rule:zero-holonomy-filled-loop vs zero-holonomy-filled-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=10; semanticEvidence=0; traceAxes=0; missing=0",
       "comparedContinuationRefs": [
         "Cont_axis:homotopy-report-fixture(path-rule:zero-holonomy-filled-loop)",
         "Cont_axis:homotopy-report-fixture(zero-holonomy-filled-loop-path)"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
-        "atom:cache-read",
-        "atom:coupon-tax-rounding",
-        "atom:event-projection",
-        "atom:repository-read",
-        "atom:retry-idempotency"
+        "doc-auth-policy",
+        "filler-candidate:loop-candidate-path-pair-path-rule-zero-holonomy-filled-loop-1:filler-rule-contract-or-test",
+        "path-rule:zero-holonomy-filled-loop",
+        "src-auth-bypass",
+        "src-cache-read",
+        "src-direct-read",
+        "src-event-projection",
+        "src-pricing-checkout",
+        "src-repository-read",
+        "src-retry-effect",
+        "test-homotopy-fillers"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-zero-holonomy-filled-loop:axis-homotopy-report-fixture"
       ],
       "sourceRefs": [
         "doc-auth-policy",
+        "filler-candidate:loop-candidate-path-pair-path-rule-zero-holonomy-filled-loop-1:filler-rule-contract-or-test",
         "src-auth-bypass",
         "src-cache-read",
         "src-direct-read",
@@ -6008,12 +5948,7 @@
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "path-rule:zero-holonomy-filled-loop"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-zero-holonomy-filled-loop-1:filler-rule-contract-or-test"
@@ -6052,40 +5987,45 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path-rule:nonzero-holonomy-filled-loop vs nonzero-holonomy-filled-loop-path on axis:homotopy-report-fixture",
+      "comparedContinuationSummary": "path-rule:nonzero-holonomy-filled-loop vs nonzero-holonomy-filled-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=5; semanticEvidence=1; traceAxes=2; missing=0",
       "comparedContinuationRefs": [
+        "Cont_axis:homotopy-report-fixture(nonzero-holonomy-filled-loop-path)",
         "Cont_axis:homotopy-report-fixture(path-rule:nonzero-holonomy-filled-loop)",
-        "Cont_axis:homotopy-report-fixture(nonzero-holonomy-filled-loop-path)"
+        "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+        "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+        "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
-        "atom:cache-read",
-        "atom:coupon-tax-rounding",
         "atom:event-projection",
         "atom:repository-read",
-        "atom:retry-idempotency"
+        "continuation-value:semantic-endpoints-orderview",
+        "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+        "filler-candidate:loop-candidate-path-pair-path-rule-nonzero-holonomy-filled-loop-2:filler-rule-contract-or-test",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:nonzero-holonomy-filled-loop",
+        "src-cache-read",
+        "src-event-projection",
+        "src-repository-read",
+        "test-homotopy-fillers"
       ],
       "muDefectRefs": [
-        "mu:path-pair-path-rule-nonzero-holonomy-filled-loop:axis-homotopy-report-fixture"
+        "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
+        "filler-candidate:loop-candidate-path-pair-path-rule-nonzero-holonomy-filled-loop-2:filler-rule-contract-or-test",
         "src-cache-read",
-        "src-direct-read",
         "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
         "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:nonzero-holonomy-filled-loop"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-nonzero-holonomy-filled-loop-2:filler-rule-contract-or-test"
@@ -6124,40 +6064,43 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path-rule:cache-repository-semantic-loop vs cache-repository-semantic-loop-path on axis:homotopy-report-fixture",
+      "comparedContinuationSummary": "path-rule:cache-repository-semantic-loop vs cache-repository-semantic-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=0",
       "comparedContinuationRefs": [
+        "Cont_axis:homotopy-report-fixture(cache-repository-semantic-loop-path)",
         "Cont_axis:homotopy-report-fixture(path-rule:cache-repository-semantic-loop)",
-        "Cont_axis:homotopy-report-fixture(cache-repository-semantic-loop-path)"
+        "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+        "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+        "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
         "atom:cache-read",
-        "atom:coupon-tax-rounding",
-        "atom:event-projection",
         "atom:repository-read",
-        "atom:retry-idempotency"
+        "continuation-value:semantic-endpoints-orderview",
+        "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-semantic-loop-3:filler-rule-contract-or-test",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:cache-repository-semantic-loop",
+        "src-cache-read",
+        "src-repository-read",
+        "test-homotopy-fillers"
       ],
       "muDefectRefs": [
-        "mu:path-pair-path-rule-cache-repository-semantic-loop:axis-homotopy-report-fixture"
+        "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-semantic-loop-3:filler-rule-contract-or-test",
         "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
         "atom:cache-read",
         "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:cache-repository-semantic-loop"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-semantic-loop-3:filler-rule-contract-or-test"
@@ -6196,40 +6139,47 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path-rule:event-projection-direct-read vs event-projection-direct-read-path on axis:homotopy-report-fixture",
+      "comparedContinuationSummary": "path-rule:event-projection-direct-read vs event-projection-direct-read-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=0",
       "comparedContinuationRefs": [
+        "Cont_axis:homotopy-report-fixture(event-projection-direct-read-path)",
         "Cont_axis:homotopy-report-fixture(path-rule:event-projection-direct-read)",
-        "Cont_axis:homotopy-report-fixture(event-projection-direct-read-path)"
+        "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+        "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+        "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
-        "atom:cache-read",
-        "atom:coupon-tax-rounding",
         "atom:event-projection",
         "atom:repository-read",
-        "atom:retry-idempotency"
-      ],
-      "muDefectRefs": [
-        "mu:path-pair-path-rule-event-projection-direct-read:axis-homotopy-report-fixture"
-      ],
-      "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
+        "continuation-value:semantic-endpoints-orderview",
+        "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+        "filler-candidate:loop-candidate-path-pair-path-rule-event-projection-direct-read-4:filler-rule-contract-or-test",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:event-projection-direct-read",
         "src-cache-read",
         "src-direct-read",
         "src-event-projection",
-        "src-pricing-checkout",
         "src-repository-read",
-        "src-retry-effect",
+        "test-homotopy-fillers"
+      ],
+      "muDefectRefs": [
+        "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
+      ],
+      "sourceRefs": [
+        "filler-candidate:loop-candidate-path-pair-path-rule-event-projection-direct-read-4:filler-rule-contract-or-test",
+        "src-cache-read",
+        "src-direct-read",
+        "src-event-projection",
+        "src-repository-read",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
         "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:repository-read",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:event-projection-direct-read"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-event-projection-direct-read-4:filler-rule-contract-or-test"
@@ -6268,40 +6218,41 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path-rule:retry-idempotency-effect vs retry-idempotency-effect-path on axis:homotopy-report-fixture",
+      "comparedContinuationSummary": "path-rule:retry-idempotency-effect vs retry-idempotency-effect-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=0",
       "comparedContinuationRefs": [
         "Cont_axis:homotopy-report-fixture(path-rule:retry-idempotency-effect)",
-        "Cont_axis:homotopy-report-fixture(retry-idempotency-effect-path)"
+        "Cont_axis:homotopy-report-fixture(retry-idempotency-effect-path)",
+        "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+        "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+        "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
-        "atom:cache-read",
-        "atom:coupon-tax-rounding",
-        "atom:event-projection",
-        "atom:repository-read",
-        "atom:retry-idempotency"
+        "atom:retry-idempotency",
+        "continuation-value:semantic-endpoints-orderview",
+        "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+        "filler-candidate:loop-candidate-path-pair-path-rule-retry-idempotency-effect-5:filler-rule-contract-or-test",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:retry-idempotency-effect",
+        "src-cache-read",
+        "src-retry-effect",
+        "test-homotopy-fillers"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-retry-idempotency-effect:axis-homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
+        "filler-candidate:loop-candidate-path-pair-path-rule-retry-idempotency-effect-5:filler-rule-contract-or-test",
         "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
-        "src-pricing-checkout",
-        "src-repository-read",
         "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
         "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:retry-idempotency-effect"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-retry-idempotency-effect-5:filler-rule-contract-or-test"
@@ -6339,26 +6290,31 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:authorization-bypass-hole vs authorization-bypass-hole-path on axis:homotopy-report-fixture",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:authorization-bypass-hole vs authorization-bypass-hole-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=10; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:homotopy-report-fixture(path-rule:authorization-bypass-hole)",
-        "Cont_axis:homotopy-report-fixture(authorization-bypass-hole-path)"
+        "Cont_axis:homotopy-report-fixture(authorization-bypass-hole-path)",
+        "Cont_axis:homotopy-report-fixture(path-rule:authorization-bypass-hole)"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
-        "atom:cache-read",
-        "atom:coupon-tax-rounding",
-        "atom:event-projection",
-        "atom:repository-read",
-        "atom:retry-idempotency",
-        "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+        "doc-auth-policy",
+        "filler-candidate:loop-candidate-path-pair-path-rule-authorization-bypass-hole-6:filler-rule-contract-or-test",
+        "path-rule:authorization-bypass-hole",
+        "src-auth-bypass",
+        "src-cache-read",
+        "src-direct-read",
+        "src-event-projection",
+        "src-pricing-checkout",
+        "src-repository-read",
+        "src-retry-effect",
+        "test-homotopy-fillers"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-authorization-bypass-hole:axis-homotopy-report-fixture"
       ],
       "sourceRefs": [
         "doc-auth-policy",
+        "filler-candidate:loop-candidate-path-pair-path-rule-authorization-bypass-hole-6:filler-rule-contract-or-test",
         "src-auth-bypass",
         "src-cache-read",
         "src-direct-read",
@@ -6369,12 +6325,7 @@
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "path-rule:authorization-bypass-hole"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-authorization-bypass-hole-6:filler-rule-contract-or-test"
@@ -6415,40 +6366,41 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path-rule:coupon-tax-rounding-semantic-loop vs coupon-tax-rounding-semantic-loop-path on axis:homotopy-report-fixture",
+      "comparedContinuationSummary": "path-rule:coupon-tax-rounding-semantic-loop vs coupon-tax-rounding-semantic-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=0",
       "comparedContinuationRefs": [
+        "Cont_axis:homotopy-report-fixture(coupon-tax-rounding-semantic-loop-path)",
         "Cont_axis:homotopy-report-fixture(path-rule:coupon-tax-rounding-semantic-loop)",
-        "Cont_axis:homotopy-report-fixture(coupon-tax-rounding-semantic-loop-path)"
+        "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+        "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+        "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
-        "atom:authorization-bypass",
-        "atom:cache-read",
         "atom:coupon-tax-rounding",
-        "atom:event-projection",
-        "atom:repository-read",
-        "atom:retry-idempotency"
+        "continuation-value:semantic-endpoints-orderview",
+        "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+        "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+        "filler-candidate:loop-candidate-path-pair-path-rule-coupon-tax-rounding-semantic-loop-7:filler-rule-contract-or-test",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:coupon-tax-rounding-semantic-loop",
+        "src-cache-read",
+        "src-pricing-checkout",
+        "test-homotopy-fillers"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-coupon-tax-rounding-semantic-loop:axis-homotopy-report-fixture"
       ],
       "sourceRefs": [
-        "doc-auth-policy",
-        "src-auth-bypass",
+        "filler-candidate:loop-candidate-path-pair-path-rule-coupon-tax-rounding-semantic-loop-7:filler-rule-contract-or-test",
         "src-cache-read",
-        "src-direct-read",
-        "src-event-projection",
         "src-pricing-checkout",
-        "src-repository-read",
-        "src-retry-effect",
         "test-homotopy-fillers"
       ],
       "observationRefs": [
-        "atom:cache-read",
-        "atom:repository-read",
-        "atom:event-projection",
-        "atom:retry-idempotency",
-        "atom:authorization-bypass",
-        "atom:coupon-tax-rounding"
+        "atom:coupon-tax-rounding",
+        "molecule:homotopy-report-fixture",
+        "semantic:path-rule:coupon-tax-rounding-semantic-loop"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-coupon-tax-rounding-semantic-loop-7:filler-rule-contract-or-test"
@@ -6469,7 +6421,7 @@
     {
       "readingId": "stokes-style:loop-candidate-path-pair-semantic-contract-loop-0",
       "loopRef": "loop-candidate:path-pair-semantic-contract-loop-0",
-      "status": "measuredZeroWithinBoundary",
+      "status": "filledNonzeroHolonomyReview",
       "measurementStatus": "measured",
       "readingBoundary": {
         "readingStrength": "boundedMeasuredWithCandidatePaths",
@@ -6504,10 +6456,12 @@
         "test-homotopy-fillers"
       ],
       "nonFillabilityWitnessRefs": [],
-      "localCurvatureCondition": "missing measured filler evidence blocks Stokes-style local curvature conclusion",
-      "localCurvatureCellCandidates": [],
+      "localCurvatureCondition": "measured filling plus nonzero holonomy localizes review curvature to selected 2-cells",
+      "localCurvatureCellCandidates": [
+        "2-cell:obstruction-homotopy-report-fixture"
+      ],
       "reviewQueueRefs": [
-        "homotopy-holonomy:loop-candidate-path-pair-semantic-contract-loop-0:axis-homotopy-report-fixture"
+        "2-cell:obstruction-homotopy-report-fixture"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "Stokes-style reading is a bounded review queue, not theorem discharge",
@@ -6923,12 +6877,12 @@
       "loop-candidate:path-pair-path-rule-authorization-bypass-hole-6"
     ],
     "nonzeroHolonomyLoops": [
-      "loop-candidate:path-pair-path-rule-authorization-bypass-hole-6",
       "loop-candidate:path-pair-path-rule-cache-repository-semantic-loop-3",
       "loop-candidate:path-pair-path-rule-coupon-tax-rounding-semantic-loop-7",
       "loop-candidate:path-pair-path-rule-event-projection-direct-read-4",
       "loop-candidate:path-pair-path-rule-nonzero-holonomy-filled-loop-2",
-      "loop-candidate:path-pair-path-rule-retry-idempotency-effect-5"
+      "loop-candidate:path-pair-path-rule-retry-idempotency-effect-5",
+      "loop-candidate:path-pair-semantic-contract-loop-0"
     ],
     "topLocalCurvatureCells": [
       "2-cell:obstruction-homotopy-report-fixture"

--- a/tools/archsig/tests/fixtures/homotopy_report/validation.json
+++ b/tools/archsig/tests/fixtures/homotopy_report/validation.json
@@ -2,7 +2,7 @@
   "schemaVersion": "archsig-analysis-packet-validation-report-v0",
   "input": {
     "schemaVersion": "archsig-analysis-packet-v0",
-    "path": "/private/tmp/archsig1599-homotopy-final/archsig-analysis-packet.json",
+    "path": "/private/tmp/archsig1600-homotopy-final/archsig-analysis-packet.json",
     "analysisId": "archsig-analysis:homotopy-report-fixture-archmap:homotopy-report-fixture-policy",
     "archMapRef": "homotopy-report-fixture-archmap",
     "selectedLawPolicyRef": "homotopy-report-fixture-policy"
@@ -4330,12 +4330,7 @@
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "path-rule:zero-holonomy-filled-loop"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "zero holonomy fixture path is a bounded review cue, not path truth",
@@ -4391,23 +4386,15 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
-          "src-direct-read",
           "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
           "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:nonzero-holonomy-filled-loop"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "nonzero holonomy fixture path is bounded to supplied semantic observation",
@@ -4463,23 +4450,15 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
           "atom:cache-read",
           "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "cache / repository fixture path is bounded to source refs and selected law policy",
@@ -4535,23 +4514,16 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
           "src-direct-read",
           "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
           "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:event-projection-direct-read"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "event projection fixture path is bounded to supplied source refs",
@@ -4607,23 +4579,13 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
-          "src-repository-read",
           "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
           "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:retry-idempotency-effect"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "retry fixture path is bounded to supplied test and runtime trace expectations",
@@ -4690,12 +4652,7 @@
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "path-rule:authorization-bypass-hole"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "authorization bypass fixture path remains a hole until policy/test filler evidence is supplied",
@@ -4751,23 +4708,13 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
           "src-pricing-checkout",
-          "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:coupon-tax-rounding",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:coupon-tax-rounding-semantic-loop"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "coupon fixture path is bounded to selected examples, not global pricing correctness",
@@ -4927,14 +4874,8 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
-          "src-direct-read",
           "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -4983,14 +4924,8 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -5039,14 +4974,9 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
           "src-direct-read",
           "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -5095,13 +5025,6 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
-          "src-repository-read",
           "src-retry-effect",
           "test-homotopy-fillers"
         ],
@@ -5209,14 +5132,7 @@
           "axis:homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
-          "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
           "src-pricing-checkout",
-          "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
@@ -5908,11 +5824,16 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 0,
-        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:homotopy-report-fixture on axis:homotopy-report-fixture",
+        "value": 1,
+        "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:homotopy-report-fixture on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=8; semanticEvidence=5; traceAxes=2; missing=0",
         "comparedContinuationRefs": [
+          "Cont_axis:homotopy-report-fixture(molecule:homotopy-report-fixture)",
           "Cont_axis:homotopy-report-fixture(path:semantic-operation-flow)",
-          "Cont_axis:homotopy-report-fixture(molecule:homotopy-report-fixture)"
+          "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+          "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+          "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
           "atom:authorization-bypass",
@@ -5921,16 +5842,29 @@
           "atom:event-projection",
           "atom:repository-read",
           "atom:retry-idempotency",
+          "continuation-value:semantic-endpoints-orderview",
+          "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
           "semantic:path-rule:cache-repository-semantic-loop",
           "semantic:path-rule:coupon-tax-rounding-semantic-loop",
           "semantic:path-rule:event-projection-direct-read",
           "semantic:path-rule:nonzero-holonomy-filled-loop",
-          "semantic:path-rule:retry-idempotency-effect"
+          "semantic:path-rule:retry-idempotency-effect",
+          "src-auth-bypass",
+          "src-cache-read",
+          "src-direct-read",
+          "src-event-projection",
+          "src-pricing-checkout",
+          "src-repository-read",
+          "src-retry-effect"
         ],
         "muDefectRefs": [
-          "mu:path-pair-semantic-contract-loop:axis-homotopy-report-fixture"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:effect",
+          "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
         ],
         "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
           "src-auth-bypass",
           "src-cache-read",
           "src-direct-read",
@@ -5989,24 +5923,30 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 0,
-        "comparedContinuationSummary": "path-rule:zero-holonomy-filled-loop vs zero-holonomy-filled-loop-path on axis:homotopy-report-fixture",
+        "comparedContinuationSummary": "path-rule:zero-holonomy-filled-loop vs zero-holonomy-filled-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=10; semanticEvidence=0; traceAxes=0; missing=0",
         "comparedContinuationRefs": [
           "Cont_axis:homotopy-report-fixture(path-rule:zero-holonomy-filled-loop)",
           "Cont_axis:homotopy-report-fixture(zero-holonomy-filled-loop-path)"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
-          "atom:cache-read",
-          "atom:coupon-tax-rounding",
-          "atom:event-projection",
-          "atom:repository-read",
-          "atom:retry-idempotency"
+          "doc-auth-policy",
+          "filler-candidate:loop-candidate-path-pair-path-rule-zero-holonomy-filled-loop-1:filler-rule-contract-or-test",
+          "path-rule:zero-holonomy-filled-loop",
+          "src-auth-bypass",
+          "src-cache-read",
+          "src-direct-read",
+          "src-event-projection",
+          "src-pricing-checkout",
+          "src-repository-read",
+          "src-retry-effect",
+          "test-homotopy-fillers"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-zero-holonomy-filled-loop:axis-homotopy-report-fixture"
         ],
         "sourceRefs": [
           "doc-auth-policy",
+          "filler-candidate:loop-candidate-path-pair-path-rule-zero-holonomy-filled-loop-1:filler-rule-contract-or-test",
           "src-auth-bypass",
           "src-cache-read",
           "src-direct-read",
@@ -6017,12 +5957,7 @@
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "path-rule:zero-holonomy-filled-loop"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-zero-holonomy-filled-loop-1:filler-rule-contract-or-test"
@@ -6061,40 +5996,45 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path-rule:nonzero-holonomy-filled-loop vs nonzero-holonomy-filled-loop-path on axis:homotopy-report-fixture",
+        "comparedContinuationSummary": "path-rule:nonzero-holonomy-filled-loop vs nonzero-holonomy-filled-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=5; semanticEvidence=1; traceAxes=2; missing=0",
         "comparedContinuationRefs": [
+          "Cont_axis:homotopy-report-fixture(nonzero-holonomy-filled-loop-path)",
           "Cont_axis:homotopy-report-fixture(path-rule:nonzero-holonomy-filled-loop)",
-          "Cont_axis:homotopy-report-fixture(nonzero-holonomy-filled-loop-path)"
+          "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+          "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+          "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
-          "atom:cache-read",
-          "atom:coupon-tax-rounding",
           "atom:event-projection",
           "atom:repository-read",
-          "atom:retry-idempotency"
+          "continuation-value:semantic-endpoints-orderview",
+          "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "filler-candidate:loop-candidate-path-pair-path-rule-nonzero-holonomy-filled-loop-2:filler-rule-contract-or-test",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:nonzero-holonomy-filled-loop",
+          "src-cache-read",
+          "src-event-projection",
+          "src-repository-read",
+          "test-homotopy-fillers"
         ],
         "muDefectRefs": [
-          "mu:path-pair-path-rule-nonzero-holonomy-filled-loop:axis-homotopy-report-fixture"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
+          "filler-candidate:loop-candidate-path-pair-path-rule-nonzero-holonomy-filled-loop-2:filler-rule-contract-or-test",
           "src-cache-read",
-          "src-direct-read",
           "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
           "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:nonzero-holonomy-filled-loop"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-nonzero-holonomy-filled-loop-2:filler-rule-contract-or-test"
@@ -6133,40 +6073,43 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path-rule:cache-repository-semantic-loop vs cache-repository-semantic-loop-path on axis:homotopy-report-fixture",
+        "comparedContinuationSummary": "path-rule:cache-repository-semantic-loop vs cache-repository-semantic-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=0",
         "comparedContinuationRefs": [
+          "Cont_axis:homotopy-report-fixture(cache-repository-semantic-loop-path)",
           "Cont_axis:homotopy-report-fixture(path-rule:cache-repository-semantic-loop)",
-          "Cont_axis:homotopy-report-fixture(cache-repository-semantic-loop-path)"
+          "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+          "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+          "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
           "atom:cache-read",
-          "atom:coupon-tax-rounding",
-          "atom:event-projection",
           "atom:repository-read",
-          "atom:retry-idempotency"
+          "continuation-value:semantic-endpoints-orderview",
+          "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-semantic-loop-3:filler-rule-contract-or-test",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:cache-repository-semantic-loop",
+          "src-cache-read",
+          "src-repository-read",
+          "test-homotopy-fillers"
         ],
         "muDefectRefs": [
-          "mu:path-pair-path-rule-cache-repository-semantic-loop:axis-homotopy-report-fixture"
+          "mu:operation-square-operation-square-evidence-cache-repository-read:semantic"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
+          "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-semantic-loop-3:filler-rule-contract-or-test",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
           "atom:cache-read",
           "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:cache-repository-semantic-loop"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-semantic-loop-3:filler-rule-contract-or-test"
@@ -6205,40 +6148,47 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path-rule:event-projection-direct-read vs event-projection-direct-read-path on axis:homotopy-report-fixture",
+        "comparedContinuationSummary": "path-rule:event-projection-direct-read vs event-projection-direct-read-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=0",
         "comparedContinuationRefs": [
+          "Cont_axis:homotopy-report-fixture(event-projection-direct-read-path)",
           "Cont_axis:homotopy-report-fixture(path-rule:event-projection-direct-read)",
-          "Cont_axis:homotopy-report-fixture(event-projection-direct-read-path)"
+          "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+          "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+          "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
-          "atom:cache-read",
-          "atom:coupon-tax-rounding",
           "atom:event-projection",
           "atom:repository-read",
-          "atom:retry-idempotency"
-        ],
-        "muDefectRefs": [
-          "mu:path-pair-path-rule-event-projection-direct-read:axis-homotopy-report-fixture"
-        ],
-        "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
+          "continuation-value:semantic-endpoints-orderview",
+          "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "filler-candidate:loop-candidate-path-pair-path-rule-event-projection-direct-read-4:filler-rule-contract-or-test",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:event-projection-direct-read",
           "src-cache-read",
           "src-direct-read",
           "src-event-projection",
-          "src-pricing-checkout",
           "src-repository-read",
-          "src-retry-effect",
+          "test-homotopy-fillers"
+        ],
+        "muDefectRefs": [
+          "mu:operation-square-operation-square-evidence-cache-repository-read:effect"
+        ],
+        "sourceRefs": [
+          "filler-candidate:loop-candidate-path-pair-path-rule-event-projection-direct-read-4:filler-rule-contract-or-test",
+          "src-cache-read",
+          "src-direct-read",
+          "src-event-projection",
+          "src-repository-read",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
           "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:repository-read",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:event-projection-direct-read"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-event-projection-direct-read-4:filler-rule-contract-or-test"
@@ -6277,40 +6227,41 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path-rule:retry-idempotency-effect vs retry-idempotency-effect-path on axis:homotopy-report-fixture",
+        "comparedContinuationSummary": "path-rule:retry-idempotency-effect vs retry-idempotency-effect-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=0",
         "comparedContinuationRefs": [
           "Cont_axis:homotopy-report-fixture(path-rule:retry-idempotency-effect)",
-          "Cont_axis:homotopy-report-fixture(retry-idempotency-effect-path)"
+          "Cont_axis:homotopy-report-fixture(retry-idempotency-effect-path)",
+          "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+          "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+          "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
-          "atom:cache-read",
-          "atom:coupon-tax-rounding",
-          "atom:event-projection",
-          "atom:repository-read",
-          "atom:retry-idempotency"
+          "atom:retry-idempotency",
+          "continuation-value:semantic-endpoints-orderview",
+          "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "filler-candidate:loop-candidate-path-pair-path-rule-retry-idempotency-effect-5:filler-rule-contract-or-test",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:retry-idempotency-effect",
+          "src-cache-read",
+          "src-retry-effect",
+          "test-homotopy-fillers"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-retry-idempotency-effect:axis-homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
+          "filler-candidate:loop-candidate-path-pair-path-rule-retry-idempotency-effect-5:filler-rule-contract-or-test",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
-          "src-pricing-checkout",
-          "src-repository-read",
           "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
           "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:retry-idempotency-effect"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-retry-idempotency-effect-5:filler-rule-contract-or-test"
@@ -6348,26 +6299,31 @@
           "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
         },
         "distanceKind": "selected-axis-continuation-distance",
-        "value": 1,
-        "comparedContinuationSummary": "path-rule:authorization-bypass-hole vs authorization-bypass-hole-path on axis:homotopy-report-fixture",
+        "value": 0,
+        "comparedContinuationSummary": "path-rule:authorization-bypass-hole vs authorization-bypass-hole-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=10; semanticEvidence=0; traceAxes=0; missing=1",
         "comparedContinuationRefs": [
-          "Cont_axis:homotopy-report-fixture(path-rule:authorization-bypass-hole)",
-          "Cont_axis:homotopy-report-fixture(authorization-bypass-hole-path)"
+          "Cont_axis:homotopy-report-fixture(authorization-bypass-hole-path)",
+          "Cont_axis:homotopy-report-fixture(path-rule:authorization-bypass-hole)"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
-          "atom:cache-read",
-          "atom:coupon-tax-rounding",
-          "atom:event-projection",
-          "atom:repository-read",
-          "atom:retry-idempotency",
-          "gap:path-rule:authorization-bypass-hole:missing-policy-test"
+          "doc-auth-policy",
+          "filler-candidate:loop-candidate-path-pair-path-rule-authorization-bypass-hole-6:filler-rule-contract-or-test",
+          "path-rule:authorization-bypass-hole",
+          "src-auth-bypass",
+          "src-cache-read",
+          "src-direct-read",
+          "src-event-projection",
+          "src-pricing-checkout",
+          "src-repository-read",
+          "src-retry-effect",
+          "test-homotopy-fillers"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-authorization-bypass-hole:axis-homotopy-report-fixture"
         ],
         "sourceRefs": [
           "doc-auth-policy",
+          "filler-candidate:loop-candidate-path-pair-path-rule-authorization-bypass-hole-6:filler-rule-contract-or-test",
           "src-auth-bypass",
           "src-cache-read",
           "src-direct-read",
@@ -6378,12 +6334,7 @@
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "path-rule:authorization-bypass-hole"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-authorization-bypass-hole-6:filler-rule-contract-or-test"
@@ -6424,40 +6375,41 @@
         },
         "distanceKind": "selected-axis-continuation-distance",
         "value": 1,
-        "comparedContinuationSummary": "path-rule:coupon-tax-rounding-semantic-loop vs coupon-tax-rounding-semantic-loop-path on axis:homotopy-report-fixture",
+        "comparedContinuationSummary": "path-rule:coupon-tax-rounding-semantic-loop vs coupon-tax-rounding-semantic-loop-path on axis:homotopy-report-fixture; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=0",
         "comparedContinuationRefs": [
+          "Cont_axis:homotopy-report-fixture(coupon-tax-rounding-semantic-loop-path)",
           "Cont_axis:homotopy-report-fixture(path-rule:coupon-tax-rounding-semantic-loop)",
-          "Cont_axis:homotopy-report-fixture(coupon-tax-rounding-semantic-loop-path)"
+          "Cont_semantic[0]=operation:read-from-repository; comparableValues=2",
+          "Cont_semantic[0]=operation:read-through-cache; comparableValues=2",
+          "Cont_semantic[1]=operation:project-order-event; comparableValues=2",
+          "Cont_semantic[endpoint]=p; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch",
+          "Cont_semantic[endpoint]=q; endpointRefs=1; evaluator=witness-mismatch-count:semantic-sequence-mismatch"
         ],
         "distanceInputRefs": [
-          "atom:authorization-bypass",
-          "atom:cache-read",
           "atom:coupon-tax-rounding",
-          "atom:event-projection",
-          "atom:repository-read",
-          "atom:retry-idempotency"
+          "continuation-value:semantic-endpoints-orderview",
+          "continuation-value:semantic-path-p-operation-read-through-cache-operation-project-order-event",
+          "continuation-value:semantic-path-q-operation-read-from-repository-operation-project-order-event",
+          "filler-candidate:loop-candidate-path-pair-path-rule-coupon-tax-rounding-semantic-loop-7:filler-rule-contract-or-test",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:coupon-tax-rounding-semantic-loop",
+          "src-cache-read",
+          "src-pricing-checkout",
+          "test-homotopy-fillers"
         ],
         "muDefectRefs": [
           "mu:path-pair-path-rule-coupon-tax-rounding-semantic-loop:axis-homotopy-report-fixture"
         ],
         "sourceRefs": [
-          "doc-auth-policy",
-          "src-auth-bypass",
+          "filler-candidate:loop-candidate-path-pair-path-rule-coupon-tax-rounding-semantic-loop-7:filler-rule-contract-or-test",
           "src-cache-read",
-          "src-direct-read",
-          "src-event-projection",
           "src-pricing-checkout",
-          "src-repository-read",
-          "src-retry-effect",
           "test-homotopy-fillers"
         ],
         "observationRefs": [
-          "atom:cache-read",
-          "atom:repository-read",
-          "atom:event-projection",
-          "atom:retry-idempotency",
-          "atom:authorization-bypass",
-          "atom:coupon-tax-rounding"
+          "atom:coupon-tax-rounding",
+          "molecule:homotopy-report-fixture",
+          "semantic:path-rule:coupon-tax-rounding-semantic-loop"
         ],
         "fillerRefs": [
           "filler-candidate:loop-candidate-path-pair-path-rule-coupon-tax-rounding-semantic-loop-7:filler-rule-contract-or-test"
@@ -6478,7 +6430,7 @@
       {
         "readingId": "stokes-style:loop-candidate-path-pair-semantic-contract-loop-0",
         "loopRef": "loop-candidate:path-pair-semantic-contract-loop-0",
-        "status": "measuredZeroWithinBoundary",
+        "status": "filledNonzeroHolonomyReview",
         "measurementStatus": "measured",
         "readingBoundary": {
           "readingStrength": "boundedMeasuredWithCandidatePaths",
@@ -6513,10 +6465,12 @@
           "test-homotopy-fillers"
         ],
         "nonFillabilityWitnessRefs": [],
-        "localCurvatureCondition": "missing measured filler evidence blocks Stokes-style local curvature conclusion",
-        "localCurvatureCellCandidates": [],
+        "localCurvatureCondition": "measured filling plus nonzero holonomy localizes review curvature to selected 2-cells",
+        "localCurvatureCellCandidates": [
+          "2-cell:obstruction-homotopy-report-fixture"
+        ],
         "reviewQueueRefs": [
-          "homotopy-holonomy:loop-candidate-path-pair-semantic-contract-loop-0:axis-homotopy-report-fixture"
+          "2-cell:obstruction-homotopy-report-fixture"
         ],
         "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
         "evidenceBoundary": "Stokes-style reading is a bounded review queue, not theorem discharge",
@@ -6932,12 +6886,12 @@
         "loop-candidate:path-pair-path-rule-authorization-bypass-hole-6"
       ],
       "nonzeroHolonomyLoops": [
-        "loop-candidate:path-pair-path-rule-authorization-bypass-hole-6",
         "loop-candidate:path-pair-path-rule-cache-repository-semantic-loop-3",
         "loop-candidate:path-pair-path-rule-coupon-tax-rounding-semantic-loop-7",
         "loop-candidate:path-pair-path-rule-event-projection-direct-read-4",
         "loop-candidate:path-pair-path-rule-nonzero-holonomy-filled-loop-2",
-        "loop-candidate:path-pair-path-rule-retry-idempotency-effect-5"
+        "loop-candidate:path-pair-path-rule-retry-idempotency-effect-5",
+        "loop-candidate:path-pair-semantic-contract-loop-0"
       ],
       "topLocalCurvatureCells": [
         "2-cell:obstruction-homotopy-report-fixture"

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -4414,10 +4414,7 @@
         "test-user-contract"
       ],
       "observationRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "path-rule:interface-implementation"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "candidate paths are bounded review cues derived from ArchMap evidence and selected LawPolicy",
@@ -4484,10 +4481,7 @@
         "test-user-contract"
       ],
       "observationRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "path-rule:cache-repository"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "absence of a candidate path is not proof that no architectural loop exists",
@@ -5229,24 +5223,40 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
+        "Cont_axis:layer-violation(molecule:user-request-responsibility)",
         "Cont_axis:layer-violation(path:semantic-operation-flow)",
-        "Cont_axis:layer-violation(molecule:user-request-responsibility)"
+        "Cont_semantic[0]=operation:route-create-user; comparableValues=2",
+        "Cont_semantic[0]=operation:service-create-user; comparableValues=2",
+        "Cont_semantic[1]=operation:route-create-user; comparableValues=2",
+        "Cont_semantic[1]=operation:service-create-user; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "gap-runtime-user-db-trace",
-        "semantic:create-user-flow"
+        "continuation-value:semantic-endpoints-route-users-service-user",
+        "continuation-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+        "continuation-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+        "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+        "semantic:create-user-flow",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "muDefectRefs": [
-        "mu:path-pair-semantic-contract-loop:axis-layer-violation"
+        "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
       ],
       "sourceRefs": [
         "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
@@ -5300,24 +5310,40 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:semantic-inconsistency",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
+        "Cont_axis:semantic-inconsistency(molecule:user-request-responsibility)",
         "Cont_axis:semantic-inconsistency(path:semantic-operation-flow)",
-        "Cont_axis:semantic-inconsistency(molecule:user-request-responsibility)"
+        "Cont_semantic[0]=operation:route-create-user; comparableValues=2",
+        "Cont_semantic[0]=operation:service-create-user; comparableValues=2",
+        "Cont_semantic[1]=operation:route-create-user; comparableValues=2",
+        "Cont_semantic[1]=operation:service-create-user; comparableValues=2",
+        "Cont_semantic[endpoint]=p; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch",
+        "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "gap-runtime-user-db-trace",
-        "semantic:create-user-flow"
+        "continuation-value:semantic-endpoints-route-users-service-user",
+        "continuation-value:semantic-path-p-operation-route-create-user-operation-service-create-user",
+        "continuation-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
+        "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
+        "semantic:create-user-flow",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "muDefectRefs": [
-        "mu:path-pair-semantic-contract-loop:axis-semantic-inconsistency"
+        "mu:operation-square-operation-square-evidence-create-user-route-service:semantic"
       ],
       "sourceRefs": [
         "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
@@ -5370,18 +5396,21 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:layer-violation(path-rule:interface-implementation)",
-        "Cont_axis:layer-violation(interface-implementation-path)"
+        "Cont_axis:layer-violation(interface-implementation-path)",
+        "Cont_axis:layer-violation(path-rule:interface-implementation)"
       ],
       "distanceInputRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:contract:create-user",
-        "atom:relation:route-service",
-        "gap-runtime-user-db-trace"
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+        "path-rule:interface-implementation",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-interface-implementation:axis-layer-violation"
@@ -5389,15 +5418,14 @@
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
       ],
       "observationRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "path-rule:interface-implementation"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5440,18 +5468,21 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:interface-implementation vs interface-implementation-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)",
-        "Cont_axis:semantic-inconsistency(interface-implementation-path)"
+        "Cont_axis:semantic-inconsistency(interface-implementation-path)",
+        "Cont_axis:semantic-inconsistency(path-rule:interface-implementation)"
       ],
       "distanceInputRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:contract:create-user",
-        "atom:relation:route-service",
-        "gap-runtime-user-db-trace"
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
+        "path-rule:interface-implementation",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-interface-implementation:axis-semantic-inconsistency"
@@ -5459,15 +5490,14 @@
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
       ],
       "observationRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "path-rule:interface-implementation"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-interface-implementation-1:filler-rule-contract-or-test",
@@ -5510,18 +5540,21 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:layer-violation(path-rule:cache-repository)",
-        "Cont_axis:layer-violation(cache-repository-path)"
+        "Cont_axis:layer-violation(cache-repository-path)",
+        "Cont_axis:layer-violation(path-rule:cache-repository)"
       ],
       "distanceInputRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:contract:create-user",
-        "atom:relation:route-service",
-        "gap-runtime-user-db-trace"
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+        "path-rule:cache-repository",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-cache-repository:axis-layer-violation"
@@ -5529,15 +5562,14 @@
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
       ],
       "observationRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "path-rule:cache-repository"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5580,18 +5612,21 @@
         "witnessCompletenessBoundary": "homotopy zero reflects only measured path pairs and fillers inside the selected coverage universe; unresolved paths stay coverage gaps"
       },
       "distanceKind": "selected-axis-continuation-distance",
-      "value": 1,
-      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency",
+      "value": 0,
+      "comparedContinuationSummary": "path-rule:cache-repository vs cache-repository-path on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=7; semanticEvidence=0; traceAxes=0; missing=1",
       "comparedContinuationRefs": [
-        "Cont_axis:semantic-inconsistency(path-rule:cache-repository)",
-        "Cont_axis:semantic-inconsistency(cache-repository-path)"
+        "Cont_axis:semantic-inconsistency(cache-repository-path)",
+        "Cont_axis:semantic-inconsistency(path-rule:cache-repository)"
       ],
       "distanceInputRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:contract:create-user",
-        "atom:relation:route-service",
-        "gap-runtime-user-db-trace"
+        ".lake/runtime-trace.json",
+        "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
+        "path-rule:cache-repository",
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "muDefectRefs": [
         "mu:path-pair-path-rule-cache-repository:axis-semantic-inconsistency"
@@ -5599,15 +5634,14 @@
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-authority-or-idempotency",
+        "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
       ],
       "observationRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "path-rule:cache-repository"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-path-rule-cache-repository-2:filler-rule-contract-or-test",
@@ -5793,8 +5827,6 @@
       "loop-candidate:path-pair-semantic-contract-loop-0"
     ],
     "nonzeroHolonomyLoops": [
-      "loop-candidate:path-pair-path-rule-cache-repository-2",
-      "loop-candidate:path-pair-path-rule-interface-implementation-1",
       "loop-candidate:path-pair-semantic-contract-loop-0"
     ],
     "topLocalCurvatureCells": [],
@@ -5807,7 +5839,7 @@
       },
       {
         "aggregateId": "hol-mass:nonzero-holonomy-loop-count",
-        "value": 3,
+        "value": 1,
         "reading": "bounded count of loops with nonzero selected-axis holonomy",
         "boundary": "not future incident or empirical cost prediction"
       },


### PR DESCRIPTION
## 概要

Closes #1600

- `homotopyHolonomyReadings` の value 計算を path pair id / p/q path ref の文字列包含から外し、source-backed continuation comparison resolver に置き換えた
- path rule ごとの semantic observation / source refs / supplied p/q continuation traces / axis-wise `mu_x` defects / filler evidence / missing filler refs を holonomy の比較入力として保存するようにした
- Stokes-style positive reading を measured filler + measured nonzero holonomy + local curvature cell に限定し、architectural hole は blocked reading と non-fillability witness refs に分離した
- homotopy report fixture と validation を更新し、zero holonomy / nonzero holonomy / architectural hole の source-backed 条件を CLI test で固定した

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling implementation / docs tracking.
