### PR TITLE
ArchSig analyze の出力契約を更新する

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -52,10 +52,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          out_dir=".lake/archsig-analyze-e2e"
+          out_dir=".tmp/archsig-analyze-e2e"
           archsig_dir="$out_dir/archsig"
+          archsig_raw_dir="$out_dir/archsig-raw"
           fieldsig_dir="$out_dir/fieldsig"
-          mkdir -p "$archsig_dir" "$fieldsig_dir"
+          mkdir -p "$archsig_dir" "$archsig_raw_dir" "$fieldsig_dir"
 
           cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
             --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
@@ -64,10 +65,51 @@ jobs:
 
           test -s "$archsig_dir/archmap-validation.json"
           test -s "$archsig_dir/law-policy-validation.json"
-          test -s "$archsig_dir/archsig-analysis-packet.json"
-          test -s "$archsig_dir/archsig-analysis-detail-index.json"
           test -s "$archsig_dir/archsig-analysis-validation.json"
-          test -s "$archsig_dir/llm-interpretation-packet.json"
+          test -s "$archsig_dir/archsig-analysis-summary.json"
+          test -s "$archsig_dir/archsig-atom-viewer-data.json"
+          test -s "$archsig_dir/archsig-run-manifest.json"
+          test ! -e "$archsig_dir/archsig-analysis-packet.json"
+          test ! -e "$archsig_dir/archsig-analysis-detail-index.json"
+          test ! -e "$archsig_dir/llm-interpretation-packet.json"
+
+          jq -e '
+            .schemaVersion == "archsig-run-manifest-v0"
+            and .rawArtifactRetention == "omitted"
+            and ([.generatedArtifacts[]] | index("archsig-analysis-summary.json") != null)
+            and ([.generatedArtifacts[]] | index("archsig-atom-viewer-data.json") != null)
+            and ([.omittedArtifacts[]] | index("archsig-analysis-packet.json") != null)
+          ' "$archsig_dir/archsig-run-manifest.json"
+
+          jq -e '
+            .schemaVersion == "archsig-atom-viewer-data-v0"
+            and .dataKind == "bounded-atom-viewer-projection"
+            and ((.atomNodes | length) > 0)
+            and .reportPane.overview.summaryVerdict.readingMode == "measurementOverSuppliedArchMapAndLawPolicy"
+          ' "$archsig_dir/archsig-atom-viewer-data.json"
+
+          cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
+            --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+            --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+            --out-dir "$archsig_raw_dir" \
+            --emit-raw-artifacts
+
+          test -s "$archsig_raw_dir/archmap-validation.json"
+          test -s "$archsig_raw_dir/law-policy-validation.json"
+          test -s "$archsig_raw_dir/archsig-analysis-validation.json"
+          test -s "$archsig_raw_dir/archsig-analysis-summary.json"
+          test -s "$archsig_raw_dir/archsig-atom-viewer-data.json"
+          test -s "$archsig_raw_dir/archsig-run-manifest.json"
+          test -s "$archsig_raw_dir/archsig-analysis-packet.json"
+          test -s "$archsig_raw_dir/archsig-analysis-detail-index.json"
+          test -s "$archsig_raw_dir/llm-interpretation-packet.json"
+
+          jq -e '
+            .schemaVersion == "archsig-run-manifest-v0"
+            and .rawArtifactRetention == "full"
+            and ([.generatedArtifacts[]] | index("archsig-analysis-packet.json") != null)
+            and (.omittedArtifacts | length) == 0
+          ' "$archsig_raw_dir/archsig-run-manifest.json"
 
           jq -e '
             .schemaVersion == "archsig-analysis-packet-v0"
@@ -76,26 +118,26 @@ jobs:
             and ((.obstructionCircuits | length) > 0)
             and ((.signatureAxes | length) > 0)
             and ([.nonConclusions[] | contains("not a Lean theorem proof")] | any)
-          ' "$archsig_dir/archsig-analysis-packet.json"
+          ' "$archsig_raw_dir/archsig-analysis-packet.json"
 
           jq -e '
             .schemaVersion == "archsig-analysis-detail-index-v0"
             and .indexKind == "deduplicated-string-ref-set-dictionary"
             and (.refDictionary | type == "array")
             and (.refSets | type == "array")
-          ' "$archsig_dir/archsig-analysis-detail-index.json"
+          ' "$archsig_raw_dir/archsig-analysis-detail-index.json"
 
-          jq -e --slurpfile packet "$archsig_dir/archsig-analysis-packet.json" '
+          jq -e --slurpfile packet "$archsig_raw_dir/archsig-analysis-packet.json" '
             . == $packet[0].llmInterpretationPacket
-          ' "$archsig_dir/llm-interpretation-packet.json"
+          ' "$archsig_raw_dir/llm-interpretation-packet.json"
 
           jq -e '
             .summary.result == "pass"
             and ([.checks[]?.id] | index("archsig-analysis-packet-non-conclusion-boundary") != null)
-          ' "$archsig_dir/archsig-analysis-validation.json"
+          ' "$archsig_raw_dir/archsig-analysis-validation.json"
 
           cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
-            --analysis-packet "$archsig_dir/archsig-analysis-packet.json" \
+            --analysis-packet "$archsig_raw_dir/archsig-analysis-packet.json" \
             --out "$fieldsig_dir/operation-support-estimate.json"
 
           jq -e '
@@ -117,4 +159,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: archsig-analyze-e2e-${{ github.run_id }}
-          path: .lake/archsig-analyze-e2e
+          path: .tmp/archsig-analyze-e2e

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -40,7 +40,7 @@ are not measured zeros.
 | --- | --- | --- |
 | ArchMap validation and authoring | `archmap`, `archmap-generate` | ArchMap records source-grounded Atom observations, molecule observations, semantic readings, projection hints, concern hints, and gaps. Complete-first authoring should collect spectrum support, homotopy candidates, filler evidence, non-fillability witnesses, and targeted gaps before handoff. It does not select laws or output obstruction circuits. |
 | Interpretation profile | `law-policy`, `interpretation-profile` | The profile selects the LawUniverse, witness rules, molecule patterns, obstruction circuit definitions, signature axes, coverage requirements, exactness assumptions, optional ACTS spectrum profile, optional homotopy measurement profile, and non-conclusions. It is not AAT itself. |
-| ArchSig analysis | `analyze`, `llm-native-workflow`, `north-star-workflow`, `archsig-analysis`, `aat-analysis`, `analysis-summary`, `summary` | `analyze` is the primary workflow from ArchMap + LawPolicy to validation reports, `archsig-analysis-packet-v0`, and the LLM interpretation packet. `llm-native-workflow` and `north-star-workflow` remain compatibility aliases for the same workflow. `archsig-analysis` / `aat-analysis` build a packet from already validated inputs. `analysis-summary` emits the compact human / LLM reading surface from an existing packet. |
+| ArchSig analysis | `analyze`, `llm-native-workflow`, `north-star-workflow`, `archsig-analysis`, `aat-analysis`, `analysis-summary`, `summary` | `analyze` is the primary workflow from ArchMap + LawPolicy to validation reports, `archsig-analysis-summary.json`, `archsig-atom-viewer-data.json`, and `archsig-run-manifest.json`. Raw packet artifacts for FieldSig handoff are emitted only with `--emit-raw-artifacts`. `llm-native-workflow` and `north-star-workflow` remain compatibility aliases for the same workflow. `archsig-analysis` / `aat-analysis` build a packet from already validated inputs. `analysis-summary` emits the compact LLM reading surface from an existing packet. |
 | Codebase inspection | `codebase-inspection` | Reads latest `archmap-snapshot-v0`, `archmap-index-v0`, optional recent deltas, optional LawPolicy provenance, and an `archsig-analysis-packet-v0` to produce current-state architectural diagnosis. It is not PR / diff evolution analysis or global safety. |
 | Lightweight PR review | `pr-review` | Reads base `archmap-observation-map-v0`, PR-local `archmap-delta-v0`, and required `law-policy-v0`. It does not accept raw diff, ArchMapCommit, or base/head analysis packets as PR-review inputs. |
 | Schema | `schema-catalog` | The catalog lists the current ArchMap, LawPolicy, ArchSig analysis packet, and validation report artifacts. |
@@ -58,7 +58,7 @@ not first-class ArchMap outputs.
 measured verdict, quality counts, measurement-status counts, dominant findings,
 action queue, trend diagnosis, review support, compact section summaries,
 detail index, measurement basis, and metadata. The full evidence remains in
-`archsig-analysis-packet.json`.
+`archsig-analysis-packet.json` when raw artifacts are emitted.
 
 Large ArchMaps may be authored in shards for review and parallel generation,
 but current commands consume the exported monolithic
@@ -114,15 +114,14 @@ This writes:
 
 - `.archsig/analyze/archmap-validation.json`
 - `.archsig/analyze/law-policy-validation.json`
-- `.archsig/analyze/archsig-analysis-packet.json`
-- `.archsig/analyze/archsig-analysis-detail-index.json`
 - `.archsig/analyze/archsig-analysis-validation.json`
-- `.archsig/analyze/llm-interpretation-packet.json`
+- `.archsig/analyze/archsig-analysis-summary.json`
+- `.archsig/analyze/archsig-atom-viewer-data.json`
+- `.archsig/analyze/archsig-run-manifest.json`
 
-`archsig-analysis-packet.json` is compact-first: large repeated string ref
-sets are replaced by `archsig-detail-ref-v0` objects with counts, samples, and
-detail refs. Full ref sets are stored through a dictionary-backed
-`archsig-analysis-detail-index.json`.
+Use `archsig-analysis-summary.json` as the LLM-readable first pass and
+`archsig-atom-viewer-data.json` with the fixed Atom Viewer app for human visual
+review. `archsig-run-manifest.json` records generated and omitted artifacts.
 
 For large ArchMaps, prefer the optimized binary:
 
@@ -132,6 +131,27 @@ cargo run --release --manifest-path tools/archsig/Cargo.toml -- analyze \
   --law-policy .archsig/hilda/hilda-law-policy.json \
   --out-dir .archsig/analyze
 ```
+
+For FieldSig handoff or deep evidence lookup, emit raw artifacts explicitly:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .archsig/analyze \
+  --emit-raw-artifacts
+```
+
+This additionally writes:
+
+- `.archsig/analyze/archsig-analysis-packet.json`
+- `.archsig/analyze/archsig-analysis-detail-index.json`
+- `.archsig/analyze/llm-interpretation-packet.json`
+
+`archsig-analysis-packet.json` is compact-first when emitted: large repeated
+string ref sets are replaced by `archsig-detail-ref-v0` objects with counts,
+samples, and detail refs. Full ref sets are stored through a dictionary-backed
+`archsig-analysis-detail-index.json`.
 
 `llm-interpretation-packet.json` contains the compact
 `llmInterpretationPacket` reading surface from the analysis packet. Treat it as

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -40,21 +40,36 @@ The command emits only:
 
 - `archmap-validation.json`
 - `law-policy-validation.json`
+- `archsig-analysis-validation.json`
+- `archsig-analysis-summary.json`
+- `archsig-atom-viewer-data.json`
+- `archsig-run-manifest.json`
+
+`archsig-analysis-summary.json` is the LLM-readable compact reading surface.
+`archsig-atom-viewer-data.json` is a bounded visual projection for the fixed
+Atom Viewer app. `archsig-run-manifest.json` records generated and omitted
+artifacts. For large ArchMaps, run `analyze` with `cargo run --release`.
+
+Raw evidence artifacts are opt-in:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
+  --archmap tools/archsig/tests/fixtures/minimal/archmap.json \
+  --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json \
+  --out-dir .archsig/analyze \
+  --emit-raw-artifacts
+```
+
+This additionally writes:
+
 - `archsig-analysis-packet.json`
 - `archsig-analysis-detail-index.json`
-- `archsig-analysis-validation.json`
 - `llm-interpretation-packet.json`
 
-`archsig-analysis-packet.json` is compact-first: large repeated string ref sets
-are replaced by `archsig-detail-ref-v0` objects with counts, samples, and detail
-refs. Full ref sets are stored through a dictionary-backed
-`archsig-analysis-detail-index.json`. For large ArchMaps, run `analyze` with
-`cargo run --release`.
-
-`llm-interpretation-packet.json` contains the compact
-`llmInterpretationPacket` reading surface from the analysis packet. It is not a
-natural-language judgement, Lean proof, architecture lawfulness certificate, or
-automatic repair instruction.
+`archsig-analysis-packet.json` is compact-first when emitted: large repeated
+string ref sets are replaced by `archsig-detail-ref-v0` objects with counts,
+samples, and detail refs. Full ref sets are stored through a dictionary-backed
+`archsig-analysis-detail-index.json`.
 
 To emit a compact review summary from an existing packet, run:
 

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -69,6 +69,10 @@ enum Command {
         /// Output directory for ArchSig analysis workflow artifacts.
         #[arg(long = "out-dir")]
         out_dir: PathBuf,
+
+        /// Also write full raw analysis artifacts for FieldSig handoff and deep evidence lookup.
+        #[arg(long = "emit-raw-artifacts")]
+        emit_raw_artifacts: bool,
     },
 
     /// Build an ArchSig AAT analysis packet from ArchMap + interpretation profile.
@@ -466,9 +470,13 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             archmap,
             law_policy,
             out_dir,
+            emit_raw_artifacts,
         }) => {
             let archmap_validation_path = out_dir.join("archmap-validation.json");
             let law_policy_validation_path = out_dir.join("law-policy-validation.json");
+            let analysis_summary_path = out_dir.join("archsig-analysis-summary.json");
+            let atom_viewer_data_path = out_dir.join("archsig-atom-viewer-data.json");
+            let run_manifest_path = out_dir.join("archsig-run-manifest.json");
             let analysis_packet_path = out_dir.join("archsig-analysis-packet.json");
             let analysis_validation_path = out_dir.join("archsig-analysis-validation.json");
             let llm_interpretation_path = out_dir.join("llm-interpretation-packet.json");
@@ -521,22 +529,53 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 Some(&archmap.display().to_string()),
                 Some(&law_policy.display().to_string()),
             );
-            let analysis_detail_index_path = out_dir.join("archsig-analysis-detail-index.json");
-            write_analysis_packet_artifacts(
-                Some(analysis_packet_path.clone()),
-                &analysis_packet,
-                Some(analysis_detail_index_path),
-            )?;
-            write_json(
-                Some(llm_interpretation_path),
-                &analysis_packet.llm_interpretation_packet,
-            )?;
             let analysis_validation = validate_archsig_analysis_packet_report(
                 &analysis_packet,
                 &analysis_packet_path.display().to_string(),
             );
             let analysis_failed = analysis_validation.summary.result == "fail";
             write_json(Some(analysis_validation_path), &analysis_validation)?;
+            let analysis_packet_value = serde_json::to_value(&analysis_packet)?;
+            let archmap_validation_value = serde_json::to_value(&archmap_validation)?;
+            let law_policy_validation_value = serde_json::to_value(&law_policy_validation)?;
+            let analysis_validation_value = serde_json::to_value(&analysis_validation)?;
+            let analysis_summary = build_analysis_summary(
+                &analysis_packet_value,
+                Some(&archmap_validation_value),
+                Some(&law_policy_validation_value),
+                Some(&analysis_validation_value),
+            );
+            write_json(Some(analysis_summary_path.clone()), &analysis_summary)?;
+            let atom_viewer_data = build_atom_viewer_data(
+                &archmap_document,
+                &analysis_packet_value,
+                &analysis_summary,
+                &archmap,
+                &law_policy,
+            )?;
+            write_json(Some(atom_viewer_data_path.clone()), &atom_viewer_data)?;
+
+            let analysis_detail_index_path = out_dir.join("archsig-analysis-detail-index.json");
+            if emit_raw_artifacts {
+                write_analysis_packet_artifacts(
+                    Some(analysis_packet_path.clone()),
+                    &analysis_packet,
+                    Some(analysis_detail_index_path.clone()),
+                )?;
+                write_json(
+                    Some(llm_interpretation_path.clone()),
+                    &analysis_packet.llm_interpretation_packet,
+                )?;
+            }
+            let run_manifest = build_analyze_run_manifest(
+                &archmap,
+                &law_policy,
+                emit_raw_artifacts,
+                &archmap_validation,
+                &law_policy_validation,
+                &analysis_validation,
+            );
+            write_json(Some(run_manifest_path), &run_manifest)?;
 
             report_analyze_validation_failures(
                 out_dir.as_path(),
@@ -612,6 +651,227 @@ fn write_analysis_packet_artifacts(
     }
     write_json_minified(out, &packet_value)?;
     Ok(())
+}
+
+fn build_analyze_run_manifest(
+    archmap: &Path,
+    law_policy: &Path,
+    emit_raw_artifacts: bool,
+    archmap_validation: &ArchMapValidationReportV0,
+    law_policy_validation: &LawPolicyValidationReportV0,
+    analysis_validation: &ArchSigAnalysisPacketValidationReportV0,
+) -> serde_json::Value {
+    let mut generated_artifacts = vec![
+        "archmap-validation.json",
+        "law-policy-validation.json",
+        "archsig-analysis-validation.json",
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
+    ];
+    let mut omitted_artifacts = Vec::new();
+    if emit_raw_artifacts {
+        generated_artifacts.extend([
+            "archsig-analysis-packet.json",
+            "archsig-analysis-detail-index.json",
+            "llm-interpretation-packet.json",
+        ]);
+    } else {
+        omitted_artifacts.extend([
+            "archsig-analysis-packet.json",
+            "archsig-analysis-detail-index.json",
+            "llm-interpretation-packet.json",
+        ]);
+    }
+
+    serde_json::json!({
+        "schemaVersion": "archsig-run-manifest-v0",
+        "commandName": "analyze",
+        "archmapInputPath": archmap.display().to_string(),
+        "lawPolicyInputPath": law_policy.display().to_string(),
+        "outputMode": if emit_raw_artifacts {
+            "summary-viewer-manifest-with-raw-artifacts"
+        } else {
+            "summary-viewer-manifest"
+        },
+        "rawArtifactRetention": if emit_raw_artifacts { "full" } else { "omitted" },
+        "generatedArtifacts": generated_artifacts,
+        "omittedArtifacts": omitted_artifacts,
+        "summaryPath": "archsig-analysis-summary.json",
+        "atomViewerDataPath": "archsig-atom-viewer-data.json",
+        "validationReports": {
+            "archmap": "archmap-validation.json",
+            "lawPolicy": "law-policy-validation.json",
+            "analysis": "archsig-analysis-validation.json"
+        },
+        "rawArtifactPaths": if emit_raw_artifacts {
+            serde_json::json!({
+                "analysisPacket": "archsig-analysis-packet.json",
+                "analysisDetailIndex": "archsig-analysis-detail-index.json",
+                "llmInterpretationPacket": "llm-interpretation-packet.json"
+            })
+        } else {
+            serde_json::Value::Null
+        },
+        "validationResultSummary": {
+            "archmap": {
+                "result": &archmap_validation.summary.result,
+                "failedCheckCount": archmap_validation.summary.failed_check_count,
+                "warningCheckCount": archmap_validation.summary.warning_check_count
+            },
+            "lawPolicy": {
+                "result": &law_policy_validation.summary.result,
+                "failedCheckCount": law_policy_validation.summary.failed_check_count,
+                "warningCheckCount": law_policy_validation.summary.warning_check_count
+            },
+            "analysis": {
+                "result": &analysis_validation.summary.result,
+                "failedCheckCount": analysis_validation.summary.failed_check_count,
+                "warningCheckCount": analysis_validation.summary.warning_check_count
+            }
+        },
+        "nonConclusions": [
+            "run manifest records generated and omitted artifacts for this ArchSig analyze run",
+            "omitted raw artifacts can be regenerated by rerunning analyze with --emit-raw-artifacts",
+            "manifest paths are artifact navigation aids, not source completeness proof"
+        ]
+    })
+}
+
+fn build_atom_viewer_data(
+    archmap: &ArchMapDocumentV0,
+    packet: &serde_json::Value,
+    summary: &serde_json::Value,
+    archmap_path: &Path,
+    law_policy_path: &Path,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    const ATOM_NODE_LIMIT: usize = 250;
+    const MOLECULE_GROUP_LIMIT: usize = 120;
+    const OVERLAY_LIMIT: usize = 80;
+
+    let atom_nodes = archmap
+        .atom_observations
+        .iter()
+        .take(ATOM_NODE_LIMIT)
+        .map(|atom| {
+            Ok(serde_json::json!({
+                "nodeId": &atom.atom_observation_id,
+                "atomFamily": &atom.atom_family,
+                "subjectRef": &atom.subject_ref,
+                "predicate": &atom.predicate,
+                "observationStatus": &atom.observation_status,
+                "confidence": &atom.confidence,
+                "objectRefCount": atom.object_refs.len(),
+                "sourceRefSamples": source_ref_samples(&atom.source_refs)?,
+                "projectionRefs": &atom.projection_refs,
+                "visual": {
+                    "kind": "atom",
+                    "colorBy": "observationStatus",
+                    "sizeBy": "sourceRefCount"
+                }
+            }))
+        })
+        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
+    let molecule_groups = archmap
+        .molecule_observations
+        .iter()
+        .take(MOLECULE_GROUP_LIMIT)
+        .map(|molecule| {
+            Ok(serde_json::json!({
+                "groupId": &molecule.molecule_observation_id,
+                "moleculeFamily": &molecule.molecule_family,
+                "roleName": &molecule.role_name,
+                "atomObservationRefs": &molecule.atom_observation_refs,
+                "observationStatus": &molecule.observation_status,
+                "confidence": &molecule.confidence,
+                "sourceRefSamples": source_ref_samples(&molecule.source_refs)?,
+                "visual": {
+                    "kind": "moleculeGroup",
+                    "hullBy": "atomObservationRefs"
+                }
+            }))
+        })
+        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
+
+    let overlays = serde_json::json!({
+        "signatureAxes": array_field_with_limit(packet, "signatureAxes", Some(OVERLAY_LIMIT)),
+        "obstructionCircuits": array_field_with_limit(packet, "obstructionCircuits", Some(OVERLAY_LIMIT)),
+        "coverageGaps": json_field(summary, "coverageGapSummary"),
+        "dominantFindings": json_field(summary, "dominantFindings"),
+        "actionQueue": json_field(summary, "actionQueue")
+    });
+    let report_pane = serde_json::json!({
+        "overview": {
+            "mapId": &archmap.map_id,
+            "architectureId": &archmap.architecture_id,
+            "analysisId": json_field(packet, "analysisId"),
+            "summaryVerdict": json_field(summary, "verdict"),
+            "validation": json_field(summary, "validation"),
+            "measurementStatusSummary": json_field(summary, "measurementStatusSummary")
+        },
+        "topFindings": json_field(summary, "dominantFindings"),
+        "actionQueue": json_field(summary, "actionQueue"),
+        "coverageAndBoundaries": {
+            "coverageGaps": json_field(summary, "coverageGapSummary"),
+            "measurementBasis": json_field(summary, "measurementBasis"),
+            "metadata": json_field(summary, "metadata")
+        },
+        "artifacts": {
+            "summary": "archsig-analysis-summary.json",
+            "manifest": "archsig-run-manifest.json",
+            "rawArtifacts": "see archsig-run-manifest.json rawArtifactRetention"
+        }
+    });
+
+    Ok(serde_json::json!({
+        "schemaVersion": "archsig-atom-viewer-data-v0",
+        "dataKind": "bounded-atom-viewer-projection",
+        "sourceArtifactRefs": {
+            "archmap": archmap_path.display().to_string(),
+            "lawPolicy": law_policy_path.display().to_string(),
+            "summary": "archsig-analysis-summary.json",
+            "manifest": "archsig-run-manifest.json"
+        },
+        "layoutSettings": {
+            "layoutKind": "aat-bounded-force-3d",
+            "nodeLimit": ATOM_NODE_LIMIT,
+            "moleculeGroupLimit": MOLECULE_GROUP_LIMIT,
+            "overlayLimit": OVERLAY_LIMIT,
+            "distanceBoundary": "3D distance is a visual projection, not an AAT theorem metric"
+        },
+        "atomNodes": atom_nodes,
+        "moleculeGroups": molecule_groups,
+        "lawAxisOverlays": overlays["signatureAxes"],
+        "analysisOverlays": overlays,
+        "reportPane": report_pane,
+        "omittedDetailCounts": {
+            "atomNodes": archmap.atom_observations.len().saturating_sub(ATOM_NODE_LIMIT),
+            "moleculeGroups": archmap.molecule_observations.len().saturating_sub(MOLECULE_GROUP_LIMIT),
+            "rawPacketDetail": "raw packet is not embedded in viewer data"
+        },
+        "truncationPolicy": {
+            "atomNodes": format!("first {ATOM_NODE_LIMIT} ArchMap atom observations"),
+            "moleculeGroups": format!("first {MOLECULE_GROUP_LIMIT} ArchMap molecule observations"),
+            "overlays": format!("first {OVERLAY_LIMIT} items per selected overlay family"),
+            "futureWork": "Issue #1638 owns priority selection, aggregation, and focus filters"
+        },
+        "nonConclusions": [
+            "viewer data is a bounded visual projection, not a replacement for the analysis packet",
+            "3D layout distance is not a theorem metric, semantic equivalence, or causal relation",
+            "raw packet detail is intentionally omitted unless analyze is rerun with --emit-raw-artifacts"
+        ]
+    }))
+}
+
+fn source_ref_samples<T: serde::Serialize>(
+    refs: &[T],
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    Ok(serde_json::Value::Array(
+        refs.iter()
+            .take(3)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?,
+    ))
 }
 
 fn default_detail_index_path(packet_path: &Path) -> PathBuf {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -800,6 +800,7 @@ fn cli_accepts_analysis_command_aliases() {
             .expect("profile path is utf-8"),
         "--out-dir",
         workflow_dir.to_str().expect("workflow dir is utf-8"),
+        "--emit-raw-artifacts",
     ]);
     assert!(workflow_dir.join("archsig-analysis-packet.json").is_file());
 
@@ -816,6 +817,7 @@ fn cli_accepts_analysis_command_aliases() {
             .expect("profile path is utf-8"),
         "--out-dir",
         llm_native_dir.to_str().expect("workflow dir is utf-8"),
+        "--emit-raw-artifacts",
     ]);
     assert!(
         llm_native_dir
@@ -867,15 +869,25 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
     let expected = [
         "archmap-validation.json",
         "law-policy-validation.json",
-        "archsig-analysis-packet.json",
-        "archsig-analysis-detail-index.json",
         "archsig-analysis-validation.json",
-        "llm-interpretation-packet.json",
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
     ];
     for file in expected {
         assert!(
             out_dir.join(file).is_file(),
             "analyze workflow must write {file}"
+        );
+    }
+    for omitted_file in [
+        "archsig-analysis-packet.json",
+        "archsig-analysis-detail-index.json",
+        "llm-interpretation-packet.json",
+    ] {
+        assert!(
+            !out_dir.join(omitted_file).exists(),
+            "analyze workflow must omit raw artifact {omitted_file} by default"
         );
     }
     for removed_file in [
@@ -902,6 +914,90 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         law_policy_validation["schemaVersion"],
         "law-policy-validation-report-v0"
     );
+    let analysis_validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
+    assert_eq!(
+        analysis_validation["summary"]["result"].as_str(),
+        Some("pass")
+    );
+    let analysis_summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    assert_eq!(
+        analysis_summary["packet"]["schemaVersion"].as_str(),
+        Some("archsig-analysis-packet-v0")
+    );
+    assert_eq!(
+        analysis_summary["validation"]["analysis"]["result"].as_str(),
+        Some("pass")
+    );
+    let viewer_data = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    assert_eq!(
+        viewer_data["schemaVersion"].as_str(),
+        Some("archsig-atom-viewer-data-v0")
+    );
+    assert!(
+        viewer_data["atomNodes"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "viewer data must project ArchMap atom observations"
+    );
+    assert_eq!(
+        viewer_data["reportPane"]["overview"]["summaryVerdict"]["readingMode"].as_str(),
+        Some("measurementOverSuppliedArchMapAndLawPolicy")
+    );
+    assert_eq!(
+        viewer_data["omittedDetailCounts"]["rawPacketDetail"].as_str(),
+        Some("raw packet is not embedded in viewer data")
+    );
+    let run_manifest = read_json(&out_dir.join("archsig-run-manifest.json"));
+    assert_eq!(
+        run_manifest["schemaVersion"].as_str(),
+        Some("archsig-run-manifest-v0")
+    );
+    assert_eq!(
+        run_manifest["rawArtifactRetention"].as_str(),
+        Some("omitted")
+    );
+    assert!(
+        run_manifest["omittedArtifacts"]
+            .as_array()
+            .expect("omitted artifacts are array")
+            .iter()
+            .any(|artifact| artifact == "archsig-analysis-packet.json"),
+        "manifest must record omitted raw analysis packet"
+    );
+    assert!(
+        analysis_validation.get("packet").is_none(),
+        "analysis validation must not embed the full analysis packet"
+    );
+}
+
+#[test]
+fn cli_analyze_emit_raw_artifacts_writes_field_sig_handoff_packet() {
+    let out_dir = temp_dir("analyze-workflow-raw-artifacts");
+    let root = fixture_root();
+    let archmap = root.join("archmap.json");
+    let law_policy = root.join("law_policy.json");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap.to_str().expect("archmap path is utf-8"),
+        "--law-policy",
+        law_policy.to_str().expect("law policy path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("output directory path is utf-8"),
+        "--emit-raw-artifacts",
+    ]);
+
+    for file in [
+        "archsig-analysis-packet.json",
+        "archsig-analysis-detail-index.json",
+        "llm-interpretation-packet.json",
+    ] {
+        assert!(
+            out_dir.join(file).is_file(),
+            "--emit-raw-artifacts must write {file}"
+        );
+    }
     let analysis_packet = read_json(&out_dir.join("archsig-analysis-packet.json"));
     assert_eq!(
         analysis_packet["schemaVersion"],
@@ -935,10 +1031,6 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
     );
     assert_north_star_packet_surfaces(&analysis_packet);
     let analysis_validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
-    assert_eq!(
-        analysis_validation["summary"]["result"].as_str(),
-        Some("pass")
-    );
     assert_eq!(analysis_validation["summary"]["aatConceptSurfaceCount"], 12);
     assert_eq!(
         analysis_validation["summary"]["designPrincipleReadingCount"],
@@ -960,6 +1052,8 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         analysis_validation.get("packet").is_none(),
         "analysis validation must not embed the full analysis packet"
     );
+    let run_manifest = read_json(&out_dir.join("archsig-run-manifest.json"));
+    assert_eq!(run_manifest["rawArtifactRetention"].as_str(), Some("full"));
 }
 
 #[test]
@@ -983,9 +1077,19 @@ fn cli_analyze_reports_failed_validation_checks_to_stderr() {
         !output.status.success(),
         "invalid analyze input must return a validation failure"
     );
+    for file in [
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
+    ] {
+        assert!(
+            out_dir.join(file).is_file(),
+            "analyze should still write {file} before returning validation failure"
+        );
+    }
     assert!(
-        out_dir.join("archsig-analysis-packet.json").is_file(),
-        "analyze should still write inspection artifacts before returning validation failure"
+        !out_dir.join("archsig-analysis-packet.json").exists(),
+        "analyze should still omit raw packet by default on validation failure"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -1666,6 +1770,7 @@ fn complete_archmap_acceptance_fixture_runs_full_measurement_without_private_nam
             .expect("law policy path is utf-8"),
         "--out-dir",
         out_dir.to_str().expect("output directory path is utf-8"),
+        "--emit-raw-artifacts",
     ]);
 
     for (file, label) in [


### PR DESCRIPTION
## 概要

Closes #1634

`archsig analyze` の通常出力を summary / Atom Viewer data / run manifest / validation reports に変更し、容量の大きい raw artifacts は `--emit-raw-artifacts` 指定時だけ保存する契約に更新しました。

主な変更:

- 通常 `analyze` で `archsig-analysis-summary.json`, `archsig-atom-viewer-data.json`, `archsig-run-manifest.json`, validation reports を保存
- 通常 `analyze` では `archsig-analysis-packet.json`, `archsig-analysis-detail-index.json`, `llm-interpretation-packet.json` を保存しない
- `--emit-raw-artifacts` で FieldSig handoff / deep evidence lookup 用の既存 raw artifacts を保存
- validation failure 時も可能な範囲で summary / viewer data / manifest を出力
- CLI tests と README / command docs を新しい output contract に同期
- ArchSig analyze / FieldSig handoff e2e CI を、通常出力確認と raw opt-in handoff 確認に分割

Atom Viewer data は Issue #1634 の範囲として bounded projection の最小契約を置いています。詳細な schema / 3D layout / 大規模 repo 向け projection policy は後続 Issue #1639 / #1638 の担当です。

## 証明した定理

- なし

Lean status: tooling implementation. Lean theorem の追加は対象外。

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

追加で実施:

- [x] `.github/workflows/lean.yml` の ArchSig analyze / FieldSig handoff e2e 相当 block を local 実行

未実施:

- `lake build`: Lean 変更なし
- `cargo test --manifest-path tools/fieldsig/Cargo.toml`: FieldSig 実装変更なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
