### PR TITLE
ArchSig Part IV anti-proxy検証を固定

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -142,6 +142,26 @@ jobs:
           jq -e '
             .summary.result == "pass"
             and ([.checks[]?.id] | index("archsig-analysis-packet-non-conclusion-boundary") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-part4-distance-foundation") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-atom-distance-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-configuration-distance-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-signature-distance-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-operation-distance-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-obstruction-measure-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-curvature-mass-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-homotopy-distance-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-representation-metric-readings") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-measurement-depth") != null)
+            and ([.checks[]? | select(.result == "pass") | .id] | index("archsig-analysis-packet-proxy-regression-guardrails") != null)
+            and (.summary.part4SupportingDistanceCount >= 7)
+            and (.summary.atomDistanceReadingCount > 0)
+            and (.summary.configurationDistanceReadingCount > 0)
+            and (.summary.signatureDistanceReadingCount > 0)
+            and (.summary.operationDistanceReadingCount > 0)
+            and (.summary.obstructionMeasureReadingCount > 0)
+            and (.summary.curvatureMassReadingCount > 0)
+            and (.summary.homotopyDistanceReadingCount > 0)
+            and (.summary.representationMetricReadingCount > 0)
           ' "$archsig_raw_dir/archsig-analysis-validation.json"
 
           cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \

--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -338,9 +338,10 @@ Packet validation has separate JSON surface, measurement-depth, and
 proxy-regression checks. Surface checks confirm the packet contract and
 cross-references; measurement-depth checks require evaluator input refs,
 distance value provenance, witness rule / law / axis alignment, and coverage
-blockers for measured or blocked readings and reject hard-coded fixture markers
-as measured provenance; proxy-regression checks reject `schemaFoundationOnly`
-or bounded proxy rows when they masquerade as measured analysis. Packet
+blockers for measured or blocked readings, require Part IV rows to stay tied
+to the selected `DistanceProfile` / `DiagnosticScope`, and reject hard-coded
+fixture markers as measured provenance; proxy-regression checks reject
+`schemaFoundationOnly` or bounded proxy rows when they masquerade as measured analysis. Packet
 validation checks identity, ArchMap / interpretation profile
 references, AAT concept coverage, bounded judgement statuses, analytic axes,
 spectral analysis readings, spectral mode readings,

--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -60,6 +60,30 @@ boundary cues, feature-like clusters, operation-like relations, top boundary
 holonomy, top order-sensitive squares, and coverage / exactness boundaries
 without replaying all historical deltas.
 
+The Part IV Distance Engine golden corpus is the complete-first ArchSig packet
+and validation report generated from
+`tools/archsig/tests/fixtures/minimal/archmap.json` plus
+`tools/archsig/tests/fixtures/minimal/law_policy.json`. Local and CI tests
+require the validation report to pass the first-class Part IV checks for:
+
+- `part4DistanceFoundation`
+- `atomDistanceReadings`
+- `configurationDistanceReadings`
+- `signatureDistanceReadings`
+- `operationDistanceReadings`
+- `obstructionMeasureReadings`
+- `curvatureMassReadings`
+- `homotopyDistanceReadings`
+- `representationMetricReadings`
+- `measurement-depth`
+- `proxy-regression`
+
+This corpus is intentionally distance-surface complete rather than minimal.
+It must keep measured / zero values tied to provenance refs, evaluator-basis
+refs, coverage refs, selected `DistanceProfile`, and selected
+`DiagnosticScope`. Blocked, unmeasured, unavailable, incomparable, or infinite
+values must carry blocker refs. A missing measurement is not a measured zero.
+
 ## Negative Fixtures
 
 - `tools/archsig/tests/fixtures/minimal/archmap_invalid_concern_promoted.json`
@@ -69,6 +93,25 @@ These fixtures lock the two main guardrails:
 
 - `concernHints` are not obstruction circuits.
 - `observationGaps` are not measured zero.
+
+Part IV anti-proxy negative fixtures live as Rust validation tests instead of
+public JSON files when a single field mutation is clearer than maintaining a
+large copied packet. The suite mutates the static packet to reject:
+
+- measured distance without provenance / evaluator basis / coverage refs
+- stale or missing `DistanceProfile` / `DiagnosticScope` alignment
+- `schemaFoundationOnly` promoted into distance status
+- concern-only provenance promoted into measured distance
+- hard-coded fixture markers
+- name-only Atom basis refs
+- relation-count-only configuration distance
+- observation gap rounded to zero
+- signature axis without distance refs
+- signature rho without evaluator basis
+- repair candidate / operation delta without Part IV refs
+- operation side-effect bound rounded to zero while transfer risk remains
+- curvature / representation surfaces without Part IV refs
+- representation faithfulness measured while coverage blockers remain
 
 ## FieldSig Handoff Fixtures
 

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -22436,6 +22436,13 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
         "part4DistanceFoundation.profile.profileSourceRef",
         &foundation.profile.profile_source_ref,
     );
+    if foundation.diagnostic_scope.distance_profile_ref != foundation.profile.profile_id {
+        examples.push(generic_validation_example(
+            "part4DistanceFoundation.diagnosticScope.distanceProfileRef",
+            "profileRef",
+            "DiagnosticScope must point to the selected DistanceProfile, not a stale or unrelated profile",
+        ));
+    }
     if foundation.profile.atom_weights.is_empty() || foundation.profile.signature_weights.is_empty()
     {
         examples.push(generic_validation_example(
@@ -22511,6 +22518,15 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
             &format!("{} profileRef", distance.distance_id),
             &distance.profile_ref,
         );
+        if distance.profile_ref != foundation.profile.profile_id
+            || distance.diagnostic_scope_ref != foundation.diagnostic_scope.scope_id
+        {
+            examples.push(generic_validation_example(
+                &distance.distance_id,
+                "profile/scope",
+                "supporting DistanceValue rows must be tied to the selected DistanceProfile and DiagnosticScope",
+            ));
+        }
         let status = distance.value.status.as_str();
         if !allowed.contains(status) {
             examples.push(generic_validation_example(
@@ -26325,6 +26341,42 @@ mod tests {
                         .target
                         .as_deref()
                         .is_some_and(|target| target == "concern-only provenance")
+                })
+        }));
+    }
+
+    #[test]
+    fn part4_negative_fixture_stale_profile_ref_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        packet
+            .part4_distance_foundation
+            .diagnostic_scope
+            .distance_profile_ref = "part4-distance-profile:stale".to_string();
+        packet
+            .part4_distance_foundation
+            .supporting_distances
+            .first_mut()
+            .expect("static fixture has Part IV distance contract rows")
+            .profile_ref = "part4-distance-profile:stale".to_string();
+
+        let report = validate_archsig_analysis_packet_report(
+            &packet,
+            "negative-fixture-part4-stale-profile-ref.json",
+        );
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-part4-distance-foundation"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example
+                        .target
+                        .as_deref()
+                        .is_some_and(|target| target == "profile/scope")
+                        || example
+                            .target
+                            .as_deref()
+                            .is_some_and(|target| target == "profileRef")
                 })
         }));
     }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2447,6 +2447,55 @@ fn complete_archmap_acceptance_fixture_runs_full_measurement_without_private_nam
             "{label} must pass for complete-first acceptance fixture"
         );
     }
+    let archsig_validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
+    for check_id in [
+        "archsig-analysis-packet-part4-distance-foundation",
+        "archsig-analysis-packet-atom-distance-readings",
+        "archsig-analysis-packet-configuration-distance-readings",
+        "archsig-analysis-packet-signature-distance-readings",
+        "archsig-analysis-packet-operation-distance-readings",
+        "archsig-analysis-packet-obstruction-measure-readings",
+        "archsig-analysis-packet-curvature-mass-readings",
+        "archsig-analysis-packet-homotopy-distance-readings",
+        "archsig-analysis-packet-representation-metric-readings",
+        "archsig-analysis-packet-measurement-depth",
+        "archsig-analysis-packet-proxy-regression-guardrails",
+    ] {
+        assert!(
+            has_check_result(&archsig_validation, check_id, "pass"),
+            "complete-first fixture validation must include passing Part IV anti-proxy check {check_id}"
+        );
+    }
+    assert!(
+        archsig_validation["summary"]["part4SupportingDistanceCount"]
+            .as_u64()
+            .is_some_and(|count| count >= 7)
+            && archsig_validation["summary"]["atomDistanceReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["configurationDistanceReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["signatureDistanceReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["operationDistanceReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["obstructionMeasureReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["curvatureMassReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["homotopyDistanceReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0)
+            && archsig_validation["summary"]["representationMetricReadingCount"]
+                .as_u64()
+                .is_some_and(|count| count > 0),
+        "complete-first fixture must be the golden corpus for all major Part IV distance surfaces"
+    );
 
     let packet = read_json(&out_dir.join("archsig-analysis-packet.json"));
     let spectrum = &packet["architectureSpectrumReport"];


### PR DESCRIPTION
## 概要

Closes #1713

ArchSig Part IV Distance Engine の anti-proxy validation / negative fixtures / golden corpus を補強しました。

- `part4DistanceFoundation` validation で `DistanceProfile` / `DiagnosticScope` alignment を強制し、stale profile refs を fail にする
- stale profile ref negative fixture test を追加し、proxy / schema-only / concern-only / fixed marker だけでなく profile drift も検出する
- complete-first fixture の CLI test で、Part IV 全主要 surface と measurement-depth / proxy-regression checks が pass することを golden corpus として固定する
- CI e2e の `archsig-analysis-validation.json` assertion を Part IV 全主要 surface count と anti-proxy checks まで拡張する
- `docs/tool/golden_corpus.md` と validation boundary docs に Part IV corpus / negative suite / profile-scope alignment を記録する

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/archsig_analysis_packet.md`
- `docs/tool/golden_corpus.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
