### PR TITLE
ArchSig analysis packetをcompact-first化する

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -65,10 +65,9 @@ jobs:
           test -s "$archsig_dir/archmap-validation.json"
           test -s "$archsig_dir/law-policy-validation.json"
           test -s "$archsig_dir/archsig-analysis-packet.json"
+          test -s "$archsig_dir/archsig-analysis-detail-index.json"
           test -s "$archsig_dir/archsig-analysis-validation.json"
           test -s "$archsig_dir/llm-interpretation-packet.json"
-
-          cmp "$archsig_dir/archsig-analysis-packet.json" "$archsig_dir/llm-interpretation-packet.json"
 
           jq -e '
             .schemaVersion == "archsig-analysis-packet-v0"
@@ -78,6 +77,17 @@ jobs:
             and ((.signatureAxes | length) > 0)
             and ([.nonConclusions[] | contains("not a Lean theorem proof")] | any)
           ' "$archsig_dir/archsig-analysis-packet.json"
+
+          jq -e '
+            .schemaVersion == "archsig-analysis-detail-index-v0"
+            and .indexKind == "deduplicated-string-ref-set-dictionary"
+            and (.refDictionary | type == "array")
+            and (.refSets | type == "array")
+          ' "$archsig_dir/archsig-analysis-detail-index.json"
+
+          jq -e --slurpfile packet "$archsig_dir/archsig-analysis-packet.json" '
+            . == $packet[0].llmInterpretationPacket
+          ' "$archsig_dir/llm-interpretation-packet.json"
 
           jq -e '
             .summary.result == "pass"

--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -56,18 +56,19 @@ Expected ArchSig outputs:
 .lake/archsig-analyze-e2e/archsig/archmap-validation.json
 .lake/archsig-analyze-e2e/archsig/law-policy-validation.json
 .lake/archsig-analyze-e2e/archsig/archsig-analysis-packet.json
