### PR TITLE
ArchSig Part IV診断surfaceを同期する

### DIFF
--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -97,20 +97,31 @@ contributions carry evidence blockers.
 
 - `tools/archsig/tests/fixtures/minimal/archmap_invalid_concern_promoted.json`
 - `tools/archsig/tests/fixtures/minimal/archmap_invalid_gap_measured_zero.json`
+- `tools/archsig/tests/fixtures/negative/part4_distance_surface_negative_cases.json`
+- `tools/archsig/tests/fixtures/negative/part4_distance_policy_negative_cases.json`
 
 These fixtures lock the two main guardrails:
 
 - `concernHints` are not obstruction circuits.
 - `observationGaps` are not measured zero.
 
-Part IV anti-proxy negative fixtures live as Rust validation tests instead of
-public JSON files when a single field mutation is clearer than maintaining a
-large copied packet. The suite mutates the static packet to reject:
+Part IV anti-proxy negative fixtures are split between a persisted distance
+surface corpus, executable persisted LawPolicy mutation cases, and Rust
+validation tests. The persisted corpus records the regression classes that
+must remain covered across CLI / serde / artifact surfaces without copying a
+large raw packet. The persisted LawPolicy mutation cases are read by CLI tests
+and run through `analyze --strict-distance`. The Rust suite mutates the static
+packet when a single field mutation is clearer than maintaining a copied
+packet. Together they reject:
 
 - measured distance without provenance / evaluator basis / coverage refs
 - stale or missing `DistanceProfile` / `DiagnosticScope` alignment
 - measured or zero signature axes left in `DiagnosticScope.unmeasuredAxisRefs`
   or summary/viewer `distanceDiagnosis.unmeasuredAxes`
+- ignored `part4DistanceProfile` atom / signature weights
+- missing operation costs that fail to block `operationGeometry`
+- null summary ids for operation / curvature distance refs
+- stale `distanceDiagnosis.detailRefs` that do not resolve into the raw packet
 - closed implementation Issue placeholder blockers left in final
   `DiagnosticScope.blockerRefs`
 - `unmeasuredAxis:<axis>` blockers left in final `DiagnosticScope.blockerRefs`

--- a/tools/archsig/docs/artifacts-and-boundaries.md
+++ b/tools/archsig/docs/artifacts-and-boundaries.md
@@ -46,7 +46,7 @@ fragments.
 | ArchSig run manifest | `archsig-run-manifest-v0` | Run navigation artifact emitted by default from `analyze`. It records command name, input paths, output mode, generated / omitted artifacts, validation report paths, optional raw artifact paths, and validation result summary. |
 | ArchSig analysis packet | `archsig-analysis-packet-v0` | Raw evidence artifact emitted only when raw artifact retention is requested. It records molecule readings, law-relative obstruction circuits, signature axes, flatness reading, repair candidates, coverage gaps, child-level `missingEvidence` / `excludedReadings`, evidence boundaries, LLM interpretation notes, and non-conclusions. |
 | ArchSig analysis validation report | `archsig-analysis-packet-validation-report-v0` | Checks the analysis packet boundary without proving lawfulness, source completeness, flatness, or repair safety. |
-| LLM interpretation packet | `archsig-analysis-packet-v0` | Optional raw artifact: a second serialization of the packet's structured LLM interpretation surface. |
+| LLM interpretation packet | `llmInterpretationPacket` payload | Optional raw artifact: a serialization of the packet's structured LLM interpretation surface. It is not a second standalone `archsig-analysis-packet-v0` packet and does not carry the raw packet schema version by itself. |
 
 Release archives include a fixed `archsig-atom-viewer.html` at the package root
 and under `viewer/`. The app reads `archsig-atom-viewer-data-v0` projection

--- a/tools/archsig/skills/archsig-reader/SKILL.md
+++ b/tools/archsig/skills/archsig-reader/SKILL.md
@@ -139,14 +139,16 @@ Read in this order:
    - Prefer `archsig-analysis-summary.json` when available.
    - Read the whole summary before opening raw packet details. Start with
      `verdict`, `qualityMeasurement`, `distanceDiagnosis`,
-     `dominantFindings`, `actionQueue`, `axisSummary`, `workflowRiskSummary`,
-     `architecturalHoleSummary`, `bridgeSummary`, `coverageGapSummary`,
-     `detailIndex`, and `measurementBasis`.
+     `trendDiagnosis`, `architectureInsightSummary`, `reviewSupport`,
+     `dominantFindings`, `actionQueue`, `axisSummary`,
+     `aatObservationAxisSummary`, `architecturalHoleSummary`,
+     `bridgeSummary`, `coverageGapSummary`, `detailIndex`, and
+     `measurementBasis`.
    - When a human visual reading is useful, open the fixed Atom Viewer and use
      its report pane as the human first surface for overview, top findings,
      distance diagnosis, action queue, coverage boundaries, validation status,
      artifacts, and omitted raw detail.
-   - Say what the supplied ArchMap + LawPolicy measured: flat/nonflat under selected policy, nonzero axes, hotspots, recurrent pressure, architectural holes, workflow risk, bridge pressure, and review action queue.
+   - Say what the supplied ArchMap + LawPolicy measured: flat/nonflat under selected policy, nonzero axes, hotspots, recurrent pressure, architectural holes, trend / review support, bridge pressure, and review action queue.
    - Report Part IV distance as selected-scope diagnosis: measured movement,
      unmeasured axes, safe margin, repair / curvature / homotopy distance, and
      representation metric boundaries. Never collapse blocked or unmeasured
@@ -173,7 +175,9 @@ Read in this order:
    - Treat coverage gaps as measurement basis for why zero was not measured.
 
 5. Dominant pressure
-   - Use `dominantFindings`, `actionQueue`, `workflowRiskSummary`, `architecturalHoleSummary`, and `bridgeSummary` before opening raw packet sections.
+   - Use `dominantFindings`, `actionQueue`, `trendDiagnosis`, `reviewSupport`,
+     `architectureInsightSummary`, `architecturalHoleSummary`, and
+     `bridgeSummary` before opening raw packet sections.
    - Follow summary `detailRefs` into `architectureSpectrumReport` when the review needs full hotspot, recurrent obstruction, witness cluster, coverage gap, measured boundary, or review focus detail.
    - Treat the report as a current-state architecture quality measurement over
      the selected axes only after checking `measurementStatus` and

--- a/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
+++ b/tools/archsig/skills/archsig-reader/references/output-reading-guide.md
@@ -23,7 +23,8 @@ Read `archsig-analysis-summary.json` before raw packet details:
    nonzero holonomy, nonzero axes, workflow pressure, and bridge pressure.
    Queue entries use `detailRefs`; they do not carry nested support/source/
    witness evidence arrays.
-6. `axisSummary`, `workflowRiskSummary`, `architecturalHoleSummary`,
+6. `axisSummary`, `aatObservationAxisSummary`, `trendDiagnosis`,
+   `reviewSupport`, `architectureInsightSummary`, `architecturalHoleSummary`,
    `bridgeSummary`, and `coverageGapSummary`: compact counts and examples for
    the major surfaces.
 7. `detailIndex`: packet sections and `packet:<json-pointer>` refs for reading
@@ -59,7 +60,7 @@ truly unavailable, private, or out of scope.
 | --- | --- |
 | `archMapRef`, `selectedLawPolicyRef` | Identifies the observed source state and selected law universe. |
 | `axisSummary` / `detailIndex` | States selected/nonzero axis counts and points to `flatnessReading` / `signatureAxes[]` detail when needed. |
-| `workflowRiskSummary` / `actionQueue` | Prioritizes molecule-local review pressure such as permission, LLM mediation, state/effect reconciliation, and domain cohesion, with refs into `workflowRiskReadings[]`. |
+| `trendDiagnosis` / `reviewSupport` / `actionQueue` | Prioritizes measured trend pressure, blocker queues, coverage gaps, and compact review actions with refs into packet detail surfaces. |
 | `distanceDiagnosis` | First Part IV distance surface for verdict, measured movement, unmeasured axes, safe margin, repair / curvature / homotopy distance, representation metric summary, and detail refs. |
 | `dominantFindings` / `detailRefs` | Gives compact hotspots, recurrent pressure, architectural holes, nonzero holonomy, workflow risks, and bridge pressure before raw packet inspection. |
 | `part4DistanceFoundation` | Packet detail surface for selected `DistanceProfile`, observed `DiagnosticScope`, status-summary counts, and anti-proxy guardrails. |

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -3391,10 +3391,26 @@ fn build_atom_distance_readings(
                 &coverage_refs,
             );
             let component_distances = vec![
-                atom_distance_component("fiber", 250, fiber_distance.clone()),
-                atom_distance_component("carrier", 350, carrier_distance.clone()),
-                atom_distance_component("valence", 250, valence_distance.clone()),
-                atom_distance_component("semanticAnchor", 150, semantic_anchor_distance.clone()),
+                atom_distance_component(
+                    "fiber",
+                    weighted_atom_component_weight("atom.fiber", 250, foundation),
+                    fiber_distance.clone(),
+                ),
+                atom_distance_component(
+                    "carrier",
+                    weighted_atom_component_weight("atom.carrier", 350, foundation),
+                    carrier_distance.clone(),
+                ),
+                atom_distance_component(
+                    "valence",
+                    weighted_atom_component_weight("atom.valence", 250, foundation),
+                    valence_distance.clone(),
+                ),
+                atom_distance_component(
+                    "semanticAnchor",
+                    weighted_atom_component_weight("atom.semanticAnchor", 150, foundation),
+                    semantic_anchor_distance.clone(),
+                ),
             ];
             let atom_layout_distance_bundle =
                 atom_layout_distance_bundle_value(&component_distances, &coverage_refs);
