### PR TITLE
AGENTSにlakeを一時置き場にしない運用を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .lake/
+.tmp/
 .archsig/
 build/
 target/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - PR 本文には対象 Issue を `Closes #N` 形式で明記し、`.github/pull_request_template.md` に沿って書く。
 - 既存の未コミット変更はユーザーの変更として扱い、勝手に戻さない。
 - `git reset --hard` や `git checkout --` のような破壊的操作は、明示的な依頼なしに実行しない。
+- `.lake` は Lake の build / dependency cache 専用として扱い、検証出力、PR / Issue 下書き、一時 JSON などの temp 置き場に使わない。一時出力は `.tmp/` または `/private/tmp` などに置く。
 
 ## モノレポの地図
 
@@ -76,7 +77,7 @@ ArchSig の現行一次 workflow は `analyze` である。
 cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
   --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
   --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
-  --out-dir .lake/archsig-analyze
+  --out-dir .tmp/archsig-analyze
 ```
 
 website は no-build static stack として扱う。directory route、asset path、`sitemap.xml`、`robots.txt` を確認する場合は local server で preview する。


### PR DESCRIPTION
## 概要

`.lake` を Lake の build / dependency cache 専用として扱い、検証出力や PR / Issue 下書きなどの temp 置き場に使わない運用を AGENTS.md に追加します。

Issue 起点ではないリポジトリ運用メモの更新です。

## 証明した定理

- なし

## 編集したドキュメント

- AGENTS.md
- .gitignore

## 実施したテスト

- [ ] `lake build`（docs-only のため未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 実装変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 実装変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `rg -nP "[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}]" AGENTS.md .gitignore`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない