### PR TITLE
[codex] AATとArchSigの作業境界を明確化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,24 @@
 - 作業は原則として GitHub Issue 起点で進める。次タスクを選ぶ場合は `priority:blocking`, `status:ready`, milestone の依存順を優先する。
 - このリポジトリは個人開発であり、常に最小実装・最小差分を選ぶ必要はない。目的に対して自然に必要な設計、実装、docs、tests、website surface まで広げてよい。
 - ただし、無関係な既存変更の巻き戻し、claim boundary を越える主張、根拠のない互換性維持、不要な抽象化は避ける。
+- AAT / Lean / ArchSig の境界は作業前に必ず分ける。
+  - AAT は Atom を公理とする純粋数学理論である。AAT 自体に source observation、measurement、
+    tooling validation の境界を持ち込まない。測定境界は ArchMap / ArchSig / FieldSig 側の
+    artifact contract として扱う。
+  - Lean 形式化は神様の視点ではない。語れる命題だけを形式化し、全 runtime、全 semantic universe、
+    全未来予測のような証明対象を勝手にスコープへ入れない。
+  - ArchSig は Rust tooling であり Lean 証明器ではない。Rust と Lean の対応を要求しない。
+    ArchSig は `ArchMap + LawPolicy + evidence contract` に相対化して、選ばれた語彙内の肯定的な
+    diagnostic conclusion を出す。
 - 完了レビューや残タスク整理では、対象 Issue / PRD / 計画書 / acceptance test が実際に要求している
   concrete condition だけを判定する。現実コード全体、意味宇宙全体、未来予測全体のような
   無制限 claim を勝手に残タスク化しない。
 - claim boundary は、現在の主張を正確に保つための制約として扱う。ユーザーが求めていない限り、
   「証明できない巨大 claim」や一般的限界を列挙して作業計画の中心にしない。
+- 語り得ない領域は、残タスクや失敗ではなく沈黙として扱う。必要な場合だけ、結論の近くに
+  最小限の boundary として書く。ArchSig / website / report では `SAFE_WITHIN_POLICY`、
+  `NO_SELECTED_OBSTRUCTION`、`ACCEPTABLE_UNDER_EVIDENCE_CONTRACT` のような肯定的結論を中心にし、
+  外側の未観測領域を長い `non-conclusion` 一覧として主役化しない。
 - 禁止: AAT の完了レビューで source extraction / ArchMap observation / tooling validation の完全性を
   「未完了部分」「非主張」「残タスク」「証明不能な限界」として持ち出さない。AAT は Atom を公理とするため、
   source-observation layer の性質は AAT の内側の claim ではない。必要な場合は tooling / SFT 側の
@@ -55,7 +68,7 @@
 - SFT は artifact、practice、AI、review、CI、operational feedback が software evolution の reachable future をどう変えるかを扱う。
 - ArchMap は source-grounded Atom observation map であり、law-independent な観測を記録する。
 - LawPolicy / interpretation profile は選ばれた law universe、witness rule、signature axis、coverage requirement を与える profile であり、AAT そのものではない。
-- ArchSig は ArchMap と interpretation profile から `archsig-analysis-packet-v0` を作る AAT structural analysis layer である。Lean 証明器ではない。
+- ArchSig は ArchMap と interpretation profile から `archsig-analysis-packet-v0` を作る AAT structural analysis layer である。Lean 証明器ではない。選ばれた LawPolicy と evidence contract の中で語れることを確かに語り、その外側は証明不能な限界として騒がず沈黙する。
 - FieldSig は ArchSig analysis packet と workflow evidence を SFT 側の evolution measurement / governance input として読む。raw ArchMap を forecast truth として読まない。
 - Website は docs の複製ではなく、AAT / SFT / ArchSig を公開向けに読むための web-native publication surface である。
 

--- a/docs/aat/guideline.md
+++ b/docs/aat/guideline.md
@@ -7,8 +7,13 @@
 - AAT は Atom から architecture object、law、obstruction circuit、operation、flatness、path / homotopy、analytic representation を構成する局所代数の核である。
 - AAT は Atom を公理的出発点とする。実コードベース抽出器、ArchMap observation、tooling validation は
   Atom 入力を提示・検査する前段または後段 surface であり、AAT の theorem package の完了条件ではない。
+- AAT 自体に observation / measurement / tooling boundary はない。境界を持つのは、Atom 入力を提示する
+  ArchMap、LawPolicy による選択、ArchSig / FieldSig の測定 artifact、または empirical dataset である。
 - Lean source は Atom から生成される純粋な algebra / theorem package を形式化する場所である。
   実測や empirical correlation は、AAT ではなく tooling / SFT 側の artifact に相対化して扱う。
+- Lean 形式化は全知の検査器ではない。形式化対象は、AAT の語彙で明示的に述べられる命題に限る。
+  全 runtime、全 semantic universe、source extraction completeness、tooling validation completeness を
+  AAT theorem package のスコープに入れない。
 - `docs/aat/mathematical_theory/` は数学本文である。Lean status、Issue 番号、実装済み API の進捗管理は本文に混ぜない。
 - `docs/aat/mathematical_theory/` は AAT の根幹文書である。ユーザーの明示的な指示なしに更新しない。
 - Lean status と Issue との対応は `docs/aat/proof_obligations.md` と `docs/aat/lean_theorem_index.md` で管理する。
@@ -24,6 +29,8 @@
 - executable metrics は、まず有限な measurement universe 上の計算として定義し、graph-level facts との接続は別 theorem として証明する。
 - `ComponentUniverse` は proof-carrying measurement universe として扱う。source extraction の成否は
   AAT core の定理ではなく、ArchMap / tooling 側の入力生成 contract として扱う。
+- ArchSig や Rust tooling の有用性を Lean との対応で正当化しない。Lean 側は AAT の語れる命題を支える
+  形式化であり、ArchSig は別に `ArchMap + LawPolicy + evidence contract` から診断結論を出す tool である。
 
 ## docs の claim discipline
 
@@ -37,6 +44,8 @@
   具体的な artifact、fixture、schema、validator、Issue acceptance として別管理する。
 - non-conclusion / claim boundary は、具体的な theorem や artifact の近くで必要な分だけ記録する。
   レビュー報告や残タスク欄を、一般的に証明不能な巨大 claim の一覧にしない。
+- 語れることだけを確かに語る。AAT / Lean docs では、語れない外部領域を `non-conclusion` 一覧として
+  主役化しない。必要な boundary は、定理や artifact の有効範囲を示すために最小限だけ置く。
 - theorem や定義を追加した場合は、必要に応じて `docs/aat/proof_obligations.md` と `docs/aat/lean_theorem_index.md` を更新する。
 - `docs/archive` は歴史的参照として扱い、現行文書の更新時に同じ変更を反映しない。
 - Architecture Signature は単一スコアではなく、多軸診断として扱う。

--- a/docs/sft/guideline.md
+++ b/docs/sft/guideline.md
@@ -7,6 +7,8 @@
 - SFT は field-shaped software evolution の計算理論である。
 - SFT は AAT の architecture object、operation、invariant、obstruction witness、signature、theorem boundary / non-conclusions を観測量・制約・制御入力として使う。
 - SFT は AAT の数学的核を置き換えない。AAT から SFT への依存は片方向として保つ。
+- AAT は Atom を公理とする純粋数学理論であり、測定境界は SFT / ArchSig / empirical artifact 側にある。
+  SFT 側でも、AAT の外部にある観測限界を AAT の未完了 theorem として扱わない。
 - `docs/sft/software_field_theory.md` は SFT 本文、`docs/sft/aat_interface.md` は AAT / SFT 境界の source of truth である。
 - `docs/sft/software_field_theory.md` と `docs/sft/aat_interface.md` は SFT / interface の根幹文書である。ユーザーの明示的な指示なしに更新しない。
 
@@ -17,6 +19,8 @@
   dataset / operational artifact に相対化して扱う。
 - empirical dataset、operational feedback、calibration artifact は、相関・観測・仮説を因果 theorem と混同しない。
 - Lean theorem claim として読める範囲は AAT / Lean 側に置く。SFT docs で theorem boundary に触れる場合は、対応する `docs/aat/proof_obligations.md` や `docs/aat/lean_theorem_index.md` も確認する。
+- ArchSig / FieldSig 由来の report は、選ばれた evidence contract の中で語れる肯定的な conclusion として読む。
+  語れない外側を一般的な non-conclusion や残タスクとして増幅しない。
 - レビューやタスク整理では、SFT 文書が定義した artifact、typed conclusion、accessor theorem、
   calibration step だけを完了条件にする。現実の未来全体や因果全体を、未完了タスクとして持ち出さない。
 

--- a/docs/tool/guideline.md
+++ b/docs/tool/guideline.md
@@ -8,7 +8,14 @@
 - AAT は Atom を公理的出発点とする。ArchMap / extractor は source code から Atom input を提示・検査する
   実測 surface であり、AAT の定理や完了条件を定義しない。
 - LawPolicy / interpretation profile は、law universe、witness rule、molecule pattern、obstruction circuit definition、signature axis、coverage requirement、exactness assumption を選ぶ profile である。AAT そのものではない。
-- ArchSig は ArchMap + interpretation profile から `archsig-analysis-packet-v0` を作る AAT structural analysis layer である。Lean 証明器ではない。
+- ArchSig は ArchMap + interpretation profile から `archsig-analysis-packet-v0` を作る AAT structural analysis layer である。Lean 証明器ではない。Rust と Lean の対応を tooling contract として要求しない。
+- ArchSig は tool として肯定的な bounded diagnostic conclusion を出す。たとえば
+  `SAFE_WITHIN_POLICY`、`NO_SELECTED_OBSTRUCTION`、`ACCEPTABLE_UNDER_EVIDENCE_CONTRACT`、
+  `DISTANCE_WITHIN_THRESHOLD` のように、選ばれた LawPolicy、DistanceProfile、evidence contract の中で
+  語れることを確かに語る。
+- ArchSig は、未観測 runtime 全体や global semantic safety のように選ばれた evidence language の外にあるものを、
+  failure、残タスク、Lean linkage requirement、長い `non-conclusion` 一覧として扱わない。外側は必要最小限の
+  silence boundary として扱う。
 - `concernHints` は review cue であり、obstruction circuit、law violation、theorem evidence ではない。
 - FieldSig は `archsig-analysis-packet-v0` を bounded current AAT structural state として読み、SFT 側の evolution measurement / governance input へ写す。raw ArchMap observations を forecast truth として読まない。
 - ArchSig validation は、schema、refs、generated middle layer、selected law-policy reading、fixture expectation など、
@@ -26,6 +33,8 @@
 - CLI surface を追加・変更する場合は、必要に応じて `tools/archsig/README.md`、`tools/archsig/docs/commands.md`、`tools/fieldsig/README.md`、`tools/fieldsig/docs/commands.md` を更新する。
 - Rust 型共有を ArchSig / FieldSig 間の cross-tool contract として扱わない。serialized JSON artifact boundary を重視する。
 - Rust source では不用意な `unwrap`, `expect`, `panic!`、placeholder 実装、claim boundary を曖昧にする fallback を避ける。
+- Report / schema / CLI wording は「これは結論ではない」を主文にしない。結論、根拠、選ばれた evidence contract を
+  先に出し、語らない領域は必要な場合だけ短い boundary として添える。
 
 ## 主要コマンド
 

--- a/docs/website/guideline.md
+++ b/docs/website/guideline.md
@@ -8,12 +8,16 @@
 - `docs/website/` は公開 artifact に含めない内部運用メモである。
 - website は docs の複製ではない。AAT / SFT / ArchSig を公開向けに読むための web-native publication surface として扱う。
 - AAT / SFT の公開ページは宣伝文ではなく、web-native preprint / monograph として、定義、前提、定理境界、例、反例、Lean status、non-conclusion を保つ。
+- 公開 surface では、AAT は Atom を公理とする純粋数学理論、ArchSig は Lean 証明器ではなく
+  `ArchMap + LawPolicy + evidence contract` を読む Rust tool、として分けて説明する。
 
 ## 編集方針
 
 - website copy は `docs/website/README.md` の Tone Guide に従う。防衛的な書き方や否定から入る説明を避ける。
 - 読者向け本文では「何を読めるか」「何を理解できるか」「どの概念へ進むか」を中心に書く。
 - claim boundary、Lean status、Issue 管理、repository / docs の責務分離は編集時の制約として扱い、公開コピーにそのまま出さない。
+- ArchSig の説明では、`SAFE_WITHIN_POLICY` や `NO_SELECTED_OBSTRUCTION` のような選ばれた語彙内の
+  肯定的診断を中心に置く。語れない外側は、長い non-conclusion ではなく必要最小限の boundary として扱う。
 - 公開ページや renewal plan では、読者が検討できる具体的な artifact / theorem / example / command を中心にする。
   一般的に証明できない巨大 claim の否定を、見出しや残タスクの中心にしない。
 - 理論上の新規 claim は先に `docs/aat/mathematical_theory/`、`docs/sft/software_field_theory.md`、`docs/sft/aat_interface.md`、または `docs/tool/` に反映する。


### PR DESCRIPTION
## 概要

AAT / Lean / ArchSig の作業境界を、`AGENTS.md` と領域別 guideline に明記しました。

- AAT は Atom を公理とする純粋数学理論であり、測定境界は ArchMap / ArchSig / FieldSig / empirical artifact 側に置くことを明確化
- Lean は全 runtime / 全 semantic universe / tooling validation completeness を勝手に証明対象へ入れないことを明確化
- ArchSig は Lean 証明器ではなく、`ArchMap + LawPolicy + evidence contract` に相対化した肯定的な bounded diagnostic conclusion を出す Rust tool であることを明確化
- 語れない外側を残タスクや長い `non-conclusion` 一覧として主役化せず、必要最小限の boundary として扱う方針を追加

Issue 起点ではない運用ガイド更新のため、`Closes #N` はありません。

## 証明した定理

- なし

## 編集したドキュメント

- `AGENTS.md`
- `docs/aat/guideline.md`
- `docs/tool/guideline.md`
- `docs/sft/guideline.md`
- `docs/website/guideline.md`

## 実施したテスト

- [ ] `lake build`（docs-only のため未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（Rust 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（Rust 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean / theorem docs 変更なしのため未実施）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（定理追加なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない