### PR TITLE
ArchSig Part IV距離docsとskillsを同期

### DIFF
--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -69,7 +69,10 @@ Default `analyze` does not save the raw analysis packet, detail index, or LLM
 interpretation packet. Read `archsig-analysis-summary.json` as the LLM first
 surface and open the fixed release-bundled `archsig-atom-viewer.html` with
 `archsig-atom-viewer-data.json` as the human first surface. The Viewer report
-pane also reads the same-directory summary and manifest when available.
+pane also reads the same-directory summary and manifest when available. Part IV
+distance diagnosis is read from summary `distanceDiagnosis` and viewer report
+pane diagnostic overlays first; raw packet distance rows are detail evidence,
+not the primary human or LLM surface.
 
 Use raw artifacts only when FieldSig handoff or detailed evidence lookup needs
 the packet:
@@ -123,10 +126,15 @@ The E2E flow must preserve these boundaries:
   coverage gaps, and non-conclusions.
 - `archsig-analysis-summary.json` is the LLM first reading surface. It is
   structured analysis input, not a natural-language judgement, proof, or
-  automatic repair instruction.
+  automatic repair instruction. Its `distanceDiagnosis` section is the first
+  Part IV distance surface for measured movement, unmeasured axes, safe margin,
+  repair / curvature / homotopy distance, representation metric boundaries,
+  and packet refs.
 - `archsig-atom-viewer-data.json` plus fixed `archsig-atom-viewer.html` is the
   human visual/report surface. It is a bounded projection and does not parse
-  raw packet detail in the browser.
+  raw packet detail in the browser. Diagnostic distance overlays are bounded
+  Part IV evaluator projections; viewer layout distances are visual placement
+  support, not ArchSig metrics.
 - `llm-interpretation-packet.json` is emitted only in raw mode and remains a
   compact packet sub-surface, not a separate source of truth.
 - FieldSig accepts `archsig-analysis-packet-v0` as bounded current AAT
@@ -148,6 +156,9 @@ The E2E flow must preserve these boundaries:
   is separate from change-local PR review and from FieldSig evolution analysis.
 - Coverage gaps are carried as unknown remainder; they are not rounded to
   absence, measured zero, or forecast truth.
+- `unmeasured`, `blocked`, `unavailable`, `incomparable`, and `infinite`
+  Part IV distance values are not zeros. They stay tied to coverage blockers,
+  `DistanceProfile`, and `DiagnosticScope`.
 - ArchSig default `analyze` emits only the current validation reports, summary,
   Atom Viewer data, and run manifest. Raw packet, detail index, and LLM
   interpretation packet are opt-in through `--emit-raw-artifacts`.

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -207,7 +207,7 @@ from AAT structural output into source-level review language.
 | --- | --- |
 | `archmap-creater` | Create bounded `archmap-observation-map-v0` artifacts from repository evidence. It keeps ArchMap as source-grounded Atom observations, molecule observations, semantic readings, concern hints, and gaps, not law-relative analysis. |
 | `law-policy-creater` | Create project-specific `law-policy-v0` interpretation profiles from repository coding conventions, architecture rules, and user decisions. If docs do not define the law universe, ask the user before selecting laws. |
-| `archsig-reader` | Run an ArchMap with a selected LawPolicy, read the `archsig-analysis-packet-v0`, compare high-priority readings with source evidence, and propose bounded improvements. It does not silently use a generic LawPolicy as project analysis. |
+| `archsig-reader` | Run an ArchMap with a selected LawPolicy, read summary / viewer report / manifest first, follow `distanceDiagnosis` detail refs only when needed, compare high-priority readings with source evidence, and propose bounded improvements. It does not silently use a generic LawPolicy as project analysis. |
 | `archsig-pr-reviewer` | Derive PR-local `archmap-delta-v0` from the base branch diff, run `pr-review` with base ArchMap and LawPolicy, read the changed code, and explain review focus in human code-review language. It stops if the base ArchMap or LawPolicy is missing. |
 
 Typical use:
@@ -216,8 +216,10 @@ Typical use:
 2. Use `law-policy-creater` to produce the selected LawPolicy for the target
    repository or subsystem.
 3. Run `analyze`.
-4. Use `archsig-reader` to interpret the packet and compare it with source
-   evidence before proposing improvements.
+4. Use `archsig-reader` to interpret `archsig-analysis-summary.json`,
+   `archsig-atom-viewer-data.json`, and `archsig-run-manifest.json` first, then
+   compare selected detail refs with source evidence before proposing
+   improvements.
 
 For pull requests, use `archsig-pr-reviewer` after a base ArchMap and LawPolicy
 exist. It derives the PR-local `archmap-delta-v0` from the base branch diff,

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -41,8 +41,8 @@ fragments.
 | ArchMap validation report | `archmap-validation-report-v0` | Checks schema support, identity, references, provenance, source refs, observation / concern guardrails, projection separation, gap boundaries, and formal-promotion non-conclusions. |
 | LawPolicy | `law-policy-v0` | Selected LawUniverse / witness-rule / molecule-pattern / obstruction-definition / signature-axis policy for one review context. |
 | LawPolicy validation report | `law-policy-validation-report-v0` | Checks LawPolicy identity, uniqueness, cross references, witness / obstruction guardrails, coverage requirements, exactness assumptions, and non-conclusions. |
-| ArchSig analysis summary | `archsig-analysis-summary.json` | LLM-readable compact reading surface emitted by default from `analyze`. It summarizes verdict, validation, measurement status, findings, action queue, coverage, measurement basis, and artifact metadata without reprinting raw packet detail. |
-| ArchSig Atom Viewer data | `archsig-atom-viewer-data-v0` | Bounded browser projection emitted by default from `analyze`. It records source refs as count plus samples, layout settings, priority-selected atom nodes, molecule groups, molecule-to-atom edges, overlays, report pane sections, omitted counts / reasons, truncation policy, and non-conclusions. It is not a raw packet copy. |
+| ArchSig analysis summary | `archsig-analysis-summary.json` | LLM-readable compact reading surface emitted by default from `analyze`. It summarizes verdict, validation, Part IV `distanceDiagnosis`, measurement status, findings, action queue, coverage, measurement basis, and artifact metadata without reprinting raw packet detail. |
+| ArchSig Atom Viewer data | `archsig-atom-viewer-data-v0` | Bounded browser projection emitted by default from `analyze`. It records source refs as count plus samples, layout settings, priority-selected atom nodes, molecule groups, molecule-to-atom edges, diagnostic distance overlays, report pane sections, omitted counts / reasons, truncation policy, and non-conclusions. It is not a raw packet copy, and `viewerDistanceInputs` remain visual layout support rather than diagnostic metrics. |
 | ArchSig run manifest | `archsig-run-manifest-v0` | Run navigation artifact emitted by default from `analyze`. It records command name, input paths, output mode, generated / omitted artifacts, validation report paths, optional raw artifact paths, and validation result summary. |
 | ArchSig analysis packet | `archsig-analysis-packet-v0` | Raw evidence artifact emitted only when raw artifact retention is requested. It records molecule readings, law-relative obstruction circuits, signature axes, flatness reading, repair candidates, coverage gaps, child-level `missingEvidence` / `excludedReadings`, evidence boundaries, LLM interpretation notes, and non-conclusions. |
 | ArchSig analysis validation report | `archsig-analysis-packet-validation-report-v0` | Checks the analysis packet boundary without proving lawfulness, source completeness, flatness, or repair safety. |
@@ -52,9 +52,9 @@ Release archives include a fixed `archsig-atom-viewer.html` at the package root
 and under `viewer/`. The app reads `archsig-atom-viewer-data-v0` projection
 data, not raw packet detail. Its report pane uses the projection data first and
 then same-directory `archsig-analysis-summary.json` / `archsig-run-manifest.json`
-when available to display verdict, findings, action queue, coverage,
-validation failures, generated / omitted artifacts, and relative raw artifact
-links.
+when available to display verdict, distance diagnosis, findings, action queue,
+coverage, validation failures, generated / omitted artifacts, and relative raw
+artifact links.
 
 ## Removed Surfaces
 
@@ -71,7 +71,9 @@ signature axes, repair candidates, and coverage gaps into
 `operation-support-estimate-v0` as bounded refs and unknown remainder. Raw
 ArchMap observation files are not the current FieldSig handoff. When `analyze`
 runs in the default summary / viewer / manifest mode, rerun it with explicit raw
-artifact retention before invoking FieldSig handoff.
+artifact retention before invoking FieldSig handoff. Do not treat
+`distanceDiagnosis` as a FieldSig forecast; it is ArchSig current-state
+diagnosis under the selected ArchMap + LawPolicy evidence contract.
 
 ArchSig does not own SFT forecast, IntentMap, workflow evidence, operational
 feedback, dynamics, governance, or calibration.

--- a/tools/archsig/skills/archsig-reader/SKILL.md
+++ b/tools/archsig/skills/archsig-reader/SKILL.md
@@ -138,15 +138,19 @@ Read in this order:
 2. Verdict and quality measurement
    - Prefer `archsig-analysis-summary.json` when available.
    - Read the whole summary before opening raw packet details. Start with
-     `verdict`, `qualityMeasurement`, `dominantFindings`, `actionQueue`,
-     `axisSummary`, `workflowRiskSummary`, `architecturalHoleSummary`,
-     `bridgeSummary`, `coverageGapSummary`, `detailIndex`, and
-     `measurementBasis`.
+     `verdict`, `qualityMeasurement`, `distanceDiagnosis`,
+     `dominantFindings`, `actionQueue`, `axisSummary`, `workflowRiskSummary`,
+     `architecturalHoleSummary`, `bridgeSummary`, `coverageGapSummary`,
+     `detailIndex`, and `measurementBasis`.
    - When a human visual reading is useful, open the fixed Atom Viewer and use
      its report pane as the human first surface for overview, top findings,
-     action queue, coverage boundaries, validation status, artifacts, and
-     omitted raw detail.
+     distance diagnosis, action queue, coverage boundaries, validation status,
+     artifacts, and omitted raw detail.
    - Say what the supplied ArchMap + LawPolicy measured: flat/nonflat under selected policy, nonzero axes, hotspots, recurrent pressure, architectural holes, workflow risk, bridge pressure, and review action queue.
+   - Report Part IV distance as selected-scope diagnosis: measured movement,
+     unmeasured axes, safe margin, repair / curvature / homotopy distance, and
+     representation metric boundaries. Never collapse blocked or unmeasured
+     distance to zero.
    - Treat `actionQueue` as the full compact queue. Its entries should carry
      `detailRefs`; do not expect nested support/source/witness evidence arrays
      in the summary.
@@ -192,7 +196,12 @@ Read in this order:
    - If transfer bridge or split readiness readings are empty, report that no bridge/split surface was emitted for this packet variant and prioritize obstruction / repair / coverage evidence instead.
 
 7. LLM interpretation packet
-   - Use `detailIndex` to reach `llmInterpretationPacket.recommendedHumanReviewFocus`, `structuralReadingReviewSummary`, `currentStateEvolutionBoundarySummary`, and `transferBridgeEdgeSummary` only when raw artifacts were emitted and the compact summary is not enough.
+   - Use `detailIndex` to reach
+     `llmInterpretationPacket.recommendedHumanReviewFocus`,
+     `distanceDiagnosisSummary`, `structuralReadingReviewSummary`,
+     `currentStateEvolutionBoundarySummary`, and `transferBridgeEdgeSummary`
+     only when raw artifacts were emitted and the compact summary is not
+     enough.
    - Do not treat the LLM packet as a separate source of truth.
 
 8. Packet variant fallback
@@ -242,11 +251,12 @@ For a normal user report, answer in this order:
 
 1. Verdict
 2. Quality Measurement
-3. Top Hotspots / Holes
-4. Action Queue
-5. Measurement Basis
-6. Source-code comparison findings, when source comparison was requested
-7. Metadata / non-conclusions, only when useful for the user's decision
+3. Distance Diagnosis
+4. Top Hotspots / Holes
+5. Action Queue
+6. Measurement Basis
+7. Source-code comparison findings, when source comparison was requested
+8. Metadata / non-conclusions, only when useful for the user's decision
 
 Use concise Japanese when working in this repository.
 
@@ -255,6 +265,7 @@ Recommended phrasing:
 - "ArchSig measured this as..."
 - "For this ArchMap + LawPolicy, the verdict is..."
 - "The selected law axes measured nonzero pressure..."
+- "Part IV distance is blocked by coverage on these axes, not measured zero..."
 - "This loop is an unfilled architectural hole in the supplied model..."
 - "Source comparison supports / partially supports / does not yet support this reading..."
 - "The next useful improvement is..."

--- a/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
+++ b/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
@@ -13,21 +13,25 @@ Read `archsig-analysis-summary.json` before raw packet details:
 1. `verdict`: the measured conclusion for the supplied ArchMap + LawPolicy.
 2. `qualityMeasurement`: counts for nonzero axes, hotspots, recurrent pressure,
    unfilled architectural holes, nonzero holonomy loops, and coverage gaps.
-3. `dominantFindings`: compact nonzero axes, hotspots, recurrent pressure,
+3. `distanceDiagnosis`: compact Part IV distance verdict, measured movement,
+   unmeasured axes, top moved atoms / axes, safe margin, repair distance,
+   curvature / homotopy distance, representation metric summary, and packet
+   detail refs. Blocked or unmeasured distance is not measured zero.
+4. `dominantFindings`: compact nonzero axes, hotspots, recurrent pressure,
    architectural holes, nonzero holonomy, workflow risks, and bridge pressure.
-4. `actionQueue`: the full compact review queue derived from hotspots, holes,
+5. `actionQueue`: the full compact review queue derived from hotspots, holes,
    nonzero holonomy, nonzero axes, workflow pressure, and bridge pressure.
    Queue entries use `detailRefs`; they do not carry nested support/source/
    witness evidence arrays.
-5. `axisSummary`, `workflowRiskSummary`, `architecturalHoleSummary`,
+6. `axisSummary`, `workflowRiskSummary`, `architecturalHoleSummary`,
    `bridgeSummary`, and `coverageGapSummary`: compact counts and examples for
    the major surfaces.
-6. `detailIndex`: packet sections and `packet:<json-pointer>` refs for reading
+7. `detailIndex`: packet sections and `packet:<json-pointer>` refs for reading
    full evidence in `archsig-analysis-packet.json` when raw artifacts were
    emitted.
-7. `measurementBasis`: input refs, profile refs, validation results, coverage
+8. `measurementBasis`: input refs, profile refs, validation results, coverage
    gaps, and measured boundaries.
-8. `metadata.nonConclusions`: claim-boundary metadata. Keep it available, but
+9. `metadata.nonConclusions`: claim-boundary metadata. Keep it available, but
    do not lead the user-facing diagnosis with it.
 
 The report posture is: "for this input model, these conclusions were measured."
@@ -37,9 +41,11 @@ finding needs evidence inspection.
 
 For human review, open the bundled `archsig-atom-viewer.html` and load
 `archsig-atom-viewer-data.json`. Its report pane should show the same verdict,
-top findings, action queue, coverage boundaries, validation status, artifact
-list, generated / omitted artifact state, and optional packet / detail-index
-links without parsing the raw packet in the browser.
+top findings, distance diagnosis, action queue, coverage boundaries,
+validation status, artifact list, generated / omitted artifact state, and
+optional packet / detail-index links without parsing the raw packet in the
+browser. Treat diagnostic distance overlays as Part IV evaluator projections;
+do not read viewer layout distance as an ArchSig metric.
 
 When ArchSig output is being read as part of complete ArchMap authoring, the
 posture is slightly different: keep the measured conclusion first, then turn
@@ -54,7 +60,12 @@ truly unavailable, private, or out of scope.
 | `archMapRef`, `selectedLawPolicyRef` | Identifies the observed source state and selected law universe. |
 | `axisSummary` / `detailIndex` | States selected/nonzero axis counts and points to `flatnessReading` / `signatureAxes[]` detail when needed. |
 | `workflowRiskSummary` / `actionQueue` | Prioritizes molecule-local review pressure such as permission, LLM mediation, state/effect reconciliation, and domain cohesion, with refs into `workflowRiskReadings[]`. |
+| `distanceDiagnosis` | First Part IV distance surface for verdict, measured movement, unmeasured axes, safe margin, repair / curvature / homotopy distance, representation metric summary, and detail refs. |
 | `dominantFindings` / `detailRefs` | Gives compact hotspots, recurrent pressure, architectural holes, nonzero holonomy, workflow risks, and bridge pressure before raw packet inspection. |
+| `part4DistanceFoundation` | Packet detail surface for selected `DistanceProfile`, observed `DiagnosticScope`, status-summary counts, and anti-proxy guardrails. |
+| `atomDistanceReadings[]` / `configurationDistanceReadings[]` | Packet detail surfaces for Atom and configuration geometry. Use them only after summary refs point there; missing semantic anchors or observation gaps are blockers, not zero. |
+| `signatureDistanceReadings[]` / `operationDistanceReadings[]` | Packet detail surfaces for axis distance, safe margin, path drift, operation cost, repair route distance, and side-effect blockers. |
+| `curvatureMassReadings[]` / `homotopyDistanceReadings[]` / `representationMetricReadings[]` | Packet detail surfaces for curvature transport, filling cost, and representation stability / faithfulness. These are current-state diagnostic readings, not forecast, proof, merge approval, or quality score. |
 | `architectureSpectrumReport` | Packet detail surface for ACTS evidence: top hotspots, bounded mode data, witness clusters, recurrent obstruction entries, coverage gaps, measured boundary, and review focus. |
 | `architectureHomotopyReport` | Packet detail surface for Homotopy / Holonomy / Stokes evidence: filled loops, unfilled loops, nonzero holonomy loops, local curvature cells, bounded aggregate readings, coverage gaps, and review focus. |
 | `transferBridgeReadings[]` | Packet detail surface for repair transfer axes, molecule overlap paths, bridge edge source refs, review focus, and boundary preparation. |
@@ -78,6 +89,15 @@ For Homotopy / Holonomy / Stokes readings, confirm that the selected LawPolicy
 contains `homotopyMeasurementProfile`. If it is absent, report that
 `ArchitectureHomotopyReport` may be absent and do not infer loop, filler,
 holonomy, or local-curvature readings from generic obstruction fields.
+
+For Part IV distance readings, confirm that `distanceDiagnosis` is present in
+the summary before opening raw packet rows. If a packet variant lacks it, fall
+back to `part4DistanceFoundation` and the specific distance reading arrays only
+when raw artifacts are present. Every measured or zero `DistanceValue` must be
+read together with provenance refs, evaluator-basis refs, coverage refs, and
+the selected `DistanceProfile` / `DiagnosticScope`. `unmeasured`, `blocked`,
+`unavailable`, `incomparable`, and `infinite` remain missing or bounded
+evidence states, not zeros.
 
 For both reports, read `measurementStatus` and `readingBoundary` before
 interpreting values. `measured` means the selected evidence needed by that


### PR DESCRIPTION
## 概要

Closes #1714

ArchSig Part IV Distance Engine の実装結果に合わせて docs / skills / release-facing surface を同期しました。

- artifact boundary docs に `distanceDiagnosis`、diagnostic distance overlays、viewer layout distance との境界、FieldSig forecast ではないことを追加
- `archsig-reader` skill と output reading guide を summary / viewer / manifest first に更新し、Distance Diagnosis を通常レポートの第一級 section にする
- raw packet は FieldSig handoff / detail lookup / fixture maintenance 用で、通常の primary reading surface ではないことを再固定
- E2E workflow docs に Part IV distance diagnosis の読み順、viewer overlay boundary、`unmeasured is not zero` を追加
- README の skill 説明を packet-first から summary/viewer/manifest-first に更新

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/llm_native_e2e_workflow.md`
- `tools/archsig/README.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`
- `tools/archsig/skills/archsig-reader/SKILL.md`
- `tools/archsig/skills/archsig-reader/references/output-reading-guide.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig docs / skill bundle surface 確認）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
