### PR TITLE
ArchSig Viewer report pane を同期する

### DIFF
--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -130,7 +130,12 @@ Release archives include `archsig-atom-viewer.html` as a fixed viewer app. Open
 it in a browser and load `archsig-atom-viewer-data.json` with the file picker,
 drag-and-drop, or the same-directory default fetch. The viewer uses CDN Three.js,
 tries the WebGPU renderer first when available, and falls back to WebGL. It
-does not load `archsig-analysis-packet.json`.
+does not load `archsig-analysis-packet.json`. Its lower report pane reads the
+bounded viewer data plus same-directory `archsig-analysis-summary.json` and
+`archsig-run-manifest.json` when present, so the human surface can show verdict,
+top findings, action queue, coverage boundaries, validation status, generated /
+omitted artifacts, and relative raw artifact links without embedding raw packet
+detail.
 
 For large ArchMaps, prefer the optimized binary:
 

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -50,7 +50,11 @@ fragments.
 
 Release archives include a fixed `archsig-atom-viewer.html` at the package root
 and under `viewer/`. The app reads `archsig-atom-viewer-data-v0` projection
-data, not raw packet detail.
+data, not raw packet detail. Its report pane uses the projection data first and
+then same-directory `archsig-analysis-summary.json` / `archsig-run-manifest.json`
+when available to display verdict, findings, action queue, coverage,
+validation failures, generated / omitted artifacts, and relative raw artifact
+links.
 
 ## Removed Surfaces
 

--- a/tools/archsig/docs/commands.md
+++ b/tools/archsig/docs/commands.md
@@ -57,7 +57,11 @@ The release bundle includes a fixed `archsig-atom-viewer.html`. The page loads
 CDN Three.js, tries WebGPU first when the browser exposes it, falls back to
 WebGL, and reads `archsig-atom-viewer-data.json` through a file picker,
 drag-and-drop, or same-directory default fetch. It does not read the raw
-analysis packet.
+analysis packet. Its report pane also reads same-directory
+`archsig-analysis-summary.json` and `archsig-run-manifest.json` when available
+to show the verdict, top findings, action queue, coverage boundaries,
+validation status, generated / omitted artifacts, and relative links to raw
+packet / detail-index files when raw artifacts were emitted.
 
 Raw evidence artifacts are opt-in:
 

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -981,6 +981,21 @@ fn cli_runs_primary_archmap_lawpolicy_archsig_analyze_workflow() {
         viewer_data["reportPane"]["overview"]["summaryVerdict"]["readingMode"].as_str(),
         Some("measurementOverSuppliedArchMapAndLawPolicy")
     );
+    assert!(
+        viewer_data["reportPane"]["topFindings"].is_object()
+            && viewer_data["reportPane"]["actionQueue"].is_array()
+            && viewer_data["reportPane"]["coverageAndBoundaries"].is_object()
+            && viewer_data["reportPane"]["artifacts"].is_object(),
+        "viewer data report pane must carry overview, top findings, action queue, coverage, and artifact sections"
+    );
+    assert_eq!(
+        viewer_data["reportPane"]["artifacts"]["summary"].as_str(),
+        Some("archsig-analysis-summary.json")
+    );
+    assert_eq!(
+        viewer_data["reportPane"]["artifacts"]["manifest"].as_str(),
+        Some("archsig-run-manifest.json")
+    );
     assert_eq!(
         viewer_data["omittedDetailCounts"]["rawPacketDetail"].as_str(),
         Some("raw packet is not embedded in viewer data")
@@ -2508,6 +2523,27 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("./archsig-atom-viewer-data.json"),
         "viewer must support file picker, drag-and-drop, and default viewer data loading"
     );
+    assert!(
+        html.contains("./archsig-analysis-summary.json")
+            && html.contains("./archsig-run-manifest.json")
+            && html.contains("rawArtifactPaths")
+            && html.contains("analysisDetailIndex"),
+        "viewer report pane must integrate summary, manifest, and raw artifact links when present"
+    );
+    for section in [
+        "Overview",
+        "Top Findings",
+        "Action Queue",
+        "Coverage And Boundaries",
+        "Artifacts",
+        "Validation Status",
+        "Omitted Detail",
+    ] {
+        assert!(
+            html.contains(section),
+            "viewer report pane must render {section}"
+        );
+    }
     assert!(
         html.contains("atomEdges")
             && html.contains("moleculeGroups")

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -191,7 +191,7 @@
 
     .metric-row {
       display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(5, minmax(0, 1fr));
       gap: 8px;
       margin-bottom: 16px;
     }
@@ -351,7 +351,12 @@
           <div class="metric"><div class="label">Atoms</div><div id="metric-atoms" class="value">0</div></div>
           <div class="metric"><div class="label">Molecules</div><div id="metric-groups" class="value">0</div></div>
           <div class="metric"><div class="label">Edges</div><div id="metric-edges" class="value">0</div></div>
+          <div class="metric"><div class="label">Verdict</div><div id="metric-verdict" class="value">-</div></div>
           <div class="metric"><div class="label">Validation</div><div id="metric-validation" class="value">-</div></div>
+        </div>
+        <div class="section">
+          <h2>Overview</h2>
+          <div id="overview" class="list"></div>
         </div>
         <div class="section">
           <h2>Top Findings</h2>
@@ -368,6 +373,10 @@
         <div class="section">
           <h2>Artifacts</h2>
           <div id="artifacts" class="list"></div>
+        </div>
+        <div class="section">
+          <h2>Validation Status</h2>
+          <div id="validation-status" class="list"></div>
         </div>
         <div class="section">
           <h2>Omitted Detail</h2>
@@ -471,7 +480,25 @@
       }
     }
 
-    function renderData(data, label = "archsig-atom-viewer-data.json") {
+    async function loadCompanionReports() {
+      const [summary, manifest] = await Promise.all([
+        fetchJsonIfAvailable("./archsig-analysis-summary.json"),
+        fetchJsonIfAvailable("./archsig-run-manifest.json")
+      ]);
+      return { summary, manifest };
+    }
+
+    async function fetchJsonIfAvailable(path) {
+      try {
+        const response = await fetch(path);
+        if (!response.ok) return null;
+        return await response.json();
+      } catch (_error) {
+        return null;
+      }
+    }
+
+    function renderData(data, label = "archsig-atom-viewer-data.json", companions = {}) {
       titleEl.textContent = label;
       clearGroup(atomGroup);
       clearGroup(moleculeGroup);
@@ -536,7 +563,7 @@
       });
 
       updateVisibility();
-      renderReport(data);
+      renderReport(data, companions);
       resize();
       status(`${nodes.length} atoms, ${groups.length} molecules, ${edges.length} edges`);
     }
@@ -594,7 +621,7 @@
       const file = event.target.files?.[0];
       if (!file) return;
       const data = JSON.parse(await file.text());
-      renderData(data, file.name);
+      renderData(data, file.name, await loadCompanionReports());
     });
 
     window.addEventListener("dragover", (event) => {
@@ -608,26 +635,31 @@
       const file = event.dataTransfer?.files?.[0];
       if (!file) return;
       const data = JSON.parse(await file.text());
-      renderData(data, file.name);
+      renderData(data, file.name, await loadCompanionReports());
     });
 
-    function renderReport(data) {
+    function renderReport(data, companions = {}) {
       const report = data.reportPane || {};
+      const summary = companions.summary || {};
+      const manifest = companions.manifest || {};
       const overview = report.overview || {};
-      const verdict = overview.summaryVerdict || {};
-      const validation = overview.validation || {};
+      const verdict = overview.summaryVerdict || summary.verdict || {};
+      const validation = overview.validation || summary.validation || manifest.validationResultSummary || {};
 
       document.getElementById("report-title").textContent =
         overview.architectureId || overview.mapId || "ArchSig Atom Viewer";
       document.getElementById("metric-atoms").textContent = count(data.atomNodes);
       document.getElementById("metric-groups").textContent = count(data.moleculeGroups);
       document.getElementById("metric-edges").textContent = count(data.atomEdges);
+      document.getElementById("metric-verdict").innerHTML = verdictBadge(verdict);
       document.getElementById("metric-validation").innerHTML = validationBadge(validation);
 
-      renderItems("findings", report.topFindings || data.analysisOverlays?.dominantFindings, "finding");
-      renderItems("actions", report.actionQueue || data.analysisOverlays?.actionQueue, "action");
-      renderCoverage(report.coverageAndBoundaries || {}, verdict);
-      renderArtifacts(report.artifacts || {}, data.sourceArtifactRefs || {});
+      renderOverview(overview, verdict, summary, data.nonConclusions || []);
+      renderItems("findings", report.topFindings || summary.dominantFindings || data.analysisOverlays?.dominantFindings, "finding");
+      renderItems("actions", report.actionQueue || summary.actionQueue || data.analysisOverlays?.actionQueue, "action");
+      renderCoverage(report.coverageAndBoundaries || {}, verdict, summary);
+      renderArtifacts(report.artifacts || {}, data.sourceArtifactRefs || {}, manifest);
+      renderValidationStatus(validation);
       renderOmitted(data.omittedDetailCounts || {}, data.truncationPolicy || {});
     }
 
@@ -645,6 +677,29 @@
       return `<span class="${klass}">${escapeHtml(result || "-")}</span>`;
     }
 
+    function verdictBadge(verdict) {
+      const value = verdict.qualityState || verdict.flatness || verdict.readingMode || "-";
+      const klass = String(value).includes("fail") || String(value).includes("blocked") ? "fail"
+        : String(value).includes("warn") || String(value).includes("gap") ? "warn"
+          : "ok";
+      return `<span class="${klass}">${escapeHtml(String(value))}</span>`;
+    }
+
+    function renderOverview(overview, verdict, summary, nonConclusions) {
+      const root = document.getElementById("overview");
+      const rows = [
+        overview.analysisId && ["analysis", overview.analysisId],
+        verdict.readingMode && ["reading mode", verdict.readingMode],
+        verdict.flatness && ["flatness", verdict.flatness],
+        verdict.qualityState && ["quality", verdict.qualityState],
+        summary.measurementStatusSummary && ["measurement", compactJson(summary.measurementStatusSummary)],
+        Array.isArray(nonConclusions) && nonConclusions.length && ["non-conclusion", nonConclusions[0]]
+      ].filter(Boolean);
+      root.innerHTML = rows.length
+        ? rows.map(([label, value]) => `<div class="item"><strong>${escapeHtml(String(label))}</strong><p>${escapeHtml(String(value))}</p></div>`).join("")
+        : emptyItem();
+    }
+
     function renderItems(id, value, fallbackLabel) {
       const root = document.getElementById(id);
       const items = Array.isArray(value) ? value.slice(0, 8) : [];
@@ -660,33 +715,58 @@
       return `<div class="item"><strong>${escapeHtml(`${fallbackLabel} ${index + 1}`)}</strong><p>${escapeHtml(String(item))}</p></div>`;
     }
 
-    function renderCoverage(boundaries, verdict) {
+    function renderCoverage(boundaries, verdict, summary) {
       const root = document.getElementById("coverage");
-      const coverage = boundaries.coverageGaps || {};
+      const coverage = boundaries.coverageGaps || summary.coverageGapSummary || {};
       const chips = [
         verdict.flatness && `flatness: ${verdict.flatness}`,
         verdict.qualityState && `quality: ${verdict.qualityState}`,
         coverage.gapCount != null && `coverage gaps: ${coverage.gapCount}`,
-        boundaries.measurementBasis?.basis && `basis: ${boundaries.measurementBasis.basis}`
+        boundaries.measurementBasis?.basis && `basis: ${boundaries.measurementBasis.basis}`,
+        summary.measurementBasis?.basis && `basis: ${summary.measurementBasis.basis}`
       ].filter(Boolean);
       root.innerHTML = chips.length
         ? `<div class="item"><div class="chips">${chips.map((chip) => `<span class="chip">${escapeHtml(chip)}</span>`).join("")}</div></div>`
         : emptyItem();
     }
 
-    function renderArtifacts(artifacts, sourceRefs) {
+    function renderArtifacts(artifacts, sourceRefs, manifest) {
       const root = document.getElementById("artifacts");
+      const rawPaths = manifest.rawArtifactPaths || {};
+      const generated = Array.isArray(manifest.generatedArtifacts) ? manifest.generatedArtifacts : [];
+      const omitted = Array.isArray(manifest.omittedArtifacts) ? manifest.omittedArtifacts : [];
       const pairs = [
         ["viewer data", "archsig-atom-viewer-data.json"],
         ["summary", artifacts.summary || sourceRefs.summary],
         ["manifest", artifacts.manifest || sourceRefs.manifest],
-        ["raw artifacts", artifacts.rawArtifacts || "see manifest"]
+        ["packet", rawPaths.analysisPacket],
+        ["detail-index", rawPaths.analysisDetailIndex],
+        ["llm interpretation", rawPaths.llmInterpretationPacket],
+        ["generated", generated.length ? generated.join(", ") : null],
+        ["omitted", omitted.length ? omitted.join(", ") : null],
+        ["raw artifacts", artifacts.rawArtifacts || (manifest.rawArtifactRetention ? `retention: ${manifest.rawArtifactRetention}` : "see manifest")]
       ].filter(([, value]) => value);
       root.innerHTML = pairs.map(([label, value]) => {
         const text = String(value);
         const link = text.endsWith(".json") ? `<a href="${escapeAttr(text)}">${escapeHtml(text)}</a>` : escapeHtml(text);
         return `<div class="item"><strong>${escapeHtml(label)}</strong><p>${link}</p></div>`;
       }).join("");
+    }
+
+    function renderValidationStatus(validation) {
+      const root = document.getElementById("validation-status");
+      const rows = Object.entries(validation || {})
+        .filter(([, value]) => value && typeof value === "object")
+        .map(([key, value]) => {
+          const result = value.result || "unknown";
+          const counts = [
+            value.failedCheckCount != null && `failed: ${value.failedCheckCount}`,
+            value.warningCheckCount != null && `warnings: ${value.warningCheckCount}`
+          ].filter(Boolean).join(", ");
+          const klass = result === "fail" ? "fail" : result === "warn" ? "warn" : "ok";
+          return `<div class="item"><strong>${escapeHtml(key)}</strong><p><span class="${klass}">${escapeHtml(String(result))}</span>${counts ? ` ${escapeHtml(counts)}` : ""}</p></div>`;
+        });
+      root.innerHTML = rows.length ? rows.join("") : emptyItem();
     }
 
     function renderOmitted(counts, policy) {
@@ -704,6 +784,10 @@
 
     function emptyItem() {
       return `<div class="item"><p>No data loaded</p></div>`;
+    }
+
+    function compactJson(value) {
+      return JSON.stringify(value).slice(0, 260);
     }
 
     function escapeHtml(value) {
@@ -725,7 +809,7 @@
     try {
       const response = await fetch("./archsig-atom-viewer-data.json");
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      renderData(await response.json());
+      renderData(await response.json(), "archsig-atom-viewer-data.json", await loadCompanionReports());
     } catch (error) {
       renderData({
         schemaVersion: "archsig-atom-viewer-data-v0",
@@ -741,7 +825,7 @@
         omittedDetailCounts: {
           rawPacketDetail: "raw packet detail is not loaded by this viewer"
         }
-      });
+      }, "archsig-atom-viewer-data.json", {});
       status("Open archsig-atom-viewer-data.json");
     }
   </script>


### PR DESCRIPTION
## 概要

Closes #1635

Atom Viewer 下段の report pane を、`archsig-atom-viewer-data.json` だけでなく同一ディレクトリの `archsig-analysis-summary.json` と `archsig-run-manifest.json` からも補完するようにしました。Overview / Top Findings / Action Queue / Coverage And Boundaries / Artifacts / Validation Status / Omitted Detail を表示し、raw artifacts が出力されている run では packet / detail-index / LLM interpretation への相対 link を表示します。

3D layout は引き続き bounded visual projection として扱い、距離や近さを theorem / semantic equivalence として表示しません。

## 証明した定理

- なし

Lean status: tooling / docs reading surface. Lean theorem の追加は対象外です。

## 編集したドキュメント

- `tools/archsig/README.md`
- `tools/archsig/docs/commands.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] viewer smoke test（`--emit-raw-artifacts` 出力で report pane DOM と screenshot を確認）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
