### PR TITLE
ArchMap v1入力validationを追加

### DIFF
--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -2,17 +2,375 @@ use std::collections::BTreeSet;
 
 use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
 use crate::{
-    ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION,
-    ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ArchMapAtomicObservationSummary, ArchMapDocumentV0,
-    ArchMapLeanPreservationChecklistEntry, ArchMapLeanPreservationVocabularyEntry,
-    ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapValidationReportV0,
-    ArchMapValidationSummary, ValidationCheck,
+    ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION, ARCHMAP_V1_SCHEMA,
+    ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ArchMapAtomV1, ArchMapAtomicObservationSummary,
+    ArchMapDocumentV0, ArchMapDocumentV1, ArchMapLeanPreservationChecklistEntry,
+    ArchMapLeanPreservationVocabularyEntry, ArchMapSourceInventoryV0, ArchMapSourceRef,
+    ArchMapValidationReportV0, ArchMapValidationReportV1, ArchMapValidationSummary,
+    ArchMapValidationSummaryV1, ValidationCheck, ValidationExample,
 };
 
 pub struct ArchMapSourceInventoryInput<'a> {
     pub path: &'a str,
     pub document: Option<&'a ArchMapSourceInventoryV0>,
     pub read_error: Option<String>,
+}
+
+pub fn validate_archmap_v1_report(
+    document: &ArchMapDocumentV1,
+    input_path: &str,
+) -> ArchMapValidationReportV1 {
+    let checks = vec![
+        check_archmap_v1_schema(&document.schema),
+        check_archmap_v1_sources(document),
+        check_archmap_v1_atom_ids(document),
+        check_archmap_v1_atom_kinds(document),
+        check_archmap_v1_atom_shapes(document),
+        check_archmap_v1_atom_predicates(document),
+        check_archmap_v1_atom_refs(document),
+        check_archmap_v1_molecule_refs(document),
+    ];
+    let failed_check_count = count_checks(&checks, "fail");
+    let warning_check_count = count_checks(&checks, "warn");
+    let result = if failed_check_count > 0 {
+        "fail"
+    } else if warning_check_count > 0 {
+        "warn"
+    } else {
+        "pass"
+    };
+
+    ArchMapValidationReportV1 {
+        schema_version: "archmap-validation-report-v1".to_string(),
+        archmap_ref: input_path.to_string(),
+        input_schema: document.schema.clone(),
+        checks,
+        summary: ArchMapValidationSummaryV1 {
+            result: result.to_string(),
+            source_count: document.sources.len(),
+            atom_count: document.atoms.len(),
+            molecule_count: document.molecules.len(),
+            failed_check_count,
+            warning_check_count,
+        },
+        non_conclusions: vec![
+            "ArchMap v1 validation checks the atom map contract; it does not prove architecture lawfulness, source completeness, Lean theorem discharge, or global semantic truth.".to_string(),
+            "Missing atoms remain unavailable to evaluators; they are not measured zero.".to_string(),
+        ],
+    }
+}
+
+fn check_archmap_v1_schema(schema: &str) -> ValidationCheck {
+    let mut check = validation_check(
+        "archmap-v1-schema",
+        "ArchMap v1 uses the atom-to-AAT schema discriminator",
+        if schema == ARCHMAP_V1_SCHEMA {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!("expected {ARCHMAP_V1_SCHEMA}, found {schema}"));
+    }
+    check
+}
+
+fn check_archmap_v1_sources(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    if document.sources.is_empty() {
+        examples.push(generic_validation_example(
+            "sources",
+            "empty",
+            "ArchMap v1 needs a source table for atom refs and source refs",
+        ));
+    }
+    for (source_id, source) in &document.sources {
+        if source.kind.trim().is_empty() {
+            examples.push(generic_validation_example(
+                "sources",
+                source_id,
+                "source kind must be non-empty",
+            ));
+        }
+        if let Some(parent) = source.source.as_deref() {
+            if !document.sources.contains_key(parent) {
+                examples.push(generic_validation_example(
+                    source_id,
+                    parent,
+                    "source parent must resolve to sources",
+                ));
+            }
+        }
+    }
+    check_from_examples(
+        "archmap-v1-sources-resolve",
+        "sources table is present and internally resolvable",
+        examples,
+    )
+}
+
+fn check_archmap_v1_atom_ids(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for atom in &document.atoms {
+        if atom.id.trim().is_empty() {
+            examples.push(generic_validation_example(
+                "atoms[].id",
+                "empty",
+                "atom id must be non-empty",
+            ));
+        }
+    }
+    examples.extend(
+        duplicates(document.atoms.iter().map(|atom| atom.id.as_str()))
+            .into_iter()
+            .map(|duplicate| {
+                generic_validation_example("atoms[].id", &duplicate, "atom id must be unique")
+            }),
+    );
+    check_from_examples(
+        "archmap-v1-atom-ids",
+        "atom ids are non-empty and unique",
+        examples,
+    )
+}
+
+fn check_archmap_v1_atom_kinds(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let examples = document
+        .atoms
+        .iter()
+        .filter(|atom| !is_archmap_v1_atom_kind(&atom.kind))
+        .map(|atom| {
+            generic_validation_example(
+                &atom.id,
+                &atom.kind,
+                "atom kind must be in the v1 constructor vocabulary",
+            )
+        })
+        .collect::<Vec<_>>();
+    check_from_examples(
+        "archmap-v1-atom-kind-vocabulary",
+        "atom kinds are in the v1 constructor vocabulary",
+        examples,
+    )
+}
+
+fn check_archmap_v1_atom_shapes(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for atom in &document.atoms {
+        examples.extend(
+            v1_atom_shape_errors(atom)
+                .into_iter()
+                .map(|message| generic_validation_example(&atom.id, &atom.kind, &message)),
+        );
+    }
+    check_from_examples(
+        "archmap-v1-atom-required-shapes",
+        "atom constructor payloads match required v1 shapes",
+        examples,
+    )
+}
+
+fn check_archmap_v1_atom_predicates(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for atom in &document.atoms {
+        if let Some(predicate) = atom.predicate.as_deref() {
+            if !is_known_v1_predicate(predicate) {
+                examples.push(generic_validation_example(
+                    &atom.id,
+                    predicate,
+                    "predicate must resolve to the v1 predicate vocabulary",
+                ));
+            }
+        }
+    }
+    check_from_examples(
+        "archmap-v1-predicate-vocabulary",
+        "atom predicates resolve to the v1 predicate vocabulary",
+        examples,
+    )
+}
+
+fn check_archmap_v1_atom_refs(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for atom in &document.atoms {
+        for source_ref in atom_refs(atom) {
+            if !document.sources.contains_key(source_ref) {
+                examples.push(generic_validation_example(
+                    &atom.id,
+                    source_ref,
+                    "atom source-bearing field must resolve to sources",
+                ));
+            }
+        }
+        for source_ref in &atom.refs {
+            if !document.sources.contains_key(source_ref) {
+                examples.push(generic_validation_example(
+                    &atom.id,
+                    source_ref,
+                    "atom refs[] entry must resolve to sources",
+                ));
+            }
+        }
+    }
+    check_from_examples(
+        "archmap-v1-atom-refs-resolve",
+        "atom source refs resolve to sources",
+        examples,
+    )
+}
+
+fn check_archmap_v1_molecule_refs(document: &ArchMapDocumentV1) -> ValidationCheck {
+    let atom_ids = document
+        .atoms
+        .iter()
+        .map(|atom| atom.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = Vec::new();
+    examples.extend(
+        duplicates(
+            document
+                .molecules
+                .iter()
+                .map(|molecule| molecule.id.as_str()),
+        )
+        .into_iter()
+        .map(|duplicate| {
+            generic_validation_example("molecules[].id", &duplicate, "molecule id must be unique")
+        }),
+    );
+    for molecule in &document.molecules {
+        if molecule.id.trim().is_empty() {
+            examples.push(generic_validation_example(
+                "molecules[].id",
+                "empty",
+                "molecule id must be non-empty",
+            ));
+        }
+        if molecule.atoms.is_empty() {
+            examples.push(generic_validation_example(
+                &molecule.id,
+                "atoms",
+                "molecule must explicitly list atom membership",
+            ));
+        }
+        for atom_ref in &molecule.atoms {
+            if !atom_ids.contains(atom_ref.as_str()) {
+                examples.push(generic_validation_example(
+                    &molecule.id,
+                    atom_ref,
+                    "molecule atom ref must resolve to atoms",
+                ));
+            }
+        }
+        for source_ref in &molecule.refs {
+            if !document.sources.contains_key(source_ref) {
+                examples.push(generic_validation_example(
+                    &molecule.id,
+                    source_ref,
+                    "molecule refs[] entry must resolve to sources",
+                ));
+            }
+        }
+    }
+    check_from_examples(
+        "archmap-v1-molecule-refs-resolve",
+        "molecule membership and source refs resolve",
+        examples,
+    )
+}
+
+fn check_from_examples(id: &str, title: &str, examples: Vec<ValidationExample>) -> ValidationCheck {
+    let mut check = validation_check(id, title, if examples.is_empty() { "pass" } else { "fail" });
+    if !examples.is_empty() {
+        check.count = Some(examples.len());
+        check.examples = examples;
+    }
+    check
+}
+
+fn is_archmap_v1_atom_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "component"
+            | "relation"
+            | "capability"
+            | "dataState"
+            | "effect"
+            | "authority"
+            | "contract"
+            | "semantic"
+            | "runtime"
+    )
+}
+
+fn is_known_v1_predicate(predicate: &str) -> bool {
+    matches!(
+        predicate,
+        "placesOrder" | "checksInventoryWith" | "dependsOn" | "implements" | "calls"
+    )
+}
+
+fn v1_atom_shape_errors(atom: &ArchMapAtomV1) -> Vec<String> {
+    let mut errors = Vec::new();
+    match atom.kind.as_str() {
+        "component" => require_one(&mut errors, atom.subject.as_deref(), "subject"),
+        "relation" => {
+            if atom.edge.as_deref().map_or(true, str::is_empty) {
+                require_one(&mut errors, atom.subject.as_deref(), "subject");
+                require_one(&mut errors, atom.object.as_deref(), "object");
+                require_one(&mut errors, atom.predicate.as_deref(), "predicate");
+            }
+        }
+        "capability" => {
+            require_one(&mut errors, atom.subject.as_deref(), "subject");
+            require_one(&mut errors, atom.predicate.as_deref(), "predicate");
+        }
+        "dataState" => {
+            require_one(&mut errors, atom.diagram.as_deref(), "diagram");
+            require_one(&mut errors, atom.state.as_deref(), "state");
+        }
+        "effect" => {
+            require_one(&mut errors, atom.diagram.as_deref(), "diagram");
+            require_one(&mut errors, atom.effect.as_deref(), "effect");
+        }
+        "authority" => {
+            require_one(&mut errors, atom.subject.as_deref(), "subject");
+            require_one(&mut errors, atom.authority.as_deref(), "authority");
+        }
+        "contract" => {
+            require_one(&mut errors, atom.diagram.as_deref(), "diagram");
+            require_one(&mut errors, atom.contract.as_deref(), "contract");
+        }
+        "semantic" => {
+            require_one(&mut errors, atom.diagram.as_deref(), "diagram");
+            require_one(&mut errors, atom.meaning.as_deref(), "meaning");
+        }
+        "runtime" => {
+            require_one(&mut errors, atom.edge.as_deref(), "edge");
+            require_one(&mut errors, atom.interaction.as_deref(), "interaction");
+        }
+        _ => {}
+    }
+    errors
+}
+
+fn require_one(errors: &mut Vec<String>, value: Option<&str>, field: &str) {
+    if value.map_or(true, |value| value.trim().is_empty()) {
+        errors.push(format!("required field `{field}` is missing or empty"));
+    }
+}
+
+fn atom_refs(atom: &ArchMapAtomV1) -> Vec<&str> {
+    [
+        atom.subject.as_deref(),
+        atom.object.as_deref(),
+        atom.edge.as_deref(),
+        atom.diagram.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 pub fn validate_archmap_report(

--- a/tools/archsig/src/law_policy/mod.rs
+++ b/tools/archsig/src/law_policy/mod.rs
@@ -5,7 +5,7 @@ mod measurement_policy;
 mod validate;
 
 pub use fixture::static_law_policy;
-pub use validate::validate_law_policy_report;
+pub use validate::{validate_law_policy_report, validate_law_policy_v1_report};
 
 #[cfg(test)]
 mod tests;

--- a/tools/archsig/src/law_policy/validate.rs
+++ b/tools/archsig/src/law_policy/validate.rs
@@ -8,10 +8,238 @@ use super::measurement_policy::{
 };
 use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
 use crate::{
-    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, LawPolicyDocumentV0,
-    LawPolicyValidationInputV0, LawPolicyValidationReportV0, LawPolicyValidationSummaryV0,
-    ValidationCheck,
+    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+    LawPolicyDocumentV0, LawPolicyDocumentV1, LawPolicyValidationInputV0,
+    LawPolicyValidationInputV1, LawPolicyValidationReportV0, LawPolicyValidationReportV1,
+    LawPolicyValidationSummaryV0, LawPolicyValidationSummaryV1, ValidationCheck, ValidationExample,
 };
+
+pub fn validate_law_policy_v1_report(
+    policy: &LawPolicyDocumentV1,
+    input_path: &str,
+) -> LawPolicyValidationReportV1 {
+    let checks = vec![
+        check_v1_schema(policy),
+        check_v1_identity(policy),
+        check_v1_policy_entries(policy),
+        check_v1_basis(policy),
+        check_v1_pack_and_evaluator_vocabulary(policy),
+    ];
+    let failed_check_count = count_checks(&checks, "fail");
+    let warning_check_count = count_checks(&checks, "warn");
+    let result = if failed_check_count > 0 {
+        "fail"
+    } else if warning_check_count > 0 {
+        "warn"
+    } else {
+        "pass"
+    };
+    LawPolicyValidationReportV1 {
+        schema_version: "law-policy-validation-report-v1".to_string(),
+        input: LawPolicyValidationInputV1 {
+            schema: policy.schema.clone(),
+            path: input_path.to_string(),
+            id: policy.id.clone(),
+        },
+        checks,
+        summary: LawPolicyValidationSummaryV1 {
+            result: result.to_string(),
+            policy_entry_count: policy.policies.len(),
+            pack_entry_count: policy
+                .policies
+                .iter()
+                .filter(|entry| entry.pack.is_some())
+                .count(),
+            explicit_law_entry_count: policy
+                .policies
+                .iter()
+                .filter(|entry| entry.law.is_some())
+                .count(),
+            failed_check_count,
+            warning_check_count,
+        },
+    }
+}
+
+fn check_v1_schema(policy: &LawPolicyDocumentV1) -> ValidationCheck {
+    let mut check = validation_check(
+        "law-policy-v1-schema",
+        "LawPolicy v1 uses the selector schema discriminator",
+        if policy.schema == LAW_POLICY_V1_SCHEMA {
+            "pass"
+        } else {
+            "fail"
+        },
+    );
+    if check.result == "fail" {
+        check.reason = Some(format!(
+            "expected {LAW_POLICY_V1_SCHEMA}, found {}",
+            policy.schema
+        ));
+    }
+    check
+}
+
+fn check_v1_identity(policy: &LawPolicyDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    if policy.id.trim().is_empty() {
+        examples.push(generic_validation_example(
+            "id",
+            "empty",
+            "LawPolicy v1 id must be non-empty",
+        ));
+    }
+    if policy.policies.is_empty() {
+        examples.push(generic_validation_example(
+            "policies",
+            "empty",
+            "LawPolicy v1 must select at least one policy entry",
+        ));
+    }
+    check_examples(
+        "law-policy-v1-identity",
+        "LawPolicy v1 identity and selected policies are recorded",
+        examples,
+    )
+}
+
+fn check_v1_policy_entries(policy: &LawPolicyDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for (index, entry) in policy.policies.iter().enumerate() {
+        let selector_count = usize::from(entry.pack.is_some()) + usize::from(entry.law.is_some());
+        if selector_count != 1 {
+            examples.push(generic_validation_example(
+                &format!("policies[{index}]"),
+                "selector",
+                "policy entry must select exactly one of pack or law",
+            ));
+        }
+        if entry.law.is_some() && entry.evaluator.is_none() {
+            examples.push(generic_validation_example(
+                &format!("policies[{index}].evaluator"),
+                "missing",
+                "explicit law entry must name evaluator id / version",
+            ));
+        }
+        if entry.pack.is_some() && entry.evaluator.is_some() {
+            examples.push(generic_validation_example(
+                &format!("policies[{index}].evaluator"),
+                "present",
+                "pack entry expands through registry and must not override evaluator",
+            ));
+        }
+        if entry.severity.trim().is_empty() {
+            examples.push(generic_validation_example(
+                &format!("policies[{index}].severity"),
+                "empty",
+                "policy entry severity must be non-empty",
+            ));
+        }
+        if entry.scope.is_empty() {
+            examples.push(generic_validation_example(
+                &format!("policies[{index}].scope"),
+                "empty",
+                "policy entry must declare source scope",
+            ));
+        }
+    }
+    check_examples(
+        "law-policy-v1-entry-shape",
+        "policy entries select pack or law and carry scope / severity",
+        examples,
+    )
+}
+
+fn check_v1_basis(policy: &LawPolicyDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for (index, entry) in policy.policies.iter().enumerate() {
+        if entry.basis.is_empty() {
+            examples.push(generic_validation_example(
+                &format!("policies[{index}].basis"),
+                "empty",
+                "policy entry must carry basis refs",
+            ));
+        }
+        for basis in &entry.basis {
+            if basis.trim().is_empty() {
+                examples.push(generic_validation_example(
+                    &format!("policies[{index}].basis"),
+                    "empty",
+                    "basis refs must be non-empty",
+                ));
+            } else if !is_known_v1_basis(basis) {
+                examples.push(generic_validation_example(
+                    &format!("policies[{index}].basis"),
+                    basis,
+                    "basis ref must resolve to the v1 policy basis registry",
+                ));
+            }
+        }
+    }
+    check_examples(
+        "law-policy-v1-basis-recorded",
+        "policy entries carry explicit basis refs",
+        examples,
+    )
+}
+
+fn check_v1_pack_and_evaluator_vocabulary(policy: &LawPolicyDocumentV1) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for (index, entry) in policy.policies.iter().enumerate() {
+        if let Some(pack) = entry.pack.as_deref() {
+            if !is_known_v1_pack(pack) {
+                examples.push(generic_validation_example(
+                    &format!("policies[{index}].pack"),
+                    pack,
+                    "unknown policy pack",
+                ));
+            }
+        }
+        if let Some(evaluator) = entry.evaluator.as_deref() {
+            if !is_known_v1_evaluator(evaluator) {
+                examples.push(generic_validation_example(
+                    &format!("policies[{index}].evaluator"),
+                    evaluator,
+                    "unknown evaluator id / version",
+                ));
+            }
+        }
+    }
+    check_examples(
+        "law-policy-v1-registry-vocabulary",
+        "policy entries resolve to known registry packs and evaluators",
+        examples,
+    )
+}
+
+fn check_examples(id: &str, title: &str, examples: Vec<ValidationExample>) -> ValidationCheck {
+    let mut check = validation_check(id, title, if examples.is_empty() { "pass" } else { "fail" });
+    if !examples.is_empty() {
+        check.count = Some(examples.len());
+        check.examples = examples;
+    }
+    check
+}
+
+fn is_known_v1_pack(pack: &str) -> bool {
+    matches!(pack, "solid@1")
+}
+
+fn is_known_v1_evaluator(evaluator: &str) -> bool {
+    matches!(
+        evaluator,
+        "solid.single-responsibility@1"
+            | "solid.open-closed@1"
+            | "solid.liskov-substitution@1"
+            | "solid.interface-segregation@1"
+            | "solid.dependency-inversion@1"
+            | "domain.no-direct-infra-dependency@1"
+    )
+}
+
+fn is_known_v1_basis(basis: &str) -> bool {
+    matches!(basis, "policy-basis:solid" | "policy-basis:layering")
+}
 
 pub fn validate_law_policy_report(
     policy: &LawPolicyDocumentV0,

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -5,27 +5,34 @@ mod schema;
 mod schema_catalog;
 mod validation;
 
-pub use archmap::{ArchMapSourceInventoryInput, validate_archmap_report};
+pub use archmap::{
+    ArchMapSourceInventoryInput, validate_archmap_report, validate_archmap_v1_report,
+};
 pub use archsig_analysis_packet::{
     build_archsig_analysis_packet, validate_archsig_analysis_packet_report,
 };
-pub use law_policy::{static_law_policy, validate_law_policy_report};
+pub use law_policy::{
+    static_law_policy, validate_law_policy_report, validate_law_policy_v1_report,
+};
 pub(crate) use schema::*;
 pub use schema::{
-    ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION,
+    ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION, ARCHMAP_V1_SCHEMA,
     ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION, ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION,
-    ArchMapAtomObservationV0, ArchMapDocumentV0, ArchMapMoleculeObservationV0,
-    ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapValidationReportV0, ArchSigAnalysisPacketV0,
-    ArchSigAnalysisPacketValidationReportV0, ArchSigArtifactValidationResultV0,
-    ArchSigAtomViewerAtomNodeV0, ArchSigAtomViewerDataV0, ArchSigAtomViewerEdgeV0,
-    ArchSigAtomViewerLayoutSettingsV0, ArchSigAtomViewerMoleculeGroupV0,
+    ArchMapAtomObservationV0, ArchMapAtomV1, ArchMapDocumentV0, ArchMapDocumentV1,
+    ArchMapMoleculeObservationV0, ArchMapMoleculeV1, ArchMapSourceInventoryV0, ArchMapSourceRef,
+    ArchMapSourceV1, ArchMapValidationReportV0, ArchMapValidationReportV1,
+    ArchMapValidationSummaryV1, ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationReportV0,
+    ArchSigArtifactValidationResultV0, ArchSigAtomViewerAtomNodeV0, ArchSigAtomViewerDataV0,
+    ArchSigAtomViewerEdgeV0, ArchSigAtomViewerLayoutSettingsV0, ArchSigAtomViewerMoleculeGroupV0,
     ArchSigAtomViewerOmittedDetailCountsV0, ArchSigAtomViewerSourceArtifactRefsV0,
     ArchSigAtomViewerTruncationPolicyV0, ArchSigAtomViewerVisualV0,
     ArchSigRunManifestRawArtifactPathsV0, ArchSigRunManifestV0,
     ArchSigRunManifestValidationReportPathsV0, ArchSigRunManifestValidationResultSummaryV0,
-    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, LawPolicyDocumentV0,
-    LawPolicyValidationReportV0, SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaVersionCatalogV0,
+    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+    LawPolicyDocumentV0, LawPolicyDocumentV1, LawPolicyEntryV1, LawPolicyValidationInputV1,
+    LawPolicyValidationReportV0, LawPolicyValidationReportV1, LawPolicyValidationSummaryV1,
+    SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaVersionCatalogV0,
 };
 pub use schema_catalog::static_schema_version_catalog;

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -3,11 +3,13 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use archsig::{
-    ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ArchMapDocumentV0, ArchMapSourceInventoryInput,
-    ArchMapSourceInventoryV0, ArchMapValidationReportV0, LawPolicyDocumentV0,
+    ARCHMAP_V1_SCHEMA, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ArchMapDocumentV0,
+    ArchMapDocumentV1, ArchMapSourceInventoryInput, ArchMapSourceInventoryV0,
+    ArchMapValidationReportV0, LAW_POLICY_V1_SCHEMA, LawPolicyDocumentV0, LawPolicyDocumentV1,
     SchemaVersionCatalogV0, build_archsig_analysis_packet, static_law_policy,
-    static_schema_version_catalog, validate_archmap_report,
+    static_schema_version_catalog, validate_archmap_report, validate_archmap_v1_report,
     validate_archsig_analysis_packet_report, validate_law_policy_report,
+    validate_law_policy_v1_report,
 };
 use clap::{Parser, Subcommand};
 
@@ -230,45 +232,88 @@ fn main() -> ExitCode {
     }
 }
 
+fn validate_archmap_command_input(
+    input: &PathBuf,
+) -> Result<(serde_json::Value, bool, bool), Box<dyn Error>> {
+    let raw: serde_json::Value = read_json(input)?;
+    if json_schema(&raw) == Some(ARCHMAP_V1_SCHEMA) {
+        let document: ArchMapDocumentV1 = serde_json::from_value(raw)?;
+        let report = validate_archmap_v1_report(&document, &input.display().to_string());
+        let failed = report.summary.result == "fail";
+        return Ok((serde_json::to_value(report)?, failed, true));
+    }
+
+    let document: ArchMapDocumentV0 = serde_json::from_value(raw)?;
+    let source_inventory_path = document
+        .source_inventory_ref
+        .as_ref()
+        .and_then(|source_inventory_ref| source_inventory_ref.path.as_deref());
+    let mut source_inventory_document: Option<ArchMapSourceInventoryV0> = None;
+    let mut source_inventory_error: Option<String> = None;
+    if let Some(path) = source_inventory_path {
+        match resolve_archmap_sidecar_path(input, path) {
+            Some(resolved_path) => match read_json(&resolved_path) {
+                Ok(source_inventory) => source_inventory_document = Some(source_inventory),
+                Err(error) => {
+                    source_inventory_error = Some(format!(
+                        "source inventory artifact could not be read: {error}"
+                    ));
+                }
+            },
+            None => {
+                source_inventory_error =
+                    Some("source inventory artifact path does not exist".to_string());
+            }
+        }
+    }
+    let source_inventory = source_inventory_path.map(|path| ArchMapSourceInventoryInput {
+        path,
+        document: source_inventory_document.as_ref(),
+        read_error: source_inventory_error.clone(),
+    });
+    let report: ArchMapValidationReportV0 =
+        validate_archmap_report(&document, &input.display().to_string(), source_inventory);
+    let failed = report.summary.result == "fail";
+    Ok((serde_json::to_value(report)?, failed, false))
+}
+
+fn validate_law_policy_command_input(
+    input: Option<&PathBuf>,
+) -> Result<(serde_json::Value, bool, bool), Box<dyn Error>> {
+    let Some(input) = input else {
+        let policy = static_law_policy();
+        let report = validate_law_policy_report(&policy, "static-law-policy");
+        let failed = report.summary.result == "fail";
+        return Ok((serde_json::to_value(report)?, failed, false));
+    };
+
+    let raw: serde_json::Value = read_json(input)?;
+    if json_schema(&raw) == Some(LAW_POLICY_V1_SCHEMA) {
+        let policy: LawPolicyDocumentV1 = serde_json::from_value(raw)?;
+        let report = validate_law_policy_v1_report(&policy, &input.display().to_string());
+        let failed = report.summary.result == "fail";
+        return Ok((serde_json::to_value(report)?, failed, true));
+    }
+
+    let policy: LawPolicyDocumentV0 = serde_json::from_value(raw)?;
+    let report = validate_law_policy_report(&policy, &input.display().to_string());
+    let failed = report.summary.result == "fail";
+    Ok((serde_json::to_value(report)?, failed, false))
+}
+
+fn json_schema(document: &serde_json::Value) -> Option<&str> {
+    document
+        .get("schema")
+        .or_else(|| document.get("schemaVersion"))
+        .and_then(|value| value.as_str())
+}
+
 fn run() -> Result<ExitCode, Box<dyn Error>> {
     let args = Args::parse();
 
     match args.command {
         Some(Command::Archmap { input, out }) => {
-            let document: ArchMapDocumentV0 = read_json(&input)?;
-            let source_inventory_path = document
-                .source_inventory_ref
-                .as_ref()
-                .and_then(|source_inventory_ref| source_inventory_ref.path.as_deref());
-            let mut source_inventory_document: Option<ArchMapSourceInventoryV0> = None;
-            let mut source_inventory_error: Option<String> = None;
-            if let Some(path) = source_inventory_path {
-                match resolve_archmap_sidecar_path(&input, path) {
-                    Some(resolved_path) => match read_json(&resolved_path) {
-                        Ok(source_inventory) => source_inventory_document = Some(source_inventory),
-                        Err(error) => {
-                            source_inventory_error = Some(format!(
-                                "source inventory artifact could not be read: {error}"
-                            ));
-                        }
-                    },
-                    None => {
-                        source_inventory_error =
-                            Some("source inventory artifact path does not exist".to_string());
-                    }
-                }
-            }
-            let source_inventory = source_inventory_path.map(|path| ArchMapSourceInventoryInput {
-                path,
-                document: source_inventory_document.as_ref(),
-                read_error: source_inventory_error.clone(),
-            });
-            let report: ArchMapValidationReportV0 = validate_archmap_report(
-                &document,
-                &input.display().to_string(),
-                source_inventory,
-            );
-            let failed = report.summary.result == "fail";
+            let (report, failed, _) = validate_archmap_command_input(&input)?;
             write_json(out, &report)?;
             Ok(if failed {
                 ExitCode::from(1)
@@ -286,17 +331,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 write_json(out, &policy)?;
                 return Ok(ExitCode::SUCCESS);
             }
-            let policy: LawPolicyDocumentV0 = input
-                .as_ref()
-                .map(read_json)
-                .transpose()?
-                .unwrap_or_else(static_law_policy);
-            let input_path = input
-                .as_ref()
-                .map(|path| path.display().to_string())
-                .unwrap_or_else(|| "static-law-policy".to_string());
-            let report = validate_law_policy_report(&policy, &input_path);
-            let failed = report.summary.result == "fail";
+            let (report, failed, _) = validate_law_policy_command_input(input.as_ref())?;
             write_json(out, &report)?;
             Ok(if failed {
                 ExitCode::from(1)
@@ -543,6 +578,26 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             let analysis_validation_path = out_dir.join("archsig-analysis-validation.json");
             let llm_interpretation_path = out_dir.join("llm-interpretation-packet.json");
 
+            let (archmap_preflight, archmap_failed, archmap_is_v1) =
+                validate_archmap_command_input(&archmap)?;
+            let (law_policy_preflight, law_policy_failed, law_policy_is_v1) =
+                validate_law_policy_command_input(Some(&law_policy))?;
+            if archmap_is_v1 || law_policy_is_v1 {
+                std::fs::create_dir_all(&out_dir)?;
+                remove_analyze_success_artifacts(&out_dir)?;
+                write_json(Some(archmap_validation_path), &archmap_preflight)?;
+                write_json(Some(law_policy_validation_path), &law_policy_preflight)?;
+                eprintln!(
+                    "archsig analyze wrote v1 validation artifacts to {} but the v1 evaluator pipeline is not implemented yet",
+                    out_dir.display()
+                );
+                return Ok(if archmap_failed || law_policy_failed {
+                    ExitCode::from(1)
+                } else {
+                    ExitCode::from(1)
+                });
+            }
+
             let archmap_document: ArchMapDocumentV0 = read_json(&archmap)?;
             let source_inventory_path = archmap_document
                 .source_inventory_ref
@@ -665,4 +720,24 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             Err("ArchSig is ArchMap/LawPolicy/analysis-packet primary; use `archsig analyze` for the main analysis path.".into())
         }
     }
+}
+
+fn remove_analyze_success_artifacts(out_dir: &PathBuf) -> Result<(), Box<dyn Error>> {
+    for artifact in [
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
+        "archsig-analysis-packet.json",
+        "archsig-analysis-detail-index.json",
+        "archsig-analysis-validation.json",
+        "llm-interpretation-packet.json",
+    ] {
+        let path = out_dir.join(artifact);
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(Box::new(error)),
+        }
+    }
+    Ok(())
 }

--- a/tools/archsig/src/schema/archmap.rs
+++ b/tools/archsig/src/schema/archmap.rs
@@ -1,6 +1,106 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::validation::ValidationCheck;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArchMapDocumentV1 {
+    pub schema: String,
+    pub id: String,
+    #[serde(default)]
+    pub sources: BTreeMap<String, ArchMapSourceV1>,
+    #[serde(default)]
+    pub atoms: Vec<ArchMapAtomV1>,
+    #[serde(default)]
+    pub molecules: Vec<ArchMapMoleculeV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArchMapSourceV1 {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArchMapAtomV1 {
+    pub id: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edge: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagram: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effect: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meaning: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interaction: Option<String>,
+    #[serde(default)]
+    pub refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArchMapMoleculeV1 {
+    pub id: String,
+    #[serde(default)]
+    pub atoms: Vec<String>,
+    #[serde(default)]
+    pub refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapValidationReportV1 {
+    pub schema_version: String,
+    pub archmap_ref: String,
+    pub input_schema: String,
+    pub checks: Vec<ValidationCheck>,
+    pub summary: ArchMapValidationSummaryV1,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchMapValidationSummaryV1 {
+    pub result: String,
+    pub source_count: usize,
+    pub atom_count: usize,
+    pub molecule_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/tools/archsig/src/schema/constants.rs
+++ b/tools/archsig/src/schema/constants.rs
@@ -1,7 +1,9 @@
 pub const ARCHMAP_SCHEMA_VERSION: &str = "archmap-observation-map-v0";
+pub const ARCHMAP_V1_SCHEMA: &str = "archmap/v1";
 pub const ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION: &str = "archmap-source-inventory-v0";
 pub const ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION: &str = "archmap-validation-report-v0";
 pub const LAW_POLICY_SCHEMA_VERSION: &str = "law-policy-v0";
+pub const LAW_POLICY_V1_SCHEMA: &str = "law-policy/v1";
 pub const LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str = "law-policy-validation-report-v0";
 pub const ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION: &str = "archsig-analysis-packet-v0";
 pub const ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION: &str =

--- a/tools/archsig/src/schema/law_policy.rs
+++ b/tools/archsig/src/schema/law_policy.rs
@@ -4,6 +4,59 @@ use super::validation::ValidationCheck;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LawPolicyDocumentV1 {
+    pub schema: String,
+    pub id: String,
+    #[serde(default)]
+    pub policies: Vec<LawPolicyEntryV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LawPolicyEntryV1 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pack: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub law: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluator: Option<String>,
+    #[serde(default)]
+    pub basis: Vec<String>,
+    #[serde(default)]
+    pub scope: Vec<String>,
+    pub severity: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyValidationReportV1 {
+    pub schema_version: String,
+    pub input: LawPolicyValidationInputV1,
+    pub checks: Vec<ValidationCheck>,
+    pub summary: LawPolicyValidationSummaryV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyValidationInputV1 {
+    pub schema: String,
+    pub path: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyValidationSummaryV1 {
+    pub result: String,
+    pub policy_entry_count: usize,
+    pub pack_entry_count: usize,
+    pub explicit_law_entry_count: usize,
+    pub failed_check_count: usize,
+    pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LawPolicyDocumentV0 {
     pub schema_version: String,
     pub law_policy_id: String,

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -1,9 +1,9 @@
 use crate::{
-    ARCHMAP_SCHEMA_VERSION, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
+    ARCHMAP_SCHEMA_VERSION, ARCHMAP_V1_SCHEMA, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION, ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION,
-    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
+    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
     SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION, SCHEMA_VERSION_CATALOG_SCHEMA_VERSION,
     SchemaCompatibilityBoundaryV0, SchemaCompatibilityDimensionV0, SchemaCompatibilityPolicyV0,
     SchemaVersionCatalogEntryV0, SchemaVersionCatalogV0,
@@ -46,6 +46,19 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 ],
             ),
             artifact(
+                "archmap-v1",
+                "ArchMap v1 Atom input artifact",
+                ARCHMAP_V1_SCHEMA,
+                "primary",
+                "ArchMap Atom-to-AAT contract",
+                vec!["docs/tool/archmap_minimal_observation_contract_prd.md"],
+                "ArchMap v1 records sources, atoms, and molecules as the primary input contract. It rejects legacy v0 root fields, unknown atom kinds, unknown predicates, and unresolved source refs before analysis.",
+                vec![
+                    "ArchMap v1 validation does not run the v1 evaluator pipeline.",
+                    "ArchMap v1 validation does not prove architecture lawfulness, source completeness, Lean theorem discharge, or global semantic truth.",
+                ],
+            ),
+            artifact(
                 "law-policy",
                 "Selected interpretation profile artifact",
                 LAW_POLICY_SCHEMA_VERSION,
@@ -62,6 +75,19 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                     "Adding a law family must preserve missing coverage as distinct from measured zero.",
                     "Changing a spectrum measurement profile changes a measurement recipe, not the selected law universe.",
                     "Changing a homotopy measurement profile changes a path / filler / loop measurement recipe, not the selected law universe.",
+                ],
+            ),
+            artifact(
+                "law-policy-v1",
+                "LawPolicy v1 selector artifact",
+                LAW_POLICY_V1_SCHEMA,
+                "primary",
+                "ArchMap Atom-to-AAT contract",
+                vec!["docs/tool/archmap_minimal_observation_contract_prd.md"],
+                "LawPolicy v1 selects policy packs or explicit law/evaluator pairs with registry-owned basis, scope, and severity. It rejects unknown packs, unknown evaluators, unresolved basis refs, and DSL-style witness rules before analysis.",
+                vec![
+                    "LawPolicy v1 selects evaluators; it does not define witness predicates, axis valuation, obstruction definitions, or Lean proofs.",
+                    "LawPolicy v1 validation does not run the v1 evaluator pipeline.",
                 ],
             ),
             artifact(
@@ -252,8 +278,10 @@ mod tests {
             BTreeSet::from([
                 "archmap",
                 "archmap-validation-report",
+                "archmap-v1",
                 "law-policy",
                 "law-policy-validation-report",
+                "law-policy-v1",
                 "archsig-analysis-packet",
                 "archsig-analysis-packet-validation-report",
                 "archsig-run-manifest",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -10,6 +10,10 @@ fn fixture_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal")
 }
 
+fn archmap_v1_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/archmap_v1")
+}
+
 fn expressiveness_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/expressiveness")
 }
@@ -48,6 +52,284 @@ fn sharded_root() -> PathBuf {
 
 fn negative_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/negative")
+}
+
+#[test]
+fn cli_validates_archmap_v1_atom_contract() {
+    let out_dir = temp_dir("archmap-v1-validation");
+    let root = archmap_v1_root();
+    let report = out_dir.join("archmap-validation.json");
+
+    run_sig0(&[
+        "archmap",
+        "--input",
+        root.join("archmap.json").to_str().expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "archmap-validation-report-v1");
+    assert_eq!(json["inputSchema"], "archmap/v1");
+    assert_eq!(json["summary"]["result"], "pass");
+    assert_eq!(json["summary"]["atomCount"], 3);
+    assert_eq!(json["summary"]["moleculeCount"], 1);
+}
+
+#[test]
+fn cli_rejects_archmap_v1_unknown_atom_kind() {
+    let out_dir = temp_dir("archmap-v1-unknown-kind");
+    let root = archmap_v1_root();
+    let report = out_dir.join("archmap-validation.json");
+
+    let output = run_sig0_output(&[
+        "archmap",
+        "--input",
+        root.join("archmap_unknown_kind.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "archmap-validation-report-v1");
+    assert_eq!(json["summary"]["result"], "fail");
+    assert!(
+        json["checks"].as_array().is_some_and(|checks| checks
+            .iter()
+            .any(|check| check["id"] == "archmap-v1-atom-kind-vocabulary"
+                && check["result"] == "fail"))
+    );
+}
+
+#[test]
+fn cli_rejects_archmap_v1_unresolved_source_ref() {
+    let out_dir = temp_dir("archmap-v1-bad-ref");
+    let root = archmap_v1_root();
+    let report = out_dir.join("archmap-validation.json");
+
+    let output = run_sig0_output(&[
+        "archmap",
+        "--input",
+        root.join("archmap_bad_ref.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    assert!(json["checks"].as_array().is_some_and(|checks| {
+        checks
+            .iter()
+            .any(|check| check["id"] == "archmap-v1-atom-refs-resolve" && check["result"] == "fail")
+    }));
+}
+
+#[test]
+fn cli_rejects_archmap_v1_unknown_predicate() {
+    let out_dir = temp_dir("archmap-v1-unknown-predicate");
+    let root = archmap_v1_root();
+    let report = out_dir.join("archmap-validation.json");
+
+    let output = run_sig0_output(&[
+        "archmap",
+        "--input",
+        root.join("archmap_unknown_predicate.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    assert!(
+        json["checks"].as_array().is_some_and(|checks| checks
+            .iter()
+            .any(|check| check["id"] == "archmap-v1-predicate-vocabulary"
+                && check["result"] == "fail"))
+    );
+}
+
+#[test]
+fn cli_rejects_archmap_v1_legacy_root_field() {
+    let out_dir = temp_dir("archmap-v1-legacy-field");
+    let root = archmap_v1_root();
+    let report = out_dir.join("archmap-validation.json");
+
+    let output = run_sig0_output(&[
+        "archmap",
+        "--input",
+        root.join("archmap_legacy_field.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    assert!(
+        !report.exists(),
+        "v1 legacy root field must stop before writing a validation report"
+    );
+}
+
+#[test]
+fn cli_validates_law_policy_v1_selector_contract() {
+    let out_dir = temp_dir("law-policy-v1-validation");
+    let root = archmap_v1_root();
+    let report = out_dir.join("law-policy-validation.json");
+
+    run_sig0(&[
+        "law-policy",
+        "--input",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "law-policy-validation-report-v1");
+    assert_eq!(json["input"]["schema"], "law-policy/v1");
+    assert_eq!(json["summary"]["result"], "pass");
+    assert_eq!(json["summary"]["policyEntryCount"], 2);
+    assert_eq!(json["summary"]["packEntryCount"], 1);
+}
+
+#[test]
+fn cli_rejects_law_policy_v1_unknown_evaluator() {
+    let out_dir = temp_dir("law-policy-v1-unknown-evaluator");
+    let root = archmap_v1_root();
+    let report = out_dir.join("law-policy-validation.json");
+
+    let output = run_sig0_output(&[
+        "law-policy",
+        "--input",
+        root.join("law_policy_unknown_evaluator.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "law-policy-validation-report-v1");
+    assert_eq!(json["summary"]["result"], "fail");
+    assert!(
+        json["checks"].as_array().is_some_and(|checks| checks
+            .iter()
+            .any(|check| check["id"] == "law-policy-v1-registry-vocabulary"
+                && check["result"] == "fail"))
+    );
+}
+
+#[test]
+fn cli_rejects_law_policy_v1_unresolved_basis() {
+    let out_dir = temp_dir("law-policy-v1-unknown-basis");
+    let root = archmap_v1_root();
+    let report = out_dir.join("law-policy-validation.json");
+
+    let output = run_sig0_output(&[
+        "law-policy",
+        "--input",
+        root.join("law_policy_unknown_basis.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "law-policy-validation-report-v1");
+    assert_eq!(json["summary"]["result"], "fail");
+    assert!(json["checks"].as_array().is_some_and(|checks| {
+        checks
+            .iter()
+            .any(|check| check["id"] == "law-policy-v1-basis-recorded" && check["result"] == "fail")
+    }));
+}
+
+#[test]
+fn cli_rejects_law_policy_v1_dsl_field() {
+    let out_dir = temp_dir("law-policy-v1-dsl-field");
+    let root = archmap_v1_root();
+    let report = out_dir.join("law-policy-validation.json");
+
+    let output = run_sig0_output(&[
+        "law-policy",
+        "--input",
+        root.join("law_policy_dsl_field.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    assert!(
+        !report.exists(),
+        "LawPolicy v1 DSL fields must stop before writing a validation report"
+    );
+}
+
+#[test]
+fn cli_analyze_v1_writes_validation_artifacts_and_stops_before_packet() {
+    let out_dir = temp_dir("analyze-v1-preflight");
+    let root = archmap_v1_root();
+    for stale_artifact in [
+        "archsig-analysis-packet.json",
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
+    ] {
+        fs::write(out_dir.join(stale_artifact), "{}").expect("stale artifact can be written");
+    }
+
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap.json").to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(
+        read_json(&out_dir.join("archmap-validation.json"))["schemaVersion"],
+        "archmap-validation-report-v1"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("law-policy-validation.json"))["schemaVersion"],
+        "law-policy-validation-report-v1"
+    );
+    assert!(
+        !out_dir.join("archsig-analysis-packet.json").exists(),
+        "v1 input must not be silently converted into a v0 analysis packet"
+    );
+    for stale_artifact in [
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
+    ] {
+        assert!(
+            !out_dir.join(stale_artifact).exists(),
+            "v1 preflight failure must remove stale success artifact {stale_artifact}"
+        );
+    }
 }
 
 #[test]
@@ -3319,7 +3601,9 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
         vec![
             "archmap",
             "archmap-validation-report",
+            "archmap-v1",
             "law-policy",
+            "law-policy-v1",
             "law-policy-validation-report",
             "archsig-analysis-packet",
             "archsig-analysis-packet-validation-report",

--- a/tools/archsig/tests/fixtures/archmap_v1/archmap.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/archmap.json
@@ -1,0 +1,65 @@
+{
+  "schema": "archmap/v1",
+  "id": "practical-rust-service",
+  "sources": {
+    "src.app": {
+      "kind": "file",
+      "path": "sample/src/app.rs"
+    },
+    "src.app.place_order": {
+      "kind": "symbol",
+      "source": "src.app",
+      "symbol": "place_order",
+      "line": 23
+    },
+    "domain.OrderService": {
+      "kind": "symbol",
+      "source": "src.app",
+      "symbol": "OrderService"
+    },
+    "domain.InventoryService": {
+      "kind": "symbol",
+      "source": "src.app",
+      "symbol": "InventoryService"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:place-order-capability",
+      "kind": "capability",
+      "subject": "domain.OrderService",
+      "predicate": "placesOrder",
+      "refs": ["src.app.place_order"],
+      "label": "OrderService places an order"
+    },
+    {
+      "id": "atom:inventory-check",
+      "kind": "relation",
+      "subject": "domain.OrderService",
+      "predicate": "checksInventoryWith",
+      "object": "domain.InventoryService",
+      "refs": ["src.app.place_order"],
+      "label": "OrderService checks inventory through InventoryService"
+    },
+    {
+      "id": "atom:reservation-effect",
+      "kind": "effect",
+      "diagram": "src.app.place_order",
+      "effect": "createsInventoryReservation",
+      "refs": ["src.app.place_order"],
+      "label": "place_order creates an inventory reservation"
+    }
+  ],
+  "molecules": [
+    {
+      "id": "mol:place-order-flow",
+      "atoms": [
+        "atom:place-order-capability",
+        "atom:inventory-check",
+        "atom:reservation-effect"
+      ],
+      "refs": ["src.app.place_order"],
+      "label": "place_order local flow"
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/archmap_bad_ref.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/archmap_bad_ref.json
@@ -1,0 +1,20 @@
+{
+  "schema": "archmap/v1",
+  "id": "bad-ref",
+  "sources": {
+    "src.app": {
+      "kind": "file",
+      "path": "sample/src/app.rs"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:missing-source",
+      "kind": "capability",
+      "subject": "domain.MissingService",
+      "predicate": "placesOrder",
+      "refs": ["src.app"]
+    }
+  ],
+  "molecules": []
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/archmap_legacy_field.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/archmap_legacy_field.json
@@ -1,0 +1,8 @@
+{
+  "schema": "archmap/v1",
+  "id": "legacy-field",
+  "sources": {},
+  "atoms": [],
+  "molecules": [],
+  "semanticObservations": []
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/archmap_unknown_kind.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/archmap_unknown_kind.json
@@ -1,0 +1,20 @@
+{
+  "schema": "archmap/v1",
+  "id": "bad-kind",
+  "sources": {
+    "src.app": {
+      "kind": "file",
+      "path": "sample/src/app.rs"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:freeform",
+      "kind": "freeformClaim",
+      "subject": "src.app",
+      "predicate": "saysAnything",
+      "refs": ["src.app"]
+    }
+  ],
+  "molecules": []
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/archmap_unknown_predicate.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/archmap_unknown_predicate.json
@@ -1,0 +1,20 @@
+{
+  "schema": "archmap/v1",
+  "id": "bad-predicate",
+  "sources": {
+    "src.app": {
+      "kind": "file",
+      "path": "sample/src/app.rs"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:unknown-predicate",
+      "kind": "capability",
+      "subject": "src.app",
+      "predicate": "whateverTheAuthorWants",
+      "refs": ["src.app"]
+    }
+  ],
+  "molecules": []
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/law_policy.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/law_policy.json
@@ -1,0 +1,19 @@
+{
+  "schema": "law-policy/v1",
+  "id": "solid-policy",
+  "policies": [
+    {
+      "pack": "solid@1",
+      "basis": ["policy-basis:solid"],
+      "scope": ["src.app"],
+      "severity": "error"
+    },
+    {
+      "law": "domain.no-direct-infra-dependency",
+      "evaluator": "domain.no-direct-infra-dependency@1",
+      "basis": ["policy-basis:layering"],
+      "scope": ["src.app"],
+      "severity": "warning"
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/law_policy_dsl_field.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/law_policy_dsl_field.json
@@ -1,0 +1,13 @@
+{
+  "schema": "law-policy/v1",
+  "id": "dsl-field",
+  "policies": [
+    {
+      "pack": "solid@1",
+      "basis": ["policy-basis:solid"],
+      "scope": ["src.app"],
+      "severity": "error"
+    }
+  ],
+  "witnessRules": []
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/law_policy_unknown_basis.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/law_policy_unknown_basis.json
@@ -1,0 +1,12 @@
+{
+  "schema": "law-policy/v1",
+  "id": "bad-basis",
+  "policies": [
+    {
+      "pack": "solid@1",
+      "basis": ["docs/policy/freeform.md"],
+      "scope": ["src.app"],
+      "severity": "error"
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/archmap_v1/law_policy_unknown_evaluator.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/law_policy_unknown_evaluator.json
@@ -1,0 +1,13 @@
+{
+  "schema": "law-policy/v1",
+  "id": "bad-policy",
+  "policies": [
+    {
+      "law": "custom.freeform",
+      "evaluator": "custom.freeform@1",
+      "basis": ["policy-basis:solid"],
+      "scope": ["src.app"],
+      "severity": "error"
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -60,6 +60,33 @@
       }
     },
     {
+      "artifactId": "archmap-v1",
+      "artifactName": "ArchMap v1 Atom input artifact",
+      "schemaVersionName": "archmap/v1",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchMap Atom-to-AAT contract",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archmap_minimal_observation_contract_prd.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "ArchMap v1 records sources, atoms, and molecules as the primary input contract. It rejects legacy v0 root fields, unknown atom kinds, unknown predicates, and unresolved source refs before analysis.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "ArchMap v1 validation does not run the v1 evaluator pipeline.",
+          "ArchMap v1 validation does not prove architecture lawfulness, source completeness, Lean theorem discharge, or global semantic truth."
+        ]
+      }
+    },
+    {
       "artifactId": "law-policy",
       "artifactName": "Selected interpretation profile artifact",
       "schemaVersionName": "law-policy-v0",
@@ -87,6 +114,33 @@
           "Adding a law family must preserve missing coverage as distinct from measured zero.",
           "Changing a spectrum measurement profile changes a measurement recipe, not the selected law universe.",
           "Changing a homotopy measurement profile changes a path / filler / loop measurement recipe, not the selected law universe."
+        ]
+      }
+    },
+    {
+      "artifactId": "law-policy-v1",
+      "artifactName": "LawPolicy v1 selector artifact",
+      "schemaVersionName": "law-policy/v1",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchMap Atom-to-AAT contract",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archmap_minimal_observation_contract_prd.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "LawPolicy v1 selects policy packs or explicit law/evaluator pairs with registry-owned basis, scope, and severity. It rejects unknown packs, unknown evaluators, unresolved basis refs, and DSL-style witness rules before analysis.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "LawPolicy v1 selects evaluators; it does not define witness predicates, axis valuation, obstruction definitions, or Lean proofs.",
+          "LawPolicy v1 validation does not run the v1 evaluator pipeline."
         ]
       }
     },


### PR DESCRIPTION
## 概要

Closes #1812

ArchMap Atom-to-AAT Presentation Contract PRD に合わせて、`archmap/v1` / `law-policy/v1` の input model と fail-closed validation path を追加しました。

- `ArchMapDocumentV1` を `sources` / `atoms` / `molecules` primary model として追加
- `LawPolicyDocumentV1` を `policies[]` selector model として追加
- v1 schema discriminator / validation report / schema catalog entry を追加
- v1 入力の `analyze` は validation artifact を出して、v1 evaluator pipeline 実装前に停止
- stale success artifact を v1 preflight failure 時に削除
- unknown atom kind / predicate / source ref / evaluator / pack / basis / legacy field / DSL field の negative fixture を追加

## 証明した定理

- なし

Lean status: tooling implementation。Lean theorem / proof object は追加していない。

## 編集したドキュメント

- `tools/archsig/tests/fixtures/minimal/schema_version_catalog.json`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない