### PR TITLE
ArchSig design principleをwitness評価へ拡張

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -295,7 +295,11 @@ The builder:
   Path, Homotopy, Diagram, and AnalyticRepresentation
 - emits architecture state, design pressure, change impact, bounded judgements,
   LLM interpretation, analytic representation, semantic coupling/cohesion,
-  workflow risk readings, spectral analysis readings, and design principle readings
+  workflow risk readings, spectral analysis readings, and design principle
+  readings. Design principles are principle-specific witness readings with
+  `witnessRuleRef`, `witnessStatus`, witness evidence refs, source refs, and
+  per-principle next actions; they are not global obstruction summaries or
+  static lint rules.
 - workflow risk readings rank molecule-local review pressure using ArchMap
   atoms, molecule roles, semantic observations, concern hints, and observation
   gaps. They are review-prioritization readings, not quality scores.

--- a/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
+++ b/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
@@ -128,6 +128,7 @@ For source comparison in this variant, build the review queue from nonzero axes,
 | `pathPairCandidates[]` and `operationSquareCandidates[]` | operation sequences, endpoint object refs, generator candidate refs | verify the candidate path basis before comparing continuations |
 | `pathContinuationTraces[]` | operation sequence, endpoint refs, continuation step refs | trace how `Cont_x(p)` and `Cont_x(q)` were built |
 | `axisWiseMonodromyDefects[]` | p/q continuation refs, distance input refs, positive witness boundary, weight | read `mu_x=d_x(Cont_x(p), Cont_x(q))` only when distance inputs are present |
+| `designPrincipleReadings[]` | principle-specific witness rule, witness status, evidence refs, source refs, obstruction refs | read principles as invariant / law / obstruction / operation preservation telemetry, not global lint status |
 | `architectureHomotopyReport.nonzeroHolonomyLoops[]` | loop refs, compared continuations, selected axes, source refs | inspect path differences as bounded current-state review queues |
 | `architectureHomotopyReport.unfilledLoops[]` | missing filler evidence, coverage gaps, next check refs | add or confirm contract/test/runtime/policy filler evidence before concluding |
 | `architectureHomotopyReport.topLocalCurvatureCells[]` | filled loop refs and local curvature cell candidates | review local curvature only inside measured fillings, not unfilled holes |

--- a/tools/archsig/skills/law-policy-creater/references/schema-guide.md
+++ b/tools/archsig/skills/law-policy-creater/references/schema-guide.md
@@ -99,6 +99,9 @@ evidence. Use conservative defaults when evidence is absent:
 - witness mismatch counts before severity scores
 - transfer edges from measured witness support overlap, not source proximity alone
 - report focus on top modes, witness refs, source refs, coverage gaps, and non-conclusions
+- design principle readings should have principle-specific witness evidence;
+  do not rely on global obstruction presence to read a principle as preserved
+  or stressed
 - reading strength that distinguishes measured support rows from bounded
   transfer proxies and coverage-blocked rows
 

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -9415,51 +9415,65 @@ fn build_design_principle_readings(
     repair_candidates: &[ArchSigRepairOperationCandidateV0],
 ) -> Vec<ArchSigDesignPrincipleReadingV0> {
     let specs = [
-        (
+        principle_spec(
             "InformationHiding",
             "representation, state, effect, and provider details stay inside declared boundaries",
+            &["state", "effect", "runtime", "projection"],
+            &["boundary", "private", "provider"],
         ),
-        (
+        principle_spec(
             "Encapsulation",
             "state mutation, effect execution, and authority checks are owned by the selected boundary",
+            &["state", "effect", "authority"],
+            &["ownership", "boundary"],
         ),
-        (
+        principle_spec(
             "SeparationOfConcerns",
             "semantic concern, state transition, effect, policy, and presentation remain unmixed",
+            &["semantic", "state", "effect", "contractSpecification"],
+            &["mixed", "concern", "semantic"],
         ),
-        (
+        principle_spec(
             "Substitutability",
             "replacement preserves contract, effect, state transition, and semantic reading",
+            &["contractSpecification", "effect", "state", "semantic"],
+            &["replacement", "contract", "semantic"],
         ),
-        (
+        principle_spec(
             "OpenClosedExtension",
             "feature extension preserves core invariants without new interaction obstruction",
+            &["contractSpecification", "relation", "semantic"],
+            &["extension", "interaction", "feature"],
         ),
-        (
+        principle_spec(
             "DependencyInversion",
             "abstract boundary semantics remain aligned with implementation obligations",
+            &["relation", "contractSpecification", "semantic"],
+            &["dependency", "abstract", "implementation"],
         ),
-        (
+        principle_spec(
             "RepresentationIndependence",
             "internal representation changes preserve selected observations and contracts",
+            &["state", "contractSpecification", "projection"],
+            &["representation", "projection"],
         ),
-        (
+        principle_spec(
             "IdempotencyAndReplaySafety",
             "retry, replay, jobs, and external effects preserve selected state transition law",
+            &["effect", "state", "runtimeInteraction"],
+            &["retry", "replay", "idempot", "runtime"],
         ),
-        (
+        principle_spec(
             "AuthorityAndTrustBoundary",
             "authority labels and trust handoffs survive operation paths",
+            &["authority", "trust", "runtimeInteraction"],
+            &["authority", "trust", "permission"],
         ),
     ];
     let gap_refs = archmap
         .observation_gaps
         .iter()
         .map(|gap| gap.gap_id.clone())
-        .collect::<Vec<_>>();
-    let obstruction_refs = obstruction_circuits
-        .iter()
-        .map(|circuit| circuit.obstruction_circuit_id.clone())
         .collect::<Vec<_>>();
     let invariant_refs = invariant_readings
         .iter()
@@ -9471,18 +9485,22 @@ fn build_design_principle_readings(
         .collect::<Vec<_>>();
     specs
         .into_iter()
-        .map(|(principle, reading)| {
-            let status = principle_status(principle, archmap, obstruction_circuits);
+        .map(|spec| {
+            let evaluation = evaluate_design_principle(&spec, archmap, obstruction_circuits);
             ArchSigDesignPrincipleReadingV0 {
-                principle_id: format!("principle:{}", stable_id(principle)),
-                principle: principle.to_string(),
-                status: status.to_string(),
-                aat_reading: format!("{principle} is read as invariant preservation / obstruction / operation preservation: {reading}"),
+                principle_id: format!("principle:{}", stable_id(spec.principle)),
+                principle: spec.principle.to_string(),
+                status: evaluation.status.clone(),
+                witness_rule_ref: format!("principle-witness:{}", stable_id(spec.principle)),
+                witness_status: evaluation.witness_status.clone(),
+                witness_evidence_refs: evaluation.evidence_refs.clone(),
+                aat_reading: format!("{} is read by {} over invariant / law / obstruction / operation preservation: {}", spec.principle, evaluation.witness_status, spec.reading),
                 invariant_refs: invariant_refs.clone(),
-                obstruction_refs: obstruction_refs.clone(),
+                obstruction_refs: evaluation.obstruction_refs.clone(),
                 operation_refs: operation_refs.clone(),
-                evidence_refs: all_atom_refs(archmap),
-                confidence: if status == "unmeasured" { "low" } else { "medium" }.to_string(),
+                evidence_refs: evaluation.evidence_refs.clone(),
+                source_refs: evaluation.source_refs.clone(),
+                confidence: if evaluation.status == "unmeasured" { "low" } else { "medium" }.to_string(),
                 coverage_boundary:
                     "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule"
                         .to_string(),
@@ -9491,34 +9509,160 @@ fn build_design_principle_readings(
                 } else {
                     gap_refs.clone()
                 },
-                recommended_next_action:
-                    "turn stressed readings into source review questions or repair preconditions"
-                        .to_string(),
+                recommended_next_action: evaluation.recommended_next_action,
                 non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
             }
         })
         .collect()
 }
 
-fn principle_status(
-    principle: &str,
+struct PrincipleSpec<'a> {
+    principle: &'a str,
+    reading: &'a str,
+    witness_families: &'a [&'a str],
+    stress_keywords: &'a [&'a str],
+}
+
+fn principle_spec<'a>(
+    principle: &'a str,
+    reading: &'a str,
+    witness_families: &'a [&'a str],
+    stress_keywords: &'a [&'a str],
+) -> PrincipleSpec<'a> {
+    PrincipleSpec {
+        principle,
+        reading,
+        witness_families,
+        stress_keywords,
+    }
+}
+
+struct PrincipleEvaluation {
+    status: String,
+    witness_status: String,
+    evidence_refs: Vec<String>,
+    source_refs: Vec<String>,
+    obstruction_refs: Vec<String>,
+    recommended_next_action: String,
+}
+
+fn evaluate_design_principle(
+    spec: &PrincipleSpec<'_>,
     archmap: &ArchMapDocumentV0,
     obstruction_circuits: &[ArchSigObstructionCircuitV0],
-) -> &'static str {
-    let lower = principle.to_ascii_lowercase();
-    if lower.contains("idempotency")
-        || lower.contains("authority")
-        || lower.contains("representation")
-    {
-        if archmap.observation_gaps.is_empty() {
-            "needsReview"
+) -> PrincipleEvaluation {
+    let evidence_atoms = archmap
+        .atom_observations
+        .iter()
+        .filter(|atom| {
+            spec.witness_families
+                .iter()
+                .any(|family| atom.atom_family == *family)
+                || spec.stress_keywords.iter().any(|keyword| {
+                    atom.predicate.to_ascii_lowercase().contains(keyword)
+                        || atom.subject_ref.to_ascii_lowercase().contains(keyword)
+                })
+        })
+        .collect::<Vec<_>>();
+    let evidence_refs = evidence_atoms
+        .iter()
+        .map(|atom| atom.atom_observation_id.clone())
+        .collect::<Vec<_>>();
+    let source_refs = evidence_atoms
+        .iter()
+        .flat_map(|atom| atom.source_refs.iter().map(source_ref_label))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let obstruction_refs = obstruction_circuits
+        .iter()
+        .filter(|circuit| {
+            let text = format!(
+                "{} {} {}",
+                circuit.law_ref, circuit.circuit_kind, circuit.evidence_summary
+            )
+            .to_ascii_lowercase();
+            spec.stress_keywords
+                .iter()
+                .any(|keyword| text.contains(keyword))
+                || circuit
+                    .atom_observation_refs
+                    .iter()
+                    .any(|atom_ref| evidence_refs.contains(atom_ref))
+        })
+        .map(|circuit| circuit.obstruction_circuit_id.clone())
+        .collect::<Vec<_>>();
+    let relevant_gaps = archmap
+        .observation_gaps
+        .iter()
+        .filter(|gap| {
+            let text = format!(
+                "{} {} {} {:?}",
+                gap.gap_id, gap.gap_kind, gap.reason, gap.expected_atom_families
+            )
+            .to_ascii_lowercase();
+            spec.stress_keywords
+                .iter()
+                .chain(spec.witness_families.iter())
+                .any(|keyword| text.contains(&keyword.to_ascii_lowercase()))
+        })
+        .map(|gap| gap.gap_id.clone())
+        .collect::<Vec<_>>();
+    let (status, witness_status, recommended_next_action) =
+        if evidence_refs.is_empty() && relevant_gaps.is_empty() {
+            (
+                "notApplicable",
+                "noSelectedWitnessRuleEvidence",
+                format!(
+                    "add source-backed witness evidence before reading {}",
+                    spec.principle
+                ),
+            )
+        } else if evidence_refs.is_empty() || !relevant_gaps.is_empty() {
+            (
+                "unmeasured",
+                "blockedByMissingWitnessEvidence",
+                format!(
+                    "collect {} witness sources for {}",
+                    spec.witness_families.join("/"),
+                    spec.principle
+                ),
+            )
+        } else if obstruction_refs.is_empty() {
+            (
+                "preserved",
+                "witnessPreservedUnderSelectedEvidence",
+                format!(
+                    "keep {} witness refs when planning operation deltas",
+                    spec.principle
+                ),
+            )
         } else {
-            "unmeasured"
+            (
+                "stressed",
+                "witnessStressedBySelectedObstruction",
+                format!(
+                    "review {} source refs before treating this principle as preserved",
+                    spec.principle
+                ),
+            )
+        };
+    let evidence_refs = if evidence_refs.is_empty() {
+        if relevant_gaps.is_empty() {
+            vec![format!("principle-witness:{}:not-applicable", stable_id(spec.principle))]
+        } else {
+            relevant_gaps
         }
-    } else if obstruction_circuits.is_empty() {
-        "preserved"
     } else {
-        "stressed"
+        evidence_refs
+    };
+    PrincipleEvaluation {
+        status: status.to_string(),
+        witness_status: witness_status.to_string(),
+        evidence_refs,
+        source_refs,
+        obstruction_refs,
+        recommended_next_action,
     }
 }
 
@@ -12648,6 +12792,51 @@ fn check_analytic_and_principle_surfaces(packet: &ArchSigAnalysisPacketV0) -> Va
                 "couplingCohesionReadings",
                 required_axis,
                 "packet must expose semantic coupling/cohesion axes",
+            ));
+        }
+    }
+    for reading in &packet.design_principle_readings {
+        if !matches!(
+            reading.status.as_str(),
+            "preserved" | "stressed" | "unmeasured" | "notApplicable"
+        ) {
+            examples.push(generic_validation_example(
+                &reading.principle_id,
+                &reading.status,
+                "design principle status must be preserved / stressed / unmeasured / notApplicable",
+            ));
+        }
+        push_blank(
+            &mut examples,
+            &format!("{} witnessRuleRef", reading.principle_id),
+            &reading.witness_rule_ref,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} witnessStatus", reading.principle_id),
+            &reading.witness_status,
+        );
+        if reading.status != "notApplicable" && reading.witness_evidence_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &reading.principle_id,
+                "witnessEvidenceRefs",
+                "applicable design principle readings must retain principle-specific witness evidence refs",
+            ));
+        }
+        if reading.status == "stressed" && reading.obstruction_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &reading.principle_id,
+                "obstructionRefs",
+                "stressed design principle readings must point to principle-specific obstruction refs",
+            ));
+        }
+        if reading.recommended_next_action
+            == "turn stressed readings into source review questions or repair preconditions"
+        {
+            examples.push(generic_validation_example(
+                &reading.principle_id,
+                "recommendedNextAction",
+                "design principle next action must be principle-specific",
             ));
         }
     }

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -1116,6 +1116,7 @@ fn build_analysis_summary(
         "axisSummary": axis_summary(packet),
         "aatObservationAxisSummary": aat_observation_axis_summary(packet),
         "workflowRiskSummary": workflow_risk_summary(packet),
+        "designPrincipleSummary": design_principle_summary(packet),
         "architecturalHoleSummary": architectural_hole_summary(packet),
         "bridgeSummary": bridge_summary(packet),
         "coverageGapSummary": coverage_gap_summary(packet),
@@ -1790,6 +1791,35 @@ fn workflow_risk_findings(packet: &serde_json::Value, limit: usize) -> serde_jso
             })
             .collect(),
     )
+}
+
+fn design_principle_summary(packet: &serde_json::Value) -> serde_json::Value {
+    let mut status_counts = BTreeMap::<String, usize>::new();
+    let items = array_items(packet, "designPrincipleReadings")
+        .into_iter()
+        .map(|reading| {
+            let status = json_field(reading, "status")
+                .as_str()
+                .unwrap_or("unknown")
+                .to_string();
+            *status_counts.entry(status.clone()).or_default() += 1;
+            serde_json::json!({
+                "principle": json_field(reading, "principle"),
+                "status": status,
+                "witnessRuleRef": json_field(reading, "witnessRuleRef"),
+                "witnessStatus": json_field(reading, "witnessStatus"),
+                "evidenceRefCount": array_len(reading, "witnessEvidenceRefs"),
+                "sourceRefCount": array_len(reading, "sourceRefs"),
+                "obstructionRefCount": array_len(reading, "obstructionRefs"),
+                "recommendedNextAction": json_field(reading, "recommendedNextAction")
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "statusCounts": status_counts,
+        "items": items,
+        "claimBoundary": "design principles are principle-specific witness readings, not static lint rules or theorem proofs"
+    })
 }
 
 fn architectural_hole_summary(packet: &serde_json::Value) -> serde_json::Value {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -2840,11 +2840,19 @@ pub struct ArchSigDesignPrincipleReadingV0 {
     pub principle_id: String,
     pub principle: String,
     pub status: String,
+    #[serde(default)]
+    pub witness_rule_ref: String,
+    #[serde(default)]
+    pub witness_status: String,
+    #[serde(default)]
+    pub witness_evidence_refs: Vec<String>,
     pub aat_reading: String,
     pub invariant_refs: Vec<String>,
     pub obstruction_refs: Vec<String>,
     pub operation_refs: Vec<String>,
     pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
     pub confidence: String,
     pub coverage_boundary: String,
     pub exactness_blockers: Vec<String>,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2229,6 +2229,24 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         );
     }
     assert!(
+        json["designPrincipleReadings"]
+            .as_array()
+            .expect("design principle readings are array")
+            .iter()
+            .all(|entry| {
+                matches!(
+                    entry["status"].as_str(),
+                    Some("preserved" | "stressed" | "unmeasured" | "notApplicable")
+                ) && entry["witnessRuleRef"].as_str().is_some()
+                    && entry["witnessStatus"].as_str().is_some()
+                    && entry["witnessEvidenceRefs"].as_array().is_some()
+                    && entry["recommendedNextAction"]
+                        .as_str()
+                        .is_some_and(|action| !action.contains("turn stressed readings"))
+            }),
+        "design principle readings must use principle-specific witness evaluation"
+    );
+    assert!(
         json["boundedJudgements"]
             .as_array()
             .expect("bounded judgements are array")

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -8805,30 +8805,31 @@
     {
       "principleId": "principle:informationhiding",
       "principle": "InformationHiding",
-      "status": "stressed",
-      "aatReading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+      "status": "unmeasured",
+      "witnessRuleRef": "principle-witness:informationhiding",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "aatReading": "InformationHiding is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
       ],
-      "obstructionRefs": [
-        "obstruction:semantic-contract-mismatch:computed"
-      ],
+      "obstructionRefs": [],
       "operationRefs": [
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
-      "confidence": "medium",
+      "sourceRefs": [],
+      "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect state/effect/runtime/projection witness sources for InformationHiding",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -8842,30 +8843,31 @@
     {
       "principleId": "principle:encapsulation",
       "principle": "Encapsulation",
-      "status": "stressed",
-      "aatReading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+      "status": "unmeasured",
+      "witnessRuleRef": "principle-witness:encapsulation",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "aatReading": "Encapsulation is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
       ],
-      "obstructionRefs": [
-        "obstruction:semantic-contract-mismatch:computed"
-      ],
+      "obstructionRefs": [],
       "operationRefs": [
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
-      "confidence": "medium",
+      "sourceRefs": [],
+      "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect state/effect/authority witness sources for Encapsulation",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -8879,8 +8881,14 @@
     {
       "principleId": "principle:separationofconcerns",
       "principle": "SeparationOfConcerns",
-      "status": "stressed",
-      "aatReading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+      "status": "unmeasured",
+      "witnessRuleRef": "principle-witness:separationofconcerns",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "aatReading": "SeparationOfConcerns is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
@@ -8892,17 +8900,20 @@
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "medium",
+      "sourceRefs": [
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect semantic/state/effect/contractSpecification witness sources for SeparationOfConcerns",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -8916,8 +8927,14 @@
     {
       "principleId": "principle:substitutability",
       "principle": "Substitutability",
-      "status": "stressed",
-      "aatReading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+      "status": "unmeasured",
+      "witnessRuleRef": "principle-witness:substitutability",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "aatReading": "Substitutability is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
@@ -8929,17 +8946,20 @@
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "medium",
+      "sourceRefs": [
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect contractSpecification/effect/state/semantic witness sources for Substitutability",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -8953,8 +8973,14 @@
     {
       "principleId": "principle:openclosedextension",
       "principle": "OpenClosedExtension",
-      "status": "stressed",
-      "aatReading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+      "status": "unmeasured",
+      "witnessRuleRef": "principle-witness:openclosedextension",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "aatReading": "OpenClosedExtension is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
@@ -8966,17 +8992,20 @@
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "medium",
+      "sourceRefs": [
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
+      ],
+      "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect contractSpecification/relation/semantic witness sources for OpenClosedExtension",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -8991,7 +9020,13 @@
       "principleId": "principle:dependencyinversion",
       "principle": "DependencyInversion",
       "status": "stressed",
-      "aatReading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+      "witnessRuleRef": "principle-witness:dependencyinversion",
+      "witnessStatus": "witnessStressedBySelectedObstruction",
+      "witnessEvidenceRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "aatReading": "DependencyInversion is read by witnessStressedBySelectedObstruction over invariant / law / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
@@ -9003,17 +9038,20 @@
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
+      ],
+      "sourceRefs": [
+        "src-route-users",
+        "src-service-user",
+        "test-user-contract"
       ],
       "confidence": "medium",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "review DependencyInversion source refs before treating this principle as preserved",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9027,8 +9065,13 @@
     {
       "principleId": "principle:representationindependence",
       "principle": "RepresentationIndependence",
-      "status": "unmeasured",
-      "aatReading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+      "status": "stressed",
+      "witnessRuleRef": "principle-witness:representationindependence",
+      "witnessStatus": "witnessStressedBySelectedObstruction",
+      "witnessEvidenceRefs": [
+        "atom:contract:create-user"
+      ],
+      "aatReading": "RepresentationIndependence is read by witnessStressedBySelectedObstruction over invariant / law / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
@@ -9040,17 +9083,17 @@
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "low",
+      "sourceRefs": [
+        "test-user-contract"
+      ],
+      "confidence": "medium",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "review RepresentationIndependence source refs before treating this principle as preserved",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9065,29 +9108,30 @@
       "principleId": "principle:idempotencyandreplaysafety",
       "principle": "IdempotencyAndReplaySafety",
       "status": "unmeasured",
-      "aatReading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+      "witnessRuleRef": "principle-witness:idempotencyandreplaysafety",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "aatReading": "IdempotencyAndReplaySafety is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
       ],
-      "obstructionRefs": [
-        "obstruction:semantic-contract-mismatch:computed"
-      ],
+      "obstructionRefs": [],
       "operationRefs": [
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
+      "sourceRefs": [],
       "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect effect/state/runtimeInteraction witness sources for IdempotencyAndReplaySafety",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9102,29 +9146,30 @@
       "principleId": "principle:authorityandtrustboundary",
       "principle": "AuthorityAndTrustBoundary",
       "status": "unmeasured",
-      "aatReading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+      "witnessRuleRef": "principle-witness:authorityandtrustboundary",
+      "witnessStatus": "blockedByMissingWitnessEvidence",
+      "witnessEvidenceRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "aatReading": "AuthorityAndTrustBoundary is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
       "invariantRefs": [
         "invariant:law-layer-respecting",
         "invariant:law-semantic-contract-alignment"
       ],
-      "obstructionRefs": [
-        "obstruction:semantic-contract-mismatch:computed"
-      ],
+      "obstructionRefs": [],
       "operationRefs": [
         "repair:obstruction-semantic-contract-mismatch-computed"
       ],
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
+      "sourceRefs": [],
       "confidence": "low",
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBlockers": [
         "gap-runtime-user-db-trace"
       ],
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect authority/trust/runtimeInteraction witness sources for AuthorityAndTrustBoundary",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9461,22 +9506,19 @@
     },
     {
       "judgementId": "judgement:principle-informationhiding",
-      "status": "actionable",
+      "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "InformationHiding is read as invariant preservation / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
+      "reading": "InformationHiding is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: representation, state, effect, and provider details stay inside declared boundaries",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
-      "confidence": "medium",
+      "confidence": "low",
       "uncertainty": [
         "gap-runtime-user-db-trace"
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect state/effect/runtime/projection witness sources for InformationHiding",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9489,22 +9531,19 @@
     },
     {
       "judgementId": "judgement:principle-encapsulation",
-      "status": "actionable",
+      "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "Encapsulation is read as invariant preservation / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
+      "reading": "Encapsulation is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: state mutation, effect execution, and authority checks are owned by the selected boundary",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
-      "confidence": "medium",
+      "confidence": "low",
       "uncertainty": [
         "gap-runtime-user-db-trace"
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect state/effect/authority witness sources for Encapsulation",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9517,22 +9556,20 @@
     },
     {
       "judgementId": "judgement:principle-separationofconcerns",
-      "status": "actionable",
+      "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "SeparationOfConcerns is read as invariant preservation / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
+      "reading": "SeparationOfConcerns is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: semantic concern, state transition, effect, policy, and presentation remain unmixed",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "medium",
+      "confidence": "low",
       "uncertainty": [
         "gap-runtime-user-db-trace"
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect semantic/state/effect/contractSpecification witness sources for SeparationOfConcerns",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9545,22 +9582,20 @@
     },
     {
       "judgementId": "judgement:principle-substitutability",
-      "status": "actionable",
+      "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "Substitutability is read as invariant preservation / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
+      "reading": "Substitutability is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: replacement preserves contract, effect, state transition, and semantic reading",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "medium",
+      "confidence": "low",
       "uncertainty": [
         "gap-runtime-user-db-trace"
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect contractSpecification/effect/state/semantic witness sources for Substitutability",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9573,22 +9608,20 @@
     },
     {
       "judgementId": "judgement:principle-openclosedextension",
-      "status": "actionable",
+      "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "OpenClosedExtension is read as invariant preservation / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
+      "reading": "OpenClosedExtension is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: feature extension preserves core invariants without new interaction obstruction",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "medium",
+      "confidence": "low",
       "uncertainty": [
         "gap-runtime-user-db-trace"
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect contractSpecification/relation/semantic witness sources for OpenClosedExtension",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9603,10 +9636,8 @@
       "judgementId": "judgement:principle-dependencyinversion",
       "status": "actionable",
       "aatConcept": "Invariant",
-      "reading": "DependencyInversion is read as invariant preservation / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
+      "reading": "DependencyInversion is read by witnessStressedBySelectedObstruction over invariant / law / obstruction / operation preservation: abstract boundary semantics remain aligned with implementation obligations",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
         "atom:relation:route-service",
         "atom:contract:create-user"
       ],
@@ -9616,7 +9647,7 @@
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "review DependencyInversion source refs before treating this principle as preserved",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9629,22 +9660,19 @@
     },
     {
       "judgementId": "judgement:principle-representationindependence",
-      "status": "blocked",
+      "status": "actionable",
       "aatConcept": "Invariant",
-      "reading": "RepresentationIndependence is read as invariant preservation / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
+      "reading": "RepresentationIndependence is read by witnessStressedBySelectedObstruction over invariant / law / obstruction / operation preservation: internal representation changes preserve selected observations and contracts",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
         "atom:contract:create-user"
       ],
-      "confidence": "low",
+      "confidence": "medium",
       "uncertainty": [
         "gap-runtime-user-db-trace"
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "review RepresentationIndependence source refs before treating this principle as preserved",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9659,12 +9687,9 @@
       "judgementId": "judgement:principle-idempotencyandreplaysafety",
       "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "IdempotencyAndReplaySafety is read as invariant preservation / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
+      "reading": "IdempotencyAndReplaySafety is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: retry, replay, jobs, and external effects preserve selected state transition law",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
       "confidence": "low",
       "uncertainty": [
@@ -9672,7 +9697,7 @@
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect effect/state/runtimeInteraction witness sources for IdempotencyAndReplaySafety",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9687,12 +9712,9 @@
       "judgementId": "judgement:principle-authorityandtrustboundary",
       "status": "blocked",
       "aatConcept": "Invariant",
-      "reading": "AuthorityAndTrustBoundary is read as invariant preservation / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
+      "reading": "AuthorityAndTrustBoundary is read by blockedByMissingWitnessEvidence over invariant / law / obstruction / operation preservation: authority labels and trust handoffs survive operation paths",
       "evidenceRefs": [
-        "atom:component:route-users",
-        "atom:component:service-user",
-        "atom:relation:route-service",
-        "atom:contract:create-user"
+        "gap-runtime-user-db-trace"
       ],
       "confidence": "low",
       "uncertainty": [
@@ -9700,7 +9722,7 @@
       ],
       "coverageBoundary": "principle reading uses semantic ArchMap evidence and is not a slogan or static lint rule",
       "exactnessBoundary": "design principle reading is not static lint and not theorem proof",
-      "recommendedNextAction": "turn stressed readings into source review questions or repair preconditions",
+      "recommendedNextAction": "collect authority/trust/runtimeInteraction witness sources for AuthorityAndTrustBoundary",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -9714,7 +9736,7 @@
   ],
   "llmInterpretationPacket": {
     "packetId": "llm-interpretation:fixture-archmap-atom-observation",
-    "shortDiagnosis": "9 actionable judgement(s), 1 design pressure reading(s), and 1 observation gap(s) require review",
+    "shortDiagnosis": "5 actionable judgement(s), 1 design pressure reading(s), and 1 observation gap(s) require review",
     "aatConceptMap": [
       "Atom -> Configuration -> ArchitectureObject",
       "InvariantFamily -> LawUniverse -> ObstructionCircuit -> ArchitectureSignature",
@@ -9907,15 +9929,15 @@
       "judgement:obstruction-semantic-contract-mismatch-computed: inspect source refs and repair operation preconditions",
       "judgement:sig-axis-layer-violation: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
       "judgement:sig-axis-semantic-inconsistency: use zero axes only with exactness assumptions; review nonzero axes as design pressure",
-      "judgement:principle-informationhiding: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-encapsulation: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-separationofconcerns: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-substitutability: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-openclosedextension: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-dependencyinversion: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-representationindependence: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-idempotencyandreplaysafety: turn stressed readings into source review questions or repair preconditions",
-      "judgement:principle-authorityandtrustboundary: turn stressed readings into source review questions or repair preconditions"
+      "judgement:principle-informationhiding: collect state/effect/runtime/projection witness sources for InformationHiding",
+      "judgement:principle-encapsulation: collect state/effect/authority witness sources for Encapsulation",
+      "judgement:principle-separationofconcerns: collect semantic/state/effect/contractSpecification witness sources for SeparationOfConcerns",
+      "judgement:principle-substitutability: collect contractSpecification/effect/state/semantic witness sources for Substitutability",
+      "judgement:principle-openclosedextension: collect contractSpecification/relation/semantic witness sources for OpenClosedExtension",
+      "judgement:principle-dependencyinversion: review DependencyInversion source refs before treating this principle as preserved",
+      "judgement:principle-representationindependence: review RepresentationIndependence source refs before treating this principle as preserved",
+      "judgement:principle-idempotencyandreplaysafety: collect effect/state/runtimeInteraction witness sources for IdempotencyAndReplaySafety",
+      "judgement:principle-authorityandtrustboundary: collect authority/trust/runtimeInteraction witness sources for AuthorityAndTrustBoundary"
     ]
   },
   "evidenceBoundary": "computed from ArchMap fixture-archmap-atom-observation and selected interpretation profile llm-native-aat-law-policy-fixture; concernHints are auxiliary cues only",


### PR DESCRIPTION
## 概要

Closes #1604

- `designPrincipleReadings` を global obstruction / gap 判定から、principle-specific witness evaluator に置き換えました。
- 各 principle に `witnessRuleRef`, `witnessStatus`, `witnessEvidenceRefs`, `sourceRefs` を追加し、status を `preserved` / `stressed` / `unmeasured` / `notApplicable` の evidence-backed reading として出します。
- `analysis-summary` に `designPrincipleSummary` を追加し、principle ごとの witness status と compact counts を読めるようにしました。
- CLI assertions、minimal fixture、ArchSig docs、archsig-reader / law-policy-creater skill docs を更新しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`
- `tools/archsig/skills/archsig-reader/references/output-reading-guide.md`
- `tools/archsig/skills/law-policy-creater/references/schema-guide.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