@@ -3804,9 +3820,14 @@ fn sync_part4_diagnostic_scope(
     operation_distance_readings: &[ArchSigOperationDistanceReadingV0],
     curvature_mass_readings: &[ArchSigCurvatureMassReadingV0],
 ) {
+    let signature_axis_aliases = part4_signature_axis_aliases(signature_distance_readings);
     let measured_axis_refs = signature_distance_readings
         .iter()
         .flat_map(|reading| reading.measured_axis_refs.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let measured_axis_aliases = measured_axis_refs
+        .iter()
+        .flat_map(|axis| part4_canonical_axis_refs(axis, &signature_axis_aliases))
         .collect::<BTreeSet<_>>();
     let unmeasured_axis_refs = signature_distance_readings
         .iter()
@@ -3826,7 +3847,11 @@ fn sync_part4_diagnostic_scope(
                 .iter()
                 .flat_map(|reading| reading.unmeasured_axis_refs.iter().cloned()),
         )
-        .filter(|axis| !measured_axis_refs.contains(axis))
+        .filter(|axis| {
+            part4_canonical_axis_refs(axis, &signature_axis_aliases)
+                .into_iter()
+                .all(|canonical| !measured_axis_aliases.contains(&canonical))
+        })
         .collect::<BTreeSet<_>>();
     let blocker_refs = signature_distance_readings
         .iter()
@@ -3852,9 +3877,11 @@ fn sync_part4_diagnostic_scope(
                 .flat_map(|reading| reading.curvature_mass.blocker_refs.iter().cloned()),
         )
         .filter(|blocker| {
-            blocker
-                .strip_prefix("unmeasuredAxis:")
-                .is_none_or(|axis| !measured_axis_refs.contains(axis))
+            blocker.strip_prefix("unmeasuredAxis:").is_none_or(|axis| {
+                part4_canonical_axis_refs(axis, &signature_axis_aliases)
+                    .into_iter()
+                    .all(|canonical| !measured_axis_aliases.contains(&canonical))
+            })
         })
         .collect::<BTreeSet<_>>();
 
@@ -3864,6 +3891,40 @@ fn sync_part4_diagnostic_scope(
     foundation.diagnostic_scope.evidence_boundary =
         "Diagnostic scope is synchronized from Part IV evaluator readings; measured or zero signature-distance axes are removed from unmeasuredAxisRefs, while operation and curvature partial measurements can keep evidence blockers rather than becoming measured zero"
             .to_string();
+}
+
+fn part4_signature_axis_aliases(
+    signature_distance_readings: &[ArchSigSignatureDistanceReadingV0],
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut aliases = BTreeMap::<String, BTreeSet<String>>::new();
+    for axis in signature_distance_readings
+        .iter()
+        .flat_map(|reading| reading.axis_distances.iter())
+    {
+        let refs = BTreeSet::from([
+            axis.signature_axis_ref.clone(),
+            axis.axis_ref.clone(),
+            axis.law_ref.clone(),
+        ]);
+        for axis_ref in &refs {
+            aliases
+                .entry(axis_ref.clone())
+                .or_default()
+                .extend(refs.iter().cloned());
+        }
+    }
+    aliases
+}
+
+fn part4_canonical_axis_refs(
+    axis_ref: &str,
+    aliases: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<String> {
+    aliases.get(axis_ref).cloned().unwrap_or_else(|| {
+        let mut refs = BTreeSet::new();
+        refs.insert(axis_ref.to_string());
+        refs
+    })
 }
 
 fn atom_fiber_distance_value(
@@ -4663,12 +4724,31 @@ fn atom_distance_component(
     weight: i64,
     value: ArchSigDistanceValueV0,
 ) -> ArchSigAtomDistanceComponentV0 {
+    let evaluator_basis_refs = unique_strings(value.evaluator_basis_refs.iter().cloned().chain(
+        std::iter::once(format!("profileWeight:{component_kind}:{weight}")),
+    ));
     ArchSigAtomDistanceComponentV0 {
         component_kind: component_kind.to_string(),
         weight,
-        evaluator_basis_refs: value.evaluator_basis_refs.clone(),
+        evaluator_basis_refs,
         value,
     }
+}
+
+fn weighted_atom_component_weight(
+    axis_ref: &str,
+    base_weight: i64,
+    foundation: &ArchSigPart4DistanceFoundationV0,
+) -> i64 {
+    base_weight.saturating_mul(
+        foundation
+            .profile
+            .atom_weights
+            .iter()
+            .find(|weight| weight.axis_ref == axis_ref)
+            .map(|weight| weight.weight)
+            .unwrap_or(1),
+    )
 }
 
 fn atom_high_distance_reasons(
@@ -5124,7 +5204,7 @@ fn build_signature_distance_readings(
     let coverage_refs = foundation.profile.coverage_policy_refs.clone();
     let axis_distances = signature_axes
         .iter()
-        .map(|axis| signature_axis_distance(axis, &coverage_refs))
+        .map(|axis| signature_axis_distance(axis, foundation, &coverage_refs))
         .collect::<Vec<_>>();
     let measured_axis_refs = axis_distances
         .iter()
@@ -5212,9 +5292,11 @@ fn attach_signature_distance_reading_refs(
 
 fn signature_axis_distance(
     axis: &ArchSigSignatureAxisReadingV0,
+    foundation: &ArchSigPart4DistanceFoundationV0,
     coverage_refs: &[String],
 ) -> ArchSigSignatureAxisDistanceV0 {
     let blocker_refs = effective_signature_axis_blockers(axis);
+    let profile_weight = selected_signature_axis_weight(axis, foundation);
     let provenance_refs = unique_strings(
         axis.source_refs
             .iter()
@@ -5225,6 +5307,7 @@ fn signature_axis_distance(
     let evaluator_basis_refs = vec![
         format!("rho_i:axis={}", axis.signature_axis_id),
         format!("axisValue:{}", axis.value),
+        format!("profileWeight:{}={profile_weight}", axis.signature_axis_id),
         format!("coverageStatus:{}", axis.coverage_status),
     ];
     let rho_i = if axis.value_type != "integer"
@@ -5255,12 +5338,14 @@ fn signature_axis_distance(
         )
     };
     let axis_distance = measured_part4_distance_value(
-        axis.value * 1000,
+        axis.value
+            .saturating_mul(1000)
+            .saturating_mul(profile_weight),
         "milli-signature-distance",
         provenance_refs,
         evaluator_basis_refs,
         coverage_refs,
-        "axis distance scales rho_i into the selected signature distance unit without converting missing coverage to zero",
+        "axis distance scales rho_i by the selected Part IV DistanceProfile signature weight without converting missing coverage to zero",
     );
     ArchSigSignatureAxisDistanceV0 {
         signature_axis_ref: axis.signature_axis_id.clone(),
@@ -5275,6 +5360,23 @@ fn signature_axis_distance(
             "axis distance is read from selected signature axis evidence and remains coverage-relative"
                 .to_string(),
     }
+}
+
+fn selected_signature_axis_weight(
+    axis: &ArchSigSignatureAxisReadingV0,
+    foundation: &ArchSigPart4DistanceFoundationV0,
+) -> i64 {
+    foundation
+        .profile
+        .signature_weights
+        .iter()
+        .find(|weight| {
+            weight.axis_ref == axis.signature_axis_id
+                || weight.axis_ref == axis.axis_ref
+                || weight.axis_ref == axis.law_ref
+        })
+        .map(|weight| weight.weight)
+        .unwrap_or(1)
 }
 
 fn effective_signature_axis_blockers(axis: &ArchSigSignatureAxisReadingV0) -> Vec<String> {
@@ -14434,7 +14536,15 @@ fn promote_operation_geometry_supporting_distance(
     {
         let blockers = readings
             .iter()
-            .flat_map(|reading| reading.side_effect_bound.blocker_refs.clone())
+            .flat_map(|reading| {
+                reading
+                    .operation_cost
+                    .blocker_refs
+                    .iter()
+                    .chain(reading.side_effect_bound.blocker_refs.iter())
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
@@ -14473,7 +14583,7 @@ fn promote_operation_geometry_supporting_distance(
                 coverage_refs: foundation.profile.coverage_policy_refs.clone(),
                 blocker_refs: blockers,
                 reading:
-                    "operationGeometry remains blocked while selected repair routes have transfer risks or unmeasured protected axes"
+                    "operationGeometry remains blocked while selected repair routes have missing profile costs, transfer risks, or unmeasured protected axes"
                         .to_string(),
             }
         };
@@ -22629,6 +22739,15 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
         .iter()
         .cloned()
         .collect::<BTreeSet<_>>();
+    let signature_axis_aliases = part4_signature_axis_aliases(&packet.signature_distance_readings);
+    let scope_measured_axis_aliases = scope_measured_axis_refs
+        .iter()
+        .flat_map(|axis| part4_canonical_axis_refs(axis, &signature_axis_aliases))
+        .collect::<BTreeSet<_>>();
+    let scope_unmeasured_axis_aliases = scope_unmeasured_axis_refs
+        .iter()
+        .flat_map(|axis| part4_canonical_axis_refs(axis, &signature_axis_aliases))
+        .collect::<BTreeSet<_>>();
     let overlap = scope_measured_axis_refs
         .intersection(&scope_unmeasured_axis_refs)
         .cloned()
@@ -22648,10 +22767,11 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
                 "DiagnosticScope blocker refs must reflect evaluator evidence gaps after measurement, not closed implementation issue placeholders",
             ));
         }
-        if blocker
-            .strip_prefix("unmeasuredAxis:")
-            .is_some_and(|axis| scope_measured_axis_refs.contains(axis))
-        {
+        if blocker.strip_prefix("unmeasuredAxis:").is_some_and(|axis| {
+            part4_canonical_axis_refs(axis, &signature_axis_aliases)
+                .into_iter()
+                .any(|axis| scope_measured_axis_aliases.contains(&axis))
+        }) {
             examples.push(generic_validation_example(
                 "part4DistanceFoundation.diagnosticScope.blockerRefs",
                 blocker,
@@ -22663,6 +22783,10 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
         .signature_distance_readings
         .iter()
         .flat_map(|reading| reading.measured_axis_refs.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let expected_measured_axis_aliases = expected_measured_axis_refs
+        .iter()
+        .flat_map(|axis| part4_canonical_axis_refs(axis, &signature_axis_aliases))
         .collect::<BTreeSet<_>>();
     let expected_unmeasured_axis_refs = packet
         .signature_distance_readings
@@ -22686,7 +22810,11 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
                 .iter()
                 .flat_map(|reading| reading.unmeasured_axis_refs.iter().cloned()),
         )
-        .filter(|axis| !expected_measured_axis_refs.contains(axis))
+        .filter(|axis| {
+            part4_canonical_axis_refs(axis, &signature_axis_aliases)
+                .into_iter()
+                .all(|axis| !expected_measured_axis_aliases.contains(&axis))
+        })
         .collect::<BTreeSet<_>>();
     let missing_measured = expected_measured_axis_refs
         .difference(&scope_measured_axis_refs)
@@ -22699,8 +22827,8 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
             "DiagnosticScope measuredAxisRefs must include measured or zero signature-distance axes",
         ));
     }
-    let stale_unmeasured = scope_unmeasured_axis_refs
-        .intersection(&expected_measured_axis_refs)
+    let stale_unmeasured = scope_unmeasured_axis_aliases
+        .intersection(&expected_measured_axis_aliases)
         .cloned()
         .collect::<Vec<_>>();
     if !stale_unmeasured.is_empty() {
@@ -22711,7 +22839,12 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
         ));
     }
     let missing_unmeasured = expected_unmeasured_axis_refs
-        .difference(&scope_unmeasured_axis_refs)
+        .iter()
+        .filter(|axis| {
+            part4_canonical_axis_refs(axis, &signature_axis_aliases)
+                .into_iter()
+                .all(|axis| !scope_unmeasured_axis_aliases.contains(&axis))
+        })
         .cloned()
         .collect::<Vec<_>>();
     if !missing_unmeasured.is_empty() {
@@ -27043,6 +27176,105 @@ mod tests {
                 .blocker_refs
                 .iter()
                 .any(|blocker| blocker.starts_with("missingOperationCost:"))
+        );
+    }
+
+    #[test]
+    fn missing_operation_cost_blocks_operation_geometry_summary() {
+        let archmap: ArchMapDocumentV0 =
+            serde_json::from_str(include_str!("../tests/fixtures/minimal/archmap.json"))
+                .expect("ArchMap fixture parses");
+        let mut law_policy = crate::law_policy::static_law_policy();
+        law_policy
+            .part4_distance_profile
+            .as_mut()
+            .expect("static policy has Part IV profile")
+            .operation_costs
+            .clear();
+
+        let packet = build_archsig_analysis_packet(&archmap, &law_policy, None, None);
+        let operation_geometry = packet
+            .part4_distance_foundation
+            .supporting_distances
+            .iter()
+            .find(|distance| distance.distance_family == "operationGeometry")
+            .expect("Part IV foundation has operationGeometry row");
+
+        assert_eq!(operation_geometry.value.status, "blocked");
+        assert_eq!(operation_geometry.value.measured_value, None);
+        assert!(
+            operation_geometry
+                .value
+                .blocker_refs
+                .iter()
+                .any(|blocker| blocker.starts_with("missingOperationCost:")),
+            "{:?}",
+            operation_geometry.value.blocker_refs
+        );
+    }
+
+    #[test]
+    fn part4_profile_weights_affect_atom_and_signature_distance() {
+        let archmap: ArchMapDocumentV0 =
+            serde_json::from_str(include_str!("../tests/fixtures/minimal/archmap.json"))
+                .expect("ArchMap fixture parses");
+        let mut law_policy = crate::law_policy::static_law_policy();
+        let profile = law_policy
+            .part4_distance_profile
+            .as_mut()
+            .expect("static policy has Part IV profile");
+        for weight in &mut profile.atom_weights {
+            if weight.axis_ref == "atom.carrier" {
+                weight.weight = 3;
+            }
+        }
+        for weight in &mut profile.signature_weights {
+            if weight.axis_ref == "sig-axis:semantic-inconsistency" {
+                weight.weight = 5;
+            }
+        }
+
+        let packet = build_archsig_analysis_packet(&archmap, &law_policy, None, None);
+        let atom_reading = packet
+            .atom_distance_readings
+            .iter()
+            .find(|reading| {
+                reading
+                    .component_distances
+                    .iter()
+                    .any(|component| component.component_kind == "carrier")
+            })
+            .expect("fixture has atom distance readings");
+        let carrier = atom_reading
+            .component_distances
+            .iter()
+            .find(|component| component.component_kind == "carrier")
+            .expect("atom reading has carrier component");
+        let signature_axis = packet
+            .signature_distance_readings
+            .first()
+            .and_then(|reading| {
+                reading
+                    .axis_distances
+                    .iter()
+                    .find(|axis| axis.signature_axis_ref == "sig-axis:semantic-inconsistency")
+            })
+            .expect("fixture has semantic signature axis distance");
+
+        assert_eq!(carrier.weight, 1050);
+        assert!(
+            carrier
+                .evaluator_basis_refs
+                .iter()
+                .any(|basis| basis == "profileWeight:carrier:1050")
+        );
+        assert_eq!(signature_axis.axis_distance.measured_value, Some(5000));
+        assert!(
+            signature_axis
+                .axis_distance
+                .evaluator_basis_refs
+                .iter()
+                .any(|basis| basis == "profileWeight:sig-axis:semantic-inconsistency=5")
         );
     }
 

--- a/tools/archsig/src/law_policy.rs
+++ b/tools/archsig/src/law_policy.rs
@@ -43,6 +43,8 @@ const REQUIRED_PART4_DISTANCE_PROFILE_NON_CONCLUSIONS: [&str; 4] = [
     "unmeasured distance is not measured zero",
     "operation distance requires a declared profile cost or explicit calibration evidence",
 ];
+const MAX_PART4_DISTANCE_PROFILE_WEIGHT: i64 = 1_000_000;
+const MAX_PART4_OPERATION_COST: i64 = 1_000_000;
 
 pub fn static_law_policy() -> LawPolicyDocumentV0 {
     LawPolicyDocumentV0 {
@@ -725,6 +727,11 @@ fn check_part4_distance_profile(policy: &LawPolicyDocumentV0) -> ValidationCheck
         .iter()
         .map(|weight| weight.axis_ref.as_str())
         .collect::<BTreeSet<_>>();
+    let present_signature_axes = profile
+        .signature_weights
+        .iter()
+        .map(|weight| weight.axis_ref.as_str())
+        .collect::<BTreeSet<_>>();
     let present_non_conclusions = profile
         .non_conclusions
         .iter()
@@ -746,12 +753,37 @@ fn check_part4_distance_profile(policy: &LawPolicyDocumentV0) -> ValidationCheck
             ));
         }
     }
+    for weight in &profile.atom_weights {
+        if ![
+            "atom.fiber",
+            "atom.carrier",
+            "atom.valence",
+            "atom.semanticAnchor",
+        ]
+        .contains(&weight.axis_ref.as_str())
+        {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                &weight.axis_ref,
+                "part4DistanceProfile.atomWeights must not include unused Atom geometry components",
+            ));
+        }
+    }
     if profile.signature_weights.is_empty() {
         examples.push(generic_validation_example(
             &profile.profile_id,
             "signatureWeights",
             "part4DistanceProfile must declare signature-axis weights from LawPolicy",
         ));
+    }
+    for signature_axis_id in &signature_axis_ids {
+        if !present_signature_axes.contains(signature_axis_id) {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                signature_axis_id,
+                "part4DistanceProfile.signatureWeights must include every selected signature axis",
+            ));
+        }
     }
     for weight in profile
         .atom_weights
@@ -773,6 +805,13 @@ fn check_part4_distance_profile(policy: &LawPolicyDocumentV0) -> ValidationCheck
                 &profile.profile_id,
                 &weight.axis_ref,
                 "part4DistanceProfile weights must be positive selected distances",
+            ));
+        }
+        if weight.weight > MAX_PART4_DISTANCE_PROFILE_WEIGHT {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                &weight.axis_ref,
+                "part4DistanceProfile weights must stay within the bounded ArchSig distance range",
             ));
         }
     }