+.lake/archsig-analyze-e2e/archsig/archsig-analysis-detail-index.json
 .lake/archsig-analyze-e2e/archsig/archsig-analysis-validation.json
 .lake/archsig-analyze-e2e/archsig/llm-interpretation-packet.json
 ```
 
-The LLM interpretation packet is byte-for-byte the same structured analysis
-packet:
+The analysis packet is compact-first. Large repeated string ref sets are
+replaced by `archsig-detail-ref-v0` objects in the packet and stored through a
+dictionary-backed `archsig-analysis-detail-index.json`. For large ArchMaps, run
+the workflow with `cargo run --release`.
 
-```bash
-cmp \
-  .lake/archsig-analyze-e2e/archsig/archsig-analysis-packet.json \
-  .lake/archsig-analyze-e2e/archsig/llm-interpretation-packet.json
-```
+The LLM interpretation packet is the compact `llmInterpretationPacket` reading
+surface from `archsig-analysis-packet.json`; it is intentionally not a
+byte-for-byte copy of the full analysis packet.
 
 Project the ArchSig analysis packet into FieldSig:
 

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -115,12 +115,28 @@ This writes:
 - `.archsig/analyze/archmap-validation.json`
 - `.archsig/analyze/law-policy-validation.json`
 - `.archsig/analyze/archsig-analysis-packet.json`
+- `.archsig/analyze/archsig-analysis-detail-index.json`
 - `.archsig/analyze/archsig-analysis-validation.json`
 - `.archsig/analyze/llm-interpretation-packet.json`
 
-`llm-interpretation-packet.json` is the same structured packet written for LLM
-reading. Treat it as structured review evidence with explicit measurement
-bounds, not as a standalone decision record or automatic repair instruction.
+`archsig-analysis-packet.json` is compact-first: large repeated string ref
+sets are replaced by `archsig-detail-ref-v0` objects with counts, samples, and
+detail refs. Full ref sets are stored through a dictionary-backed
+`archsig-analysis-detail-index.json`.
+
+For large ArchMaps, prefer the optimized binary:
+
+```bash
+cargo run --release --manifest-path tools/archsig/Cargo.toml -- analyze \
+  --archmap .archsig/hilda/archmap.json \
+  --law-policy .archsig/hilda/hilda-law-policy.json \
+  --out-dir .archsig/analyze
+```
+
+`llm-interpretation-packet.json` contains the compact
+`llmInterpretationPacket` reading surface from the analysis packet. Treat it as
+structured review evidence with explicit measurement bounds, not as a
+standalone decision record or automatic repair instruction.
 
 To write the compact reading surface from those artifacts:
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -41,12 +41,20 @@ The command emits only:
 - `archmap-validation.json`
 - `law-policy-validation.json`
 - `archsig-analysis-packet.json`
+- `archsig-analysis-detail-index.json`
 - `archsig-analysis-validation.json`
 - `llm-interpretation-packet.json`
 
-`llm-interpretation-packet.json` is the same structured packet written for LLM
-reading. It is not a natural-language judgement, Lean proof, architecture
-lawfulness certificate, or automatic repair instruction.
+`archsig-analysis-packet.json` is compact-first: large repeated string ref sets
+are replaced by `archsig-detail-ref-v0` objects with counts, samples, and detail
+refs. Full ref sets are stored through a dictionary-backed
+`archsig-analysis-detail-index.json`. For large ArchMaps, run `analyze` with
+`cargo run --release`.
+
+`llm-interpretation-packet.json` contains the compact
+`llmInterpretationPacket` reading surface from the analysis packet. It is not a
+natural-language judgement, Lean proof, architecture lawfulness certificate, or
+automatic repair instruction.
 
 To emit a compact review summary from an existing packet, run:
 

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -3346,15 +3346,13 @@ fn selected_relation_graph(archmap: &ArchMapDocumentV0) -> SelectedRelationGraph
             }
         })
         .collect::<Vec<_>>();
-    let adjacency = matrix_entries
-        .iter()
-        .map(|entry| {
-            (
-                (entry.row_ref.as_str(), entry.column_ref.as_str()),
-                entry.value,
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
+    let mut adjacency_by_source = BTreeMap::<&str, Vec<(&str, i64)>>::new();
+    for entry in &matrix_entries {
+        adjacency_by_source
+            .entry(entry.row_ref.as_str())
+            .or_default()
+            .push((entry.column_ref.as_str(), entry.value));
+    }
     let mut reachable_pairs = BTreeSet::<String>::new();
     let mut walk_witness_refs = Vec::new();
     let mut cycle_refs = BTreeSet::<String>::new();
@@ -3366,10 +3364,10 @@ fn selected_relation_graph(archmap: &ArchMapDocumentV0) -> SelectedRelationGraph
         for depth in 1..=3 {
             let mut next = BTreeSet::new();
             for node in &frontier {
-                for target in nodes.iter().map(String::as_str) {
-                    if let Some(weight) = adjacency.get(&(*node, target)) {
+                if let Some(outgoing_edges) = adjacency_by_source.get(*node) {
+                    for (target, weight) in outgoing_edges {
                         walk_count_len_le_3 += *weight as usize;
-                        next.insert(target);
+                        next.insert(*target);
                         walk_witness_refs.push(format!(
                             "walk:{}:{}:{}",
                             stable_id(start),
@@ -3377,10 +3375,10 @@ fn selected_relation_graph(archmap: &ArchMapDocumentV0) -> SelectedRelationGraph
                             stable_id(target)
                         ));
                         reachable_pairs.insert(format!("{start}->{target}"));
-                        if target == start.as_str() {
+                        if *target == start.as_str() {
                             cycle_refs.insert(format!("cycle:{start}:length-{depth}"));
                         }
-                        if seen.insert(target) {
+                        if seen.insert(*target) {
                             max_shortest_path_len = max_shortest_path_len.max(depth);
                         }
                     }
@@ -12932,7 +12930,7 @@ pub fn validate_archsig_analysis_packet_report(
             arch_map_ref: packet.arch_map_ref.artifact_id.clone(),
             selected_law_policy_ref: packet.selected_law_policy_ref.artifact_id.clone(),
         },
-        packet: packet.clone(),
+        packet: None,
         summary,
         checks,
     }

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -1,6 +1,8 @@
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fs::File;
+use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -88,7 +90,7 @@ enum Command {
         #[arg(long = "validation-out")]
         validation_out: Option<PathBuf>,
 
-        /// Optional LLM interpretation packet output path. This writes the same structured packet for LLM reading.
+        /// Optional compact LLM interpretation packet output path.
         #[arg(long = "llm-interpretation-out")]
         llm_interpretation_out: Option<PathBuf>,
     },
@@ -304,9 +306,9 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 write_json(Some(path), &validation)?;
             }
             if let Some(path) = llm_interpretation_out {
-                write_json(Some(path), &packet)?;
+                write_json(Some(path), &packet.llm_interpretation_packet)?;
             }
-            write_json(out, &packet)?;
+            write_analysis_packet_artifacts(out, &packet, None)?;
             Ok(if failed {
                 ExitCode::from(1)
             } else {
@@ -519,8 +521,16 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 Some(&archmap.display().to_string()),
                 Some(&law_policy.display().to_string()),
             );
-            write_json(Some(analysis_packet_path.clone()), &analysis_packet)?;
-            write_json(Some(llm_interpretation_path), &analysis_packet)?;
+            let analysis_detail_index_path = out_dir.join("archsig-analysis-detail-index.json");
+            write_analysis_packet_artifacts(
+                Some(analysis_packet_path.clone()),
+                &analysis_packet,
+                Some(analysis_detail_index_path),
+            )?;
+            write_json(
+                Some(llm_interpretation_path),
+                &analysis_packet.llm_interpretation_packet,
+            )?;
             let analysis_validation = validate_archsig_analysis_packet_report(
                 &analysis_packet,
                 &analysis_packet_path.display().to_string(),
@@ -561,6 +571,267 @@ fn write_json<T: serde::Serialize>(out: Option<PathBuf>, value: &T) -> Result<()
             let stdout = io::stdout();
             let mut handle = stdout.lock();
             serde_json::to_writer_pretty(&mut handle, value)?;
+            writeln!(handle)?;
+        }
+    }
+    Ok(())
+}
+
+const COMPACT_REF_ARRAY_THRESHOLD: usize = 50;
+const COMPACT_REF_SAMPLE_COUNT: usize = 5;
+
+fn write_analysis_packet_artifacts(
+    out: Option<PathBuf>,
+    packet: &archsig::ArchSigAnalysisPacketV0,
+    detail_out: Option<PathBuf>,
+) -> Result<(), Box<dyn Error>> {
+    let mut packet_value = serde_json::to_value(packet)?;
+    let detail_path = match (&out, detail_out) {
+        (_, Some(path)) => Some(path),
+        (Some(path), None) => Some(default_detail_index_path(path)),
+        (None, None) => None,
+    };
+    let detail_ref_base = detail_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "detail-index-not-written".to_string());
+    let mut compact = CompactRefContext::new(detail_ref_base);
+    let mut json_pointer = Vec::new();
+    compact_ref_arrays(&mut packet_value, &mut json_pointer, &mut compact);
+    attach_detail_index_ref(&mut packet_value, &compact);
+
+    if let Some(path) = detail_path {
+        write_json_minified(Some(path), &compact.detail_index_value())?;
+    }
+    write_json_minified(out, &packet_value)?;
+    Ok(())
+}
+
+fn default_detail_index_path(packet_path: &Path) -> PathBuf {
+    let stem = packet_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("archsig-analysis-packet");
+    let file_name = format!("{stem}-detail-index.json");
+    packet_path.with_file_name(file_name)
+}
+
+struct CompactRefContext {
+    detail_ref_base: String,
+    next_ref_set: usize,
+    ref_set_by_hash: BTreeMap<u64, Vec<String>>,
+    ref_sets: BTreeMap<String, CompactRefSet>,
+}
+
+struct CompactRefSet {
+    item_count: usize,
+    sample_refs: Vec<String>,
+    refs: Vec<String>,
+    json_pointers: Vec<String>,
+}
+
+impl CompactRefContext {
+    fn new(detail_ref_base: String) -> Self {
+        Self {
+            detail_ref_base,
+            next_ref_set: 1,
+            ref_set_by_hash: BTreeMap::new(),
+            ref_sets: BTreeMap::new(),
+        }
+    }
+
+    fn intern_ref_set(
+        &mut self,
+        refs: Vec<String>,
+        json_pointer: String,
+    ) -> (String, usize, Vec<String>) {
+        let hash = hash_refs(&refs);
+        let ref_set_id = self
+            .ref_set_by_hash
+            .get(&hash)
+            .and_then(|candidate_ids| {
+                candidate_ids.iter().find_map(|candidate_id| {
+                    self.ref_sets
+                        .get(candidate_id)
+                        .filter(|candidate| candidate.refs == refs)
+                        .map(|_| candidate_id.clone())
+                })
+            })
+            .unwrap_or_else(|| {
+                let id = format!("refset:{:06}", self.next_ref_set);
+                self.next_ref_set += 1;
+                self.ref_set_by_hash
+                    .entry(hash)
+                    .or_default()
+                    .push(id.clone());
+                self.ref_sets.insert(
+                    id.clone(),
+                    CompactRefSet {
+                        item_count: refs.len(),
+                        sample_refs: refs
+                            .iter()
+                            .take(COMPACT_REF_SAMPLE_COUNT)
+                            .cloned()
+                            .collect(),
+                        refs,
+                        json_pointers: Vec::new(),
+                    },
+                );
+                id
+            });
+        let ref_set = self
+            .ref_sets
+            .get_mut(&ref_set_id)
+            .expect("interned ref set must exist");
+        ref_set.json_pointers.push(json_pointer);
+        (ref_set_id, ref_set.item_count, ref_set.sample_refs.clone())
+    }
+
+    fn detail_ref(&self, ref_set_id: &str) -> String {
+        format!("{}#{}", self.detail_ref_base, ref_set_id)
+    }
+
+    fn detail_index_value(&self) -> serde_json::Value {
+        let mut dictionary_by_ref = BTreeMap::<String, usize>::new();
+        let mut ref_dictionary = Vec::<String>::new();
+        for ref_set in self.ref_sets.values() {
+            for ref_value in &ref_set.refs {
+                if !dictionary_by_ref.contains_key(ref_value) {
+                    let index = ref_dictionary.len();
+                    dictionary_by_ref.insert(ref_value.clone(), index);
+                    ref_dictionary.push(ref_value.clone());
+                }
+            }
+        }
+        let ref_sets = self
+            .ref_sets
+            .iter()
+            .map(|(ref_set_id, ref_set)| {
+                let ref_indexes = ref_set
+                    .refs
+                    .iter()
+                    .filter_map(|ref_value| dictionary_by_ref.get(ref_value).copied())
+                    .collect::<Vec<_>>();
+                serde_json::json!({
+                    "refSetId": ref_set_id,
+                    "refCount": ref_set.item_count,
+                    "jsonPointers": ref_set.json_pointers,
+                    "refIndexes": ref_indexes,
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "schemaVersion": "archsig-analysis-detail-index-v0",
+            "indexKind": "deduplicated-string-ref-set-dictionary",
+            "compactThreshold": COMPACT_REF_ARRAY_THRESHOLD,
+            "refSetCount": self.ref_sets.len(),
+            "refDictionary": ref_dictionary,
+            "refSets": ref_sets,
+            "nonConclusions": [
+                "detail index preserves full string reference sets omitted from the compact analysis packet",
+                "refSets[].refIndexes indexes into refDictionary and preserves ref order inside each set",
+                "detail refs are evidence navigation aids, not theorem evidence or source completeness proof"
+            ]
+        })
+    }
+}
+
+fn compact_ref_arrays(
+    value: &mut serde_json::Value,
+    json_pointer: &mut Vec<String>,
+    compact: &mut CompactRefContext,
+) {
+    match value {
+        serde_json::Value::Array(items)
+            if items.len() > COMPACT_REF_ARRAY_THRESHOLD
+                && items.iter().all(serde_json::Value::is_string) =>
+        {
+            let refs = items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            let pointer = json_pointer_string(json_pointer);
+            let (ref_set_id, ref_count, sample_refs) = compact.intern_ref_set(refs, pointer);
+            *value = serde_json::json!({
+                "schemaVersion": "archsig-detail-ref-v0",
+                "refSetId": ref_set_id,
+                "refCount": ref_count,
+                "sampleRefs": sample_refs,
+                "detailRef": compact.detail_ref(&ref_set_id),
+            });
+        }
+        serde_json::Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                json_pointer.push(index.to_string());
+                compact_ref_arrays(item, json_pointer, compact);
+                json_pointer.pop();
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                json_pointer.push(json_pointer_escape(key));
+                compact_ref_arrays(child, json_pointer, compact);
+                json_pointer.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn hash_refs(refs: &[String]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    refs.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn json_pointer_string(segments: &[String]) -> String {
+    if segments.is_empty() {
+        String::new()
+    } else {
+        format!("/{}", segments.join("/"))
+    }
+}
+
+fn attach_detail_index_ref(packet_value: &mut serde_json::Value, compact: &CompactRefContext) {
+    if let serde_json::Value::Object(map) = packet_value {
+        map.insert(
+            "detailIndexRef".to_string(),
+            serde_json::json!({
+                "schemaVersion": "archsig-analysis-detail-index-ref-v0",
+                "artifactKind": "archsig-analysis-detail-index",
+                "path": compact.detail_ref_base,
+                "refSetCount": compact.ref_sets.len(),
+                "compactThreshold": COMPACT_REF_ARRAY_THRESHOLD,
+                "detailRefFormat": "<path>#<refSetId>"
+            }),
+        );
+    }
+}
+
+fn json_pointer_escape(key: &str) -> String {
+    key.replace('~', "~0").replace('/', "~1")
+}
+
+fn write_json_minified<T: serde::Serialize>(
+    out: Option<PathBuf>,
+    value: &T,
+) -> Result<(), Box<dyn Error>> {
+    match out {
+        Some(path) => {
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent)?;
+                }
+            }
+            let mut file = File::create(path)?;
+            serde_json::to_writer(&mut file, value)?;
+            writeln!(file)?;
+        }
+        None => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            serde_json::to_writer(&mut handle, value)?;
             writeln!(handle)?;
         }
     }

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -3136,7 +3136,8 @@ pub struct ArchSigLlmInterpretationPacketV0 {
 pub struct ArchSigAnalysisPacketValidationReportV0 {
     pub schema_version: String,
     pub input: ArchSigAnalysisPacketValidationInputV0,
-    pub packet: ArchSigAnalysisPacketV0,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packet: Option<ArchSigAnalysisPacketV0>,
     pub summary: ArchSigAnalysisPacketValidationSummaryV0,
     pub checks: Vec<ValidationCheck>,
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -759,6 +759,7 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         "archmap-validation.json",
         "law-policy-validation.json",
         "archsig-analysis-packet.json",
+        "archsig-analysis-detail-index.json",
         "archsig-analysis-validation.json",
         "llm-interpretation-packet.json",
     ];
@@ -797,6 +798,15 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         analysis_packet["schemaVersion"],
         "archsig-analysis-packet-v0"
     );
+    let detail_index = read_json(&out_dir.join("archsig-analysis-detail-index.json"));
+    assert_eq!(
+        detail_index["schemaVersion"],
+        "archsig-analysis-detail-index-v0"
+    );
+    assert_eq!(
+        analysis_packet["detailIndexRef"]["artifactKind"],
+        "archsig-analysis-detail-index"
+    );
     assert!(
         analysis_packet["obstructionCircuits"]
             .as_array()
@@ -832,7 +842,15 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         "validation summary must count bounded judgements"
     );
     let llm_packet = read_json(&out_dir.join("llm-interpretation-packet.json"));
-    assert_eq!(llm_packet, analysis_packet);
+    assert_eq!(llm_packet, analysis_packet["llmInterpretationPacket"]);
+    assert!(
+        llm_packet.get("obstructionCircuits").is_none(),
+        "LLM interpretation artifact must not duplicate the full analysis packet"
+    );
+    assert!(
+        analysis_validation.get("packet").is_none(),
+        "analysis validation must not embed the full analysis packet"
+    );
 }
 
 #[test]
@@ -907,7 +925,14 @@ fn cli_archsig_analysis_step_outputs_packet_and_validation() {
         validation_json["schemaVersion"],
         "archsig-analysis-packet-validation-report-v0"
     );
-    assert_eq!(read_json(&llm_packet), packet_json);
+    assert_eq!(
+        read_json(&llm_packet),
+        packet_json["llmInterpretationPacket"]
+    );
+    assert!(
+        validation_json.get("packet").is_none(),
+        "analysis validation must not embed the full analysis packet"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

ArchSig の `analyze` / `archsig-analysis` 出力を compact-first に変更し、巨大な ref 配列を analysis packet 本体へ繰り返し埋め込まないようにしました。

- `archsig-analysis-packet.json` は長大な string ref 配列を `archsig-detail-ref-v0` に置換
- full ref set は dictionary-backed な `archsig-analysis-detail-index.json` に分離
- `llm-interpretation-packet.json` は `llmInterpretationPacket` の compact reading surface のみを出力
- validation report は full packet を再埋め込みしない
- Hilda 規模の ArchMap で packet / detail index サイズと実行時間を実測し、docs に反映

対象 Issue: なし

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/llm_native_e2e_workflow.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig handoff 確認）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加確認:

- Hilda ArchMap で `analyze` を実測
  - 変更前: 約 62.95s
  - 最適化後 dev build: 約 44.27s
  - release binary warm run: 約 27.92s
- compact packet から `analysis-summary` 生成
- compact packet から FieldSig handoff 生成

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない