### PR TITLE
ArchSig run manifest と Atom Viewer data schema を追加する

### DIFF
--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -5,9 +5,10 @@ ArchSig owns the LLM Atom ArchMap analysis surface:
 ```text
 archmap-observation-map-v0
   + law-policy-v0
-  -> archsig-analysis-packet-v0
-  -> LLM / human review packet
-  -> FieldSig handoff
+  -> archsig-analysis-summary.json
+  -> archsig-atom-viewer-data-v0
+  -> archsig-run-manifest-v0
+  -> optional archsig-analysis-packet-v0 for FieldSig handoff
 ```
 
 Git history is the archive for pre-Atom scan, projection, report, and PR-review
@@ -40,9 +41,12 @@ fragments.
 | ArchMap validation report | `archmap-validation-report-v0` | Checks schema support, identity, references, provenance, source refs, observation / concern guardrails, projection separation, gap boundaries, and formal-promotion non-conclusions. |
 | LawPolicy | `law-policy-v0` | Selected LawUniverse / witness-rule / molecule-pattern / obstruction-definition / signature-axis policy for one review context. |
 | LawPolicy validation report | `law-policy-validation-report-v0` | Checks LawPolicy identity, uniqueness, cross references, witness / obstruction guardrails, coverage requirements, exactness assumptions, and non-conclusions. |
-| ArchSig analysis packet | `archsig-analysis-packet-v0` | Current ArchSig source-of-truth output. It records molecule readings, law-relative obstruction circuits, signature axes, flatness reading, repair candidates, coverage gaps, child-level `missingEvidence` / `excludedReadings`, evidence boundaries, LLM interpretation notes, and non-conclusions. |
-| ArchSig analysis validation report | `archsig-analysis-validation-report-v0` | Checks the analysis packet boundary without proving lawfulness, source completeness, flatness, or repair safety. |
-| LLM interpretation packet | `archsig-analysis-packet-v0` | A second serialization of the same structured packet for LLM reading. |
+| ArchSig analysis summary | `archsig-analysis-summary.json` | LLM-readable compact reading surface emitted by default from `analyze`. It summarizes verdict, validation, measurement status, findings, action queue, coverage, measurement basis, and artifact metadata without reprinting raw packet detail. |
+| ArchSig Atom Viewer data | `archsig-atom-viewer-data-v0` | Bounded browser projection emitted by default from `analyze`. It records source refs, layout settings, atom nodes, molecule groups, overlays, report pane sections, omitted counts, truncation policy, and non-conclusions. It is not a raw packet copy. |
+| ArchSig run manifest | `archsig-run-manifest-v0` | Run navigation artifact emitted by default from `analyze`. It records command name, input paths, output mode, generated / omitted artifacts, validation report paths, optional raw artifact paths, and validation result summary. |
+| ArchSig analysis packet | `archsig-analysis-packet-v0` | Raw evidence artifact emitted only when raw artifact retention is requested. It records molecule readings, law-relative obstruction circuits, signature axes, flatness reading, repair candidates, coverage gaps, child-level `missingEvidence` / `excludedReadings`, evidence boundaries, LLM interpretation notes, and non-conclusions. |
+| ArchSig analysis validation report | `archsig-analysis-packet-validation-report-v0` | Checks the analysis packet boundary without proving lawfulness, source completeness, flatness, or repair safety. |
+| LLM interpretation packet | `archsig-analysis-packet-v0` | Optional raw artifact: a second serialization of the packet's structured LLM interpretation surface. |
 
 ## Removed Surfaces
 
@@ -57,7 +61,9 @@ FieldSig consumes the serialized `archsig-analysis-packet-v0` through
 `fieldsig archsig-analysis-sft-input`. FieldSig projects obstruction circuits,
 signature axes, repair candidates, and coverage gaps into
 `operation-support-estimate-v0` as bounded refs and unknown remainder. Raw
-ArchMap observation files are not the current FieldSig handoff.
+ArchMap observation files are not the current FieldSig handoff. When `analyze`
+runs in the default summary / viewer / manifest mode, rerun it with explicit raw
+artifact retention before invoking FieldSig handoff.
 
 ArchSig does not own SFT forecast, IntentMap, workflow evidence, operational
 feedback, dynamics, governance, or calibration.

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -14,10 +14,17 @@ pub(crate) use schema::*;
 pub use schema::{
     ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION,
     ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
-    ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION, ArchMapDocumentV0,
-    ArchMapSourceInventoryV0, ArchMapValidationReportV0, ArchSigAnalysisPacketV0,
-    ArchSigAnalysisPacketValidationReportV0, LAW_POLICY_SCHEMA_VERSION,
-    LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, LawPolicyDocumentV0, LawPolicyValidationReportV0,
-    SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaVersionCatalogV0,
+    ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
+    ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION, ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION,
+    ArchMapDocumentV0, ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapValidationReportV0,
+    ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationReportV0,
+    ArchSigArtifactValidationResultV0, ArchSigAtomViewerAtomNodeV0, ArchSigAtomViewerDataV0,
+    ArchSigAtomViewerLayoutSettingsV0, ArchSigAtomViewerMoleculeGroupV0,
+    ArchSigAtomViewerOmittedDetailCountsV0, ArchSigAtomViewerSourceArtifactRefsV0,
+    ArchSigAtomViewerTruncationPolicyV0, ArchSigAtomViewerVisualV0,
+    ArchSigRunManifestRawArtifactPathsV0, ArchSigRunManifestV0,
+    ArchSigRunManifestValidationReportPathsV0, ArchSigRunManifestValidationResultSummaryV0,
+    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, LawPolicyDocumentV0,
+    LawPolicyValidationReportV0, SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaVersionCatalogV0,
 };
 pub use schema_catalog::static_schema_version_catalog;

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -8,8 +8,15 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use archsig::{
-    ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ArchMapDocumentV0, ArchMapSourceInventoryInput,
+    ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION,
+    ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION, ArchMapDocumentV0, ArchMapSourceInventoryInput,
     ArchMapSourceInventoryV0, ArchMapValidationReportV0, ArchSigAnalysisPacketValidationReportV0,
+    ArchSigArtifactValidationResultV0, ArchSigAtomViewerAtomNodeV0, ArchSigAtomViewerDataV0,
+    ArchSigAtomViewerLayoutSettingsV0, ArchSigAtomViewerMoleculeGroupV0,
+    ArchSigAtomViewerOmittedDetailCountsV0, ArchSigAtomViewerSourceArtifactRefsV0,
+    ArchSigAtomViewerTruncationPolicyV0, ArchSigAtomViewerVisualV0,
+    ArchSigRunManifestRawArtifactPathsV0, ArchSigRunManifestV0,
+    ArchSigRunManifestValidationReportPathsV0, ArchSigRunManifestValidationResultSummaryV0,
     LawPolicyDocumentV0, LawPolicyValidationReportV0, SchemaVersionCatalogV0,
     build_archsig_analysis_packet, static_law_policy, static_schema_version_catalog,
     validate_archmap_report, validate_archsig_analysis_packet_report, validate_law_policy_report,
@@ -552,7 +559,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 &analysis_summary,
                 &archmap,
                 &law_policy,
-            )?;
+            );
             write_json(Some(atom_viewer_data_path.clone()), &atom_viewer_data)?;
 
             let analysis_detail_index_path = out_dir.join("archsig-analysis-detail-index.json");
@@ -660,7 +667,7 @@ fn build_analyze_run_manifest(
     archmap_validation: &ArchMapValidationReportV0,
     law_policy_validation: &LawPolicyValidationReportV0,
     analysis_validation: &ArchSigAnalysisPacketValidationReportV0,
-) -> serde_json::Value {
+) -> ArchSigRunManifestV0 {
     let mut generated_artifacts = vec![
         "archmap-validation.json",
         "law-policy-validation.json",
@@ -684,58 +691,57 @@ fn build_analyze_run_manifest(
         ]);
     }
 
-    serde_json::json!({
-        "schemaVersion": "archsig-run-manifest-v0",
-        "commandName": "analyze",
-        "archmapInputPath": archmap.display().to_string(),
-        "lawPolicyInputPath": law_policy.display().to_string(),
-        "outputMode": if emit_raw_artifacts {
+    ArchSigRunManifestV0 {
+        schema_version: ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION.to_string(),
+        command_name: "analyze".to_string(),
+        archmap_input_path: archmap.display().to_string(),
+        law_policy_input_path: law_policy.display().to_string(),
+        output_mode: if emit_raw_artifacts {
             "summary-viewer-manifest-with-raw-artifacts"
         } else {
             "summary-viewer-manifest"
+        }
+        .to_string(),
+        raw_artifact_retention: if emit_raw_artifacts { "full" } else { "omitted" }.to_string(),
+        generated_artifacts: generated_artifacts.into_iter().map(str::to_string).collect(),
+        omitted_artifacts: omitted_artifacts.into_iter().map(str::to_string).collect(),
+        summary_path: "archsig-analysis-summary.json".to_string(),
+        atom_viewer_data_path: "archsig-atom-viewer-data.json".to_string(),
+        validation_reports: ArchSigRunManifestValidationReportPathsV0 {
+            archmap: "archmap-validation.json".to_string(),
+            law_policy: "law-policy-validation.json".to_string(),
+            analysis: "archsig-analysis-validation.json".to_string(),
         },
-        "rawArtifactRetention": if emit_raw_artifacts { "full" } else { "omitted" },
-        "generatedArtifacts": generated_artifacts,
-        "omittedArtifacts": omitted_artifacts,
-        "summaryPath": "archsig-analysis-summary.json",
-        "atomViewerDataPath": "archsig-atom-viewer-data.json",
-        "validationReports": {
-            "archmap": "archmap-validation.json",
-            "lawPolicy": "law-policy-validation.json",
-            "analysis": "archsig-analysis-validation.json"
-        },
-        "rawArtifactPaths": if emit_raw_artifacts {
-            serde_json::json!({
-                "analysisPacket": "archsig-analysis-packet.json",
-                "analysisDetailIndex": "archsig-analysis-detail-index.json",
-                "llmInterpretationPacket": "llm-interpretation-packet.json"
-            })
-        } else {
-            serde_json::Value::Null
-        },
-        "validationResultSummary": {
-            "archmap": {
-                "result": &archmap_validation.summary.result,
-                "failedCheckCount": archmap_validation.summary.failed_check_count,
-                "warningCheckCount": archmap_validation.summary.warning_check_count
+        raw_artifact_paths: emit_raw_artifacts.then(|| ArchSigRunManifestRawArtifactPathsV0 {
+            analysis_packet: "archsig-analysis-packet.json".to_string(),
+            analysis_detail_index: "archsig-analysis-detail-index.json".to_string(),
+            llm_interpretation_packet: "llm-interpretation-packet.json".to_string(),
+        }),
+        validation_result_summary: ArchSigRunManifestValidationResultSummaryV0 {
+            archmap: ArchSigArtifactValidationResultV0 {
+                result: archmap_validation.summary.result.clone(),
+                failed_check_count: archmap_validation.summary.failed_check_count,
+                warning_check_count: archmap_validation.summary.warning_check_count,
             },
-            "lawPolicy": {
-                "result": &law_policy_validation.summary.result,
-                "failedCheckCount": law_policy_validation.summary.failed_check_count,
-                "warningCheckCount": law_policy_validation.summary.warning_check_count
+            law_policy: ArchSigArtifactValidationResultV0 {
+                result: law_policy_validation.summary.result.clone(),
+                failed_check_count: law_policy_validation.summary.failed_check_count,
+                warning_check_count: law_policy_validation.summary.warning_check_count,
             },
-            "analysis": {
-                "result": &analysis_validation.summary.result,
-                "failedCheckCount": analysis_validation.summary.failed_check_count,
-                "warningCheckCount": analysis_validation.summary.warning_check_count
-            }
+            analysis: ArchSigArtifactValidationResultV0 {
+                result: analysis_validation.summary.result.clone(),
+                failed_check_count: analysis_validation.summary.failed_check_count,
+                warning_check_count: analysis_validation.summary.warning_check_count,
+            },
         },
-        "nonConclusions": [
-            "run manifest records generated and omitted artifacts for this ArchSig analyze run",
-            "omitted raw artifacts can be regenerated by rerunning analyze with --emit-raw-artifacts",
-            "manifest paths are artifact navigation aids, not source completeness proof"
-        ]
-    })
+        non_conclusions: vec![
+            "run manifest records generated and omitted artifacts for this ArchSig analyze run"
+                .to_string(),
+            "omitted raw artifacts can be regenerated by rerunning analyze with --emit-raw-artifacts"
+                .to_string(),
+            "manifest paths are artifact navigation aids, not source completeness proof".to_string(),
+        ],
+    }
 }
 
 fn build_atom_viewer_data(
@@ -744,7 +750,7 @@ fn build_atom_viewer_data(
     summary: &serde_json::Value,
     archmap_path: &Path,
     law_policy_path: &Path,
-) -> Result<serde_json::Value, Box<dyn Error>> {
+) -> ArchSigAtomViewerDataV0 {
     const ATOM_NODE_LIMIT: usize = 250;
     const MOLECULE_GROUP_LIMIT: usize = 120;
     const OVERLAY_LIMIT: usize = 80;
@@ -753,45 +759,44 @@ fn build_atom_viewer_data(
         .atom_observations
         .iter()
         .take(ATOM_NODE_LIMIT)
-        .map(|atom| {
-            Ok(serde_json::json!({
-                "nodeId": &atom.atom_observation_id,
-                "atomFamily": &atom.atom_family,
-                "subjectRef": &atom.subject_ref,
-                "predicate": &atom.predicate,
-                "observationStatus": &atom.observation_status,
-                "confidence": &atom.confidence,
-                "objectRefCount": atom.object_refs.len(),
-                "sourceRefSamples": source_ref_samples(&atom.source_refs)?,
-                "projectionRefs": &atom.projection_refs,
-                "visual": {
-                    "kind": "atom",
-                    "colorBy": "observationStatus",
-                    "sizeBy": "sourceRefCount"
-                }
-            }))
+        .map(|atom| ArchSigAtomViewerAtomNodeV0 {
+            node_id: atom.atom_observation_id.clone(),
+            atom_family: atom.atom_family.clone(),
+            subject_ref: atom.subject_ref.clone(),
+            predicate: atom.predicate.clone(),
+            observation_status: atom.observation_status.clone(),
+            confidence: atom.confidence.clone(),
+            object_ref_count: atom.object_refs.len(),
+            source_ref_samples: source_ref_samples(&atom.source_refs),
+            projection_refs: atom.projection_refs.clone(),
+            visual: ArchSigAtomViewerVisualV0 {
+                kind: "atom".to_string(),
+                color_by: Some("observationStatus".to_string()),
+                size_by: Some("sourceRefCount".to_string()),
+                hull_by: None,
+            },
         })
-        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
+        .collect::<Vec<_>>();
     let molecule_groups = archmap
         .molecule_observations
         .iter()
         .take(MOLECULE_GROUP_LIMIT)
-        .map(|molecule| {
-            Ok(serde_json::json!({
-                "groupId": &molecule.molecule_observation_id,
-                "moleculeFamily": &molecule.molecule_family,
-                "roleName": &molecule.role_name,
-                "atomObservationRefs": &molecule.atom_observation_refs,
-                "observationStatus": &molecule.observation_status,
-                "confidence": &molecule.confidence,
-                "sourceRefSamples": source_ref_samples(&molecule.source_refs)?,
-                "visual": {
-                    "kind": "moleculeGroup",
-                    "hullBy": "atomObservationRefs"
-                }
-            }))
+        .map(|molecule| ArchSigAtomViewerMoleculeGroupV0 {
+            group_id: molecule.molecule_observation_id.clone(),
+            molecule_family: molecule.molecule_family.clone(),
+            role_name: molecule.role_name.clone(),
+            atom_observation_refs: molecule.atom_observation_refs.clone(),
+            observation_status: molecule.observation_status.clone(),
+            confidence: molecule.confidence.clone(),
+            source_ref_samples: source_ref_samples(&molecule.source_refs),
+            visual: ArchSigAtomViewerVisualV0 {
+                kind: "moleculeGroup".to_string(),
+                color_by: None,
+                size_by: None,
+                hull_by: Some("atomObservationRefs".to_string()),
+            },
         })
-        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
+        .collect::<Vec<_>>();
 
     let overlays = serde_json::json!({
         "signatureAxes": array_field_with_limit(packet, "signatureAxes", Some(OVERLAY_LIMIT)),
@@ -823,55 +828,56 @@ fn build_atom_viewer_data(
         }
     });
 
-    Ok(serde_json::json!({
-        "schemaVersion": "archsig-atom-viewer-data-v0",
-        "dataKind": "bounded-atom-viewer-projection",
-        "sourceArtifactRefs": {
-            "archmap": archmap_path.display().to_string(),
-            "lawPolicy": law_policy_path.display().to_string(),
-            "summary": "archsig-analysis-summary.json",
-            "manifest": "archsig-run-manifest.json"
+    ArchSigAtomViewerDataV0 {
+        schema_version: ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION.to_string(),
+        data_kind: "bounded-atom-viewer-projection".to_string(),
+        source_artifact_refs: ArchSigAtomViewerSourceArtifactRefsV0 {
+            archmap: archmap_path.display().to_string(),
+            law_policy: law_policy_path.display().to_string(),
+            summary: "archsig-analysis-summary.json".to_string(),
+            manifest: "archsig-run-manifest.json".to_string(),
         },
-        "layoutSettings": {
-            "layoutKind": "aat-bounded-force-3d",
-            "nodeLimit": ATOM_NODE_LIMIT,
-            "moleculeGroupLimit": MOLECULE_GROUP_LIMIT,
-            "overlayLimit": OVERLAY_LIMIT,
-            "distanceBoundary": "3D distance is a visual projection, not an AAT theorem metric"
+        layout_settings: ArchSigAtomViewerLayoutSettingsV0 {
+            layout_kind: "aat-bounded-force-3d".to_string(),
+            node_limit: ATOM_NODE_LIMIT,
+            molecule_group_limit: MOLECULE_GROUP_LIMIT,
+            overlay_limit: OVERLAY_LIMIT,
+            distance_boundary:
+                "3D distance is a visual projection, not an AAT theorem metric".to_string(),
         },
-        "atomNodes": atom_nodes,
-        "moleculeGroups": molecule_groups,
-        "lawAxisOverlays": overlays["signatureAxes"],
-        "analysisOverlays": overlays,
-        "reportPane": report_pane,
-        "omittedDetailCounts": {
-            "atomNodes": archmap.atom_observations.len().saturating_sub(ATOM_NODE_LIMIT),
-            "moleculeGroups": archmap.molecule_observations.len().saturating_sub(MOLECULE_GROUP_LIMIT),
-            "rawPacketDetail": "raw packet is not embedded in viewer data"
+        atom_nodes,
+        molecule_groups,
+        law_axis_overlays: overlays["signatureAxes"].clone(),
+        analysis_overlays: overlays,
+        report_pane,
+        omitted_detail_counts: ArchSigAtomViewerOmittedDetailCountsV0 {
+            atom_nodes: archmap.atom_observations.len().saturating_sub(ATOM_NODE_LIMIT),
+            molecule_groups: archmap
+                .molecule_observations
+                .len()
+                .saturating_sub(MOLECULE_GROUP_LIMIT),
+            raw_packet_detail: "raw packet is not embedded in viewer data".to_string(),
         },
-        "truncationPolicy": {
-            "atomNodes": format!("first {ATOM_NODE_LIMIT} ArchMap atom observations"),
-            "moleculeGroups": format!("first {MOLECULE_GROUP_LIMIT} ArchMap molecule observations"),
-            "overlays": format!("first {OVERLAY_LIMIT} items per selected overlay family"),
-            "futureWork": "Issue #1638 owns priority selection, aggregation, and focus filters"
+        truncation_policy: ArchSigAtomViewerTruncationPolicyV0 {
+            atom_nodes: format!("first {ATOM_NODE_LIMIT} ArchMap atom observations"),
+            molecule_groups: format!("first {MOLECULE_GROUP_LIMIT} ArchMap molecule observations"),
+            overlays: format!("first {OVERLAY_LIMIT} items per selected overlay family"),
+            future_work: "Issue #1638 owns priority selection, aggregation, and focus filters"
+                .to_string(),
         },
-        "nonConclusions": [
-            "viewer data is a bounded visual projection, not a replacement for the analysis packet",
-            "3D layout distance is not a theorem metric, semantic equivalence, or causal relation",
+        non_conclusions: vec![
+            "viewer data is a bounded visual projection, not a replacement for the analysis packet"
+                .to_string(),
+            "3D layout distance is not a theorem metric, semantic equivalence, or causal relation"
+                .to_string(),
             "raw packet detail is intentionally omitted unless analyze is rerun with --emit-raw-artifacts"
-        ]
-    }))
+                .to_string(),
+        ],
+    }
 }
 
-fn source_ref_samples<T: serde::Serialize>(
-    refs: &[T],
-) -> Result<serde_json::Value, Box<dyn Error>> {
-    Ok(serde_json::Value::Array(
-        refs.iter()
-            .take(3)
-            .map(serde_json::to_value)
-            .collect::<Result<Vec<_>, _>>()?,
-    ))
+fn source_ref_samples(refs: &[archsig::ArchMapSourceRef]) -> Vec<archsig::ArchMapSourceRef> {
+    refs.iter().take(3).cloned().collect()
 }
 
 fn default_detail_index_path(packet_path: &Path) -> PathBuf {

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -8,8 +8,155 @@ pub const LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str = "law-policy-valida
 pub const ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION: &str = "archsig-analysis-packet-v0";
 pub const ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "archsig-analysis-packet-validation-report-v0";
+pub const ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION: &str = "archsig-run-manifest-v0";
+pub const ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION: &str = "archsig-atom-viewer-data-v0";
 pub const SCHEMA_VERSION_CATALOG_SCHEMA_VERSION: &str = "schema-version-catalog-v0";
 pub const SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION: &str = "schema-compatibility-policy-v0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigRunManifestV0 {
+    pub schema_version: String,
+    pub command_name: String,
+    pub archmap_input_path: String,
+    pub law_policy_input_path: String,
+    pub output_mode: String,
+    pub raw_artifact_retention: String,
+    pub generated_artifacts: Vec<String>,
+    pub omitted_artifacts: Vec<String>,
+    pub summary_path: String,
+    pub atom_viewer_data_path: String,
+    pub validation_reports: ArchSigRunManifestValidationReportPathsV0,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_artifact_paths: Option<ArchSigRunManifestRawArtifactPathsV0>,
+    pub validation_result_summary: ArchSigRunManifestValidationResultSummaryV0,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigRunManifestValidationReportPathsV0 {
+    pub archmap: String,
+    pub law_policy: String,
+    pub analysis: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigRunManifestRawArtifactPathsV0 {
+    pub analysis_packet: String,
+    pub analysis_detail_index: String,
+    pub llm_interpretation_packet: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigRunManifestValidationResultSummaryV0 {
+    pub archmap: ArchSigArtifactValidationResultV0,
+    pub law_policy: ArchSigArtifactValidationResultV0,
+    pub analysis: ArchSigArtifactValidationResultV0,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigArtifactValidationResultV0 {
+    pub result: String,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerDataV0 {
+    pub schema_version: String,
+    pub data_kind: String,
+    pub source_artifact_refs: ArchSigAtomViewerSourceArtifactRefsV0,
+    pub layout_settings: ArchSigAtomViewerLayoutSettingsV0,
+    pub atom_nodes: Vec<ArchSigAtomViewerAtomNodeV0>,
+    pub molecule_groups: Vec<ArchSigAtomViewerMoleculeGroupV0>,
+    pub law_axis_overlays: serde_json::Value,
+    pub analysis_overlays: serde_json::Value,
+    pub report_pane: serde_json::Value,
+    pub omitted_detail_counts: ArchSigAtomViewerOmittedDetailCountsV0,
+    pub truncation_policy: ArchSigAtomViewerTruncationPolicyV0,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerSourceArtifactRefsV0 {
+    pub archmap: String,
+    pub law_policy: String,
+    pub summary: String,
+    pub manifest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerLayoutSettingsV0 {
+    pub layout_kind: String,
+    pub node_limit: usize,
+    pub molecule_group_limit: usize,
+    pub overlay_limit: usize,
+    pub distance_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerAtomNodeV0 {
+    pub node_id: String,
+    pub atom_family: String,
+    pub subject_ref: String,
+    pub predicate: String,
+    pub observation_status: String,
+    pub confidence: String,
+    pub object_ref_count: usize,
+    pub source_ref_samples: Vec<ArchMapSourceRef>,
+    pub projection_refs: Vec<String>,
+    pub visual: ArchSigAtomViewerVisualV0,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerMoleculeGroupV0 {
+    pub group_id: String,
+    pub molecule_family: String,
+    pub role_name: String,
+    pub atom_observation_refs: Vec<String>,
+    pub observation_status: String,
+    pub confidence: String,
+    pub source_ref_samples: Vec<ArchMapSourceRef>,
+    pub visual: ArchSigAtomViewerVisualV0,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerVisualV0 {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hull_by: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerOmittedDetailCountsV0 {
+    pub atom_nodes: usize,
+    pub molecule_groups: usize,
+    pub raw_packet_detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigAtomViewerTruncationPolicyV0 {
+    pub atom_nodes: String,
+    pub molecule_groups: String,
+    pub overlays: String,
+    pub future_work: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -1,11 +1,12 @@
 use crate::{
     ARCHMAP_SCHEMA_VERSION, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
-    ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION, LAW_POLICY_SCHEMA_VERSION,
-    LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION,
-    SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaCompatibilityBoundaryV0,
-    SchemaCompatibilityDimensionV0, SchemaCompatibilityPolicyV0, SchemaVersionCatalogEntryV0,
-    SchemaVersionCatalogV0,
+    ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
+    ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION, ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION,
+    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+    SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION, SCHEMA_VERSION_CATALOG_SCHEMA_VERSION,
+    SchemaCompatibilityBoundaryV0, SchemaCompatibilityDimensionV0, SchemaCompatibilityPolicyV0,
+    SchemaVersionCatalogEntryV0, SchemaVersionCatalogV0,
 };
 
 pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
@@ -104,6 +105,39 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 vec![
                     "Validation pass does not imply architecture lawfulness, source completeness, flatness proof, or repair safety.",
                     "Validation report compatibility is not a semantic-preservation theorem.",
+                ],
+            ),
+            artifact(
+                "archsig-run-manifest",
+                "ArchSig analyze run manifest",
+                ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION,
+                "primary",
+                "ArchSig Output / Viewer workflow",
+                vec![
+                    "docs/tool/archsig_output_report_prd.md",
+                    "tools/archsig/docs/commands.md",
+                ],
+                "Run manifest records the analyze command name, input artifact paths, output mode, generated and omitted artifact lists, validation report paths, optional raw artifact paths, and validation result summary for one ArchSig analyze run.",
+                vec![
+                    "Run manifest is artifact navigation metadata, not source completeness proof, architecture lawfulness, or Lean theorem discharge.",
+                    "Generated and omitted artifact lists describe this run only; omitted raw artifacts can be regenerated with explicit raw retention.",
+                ],
+            ),
+            artifact(
+                "archsig-atom-viewer-data",
+                "ArchSig Atom Viewer bounded projection data",
+                ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION,
+                "primary",
+                "ArchSig Output / Viewer workflow",
+                vec![
+                    "docs/tool/archsig_output_report_prd.md",
+                    "tools/archsig/docs/commands.md",
+                ],
+                "Atom Viewer data records source artifact refs, bounded layout settings, atom nodes, molecule groups, selected law-axis overlays, analysis overlays, report pane sections, omitted detail counts, truncation policy, and non-conclusions for browser visualization without embedding the raw analysis packet.",
+                vec![
+                    "Viewer data is a bounded visual projection, not a replacement for archsig-analysis-packet-v0 evidence lookup.",
+                    "3D layout distance is not an AAT theorem metric, semantic equivalence, or causal relation.",
+                    "Viewer data must not treat raw packet detail as browser input.",
                 ],
             ),
         ],
@@ -222,6 +256,8 @@ mod tests {
                 "law-policy-validation-report",
                 "archsig-analysis-packet",
                 "archsig-analysis-packet-validation-report",
+                "archsig-run-manifest",
+                "archsig-atom-viewer-data",
             ])
         );
         for legacy in [

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -940,6 +940,30 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         "viewer data must project ArchMap atom observations"
     );
     assert_eq!(
+        viewer_data["sourceArtifactRefs"]["archmap"].as_str(),
+        archmap.to_str()
+    );
+    assert_eq!(
+        viewer_data["sourceArtifactRefs"]["lawPolicy"].as_str(),
+        law_policy.to_str()
+    );
+    assert_eq!(
+        viewer_data["layoutSettings"]["nodeLimit"].as_u64(),
+        Some(250)
+    );
+    assert!(
+        viewer_data["moleculeGroups"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "viewer data must project ArchMap molecule groups"
+    );
+    assert!(
+        viewer_data["analysisOverlays"]["signatureAxes"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "viewer data must carry selected analysis overlays"
+    );
+    assert_eq!(
         viewer_data["reportPane"]["overview"]["summaryVerdict"]["readingMode"].as_str(),
         Some("measurementOverSuppliedArchMapAndLawPolicy")
     );
@@ -956,6 +980,16 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         run_manifest["rawArtifactRetention"].as_str(),
         Some("omitted")
     );
+    assert_eq!(run_manifest["commandName"].as_str(), Some("analyze"));
+    assert_eq!(run_manifest["archmapInputPath"].as_str(), archmap.to_str());
+    assert_eq!(
+        run_manifest["lawPolicyInputPath"].as_str(),
+        law_policy.to_str()
+    );
+    assert_eq!(
+        run_manifest["validationResultSummary"]["analysis"]["result"].as_str(),
+        Some("pass")
+    );
     assert!(
         run_manifest["omittedArtifacts"]
             .as_array()
@@ -964,6 +998,34 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
             .any(|artifact| artifact == "archsig-analysis-packet.json"),
         "manifest must record omitted raw analysis packet"
     );
+    assert!(
+        run_manifest.get("rawArtifactPaths").is_none(),
+        "manifest must not advertise raw artifact paths when raw retention is omitted"
+    );
+    assert!(
+        viewer_data.get("schemaVersion").is_some()
+            && viewer_data.get("sourceArtifactRefs").is_some()
+            && viewer_data.get("layoutSettings").is_some()
+            && viewer_data.get("atomNodes").is_some()
+            && viewer_data.get("moleculeGroups").is_some()
+            && viewer_data.get("analysisOverlays").is_some()
+            && viewer_data.get("reportPane").is_some()
+            && viewer_data.get("omittedDetailCounts").is_some(),
+        "viewer data shape must contain the schema sections owned by archsig-atom-viewer-data-v0"
+    );
+    for raw_packet_field in [
+        "aatConcepts",
+        "architectureState",
+        "moleculeReadings",
+        "obstructionCircuits",
+        "signatureAxes",
+        "llmInterpretationPacket",
+    ] {
+        assert!(
+            viewer_data.get(raw_packet_field).is_none(),
+            "viewer data must not copy raw packet field {raw_packet_field}"
+        );
+    }
     assert!(
         analysis_validation.get("packet").is_none(),
         "analysis validation must not embed the full analysis packet"
@@ -1054,6 +1116,10 @@ fn cli_analyze_emit_raw_artifacts_writes_field_sig_handoff_packet() {
     );
     let run_manifest = read_json(&out_dir.join("archsig-run-manifest.json"));
     assert_eq!(run_manifest["rawArtifactRetention"].as_str(), Some("full"));
+    assert_eq!(
+        run_manifest["rawArtifactPaths"]["analysisPacket"].as_str(),
+        Some("archsig-analysis-packet.json")
+    );
 }
 
 #[test]
@@ -2273,6 +2339,8 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
             "law-policy-validation-report",
             "archsig-analysis-packet",
             "archsig-analysis-packet-validation-report",
+            "archsig-run-manifest",
+            "archsig-atom-viewer-data",
         ]
     );
     for entry in artifacts {

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -172,6 +172,63 @@
           "Validation report compatibility is not a semantic-preservation theorem."
         ]
       }
+    },
+    {
+      "artifactId": "archsig-run-manifest",
+      "artifactName": "ArchSig analyze run manifest",
+      "schemaVersionName": "archsig-run-manifest-v0",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchSig Output / Viewer workflow",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archsig_output_report_prd.md",
+        "tools/archsig/docs/commands.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Run manifest records the analyze command name, input artifact paths, output mode, generated and omitted artifact lists, validation report paths, optional raw artifact paths, and validation result summary for one ArchSig analyze run.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "Run manifest is artifact navigation metadata, not source completeness proof, architecture lawfulness, or Lean theorem discharge.",
+          "Generated and omitted artifact lists describe this run only; omitted raw artifacts can be regenerated with explicit raw retention."
+        ]
+      }
+    },
+    {
+      "artifactId": "archsig-atom-viewer-data",
+      "artifactName": "ArchSig Atom Viewer bounded projection data",
+      "schemaVersionName": "archsig-atom-viewer-data-v0",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchSig Output / Viewer workflow",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archsig_output_report_prd.md",
+        "tools/archsig/docs/commands.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Atom Viewer data records source artifact refs, bounded layout settings, atom nodes, molecule groups, selected law-axis overlays, analysis overlays, report pane sections, omitted detail counts, truncation policy, and non-conclusions for browser visualization without embedding the raw analysis packet.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "Viewer data is a bounded visual projection, not a replacement for archsig-analysis-packet-v0 evidence lookup.",
+          "3D layout distance is not an AAT theorem metric, semantic equivalence, or causal relation.",
+          "Viewer data must not treat raw packet detail as browser input."
+        ]
+      }
     }
   ],
   "compatibilityPolicy": {


### PR DESCRIPTION
## 概要

Closes #1639

`archsig-run-manifest-v0` と `archsig-atom-viewer-data-v0` を型付き artifact として定義し、`analyze` の builder / schema catalog / CLI tests / artifact docs を同期しました。

主な対応:

- `ArchSigRunManifestV0` と下位 schema 型を追加
- `ArchSigAtomViewerDataV0` と source refs / layout settings / nodes / groups / omitted counts / truncation policy の schema 型を追加
- `analyze` の manifest / viewer data builder を `serde_json::Value` 直組みから型付き artifact 生成へ変更
- schema catalog に `archsig-run-manifest` と `archsig-atom-viewer-data` を追加し、canonical fixture を更新
- CLI tests で manifest の command / input paths / generated・omitted artifacts / validation summary と、viewer data の source refs / layout / nodes / groups / overlays / report pane / omitted counts を固定
- viewer data が raw packet の top-level field copy ではないことを test で固定
- artifact boundary docs を summary / viewer data / manifest first の出力契約に同期

計画変更: なし。Three.js viewer UI と大規模 repo 向け top-N policy tuning は Issue 本文の非目標どおり対象外です。

## 証明した定理

- なし

Lean status: tooling schema / definition. Lean theorem の追加は対象外。

## 編集したドキュメント

- `tools/archsig/docs/artifacts-and-boundaries.md`

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

未実施:

- `lake build`: Lean 変更なし
- `cargo test --manifest-path tools/fieldsig/Cargo.toml`: FieldSig 実装変更なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