@@ -811,6 +850,13 @@ fn check_part4_distance_profile(policy: &LawPolicyDocumentV0) -> ValidationCheck
                 &profile.profile_id,
                 &cost.operation_kind,
                 "part4DistanceProfile operation costs must be positive selected distances",
+            ));
+        }
+        if cost.cost > MAX_PART4_OPERATION_COST {
+            examples.push(generic_validation_example(
+                &profile.profile_id,
+                &cost.operation_kind,
+                "part4DistanceProfile operation costs must stay within the bounded ArchSig distance range",
             ));
         }
     }
@@ -2092,6 +2138,77 @@ mod tests {
         assert_eq!(report.summary.result, "fail");
         assert!(report.checks.iter().any(|check| {
             check.id == "law-policy-part4-distance-profile" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn part4_distance_profile_rejects_sparse_and_unused_weights() {
+        let mut missing_signature = static_law_policy();
+        missing_signature
+            .part4_distance_profile
+            .as_mut()
+            .expect("fixture declares a Part IV distance profile")
+            .signature_weights
+            .retain(|weight| weight.axis_ref != "sig-axis:semantic-inconsistency");
+        let missing_report = validate_law_policy_report(&missing_signature, "bad-law-policy.json");
+        assert_eq!(missing_report.summary.result, "fail");
+        assert!(missing_report.checks.iter().any(|check| {
+            check.id == "law-policy-part4-distance-profile"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example.evidence.as_deref().is_some_and(|evidence| {
+                        evidence.contains("must include every selected signature axis")
+                    })
+                })
+        }));
+
+        let mut unused_atom = static_law_policy();
+        unused_atom
+            .part4_distance_profile
+            .as_mut()
+            .expect("fixture declares a Part IV distance profile")
+            .atom_weights
+            .push(LawPolicyPart4DistanceWeightV0 {
+                axis_ref: "atom.unused".to_string(),
+                weight: 1,
+                source_ref: "fixture:unused".to_string(),
+            });
+        let unused_report = validate_law_policy_report(&unused_atom, "bad-law-policy.json");
+        assert_eq!(unused_report.summary.result, "fail");
+        assert!(unused_report.checks.iter().any(|check| {
+            check.id == "law-policy-part4-distance-profile"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example.evidence.as_deref().is_some_and(|evidence| {
+                        evidence.contains("must not include unused Atom geometry components")
+                    })
+                })
+        }));
+    }
+
+    #[test]
+    fn part4_distance_profile_rejects_unbounded_weights_and_costs() {
+        let mut policy = static_law_policy();
+        let profile = policy
+            .part4_distance_profile
+            .as_mut()
+            .expect("fixture declares a Part IV distance profile");
+        profile.atom_weights[0].weight = MAX_PART4_DISTANCE_PROFILE_WEIGHT + 1;
+        profile.signature_weights[0].weight = MAX_PART4_DISTANCE_PROFILE_WEIGHT + 1;
+        profile.operation_costs[0].cost = MAX_PART4_OPERATION_COST + 1;
+
+        let report = validate_law_policy_report(&policy, "bad-law-policy.json");
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "law-policy-part4-distance-profile"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example
+                        .evidence
+                        .as_deref()
+                        .is_some_and(|evidence| evidence.contains("bounded ArchSig distance range"))
+                })
         }));
     }
 

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -4233,13 +4233,18 @@ fn distance_diagnosis(packet: &serde_json::Value) -> serde_json::Value {
         "topMovedAxes": top_signature_axis_distance_rows(packet, 6),
         "safeMargin": compact_distance_value(&signature_distance, "safeRegionMargin"),
         "repairDistance": {
-            "operationRef": json_field(&operation_distance, "operationRef"),
+            "readingId": json_field(&operation_distance, "operationDistanceReadingId"),
+            "operationRef": json_field(&operation_distance, "operationDeltaRef"),
+            "operationDeltaRef": json_field(&operation_distance, "operationDeltaRef"),
+            "operationKind": json_field(&operation_distance, "operationKind"),
             "operationCost": compact_distance_value(&operation_distance, "operationCost"),
             "targetDistanceDecrease": compact_distance_value(&operation_distance, "targetDistanceDecrease"),
             "sideEffectBound": compact_distance_value(&operation_distance, "sideEffectBound")
         },
         "curvatureDistance": {
-            "readingId": json_field(&curvature_distance, "readingId"),
+            "readingId": json_field(&curvature_distance, "curvatureMassReadingId"),
+            "profileRef": json_field(&curvature_distance, "profileRef"),
+            "supportReadingRef": json_field(&curvature_distance, "supportReadingRef"),
             "curvatureMass": compact_distance_value(&curvature_distance, "curvatureMass"),
             "transportDistance": compact_distance_value(&curvature_distance, "transportDistance")
         },
@@ -4273,12 +4278,14 @@ fn distance_diagnosis_unmeasured_axes(
     diagnostic_scope: &serde_json::Value,
     signature_distance: &serde_json::Value,
 ) -> serde_json::Value {
+    let signature_axis_aliases = signature_axis_aliases(signature_distance);
     let measured_axis_refs = string_vec_from_value(diagnostic_scope, "measuredAxisRefs")
         .into_iter()
         .chain(string_vec_from_value(
             signature_distance,
             "measuredAxisRefs",
         ))
+        .flat_map(|axis| canonical_axis_refs(&axis, &signature_axis_aliases))
         .collect::<BTreeSet<_>>();
     let unmeasured_axis_refs = string_vec_from_value(diagnostic_scope, "unmeasuredAxisRefs")
         .into_iter()
@@ -4290,9 +4297,44 @@ fn distance_diagnosis_unmeasured_axes(
             signature_distance,
             "incomparableAxisRefs",
         ))
-        .filter(|axis| !measured_axis_refs.contains(axis))
+        .filter(|axis| {
+            canonical_axis_refs(axis, &signature_axis_aliases)
+                .into_iter()
+                .all(|canonical| !measured_axis_refs.contains(&canonical))
+        })
         .collect::<BTreeSet<_>>();
     json_string_array(unmeasured_axis_refs.into_iter())
+}
+
+fn signature_axis_aliases(
+    signature_distance: &serde_json::Value,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut aliases = BTreeMap::<String, BTreeSet<String>>::new();
+    for axis in array_items(signature_distance, "axisDistances") {
+        let refs = ["signatureAxisRef", "axisRef", "lawRef"]
+            .into_iter()
+            .filter_map(|key| axis.get(key).and_then(serde_json::Value::as_str))
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>();
+        for axis_ref in &refs {
+            aliases
+                .entry(axis_ref.clone())
+                .or_default()
+                .extend(refs.iter().cloned());
+        }
+    }
+    aliases
+}
+
+fn canonical_axis_refs(
+    axis_ref: &str,
+    aliases: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<String> {
+    aliases.get(axis_ref).cloned().unwrap_or_else(|| {
+        let mut refs = BTreeSet::new();
+        refs.insert(axis_ref.to_string());
+        refs
+    })
 }
 
 fn compact_distance_value(container: &serde_json::Value, key: &str) -> serde_json::Value {
@@ -4338,6 +4380,13 @@ fn top_signature_axis_distance_rows(packet: &serde_json::Value, limit: usize) ->
     let mut rows = array_items(packet, "signatureDistanceReadings")
         .into_iter()
         .flat_map(|reading| array_items(reading, "axisDistances"))
+        .filter(|axis| {
+            axis.get("axisDistance")
+                .and_then(|value| value.get("measuredValue"))
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or_default()
+                > 0
+        })
         .map(|axis| {
             let axis_distance = axis.get("axisDistance").unwrap_or(&serde_json::Value::Null);
             serde_json::json!({

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -46,6 +46,10 @@ fn sharded_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sharded")
 }
 
+fn negative_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/negative")
+}
+
 #[test]
 fn cli_help_exposes_only_llm_atom_archmap_surface() {
     let output = run_sig0_output(&["--help"]);
@@ -193,6 +197,31 @@ fn cli_summarizes_archsig_analysis_packet() {
                         .is_some_and(|value| value.contains("/signatureDistanceReadings"))
                 })),
         "analysis-summary must expose Part IV distance diagnosis with detail refs"
+    );
+    assert_part4_distance_diagnosis_refs_resolve(&json, &packet);
+    assert!(
+        json["distanceDiagnosis"]["repairDistance"]["readingId"]
+            .as_str()
+            .is_some()
+            && json["distanceDiagnosis"]["repairDistance"]["operationDeltaRef"]
+                .as_str()
+                .is_some()
+            && json["distanceDiagnosis"]["curvatureDistance"]["readingId"]
+                .as_str()
+                .is_some(),
+        "analysis-summary distanceDiagnosis must expose non-null raw packet ids for repair and curvature distances"
+    );
+    assert!(
+        json["distanceDiagnosis"]["topMovedAxes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .all(|axis| {
+                axis["axisDistance"]["measuredValue"]
+                    .as_i64()
+                    .is_some_and(|value| value > 0)
+            }),
+        "topMovedAxes must only report positive measured movement axes"
     );
     assert!(
         unmeasured_surface_excludes_measured_axes(&json["distanceDiagnosis"], &measured_axis_refs),
@@ -1226,6 +1255,105 @@ fn cli_analyze_strict_distance_requires_part4_profile() {
         law_policy_validation["summary"]["result"].as_str(),
         Some("warn"),
         "legacy profile should be visible in the emitted LawPolicy validation report"
+    );
+}
+
+#[test]
+fn cli_analyze_strict_distance_uses_part4_profile_weights() {
+    let out_dir = temp_dir("analyze-strict-distance-weights");
+    let root = fixture_root();
+    let archmap = root.join("archmap.json");
+    let law_policy = root.join("law_policy.json");
+    let weighted_policy_path = out_dir.join("law_policy_weighted_part4.json");
+    let mut weighted_policy = read_json(&law_policy);
+    let signature_weights = weighted_policy["part4DistanceProfile"]["signatureWeights"]
+        .as_array_mut()
+        .expect("fixture LawPolicy has signature weights");
+    for weight in signature_weights {
+        if weight["axisRef"] == "sig-axis:semantic-inconsistency" {
+            weight["weight"] = Value::from(5);
+        }
+    }
+    let atom_weights = weighted_policy["part4DistanceProfile"]["atomWeights"]
+        .as_array_mut()
+        .expect("fixture LawPolicy has atom weights");
+    for weight in atom_weights {
+        if weight["axisRef"] == "atom.carrier" {
+            weight["weight"] = Value::from(3);
+        }
+    }
+    fs::write(
+        &weighted_policy_path,
+        serde_json::to_vec_pretty(&weighted_policy).expect("weighted policy serializes"),
+    )
+    .expect("weighted policy can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap.to_str().expect("archmap path is utf-8"),
+        "--law-policy",
+        weighted_policy_path
+            .to_str()
+            .expect("weighted law policy path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("output directory path is utf-8"),
+        "--strict-distance",
+        "--emit-raw-artifacts",
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-analysis-packet.json"));
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    let semantic_axis = packet["signatureDistanceReadings"][0]["axisDistances"]
+        .as_array()
+        .expect("axisDistances are present")
+        .iter()
+        .find(|axis| axis["signatureAxisRef"] == "sig-axis:semantic-inconsistency")
+        .expect("semantic axis distance is present");
+
+    assert_eq!(
+        semantic_axis["axisDistance"]["measuredValue"].as_i64(),
+        Some(5000),
+        "strict-distance analyze must use selected signature weight"
+    );
+    assert!(
+        semantic_axis["axisDistance"]["evaluatorBasisRefs"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|basis| basis.as_str() == Some("profileWeight:sig-axis:semantic-inconsistency=5")),
+        "axis distance must expose the selected profile weight in evaluator basis"
+    );
+    assert_eq!(
+        summary["distanceDiagnosis"]["topMovedAxes"][0]["axisDistance"]["measuredValue"].as_i64(),
+        Some(5000),
+        "summary topMovedAxes must reflect the weighted raw packet distance"
+    );
+
+    let carrier_component = packet["atomDistanceReadings"]
+        .as_array()
+        .expect("atom distance readings are present")
+        .iter()
+        .flat_map(|reading| {
+            reading["componentDistances"]
+                .as_array()
+                .into_iter()
+                .flatten()
+        })
+        .find(|component| component["componentKind"] == "carrier")
+        .expect("carrier component distance is present");
+    assert_eq!(
+        carrier_component["weight"].as_i64(),
+        Some(1050),
+        "strict-distance analyze must use selected atom component weight"
+    );
+    assert!(
+        carrier_component["evaluatorBasisRefs"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|basis| basis.as_str() == Some("profileWeight:carrier:1050")),
+        "atom component distance must expose the selected profile weight in evaluator basis"
     );
 }
 
@@ -3233,6 +3361,7 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
     for section in [
         "Overview",
         "Top Findings",
+        "Distance Diagnosis",
         "Action Queue",
         "Coverage And Boundaries",
         "Artifacts",
@@ -3245,6 +3374,15 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
         );
     }
     assert!(
+        html.contains("renderDistanceDiagnosis")
+            && html.contains("compactRepresentationMetricValues")
+            && html.contains("representationMetric")
+            && html.contains("distanceBoundary")
+            && html.contains("nonClaims")
+            && html.contains("detailRefs"),
+        "viewer must render distanceDiagnosis with boundary, non-claims, and detail refs"
+    );
+    assert!(
         html.contains("atomEdges")
             && html.contains("moleculeGroups")
             && html.contains("analysisOverlays"),
@@ -3254,6 +3392,143 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
         !html.contains("archsig-analysis-packet.json"),
         "viewer must not embed or load the raw analysis packet"
     );
+}
+
+#[test]
+fn part4_negative_fixture_corpus_tracks_distance_surface_regressions() {
+    let corpus = read_json(&negative_root().join("part4_distance_surface_negative_cases.json"));
+    let cases = corpus["cases"]
+        .as_array()
+        .expect("Part IV negative corpus has cases");
+    for expected in [
+        "stale-axis-namespace",
+        "profile-weight-ignored",
+        "missing-operation-cost-not-promoted",
+        "summary-distance-id-null",
+        "stale-detail-ref",
+    ] {
+        assert!(
+            cases
+                .iter()
+                .any(|case| case["caseId"].as_str() == Some(expected)),
+            "negative corpus must track {expected}"
+        );
+    }
+    assert!(
+        cases.iter().all(|case| {
+            case["sourceIssue"]
+                .as_str()
+                .is_some_and(|issue| issue.starts_with('#'))
+                && case["assertion"].as_str().is_some()
+                && case["fixtureKind"].as_str().is_some()
+        }),
+        "each negative case must record source issue, fixture kind, and assertion"
+    );
+
+    let policy_cases =
+        read_json(&negative_root().join("part4_distance_policy_negative_cases.json"));
+    let policy_cases = policy_cases["cases"]
+        .as_array()
+        .expect("Part IV policy negative corpus has cases");
+    assert!(
+        policy_cases.len() >= 3,
+        "policy negative corpus must contain executable validation cases"
+    );
+    for case in policy_cases {
+        let out_dir = temp_dir(case["caseId"].as_str().expect("negative case has caseId"));
+        let root = fixture_root();
+        let policy_path = out_dir.join("law_policy_negative.json");
+        let mut policy = read_json(&root.join("law_policy.json"));
+        apply_part4_policy_negative_mutation(&mut policy, case);
+        fs::write(
+            &policy_path,
+            serde_json::to_vec_pretty(&policy).expect("negative policy serializes"),
+        )
+        .expect("negative policy can be written");
+
+        let output = run_sig0_output(&[
+            "analyze",
+            "--archmap",
+            root.join("archmap.json")
+                .to_str()
+                .expect("archmap path is utf-8"),
+            "--law-policy",
+            policy_path
+                .to_str()
+                .expect("negative law policy path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("negative out dir is utf-8"),
+            "--strict-distance",
+        ]);
+
+        assert!(
+            !output.status.success(),
+            "negative policy case must fail strict-distance: {}",
+            case["caseId"]
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let expected = case["expectedStderr"]
+            .as_str()
+            .expect("negative case declares expected stderr");
+        assert!(
+            stderr.contains(expected),
+            "negative policy case {} stderr should contain {expected}\n{stderr}",
+            case["caseId"]
+        );
+    }
+}
+
+fn apply_part4_policy_negative_mutation(policy: &mut Value, case: &Value) {
+    let mutation = &case["mutation"];
+    let kind = mutation["kind"]
+        .as_str()
+        .expect("negative case mutation has kind");
+    match kind {
+        "removeSignatureWeight" => {
+            let axis_ref = mutation["axisRef"]
+                .as_str()
+                .expect("removeSignatureWeight has axisRef");
+            let weights = policy["part4DistanceProfile"]["signatureWeights"]
+                .as_array_mut()
+                .expect("fixture policy has signatureWeights");
+            weights.retain(|weight| weight["axisRef"].as_str() != Some(axis_ref));
+        }
+        "addAtomWeight" => {
+            let axis_ref = mutation["axisRef"]
+                .as_str()
+                .expect("addAtomWeight has axisRef");
+            let weight = mutation["weight"]
+                .as_i64()
+                .expect("addAtomWeight has weight");
+            let weights = policy["part4DistanceProfile"]["atomWeights"]
+                .as_array_mut()
+                .expect("fixture policy has atomWeights");
+            weights.push(serde_json::json!({
+                "axisRef": axis_ref,
+                "weight": weight,
+                "sourceRef": "fixture:negative-part4-distance-policy"
+            }));
+        }
+        "setSignatureWeight" => {
+            let axis_ref = mutation["axisRef"]
+                .as_str()
+                .expect("setSignatureWeight has axisRef");
+            let value = Value::from(
+                mutation["weight"]
+                    .as_i64()
+                    .expect("setSignatureWeight has weight"),
+            );
+            let weights = policy["part4DistanceProfile"]["signatureWeights"]
+                .as_array_mut()
+                .expect("fixture policy has signatureWeights");
+            let weight = weights
+                .iter_mut()
+                .find(|weight| weight["axisRef"].as_str() == Some(axis_ref))
+                .expect("fixture policy has target signature weight");
+            weight["weight"] = value;
+        }
+        other => panic!("unknown Part IV negative policy mutation kind: {other}"),
+    }
 }
 
 #[test]
@@ -3369,10 +3644,54 @@ fn unmeasured_surface_excludes_measured_axes(
     measured_axis_refs: &BTreeSet<String>,
 ) -> bool {
     let unmeasured_axes = string_set(&distance_diagnosis["unmeasuredAxes"]);
-    unmeasured_axes
-        .intersection(measured_axis_refs)
+    let measured_axis_aliases = measured_axis_refs
+        .iter()
+        .flat_map(|axis| axis_aliases(axis))
+        .collect::<BTreeSet<_>>();
+    let unmeasured_axis_aliases = unmeasured_axes
+        .iter()
+        .flat_map(|axis| axis_aliases(axis))
+        .collect::<BTreeSet<_>>();
+    unmeasured_axis_aliases
+        .intersection(&measured_axis_aliases)
         .next()
         .is_none()
+}
+
+fn axis_aliases(axis_ref: &str) -> BTreeSet<String> {
+    let mut aliases = BTreeSet::from([axis_ref.to_string()]);
+    if let Some(suffix) = axis_ref.strip_prefix("sig-axis:") {
+        aliases.insert(format!("axis:{suffix}"));
+    }
+    if let Some(suffix) = axis_ref.strip_prefix("axis:") {
+        aliases.insert(format!("sig-axis:{suffix}"));
+    }
+    aliases
+}
+
+fn assert_part4_distance_diagnosis_refs_resolve(summary: &Value, packet: &Value) {
+    let refs = summary["distanceDiagnosis"]["detailRefs"]
+        .as_array()
+        .expect("distanceDiagnosis detailRefs is array");
+    assert!(
+        !refs.is_empty(),
+        "distanceDiagnosis detailRefs must be nonempty"
+    );
+    for reference in refs {
+        let reference = reference
+            .as_str()
+            .expect("distanceDiagnosis detail ref is string");
+        let pointer = reference
+            .strip_prefix("packet:")
+            .expect("distanceDiagnosis detail ref uses packet: prefix");
+        let target = packet.pointer(pointer).unwrap_or_else(|| {
+            panic!("distanceDiagnosis detail ref must resolve into raw packet: {reference}")
+        });
+        assert!(
+            !target.as_array().is_some_and(Vec::is_empty),
+            "distanceDiagnosis detail ref must not resolve to an empty packet section: {reference}"
+        );
+    }
 }
 
 fn signature_measured_axis_refs(packet: &Value) -> BTreeSet<String> {
@@ -3388,6 +3707,14 @@ fn assert_part4_cross_surface_axis_status_consistency(packet: &Value) {
     let diagnostic_scope = &packet["part4DistanceFoundation"]["diagnosticScope"];
     let scope_measured_axes = string_set(&diagnostic_scope["measuredAxisRefs"]);
     let scope_unmeasured_axes = string_set(&diagnostic_scope["unmeasuredAxisRefs"]);
+    let scope_measured_axis_aliases = scope_measured_axes
+        .iter()
+        .flat_map(|axis| axis_aliases(axis))
+        .collect::<BTreeSet<_>>();
+    let scope_unmeasured_axis_aliases = scope_unmeasured_axes
+        .iter()
+        .flat_map(|axis| axis_aliases(axis))
+        .collect::<BTreeSet<_>>();
     let overlap = scope_measured_axes
         .intersection(&scope_unmeasured_axes)
         .cloned()
@@ -3411,7 +3738,11 @@ fn assert_part4_cross_surface_axis_status_consistency(packet: &Value) {
         .flatten()
         .filter_map(Value::as_str)
         .filter_map(|blocker| blocker.strip_prefix("unmeasuredAxis:"))
-        .filter(|axis| scope_measured_axes.contains(*axis))
+        .filter(|axis| {
+            axis_aliases(axis)
+                .into_iter()
+                .any(|axis| scope_measured_axis_aliases.contains(&axis))
+        })
         .map(str::to_string)
         .collect::<Vec<_>>();
     assert!(
@@ -3420,6 +3751,10 @@ fn assert_part4_cross_surface_axis_status_consistency(packet: &Value) {
     );
 
     let signature_measured_axes = signature_measured_axis_refs(packet);
+    let signature_measured_axis_aliases = signature_measured_axes
+        .iter()
+        .flat_map(|axis| axis_aliases(axis))
+        .collect::<BTreeSet<_>>();
     let signature_unmeasured_axes = packet["signatureDistanceReadings"]
         .as_array()
         .into_iter()
@@ -3440,8 +3775,8 @@ fn assert_part4_cross_surface_axis_status_consistency(packet: &Value) {
         missing_measured.is_empty(),
         "DiagnosticScope measuredAxisRefs must include measured or zero signature axes: {missing_measured:?}"
     );
-    let stale_unmeasured = scope_unmeasured_axes
-        .intersection(&signature_measured_axes)
+    let stale_unmeasured = scope_unmeasured_axis_aliases
+        .intersection(&signature_measured_axis_aliases)
         .cloned()
         .collect::<Vec<_>>();
     assert!(

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -1341,10 +1341,7 @@
         "sig-axis:layer-violation",
         "sig-axis:semantic-inconsistency"
       ],
-      "unmeasuredAxisRefs": [
-        "axis:layer-violation",
-        "axis:semantic-inconsistency"
-      ],
+      "unmeasuredAxisRefs": [],
       "coveragePolicyRefs": [
         "coverage:layer-atoms",
         "coverage:semantic-contract-atoms"
@@ -1353,9 +1350,7 @@
         "coverage:layer-atoms: report observation gap and block signature-zero reflection",
         "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
         "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
-        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary",
-        "unmeasuredAxis:axis:layer-violation",
-        "unmeasuredAxis:axis:semantic-inconsistency"
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
       ],
       "evidenceBoundary": "Diagnostic scope is synchronized from Part IV evaluator readings; measured or zero signature-distance axes are removed from unmeasuredAxisRefs, while operation and curvature partial measurements can keep evidence blockers rather than becoming measured zero"
     },
@@ -1515,7 +1510,7 @@
             "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
             "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
           ],
-          "reading": "operationGeometry remains blocked while selected repair routes have transfer risks or unmeasured protected axes"
+          "reading": "operationGeometry remains blocked while selected repair routes have missing profile costs, transfer risks, or unmeasured protected axes"
         },
         "profileRef": "part4-distance-profile:llm-native-aat-law-policy-fixture",
         "diagnosticScopeRef": "part4-diagnostic-scope:fixture-archmap-atom-observation",
@@ -1821,6 +1816,10 @@
           "fiber:confidence:left=medium:right=high",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=create-user-capability-is-observed:right=component-route-users-exists",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_be_vertex"
         ],
@@ -1865,9 +1864,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=capability:right=existence",
             "fiber:axis:left=static:right=static",
-            "fiber:predicate:left=create-user-capability-is-observed:right=component-route-users-exists",
+            "fiber:confidence:left=medium:right=high",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=medium:right=high"
+            "fiber:predicate:left=create-user-capability-is-observed:right=component-route-users-exists",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -1897,7 +1897,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:test-user-contract|subject:operation-createuser",
-            "carrier:right=object:route-users|source:src-route-users|subject:route-users"
+            "carrier:right=object:route-users|source:src-route-users|subject:route-users",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -1926,6 +1927,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_be_vertex"
           ]
@@ -1953,7 +1955,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -2091,6 +2095,10 @@
           "fiber:confidence:left=medium:right=high",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=create-user-capability-is-observed:right=component-service-user-exists",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_be_vertex"
         ],
@@ -2135,9 +2143,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=capability:right=existence",
             "fiber:axis:left=static:right=static",
-            "fiber:predicate:left=create-user-capability-is-observed:right=component-service-user-exists",
+            "fiber:confidence:left=medium:right=high",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=medium:right=high"
+            "fiber:predicate:left=create-user-capability-is-observed:right=component-service-user-exists",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -2167,7 +2176,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:test-user-contract|subject:operation-createuser",
-            "carrier:right=object:service-user|source:src-service-user|subject:service-user"
+            "carrier:right=object:service-user|source:src-service-user|subject:service-user",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -2196,6 +2206,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_be_vertex"
           ]
@@ -2223,7 +2234,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -2356,6 +2369,10 @@
           "fiber:confidence:left=medium:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=create-user-capability-is-observed:right=contract-test-observes-create-user-success",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_attach_contract|can_be_vertex"
         ],
@@ -2399,9 +2416,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=capability:right=contractspecification",
             "fiber:axis:left=static:right=specification",
-            "fiber:predicate:left=create-user-capability-is-observed:right=contract-test-observes-create-user-success",
+            "fiber:confidence:left=medium:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=medium:right=medium"
+            "fiber:predicate:left=create-user-capability-is-observed:right=contract-test-observes-create-user-success",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -2430,7 +2448,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:test-user-contract|subject:operation-createuser",
-            "carrier:right=object:service-user|source:test-user-contract|subject:contract-createsuser"
+            "carrier:right=object:service-user|source:test-user-contract|subject:contract-createsuser",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -2458,6 +2477,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_attach_contract|can_be_vertex"
           ]
@@ -2484,7 +2504,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -2628,6 +2650,10 @@
           "fiber:confidence:left=medium:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=create-user-capability-is-observed:right=route-users-delegates-user-creation-to-service-user",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_be_edge|can_be_vertex"
         ],
@@ -2673,9 +2699,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=capability:right=relation",
             "fiber:axis:left=static:right=static",
-            "fiber:predicate:left=create-user-capability-is-observed:right=route-users-delegates-user-creation-to-service-user",
+            "fiber:confidence:left=medium:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=medium:right=medium"
+            "fiber:predicate:left=create-user-capability-is-observed:right=route-users-delegates-user-creation-to-service-user",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -2706,7 +2733,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:test-user-contract|subject:operation-createuser",
-            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user"
+            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -2736,6 +2764,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_be_edge|can_be_vertex"
           ]
@@ -2764,7 +2793,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -2902,6 +2933,10 @@
           "fiber:confidence:left=high:right=high",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=component-route-users-exists:right=component-service-user-exists",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_be_vertex"
         ],
@@ -2946,9 +2981,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=existence:right=existence",
             "fiber:axis:left=static:right=static",
-            "fiber:predicate:left=component-route-users-exists:right=component-service-user-exists",
+            "fiber:confidence:left=high:right=high",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=high:right=high"
+            "fiber:predicate:left=component-route-users-exists:right=component-service-user-exists",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -2978,7 +3014,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:route-users|source:src-route-users|subject:route-users",
-            "carrier:right=object:service-user|source:src-service-user|subject:service-user"
+            "carrier:right=object:service-user|source:src-service-user|subject:service-user",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -3007,6 +3044,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_be_vertex"
           ]
@@ -3034,7 +3072,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -3171,6 +3211,10 @@
           "fiber:confidence:left=high:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=component-route-users-exists:right=contract-test-observes-create-user-success",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_attach_contract|can_be_vertex"
         ],
@@ -3215,9 +3259,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=existence:right=contractspecification",
             "fiber:axis:left=static:right=specification",
-            "fiber:predicate:left=component-route-users-exists:right=contract-test-observes-create-user-success",
+            "fiber:confidence:left=high:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=high:right=medium"
+            "fiber:predicate:left=component-route-users-exists:right=contract-test-observes-create-user-success",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -3247,7 +3292,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:route-users|source:src-route-users|subject:route-users",
-            "carrier:right=object:service-user|source:test-user-contract|subject:contract-createsuser"
+            "carrier:right=object:service-user|source:test-user-contract|subject:contract-createsuser",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -3276,6 +3322,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_attach_contract|can_be_vertex"
           ]
@@ -3303,7 +3350,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -3442,6 +3491,10 @@
           "fiber:confidence:left=high:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=component-route-users-exists:right=route-users-delegates-user-creation-to-service-user",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_be_edge|can_be_vertex"
         ],
@@ -3486,9 +3539,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=existence:right=relation",
             "fiber:axis:left=static:right=static",
-            "fiber:predicate:left=component-route-users-exists:right=route-users-delegates-user-creation-to-service-user",
+            "fiber:confidence:left=high:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=high:right=medium"
+            "fiber:predicate:left=component-route-users-exists:right=route-users-delegates-user-creation-to-service-user",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -3518,7 +3572,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:route-users|source:src-route-users|subject:route-users",
-            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user"
+            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -3547,6 +3602,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_be_edge|can_be_vertex"
           ]
@@ -3574,7 +3630,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -3713,6 +3771,10 @@
           "fiber:confidence:left=high:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=component-service-user-exists:right=contract-test-observes-create-user-success",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_attach_contract|can_be_vertex"
         ],
@@ -3757,9 +3819,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=existence:right=contractspecification",
             "fiber:axis:left=static:right=specification",
-            "fiber:predicate:left=component-service-user-exists:right=contract-test-observes-create-user-success",
+            "fiber:confidence:left=high:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=high:right=medium"
+            "fiber:predicate:left=component-service-user-exists:right=contract-test-observes-create-user-success",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -3789,7 +3852,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:src-service-user|subject:service-user",
-            "carrier:right=object:service-user|source:test-user-contract|subject:contract-createsuser"
+            "carrier:right=object:service-user|source:test-user-contract|subject:contract-createsuser",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -3818,6 +3882,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_attach_contract|can_be_vertex"
           ]
@@ -3845,7 +3910,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -3984,6 +4051,10 @@
           "fiber:confidence:left=high:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=component-service-user-exists:right=route-users-delegates-user-creation-to-service-user",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "valence:left=can_be_vertex",
           "valence:right=can_be_edge|can_be_vertex"
         ],
@@ -4028,9 +4099,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=existence:right=relation",
             "fiber:axis:left=static:right=static",
-            "fiber:predicate:left=component-service-user-exists:right=route-users-delegates-user-creation-to-service-user",
+            "fiber:confidence:left=high:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=high:right=medium"
+            "fiber:predicate:left=component-service-user-exists:right=route-users-delegates-user-creation-to-service-user",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -4060,7 +4132,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:src-service-user|subject:service-user",
-            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user"
+            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -4089,6 +4162,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_be_vertex",
             "valence:right=can_be_edge|can_be_vertex"
           ]
@@ -4116,7 +4190,9 @@
             ],
             "reading": "semantic anchor distance is unmeasured until both atoms have semantic observation support"
           },
-          "evaluatorBasisRefs": []
+          "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150"
+          ]
         }
       ],
       "highDistanceReasons": [
@@ -4263,6 +4339,10 @@
           "fiber:confidence:left=medium:right=medium",
           "fiber:observationStatus:left=observed:right=observed",
           "fiber:predicate:left=contract-test-observes-create-user-success:right=route-users-delegates-user-creation-to-service-user",
+          "profileWeight:carrier:350",
+          "profileWeight:fiber:250",
+          "profileWeight:semanticAnchor:150",
+          "profileWeight:valence:250",
           "semantic:left=semanticFamily:operationmeaning|semanticFamily:semanticinterpretation|semanticObservation:semantic-create-user-flow|semanticObservation:semantic-interpretation-create-user|semanticPredicate:create-user-operation-has-a-selected-semantic-interpretation|semanticPredicate:route-service-and-contract-jointly-describe-create-user-behavior|semanticSubject:operation-createuser",
           "semantic:right=semanticFamily:operationmeaning|semanticFamily:semanticinterpretation|semanticObservation:semantic-create-user-flow|semanticObservation:semantic-interpretation-create-user|semanticPredicate:create-user-operation-has-a-selected-semantic-interpretation|semanticPredicate:route-service-and-contract-jointly-describe-create-user-behavior|semanticSubject:operation-createuser",
           "valence:left=can_attach_contract|can_be_vertex",
@@ -4308,9 +4388,10 @@
           "evaluatorBasisRefs": [
             "fiber:atomFamily:left=contractspecification:right=relation",
             "fiber:axis:left=specification:right=static",
-            "fiber:predicate:left=contract-test-observes-create-user-success:right=route-users-delegates-user-creation-to-service-user",
+            "fiber:confidence:left=medium:right=medium",
             "fiber:observationStatus:left=observed:right=observed",
-            "fiber:confidence:left=medium:right=medium"
+            "fiber:predicate:left=contract-test-observes-create-user-success:right=route-users-delegates-user-creation-to-service-user",
+            "profileWeight:fiber:250"
           ]
         },
         {
@@ -4341,7 +4422,8 @@
           },
           "evaluatorBasisRefs": [
             "carrier:left=object:service-user|source:test-user-contract|subject:contract-createsuser",
-            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user"
+            "carrier:right=object:route-users|object:service-user|source:src-route-users|source:src-service-user|subject:semantic-route-users-service-user",
+            "profileWeight:carrier:350"
           ]
         },
         {
@@ -4371,6 +4453,7 @@
             "reading": "valence distance compares architectural affordance sets derived from atom family and relation roles"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:valence:250",
             "valence:left=can_attach_contract|can_be_vertex",
             "valence:right=can_be_edge|can_be_vertex"
           ]
@@ -4402,6 +4485,7 @@
             "reading": "semantic anchor distance compares supplied ArchMap semantic observation closures and does not infer ontology distance from names"
           },
           "evaluatorBasisRefs": [
+            "profileWeight:semanticAnchor:150",
             "semantic:left=semanticFamily:operationmeaning|semanticFamily:semanticinterpretation|semanticObservation:semantic-create-user-flow|semanticObservation:semantic-interpretation-create-user|semanticPredicate:create-user-operation-has-a-selected-semantic-interpretation|semanticPredicate:route-service-and-contract-jointly-describe-create-user-behavior|semanticSubject:operation-createuser",
             "semantic:right=semanticFamily:operationmeaning|semanticFamily:semanticinterpretation|semanticObservation:semantic-create-user-flow|semanticObservation:semantic-interpretation-create-user|semanticPredicate:create-user-operation-has-a-selected-semantic-interpretation|semanticPredicate:route-service-and-contract-jointly-describe-create-user-behavior|semanticSubject:operation-createuser"
           ]
@@ -5708,6 +5792,7 @@
             "evaluatorBasisRefs": [
               "rho_i:axis=sig-axis:layer-violation",
               "axisValue:0",
+              "profileWeight:sig-axis:layer-violation=1",
               "coverageStatus:coverage-gap-preserved"
             ],
             "coverageRefs": [
@@ -5729,6 +5814,7 @@
             "evaluatorBasisRefs": [
               "rho_i:axis=sig-axis:layer-violation",
               "axisValue:0",
+              "profileWeight:sig-axis:layer-violation=1",
               "coverageStatus:coverage-gap-preserved"
             ],
             "coverageRefs": [
@@ -5736,7 +5822,7 @@
               "coverage:semantic-contract-atoms"
             ],
             "blockerRefs": [],
-            "reading": "axis distance scales rho_i into the selected signature distance unit without converting missing coverage to zero"
+            "reading": "axis distance scales rho_i by the selected Part IV DistanceProfile signature weight without converting missing coverage to zero"
           },
           "coverageStatus": "coverage-gap-preserved",
           "sourceRefs": [
@@ -5765,6 +5851,7 @@
             "evaluatorBasisRefs": [
               "rho_i:axis=sig-axis:semantic-inconsistency",
               "axisValue:1",
+              "profileWeight:sig-axis:semantic-inconsistency=1",
               "coverageStatus:coverage-gap-preserved"
             ],
             "coverageRefs": [
@@ -5787,6 +5874,7 @@
             "evaluatorBasisRefs": [
               "rho_i:axis=sig-axis:semantic-inconsistency",
               "axisValue:1",
+              "profileWeight:sig-axis:semantic-inconsistency=1",
               "coverageStatus:coverage-gap-preserved"
             ],
             "coverageRefs": [
@@ -5794,7 +5882,7 @@
               "coverage:semantic-contract-atoms"
             ],
             "blockerRefs": [],
-            "reading": "axis distance scales rho_i into the selected signature distance unit without converting missing coverage to zero"
+            "reading": "axis distance scales rho_i by the selected Part IV DistanceProfile signature weight without converting missing coverage to zero"
           },
           "coverageStatus": "coverage-gap-preserved",
           "sourceRefs": [
@@ -18252,7 +18340,7 @@
     ],
     "distanceDiagnosisSummary": [
       "distanceProfile=part4-distance-profile:llm-native-aat-law-policy-fixture measured=0 blocked=7 unmeasured=0 schemaFoundationOnly=0",
-      "diagnosticScope measuredAxes=2 unmeasuredAxes=2 blockers=6 boundary=evaluator-synchronized",
+      "diagnosticScope measuredAxes=2 unmeasuredAxes=0 blockers=4 boundary=evaluator-synchronized",
       "diagnostic distance is Part IV evaluator output; viewer layout distance is visual placement only",
       "blocked or unmeasured distance is not measured zero; safe margin remains coverage-qualified",
       "signature-distance:llm-native-aat-law-policy-fixture total=blocked:milli-signature-distance endpoint=blocked:milli-signature-endpoint-distance pathDrift=blocked:milli-signature-drift safe=blocked:milli-safe-region-margin hiddenExcursion=hiddenExcursionBlockedByCoverage",

--- a/tools/archsig/tests/fixtures/negative/part4_distance_policy_negative_cases.json
+++ b/tools/archsig/tests/fixtures/negative/part4_distance_policy_negative_cases.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "archsig-part4-distance-policy-negative-cases-v0",
+  "cases": [
+    {
+      "caseId": "missing-signature-weight",
+      "sourceIssue": "#1793",
+      "mutation": {
+        "kind": "removeSignatureWeight",
+        "axisRef": "sig-axis:semantic-inconsistency"
+      },
+      "expectedStderr": "Part IV DistanceProfile"
+    },
+    {
+      "caseId": "unused-atom-weight",
+      "sourceIssue": "#1793",
+      "mutation": {
+        "kind": "addAtomWeight",
+        "axisRef": "atom.unused",
+        "weight": 1
+      },
+      "expectedStderr": "Part IV DistanceProfile"
+    },
+    {
+      "caseId": "unbounded-signature-weight",
+      "sourceIssue": "#1793",
+      "mutation": {
+        "kind": "setSignatureWeight",
+        "axisRef": "sig-axis:semantic-inconsistency",
+        "weight": 1000001
+      },
+      "expectedStderr": "Part IV DistanceProfile"
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/negative/part4_distance_surface_negative_cases.json
+++ b/tools/archsig/tests/fixtures/negative/part4_distance_surface_negative_cases.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "archsig-part4-distance-negative-corpus-v0",
+  "corpusId": "negative-corpus:archsig-part4-distance-surface",
+  "boundary": "These cases exercise ArchSig bounded diagnostic consistency over supplied ArchMap, LawPolicy, and evidence contract. They do not require ArchSig to implement the full generality of AAT Part IV.",
+  "cases": [
+    {
+      "caseId": "stale-axis-namespace",
+      "sourceIssue": "#1792",
+      "fixtureKind": "summary-cross-surface",
+      "assertion": "A measured or zero signature axis must not remain in distanceDiagnosis.unmeasuredAxes through an axis:* / sig-axis:* namespace mismatch.",
+      "expectedFailure": "summary reports a measured axis as unmeasured"
+    },
+    {
+      "caseId": "profile-weight-ignored",
+      "sourceIssue": "#1793",
+      "fixtureKind": "non-unit-law-policy; executable negative cases in part4_distance_policy_negative_cases.json",
+      "assertion": "Changing part4DistanceProfile atomWeights or signatureWeights must change the corresponding atom or signature distance readings.",
+      "expectedFailure": "non-unit profile weights are copied into packet metadata but do not affect evaluator values"
+    },
+    {
+      "caseId": "missing-operation-cost-not-promoted",
+      "sourceIssue": "#1789",
+      "fixtureKind": "law-policy-missing-operation-cost",
+      "assertion": "A missing selected operation cost must block operationGeometry and summary repair distance instead of being omitted from the family aggregate.",
+      "expectedFailure": "operationGeometry becomes measured from remaining measured costs"
+    },
+    {
+      "caseId": "summary-distance-id-null",
+      "sourceIssue": "#1791",
+      "fixtureKind": "summary-field-ref",
+      "assertion": "distanceDiagnosis repair and curvature compact refs must read actual raw packet field names and be non-null.",
+      "expectedFailure": "summary emits null operation or curvature ids"
+    },
+    {
+      "caseId": "stale-detail-ref",
+      "sourceIssue": "#1795",
+      "fixtureKind": "json-pointer-resolution",
+      "assertion": "Every distanceDiagnosis.detailRefs packet pointer must resolve into the raw analysis packet.",
+      "expectedFailure": "summary and viewer share a stale packet ref that no test resolves"
+    }
+  ]
+}

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -2216,7 +2216,7 @@
 
       renderOverview(overview, verdict, summary, data.nonConclusions || []);
       renderItems("findings", report.topFindings || summary.dominantFindings || data.analysisOverlays?.dominantFindings, "finding");
-      renderItems("distance-diagnosis", report.distanceDiagnosis || summary.distanceDiagnosis || data.aatGeometryOverlays?.diagnosticDistanceReadings, "distance");
+      renderDistanceDiagnosis(report.distanceDiagnosis || summary.distanceDiagnosis || data.aatGeometryOverlays?.diagnosticDistanceReadings);
       renderItems("actions", report.actionQueue || summary.actionQueue || data.analysisOverlays?.actionQueue, "action");
       renderCoverage(report.coverageAndBoundaries || {}, verdict, summary);
       renderArtifacts(report.artifacts || {}, data.sourceArtifactRefs || {}, manifest);
@@ -2266,6 +2266,83 @@
       const root = document.getElementById(id);
       const items = flattenReportItems(value).slice(0, 12);
       root.innerHTML = items.length ? items.map((item, index) => itemHtml(item, fallbackLabel, index)).join("") : emptyItem();
+    }
+
+    function renderDistanceDiagnosis(value) {
+      const root = document.getElementById("distance-diagnosis");
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        renderItems("distance-diagnosis", value, "distance");
+        return;
+      }
+      const status = value.distanceStatusSummary || {};
+      const measuredMovement = value.measuredMovement || {};
+      const blocks = [
+        ["verdict", value.verdict],
+        ["profile", value.distanceProfileRef],
+        ["status", compactStatusSummary(status)],
+        ["movement", compactDistanceValues(measuredMovement, ["totalMeasuredDistance", "pathDrift", "endpointDistance"])],
+        ["safe margin", distanceValueText(value.safeMargin)],
+        ["unmeasured axes", Array.isArray(value.unmeasuredAxes) && value.unmeasuredAxes.length ? value.unmeasuredAxes.join(", ") : "none"],
+        ["repair", compactDistanceValues(value.repairDistance, ["operationCost", "targetDistanceDecrease", "sideEffectBound"])],
+        ["curvature", compactDistanceValues(value.curvatureDistance, ["curvatureMass", "transportDistance"])],
+        ["homotopy", compactDistanceValues(value.homotopyDistance, ["homotopyDistance", "fillingCost", "observationGapLowerBound"])],
+        ["representation", compactRepresentationMetricValues(value.representationMetric)],
+        ["boundary", value.distanceBoundary],
+        ["non-claims", Array.isArray(value.nonClaims) ? value.nonClaims.join("; ") : null],
+        ["detail refs", Array.isArray(value.detailRefs) ? value.detailRefs.join(", ") : null]
+      ].filter(([, text]) => text != null && text !== "");
+      root.innerHTML = blocks.length
+        ? blocks.map(([label, text]) => `<div class="item"><strong>${escapeHtml(String(label))}</strong><p>${escapeHtml(String(text))}</p></div>`).join("")
+        : emptyItem();
+    }
+
+    function compactStatusSummary(summary) {
+      const parts = [
+        summary.measuredCount != null && `measured: ${summary.measuredCount}`,
+        summary.zeroCount != null && `zero: ${summary.zeroCount}`,
+        summary.blockedCount != null && `blocked: ${summary.blockedCount}`,
+        summary.unmeasuredCount != null && `unmeasured: ${summary.unmeasuredCount}`,
+        summary.schemaFoundationOnlyCount != null && `schema-only: ${summary.schemaFoundationOnlyCount}`
+      ].filter(Boolean);
+      return parts.join(", ") || null;
+    }
+
+    function compactDistanceValues(container, keys) {
+      if (!container || typeof container !== "object") return null;
+      const refs = [
+        container.readingId && `reading: ${container.readingId}`,
+        container.operationDeltaRef && `operation: ${container.operationDeltaRef}`,
+        container.operationRef && !container.operationDeltaRef && `operation: ${container.operationRef}`,
+        container.profileRef && `profile: ${container.profileRef}`,
+        container.supportReadingRef && `support: ${container.supportReadingRef}`
+      ].filter(Boolean);
+      const values = keys.map((key) => {
+        const text = distanceValueText(container[key]);
+        return text ? `${key}: ${text}` : null;
+      }).filter(Boolean);
+      return [...refs, ...values].join("; ") || null;
+    }
+
+    function distanceValueText(value) {
+      if (!value || typeof value !== "object") return null;
+      const status = value.status || "unknown";
+      const measured = value.measuredValue == null ? "n/a" : value.measuredValue;
+      const unit = value.unit || "";
+      const blockers = value.blockerRefCount != null ? ` blockers=${value.blockerRefCount}` : "";
+      return `${status} ${measured}${unit ? ` ${unit}` : ""}${blockers}`;
+    }
+
+    function compactRepresentationMetricValues(metrics) {
+      if (!Array.isArray(metrics) || !metrics.length) return null;
+      const rows = metrics.slice(0, 4).map((metric) => {
+        const id = metric.readingId || metric.representationFamily || "representation";
+        const structural = distanceValueText(metric.structuralDistance);
+        const analytic = distanceValueText(metric.analyticDistance);
+        const faithfulness = distanceValueText(metric.biLipschitzFaithfulness);
+        return `${id}: structural=${structural || "n/a"}, analytic=${analytic || "n/a"}, faithfulness=${faithfulness || "n/a"}`;
+      });
+      if (metrics.length > rows.length) rows.push(`more: ${metrics.length - rows.length}`);
+      return rows.join("; ");
     }
 
     function itemHtml(item, fallbackLabel, index) {


### PR DESCRIPTION
## 概要

ArchSig の Part IV distance surface を、AAT Part4 本文の全一般性ではなく `ArchMap + LawPolicy + evidence contract` に相対化された bounded diagnostic として同期しました。

Closes #1788
Closes #1789
Closes #1790
Closes #1791
Closes #1792
Closes #1793
Closes #1794
Closes #1795
Closes #1796
Closes #1797
Closes #1798

主な変更:

- `part4DistanceProfile` の atom / signature weights を実距離評価へ反映し、欠落・未使用・過大 weight / operation cost を LawPolicy validation で拒否
- raw `DiagnosticScope` と summary/viewer の axis namespace を同期し、測定済み axis を unmeasured surface から除外
- operation / curvature distance の raw id を summary `distanceDiagnosis` に露出し、`detailRefs` の JSON Pointer 解決をテスト
- viewer に `Distance Diagnosis` 専用 pane を追加し、boundary / non-claims / repair / curvature / homotopy / representation metric を表示
- executable negative corpus と golden corpus docs を追加・同期
- archsig-reader と artifact boundary docs を現行 summary / LLM interpretation artifact 境界へ同期

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/golden_corpus.md`
- `tools/archsig/docs/artifacts-and-boundaries.md`
- `tools/archsig/skills/archsig-reader/SKILL.md`
- `tools/archsig/skills/archsig-reader/references/output-reading-guide.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/tests/fixtures/minimal/archmap.json --law-policy tools/archsig/tests/fixtures/minimal/law_policy.json --out-dir .tmp/archsig-part4-review --strict-distance --emit-raw-artifacts`
- [x] viewer runtime smoke: local HTTP preview で `Distance Diagnosis` pane / repair / curvature / representation metric 表示と console error なしを確認
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
