### PR TITLE
ArchSig Part IV representation metricを実装

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -278,6 +278,7 @@ The implemented schema records:
 - `monodromyReadingFamily`
 - `boundaryHolonomyReadingFamily`
 - `representationStrengthReadings`
+- `representationMetricReadings`
 - `localCurvatureDiagramReadings`
 - `threeLayerFlatnessReadings`
 - `observationProjectionReadings`
@@ -552,6 +553,17 @@ The builder:
   refs, and `repairOperationCandidates[]` / `operationDeltas[]` retain
   `part4DistanceRefs` so repair candidates cannot be read as automatic safe
   patches.
+- `representationMetricReadings[]` computes selected Part IV representation
+  metric readings from `analyticRepresentations[]`,
+  `spectralAnalysisReadings[]`, `spectralModeReadings[]`,
+  `spectralDrilldownReadings[]`, and `representationStrengthReadings[]`.
+  Each row separates `structuralDistance`, `analyticDistance`,
+  `lipschitzStability`, and `biLipschitzFaithfulness`. Analytic distance is a
+  selected representation reading, not an architecture quality score.
+  Bi-Lipschitz lower-bound faithfulness remains `blocked` while coverage or
+  witness-completeness blockers remain. The source analytic / spectral /
+  strength surfaces retain `part4DistanceRefs` so representation conclusions
+  cannot be read without the metric evidence boundary.
 - `operationSquareCandidates` enumerates supplied, inferred, or blocked
   operation pairs as path pairs `p = g . f` and `q = f . g`. Supplied
   candidates are read from first-class ArchMap `operationSquareEvidence[]` and

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -61,12 +61,13 @@ use crate::{
     ArchSigProjectionNonInjectivityCandidateV0, ArchSigProjectionReconstructionBlockerV0,
     ArchSigRecurrentObstructionModeV0, ArchSigRepairAxisDeltaReadingV0,
     ArchSigRepairOperationCandidateV0, ArchSigRepairTransferRiskRankV0,
-    ArchSigRepresentationStrengthReadingV0, ArchSigSignatureAxisDistanceV0,
-    ArchSigSignatureAxisReadingV0, ArchSigSignatureDistanceReadingV0,
-    ArchSigSignatureTrajectoryHomotopyRefutationReadingV0, ArchSigSpectralAnalysisReadingV0,
-    ArchSigSpectralDominantComponentV0, ArchSigSpectralDrilldownReadingV0,
-    ArchSigSpectralMatrixShapeV0, ArchSigSpectralModeComponentV0, ArchSigSpectralModeReadingV0,
-    ArchSigSpectralValueV0, ArchSigSplitReadinessReadingV0, ArchSigStateTransitionAlgebraReadingV0,
+    ArchSigRepresentationMetricReadingV0, ArchSigRepresentationStrengthReadingV0,
+    ArchSigSignatureAxisDistanceV0, ArchSigSignatureAxisReadingV0,
+    ArchSigSignatureDistanceReadingV0, ArchSigSignatureTrajectoryHomotopyRefutationReadingV0,
+    ArchSigSpectralAnalysisReadingV0, ArchSigSpectralDominantComponentV0,
+    ArchSigSpectralDrilldownReadingV0, ArchSigSpectralMatrixShapeV0,
+    ArchSigSpectralModeComponentV0, ArchSigSpectralModeReadingV0, ArchSigSpectralValueV0,
+    ArchSigSplitReadinessReadingV0, ArchSigStateTransitionAlgebraReadingV0,
     ArchSigStateTransitionLawEvaluationV0, ArchSigStateTransitionRelationInputV0,
     ArchSigStokesStyleReadingV0, ArchSigStructuralReadingReviewSurfaceV0,
     ArchSigSubjectFamilySpreadV0, ArchSigSupportingDistanceV0, ArchSigSynthesisBlockageReadingV0,
@@ -182,7 +183,7 @@ pub fn build_archsig_analysis_packet(
     let invariant_family_readings =
         build_invariant_family_readings(archmap, law_policy, &obstruction_circuits);
     let law_universe_reading = build_law_universe_reading(law_policy);
-    let analytic_representations =
+    let mut analytic_representations =
         build_analytic_representations(archmap, &signature_axes, &obstruction_circuits);
     let coupling_cohesion_readings = build_coupling_cohesion_readings(archmap);
     let design_principle_readings = build_design_principle_readings(
@@ -208,14 +209,14 @@ pub fn build_archsig_analysis_packet(
         &mut part4_distance_foundation,
         &operation_distance_readings,
     );
-    let spectral_analysis_readings = build_spectral_analysis_readings(
+    let mut spectral_analysis_readings = build_spectral_analysis_readings(
         archmap,
         &obstruction_circuits,
         &signature_axes,
         &operation_deltas,
     );
-    let spectral_mode_readings = build_spectral_mode_readings(&spectral_analysis_readings);
-    let spectral_drilldown_readings = build_spectral_drilldown_readings(
+    let mut spectral_mode_readings = build_spectral_mode_readings(&spectral_analysis_readings);
+    let mut spectral_drilldown_readings = build_spectral_drilldown_readings(
         archmap,
         &spectral_mode_readings,
         &obstruction_circuits,
@@ -272,11 +273,32 @@ pub fn build_archsig_analysis_packet(
     let path_homotopy_diagram_readings =
         build_path_homotopy_diagram_readings(archmap, &molecule_readings, &obstruction_circuits);
     let layer_split = build_layer_split(archmap);
-    let representation_strength_readings = build_representation_strength_readings(
+    let mut representation_strength_readings = build_representation_strength_readings(
         archmap,
         &analytic_representations,
         &spectral_analysis_readings,
         &flatness_reading,
+    );
+    let representation_metric_readings = build_representation_metric_readings(
+        archmap,
+        &analytic_representations,
+        &spectral_analysis_readings,
+        &spectral_mode_readings,
+        &spectral_drilldown_readings,
+        &representation_strength_readings,
+        &part4_distance_foundation,
+    );
+    attach_representation_metric_refs(
+        &mut analytic_representations,
+        &mut spectral_analysis_readings,
+        &mut spectral_mode_readings,
+        &mut spectral_drilldown_readings,
+        &mut representation_strength_readings,
+        &representation_metric_readings,
+    );
+    promote_representation_metric_supporting_distance(
+        &mut part4_distance_foundation,
+        &representation_metric_readings,
     );
     let local_curvature_diagram_readings =
         build_local_curvature_diagram_readings(archmap, &obstruction_circuits);
@@ -539,6 +561,7 @@ pub fn build_archsig_analysis_packet(
         &path_multiplicity_loss_readings,
         &signature_trajectory_homotopy_refutation_readings,
         &bridge_split_obstruction_transfer_readings,
+        &representation_metric_readings,
         &representation_strength_readings,
         &local_curvature_diagram_readings,
         &three_layer_flatness_readings,
@@ -645,6 +668,7 @@ pub fn build_archsig_analysis_packet(
         monodromy_reading_family,
         boundary_holonomy_reading_family,
         representation_strength_readings,
+        representation_metric_readings,
         local_curvature_diagram_readings,
         three_layer_flatness_readings,
         observation_projection_readings,
@@ -5945,6 +5969,7 @@ fn analytic_representation(
         zero_reflecting_boundary:
             "zero reflects only the selected representation when coverage and exactness assumptions hold"
                 .to_string(),
+        part4_distance_refs: Vec::new(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
 }
@@ -6723,6 +6748,7 @@ fn spectral_reading(
         coverage_boundary: coverage_boundary.to_string(),
         zero_reflecting_boundary: zero_reflecting_boundary.to_string(),
         recommended_next_action: recommended_next_action.to_string(),
+        part4_distance_refs: Vec::new(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
 }
@@ -8101,6 +8127,7 @@ fn spectral_mode_reading(
             localization,
             density,
         ),
+        part4_distance_refs: Vec::new(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }
 }
@@ -8253,6 +8280,7 @@ fn build_spectral_drilldown_readings(
         recommended_next_action:
             "review dominant atom families, high-overlap molecule pairs, and positive/negative repair delta axes before changing boundaries"
                 .to_string(),
+        part4_distance_refs: Vec::new(),
         non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
     }]
 }
@@ -9074,6 +9102,7 @@ fn build_representation_strength_readings(
                 representation.representation_family
             ),
             evidence_boundary: representation.coverage_boundary.clone(),
+            part4_distance_refs: Vec::new(),
             non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
         })
         .chain(spectral_analysis_readings.iter().map(|reading| {
@@ -9127,10 +9156,487 @@ fn build_representation_strength_readings(
                     )
                 },
                 evidence_boundary: reading.coverage_boundary.clone(),
+                part4_distance_refs: Vec::new(),
                 non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
             }
         }))
         .collect()
+}
+
+fn build_representation_metric_readings(
+    archmap: &ArchMapDocumentV0,
+    analytic_representations: &[ArchSigAnalyticRepresentationV0],
+    spectral_analysis_readings: &[ArchSigSpectralAnalysisReadingV0],
+    spectral_mode_readings: &[ArchSigSpectralModeReadingV0],
+    spectral_drilldown_readings: &[ArchSigSpectralDrilldownReadingV0],
+    representation_strength_readings: &[ArchSigRepresentationStrengthReadingV0],
+    foundation: &ArchSigPart4DistanceFoundationV0,
+) -> Vec<ArchSigRepresentationMetricReadingV0> {
+    let analytic_by_id = analytic_representations
+        .iter()
+        .map(|reading| (reading.representation_id.as_str(), reading))
+        .collect::<BTreeMap<_, _>>();
+    let spectral_by_id = spectral_analysis_readings
+        .iter()
+        .map(|reading| (reading.spectral_reading_id.as_str(), reading))
+        .collect::<BTreeMap<_, _>>();
+    let modes_by_spectral_ref = spectral_mode_readings.iter().fold(
+        BTreeMap::<&str, Vec<&ArchSigSpectralModeReadingV0>>::new(),
+        |mut map, mode| {
+            map.entry(mode.source_spectral_reading_ref.as_str())
+                .or_default()
+                .push(mode);
+            map
+        },
+    );
+    let drilldowns_by_mode_ref = spectral_drilldown_readings
+        .iter()
+        .flat_map(|drilldown| {
+            drilldown
+                .source_spectral_mode_refs
+                .iter()
+                .map(move |mode_ref| (mode_ref.as_str(), drilldown))
+        })
+        .fold(
+            BTreeMap::<&str, Vec<&ArchSigSpectralDrilldownReadingV0>>::new(),
+            |mut map, (mode_ref, drilldown)| {
+                map.entry(mode_ref).or_default().push(drilldown);
+                map
+            },
+        );
+    let coverage_blockers = archmap
+        .observation_gaps
+        .iter()
+        .map(|gap| gap.gap_id.clone())
+        .collect::<Vec<_>>();
+    let witness_blockers = vec![
+        "witness-completeness:selected-LawPolicy-not-certified".to_string(),
+        "coverage-completeness:selected-representation-not-global".to_string(),
+    ];
+    let coverage_refs = foundation.profile.coverage_policy_refs.clone();
+
+    representation_strength_readings
+        .iter()
+        .map(|strength| {
+            let mut source_reading_refs = vec![strength.source_reading_ref.clone()];
+            let mut analytic_representation_refs = Vec::new();
+            let mut spectral_reading_refs = Vec::new();
+            let mut spectral_mode_refs = Vec::new();
+            let mut spectral_drilldown_refs = Vec::new();
+            let mut evidence_refs = Vec::new();
+            let mut structural_basis = vec![
+                format!("structuralDistance:representationStrength:{}", strength.reading_id),
+                format!("structuralDistance:family:{}", strength.representation_family),
+            ];
+            let mut analytic_basis = vec![
+                format!("analyticDistance:representationFamily:{}", strength.representation_family),
+            ];
+            let mut structural_value = 0_i64;
+            let mut analytic_value = 0_i64;
+            let mut analytic_status = "measured";
+
+            if let Some(representation) = analytic_by_id.get(strength.source_reading_ref.as_str()) {
+                analytic_representation_refs.push(representation.representation_id.clone());
+                evidence_refs.extend(representation.graph_scope_refs.clone());
+                evidence_refs.extend(representation.walk_witness_refs.clone());
+                structural_value += representation.graph_scope_refs.len() as i64;
+                structural_value += representation.axis_refs.len() as i64;
+                structural_value += representation.walk_witness_refs.len() as i64;
+                structural_basis.extend(
+                    representation
+                        .axis_refs
+                        .iter()
+                        .map(|axis| format!("structuralDistance:axis:{axis}")),
+                );
+                structural_basis.extend(
+                    representation
+                        .graph_scope_refs
+                        .iter()
+                        .map(|graph_ref| format!("structuralDistance:graphScope:{graph_ref}")),
+                );
+                let (value, basis, measured) = analytic_metric_value_from_representation(representation);
+                analytic_value += value;
+                analytic_basis.extend(basis);
+                if !measured {
+                    analytic_status = "blocked";
+                }
+            }
+
+            if let Some(spectral) = spectral_by_id.get(strength.source_reading_ref.as_str()) {
+                spectral_reading_refs.push(spectral.spectral_reading_id.clone());
+                evidence_refs.extend(spectral.support_refs.clone());
+                structural_value += spectral.support_refs.len() as i64;
+                structural_value += spectral.dominant_components.len() as i64;
+                structural_basis.extend(
+                    spectral
+                        .support_refs
+                        .iter()
+                        .map(|support| format!("structuralDistance:spectralSupport:{support}")),
+                );
+                let (value, basis) = analytic_metric_value_from_spectral(spectral);
+                analytic_value += value;
+                analytic_basis.extend(basis);
+                if let Some(modes) = modes_by_spectral_ref.get(strength.source_reading_ref.as_str()) {
+                    for mode in modes {
+                        spectral_mode_refs.push(mode.spectral_mode_id.clone());
+                        source_reading_refs.push(mode.spectral_mode_id.clone());
+                        analytic_basis.push(format!(
+                            "analyticDistance:spectralMode:{}:gap={}:localization={}:density={}",
+                            mode.spectral_mode_id,
+                            mode.spectral_gap_proxy.value,
+                            mode.localization_index.value,
+                            mode.matrix_density.value
+                        ));
+                        analytic_value += scaled_spectral_value(&mode.spectral_gap_proxy.value).abs();
+                        analytic_value += scaled_spectral_value(&mode.localization_index.value).abs();
+                        analytic_value += scaled_spectral_value(&mode.matrix_density.value).abs();
+                        if let Some(drilldowns) = drilldowns_by_mode_ref.get(mode.spectral_mode_id.as_str()) {
+                            for drilldown in drilldowns {
+                                spectral_drilldown_refs.push(drilldown.drilldown_id.clone());
+                                source_reading_refs.push(drilldown.drilldown_id.clone());
+                                evidence_refs.extend(
+                                    drilldown
+                                        .dominant_atom_family_composition
+                                        .iter()
+                                        .flat_map(|composition| composition.atom_observation_refs.clone()),
+                                );
+                                analytic_basis.push(format!(
+                                    "analyticDistance:spectralDrilldown:{}:atomFamilies={}:overlapPairs={}:repairAxisDeltas={}",
+                                    drilldown.drilldown_id,
+                                    drilldown.dominant_atom_family_composition.len(),
+                                    drilldown.high_overlap_molecule_pairs.len(),
+                                    drilldown.repair_axis_delta_readings.len()
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+
+            let coverage_blocker_refs = unique_strings(
+                coverage_blockers
+                    .iter()
+                    .cloned()
+                    .chain(strength.blocked_by.iter().cloned()),
+            );
+            let witness_completeness_blocker_refs = unique_strings(
+                witness_blockers
+                    .iter()
+                    .cloned()
+                    .chain(strength.blocked_reflection_or_preservation_reasons.iter().cloned()),
+            );
+            let evidence_refs = if evidence_refs.is_empty() {
+                vec![strength.source_reading_ref.clone()]
+            } else {
+                unique_strings(evidence_refs.into_iter())
+            };
+            let source_reading_refs = unique_strings(source_reading_refs.into_iter());
+            let structural_distance = measured_part4_distance_value(
+                structural_value.max(0),
+                "selected-structural-support-count",
+                evidence_refs.clone(),
+                unique_strings(structural_basis.into_iter()),
+                &coverage_refs,
+                "selected structural distance is the bounded support size of this representation reading, not global architecture distance",
+            );
+            let analytic_distance = if analytic_status == "measured" {
+                measured_part4_distance_value(
+                    analytic_value.max(0),
+                    "selected-analytic-magnitude-x100",
+                    source_reading_refs.clone(),
+                    unique_strings(analytic_basis.into_iter()),
+                    &coverage_refs,
+                    "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score",
+                )
+            } else {
+                blocked_curvature_distance_value(
+                    "selected-analytic-magnitude-x100",
+                    source_reading_refs.clone(),
+                    unique_strings(analytic_basis.into_iter()),
+                    &coverage_refs,
+                    witness_completeness_blocker_refs.clone(),
+                    "selected analytic distance is blocked when the representation value is boundary-only or unavailable; it is not an architecture quality score",
+                )
+            };
+            let lipschitz_stability = if matches!(analytic_distance.status.as_str(), "measured" | "zero") {
+                let denominator = structural_distance.measured_value.unwrap_or_default().max(1);
+                let numerator = analytic_distance.measured_value.unwrap_or_default();
+                measured_part4_distance_value(
+                    ((numerator + denominator - 1) / denominator).max(1),
+                    "selected-L-upper-bound-x100",
+                    source_reading_refs.clone(),
+                    vec![
+                        format!("lipschitz:analyticDistance={numerator}"),
+                        format!("lipschitz:structuralDistance={denominator}"),
+                        format!("lipschitz:selectedRepresentation:{}", strength.representation_family),
+                    ],
+                    &coverage_refs,
+                    "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures",
+                )
+            } else {
+                blocked_curvature_distance_value(
+                    "selected-L-upper-bound-x100",
+                    source_reading_refs.clone(),
+                    vec![format!("lipschitz:selectedRepresentation:{}", strength.representation_family)],
+                    &coverage_refs,
+                    analytic_distance.blocker_refs.clone(),
+                    "Lipschitz upper-bound reading is blocked because analytic distance is unavailable",
+                )
+            };
+            let bi_lipschitz_faithfulness = blocked_curvature_distance_value(
+                "selected-bi-lipschitz-lower-bound",
+                source_reading_refs.clone(),
+                vec![
+                    format!("biLipschitz:structuralDistance:{}", strength.representation_family),
+                    format!("biLipschitz:analyticDistance:{}", strength.representation_family),
+                    "biLipschitz:requiresCoverageAndWitnessCompleteness".to_string(),
+                ],
+                &coverage_refs,
+                unique_strings(
+                    coverage_blocker_refs
+                        .iter()
+                        .cloned()
+                        .chain(witness_completeness_blocker_refs.iter().cloned()),
+                ),
+                "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope",
+            );
+
+            ArchSigRepresentationMetricReadingV0 {
+                representation_metric_reading_id: format!(
+                    "representation-metric:{}",
+                    stable_id(&strength.reading_id)
+                ),
+                representation_ref: strength.source_reading_ref.clone(),
+                representation_family: strength.representation_family.clone(),
+                source_reading_refs,
+                distance_profile_ref: foundation.profile.profile_id.clone(),
+                diagnostic_scope_ref: foundation.diagnostic_scope.scope_id.clone(),
+                structural_distance,
+                analytic_distance,
+                lipschitz_stability,
+                bi_lipschitz_faithfulness,
+                coverage_blocker_refs,
+                witness_completeness_blocker_refs,
+                analytic_representation_refs,
+                spectral_reading_refs,
+                spectral_mode_refs: unique_strings(spectral_mode_refs.into_iter()),
+                spectral_drilldown_refs: unique_strings(spectral_drilldown_refs.into_iter()),
+                representation_strength_refs: vec![strength.reading_id.clone()],
+                evidence_refs,
+                evidence_boundary:
+                    "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness"
+                        .to_string(),
+                non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+            }
+        })
+        .collect()
+}
+
+fn analytic_metric_value_from_representation(
+    representation: &ArchSigAnalyticRepresentationV0,
+) -> (i64, Vec<String>, bool) {
+    let mut basis = Vec::new();
+    match representation.value_type.as_str() {
+        "nat" => {
+            let value = representation.value.parse::<i64>().unwrap_or_default();
+            basis.push(format!(
+                "analyticDistance:{}:nat={value}",
+                representation.representation_id
+            ));
+            (value, basis, true)
+        }
+        "float" => {
+            let value = scaled_spectral_value(&representation.value).abs();
+            basis.push(format!(
+                "analyticDistance:{}:float={}",
+                representation.representation_id, representation.value
+            ));
+            (value, basis, true)
+        }
+        "matrixShape" => {
+            let value = representation
+                .sparse_matrix_entries
+                .iter()
+                .map(|entry| entry.value.abs())
+                .sum::<i64>();
+            basis.push(format!(
+                "analyticDistance:{}:matrixEntries={}",
+                representation.representation_id,
+                representation.sparse_matrix_entries.len()
+            ));
+            (value, basis, true)
+        }
+        "vector" => {
+            let trimmed = representation
+                .value
+                .trim_matches(|ch| ch == '[' || ch == ']');
+            let value = scaled_spectral_value(trimmed).abs();
+            basis.push(format!(
+                "analyticDistance:{}:vector={}",
+                representation.representation_id, representation.value
+            ));
+            (value, basis, true)
+        }
+        "boundaryStatus" if representation.status == "measured" => {
+            basis.push(format!(
+                "analyticDistance:{}:boundaryStatus={}",
+                representation.representation_id, representation.value
+            ));
+            (1, basis, true)
+        }
+        _ => {
+            basis.push(format!(
+                "analyticDistance:{}:blockedBoundaryStatus={}",
+                representation.representation_id, representation.value
+            ));
+            (0, basis, false)
+        }
+    }
+}
+
+fn analytic_metric_value_from_spectral(
+    spectral: &ArchSigSpectralAnalysisReadingV0,
+) -> (i64, Vec<String>) {
+    let mut value = 0_i64;
+    let mut basis = Vec::new();
+    for spectral_value in &spectral.values {
+        let scaled = scaled_spectral_value(&spectral_value.value).abs();
+        value += scaled;
+        basis.push(format!(
+            "analyticDistance:{}:{}={}",
+            spectral.spectral_reading_id, spectral_value.name, spectral_value.value
+        ));
+    }
+    (value, basis)
+}
+
+fn scaled_spectral_value(value: &str) -> i64 {
+    value
+        .parse::<f64>()
+        .map(|value| (value * 100.0).round() as i64)
+        .unwrap_or_default()
+}
+
+fn attach_representation_metric_refs(
+    analytic_representations: &mut [ArchSigAnalyticRepresentationV0],
+    spectral_analysis_readings: &mut [ArchSigSpectralAnalysisReadingV0],
+    spectral_mode_readings: &mut [ArchSigSpectralModeReadingV0],
+    spectral_drilldown_readings: &mut [ArchSigSpectralDrilldownReadingV0],
+    representation_strength_readings: &mut [ArchSigRepresentationStrengthReadingV0],
+    metric_readings: &[ArchSigRepresentationMetricReadingV0],
+) {
+    for metric in metric_readings {
+        for representation in analytic_representations.iter_mut().filter(|reading| {
+            metric
+                .analytic_representation_refs
+                .contains(&reading.representation_id)
+        }) {
+            representation
+                .part4_distance_refs
+                .push(metric.representation_metric_reading_id.clone());
+        }
+        for spectral in spectral_analysis_readings.iter_mut().filter(|reading| {
+            metric
+                .spectral_reading_refs
+                .contains(&reading.spectral_reading_id)
+        }) {
+            spectral
+                .part4_distance_refs
+                .push(metric.representation_metric_reading_id.clone());
+        }
+        for mode in spectral_mode_readings.iter_mut().filter(|reading| {
+            metric
+                .spectral_mode_refs
+                .contains(&reading.spectral_mode_id)
+        }) {
+            mode.part4_distance_refs
+                .push(metric.representation_metric_reading_id.clone());
+        }
+        for drilldown in spectral_drilldown_readings.iter_mut().filter(|reading| {
+            metric
+                .spectral_drilldown_refs
+                .contains(&reading.drilldown_id)
+        }) {
+            drilldown
+                .part4_distance_refs
+                .push(metric.representation_metric_reading_id.clone());
+        }
+        for strength in representation_strength_readings
+            .iter_mut()
+            .filter(|reading| {
+                metric
+                    .representation_strength_refs
+                    .contains(&reading.reading_id)
+            })
+        {
+            strength
+                .part4_distance_refs
+                .push(metric.representation_metric_reading_id.clone());
+        }
+    }
+}
+
+fn promote_representation_metric_supporting_distance(
+    foundation: &mut ArchSigPart4DistanceFoundationV0,
+    readings: &[ArchSigRepresentationMetricReadingV0],
+) {
+    if readings.is_empty() {
+        return;
+    }
+    if let Some(distance) = foundation
+        .supporting_distances
+        .iter_mut()
+        .find(|distance| distance.distance_family == "representationMetric")
+    {
+        let blockers = readings
+            .iter()
+            .flat_map(|reading| reading.bi_lipschitz_faithfulness.blocker_refs.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        distance.value = if blockers.is_empty() {
+            measured_part4_distance_value(
+                readings
+                    .iter()
+                    .filter_map(|reading| reading.lipschitz_stability.measured_value)
+                    .sum::<i64>(),
+                "selected-representation-stability",
+                readings
+                    .iter()
+                    .map(|reading| reading.representation_metric_reading_id.clone())
+                    .collect(),
+                readings
+                    .iter()
+                    .map(|reading| {
+                        format!("representationMetric:{}", reading.representation_family)
+                    })
+                    .collect(),
+                &foundation.profile.coverage_policy_refs,
+                "representationMetric aggregates selected representation stability readings only",
+            )
+        } else {
+            blocked_curvature_distance_value(
+                "selected-representation-faithfulness",
+                readings
+                    .iter()
+                    .map(|reading| reading.representation_metric_reading_id.clone())
+                    .collect(),
+                readings
+                    .iter()
+                    .map(|reading| {
+                        format!("representationMetric:{}", reading.representation_family)
+                    })
+                    .collect(),
+                &foundation.profile.coverage_policy_refs,
+                blockers,
+                "representationMetric supporting distance is blocked for faithfulness until coverage and witness completeness are supplied",
+            )
+        };
+        distance.evidence_boundary =
+            "representationMetric reads selected analytic stability; it does not certify global structural faithfulness"
+                .to_string();
+    }
+    refresh_part4_status_summary(foundation);
 }
 
 fn build_atom_support_axis_readings(
@@ -15490,6 +15996,7 @@ fn build_llm_interpretation_packet(
     signature_trajectory_homotopy_refutation_readings:
         &[ArchSigSignatureTrajectoryHomotopyRefutationReadingV0],
     bridge_split_obstruction_transfer_readings: &[ArchSigBridgeSplitObstructionTransferReadingV0],
+    representation_metric_readings: &[ArchSigRepresentationMetricReadingV0],
     representation_strength_readings: &[ArchSigRepresentationStrengthReadingV0],
     local_curvature_diagram_readings: &[ArchSigLocalCurvatureDiagramReadingV0],
     three_layer_flatness_readings: &[ArchSigThreeLayerFlatnessReadingV0],
@@ -15588,6 +16095,20 @@ fn build_llm_interpretation_packet(
                     reading.high_overlap_molecule_pairs.len(),
                     reading.repair_axis_delta_readings.len(),
                     reading.status
+                )
+            })
+            .collect(),
+        representation_metric_summary: representation_metric_readings
+            .iter()
+            .map(|reading| {
+                format!(
+                    "{} analytic={} structural={} lipschitz={} faithfulness={} ({})",
+                    reading.representation_family,
+                    reading.analytic_distance.measured_value.unwrap_or_default(),
+                    reading.structural_distance.measured_value.unwrap_or_default(),
+                    reading.lipschitz_stability.status,
+                    reading.bi_lipschitz_faithfulness.status,
+                    reading.representation_metric_reading_id
                 )
             })
             .collect(),
@@ -16180,6 +16701,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_operation_distance_reading_surface(packet),
         check_obstruction_measure_reading_surface(packet),
         check_curvature_mass_reading_surface(packet),
+        check_representation_metric_reading_surface(packet),
         check_aat_structural_reading_surfaces(packet),
         check_current_state_evolution_boundary(packet),
         check_operation_square_trace_surface(packet),
@@ -16259,6 +16781,7 @@ pub fn validate_archsig_analysis_packet_report(
             .bridge_split_obstruction_transfer_readings
             .len(),
         representation_strength_reading_count: packet.representation_strength_readings.len(),
+        representation_metric_reading_count: packet.representation_metric_readings.len(),
         local_curvature_diagram_reading_count: packet.local_curvature_diagram_readings.len(),
         three_layer_flatness_reading_count: packet.three_layer_flatness_readings.len(),
         observation_projection_reading_count: packet.observation_projection_readings.len(),
@@ -23080,6 +23603,292 @@ fn check_curvature_distance_value(
     }
 }
 
+fn check_representation_metric_reading_surface(
+    packet: &ArchSigAnalysisPacketV0,
+) -> ValidationCheck {
+    let mut examples = Vec::new();
+    let metric_ids = packet
+        .representation_metric_readings
+        .iter()
+        .map(|reading| reading.representation_metric_reading_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let analytic_ids = set(packet
+        .analytic_representations
+        .iter()
+        .map(|reading| reading.representation_id.as_str()));
+    let spectral_ids = set(packet
+        .spectral_analysis_readings
+        .iter()
+        .map(|reading| reading.spectral_reading_id.as_str()));
+    let spectral_mode_ids = set(packet
+        .spectral_mode_readings
+        .iter()
+        .map(|reading| reading.spectral_mode_id.as_str()));
+    let drilldown_ids = set(packet
+        .spectral_drilldown_readings
+        .iter()
+        .map(|reading| reading.drilldown_id.as_str()));
+    let strength_ids = set(packet
+        .representation_strength_readings
+        .iter()
+        .map(|reading| reading.reading_id.as_str()));
+    if !packet.representation_strength_readings.is_empty()
+        && packet.representation_metric_readings.is_empty()
+    {
+        examples.push(generic_validation_example(
+            "representationMetricReadings",
+            "empty",
+            "representation strength readings must be backed by Part IV representation metric readings",
+        ));
+    }
+    for representation in &packet.analytic_representations {
+        if representation.part4_distance_refs.is_empty()
+            || representation
+                .part4_distance_refs
+                .iter()
+                .any(|reading_ref| !metric_ids.contains(reading_ref.as_str()))
+        {
+            examples.push(generic_validation_example(
+                &representation.representation_id,
+                "part4DistanceRefs",
+                "analytic representations must point to representation metric readings",
+            ));
+        }
+    }
+    for spectral in &packet.spectral_analysis_readings {
+        if spectral.part4_distance_refs.is_empty()
+            || spectral
+                .part4_distance_refs
+                .iter()
+                .any(|reading_ref| !metric_ids.contains(reading_ref.as_str()))
+        {
+            examples.push(generic_validation_example(
+                &spectral.spectral_reading_id,
+                "part4DistanceRefs",
+                "spectral readings must point to representation metric readings",
+            ));
+        }
+    }
+    for mode in &packet.spectral_mode_readings {
+        if mode.part4_distance_refs.is_empty()
+            || mode
+                .part4_distance_refs
+                .iter()
+                .any(|reading_ref| !metric_ids.contains(reading_ref.as_str()))
+        {
+            examples.push(generic_validation_example(
+                &mode.spectral_mode_id,
+                "part4DistanceRefs",
+                "spectral mode readings must point to representation metric readings",
+            ));
+        }
+    }
+    for drilldown in &packet.spectral_drilldown_readings {
+        if drilldown.part4_distance_refs.is_empty()
+            || drilldown
+                .part4_distance_refs
+                .iter()
+                .any(|reading_ref| !metric_ids.contains(reading_ref.as_str()))
+        {
+            examples.push(generic_validation_example(
+                &drilldown.drilldown_id,
+                "part4DistanceRefs",
+                "spectral drilldown readings must point to representation metric readings",
+            ));
+        }
+    }
+    for strength in &packet.representation_strength_readings {
+        if strength.part4_distance_refs.is_empty()
+            || strength
+                .part4_distance_refs
+                .iter()
+                .any(|reading_ref| !metric_ids.contains(reading_ref.as_str()))
+        {
+            examples.push(generic_validation_example(
+                &strength.reading_id,
+                "part4DistanceRefs",
+                "representation strength readings must point to representation metric readings",
+            ));
+        }
+    }
+
+    for reading in &packet.representation_metric_readings {
+        if reading.distance_profile_ref != packet.part4_distance_foundation.profile.profile_id
+            || reading.diagnostic_scope_ref
+                != packet.part4_distance_foundation.diagnostic_scope.scope_id
+        {
+            examples.push(generic_validation_example(
+                &reading.representation_metric_reading_id,
+                "profile/scope",
+                "representation metric reading must be tied to the selected Part IV DistanceProfile and DiagnosticScope",
+            ));
+        }
+        for reference in &reading.analytic_representation_refs {
+            if !analytic_ids.contains(reference.as_str()) {
+                examples.push(generic_validation_example(
+                    &reading.representation_metric_reading_id,
+                    reference,
+                    "representation metric analyticRepresentationRefs must resolve",
+                ));
+            }
+        }
+        for reference in &reading.spectral_reading_refs {
+            if !spectral_ids.contains(reference.as_str()) {
+                examples.push(generic_validation_example(
+                    &reading.representation_metric_reading_id,
+                    reference,
+                    "representation metric spectralReadingRefs must resolve",
+                ));
+            }
+        }
+        for reference in &reading.spectral_mode_refs {
+            if !spectral_mode_ids.contains(reference.as_str()) {
+                examples.push(generic_validation_example(
+                    &reading.representation_metric_reading_id,
+                    reference,
+                    "representation metric spectralModeRefs must resolve",
+                ));
+            }
+        }
+        for reference in &reading.spectral_drilldown_refs {
+            if !drilldown_ids.contains(reference.as_str()) {
+                examples.push(generic_validation_example(
+                    &reading.representation_metric_reading_id,
+                    reference,
+                    "representation metric spectralDrilldownRefs must resolve",
+                ));
+            }
+        }
+        for reference in &reading.representation_strength_refs {
+            if !strength_ids.contains(reference.as_str()) {
+                examples.push(generic_validation_example(
+                    &reading.representation_metric_reading_id,
+                    reference,
+                    "representation metric representationStrengthRefs must resolve",
+                ));
+            }
+        }
+        for (field, value, prefix) in [
+            (
+                "structuralDistance",
+                &reading.structural_distance,
+                "structuralDistance:",
+            ),
+            (
+                "analyticDistance",
+                &reading.analytic_distance,
+                "analyticDistance:",
+            ),
+            (
+                "lipschitzStability",
+                &reading.lipschitz_stability,
+                "lipschitz:",
+            ),
+            (
+                "biLipschitzFaithfulness",
+                &reading.bi_lipschitz_faithfulness,
+                "biLipschitz:",
+            ),
+        ] {
+            check_representation_metric_distance_value(
+                &mut examples,
+                &reading.representation_metric_reading_id,
+                field,
+                value,
+                prefix,
+            );
+        }
+        if reading.coverage_blocker_refs.is_empty()
+            && reading.witness_completeness_blocker_refs.is_empty()
+        {
+            examples.push(generic_validation_example(
+                &reading.representation_metric_reading_id,
+                "coverage/witness blockers",
+                "representation faithfulness must retain coverage and witness-completeness blockers instead of silently claiming lower-bound faithfulness",
+            ));
+        }
+        if !reading.bi_lipschitz_faithfulness.blocker_refs.is_empty()
+            && matches!(
+                reading.bi_lipschitz_faithfulness.status.as_str(),
+                "measured" | "zero"
+            )
+        {
+            examples.push(generic_validation_example(
+                &reading.representation_metric_reading_id,
+                "biLipschitzFaithfulness",
+                "bi-Lipschitz lower-bound faithfulness must not be measured while coverage or witness blockers remain",
+            ));
+        }
+        if !reading
+            .evidence_boundary
+            .contains("not structural faithfulness")
+        {
+            examples.push(generic_validation_example(
+                &reading.representation_metric_reading_id,
+                "evidenceBoundary",
+                "representation metric must state that analytic closeness is not structural faithfulness without coverage and witness completeness",
+            ));
+        }
+        if !reading
+            .analytic_distance
+            .reading
+            .contains("not an architecture quality score")
+        {
+            examples.push(generic_validation_example(
+                &reading.representation_metric_reading_id,
+                "analyticDistance.reading",
+                "analytic distance must be framed as a selected representation reading, not a quality score",
+            ));
+        }
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-representation-metric-readings",
+        "packet exposes Part IV representation metric, Lipschitz stability, and coverage-blocked faithfulness readings",
+        examples,
+        "fail",
+    )
+}
+
+fn check_representation_metric_distance_value(
+    examples: &mut Vec<ValidationExample>,
+    reading_id: &str,
+    field: &str,
+    value: &ArchSigDistanceValueV0,
+    required_basis_prefix: &str,
+) {
+    if matches!(value.status.as_str(), "measured" | "zero") {
+        if value.measured_value.is_none()
+            || value.provenance_refs.is_empty()
+            || value.evaluator_basis_refs.is_empty()
+            || value.coverage_refs.is_empty()
+        {
+            examples.push(generic_validation_example(
+                reading_id,
+                field,
+                "measured or zero Representation metric distance must retain value, provenance refs, evaluator basis refs, and coverage refs",
+            ));
+        }
+        if !value
+            .evaluator_basis_refs
+            .iter()
+            .any(|basis| basis.starts_with(required_basis_prefix))
+        {
+            examples.push(generic_validation_example(
+                reading_id,
+                required_basis_prefix,
+                "representation metric distance must be backed by representation-specific evaluator basis refs",
+            ));
+        }
+    } else if value.blocker_refs.is_empty() {
+        examples.push(generic_validation_example(
+            reading_id,
+            field,
+            "blocked or unmeasured Representation metric distance must retain blocker refs",
+        ));
+    }
+}
+
 fn check_atom_distance_value(
     examples: &mut Vec<ValidationExample>,
     reading_id: &str,
@@ -24845,6 +25654,60 @@ mod tests {
     }
 
     #[test]
+    fn representation_metric_negative_fixture_missing_part4_refs_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        packet.analytic_representations[0]
+            .part4_distance_refs
+            .clear();
+
+        let report = validate_archsig_analysis_packet_report(
+            &packet,
+            "negative-fixture-representation-metric-missing-ref.json",
+        );
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-representation-metric-readings"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example
+                        .target
+                        .as_deref()
+                        .is_some_and(|target| target == "part4DistanceRefs")
+                })
+        }));
+    }
+
+    #[test]
+    fn representation_metric_negative_fixture_faithfulness_measured_with_blockers_fails_validation()
+    {
+        let mut packet = static_archsig_analysis_packet();
+        let reading = packet
+            .representation_metric_readings
+            .first_mut()
+            .expect("static fixture has representation metric readings");
+        reading.bi_lipschitz_faithfulness.status = "measured".to_string();
+        reading.bi_lipschitz_faithfulness.measured_value = Some(1);
+
+        let report = validate_archsig_analysis_packet_report(
+            &packet,
+            "negative-fixture-representation-faithfulness-measured.json",
+        );
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-representation-metric-readings"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example
+                        .target
+                        .as_deref()
+                        .is_some_and(|target| target == "biLipschitzFaithfulness")
+                })
+        }));
+    }
+
+    #[test]
     fn obstruction_measure_negative_fixture_missing_witness_zero_fails_validation() {
         let mut packet = static_archsig_analysis_packet();
         let reading = packet
@@ -25227,7 +26090,11 @@ mod tests {
         packet
             .part4_distance_foundation
             .status_summary
-            .unmeasured_count -= 1;
+            .unmeasured_count = packet
+            .part4_distance_foundation
+            .status_summary
+            .unmeasured_count
+            .saturating_sub(1);
 
         let report = validate_archsig_analysis_packet_report(
             &packet,
@@ -25263,7 +26130,11 @@ mod tests {
         packet
             .part4_distance_foundation
             .status_summary
-            .unmeasured_count -= 1;
+            .unmeasured_count = packet
+            .part4_distance_foundation
+            .status_summary
+            .unmeasured_count
+            .saturating_sub(1);
 
         let report = validate_archsig_analysis_packet_report(
             &packet,
@@ -25334,7 +26205,11 @@ mod tests {
         packet
             .part4_distance_foundation
             .status_summary
-            .unmeasured_count -= 1;
+            .unmeasured_count = packet
+            .part4_distance_foundation
+            .status_summary
+            .unmeasured_count
+            .saturating_sub(1);
 
         let report = validate_archsig_analysis_packet_report(
             &packet,

--- a/tools/archsig/src/schema.rs
+++ b/tools/archsig/src/schema.rs
@@ -1082,6 +1082,8 @@ pub struct ArchSigAnalysisPacketV0 {
     pub monodromy_reading_family: ArchSigMonodromyReadingFamilyV0,
     pub boundary_holonomy_reading_family: ArchSigBoundaryHolonomyReadingFamilyV0,
     pub representation_strength_readings: Vec<ArchSigRepresentationStrengthReadingV0>,
+    #[serde(default)]
+    pub representation_metric_readings: Vec<ArchSigRepresentationMetricReadingV0>,
     pub local_curvature_diagram_readings: Vec<ArchSigLocalCurvatureDiagramReadingV0>,
     pub three_layer_flatness_readings: Vec<ArchSigThreeLayerFlatnessReadingV0>,
     pub observation_projection_readings: Vec<ArchSigObservationProjectionReadingV0>,
@@ -1943,6 +1945,8 @@ pub struct ArchSigAnalyticRepresentationV0 {
     pub reading: String,
     pub coverage_boundary: String,
     pub zero_reflecting_boundary: String,
+    #[serde(default)]
+    pub part4_distance_refs: Vec<String>,
     pub non_conclusions: Vec<String>,
 }
 
@@ -1998,6 +2002,8 @@ pub struct ArchSigSpectralAnalysisReadingV0 {
     pub coverage_boundary: String,
     pub zero_reflecting_boundary: String,
     pub recommended_next_action: String,
+    #[serde(default)]
+    pub part4_distance_refs: Vec<String>,
     pub non_conclusions: Vec<String>,
 }
 
@@ -2398,6 +2404,8 @@ pub struct ArchSigSpectralModeReadingV0 {
     pub repair_perturbation_reading: String,
     pub evidence_boundary: String,
     pub recommended_next_action: String,
+    #[serde(default)]
+    pub part4_distance_refs: Vec<String>,
     pub non_conclusions: Vec<String>,
 }
 
@@ -2423,6 +2431,8 @@ pub struct ArchSigSpectralDrilldownReadingV0 {
     pub reading: String,
     pub evidence_boundary: String,
     pub recommended_next_action: String,
+    #[serde(default)]
+    pub part4_distance_refs: Vec<String>,
     pub non_conclusions: Vec<String>,
 }
 
@@ -3287,6 +3297,33 @@ pub struct ArchSigRepresentationStrengthReadingV0 {
     pub blocked_reflection_or_preservation_reasons: Vec<String>,
     pub reading: String,
     pub evidence_boundary: String,
+    #[serde(default)]
+    pub part4_distance_refs: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigRepresentationMetricReadingV0 {
+    pub representation_metric_reading_id: String,
+    pub representation_ref: String,
+    pub representation_family: String,
+    pub source_reading_refs: Vec<String>,
+    pub distance_profile_ref: String,
+    pub diagnostic_scope_ref: String,
+    pub structural_distance: ArchSigDistanceValueV0,
+    pub analytic_distance: ArchSigDistanceValueV0,
+    pub lipschitz_stability: ArchSigDistanceValueV0,
+    pub bi_lipschitz_faithfulness: ArchSigDistanceValueV0,
+    pub coverage_blocker_refs: Vec<String>,
+    pub witness_completeness_blocker_refs: Vec<String>,
+    pub analytic_representation_refs: Vec<String>,
+    pub spectral_reading_refs: Vec<String>,
+    pub spectral_mode_refs: Vec<String>,
+    pub spectral_drilldown_refs: Vec<String>,
+    pub representation_strength_refs: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub evidence_boundary: String,
     pub non_conclusions: Vec<String>,
 }
 
@@ -3661,6 +3698,8 @@ pub struct ArchSigLlmInterpretationPacketV0 {
     pub spectral_mode_summary: Vec<String>,
     pub spectral_drilldown_summary: Vec<String>,
     #[serde(default)]
+    pub representation_metric_summary: Vec<String>,
+    #[serde(default)]
     pub curvature_support_summary: Vec<String>,
     #[serde(default)]
     pub curvature_transfer_summary: Vec<String>,
@@ -3803,6 +3842,8 @@ pub struct ArchSigAnalysisPacketValidationSummaryV0 {
     pub homotopy_distance_reading_count: usize,
     pub bridge_split_obstruction_transfer_reading_count: usize,
     pub representation_strength_reading_count: usize,
+    #[serde(default)]
+    pub representation_metric_reading_count: usize,
     pub local_curvature_diagram_reading_count: usize,
     pub three_layer_flatness_reading_count: usize,
     pub observation_projection_reading_count: usize,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2145,6 +2145,36 @@ fn acts_spectrum_fixture_manifest_locks_golden_validation() {
                     "coverage gap must remain explicit in ArchitectureSpectrumReport"
                 );
             }
+            "representation-metric-faithfulness-boundary" => {
+                let minimum = case["minimumRepresentationMetricReadings"]
+                    .as_u64()
+                    .expect("minimum representation metric readings is present");
+                let readings = packet["representationMetricReadings"]
+                    .as_array()
+                    .expect("representation metric readings are array");
+                assert!(
+                    readings.len() as u64 >= minimum
+                        && readings.iter().all(|reading| {
+                            reading["biLipschitzFaithfulness"]["status"] == "blocked"
+                                && reading["biLipschitzFaithfulness"]["blockerRefs"]
+                                    .as_array()
+                                    .is_some_and(|items| !items.is_empty())
+                                && reading["analyticDistance"]["reading"].as_str().is_some_and(
+                                    |text| text.contains("not an architecture quality score"),
+                                )
+                        }),
+                    "representation metric readings must keep faithfulness lower bounds blocked by coverage / witness completeness"
+                );
+                assert!(
+                    validation["summary"]["representationMetricReadingCount"]
+                        .as_u64()
+                        .is_some_and(|count| count >= minimum)
+                        && packet["llmInterpretationPacket"]["representationMetricSummary"]
+                            .as_array()
+                            .is_some_and(|items| !items.is_empty()),
+                    "ACTS validation and LLM summary must expose representation metric readings"
+                );
+            }
             "coupon-tax-rounding-acts" => {
                 let required_text = case["requiredText"]
                     .as_str()
@@ -3376,12 +3406,16 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                 let homotopy_filling_is_evaluator_backed = entry["distanceFamily"]
                     == "homotopyFillingGeometry"
                     && entry["value"]["status"] != "unmeasured";
+                let representation_metric_is_evaluator_backed = entry["distanceFamily"]
+                    == "representationMetric"
+                    && entry["value"]["status"] != "unmeasured";
                 if entry["distanceFamily"] == "atomGeometry"
                     || entry["distanceFamily"] == "configurationGeometry"
                     || entry["distanceFamily"] == "signatureGeometry"
                     || entry["distanceFamily"] == "operationGeometry"
                     || curvature_geometry_is_evaluator_backed
                     || homotopy_filling_is_evaluator_backed
+                    || representation_metric_is_evaluator_backed
                 {
                     (entry["value"]["status"] == "measured"
                         || entry["value"]["status"] == "zero"
@@ -3403,12 +3437,12 @@ fn assert_north_star_packet_surfaces(json: &Value) {
             })
             && part4_distance["statusSummary"]["blockedCount"]
                 .as_u64()
-                .is_some_and(|count| count >= 4)
+                .is_some_and(|count| count >= 7)
             && part4_distance["statusSummary"]["unmeasuredCount"]
                 .as_u64()
-                .is_some_and(|count| count >= 1)
+                .is_some_and(|count| count == 0)
             && part4_distance["statusSummary"]["schemaFoundationOnlyCount"] == 0,
-        "Part IV foundation must route atom/configuration/signature/operation/curvature geometry through evaluator readings while preserving semantic/gap blockers and keeping remaining evaluators unmeasured"
+        "Part IV foundation must route atom/configuration/signature/operation/curvature/homotopy/representation geometry through evaluator readings while preserving semantic/gap blockers"
     );
     let atom_distance_readings = json["atomDistanceReadings"]
         .as_array()
@@ -4074,6 +4108,7 @@ fn assert_north_star_packet_surfaces(json: &Value) {
         "operationPreconditionReadinessReadings",
         "pathMultiplicityLossReadings",
         "representationStrengthReadings",
+        "representationMetricReadings",
         "localCurvatureDiagramReadings",
         "threeLayerFlatnessReadings",
         "observationProjectionReadings",
@@ -4438,9 +4473,44 @@ fn assert_north_star_packet_surfaces(json: &Value) {
                     && reading["requiredAssumptions"]
                         .as_array()
                         .is_some_and(|items| !items.is_empty())
+                    && reading["part4DistanceRefs"]
+                        .as_array()
+                        .is_some_and(|items| !items.is_empty())
                     && reading["evidenceBoundary"].as_str().is_some()
             }),
         "representation strength readings must carry strength classes and assumptions"
+    );
+    assert!(
+        json["representationMetricReadings"]
+            .as_array()
+            .expect("representation metric readings are array")
+            .iter()
+            .all(|reading| {
+                reading["representationMetricReadingId"].as_str().is_some()
+                    && reading["representationRef"].as_str().is_some()
+                    && reading["representationFamily"].as_str().is_some()
+                    && reading["structuralDistance"]["evaluatorBasisRefs"]
+                        .as_array()
+                        .is_some_and(|items| !items.is_empty())
+                    && reading["analyticDistance"]["reading"]
+                        .as_str()
+                        .is_some_and(|text| text.contains("not an architecture quality score"))
+                    && reading["lipschitzStability"]["evaluatorBasisRefs"]
+                        .as_array()
+                        .is_some()
+                    && reading["biLipschitzFaithfulness"]["status"] == "blocked"
+                    && reading["biLipschitzFaithfulness"]["blockerRefs"]
+                        .as_array()
+                        .is_some_and(|items| !items.is_empty())
+                    && reading["coverageBlockerRefs"].as_array().is_some()
+                    && reading["witnessCompletenessBlockerRefs"]
+                        .as_array()
+                        .is_some_and(|items| !items.is_empty())
+                    && reading["evidenceBoundary"]
+                        .as_str()
+                        .is_some_and(|text| text.contains("not structural faithfulness"))
+            }),
+        "representation metric readings must expose selected structural/analytic distance, Lipschitz stability, and blocked faithfulness lower bounds"
     );
     assert!(
         json["threeLayerFlatnessReadings"]

--- a/tools/archsig/tests/fixtures/acts_spectrum/manifest.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/manifest.json
@@ -41,6 +41,16 @@
       "requiredText": "runtime trace was requested but not supplied"
     },
     {
+      "caseId": "representation-metric-faithfulness-boundary",
+      "description": "Minimal fixture exposes Part IV representation metric readings and keeps bi-Lipschitz faithfulness blocked by coverage / witness completeness.",
+      "packetPath": "minimal/archsig_analysis_packet.json",
+      "validationPath": "acts_spectrum/minimal_validation.json",
+      "expectedSurface": "representationMetricReadings",
+      "minimumRepresentationMetricReadings": 1,
+      "requiresFaithfulnessBlockers": true,
+      "requiresSelectedMetricSummary": true
+    },
+    {
       "caseId": "coupon-tax-rounding-acts",
       "description": "Coupon/tax/rounding fixture exposes ACTS report and keeps payment trace coverage as a gap.",
       "packetPath": "coupon_rounding/archsig_analysis_packet.json",

--- a/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
+++ b/tools/archsig/tests/fixtures/acts_spectrum/minimal_validation.json
@@ -17,6 +17,13 @@
     "generatedObstructionCount": 1,
     "generatedRepairTargetCount": 1,
     "viewerDistanceInputCount": 10,
+    "part4SupportingDistanceCount": 7,
+    "atomDistanceReadingCount": 10,
+    "configurationDistanceReadingCount": 10,
+    "signatureDistanceReadingCount": 1,
+    "operationDistanceReadingCount": 1,
+    "obstructionMeasureReadingCount": 4,
+    "curvatureMassReadingCount": 1,
     "obstructionCircuitCount": 1,
     "signatureAxisCount": 2,
     "analyticRepresentationCount": 10,
@@ -43,8 +50,10 @@
     "operationPreconditionReadinessReadingCount": 1,
     "pathMultiplicityLossReadingCount": 1,
     "signatureTrajectoryHomotopyRefutationReadingCount": 1,
+    "homotopyDistanceReadingCount": 3,
     "bridgeSplitObstructionTransferReadingCount": 1,
     "representationStrengthReadingCount": 14,
+    "representationMetricReadingCount": 14,
     "localCurvatureDiagramReadingCount": 1,
     "threeLayerFlatnessReadingCount": 1,
     "observationProjectionReadingCount": 1,
@@ -94,6 +103,12 @@
     {
       "id": "archsig-analysis-packet-homotopy-holonomy-stokes-surface",
       "title": "packet reports selected-axis homotopy holonomy and bounded Stokes-style review queues",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-homotopy-distance-readings",
+      "title": "packet exposes Part IV homotopy distance, filling cost, observation-gap lower bound, and selected Dehn-style area without treating missing fillers as zero",
       "result": "pass",
       "count": 0
     },
@@ -160,6 +175,54 @@
     {
       "id": "archsig-analysis-packet-generated-middle-layer",
       "title": "packet materializes generated AtomShape, molecule, law input, obstruction, repair target, and viewer distance inputs",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-part4-distance-foundation",
+      "title": "packet exposes Part IV DistanceValue, DistanceProfile, DiagnosticScope, and anti-proxy distance provenance",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-atom-distance-readings",
+      "title": "packet exposes proxy-free Part IV Atom distance evaluator readings separated from viewer layout distance",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-configuration-distance-readings",
+      "title": "packet exposes proxy-free Part IV configuration hypergraph distance readings with shortest-path, context, and gap blockers",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-signature-distance-readings",
+      "title": "packet exposes proxy-free Part IV signature distance readings with rho_i, safe-region margin, drift, and coverage blockers",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-operation-distance-readings",
+      "title": "packet exposes proxy-free Part IV operation cost, repair distance, protected-axis movement, and side-effect blockers",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-obstruction-measure-readings",
+      "title": "packet exposes witness-backed Part IV obstruction measure rows and preserves missing witnesses as blockers",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-curvature-mass-readings",
+      "title": "packet exposes Part IV curvature mass and curvature transport distances without promoting unmeasured witnesses to zero",
+      "result": "pass",
+      "count": 0
+    },
+    {
+      "id": "archsig-analysis-packet-representation-metric-readings",
+      "title": "packet exposes Part IV representation metric, Lipschitz stability, and coverage-blocked faithfulness readings",
       "result": "pass",
       "count": 0
     },

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -1600,25 +1600,54 @@
         "sourceRef": "ArchMap",
         "targetRef": "Part4DistanceEngine",
         "value": {
-          "status": "unmeasured",
-          "unit": "selected-distance-unit",
+          "status": "blocked",
+          "unit": "selected-representation-faithfulness",
           "provenanceRefs": [
-            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md",
-            "docs/aat/AAT_Distance_Extension_Design.md"
+            "representation-metric:representation-strength-analytic-weighted-adjacency",
+            "representation-metric:representation-strength-analytic-reachable-cone-size",
+            "representation-metric:representation-strength-analytic-walk-count",
+            "representation-metric:representation-strength-analytic-nilpotence-boundary",
+            "representation-metric:representation-strength-analytic-selected-subgraph-spectrum",
+            "representation-metric:representation-strength-analytic-propagation-depth",
+            "representation-metric:representation-strength-analytic-spectral-radius",
+            "representation-metric:representation-strength-analytic-curvature-valuation",
+            "representation-metric:representation-strength-analytic-state-algebra-boundary",
+            "representation-metric:representation-strength-analytic-zero-reflecting-aggregate-boundary",
+            "representation-metric:representation-strength-spectral-relation-atom-adjacency",
+            "representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling",
+            "representation-metric:representation-strength-spectral-obstruction-axis-curvature",
+            "representation-metric:representation-strength-spectral-operation-signature-delta"
           ],
-          "evaluatorBasisRefs": [],
+          "evaluatorBasisRefs": [
+            "representationMetric:weightedAdjacencyMatrix",
+            "representationMetric:reachableConeSize",
+            "representationMetric:walkCount",
+            "representationMetric:nilpotenceBoundary",
+            "representationMetric:selectedSubgraphSpectrum",
+            "representationMetric:propagationDepth",
+            "representationMetric:spectralRadius",
+            "representationMetric:curvatureValuation",
+            "representationMetric:stateAlgebra",
+            "representationMetric:zeroReflectingAggregateBoundary",
+            "representationMetric:relationAtomWeightedAdjacencyMatrix",
+            "representationMetric:moleculeAtomOverlapCouplingMatrix",
+            "representationMetric:obstructionAxisCurvatureMatrix",
+            "representationMetric:operationSignatureDeltaMatrix"
+          ],
           "coverageRefs": [
             "coverage:layer-atoms",
             "coverage:semantic-contract-atoms"
           ],
           "blockerRefs": [
-            "issue:#1711 representation metric evaluator"
+            "coverage-completeness:selected-representation-not-global",
+            "gap-runtime-user-db-trace",
+            "witness-completeness:selected-LawPolicy-not-certified"
           ],
-          "reading": "distance family is represented in the Part4 contract but has not been measured by its evaluator yet"
+          "reading": "representationMetric supporting distance is blocked for faithfulness until coverage and witness completeness are supplied"
         },
         "profileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
         "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
-        "evidenceBoundary": "unmeasured means no evaluator result has been supplied; it must not be aggregated as zero",
+        "evidenceBoundary": "representationMetric reads selected analytic stability; it does not certify global structural faithfulness",
         "nonConclusions": [
           "ArchSig analysis packet is not a Lean theorem proof",
           "ArchSig analysis packet is not global architecture truth",
@@ -1633,11 +1662,11 @@
     "statusSummary": {
       "measuredCount": 0,
       "zeroCount": 0,
-      "unmeasuredCount": 1,
+      "unmeasuredCount": 0,
       "unavailableCount": 0,
       "incomparableCount": 0,
       "infiniteCount": 0,
-      "blockedCount": 6,
+      "blockedCount": 7,
       "schemaFoundationOnlyCount": 0
     },
     "measurementBoundary": "Part4 distance foundation is a proxy-free measurement contract: no distance is measured until an evaluator supplies provenance, basis refs, and coverage refs",
@@ -6664,6 +6693,9 @@
       "reading": "selected relation atoms induce a bounded weighted adjacency representation with traceable sparse matrix entries",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-weighted-adjacency"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6722,6 +6754,9 @@
       "reading": "reachable cone is computed by finite graph traversal over selected relation atoms",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-reachable-cone-size"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6780,6 +6815,9 @@
       "reading": "walk count enumerates selected relation-graph walks up to length 3",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-walk-count"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6836,6 +6874,9 @@
       "reading": "nilpotence is read from cycle detection in the selected finite relation graph, not folded into Decomposable or global acyclicity",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-nilpotence-boundary"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6894,6 +6935,9 @@
       "reading": "selected subgraph spectrum is estimated from power iteration over the finite nonnegative adjacency matrix",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-selected-subgraph-spectrum"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -6952,6 +6996,9 @@
       "reading": "propagation depth is computed over observed relation atoms only",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-propagation-depth"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7010,6 +7057,9 @@
       "reading": "spectral radius is estimated from the selected finite nonnegative adjacency matrix under bounded iteration",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-spectral-radius"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7040,6 +7090,9 @@
       "reading": "curvature valuation counts constructed obstruction circuits under the selected profile",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-curvature-valuation"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7074,6 +7127,9 @@
       "reading": "state algebra is preserved as a first-class analytic boundary even when state evidence is unavailable",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-state-algebra-boundary"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7104,6 +7160,9 @@
       "reading": "zero-reflecting aggregate boundary says when zero axes may and may not be read as absence",
       "coverageBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
       "zeroReflectingBoundary": "zero reflects only the selected representation when coverage and exactness assumptions hold",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-zero-reflecting-aggregate-boundary"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7276,6 +7335,9 @@
       "coverageBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
       "zeroReflectingBoundary": "zero entries mean no selected relation atom endpoint under the current ArchMap, not proof of independence",
       "recommendedNextAction": "inspect dominant source/target nodes, cycle readings, and coverage gaps before selecting repair operations",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-relation-atom-adjacency"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7331,6 +7393,9 @@
       "coverageBoundary": "missing atom families and observation gaps can make overlap coupling appear smaller than the source architecture actually is",
       "zeroReflectingBoundary": "zero off-diagonal overlap means no shared observed atom/family evidence, not guaranteed independence",
       "recommendedNextAction": "inspect the dominant molecule and any high-overlap neighbors before splitting or moving responsibilities",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7397,6 +7462,9 @@
       "coverageBoundary": "only constructed obstruction circuits are represented; concern hints that lack witness rules remain outside this matrix",
       "zeroReflectingBoundary": "zero incidence means no constructed obstruction-to-axis edge, not proof of zero curvature",
       "recommendedNextAction": "review the dominant obstruction row and repeated axis column before treating a signature axis as local",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-obstruction-axis-curvature"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7463,6 +7531,9 @@
       "coverageBoundary": "candidate operations are bounded review artifacts; absent delta entries are not proof that an operation preserves an axis",
       "zeroReflectingBoundary": "zero delta incidence means no declared or text-mentioned axis movement under current candidates, not repair safety",
       "recommendedNextAction": "review the dominant operation row and repeated axis column before converting a repair candidate into code changes",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-operation-signature-delta"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7516,6 +7587,9 @@
       "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
       "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
       "recommendedNextAction": "review dominant components and evidence boundaries before drawing architectural conclusions",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-relation-atom-adjacency"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7560,6 +7634,9 @@
       "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
       "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
       "recommendedNextAction": "map shared atom families across the dense molecule cluster before splitting boundaries",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7611,6 +7688,9 @@
       "repairPerturbationReading": "not an operation transition matrix; use this mode to choose review focus before evaluating repair perturbations",
       "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
       "recommendedNextAction": "review whether repeated obstruction-axis curvature is local, transferred, or a law-policy coverage gap",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-obstruction-axis-curvature"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7662,6 +7742,9 @@
       "repairPerturbationReading": "candidate operations have a dominant perturbation mode; review the leading operation before broad refactoring",
       "evidenceBoundary": "spectral mode is a bounded proxy computed from ArchSig finite representation summaries, not an exact eigenvector theorem",
       "recommendedNextAction": "compare the perturbation mode against candidate repair preconditions before changing code",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-operation-signature-delta"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -7757,6 +7840,12 @@
       "reading": "spectral drilldown explains dominant modes with atom-family composition, molecule overlap pairs, and repair axis deltas",
       "evidenceBoundary": "drilldown is derived from ArchMap atom/molecule observations and ArchSig spectral summaries; it is not exact eigendecomposition or repair correctness",
       "recommendedNextAction": "review dominant atom families, high-overlap molecule pairs, and positive/negative repair delta axes before changing boundaries",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-relation-atom-adjacency",
+        "representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling",
+        "representation-metric:representation-strength-spectral-obstruction-axis-curvature",
+        "representation-metric:representation-strength-spectral-operation-signature-delta"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14250,6 +14339,9 @@
       ],
       "reading": "weightedAdjacencyMatrix is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-weighted-adjacency"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14283,6 +14375,9 @@
       ],
       "reading": "reachableConeSize is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-reachable-cone-size"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14316,6 +14411,9 @@
       ],
       "reading": "walkCount is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-walk-count"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14349,6 +14447,9 @@
       ],
       "reading": "nilpotenceBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-nilpotence-boundary"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14382,6 +14483,9 @@
       ],
       "reading": "selectedSubgraphSpectrum is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-selected-subgraph-spectrum"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14415,6 +14519,9 @@
       ],
       "reading": "propagationDepth is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-propagation-depth"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14448,6 +14555,9 @@
       ],
       "reading": "spectralRadius is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-spectral-radius"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14481,6 +14591,9 @@
       ],
       "reading": "curvatureValuation is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-curvature-valuation"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14514,6 +14627,9 @@
       ],
       "reading": "stateAlgebra is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-state-algebra-boundary"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14547,6 +14663,9 @@
       ],
       "reading": "zeroReflectingAggregateBoundary is a bounded analytic representation; use its zero/obstruction readings only with the recorded strength boundary",
       "evidenceBoundary": "analytic value is relative to selected graph / matrix representation and is not a quality score",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-analytic-zero-reflecting-aggregate-boundary"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14580,6 +14699,9 @@
       ],
       "reading": "relationAtomWeightedAdjacencyMatrix is a finite selected relation-graph matrix reading; it preserves observed relation edges but does not reflect global architecture truth",
       "evidenceBoundary": "observation gaps block measured-zero interpretation for absent relation edges",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-relation-atom-adjacency"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14613,6 +14735,9 @@
       ],
       "reading": "moleculeAtomOverlapCouplingMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
       "evidenceBoundary": "missing atom families and observation gaps can make overlap coupling appear smaller than the source architecture actually is",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14646,6 +14771,9 @@
       ],
       "reading": "obstructionAxisCurvatureMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
       "evidenceBoundary": "only constructed obstruction circuits are represented; concern hints that lack witness rules remain outside this matrix",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-obstruction-axis-curvature"
+      ],
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -14679,6 +14807,1823 @@
       ],
       "reading": "operationSignatureDeltaMatrix is a spectral proxy for review; it preserves selected pressure but does not reflect global architecture truth",
       "evidenceBoundary": "candidate operations are bounded review artifacts; absent delta entries are not proof that an operation preserves an axis",
+      "part4DistanceRefs": [
+        "representation-metric:representation-strength-spectral-operation-signature-delta"
+      ],
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
+  "representationMetricReadings": [
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-weighted-adjacency",
+      "representationRef": "analytic:weighted-adjacency",
+      "representationFamily": "weightedAdjacencyMatrix",
+      "sourceReadingRefs": [
+        "analytic:weighted-adjacency"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 4,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:relation:route-service",
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:weightedAdjacencyMatrix",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-weighted-adjacency"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:weighted-adjacency"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:weighted-adjacency:matrixEntries=1",
+          "analyticDistance:representationFamily:weightedAdjacencyMatrix"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:weighted-adjacency"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=1",
+          "lipschitz:structuralDistance=4",
+          "lipschitz:selectedRepresentation:weightedAdjacencyMatrix"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:weighted-adjacency"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:weightedAdjacencyMatrix",
+          "biLipschitz:analyticDistance:weightedAdjacencyMatrix",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:weighted-adjacency"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-weighted-adjacency"
+      ],
+      "evidenceRefs": [
+        "atom:relation:route-service",
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-reachable-cone-size",
+      "representationRef": "analytic:reachable-cone-size",
+      "representationFamily": "reachableConeSize",
+      "sourceReadingRefs": [
+        "analytic:reachable-cone-size"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 4,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:relation:route-service",
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:reachableConeSize",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-reachable-cone-size"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:reachable-cone-size"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:reachable-cone-size:nat=1",
+          "analyticDistance:representationFamily:reachableConeSize"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:reachable-cone-size"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=1",
+          "lipschitz:structuralDistance=4",
+          "lipschitz:selectedRepresentation:reachableConeSize"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:reachable-cone-size"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:reachableConeSize",
+          "biLipschitz:analyticDistance:reachableConeSize",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:reachable-cone-size"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-reachable-cone-size"
+      ],
+      "evidenceRefs": [
+        "atom:relation:route-service",
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-walk-count",
+      "representationRef": "analytic:walk-count",
+      "representationFamily": "walkCount",
+      "sourceReadingRefs": [
+        "analytic:walk-count"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 4,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:relation:route-service",
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:walkCount",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-walk-count"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:walk-count"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:walk-count:nat=1",
+          "analyticDistance:representationFamily:walkCount"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:walk-count"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=1",
+          "lipschitz:structuralDistance=4",
+          "lipschitz:selectedRepresentation:walkCount"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:walk-count"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:walkCount",
+          "biLipschitz:analyticDistance:walkCount",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:walk-count"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-walk-count"
+      ],
+      "evidenceRefs": [
+        "atom:relation:route-service",
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-nilpotence-boundary",
+      "representationRef": "analytic:nilpotence-boundary",
+      "representationFamily": "nilpotenceBoundary",
+      "sourceReadingRefs": [
+        "analytic:nilpotence-boundary"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 3,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:nilpotenceBoundary",
+          "structuralDistance:representationStrength:representation-strength:analytic-nilpotence-boundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "blocked",
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:nilpotence-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:nilpotence-boundary:blockedBoundaryStatus=blockedByCoverageGap",
+          "analyticDistance:representationFamily:nilpotenceBoundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "selected analytic distance is blocked when the representation value is boundary-only or unavailable; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "blocked",
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:nilpotence-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:selectedRepresentation:nilpotenceBoundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "Lipschitz upper-bound reading is blocked because analytic distance is unavailable"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:nilpotence-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:nilpotenceBoundary",
+          "biLipschitz:analyticDistance:nilpotenceBoundary",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:nilpotence-boundary"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-nilpotence-boundary"
+      ],
+      "evidenceRefs": [
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-selected-subgraph-spectrum",
+      "representationRef": "analytic:selected-subgraph-spectrum",
+      "representationFamily": "selectedSubgraphSpectrum",
+      "sourceReadingRefs": [
+        "analytic:selected-subgraph-spectrum"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 4,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:relation:route-service",
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:selectedSubgraphSpectrum",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-selected-subgraph-spectrum"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "zero",
+        "measuredValue": 0,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:selected-subgraph-spectrum"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:selected-subgraph-spectrum:vector=[0.000]",
+          "analyticDistance:representationFamily:selectedSubgraphSpectrum"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:selected-subgraph-spectrum"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=0",
+          "lipschitz:structuralDistance=4",
+          "lipschitz:selectedRepresentation:selectedSubgraphSpectrum"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:selected-subgraph-spectrum"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:selectedSubgraphSpectrum",
+          "biLipschitz:analyticDistance:selectedSubgraphSpectrum",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:selected-subgraph-spectrum"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-selected-subgraph-spectrum"
+      ],
+      "evidenceRefs": [
+        "atom:relation:route-service",
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-propagation-depth",
+      "representationRef": "analytic:propagation-depth",
+      "representationFamily": "propagationDepth",
+      "sourceReadingRefs": [
+        "analytic:propagation-depth"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 4,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:relation:route-service",
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:propagationDepth",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-propagation-depth"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:propagation-depth"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:propagation-depth:nat=1",
+          "analyticDistance:representationFamily:propagationDepth"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:propagation-depth"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=1",
+          "lipschitz:structuralDistance=4",
+          "lipschitz:selectedRepresentation:propagationDepth"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:propagation-depth"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:propagationDepth",
+          "biLipschitz:analyticDistance:propagationDepth",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:propagation-depth"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-propagation-depth"
+      ],
+      "evidenceRefs": [
+        "atom:relation:route-service",
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-spectral-radius",
+      "representationRef": "analytic:spectral-radius",
+      "representationFamily": "spectralRadius",
+      "sourceReadingRefs": [
+        "analytic:spectral-radius"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 4,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:relation:route-service",
+          "walk:route-users:1:service-user"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:spectralRadius",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-spectral-radius"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "zero",
+        "measuredValue": 0,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:spectral-radius"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:spectral-radius:float=0.000",
+          "analyticDistance:representationFamily:spectralRadius"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:spectral-radius"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=0",
+          "lipschitz:structuralDistance=4",
+          "lipschitz:selectedRepresentation:spectralRadius"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:spectral-radius"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:spectralRadius",
+          "biLipschitz:analyticDistance:spectralRadius",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:spectral-radius"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-spectral-radius"
+      ],
+      "evidenceRefs": [
+        "atom:relation:route-service",
+        "walk:route-users:1:service-user"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-curvature-valuation",
+      "representationRef": "analytic:curvature-valuation",
+      "representationFamily": "curvatureValuation",
+      "sourceReadingRefs": [
+        "analytic:curvature-valuation"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 3,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:curvatureValuation",
+          "structuralDistance:graphScope:obstruction:semantic-contract-mismatch:computed",
+          "structuralDistance:representationStrength:representation-strength:analytic-curvature-valuation"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:curvature-valuation"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:curvature-valuation:nat=1",
+          "analyticDistance:representationFamily:curvatureValuation"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:curvature-valuation"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=1",
+          "lipschitz:structuralDistance=3",
+          "lipschitz:selectedRepresentation:curvatureValuation"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:curvature-valuation"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:curvatureValuation",
+          "biLipschitz:analyticDistance:curvatureValuation",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:curvature-valuation"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-curvature-valuation"
+      ],
+      "evidenceRefs": [
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-state-algebra-boundary",
+      "representationRef": "analytic:state-algebra-boundary",
+      "representationFamily": "stateAlgebra",
+      "sourceReadingRefs": [
+        "analytic:state-algebra-boundary"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 7,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:capability:create-user",
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:stateAlgebra",
+          "structuralDistance:graphScope:atom:capability:create-user",
+          "structuralDistance:graphScope:atom:component:route-users",
+          "structuralDistance:graphScope:atom:component:service-user",
+          "structuralDistance:graphScope:atom:contract:create-user",
+          "structuralDistance:graphScope:atom:relation:route-service",
+          "structuralDistance:representationStrength:representation-strength:analytic-state-algebra-boundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "blocked",
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:state-algebra-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:state-algebra-boundary:blockedBoundaryStatus=state/effect algebra requires explicit state transition and runtime/effect atoms",
+          "analyticDistance:representationFamily:stateAlgebra"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "selected analytic distance is blocked when the representation value is boundary-only or unavailable; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "blocked",
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:state-algebra-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:selectedRepresentation:stateAlgebra"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "Lipschitz upper-bound reading is blocked because analytic distance is unavailable"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:state-algebra-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:stateAlgebra",
+          "biLipschitz:analyticDistance:stateAlgebra",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:state-algebra-boundary"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-state-algebra-boundary"
+      ],
+      "evidenceRefs": [
+        "atom:capability:create-user",
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:contract:create-user",
+        "atom:relation:route-service"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-analytic-zero-reflecting-aggregate-boundary",
+      "representationRef": "analytic:zero-reflecting-aggregate-boundary",
+      "representationFamily": "zeroReflectingAggregateBoundary",
+      "sourceReadingRefs": [
+        "analytic:zero-reflecting-aggregate-boundary"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 3,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "gap-runtime-user-db-trace"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:axis:sig-axis:layer-violation",
+          "structuralDistance:axis:sig-axis:semantic-inconsistency",
+          "structuralDistance:family:zeroReflectingAggregateBoundary",
+          "structuralDistance:graphScope:gap-runtime-user-db-trace",
+          "structuralDistance:representationStrength:representation-strength:analytic-zero-reflecting-aggregate-boundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "blocked",
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "analytic:zero-reflecting-aggregate-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:analytic:zero-reflecting-aggregate-boundary:blockedBoundaryStatus=blockedByObservationGaps",
+          "analyticDistance:representationFamily:zeroReflectingAggregateBoundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "selected analytic distance is blocked when the representation value is boundary-only or unavailable; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "blocked",
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "analytic:zero-reflecting-aggregate-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:selectedRepresentation:zeroReflectingAggregateBoundary"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "Lipschitz upper-bound reading is blocked because analytic distance is unavailable"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "analytic:zero-reflecting-aggregate-boundary"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:zeroReflectingAggregateBoundary",
+          "biLipschitz:analyticDistance:zeroReflectingAggregateBoundary",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [
+        "analytic:zero-reflecting-aggregate-boundary"
+      ],
+      "spectralReadingRefs": [],
+      "spectralModeRefs": [],
+      "spectralDrilldownRefs": [],
+      "representationStrengthRefs": [
+        "representation-strength:analytic-zero-reflecting-aggregate-boundary"
+      ],
+      "evidenceRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-spectral-relation-atom-adjacency",
+      "representationRef": "spectral:relation-atom-adjacency",
+      "representationFamily": "relationAtomWeightedAdjacencyMatrix",
+      "sourceReadingRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation",
+        "spectral-mode:spectral-relation-atom-adjacency",
+        "spectral:relation-atom-adjacency"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 3,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:capability:create-user",
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:family:relationAtomWeightedAdjacencyMatrix",
+          "structuralDistance:representationStrength:representation-strength:spectral-relation-atom-adjacency",
+          "structuralDistance:spectralSupport:atom:relation:route-service"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 525,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-relation-atom-adjacency",
+          "spectral:relation-atom-adjacency"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:representationFamily:relationAtomWeightedAdjacencyMatrix",
+          "analyticDistance:spectral:relation-atom-adjacency:frobeniusNorm=1.000",
+          "analyticDistance:spectral:relation-atom-adjacency:maxColumnSum=1",
+          "analyticDistance:spectral:relation-atom-adjacency:maxRowSum=1",
+          "analyticDistance:spectral:relation-atom-adjacency:spectralRadius=0.000",
+          "analyticDistance:spectralDrilldown:spectral-drilldown:fixture-archmap-atom-observation:atomFamilies=4:overlapPairs=0:repairAxisDeltas=1",
+          "analyticDistance:spectralMode:spectral-mode:spectral-relation-atom-adjacency:gap=1.000:localization=1.000:density=0.250"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 175,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-relation-atom-adjacency",
+          "spectral:relation-atom-adjacency"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=525",
+          "lipschitz:structuralDistance=3",
+          "lipschitz:selectedRepresentation:relationAtomWeightedAdjacencyMatrix"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-relation-atom-adjacency",
+          "spectral:relation-atom-adjacency"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:relationAtomWeightedAdjacencyMatrix",
+          "biLipschitz:analyticDistance:relationAtomWeightedAdjacencyMatrix",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [],
+      "spectralReadingRefs": [
+        "spectral:relation-atom-adjacency"
+      ],
+      "spectralModeRefs": [
+        "spectral-mode:spectral-relation-atom-adjacency"
+      ],
+      "spectralDrilldownRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation"
+      ],
+      "representationStrengthRefs": [
+        "representation-strength:spectral-relation-atom-adjacency"
+      ],
+      "evidenceRefs": [
+        "atom:capability:create-user",
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:contract:create-user",
+        "atom:relation:route-service"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling",
+      "representationRef": "spectral:molecule-atom-overlap-coupling",
+      "representationFamily": "moleculeAtomOverlapCouplingMatrix",
+      "sourceReadingRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation",
+        "spectral-mode:spectral-molecule-atom-overlap-coupling",
+        "spectral:molecule-atom-overlap-coupling"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 2,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:capability:create-user",
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "molecule:user-request-responsibility"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:family:moleculeAtomOverlapCouplingMatrix",
+          "structuralDistance:representationStrength:representation-strength:spectral-molecule-atom-overlap-coupling",
+          "structuralDistance:spectralSupport:molecule:user-request-responsibility"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 2200,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-molecule-atom-overlap-coupling",
+          "spectral:molecule-atom-overlap-coupling"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:representationFamily:moleculeAtomOverlapCouplingMatrix",
+          "analyticDistance:spectral:molecule-atom-overlap-coupling:frobeniusNorm=5.000",
+          "analyticDistance:spectral:molecule-atom-overlap-coupling:maxRowSum=5",
+          "analyticDistance:spectral:molecule-atom-overlap-coupling:spectralRadiusUpperBound=5.000",
+          "analyticDistance:spectralDrilldown:spectral-drilldown:fixture-archmap-atom-observation:atomFamilies=4:overlapPairs=0:repairAxisDeltas=1",
+          "analyticDistance:spectralMode:spectral-mode:spectral-molecule-atom-overlap-coupling:gap=5.000:localization=1.000:density=1.000"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 1100,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-molecule-atom-overlap-coupling",
+          "spectral:molecule-atom-overlap-coupling"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=2200",
+          "lipschitz:structuralDistance=2",
+          "lipschitz:selectedRepresentation:moleculeAtomOverlapCouplingMatrix"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-molecule-atom-overlap-coupling",
+          "spectral:molecule-atom-overlap-coupling"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:moleculeAtomOverlapCouplingMatrix",
+          "biLipschitz:analyticDistance:moleculeAtomOverlapCouplingMatrix",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [],
+      "spectralReadingRefs": [
+        "spectral:molecule-atom-overlap-coupling"
+      ],
+      "spectralModeRefs": [
+        "spectral-mode:spectral-molecule-atom-overlap-coupling"
+      ],
+      "spectralDrilldownRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation"
+      ],
+      "representationStrengthRefs": [
+        "representation-strength:spectral-molecule-atom-overlap-coupling"
+      ],
+      "evidenceRefs": [
+        "atom:capability:create-user",
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:contract:create-user",
+        "atom:relation:route-service",
+        "molecule:user-request-responsibility"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-spectral-obstruction-axis-curvature",
+      "representationRef": "spectral:obstruction-axis-curvature",
+      "representationFamily": "obstructionAxisCurvatureMatrix",
+      "sourceReadingRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation",
+        "spectral-mode:spectral-obstruction-axis-curvature",
+        "spectral:obstruction-axis-curvature"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 3,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:capability:create-user",
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "obstruction:semantic-contract-mismatch:computed"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:family:obstructionAxisCurvatureMatrix",
+          "structuralDistance:representationStrength:representation-strength:spectral-obstruction-axis-curvature",
+          "structuralDistance:spectralSupport:obstruction:semantic-contract-mismatch:computed"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 650,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-obstruction-axis-curvature",
+          "spectral:obstruction-axis-curvature"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:representationFamily:obstructionAxisCurvatureMatrix",
+          "analyticDistance:spectral:obstruction-axis-curvature:frobeniusNorm=1.000",
+          "analyticDistance:spectral:obstruction-axis-curvature:maxColumnSum=1",
+          "analyticDistance:spectral:obstruction-axis-curvature:maxRowSum=1",
+          "analyticDistance:spectral:obstruction-axis-curvature:spectralRadiusUpperBound=1.000",
+          "analyticDistance:spectralDrilldown:spectral-drilldown:fixture-archmap-atom-observation:atomFamilies=4:overlapPairs=0:repairAxisDeltas=1",
+          "analyticDistance:spectralMode:spectral-mode:spectral-obstruction-axis-curvature:gap=1.000:localization=1.000:density=0.500"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 217,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-obstruction-axis-curvature",
+          "spectral:obstruction-axis-curvature"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=650",
+          "lipschitz:structuralDistance=3",
+          "lipschitz:selectedRepresentation:obstructionAxisCurvatureMatrix"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-obstruction-axis-curvature",
+          "spectral:obstruction-axis-curvature"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:obstructionAxisCurvatureMatrix",
+          "biLipschitz:analyticDistance:obstructionAxisCurvatureMatrix",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [],
+      "spectralReadingRefs": [
+        "spectral:obstruction-axis-curvature"
+      ],
+      "spectralModeRefs": [
+        "spectral-mode:spectral-obstruction-axis-curvature"
+      ],
+      "spectralDrilldownRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation"
+      ],
+      "representationStrengthRefs": [
+        "representation-strength:spectral-obstruction-axis-curvature"
+      ],
+      "evidenceRefs": [
+        "atom:capability:create-user",
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:contract:create-user",
+        "atom:relation:route-service",
+        "obstruction:semantic-contract-mismatch:computed"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "representationMetricReadingId": "representation-metric:representation-strength-spectral-operation-signature-delta",
+      "representationRef": "spectral:operation-signature-delta",
+      "representationFamily": "operationSignatureDeltaMatrix",
+      "sourceReadingRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation",
+        "spectral-mode:spectral-operation-signature-delta",
+        "spectral:operation-signature-delta"
+      ],
+      "distanceProfileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
+      "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
+      "structuralDistance": {
+        "status": "measured",
+        "measuredValue": 3,
+        "unit": "selected-structural-support-count",
+        "provenanceRefs": [
+          "atom:capability:create-user",
+          "atom:component:route-users",
+          "atom:component:service-user",
+          "atom:contract:create-user",
+          "atom:relation:route-service",
+          "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "evaluatorBasisRefs": [
+          "structuralDistance:family:operationSignatureDeltaMatrix",
+          "structuralDistance:representationStrength:representation-strength:spectral-operation-signature-delta",
+          "structuralDistance:spectralSupport:operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected structural distance is the bounded support size of this representation reading, not global architecture distance"
+      },
+      "analyticDistance": {
+        "status": "measured",
+        "measuredValue": 650,
+        "unit": "selected-analytic-magnitude-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-operation-signature-delta",
+          "spectral:operation-signature-delta"
+        ],
+        "evaluatorBasisRefs": [
+          "analyticDistance:representationFamily:operationSignatureDeltaMatrix",
+          "analyticDistance:spectral:operation-signature-delta:frobeniusNorm=1.000",
+          "analyticDistance:spectral:operation-signature-delta:maxColumnSum=1",
+          "analyticDistance:spectral:operation-signature-delta:maxRowSum=1",
+          "analyticDistance:spectral:operation-signature-delta:spectralRadiusUpperBound=1.000",
+          "analyticDistance:spectralDrilldown:spectral-drilldown:fixture-archmap-atom-observation:atomFamilies=4:overlapPairs=0:repairAxisDeltas=1",
+          "analyticDistance:spectralMode:spectral-mode:spectral-operation-signature-delta:gap=1.000:localization=1.000:density=0.500"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "selected analytic distance reads this representation's finite matrix, vector, spectral, or boundary magnitude; it is not an architecture quality score"
+      },
+      "lipschitzStability": {
+        "status": "measured",
+        "measuredValue": 217,
+        "unit": "selected-L-upper-bound-x100",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-operation-signature-delta",
+          "spectral:operation-signature-delta"
+        ],
+        "evaluatorBasisRefs": [
+          "lipschitz:analyticDistance=650",
+          "lipschitz:structuralDistance=3",
+          "lipschitz:selectedRepresentation:operationSignatureDeltaMatrix"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [],
+        "reading": "Lipschitz stability is a selected finite-representation upper-bound reading; it does not prove stability for all comparable architectures"
+      },
+      "biLipschitzFaithfulness": {
+        "status": "blocked",
+        "unit": "selected-bi-lipschitz-lower-bound",
+        "provenanceRefs": [
+          "spectral-drilldown:fixture-archmap-atom-observation",
+          "spectral-mode:spectral-operation-signature-delta",
+          "spectral:operation-signature-delta"
+        ],
+        "evaluatorBasisRefs": [
+          "biLipschitz:structuralDistance:operationSignatureDeltaMatrix",
+          "biLipschitz:analyticDistance:operationSignatureDeltaMatrix",
+          "biLipschitz:requiresCoverageAndWitnessCompleteness"
+        ],
+        "coverageRefs": [
+          "coverage:layer-atoms",
+          "coverage:semantic-contract-atoms"
+        ],
+        "blockerRefs": [
+          "coverage-completeness:selected-representation-not-global",
+          "gap-runtime-user-db-trace",
+          "witness-completeness:selected-LawPolicy-not-certified"
+        ],
+        "reading": "bi-Lipschitz faithfulness lower bound is blocked unless coverage and witness completeness are supplied for the selected scope"
+      },
+      "coverageBlockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "witnessCompletenessBlockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "analyticRepresentationRefs": [],
+      "spectralReadingRefs": [
+        "spectral:operation-signature-delta"
+      ],
+      "spectralModeRefs": [
+        "spectral-mode:spectral-operation-signature-delta"
+      ],
+      "spectralDrilldownRefs": [
+        "spectral-drilldown:fixture-archmap-atom-observation"
+      ],
+      "representationStrengthRefs": [
+        "representation-strength:spectral-operation-signature-delta"
+      ],
+      "evidenceRefs": [
+        "atom:capability:create-user",
+        "atom:component:route-users",
+        "atom:component:service-user",
+        "atom:contract:create-user",
+        "atom:relation:route-service",
+        "operation-delta:repair-obstruction-semantic-contract-mismatch-computed"
+      ],
+      "evidenceBoundary": "representation metric is selected-scope evidence over ArchMap + LawPolicy; analytic closeness is not structural faithfulness without coverage and witness completeness",
       "nonConclusions": [
         "ArchSig analysis packet is not a Lean theorem proof",
         "ArchSig analysis packet is not global architecture truth",
@@ -16314,6 +18259,22 @@
     ],
     "spectralDrilldownSummary": [
       "spectral-drilldown:fixture-archmap-atom-observation atomFamilies=4 overlapPairs=0 repairAxisDeltas=1 (actionable)"
+    ],
+    "representationMetricSummary": [
+      "weightedAdjacencyMatrix analytic=1 structural=4 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-weighted-adjacency)",
+      "reachableConeSize analytic=1 structural=4 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-reachable-cone-size)",
+      "walkCount analytic=1 structural=4 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-walk-count)",
+      "nilpotenceBoundary analytic=0 structural=3 lipschitz=blocked faithfulness=blocked (representation-metric:representation-strength-analytic-nilpotence-boundary)",
+      "selectedSubgraphSpectrum analytic=0 structural=4 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-selected-subgraph-spectrum)",
+      "propagationDepth analytic=1 structural=4 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-propagation-depth)",
+      "spectralRadius analytic=0 structural=4 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-spectral-radius)",
+      "curvatureValuation analytic=1 structural=3 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-analytic-curvature-valuation)",
+      "stateAlgebra analytic=0 structural=7 lipschitz=blocked faithfulness=blocked (representation-metric:representation-strength-analytic-state-algebra-boundary)",
+      "zeroReflectingAggregateBoundary analytic=0 structural=3 lipschitz=blocked faithfulness=blocked (representation-metric:representation-strength-analytic-zero-reflecting-aggregate-boundary)",
+      "relationAtomWeightedAdjacencyMatrix analytic=525 structural=3 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-spectral-relation-atom-adjacency)",
+      "moleculeAtomOverlapCouplingMatrix analytic=2200 structural=2 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-spectral-molecule-atom-overlap-coupling)",
+      "obstructionAxisCurvatureMatrix analytic=650 structural=3 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-spectral-obstruction-axis-curvature)",
+      "operationSignatureDeltaMatrix analytic=650 structural=3 lipschitz=measured faithfulness=blocked (representation-metric:representation-strength-spectral-operation-signature-delta)"
     ],
     "curvatureSupportSummary": [
       "curvature-support-reading:spectrum-profile-curvature-transfer-default supports=4 topModes=4 clusters=2 measuredAxes=1 unmeasuredAxes=2 (needsReview)"


### PR DESCRIPTION
## 概要

Closes #1711

Part IV §8 の Representation Metric / stability / faithfulness を ArchSig analysis packet に実装しました。`representationMetricReadings[]` を追加し、analytic / spectral / mode / drilldown / representation strength の各 surface から `part4DistanceRefs` で接続しています。

主な設計判断:

- `structuralDistance`, `analyticDistance`, `lipschitzStability`, `biLipschitzFaithfulness` を分離
- analytic distance は selected representation reading として扱い、単一 quality score にしない
- coverage / witness completeness blocker が残る限り bi-Lipschitz faithfulness lower bound は `blocked`
- `part4DistanceFoundation` の `representationMetric` family を evaluator-backed に昇格
- ACTS fixture manifest に representation metric faithfulness boundary ケースを追加

## 証明した定理

- なし

Lean status: tooling validation / design tracking

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
