### PR TITLE
ArchSigのproxy-free witness計算を強化

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -254,8 +254,9 @@ commit / snapshot / index refs, operation square candidates, axis-wise path
 continuation traces, `measurementStatus` and `readingBoundary` fields for ACTS
 and Homotopy measurement records, monodromy / boundary holonomy reading family
 policy surfaces, law-relative obstruction links, signature / flatness
-references, repair candidate guardrails, LLM interpretation notes, evidence
-boundary, and required non-conclusions.
+references, repair candidate guardrails, selected-axis continuation defect refs
+for nonzero homotopy holonomy, LLM interpretation notes, evidence boundary,
+and required non-conclusions.
 Each obstruction circuit, signature axis reading, and repair operation candidate
 must carry its own `missingEvidence` and `excludedReadings`. Packet-level
 `excludedReadings` does not stand in for child-record evidence boundaries.
@@ -298,8 +299,12 @@ The builder:
 
 - evaluates selected interpretation-profile witness rules over ArchMap atom and semantic observations
 - uses `concernHints` only as auxiliary evidence
-- constructs obstruction circuits only as ArchSig outputs
-- values required signature axes from constructed obstruction circuits
+- constructs obstruction circuits only from family-complete witness rules whose
+  required atom families and `moleculePatternRefs` are observed under the
+  selected LawPolicy
+- values required signature axes from constructed obstruction circuits; a
+  nonzero signature axis must not be emitted from concern hints, blocked
+  witnesses, incomplete molecule patterns, or policy text alone
 - preserves observation gaps as flatness blockers, not measured zero
 - emits AAT concept surfaces for Atom, Configuration, ArchitectureObject,
   Invariant, LawUniverse, ObstructionCircuit, ArchitectureSignature, Operation,

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -2473,10 +2473,23 @@ fn build_obstruction_circuits(
                 .witness_rules
                 .iter()
                 .find(|rule| rule.witness_rule_id == definition.witness_rule_ref)?;
-            let atom_refs = matching_atom_refs_for_witness(archmap, witness_rule);
+            let atom_family_refs = matching_atom_family_refs_for_witness(archmap, witness_rule);
+            let atom_refs = unique_strings(
+                atom_family_refs
+                    .iter()
+                    .flat_map(|family| family.observation_refs.iter().cloned()),
+            );
             let molecule_refs = molecule_readings
                 .iter()
-                .filter(|reading| reading.law_refs.contains(&definition.law_ref))
+                .filter(|reading| {
+                    reading.law_refs.contains(&definition.law_ref)
+                        && molecule_reading_satisfies_witness_patterns(
+                            archmap,
+                            law_policy,
+                            reading,
+                            witness_rule,
+                        )
+                })
                 .map(|reading| reading.molecule_reading_id.clone())
                 .collect::<Vec<_>>();
             let concern_refs = archmap
@@ -2486,7 +2499,7 @@ fn build_obstruction_circuits(
                 .map(|hint| hint.concern_hint_id.clone())
                 .collect::<Vec<_>>();
 
-            if !witness_constructible(witness_rule, &atom_refs, &molecule_refs, &concern_refs) {
+            if !witness_constructible(witness_rule, &atom_family_refs, &molecule_refs) {
                 return None;
             }
 
@@ -11224,20 +11237,12 @@ fn source_backed_continuation_comparison(
     } else {
         Vec::new()
     };
-    let value = if !positive_defect_refs.is_empty() || !semantic_refs.is_empty() {
-        1
-    } else {
-        0
-    };
-    let mu_defect_refs = if positive_defect_refs.is_empty() {
-        vec![format!(
-            "mu:{}:{}",
-            stable_id(&loop_candidate.path_pair_ref),
-            stable_id(axis_ref)
-        )]
-    } else {
-        positive_defect_refs
-    };
+    let value = related_defects
+        .iter()
+        .filter_map(|defect| defect.distance_value)
+        .filter(|value| *value > 0)
+        .sum::<i64>();
+    let mu_defect_refs = positive_defect_refs;
     let summary = format!(
         "{} vs {} on {axis_ref}; distanceKind={distance_kind}; sourceRefs={}; semanticEvidence={}; traceAxes={}; missing={}",
         path_pair.p_path_ref,
@@ -13017,11 +13022,11 @@ fn check_homotopy_holonomy_stokes_surface(packet: &ArchSigAnalysisPacketV0) -> V
                 "homotopy holonomy reading must connect mu_x to compared continuation refs and distance inputs",
             ));
         }
-        if reading.mu_defect_refs.is_empty() {
+        if reading.value != 0 && reading.mu_defect_refs.is_empty() {
             examples.push(generic_validation_example(
                 &reading.reading_id,
                 "muDefectRefs",
-                "homotopy holonomy reading must expose mu_x defect refs",
+                "nonzero homotopy holonomy reading must expose positive mu_x defect refs",
             ));
         }
         if reading.filler_refs.is_empty() && reading.missing_filler_refs.is_empty() {
@@ -17685,14 +17690,11 @@ fn check_measurement_depth(packet: &ArchSigAnalysisPacketV0) -> ValidationCheck 
                     "measured holonomy must retain source, observation, or monodromy defect refs",
                 ));
             }
-            if holonomy.value != 0
-                && holonomy.observation_refs.is_empty()
-                && holonomy.mu_defect_refs.is_empty()
-            {
+            if holonomy.value != 0 && holonomy.mu_defect_refs.is_empty() {
                 examples.push(generic_validation_example(
                     &holonomy.reading_id,
-                    "muDefectRefs/observationRefs",
-                    "nonzero holonomy must be backed by semantic evidence or positive monodromy defects",
+                    "muDefectRefs",
+                    "nonzero holonomy must be backed by positive selected-axis continuation defects, not semantic evidence alone",
                 ));
             }
         }
@@ -17893,6 +17895,23 @@ fn check_law_relative_analysis(packet: &ArchSigAnalysisPacketV0) -> ValidationCh
                 "obstruction circuit must declare affected signature axes",
             ));
         }
+        if circuit.atom_observation_refs.is_empty() {
+            examples.push(generic_validation_example(
+                &circuit.obstruction_circuit_id,
+                "atomObservationRefs",
+                "obstruction circuit must be backed by required witness atom families, not policy text or concern cues",
+            ));
+        }
+        if !circuit.concern_hint_refs.is_empty()
+            && (circuit.atom_observation_refs.is_empty()
+                || circuit.molecule_reading_refs.is_empty())
+        {
+            examples.push(generic_validation_example(
+                &circuit.obstruction_circuit_id,
+                "concernHintRefs",
+                "concernHints may only be auxiliary context after atom and molecule witness support are present",
+            ));
+        }
         for axis_ref in &circuit.signature_axis_refs {
             if !axis_ids.contains(axis_ref.as_str()) {
                 examples.push(generic_validation_example(
@@ -17960,12 +17979,28 @@ fn check_signature_and_flatness(packet: &ArchSigAnalysisPacketV0) -> ValidationC
         ),
     ));
     for axis in &packet.signature_axes {
+        let constructed_value = packet
+            .obstruction_circuits
+            .iter()
+            .filter(|circuit| {
+                circuit
+                    .signature_axis_refs
+                    .contains(&axis.signature_axis_id)
+            })
+            .count() as i64;
         push_blank(&mut examples, &axis.signature_axis_id, &axis.law_ref);
         push_blank(
             &mut examples,
             &format!("{} axisRef", axis.signature_axis_id),
             &axis.axis_ref,
         );
+        if axis.value != constructed_value {
+            examples.push(generic_validation_example(
+                &axis.signature_axis_id,
+                "value",
+                "signature axis value must equal constructed obstruction circuit count for that axis",
+            ));
+        }
         if axis.exactness_assumptions.is_empty() || has_blank(&axis.exactness_assumptions) {
             examples.push(generic_validation_example(
                 &axis.signature_axis_id,
@@ -18349,36 +18384,78 @@ fn selected_laws_for_atom_refs(
     law_refs
 }
 
-fn matching_atom_refs_for_witness(
+#[derive(Debug, Clone)]
+struct WitnessFamilySupport {
+    family_ref: String,
+    observation_refs: Vec<String>,
+}
+
+fn matching_atom_family_refs_for_witness(
     archmap: &ArchMapDocumentV0,
     witness_rule: &LawPolicyWitnessRuleV0,
-) -> Vec<String> {
-    let mut refs = archmap
-        .atom_observations
+) -> Vec<WitnessFamilySupport> {
+    witness_rule
+        .required_atom_families
         .iter()
-        .filter(|atom| {
-            witness_rule
-                .required_atom_families
-                .iter()
-                .any(|family| family_matches(atom.atom_family.as_str(), family.as_str()))
+        .map(|family| WitnessFamilySupport {
+            family_ref: family.clone(),
+            observation_refs: matching_observation_refs_for_family(archmap, family),
         })
-        .map(|atom| atom.atom_observation_id.clone())
-        .collect::<Vec<_>>();
-    refs.extend(
+        .collect()
+}
+
+fn matching_observation_refs_for_family(archmap: &ArchMapDocumentV0, family: &str) -> Vec<String> {
+    unique_strings(
         archmap
-            .semantic_observations
+            .atom_observations
             .iter()
-            .filter(|semantic| {
-                witness_rule.required_atom_families.iter().any(|family| {
-                    family_matches(semantic.semantic_family.as_str(), family.as_str())
-                        || family_matches(semantic.predicate.as_str(), family.as_str())
+            .filter(|atom| family_matches(atom.atom_family.as_str(), family))
+            .map(|atom| atom.atom_observation_id.clone())
+            .chain(
+                archmap
+                    .semantic_observations
+                    .iter()
+                    .filter(|semantic| {
+                        family_matches(semantic.semantic_family.as_str(), family)
+                            || family_matches(semantic.predicate.as_str(), family)
+                    })
+                    .map(|semantic| semantic.semantic_observation_id.clone()),
+            ),
+    )
+}
+
+fn molecule_reading_satisfies_witness_patterns(
+    archmap: &ArchMapDocumentV0,
+    law_policy: &LawPolicyDocumentV0,
+    reading: &ArchSigMoleculeReadingV0,
+    witness_rule: &LawPolicyWitnessRuleV0,
+) -> bool {
+    if witness_rule.molecule_pattern_refs.is_empty() {
+        return true;
+    }
+
+    witness_rule
+        .molecule_pattern_refs
+        .iter()
+        .all(|pattern_ref| {
+            law_policy
+                .molecule_patterns
+                .iter()
+                .find(|pattern| pattern.molecule_pattern_id == *pattern_ref)
+                .is_some_and(|pattern| {
+                    pattern.required_atom_families.iter().all(|family| {
+                        reading.atom_observation_refs.iter().any(|atom_ref| {
+                            archmap
+                                .atom_observations
+                                .iter()
+                                .find(|atom| atom.atom_observation_id == *atom_ref)
+                                .is_some_and(|atom| {
+                                    family_matches(atom.atom_family.as_str(), family)
+                                })
+                        })
+                    })
                 })
-            })
-            .map(|semantic| semantic.semantic_observation_id.clone()),
-    );
-    refs.sort();
-    refs.dedup();
-    refs
+        })
 }
 
 fn concern_supports_witness(concern_family: &str, witness_rule: &LawPolicyWitnessRuleV0) -> bool {
@@ -18395,21 +18472,17 @@ fn concern_supports_witness(concern_family: &str, witness_rule: &LawPolicyWitnes
 
 fn witness_constructible(
     witness_rule: &LawPolicyWitnessRuleV0,
-    atom_refs: &[String],
+    atom_family_refs: &[WitnessFamilySupport],
     molecule_refs: &[String],
-    concern_refs: &[String],
 ) -> bool {
-    if witness_rule.required_atom_families.is_empty() {
-        return !molecule_refs.is_empty() || !concern_refs.is_empty();
-    }
-    let required_count = witness_rule.required_atom_families.len();
-    atom_refs.len() >= required_count
-        || (!atom_refs.is_empty() && !molecule_refs.is_empty() && !concern_refs.is_empty())
-        || (witness_rule
-            .witness_kind
-            .to_ascii_lowercase()
-            .contains("mismatch")
-            && !concern_refs.is_empty())
+    let required_atom_families_observed = witness_rule.required_atom_families.is_empty()
+        || atom_family_refs.iter().all(|family| {
+            !family.family_ref.trim().is_empty() && !family.observation_refs.is_empty()
+        });
+    let required_molecule_patterns_observed =
+        witness_rule.molecule_pattern_refs.is_empty() || !molecule_refs.is_empty();
+
+    required_atom_families_observed && required_molecule_patterns_observed
 }
 
 fn obstruction_circuit(
@@ -18882,6 +18955,10 @@ fn strings(values: &[&str]) -> Vec<String> {
 mod tests {
     use super::*;
 
+    fn constructible_obstruction_packet() -> ArchSigAnalysisPacketV0 {
+        static_archsig_analysis_packet()
+    }
+
     fn relation_atom(
         atom_observation_id: &str,
         source_ref: &str,
@@ -19043,7 +19120,7 @@ mod tests {
 
     #[test]
     fn repair_without_preconditions_fails() {
-        let mut packet = static_archsig_analysis_packet();
+        let mut packet = constructible_obstruction_packet();
         packet.repair_operation_candidates[0].preconditions.clear();
         let report = validate_archsig_analysis_packet_report(&packet, "bad-analysis.json");
         assert_eq!(report.summary.result, "fail");
@@ -19055,7 +19132,7 @@ mod tests {
 
     #[test]
     fn child_boundary_absence_fails_validation() {
-        let mut packet = static_archsig_analysis_packet();
+        let mut packet = constructible_obstruction_packet();
         packet.obstruction_circuits[0].missing_evidence.clear();
         packet.signature_axes[0].excluded_readings.clear();
         packet.repair_operation_candidates[0]
@@ -19388,6 +19465,8 @@ mod tests {
         assert!(
             packet.obstruction_circuits.iter().any(|circuit| {
                 circuit.law_ref == "law:semantic-contract-alignment"
+                    && !circuit.atom_observation_refs.is_empty()
+                    && !circuit.molecule_reading_refs.is_empty()
                     && circuit
                         .concern_hint_refs
                         .contains(&"concern:missing-compensation".to_string())
@@ -19395,21 +19474,114 @@ mod tests {
             "{:?}",
             packet.obstruction_circuits
         );
-        assert!(
-            packet
-                .signature_axes
-                .iter()
-                .any(
-                    |axis| axis.signature_axis_id == "sig-axis:semantic-inconsistency"
-                        && axis.value == 1
-                )
-        );
+        assert!(packet.signature_axes.iter().any(|axis| {
+            axis.signature_axis_id == "sig-axis:semantic-inconsistency" && axis.value == 1
+        }));
         assert!(
             packet
                 .flatness_reading
                 .blocked_by_coverage_gaps
                 .contains(&"gap-runtime-user-db-trace".to_string())
         );
+    }
+
+    #[test]
+    fn obstruction_requires_family_complete_atom_and_molecule_witnesses() {
+        let packet = constructible_obstruction_packet();
+        let report = validate_archsig_analysis_packet_report(&packet, "computed-analysis.json");
+
+        assert_eq!(report.summary.result, "pass", "{:?}", report.checks);
+        assert_eq!(packet.obstruction_circuits.len(), 1);
+        let circuit = &packet.obstruction_circuits[0];
+        assert_eq!(circuit.law_ref, "law:semantic-contract-alignment");
+        assert!(
+            circuit
+                .atom_observation_refs
+                .contains(&"atom:contract:create-user".to_string())
+        );
+        assert!(
+            circuit
+                .atom_observation_refs
+                .contains(&"semantic:interpretation:create-user".to_string())
+        );
+        assert!(!circuit.molecule_reading_refs.is_empty());
+        assert!(
+            circuit
+                .concern_hint_refs
+                .contains(&"concern:missing-compensation".to_string()),
+            "concern hints may remain auxiliary once the real witness is constructible"
+        );
+    }
+
+    #[test]
+    fn concern_only_obstruction_and_signature_axis_fail_validation() {
+        let mut packet = constructible_obstruction_packet();
+        packet.obstruction_circuits[0].atom_observation_refs.clear();
+        packet.obstruction_circuits[0].molecule_reading_refs.clear();
+        packet.signature_axes[1].value = 1;
+        packet.obstruction_circuits.clear();
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-signature-and-flatness"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example.target.as_deref() == Some("value")
+                        && example
+                            .evidence
+                            .as_deref()
+                            .is_some_and(|evidence| evidence.contains("constructed obstruction"))
+                })
+        }));
+    }
+
+    #[test]
+    fn malformed_concern_backed_obstruction_fails_validation() {
+        let mut packet = constructible_obstruction_packet();
+        packet.obstruction_circuits[0].atom_observation_refs.clear();
+        packet.obstruction_circuits[0].molecule_reading_refs.clear();
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-law-relative-obstructions"
+                && check.result == "fail"
+                && check
+                    .examples
+                    .iter()
+                    .any(|example| example.target.as_deref() == Some("concernHintRefs"))
+        }));
+    }
+
+    #[test]
+    fn semantic_only_holonomy_nonzero_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        let holonomy = packet
+            .homotopy_holonomy_readings
+            .iter_mut()
+            .find(|reading| !reading.observation_refs.is_empty())
+            .expect("fixture has holonomy with semantic observation refs");
+        holonomy.measurement_status = "measured".to_string();
+        holonomy.value = 1;
+        holonomy.mu_defect_refs.clear();
+
+        let report = validate_archsig_analysis_packet_report(&packet, "invalid.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-measurement-depth"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example.target.as_deref() == Some("muDefectRefs")
+                        && example
+                            .evidence
+                            .as_deref()
+                            .is_some_and(|evidence| evidence.contains("semantic evidence alone"))
+                })
+        }));
     }
 
     #[test]

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2036,9 +2036,8 @@ fn cli_locks_archmap_atom_observation_regression() {
         full["obstructionCircuits"]
             .as_array()
             .expect("full obstruction circuits are array")
-            .iter()
-            .any(|entry| entry["lawRef"] == "law:semantic-contract-alignment"),
-        "semantic LawPolicy should construct law-relative obstruction from the same ArchMap"
+            .is_empty(),
+        "expressiveness ArchMap lacks complete witness families and must not construct concern-only obstruction"
     );
 
     let layer_packet = out_dir.join("archsig-analysis-layer-only.json");
@@ -2639,6 +2638,9 @@ fn assert_north_star_packet_surfaces(json: &Value) {
     );
     assert!(
         curvature_transfer.iter().all(|entry| {
+            let nonzero_edge_count = entry["transferOperator"]["nonzeroEdgeCount"]
+                .as_u64()
+                .unwrap_or_default();
             entry["profileRef"].as_str().is_some()
                 && entry["transferOperator"]["nonzeroEdgeCount"]
                     .as_u64()
@@ -2646,10 +2648,10 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                 && entry["transferOperator"]["entryRule"].as_str().is_some()
                 && entry["transferEdges"]
                     .as_array()
-                    .is_some_and(|items| !items.is_empty())
+                    .is_some_and(|items| nonzero_edge_count == 0 || !items.is_empty())
                 && entry["recurrentObstructionModes"]
                     .as_array()
-                    .is_some_and(|items| !items.is_empty())
+                    .is_some_and(|items| nonzero_edge_count == 0 || !items.is_empty())
                 && entry["spectralRadiusReading"]["value"].as_str().is_some()
                 && entry["evidenceBoundary"].as_str().is_some()
                 && entry["nonConclusions"]
@@ -2692,6 +2694,11 @@ fn assert_north_star_packet_surfaces(json: &Value) {
     let architecture_spectrum_report = json["architectureSpectrumReport"]
         .as_object()
         .expect("North Star packet must expose ArchitectureSpectrumReport");
+    let has_positive_transfer_edges = curvature_transfer.iter().any(|entry| {
+        entry["transferOperator"]["nonzeroEdgeCount"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    });
     assert!(
         architecture_spectrum_report["topHotspots"]
             .as_array()
@@ -2713,7 +2720,7 @@ fn assert_north_star_packet_surfaces(json: &Value) {
     assert!(
         architecture_spectrum_report["recurrentObstructions"]
             .as_array()
-            .is_some_and(|items| !items.is_empty()),
+            .is_some_and(|items| !has_positive_transfer_edges || !items.is_empty()),
         "ArchitectureSpectrumReport must expose recurrent obstruction entries"
     );
     assert!(

--- a/tools/archsig/tests/fixtures/complete_archmap_acceptance/archmap.json
+++ b/tools/archsig/tests/fixtures/complete_archmap_acceptance/archmap.json
@@ -2858,6 +2858,64 @@
       ]
     }
   ],
+  "operationSquareEvidence": [
+    {
+      "operationSquareEvidenceId": "operation-square:path-rule-nonzero-holonomy-filled-loop",
+      "evidenceKind": "supplied-operation-pair",
+      "leftOperationRef": "operation:direct-projection-read",
+      "rightOperationRef": "operation:event-projection-read",
+      "pOperationSequence": [
+        "operation:direct-projection-read",
+        "operation:event-projection-read"
+      ],
+      "qOperationSequence": [
+        "operation:event-projection-read",
+        "operation:direct-projection-read"
+      ],
+      "endpointObjectRefs": [
+        "order.read-model",
+        "order.event-stream"
+      ],
+      "generatorCandidateRefs": [
+        "generator:projection-filler"
+      ],
+      "sharedEndpointRefs": [
+        "order.read-model"
+      ],
+      "atomObservationRefs": [
+        "atom:event-projection",
+        "atom:repository-read"
+      ],
+      "moleculeObservationRefs": [
+        "molecule:homotopy-report-fixture"
+      ],
+      "semanticObservationRefs": [
+        "semantic:path-rule:nonzero-holonomy-filled-loop"
+      ],
+      "projectionRefs": [],
+      "sourceRefs": [
+        {
+          "artifactId": "src-event-projection",
+          "kind": "file",
+          "path": "src/events/project_order.ts",
+          "symbol": "projectOrderEvent",
+          "line": 22
+        },
+        {
+          "artifactId": "src-direct-read",
+          "kind": "file",
+          "path": "src/read-model/order.ts",
+          "symbol": "readOrderDirectly",
+          "line": 18
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "fixture supplies p/q event projection and direct-read operation sequences for selected-axis continuation distance",
+      "nonConclusions": [
+        "supplied operation square is fixture evidence and not global read-model correctness proof"
+      ]
+    }
+  ],
   "concernHints": [
     {
       "concernHintId": "concern:authorization-bypass-hole",

--- a/tools/archsig/tests/fixtures/minimal/archmap.json
+++ b/tools/archsig/tests/fixtures/minimal/archmap.json
@@ -241,6 +241,29 @@
       "nonConclusions": [
         "contract atom observation is not global semantic completeness"
       ]
+    },
+    {
+      "atomObservationId": "atom:capability:create-user",
+      "atomFamily": "capability",
+      "predicate": "create-user capability is observed",
+      "subjectRef": "operation.createUser",
+      "objectRefs": ["service.user"],
+      "sourceRefs": [
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "confidence": "medium",
+      "uncertainty": ["production traces not supplied"],
+      "projectionRefs": ["projection:aat:create-user-contract"],
+      "nonConclusions": [
+        "capability atom observation is not complete operation semantics"
+      ]
     }
   ],
   "moleculeObservations": [
@@ -252,7 +275,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "sourceRefs": [
         {
@@ -299,6 +323,36 @@
       "evidenceBoundary": "sourceObserved",
       "nonConclusions": [
         "semantic observation is not a proof of global semantic correctness"
+      ]
+    },
+    {
+      "semanticObservationId": "semantic:interpretation:create-user",
+      "semanticFamily": "semanticInterpretation",
+      "subjectRef": "operation.createUser",
+      "predicate": "create-user operation has a selected semantic interpretation",
+      "atomObservationRefs": [
+        "atom:relation:route-service",
+        "atom:contract:create-user"
+      ],
+      "moleculeObservationRefs": ["molecule:user-request-responsibility"],
+      "sourceRefs": [
+        {
+          "artifactId": "doc-architecture",
+          "kind": "docSection",
+          "path": "docs/architecture.md",
+          "section": "Layer policy"
+        },
+        {
+          "artifactId": "test-user-contract",
+          "kind": "test",
+          "path": "tests/user_contract.test.ts",
+          "symbol": "createsUser"
+        }
+      ],
+      "observationStatus": "observed",
+      "evidenceBoundary": "sourceObserved",
+      "nonConclusions": [
+        "semantic interpretation observation is not a proof of global semantic correctness"
       ]
     }
   ],

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -57,8 +57,9 @@
   },
   "architectureState": {
     "stateId": "architecture-state:archmap-fixture-repo",
-    "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
+    "reading": "archmap-fixture-repo is represented as 5 atom observations, 1 molecules, 2 semantic observations, and 1 preserved observation gaps",
     "atomFamilyRefs": [
+      "capability",
       "contractSpecification",
       "existence",
       "relation"
@@ -67,7 +68,8 @@
       "molecule:user-request-responsibility"
     ],
     "workflowRefs": [
-      "semantic:create-user-flow"
+      "semantic:create-user-flow",
+      "semantic:interpretation:create-user"
     ],
     "boundaryRefs": [
       "gap-runtime-user-db-trace"
@@ -101,7 +103,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "obstructionRefs": [
         "obstruction:semantic-contract-mismatch:computed"
@@ -151,12 +154,13 @@
     {
       "concept": "Atom",
       "status": "observedOrRepresented",
-      "reading": "Atom is represented with 4 bounded packet record(s)",
+      "reading": "Atom is represented with 5 bounded packet record(s)",
       "evidenceRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
       "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
@@ -173,12 +177,13 @@
     {
       "concept": "Configuration",
       "status": "observedOrRepresented",
-      "reading": "Configuration is represented with 5 bounded packet record(s)",
+      "reading": "Configuration is represented with 6 bounded packet record(s)",
       "evidenceRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
       "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
@@ -333,9 +338,10 @@
     {
       "concept": "Homotopy",
       "status": "observedOrRepresented",
-      "reading": "Homotopy is represented with 1 bounded packet record(s)",
+      "reading": "Homotopy is represented with 2 bounded packet record(s)",
       "evidenceRefs": [
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
       "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
@@ -398,19 +404,20 @@
     }
   ],
   "atomConfigurationSummary": {
-    "atomObservationCount": 4,
+    "atomObservationCount": 5,
     "moleculeObservationCount": 1,
-    "semanticObservationCount": 1,
+    "semanticObservationCount": 2,
     "observationGapCount": 1,
     "concernHintCount": 1,
     "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
     "coverageSummary": [
-      "4 atom observations",
+      "5 atom observations",
       "1 molecule observations",
-      "1 semantic observations",
+      "2 semantic observations",
       "1 observation gaps preserved as gaps"
     ],
     "sourceRefs": [
+      "atom:capability:create-user",
       "atom:component:route-users",
       "atom:component:service-user",
       "atom:contract:create-user",
@@ -589,10 +596,11 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "reading": "molecule:user-request-responsibility is read as a responsibility molecule under selected LawPolicy",
-      "evidenceSummary": "molecule uses 4 atom observation refs and 1 source refs",
+      "evidenceSummary": "molecule uses 5 atom observation refs and 1 source refs",
       "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
       "sourceRefs": [
         "doc-architecture"
@@ -618,7 +626,8 @@
       "witnessRuleRef": "witness:semantic-contract-mismatch",
       "circuitKind": "SemanticMismatchCircuit",
       "atomObservationRefs": [
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "semantic:interpretation:create-user"
       ],
       "moleculeReadingRefs": [
         "molecule-reading:molecule-user-request-responsibility"
@@ -717,7 +726,8 @@
       ],
       "evidenceSummary": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
       "sourceRefs": [
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "semantic:interpretation:create-user"
       ],
       "missingEvidence": [
         "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
@@ -1194,7 +1204,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "axisRefs": [
         "sig-axis:layer-violation",
@@ -1273,10 +1284,11 @@
       "axis": "contractCohesion",
       "status": "actionable",
       "valueType": "boundedCount",
-      "value": "2",
+      "value": "3",
       "supportingRefs": [
         "atom:contract:create-user",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "stressedRefs": [],
       "reading": "contract and semantic observations give a semantic cohesion reading",
@@ -1327,7 +1339,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "stressedRefs": [
         "gap-runtime-user-db-trace"
@@ -1429,17 +1442,17 @@
       "values": [
         {
           "name": "maxRowSum",
-          "value": "4",
+          "value": "5",
           "interpretation": "largest observed molecule overlap mass"
         },
         {
           "name": "frobeniusNorm",
-          "value": "4.000",
+          "value": "5.000",
           "interpretation": "observed overlap magnitude of the molecule coupling matrix"
         },
         {
           "name": "spectralRadiusUpperBound",
-          "value": "4.000",
+          "value": "5.000",
           "interpretation": "Gershgorin-style row-sum upper bound for this nonnegative matrix"
         }
       ],
@@ -1447,7 +1460,7 @@
         {
           "componentRef": "molecule:user-request-responsibility",
           "componentKind": "molecule",
-          "value": "4",
+          "value": "5",
           "reading": "dominant molecule by atom/family overlap mass"
         }
       ],
@@ -1663,14 +1676,14 @@
         {
           "componentRef": "molecule:user-request-responsibility",
           "componentKind": "molecule",
-          "weight": "4",
+          "weight": "5",
           "role": "primaryDominantComponent",
           "reading": "dominant molecule by atom/family overlap mass"
         }
       ],
       "spectralGapProxy": {
         "name": "dominantResidualGapProxy",
-        "value": "4.000",
+        "value": "5.000",
         "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
       },
       "localizationIndex": {
@@ -1821,6 +1834,16 @@
             "atom:component:service-user"
           ],
           "reading": "molecule:user-request-responsibility contributes 2 observed existence atom(s) to the dominant spectral mode"
+        },
+        {
+          "sourceComponentRef": "molecule:user-request-responsibility",
+          "sourceComponentKind": "molecule",
+          "atomFamily": "capability",
+          "count": 1,
+          "atomObservationRefs": [
+            "atom:capability:create-user"
+          ],
+          "reading": "molecule:user-request-responsibility contributes 1 observed capability atom(s) to the dominant spectral mode"
         },
         {
           "sourceComponentRef": "molecule:user-request-responsibility",
@@ -2070,7 +2093,8 @@
           "localCurvatureRef": "kappa:witness-semantic-contract-mismatch:axis-semantic-inconsistency",
           "diagramRef": "obstruction:semantic-contract-mismatch:computed",
           "lhsObservationRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "semantic:interpretation:create-user"
           ],
           "rhsObservationRefs": [
             "concern:missing-compensation",
@@ -2080,7 +2104,8 @@
           "distanceInputRefs": [
             "atom:contract:create-user",
             "concern:missing-compensation",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "soundnessBoundary": "kappa(D) is measured as nonnegative distance over source-backed lhs/rhs observation refs under the selected witness rule",
           "coverageStatus": "sourceBackedWitnessSupport",
@@ -2089,15 +2114,18 @@
           "supportRefs": [
             "atom:contract:create-user",
             "concern:missing-compensation",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "observationRefs": [
             "atom:contract:create-user",
             "concern:missing-compensation",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "missingEvidence": [
             "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
@@ -2115,8 +2143,9 @@
           "operatorComponentRefs": [
             "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
           ],
-          "localization": "support=curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency axis=axis:semantic-inconsistency sourceRefs=1",
+          "localization": "support=curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency axis=axis:semantic-inconsistency sourceRefs=2",
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "recommendedReviewTarget": "inspect curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency and its source-backed local curvature input",
@@ -2126,7 +2155,8 @@
           "supportRefs": [
             "atom:contract:create-user",
             "concern:missing-compensation",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "reading": "top measured curvature support mode with traceable witness and support refs"
         },
@@ -2223,9 +2253,11 @@
           "supportRefs": [
             "atom:contract:create-user",
             "concern:missing-compensation",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "transferEdgeRefs": [],
@@ -2292,7 +2324,8 @@
             "evidenceRefs": [
               "atom:contract:create-user",
               "concern:missing-compensation",
-              "molecule-reading:molecule-user-request-responsibility"
+              "molecule-reading:molecule-user-request-responsibility",
+              "semantic:interpretation:create-user"
             ]
           }
         ],
@@ -2316,12 +2349,14 @@
           "defectValue": 2,
           "weight": 1,
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "evidenceRefs": [
             "atom:contract:create-user",
             "concern:missing-compensation",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "extractionRule": "same-selected-axis",
           "closedWalkKind": "selfLoop",
@@ -2401,7 +2436,8 @@
         "supportRefs": [
           "atom:contract:create-user",
           "concern:missing-compensation",
-          "molecule-reading:molecule-user-request-responsibility"
+          "molecule-reading:molecule-user-request-responsibility",
+          "semantic:interpretation:create-user"
         ],
         "witnessRefs": [
           "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
@@ -2461,15 +2497,17 @@
         "operatorComponentRefs": [
           "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
         ],
-        "localization": "support=curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency axis=axis:semantic-inconsistency sourceRefs=1",
+        "localization": "support=curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency axis=axis:semantic-inconsistency sourceRefs=2",
         "sourceRefs": [
+          "doc-architecture",
           "test-user-contract"
         ],
         "recommendedReviewTarget": "inspect curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency and its source-backed local curvature input",
         "supportRefs": [
           "atom:contract:create-user",
           "concern:missing-compensation",
-          "molecule-reading:molecule-user-request-responsibility"
+          "molecule-reading:molecule-user-request-responsibility",
+          "semantic:interpretation:create-user"
         ],
         "witnessRefs": [
           "curvature-support:witness-semantic-contract-mismatch:axis-semantic-inconsistency"
@@ -2567,9 +2605,11 @@
         "supportRefs": [
           "atom:contract:create-user",
           "concern:missing-compensation",
-          "molecule-reading:molecule-user-request-responsibility"
+          "molecule-reading:molecule-user-request-responsibility",
+          "semantic:interpretation:create-user"
         ],
         "sourceRefs": [
+          "doc-architecture",
           "test-user-contract"
         ],
         "transferEdgeRefs": [],
@@ -2621,14 +2661,16 @@
           "targetHubMoleculeRef": "molecule:user-request-responsibility",
           "intermediateMoleculeRefs": [],
           "bridgeAtomFamilies": [
+            "capability",
             "contractSpecification",
             "existence",
             "relation"
           ],
-          "bridgeScore": 3,
+          "bridgeScore": 4,
           "pathPairRefs": [],
           "edgeBreakdowns": [],
           "sharedAxisRefs": [
+            "capability",
             "contractSpecification",
             "existence",
             "relation"
@@ -2689,13 +2731,20 @@
       "readingId": "atom-support-axis:fixture-archmap-atom-observation",
       "scopeRef": "fixture-archmap-atom-observation",
       "scopeKind": "selectedSourceUniverse",
-      "supportSize": 4,
+      "supportSize": 5,
       "subjectFamilySpread": [
         {
           "subjectRef": "contract.createsUser",
           "atomCount": 1,
           "atomFamilies": [
             "contractSpecification"
+          ]
+        },
+        {
+          "subjectRef": "operation.createUser",
+          "atomCount": 1,
+          "atomFamilies": [
+            "capability"
           ]
         },
         {
@@ -2722,6 +2771,13 @@
       ],
       "axisRestrictionCounts": [
         {
+          "axis": "capability",
+          "atomCount": 1,
+          "atomObservationRefs": [
+            "atom:capability:create-user"
+          ]
+        },
+        {
           "axis": "contractSpecification",
           "atomCount": 1,
           "atomObservationRefs": [
@@ -2744,13 +2800,14 @@
           ]
         }
       ],
-      "axisConcentration": "maxAxisShare=2/4",
+      "axisConcentration": "maxAxisShare=2/5",
       "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
       "highSupportRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -2772,13 +2829,20 @@
       "readingId": "atom-support-axis:molecule-user-request-responsibility",
       "scopeRef": "molecule:user-request-responsibility",
       "scopeKind": "molecule",
-      "supportSize": 4,
+      "supportSize": 5,
       "subjectFamilySpread": [
         {
           "subjectRef": "contract.createsUser",
           "atomCount": 1,
           "atomFamilies": [
             "contractSpecification"
+          ]
+        },
+        {
+          "subjectRef": "operation.createUser",
+          "atomCount": 1,
+          "atomFamilies": [
+            "capability"
           ]
         },
         {
@@ -2805,6 +2869,13 @@
       ],
       "axisRestrictionCounts": [
         {
+          "axis": "capability",
+          "atomCount": 1,
+          "atomObservationRefs": [
+            "atom:capability:create-user"
+          ]
+        },
+        {
           "axis": "contractSpecification",
           "atomCount": 1,
           "atomObservationRefs": [
@@ -2827,13 +2898,14 @@
           ]
         }
       ],
-      "axisConcentration": "maxAxisShare=2/4",
+      "axisConcentration": "maxAxisShare=2/5",
       "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
       "highSupportRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -2976,7 +3048,8 @@
           "refId": "sig-axis:semantic-inconsistency",
           "status": "coverage-gap-preserved",
           "evidenceRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "semantic:interpretation:create-user"
           ],
           "blockerRefs": [
             "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
@@ -3005,10 +3078,10 @@
           "refId": "coverage:semantic-contract-atoms",
           "status": "blockedByMissingSourceEvidence",
           "evidenceRefs": [
+            "atom:capability:create-user",
             "atom:contract:create-user"
           ],
           "blockerRefs": [
-            "capability",
             "semanticInterpretation",
             "gap-runtime-user-db-trace",
             "doc-section"
@@ -3022,7 +3095,8 @@
           "status": "blockedByCoverageGap",
           "evidenceRefs": [
             "atom:contract:create-user",
-            "atom:relation:route-service"
+            "atom:relation:route-service",
+            "semantic:interpretation:create-user"
           ],
           "blockerRefs": [
             "gap-runtime-user-db-trace"
@@ -3034,7 +3108,8 @@
           "status": "blockedByCoverageGap",
           "evidenceRefs": [
             "atom:contract:create-user",
-            "atom:relation:route-service"
+            "atom:relation:route-service",
+            "semantic:interpretation:create-user"
           ],
           "blockerRefs": [
             "gap-runtime-user-db-trace"
@@ -3110,10 +3185,10 @@
             "zero readings are exact only for observed atoms and declared coverage requirements"
           ],
           "sourceBackedEvidenceRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "semantic:interpretation:create-user"
           ],
           "blockerRefs": [
-            "capability",
             "doc-section",
             "gap-runtime-user-db-trace",
             "semanticInterpretation",
@@ -3191,9 +3266,11 @@
           ],
           "observationRefs": [
             "atom:contract:create-user",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
@@ -3205,9 +3282,11 @@
           ],
           "observationRefs": [
             "atom:contract:create-user",
-            "molecule-reading:molecule-user-request-responsibility"
+            "molecule-reading:molecule-user-request-responsibility",
+            "semantic:interpretation:create-user"
           ],
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "basisBoundary": "feature-extension basis is assembled from ArchMap observation refs and ArchSig witness refs, not text classification"
@@ -3516,7 +3595,8 @@
           "axisRef": "sig-axis:semantic-inconsistency",
           "maxValue": 1,
           "evidenceRefs": [
-            "atom:contract:create-user"
+            "atom:contract:create-user",
+            "semantic:interpretation:create-user"
           ],
           "reading": "max excursion is a current-state proxy, not future trajectory proof"
         }
@@ -3662,7 +3742,7 @@
       "sourceProjectionRef": "observation-projection:fixture-archmap-atom-observation",
       "sourceAxisForgettingRef": "axis-forgetting-risk:selected-projection",
       "fidelityStatus": "projectionLossObserved",
-      "observedAtomFamilyCount": 3,
+      "observedAtomFamilyCount": 4,
       "forgottenCoordinateCount": 1,
       "observationCollisionCount": 0,
       "collapsedAtomFamilyCandidateCount": 0,
@@ -3695,10 +3775,11 @@
   "atomOriginClosureDebtReadings": [
     {
       "readingId": "atom-origin-closure-debt:fixture-archmap-atom-observation",
-      "sourceBackedAtomCount": 4,
+      "sourceBackedAtomCount": 5,
       "derivedOrInferredAtomCount": 0,
       "expectedMissingAtomCount": 1,
       "sourceBackedAtomFamilyRefs": [
+        "capability",
         "contractSpecification",
         "existence",
         "relation"
@@ -3865,7 +3946,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "constraintRefs": [
         "obstruction:semantic-contract-mismatch:computed",
@@ -4141,6 +4223,26 @@
           "nonzero holonomy is bounded diagnosis, not future incident prediction",
           "homotopy complex summary is not source extraction completeness"
         ]
+      },
+      {
+        "cellId": "0-cell:atom-capability-create-user",
+        "cellDimension": 0,
+        "cellKind": "capability",
+        "status": "observed",
+        "observationRefs": [
+          "atom:capability:create-user"
+        ],
+        "sourceRefs": [
+          "test-user-contract"
+        ],
+        "reading": "observed Atom is read as a bounded 0-cell candidate",
+        "nonConclusions": [
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "nonzero holonomy is bounded diagnosis, not future incident prediction",
+          "homotopy complex summary is not source extraction completeness"
+        ]
       }
     ],
     "oneCells": [
@@ -4153,7 +4255,8 @@
           "atom:component:route-users",
           "atom:component:service-user",
           "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:contract:create-user",
+          "atom:capability:create-user"
         ],
         "sourceRefs": [
           "doc-architecture"
@@ -4174,6 +4277,27 @@
         "status": "candidate",
         "observationRefs": [
           "semantic:create-user-flow"
+        ],
+        "sourceRefs": [
+          "doc-architecture",
+          "test-user-contract"
+        ],
+        "reading": "semantic observation is read as a selected path continuation candidate",
+        "nonConclusions": [
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "nonzero holonomy is bounded diagnosis, not future incident prediction",
+          "homotopy complex summary is not source extraction completeness"
+        ]
+      },
+      {
+        "cellId": "1-cell:semantic-interpretation-create-user",
+        "cellDimension": 1,
+        "cellKind": "semanticInterpretation",
+        "status": "candidate",
+        "observationRefs": [
+          "semantic:interpretation:create-user"
         ],
         "sourceRefs": [
           "doc-architecture",
@@ -4302,11 +4426,13 @@
         "test-user-contract"
       ],
       "observationRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "coverageBoundary": "missing path or filler evidence blocks zero and Stokes-style readings",
       "evidenceBoundary": "candidate path pair is a bounded review cue, not a path equality proof",
@@ -5182,7 +5308,7 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=1",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=2; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
         "Cont_axis:layer-violation(molecule:user-request-responsibility)",
         "Cont_axis:layer-violation(path:semantic-operation-flow)",
@@ -5194,6 +5320,7 @@
         "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
@@ -5205,6 +5332,7 @@
         "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
         "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "semantic:create-user-flow",
+        "semantic:interpretation:create-user",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
@@ -5221,11 +5349,13 @@
         "test-user-contract"
       ],
       "observationRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
@@ -5269,7 +5399,7 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=1; traceAxes=2; missing=1",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:semantic-inconsistency; distanceKind=selected-axis-continuation-distance; sourceRefs=6; semanticEvidence=2; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
         "Cont_axis:semantic-inconsistency(molecule:user-request-responsibility)",
         "Cont_axis:semantic-inconsistency(path:semantic-operation-flow)",
@@ -5281,6 +5411,7 @@
         "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
@@ -5292,6 +5423,7 @@
         "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-authority-or-idempotency",
         "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
         "semantic:create-user-flow",
+        "semantic:interpretation:create-user",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
@@ -5308,11 +5440,13 @@
         "test-user-contract"
       ],
       "observationRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "fillerRefs": [
         "filler-candidate:loop-candidate-path-pair-semantic-contract-loop-0:filler-rule-contract-or-test",
@@ -5371,9 +5505,7 @@
         "src-service-user",
         "test-user-contract"
       ],
-      "muDefectRefs": [
-        "mu:path-pair-path-rule-interface-implementation:axis-layer-violation"
-      ],
+      "muDefectRefs": [],
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
@@ -5443,9 +5575,7 @@
         "src-service-user",
         "test-user-contract"
       ],
-      "muDefectRefs": [
-        "mu:path-pair-path-rule-interface-implementation:axis-semantic-inconsistency"
-      ],
+      "muDefectRefs": [],
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
@@ -5515,9 +5645,7 @@
         "src-service-user",
         "test-user-contract"
       ],
-      "muDefectRefs": [
-        "mu:path-pair-path-rule-cache-repository:axis-layer-violation"
-      ],
+      "muDefectRefs": [],
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
@@ -5587,9 +5715,7 @@
         "src-service-user",
         "test-user-contract"
       ],
-      "muDefectRefs": [
-        "mu:path-pair-path-rule-cache-repository:axis-semantic-inconsistency"
-      ],
+      "muDefectRefs": [],
       "sourceRefs": [
         ".lake/runtime-trace.json",
         "doc-architecture",
@@ -7549,9 +7675,11 @@
             "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
             "obstruction:semantic-contract-mismatch:computed",
             "repair:obstruction-semantic-contract-mismatch-computed",
+            "semantic:interpretation:create-user",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "inheritedCoreRefs": [
@@ -7584,9 +7712,11 @@
             "mu:operation-square-operation-square-evidence-create-user-route-service:semantic",
             "obstruction:semantic-contract-mismatch:computed",
             "repair:obstruction-semantic-contract-mismatch-computed",
+            "semantic:interpretation:create-user",
             "split-readiness:molecule-user-request-responsibility"
           ],
           "sourceRefs": [
+            "doc-architecture",
             "test-user-contract"
           ],
           "inheritedCoreRefs": [],
@@ -8261,7 +8391,8 @@
       ],
       "semanticObservationRefs": [
         "atom:contract:create-user",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "crossLayerAtomRefs": [
         "atom:contract:create-user"
@@ -8284,11 +8415,12 @@
     {
       "readingId": "observation-projection:fixture-archmap-atom-observation",
       "observedAtomFamilies": [
+        "capability",
         "contractSpecification",
         "existence",
         "relation"
       ],
-      "observedAtomFamilyCount": 3,
+      "observedAtomFamilyCount": 4,
       "sourceCoordinates": [
         {
           "coordinateId": "projection-coordinate:observed:atom-component-route-users",
@@ -8344,6 +8476,21 @@
           "predicate": "contract test observes create-user success",
           "atomObservationRefs": [
             "atom:contract:create-user"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "status": "observed",
+          "reading": "observed ArchMap atom coordinate in the canonical projection boundary"
+        },
+        {
+          "coordinateId": "projection-coordinate:observed:atom-capability-create-user",
+          "coordinateKind": "observedAtomCoordinate",
+          "atomFamily": "capability",
+          "subjectRef": "operation.createUser",
+          "predicate": "create-user capability is observed",
+          "atomObservationRefs": [
+            "atom:capability:create-user"
           ],
           "sourceRefs": [
             "test-user-contract"
@@ -8433,6 +8580,21 @@
           "predicate": "contract test observes create-user success",
           "atomObservationRefs": [
             "atom:contract:create-user"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "status": "observed",
+          "reading": "observed ArchMap atom coordinate in the canonical projection boundary"
+        },
+        {
+          "coordinateId": "projection-coordinate:observed:atom-capability-create-user",
+          "coordinateKind": "observedAtomCoordinate",
+          "atomFamily": "capability",
+          "subjectRef": "operation.createUser",
+          "predicate": "create-user capability is observed",
+          "atomObservationRefs": [
+            "atom:capability:create-user"
           ],
           "sourceRefs": [
             "test-user-contract"
@@ -9226,7 +9388,8 @@
     ],
     "semanticObservationRefs": [
       "atom:contract:create-user",
-      "semantic:create-user-flow"
+      "semantic:create-user-flow",
+      "semantic:interpretation:create-user"
     ],
     "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
     "nonConclusions": [
@@ -9352,7 +9515,8 @@
       "surface": "Path",
       "status": "observedOrRepresented",
       "pathRefs": [
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "homotopyRefs": [
         "molecule-reading:molecule-user-request-responsibility"
@@ -9380,7 +9544,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "homotopyRefs": [
         "molecule-reading:molecule-user-request-responsibility"
@@ -9411,7 +9576,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "confidence": "medium",
       "uncertainty": [
@@ -9437,6 +9603,7 @@
       "reading": "constructed by witness rule witness:semantic-contract-mismatch from observed ArchMap atoms and LawPolicy molecule boundaries",
       "evidenceRefs": [
         "atom:contract:create-user",
+        "semantic:interpretation:create-user",
         "molecule-reading:molecule-user-request-responsibility",
         "concern:missing-compensation"
       ],
@@ -9491,7 +9658,8 @@
       "aatConcept": "ArchitectureSignature",
       "reading": "1 obstruction circuit(s) contribute to sig-axis:semantic-inconsistency",
       "evidenceRefs": [
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "semantic:interpretation:create-user"
       ],
       "confidence": "medium",
       "uncertainty": [
@@ -9750,6 +9918,7 @@
       "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation"
     ],
     "observedAtomsSummary": [
+      "capability",
       "contractSpecification",
       "existence",
       "relation"
@@ -9775,18 +9944,18 @@
     ],
     "spectralReadingsSummary": [
       "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=2x2 (needsReview)",
-      "moleculeAtomOverlapCouplingMatrix upperBound=4.000 shape=1x1 (needsReview)",
+      "moleculeAtomOverlapCouplingMatrix upperBound=5.000 shape=1x1 (needsReview)",
       "obstructionAxisCurvatureMatrix upperBound=1.000 shape=1x2 (actionable)",
       "operationSignatureDeltaMatrix upperBound=1.000 shape=1x2 (actionable)"
     ],
     "spectralModeSummary": [
       "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=1.000 localization=1.000 density=0.250 (needsReview)",
-      "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=4.000 localization=1.000 density=1.000 (needsReview)",
+      "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=5.000 localization=1.000 density=1.000 (needsReview)",
       "obstructionAxisCurvatureMatrix curvatureMode gap=1.000 localization=1.000 density=0.500 (actionable)",
       "operationSignatureDeltaMatrix localizedPerturbationMode gap=1.000 localization=1.000 density=0.500 (actionable)"
     ],
     "spectralDrilldownSummary": [
-      "spectral-drilldown:fixture-archmap-atom-observation atomFamilies=3 overlapPairs=0 repairAxisDeltas=1 (actionable)"
+      "spectral-drilldown:fixture-archmap-atom-observation atomFamilies=4 overlapPairs=0 repairAxisDeltas=1 (actionable)"
     ],
     "curvatureSupportSummary": [
       "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"
@@ -9806,8 +9975,8 @@
       "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
     ],
     "atomSupportAxisSummary": [
-      "fixture-archmap-atom-observation support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent",
-      "molecule:user-request-responsibility support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent"
+      "fixture-archmap-atom-observation support=5 concentration=maxAxisShare=2/5 pressure=mixedAxisPressurePresent",
+      "molecule:user-request-responsibility support=5 concentration=maxAxisShare=2/5 pressure=mixedAxisPressurePresent"
     ],
     "atomCompatibilitySummary": [
       "atom-compatibility:fixture-archmap-atom-observation status=compatibleWithinObservedSlots sameSlotConflicts=0 uncertainty=1"
@@ -9837,7 +10006,7 @@
       "observation-projection:fixture-archmap-atom-observation status=projectionLossObserved forgotten=1 collisions=0 reflection=blockedWithoutAxisPreservationAndWitnessCompleteness"
     ],
     "atomOriginClosureDebtSummary": [
-      "atom-origin-closure-debt:fixture-archmap-atom-observation status=originClosureDebtObserved sourceBacked=4 inferred=0 missingExpected=1"
+      "atom-origin-closure-debt:fixture-archmap-atom-observation status=originClosureDebtObserved sourceBacked=5 inferred=0 missingExpected=1"
     ],
     "effectRelationAlgebraSummary": [
       "effect-relation-algebra:fixture-archmap-atom-observation pressure=effectRelationPressureObserved generators=1 unresolved=1 externalBoundaries=0"
@@ -9889,7 +10058,7 @@
       "three-layer-flatness:fixture-archmap-atom-observation static=needsReview runtime=blockedByCoverageGap semantic=stressed crossLayerAtoms=1"
     ],
     "observationProjectionSummary": [
-      "observation-projection:fixture-archmap-atom-observation families=3 forgotten=1 blockers=1"
+      "observation-projection:fixture-archmap-atom-observation families=4 forgotten=1 blockers=1"
     ],
     "stateTransitionAlgebraSummary": [
       "state-transition-algebra:fixture-archmap-atom-observation generators=0 unresolved=1 obstructions=0"

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet_layer_only.json
@@ -57,8 +57,9 @@
   },
   "architectureState": {
     "stateId": "architecture-state:archmap-fixture-repo",
-    "reading": "archmap-fixture-repo is represented as 4 atom observations, 1 molecules, 1 semantic observations, and 1 preserved observation gaps",
+    "reading": "archmap-fixture-repo is represented as 5 atom observations, 1 molecules, 2 semantic observations, and 1 preserved observation gaps",
     "atomFamilyRefs": [
+      "capability",
       "contractSpecification",
       "existence",
       "relation"
@@ -67,7 +68,8 @@
       "molecule:user-request-responsibility"
     ],
     "workflowRefs": [
-      "semantic:create-user-flow"
+      "semantic:create-user-flow",
+      "semantic:interpretation:create-user"
     ],
     "boundaryRefs": [
       "gap-runtime-user-db-trace"
@@ -99,7 +101,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "obstructionRefs": [],
       "signatureAxisRefs": [],
@@ -142,12 +145,13 @@
     {
       "concept": "Atom",
       "status": "observedOrRepresented",
-      "reading": "Atom is represented with 4 bounded packet record(s)",
+      "reading": "Atom is represented with 5 bounded packet record(s)",
       "evidenceRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
       "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
@@ -164,12 +168,13 @@
     {
       "concept": "Configuration",
       "status": "observedOrRepresented",
-      "reading": "Configuration is represented with 5 bounded packet record(s)",
+      "reading": "Configuration is represented with 6 bounded packet record(s)",
       "evidenceRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
       "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
@@ -317,9 +322,10 @@
     {
       "concept": "Homotopy",
       "status": "observedOrRepresented",
-      "reading": "Homotopy is represented with 1 bounded packet record(s)",
+      "reading": "Homotopy is represented with 2 bounded packet record(s)",
       "evidenceRefs": [
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "coverageBoundary": "concept surface records packet expressiveness, not theorem proof or extraction completeness",
       "exactnessBoundary": "exactness is relative to ArchMap coverage and selected interpretation profile",
@@ -380,19 +386,20 @@
     }
   ],
   "atomConfigurationSummary": {
-    "atomObservationCount": 4,
+    "atomObservationCount": 5,
     "moleculeObservationCount": 1,
-    "semanticObservationCount": 1,
+    "semanticObservationCount": 2,
     "observationGapCount": 1,
     "concernHintCount": 1,
     "configurationBoundary": "counts are read from one bounded ArchMap, not complete architecture enumeration",
     "coverageSummary": [
-      "4 atom observations",
+      "5 atom observations",
       "1 molecule observations",
-      "1 semantic observations",
+      "2 semantic observations",
       "1 observation gaps preserved as gaps"
     ],
     "sourceRefs": [
+      "atom:capability:create-user",
       "atom:component:route-users",
       "atom:component:service-user",
       "atom:contract:create-user",
@@ -541,10 +548,11 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "reading": "molecule:user-request-responsibility is read as a responsibility molecule under selected LawPolicy",
-      "evidenceSummary": "molecule uses 4 atom observation refs and 1 source refs",
+      "evidenceSummary": "molecule uses 5 atom observation refs and 1 source refs",
       "evidenceBoundary": "law-relative molecule reading over ArchMap observations; not a primitive atom",
       "sourceRefs": [
         "doc-architecture"
@@ -1046,7 +1054,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "axisRefs": [
         "sig-axis:layer-violation"
@@ -1123,10 +1132,11 @@
       "axis": "contractCohesion",
       "status": "actionable",
       "valueType": "boundedCount",
-      "value": "2",
+      "value": "3",
       "supportingRefs": [
         "atom:contract:create-user",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "stressedRefs": [],
       "reading": "contract and semantic observations give a semantic cohesion reading",
@@ -1177,7 +1187,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "stressedRefs": [
         "gap-runtime-user-db-trace"
@@ -1279,17 +1290,17 @@
       "values": [
         {
           "name": "maxRowSum",
-          "value": "4",
+          "value": "5",
           "interpretation": "largest observed molecule overlap mass"
         },
         {
           "name": "frobeniusNorm",
-          "value": "4.000",
+          "value": "5.000",
           "interpretation": "observed overlap magnitude of the molecule coupling matrix"
         },
         {
           "name": "spectralRadiusUpperBound",
-          "value": "4.000",
+          "value": "5.000",
           "interpretation": "Gershgorin-style row-sum upper bound for this nonnegative matrix"
         }
       ],
@@ -1297,7 +1308,7 @@
         {
           "componentRef": "molecule:user-request-responsibility",
           "componentKind": "molecule",
-          "value": "4",
+          "value": "5",
           "reading": "dominant molecule by atom/family overlap mass"
         }
       ],
@@ -1498,14 +1509,14 @@
         {
           "componentRef": "molecule:user-request-responsibility",
           "componentKind": "molecule",
-          "weight": "4",
+          "weight": "5",
           "role": "primaryDominantComponent",
           "reading": "dominant molecule by atom/family overlap mass"
         }
       ],
       "spectralGapProxy": {
         "name": "dominantResidualGapProxy",
-        "value": "4.000",
+        "value": "5.000",
         "interpretation": "dominant component magnitude minus residual Frobenius mass; bounded proxy, not an eigenvalue gap theorem"
       },
       "localizationIndex": {
@@ -1645,6 +1656,16 @@
         {
           "sourceComponentRef": "molecule:user-request-responsibility",
           "sourceComponentKind": "molecule",
+          "atomFamily": "capability",
+          "count": 1,
+          "atomObservationRefs": [
+            "atom:capability:create-user"
+          ],
+          "reading": "molecule:user-request-responsibility contributes 1 observed capability atom(s) to the dominant spectral mode"
+        },
+        {
+          "sourceComponentRef": "molecule:user-request-responsibility",
+          "sourceComponentKind": "molecule",
           "atomFamily": "contractSpecification",
           "count": 1,
           "atomObservationRefs": [
@@ -1725,14 +1746,16 @@
           "targetHubMoleculeRef": "molecule:user-request-responsibility",
           "intermediateMoleculeRefs": [],
           "bridgeAtomFamilies": [
+            "capability",
             "contractSpecification",
             "existence",
             "relation"
           ],
-          "bridgeScore": 3,
+          "bridgeScore": 4,
           "pathPairRefs": [],
           "edgeBreakdowns": [],
           "sharedAxisRefs": [
+            "capability",
             "contractSpecification",
             "existence",
             "relation"
@@ -1793,13 +1816,20 @@
       "readingId": "atom-support-axis:fixture-archmap-atom-observation",
       "scopeRef": "fixture-archmap-atom-observation",
       "scopeKind": "selectedSourceUniverse",
-      "supportSize": 4,
+      "supportSize": 5,
       "subjectFamilySpread": [
         {
           "subjectRef": "contract.createsUser",
           "atomCount": 1,
           "atomFamilies": [
             "contractSpecification"
+          ]
+        },
+        {
+          "subjectRef": "operation.createUser",
+          "atomCount": 1,
+          "atomFamilies": [
+            "capability"
           ]
         },
         {
@@ -1826,6 +1856,13 @@
       ],
       "axisRestrictionCounts": [
         {
+          "axis": "capability",
+          "atomCount": 1,
+          "atomObservationRefs": [
+            "atom:capability:create-user"
+          ]
+        },
+        {
           "axis": "contractSpecification",
           "atomCount": 1,
           "atomObservationRefs": [
@@ -1848,13 +1885,14 @@
           ]
         }
       ],
-      "axisConcentration": "maxAxisShare=2/4",
+      "axisConcentration": "maxAxisShare=2/5",
       "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
       "highSupportRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -1876,13 +1914,20 @@
       "readingId": "atom-support-axis:molecule-user-request-responsibility",
       "scopeRef": "molecule:user-request-responsibility",
       "scopeKind": "molecule",
-      "supportSize": 4,
+      "supportSize": 5,
       "subjectFamilySpread": [
         {
           "subjectRef": "contract.createsUser",
           "atomCount": 1,
           "atomFamilies": [
             "contractSpecification"
+          ]
+        },
+        {
+          "subjectRef": "operation.createUser",
+          "atomCount": 1,
+          "atomFamilies": [
+            "capability"
           ]
         },
         {
@@ -1909,6 +1954,13 @@
       ],
       "axisRestrictionCounts": [
         {
+          "axis": "capability",
+          "atomCount": 1,
+          "atomObservationRefs": [
+            "atom:capability:create-user"
+          ]
+        },
+        {
           "axis": "contractSpecification",
           "atomCount": 1,
           "atomObservationRefs": [
@@ -1931,13 +1983,14 @@
           ]
         }
       ],
-      "axisConcentration": "maxAxisShare=2/4",
+      "axisConcentration": "maxAxisShare=2/5",
       "mixedAxisMoleculePressure": "mixedAxisPressurePresent",
       "highSupportRefs": [
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "sourceRefs": [
         "src-route-users",
@@ -2425,7 +2478,7 @@
       "nonMonotoneAxisRefs": [
         "gap-runtime-user-db-trace"
       ],
-      "pathCostProxy": "support=4 transferred=1",
+      "pathCostProxy": "support=5 transferred=1",
       "preservedInvariantTrajectory": [
         "preserve all existing source-grounded atom observation refs"
       ],
@@ -2549,7 +2602,7 @@
       "sourceProjectionRef": "observation-projection:fixture-archmap-atom-observation",
       "sourceAxisForgettingRef": "axis-forgetting-risk:selected-projection",
       "fidelityStatus": "projectionLossObserved",
-      "observedAtomFamilyCount": 3,
+      "observedAtomFamilyCount": 4,
       "forgottenCoordinateCount": 1,
       "observationCollisionCount": 0,
       "collapsedAtomFamilyCandidateCount": 0,
@@ -2582,10 +2635,11 @@
   "atomOriginClosureDebtReadings": [
     {
       "readingId": "atom-origin-closure-debt:fixture-archmap-atom-observation",
-      "sourceBackedAtomCount": 4,
+      "sourceBackedAtomCount": 5,
       "derivedOrInferredAtomCount": 0,
       "expectedMissingAtomCount": 1,
       "sourceBackedAtomFamilyRefs": [
+        "capability",
         "contractSpecification",
         "existence",
         "relation"
@@ -2751,7 +2805,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "constraintRefs": [
         "split-readiness:molecule-user-request-responsibility",
@@ -2999,6 +3054,26 @@
           "nonzero holonomy is bounded diagnosis, not future incident prediction",
           "homotopy complex summary is not source extraction completeness"
         ]
+      },
+      {
+        "cellId": "0-cell:atom-capability-create-user",
+        "cellDimension": 0,
+        "cellKind": "capability",
+        "status": "observed",
+        "observationRefs": [
+          "atom:capability:create-user"
+        ],
+        "sourceRefs": [
+          "test-user-contract"
+        ],
+        "reading": "observed Atom is read as a bounded 0-cell candidate",
+        "nonConclusions": [
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "nonzero holonomy is bounded diagnosis, not future incident prediction",
+          "homotopy complex summary is not source extraction completeness"
+        ]
       }
     ],
     "oneCells": [
@@ -3011,7 +3086,8 @@
           "atom:component:route-users",
           "atom:component:service-user",
           "atom:relation:route-service",
-          "atom:contract:create-user"
+          "atom:contract:create-user",
+          "atom:capability:create-user"
         ],
         "sourceRefs": [
           "doc-architecture"
@@ -3032,6 +3108,27 @@
         "status": "candidate",
         "observationRefs": [
           "semantic:create-user-flow"
+        ],
+        "sourceRefs": [
+          "doc-architecture",
+          "test-user-contract"
+        ],
+        "reading": "semantic observation is read as a selected path continuation candidate",
+        "nonConclusions": [
+          "candidate paths and loops are review cues, not path truth",
+          "unfilled loops are architectural holes, not automatic violations",
+          "missing filler evidence is not measured zero",
+          "nonzero holonomy is bounded diagnosis, not future incident prediction",
+          "homotopy complex summary is not source extraction completeness"
+        ]
+      },
+      {
+        "cellId": "1-cell:semantic-interpretation-create-user",
+        "cellDimension": 1,
+        "cellKind": "semanticInterpretation",
+        "status": "candidate",
+        "observationRefs": [
+          "semantic:interpretation:create-user"
         ],
         "sourceRefs": [
           "doc-architecture",
@@ -3140,11 +3237,13 @@
         "test-user-contract"
       ],
       "observationRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "coverageBoundary": "homotopy profile absent; path, filler, loop, and zero readings remain blocked",
       "evidenceBoundary": "candidate path pair is a bounded review cue, not a path equality proof",
@@ -3287,7 +3386,7 @@
       },
       "distanceKind": "selected-axis-continuation-distance",
       "value": 1,
-      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=1; traceAxes=2; missing=1",
+      "comparedContinuationSummary": "path:semantic-operation-flow vs molecule:user-request-responsibility on axis:layer-violation; distanceKind=selected-axis-continuation-distance; sourceRefs=4; semanticEvidence=2; traceAxes=2; missing=1",
       "comparedContinuationRefs": [
         "Cont_axis:layer-violation(molecule:user-request-responsibility)",
         "Cont_axis:layer-violation(path:semantic-operation-flow)",
@@ -3299,6 +3398,7 @@
         "Cont_semantic[endpoint]=q; endpointRefs=2; evaluator=weighted-axis-l1:semantic-sequence-mismatch"
       ],
       "distanceInputRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
@@ -3308,6 +3408,7 @@
         "continuation-value:semantic-path-q-operation-service-create-user-operation-route-create-user",
         "doc-architecture",
         "semantic:create-user-flow",
+        "semantic:interpretation:create-user",
         "src-route-users",
         "src-service-user",
         "test-user-contract"
@@ -3322,11 +3423,13 @@
         "test-user-contract"
       ],
       "observationRefs": [
+        "atom:capability:create-user",
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:contract:create-user",
         "atom:relation:route-service",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "fillerRefs": [],
       "missingFillerRefs": [
@@ -5769,7 +5872,8 @@
       ],
       "semanticObservationRefs": [
         "atom:contract:create-user",
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "crossLayerAtomRefs": [
         "atom:contract:create-user"
@@ -5792,11 +5896,12 @@
     {
       "readingId": "observation-projection:fixture-archmap-atom-observation",
       "observedAtomFamilies": [
+        "capability",
         "contractSpecification",
         "existence",
         "relation"
       ],
-      "observedAtomFamilyCount": 3,
+      "observedAtomFamilyCount": 4,
       "sourceCoordinates": [
         {
           "coordinateId": "projection-coordinate:observed:atom-component-route-users",
@@ -5852,6 +5957,21 @@
           "predicate": "contract test observes create-user success",
           "atomObservationRefs": [
             "atom:contract:create-user"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "status": "observed",
+          "reading": "observed ArchMap atom coordinate in the canonical projection boundary"
+        },
+        {
+          "coordinateId": "projection-coordinate:observed:atom-capability-create-user",
+          "coordinateKind": "observedAtomCoordinate",
+          "atomFamily": "capability",
+          "subjectRef": "operation.createUser",
+          "predicate": "create-user capability is observed",
+          "atomObservationRefs": [
+            "atom:capability:create-user"
           ],
           "sourceRefs": [
             "test-user-contract"
@@ -5941,6 +6061,21 @@
           "predicate": "contract test observes create-user success",
           "atomObservationRefs": [
             "atom:contract:create-user"
+          ],
+          "sourceRefs": [
+            "test-user-contract"
+          ],
+          "status": "observed",
+          "reading": "observed ArchMap atom coordinate in the canonical projection boundary"
+        },
+        {
+          "coordinateId": "projection-coordinate:observed:atom-capability-create-user",
+          "coordinateKind": "observedAtomCoordinate",
+          "atomFamily": "capability",
+          "subjectRef": "operation.createUser",
+          "predicate": "create-user capability is observed",
+          "atomObservationRefs": [
+            "atom:capability:create-user"
           ],
           "sourceRefs": [
             "test-user-contract"
@@ -6685,7 +6820,8 @@
     ],
     "semanticObservationRefs": [
       "atom:contract:create-user",
-      "semantic:create-user-flow"
+      "semantic:create-user-flow",
+      "semantic:interpretation:create-user"
     ],
     "splitBoundary": "runtime gaps are preserved separately and are not interpreted as measured zero",
     "nonConclusions": [
@@ -6707,7 +6843,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "preconditions": [
         "human review selects a repair operation",
@@ -6751,7 +6888,8 @@
       "surface": "Path",
       "status": "observedOrRepresented",
       "pathRefs": [
-        "semantic:create-user-flow"
+        "semantic:create-user-flow",
+        "semantic:interpretation:create-user"
       ],
       "homotopyRefs": [
         "molecule-reading:molecule-user-request-responsibility"
@@ -6777,7 +6915,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "homotopyRefs": [
         "molecule-reading:molecule-user-request-responsibility"
@@ -6806,7 +6945,8 @@
         "atom:component:route-users",
         "atom:component:service-user",
         "atom:relation:route-service",
-        "atom:contract:create-user"
+        "atom:contract:create-user",
+        "atom:capability:create-user"
       ],
       "confidence": "medium",
       "uncertainty": [
@@ -7090,6 +7230,7 @@
       "Operation -> Path -> Homotopy -> Diagram -> AnalyticRepresentation"
     ],
     "observedAtomsSummary": [
+      "capability",
       "contractSpecification",
       "existence",
       "relation"
@@ -7112,18 +7253,18 @@
     ],
     "spectralReadingsSummary": [
       "relationAtomWeightedAdjacencyMatrix upperBound=unmeasured shape=2x2 (needsReview)",
-      "moleculeAtomOverlapCouplingMatrix upperBound=4.000 shape=1x1 (needsReview)",
+      "moleculeAtomOverlapCouplingMatrix upperBound=5.000 shape=1x1 (needsReview)",
       "obstructionAxisCurvatureMatrix upperBound=0.000 shape=0x1 (nonConclusion)",
       "operationSignatureDeltaMatrix upperBound=1.000 shape=1x1 (actionable)"
     ],
     "spectralModeSummary": [
       "relationAtomWeightedAdjacencyMatrix boundedSpectralMode gap=1.000 localization=1.000 density=0.250 (needsReview)",
-      "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=4.000 localization=1.000 density=1.000 (needsReview)",
+      "moleculeAtomOverlapCouplingMatrix delocalizedCouplingMode gap=5.000 localization=1.000 density=1.000 (needsReview)",
       "obstructionAxisCurvatureMatrix curvatureMode gap=0.000 localization=0.000 density=0.000 (nonConclusion)",
       "operationSignatureDeltaMatrix broadPerturbationMode gap=1.000 localization=1.000 density=1.000 (needsReview)"
     ],
     "spectralDrilldownSummary": [
-      "spectral-drilldown:fixture-archmap-atom-observation atomFamilies=3 overlapPairs=0 repairAxisDeltas=1 (needsReview)"
+      "spectral-drilldown:fixture-archmap-atom-observation atomFamilies=4 overlapPairs=0 repairAxisDeltas=1 (needsReview)"
     ],
     "curvatureSupportSummary": [],
     "curvatureTransferSummary": [],
@@ -7136,8 +7277,8 @@
       "v0.3.0 measurement expansion reads 2 Atom support axes, 1 compatibility surfaces, 1 LawUniverse coverage surfaces, 1 feature-extension formulas, 1 operation-law surfaces, 1 path trajectories, 1 homotopy/order surfaces, 1 diagram-fillability surfaces, 1 axis-forgetting risks, 1 projection-fidelity surfaces, 1 Atom origin-closure debts, 1 effect-relation algebras, 1 synthesis blockers, 1 operation-precondition readings, 1 path-multiplicity readings, 1 trajectory homotopy refutations, 1 bridge split-transfer surfaces, and 1 nonzero monodromy witnesses"
     ],
     "atomSupportAxisSummary": [
-      "fixture-archmap-atom-observation support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent",
-      "molecule:user-request-responsibility support=4 concentration=maxAxisShare=2/4 pressure=mixedAxisPressurePresent"
+      "fixture-archmap-atom-observation support=5 concentration=maxAxisShare=2/5 pressure=mixedAxisPressurePresent",
+      "molecule:user-request-responsibility support=5 concentration=maxAxisShare=2/5 pressure=mixedAxisPressurePresent"
     ],
     "atomCompatibilitySummary": [
       "atom-compatibility:fixture-archmap-atom-observation status=compatibleWithinObservedSlots sameSlotConflicts=0 uncertainty=1"
@@ -7152,7 +7293,7 @@
       "repair-operation:none-observed kind=noneObserved composition=unmeasured repairMonotonicity=unmeasured boundary=notASynthesisCertificate"
     ],
     "pathSignatureTrajectorySummary": [
-      "operation-delta:observe-before-repair status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=4 transferred=1"
+      "operation-delta:observe-before-repair status=candidateTrajectory endpointDeltas=1 nonMonotoneAxes=1 cost=support=5 transferred=1"
     ],
     "homotopyOrderSensitivitySummary": [
       "homotopy-order-sensitivity:selected-operations status=sensitive orderSensitivity=blockedByTransferredObstructionOrMissingEvidence blockers=1"
@@ -7167,7 +7308,7 @@
       "observation-projection:fixture-archmap-atom-observation status=projectionLossObserved forgotten=1 collisions=0 reflection=blockedWithoutAxisPreservationAndWitnessCompleteness"
     ],
     "atomOriginClosureDebtSummary": [
-      "atom-origin-closure-debt:fixture-archmap-atom-observation status=originClosureDebtObserved sourceBacked=4 inferred=0 missingExpected=1"
+      "atom-origin-closure-debt:fixture-archmap-atom-observation status=originClosureDebtObserved sourceBacked=5 inferred=0 missingExpected=1"
     ],
     "effectRelationAlgebraSummary": [
       "effect-relation-algebra:fixture-archmap-atom-observation pressure=effectRelationPressureObserved generators=1 unresolved=1 externalBoundaries=0"
@@ -7219,7 +7360,7 @@
       "three-layer-flatness:fixture-archmap-atom-observation static=candidateFlat runtime=blockedByCoverageGap semantic=candidateFlat crossLayerAtoms=1"
     ],
     "observationProjectionSummary": [
-      "observation-projection:fixture-archmap-atom-observation families=3 forgotten=1 blockers=1"
+      "observation-projection:fixture-archmap-atom-observation families=4 forgotten=1 blockers=1"
     ],
     "stateTransitionAlgebraSummary": [
       "state-transition-algebra:fixture-archmap-atom-observation generators=0 unresolved=1 obstructions=0"


### PR DESCRIPTION
## 概要

Closes #1625
Closes #1626
Closes #1627
Closes #1628
Closes #1629

ArchSig の obstruction / signature / homotopy holonomy を proxy-free な witness-driven 計算へ締め直しました。

- obstruction circuit は required atom families が family-wise に揃い、かつ `moleculePatternRefs` が実際の molecule observation で満たされる場合だけ構成する
- `concernHints` は補助 context に限定し、concern-only / blocked witness / incomplete molecule pattern から nonzero signature axis が立たないようにする
- nonzero homotopy holonomy は semantic observation の存在ではなく、positive selected-axis continuation defect refs からだけ値を出す
- validation に concern-only obstruction、signature axis value mismatch、semantic-only nonzero holonomy の退行検出を追加
- canonical / acceptance fixtures と docs を新しい計算境界に同期

Lean status: tooling analysis / design tracking。Lean theorem proof の追加ではありません。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（変更した docs / Rust source / tests に対して実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
