### PR TITLE
LawPolicy v1 evaluator registryを追加

### DIFF
--- a/tools/archsig/src/law_policy/mod.rs
+++ b/tools/archsig/src/law_policy/mod.rs
@@ -2,9 +2,11 @@ mod constants;
 mod fixture;
 mod helpers;
 mod measurement_policy;
+mod registry;
 mod validate;
 
 pub use fixture::static_law_policy;
+pub use registry::{expand_law_policy_v1, static_law_evaluator_registry_v1};
 pub use validate::{validate_law_policy_report, validate_law_policy_v1_report};
 
 #[cfg(test)]

--- a/tools/archsig/src/law_policy/registry.rs
+++ b/tools/archsig/src/law_policy/registry.rs
@@ -1,0 +1,204 @@
+use crate::{
+    ExpandedLawPolicyEntryV1, LawEvaluatorManifestV1, LawEvaluatorRegistryV1,
+    LawPolicyBasisManifestV1, LawPolicyDocumentV1, LawPolicyPackEntryV1, LawPolicyPackManifestV1,
+};
+
+const REGISTRY_SCHEMA: &str = "law-evaluator-registry/v1";
+
+pub fn static_law_evaluator_registry_v1() -> LawEvaluatorRegistryV1 {
+    LawEvaluatorRegistryV1 {
+        schema: REGISTRY_SCHEMA.to_string(),
+        registry_id: "archsig-law-evaluator-registry@1".to_string(),
+        evaluators: evaluator_manifests(),
+        policy_packs: vec![LawPolicyPackManifestV1 {
+            pack_id: "solid@1".to_string(),
+            entries: solid_pack_entries(),
+        }],
+        basis_refs: vec![
+            LawPolicyBasisManifestV1 {
+                basis_ref: "policy-basis:solid".to_string(),
+                title: "SOLID design principle basis".to_string(),
+            },
+            LawPolicyBasisManifestV1 {
+                basis_ref: "policy-basis:layering".to_string(),
+                title: "Layered architecture dependency basis".to_string(),
+            },
+        ],
+    }
+}
+
+pub fn expand_law_policy_v1(policy: &LawPolicyDocumentV1) -> Vec<ExpandedLawPolicyEntryV1> {
+    policy
+        .policies
+        .iter()
+        .enumerate()
+        .flat_map(|(index, entry)| {
+            if let Some(pack) = entry.pack.as_deref() {
+                pack_entries(pack)
+                    .into_iter()
+                    .map(|pack_entry| ExpandedLawPolicyEntryV1 {
+                        source_policy_index: index,
+                        source_selector: pack.to_string(),
+                        law: pack_entry.law,
+                        evaluator: pack_entry.evaluator,
+                        basis: entry.basis.clone(),
+                        scope: entry.scope.clone(),
+                        severity: entry.severity.clone(),
+                    })
+                    .collect::<Vec<_>>()
+            } else if let (Some(law), Some(evaluator)) =
+                (entry.law.as_deref(), entry.evaluator.as_deref())
+            {
+                vec![ExpandedLawPolicyEntryV1 {
+                    source_policy_index: index,
+                    source_selector: law.to_string(),
+                    law: law.to_string(),
+                    evaluator: evaluator.to_string(),
+                    basis: entry.basis.clone(),
+                    scope: entry.scope.clone(),
+                    severity: entry.severity.clone(),
+                }]
+            } else {
+                Vec::new()
+            }
+        })
+        .collect()
+}
+
+pub fn is_known_v1_pack(pack: &str) -> bool {
+    pack_entries(pack).len() > 0
+}
+
+pub fn is_known_v1_evaluator(evaluator: &str) -> bool {
+    evaluator_manifests()
+        .iter()
+        .any(|manifest| manifest.evaluator_id == evaluator)
+}
+
+pub fn is_known_v1_basis(basis: &str) -> bool {
+    matches!(basis, "policy-basis:solid" | "policy-basis:layering")
+}
+
+fn pack_entries(pack: &str) -> Vec<LawPolicyPackEntryV1> {
+    match pack {
+        "solid@1" => solid_pack_entries(),
+        _ => Vec::new(),
+    }
+}
+
+fn solid_pack_entries() -> Vec<LawPolicyPackEntryV1> {
+    vec![
+        LawPolicyPackEntryV1 {
+            law: "solid.single-responsibility".to_string(),
+            evaluator: "solid.single-responsibility@1".to_string(),
+        },
+        LawPolicyPackEntryV1 {
+            law: "solid.open-closed".to_string(),
+            evaluator: "solid.open-closed@1".to_string(),
+        },
+        LawPolicyPackEntryV1 {
+            law: "solid.liskov-substitution".to_string(),
+            evaluator: "solid.liskov-substitution@1".to_string(),
+        },
+        LawPolicyPackEntryV1 {
+            law: "solid.interface-segregation".to_string(),
+            evaluator: "solid.interface-segregation@1".to_string(),
+        },
+        LawPolicyPackEntryV1 {
+            law: "solid.dependency-inversion".to_string(),
+            evaluator: "solid.dependency-inversion@1".to_string(),
+        },
+    ]
+}
+
+fn evaluator_manifests() -> Vec<LawEvaluatorManifestV1> {
+    vec![
+        solid_manifest(
+            "solid.single-responsibility@1",
+            "solid.single-responsibility",
+            &["component", "capability", "semantic"],
+            &["placesOrder"],
+        ),
+        solid_manifest(
+            "solid.open-closed@1",
+            "solid.open-closed",
+            &["component", "contract", "effect"],
+            &["implements"],
+        ),
+        solid_manifest(
+            "solid.liskov-substitution@1",
+            "solid.liskov-substitution",
+            &["contract", "relation", "runtime"],
+            &["dependsOn"],
+        ),
+        solid_manifest(
+            "solid.interface-segregation@1",
+            "solid.interface-segregation",
+            &["component", "capability", "relation"],
+            &["calls"],
+        ),
+        solid_manifest(
+            "solid.dependency-inversion@1",
+            "solid.dependency-inversion",
+            &["relation", "authority", "contract"],
+            &["dependsOn"],
+        ),
+        LawEvaluatorManifestV1 {
+            evaluator_id: "domain.no-direct-infra-dependency@1".to_string(),
+            law_id: "domain.no-direct-infra-dependency".to_string(),
+            required_atom_constructors: vec!["relation".to_string(), "authority".to_string()],
+            required_predicates: vec!["dependsOn".to_string(), "calls".to_string()],
+            required_molecule_condition:
+                "explicit membership containing a domain-to-infra relation candidate".to_string(),
+            scope_filtering_rule: "filter normalized atoms by LawPolicy scope source prefixes"
+                .to_string(),
+            missing_blocker_rule:
+                "missing relation or authority atoms become blocked, not measured zero".to_string(),
+            pass_criteria: "no selected domain-to-infra relation is present under scoped atoms"
+                .to_string(),
+            violation_criteria:
+                "selected relation crosses from domain scope into infrastructure scope".to_string(),
+            typed_result_schema: "typed-evaluator-result/v1".to_string(),
+            distance_contribution: "registry-owned structural-pressure contribution".to_string(),
+            summary_output_refs: vec!["typedResults[].summary".to_string()],
+            detail_output_refs: vec!["typedResults[].evidenceRefs".to_string()],
+            negative_fixtures: vec!["law_policy_unknown_evaluator.json".to_string()],
+        },
+    ]
+}
+
+fn solid_manifest(
+    evaluator_id: &str,
+    law_id: &str,
+    required_atom_constructors: &[&str],
+    required_predicates: &[&str],
+) -> LawEvaluatorManifestV1 {
+    LawEvaluatorManifestV1 {
+        evaluator_id: evaluator_id.to_string(),
+        law_id: law_id.to_string(),
+        required_atom_constructors: required_atom_constructors
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        required_predicates: required_predicates
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        required_molecule_condition:
+            "explicit molecule membership with required normalized atom constructors".to_string(),
+        scope_filtering_rule: "filter normalized atoms by LawPolicy scope source prefixes"
+            .to_string(),
+        missing_blocker_rule:
+            "missing required atoms or molecule condition become blocked, not measured zero"
+                .to_string(),
+        pass_criteria: "scoped normalized atoms satisfy evaluator-specific law condition"
+            .to_string(),
+        violation_criteria: "scoped normalized atoms violate evaluator-specific law condition"
+            .to_string(),
+        typed_result_schema: "typed-evaluator-result/v1".to_string(),
+        distance_contribution: "registry-owned structural-pressure contribution".to_string(),
+        summary_output_refs: vec!["typedResults[].summary".to_string()],
+        detail_output_refs: vec!["typedResults[].evidenceRefs".to_string()],
+        negative_fixtures: vec!["law_policy_dsl_field.json".to_string()],
+    }
+}

--- a/tools/archsig/src/law_policy/validate.rs
+++ b/tools/archsig/src/law_policy/validate.rs
@@ -6,6 +6,9 @@ use super::measurement_policy::{
     check_homotopy_measurement_profile, check_measurement_policy, check_part4_distance_profile,
     check_spectrum_measurement_profile,
 };
+use super::registry::{
+    expand_law_policy_v1, is_known_v1_basis, is_known_v1_evaluator, is_known_v1_pack,
+};
 use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
 use crate::{
     LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
@@ -18,6 +21,7 @@ pub fn validate_law_policy_v1_report(
     policy: &LawPolicyDocumentV1,
     input_path: &str,
 ) -> LawPolicyValidationReportV1 {
+    let expanded_policies = expand_law_policy_v1(policy);
     let checks = vec![
         check_v1_schema(policy),
         check_v1_identity(policy),
@@ -41,10 +45,12 @@ pub fn validate_law_policy_v1_report(
             path: input_path.to_string(),
             id: policy.id.clone(),
         },
+        expanded_policies,
         checks,
         summary: LawPolicyValidationSummaryV1 {
             result: result.to_string(),
             policy_entry_count: policy.policies.len(),
+            expanded_policy_entry_count: expand_law_policy_v1(policy).len(),
             pack_entry_count: policy
                 .policies
                 .iter()
@@ -219,26 +225,6 @@ fn check_examples(id: &str, title: &str, examples: Vec<ValidationExample>) -> Va
         check.examples = examples;
     }
     check
-}
-
-fn is_known_v1_pack(pack: &str) -> bool {
-    matches!(pack, "solid@1")
-}
-
-fn is_known_v1_evaluator(evaluator: &str) -> bool {
-    matches!(
-        evaluator,
-        "solid.single-responsibility@1"
-            | "solid.open-closed@1"
-            | "solid.liskov-substitution@1"
-            | "solid.interface-segregation@1"
-            | "solid.dependency-inversion@1"
-            | "domain.no-direct-infra-dependency@1"
-    )
-}
-
-fn is_known_v1_basis(basis: &str) -> bool {
-    matches!(basis, "policy-basis:solid" | "policy-basis:layering")
 }
 
 pub fn validate_law_policy_report(

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -13,7 +13,8 @@ pub use archsig_analysis_packet::{
     build_archsig_analysis_packet, validate_archsig_analysis_packet_report,
 };
 pub use law_policy::{
-    static_law_policy, validate_law_policy_report, validate_law_policy_v1_report,
+    expand_law_policy_v1, static_law_evaluator_registry_v1, static_law_policy,
+    validate_law_policy_report, validate_law_policy_v1_report,
 };
 pub use normalizer::normalize_archmap_v1;
 pub(crate) use schema::*;
@@ -32,8 +33,10 @@ pub use schema::{
     ArchSigAtomViewerTruncationPolicyV0, ArchSigAtomViewerVisualV0,
     ArchSigRunManifestRawArtifactPathsV0, ArchSigRunManifestV0,
     ArchSigRunManifestValidationReportPathsV0, ArchSigRunManifestValidationResultSummaryV0,
-    LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA, LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
-    LawPolicyDocumentV0, LawPolicyDocumentV1, LawPolicyEntryV1, LawPolicyValidationInputV1,
+    ExpandedLawPolicyEntryV1, LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA,
+    LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, LawEvaluatorManifestV1, LawEvaluatorRegistryV1,
+    LawPolicyBasisManifestV1, LawPolicyDocumentV0, LawPolicyDocumentV1, LawPolicyEntryV1,
+    LawPolicyPackEntryV1, LawPolicyPackManifestV1, LawPolicyValidationInputV1,
     LawPolicyValidationReportV0, LawPolicyValidationReportV1, LawPolicyValidationSummaryV1,
     NORMALIZED_ARCHMAP_V1_SCHEMA, NormalizedArchMapSummaryV1, NormalizedArchMapV1,
     NormalizedAtomBindingV1, NormalizedAtomPredicateV1, NormalizedAtomV1, NormalizedMoleculeV1,

--- a/tools/archsig/src/schema/law_policy.rs
+++ b/tools/archsig/src/schema/law_policy.rs
@@ -32,6 +32,7 @@ pub struct LawPolicyEntryV1 {
 pub struct LawPolicyValidationReportV1 {
     pub schema_version: String,
     pub input: LawPolicyValidationInputV1,
+    pub expanded_policies: Vec<ExpandedLawPolicyEntryV1>,
     pub checks: Vec<ValidationCheck>,
     pub summary: LawPolicyValidationSummaryV1,
 }
@@ -49,10 +50,73 @@ pub struct LawPolicyValidationInputV1 {
 pub struct LawPolicyValidationSummaryV1 {
     pub result: String,
     pub policy_entry_count: usize,
+    pub expanded_policy_entry_count: usize,
     pub pack_entry_count: usize,
     pub explicit_law_entry_count: usize,
     pub failed_check_count: usize,
     pub warning_check_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawEvaluatorRegistryV1 {
+    pub schema: String,
+    pub registry_id: String,
+    pub evaluators: Vec<LawEvaluatorManifestV1>,
+    pub policy_packs: Vec<LawPolicyPackManifestV1>,
+    pub basis_refs: Vec<LawPolicyBasisManifestV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawEvaluatorManifestV1 {
+    pub evaluator_id: String,
+    pub law_id: String,
+    pub required_atom_constructors: Vec<String>,
+    pub required_predicates: Vec<String>,
+    pub required_molecule_condition: String,
+    pub scope_filtering_rule: String,
+    pub missing_blocker_rule: String,
+    pub pass_criteria: String,
+    pub violation_criteria: String,
+    pub typed_result_schema: String,
+    pub distance_contribution: String,
+    pub summary_output_refs: Vec<String>,
+    pub detail_output_refs: Vec<String>,
+    pub negative_fixtures: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyPackManifestV1 {
+    pub pack_id: String,
+    pub entries: Vec<LawPolicyPackEntryV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyPackEntryV1 {
+    pub law: String,
+    pub evaluator: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LawPolicyBasisManifestV1 {
+    pub basis_ref: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExpandedLawPolicyEntryV1 {
+    pub source_policy_index: usize,
+    pub source_selector: String,
+    pub law: String,
+    pub evaluator: String,
+    pub basis: Vec<String>,
+    pub scope: Vec<String>,
+    pub severity: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -92,6 +92,19 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 ],
             ),
             artifact(
+                "law-evaluator-registry-v1",
+                "Law evaluator registry v1",
+                "law-evaluator-registry/v1",
+                "primary",
+                "ArchMap Atom-to-AAT contract",
+                vec!["docs/tool/archmap_minimal_observation_contract_prd.md"],
+                "Law evaluator registry v1 owns evaluator manifests, policy pack expansion, basis refs, missing blocker rules, pass / violation criteria, typed result schema refs, distance contribution, and output refs. LawPolicy v1 selects entries from this registry.",
+                vec![
+                    "Evaluator registry manifest is an ArchSig computation contract, not a Lean theorem proof.",
+                    "LawPolicy v1 cannot override witness rules, axis rules, distance formula, pass criteria, or violation criteria.",
+                ],
+            ),
+            artifact(
                 "law-policy-validation-report",
                 "LawPolicy validation report",
                 LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION,
@@ -296,6 +309,7 @@ mod tests {
                 "law-policy",
                 "law-policy-validation-report",
                 "law-policy-v1",
+                "law-evaluator-registry-v1",
                 "normalized-archmap-v1",
                 "archsig-analysis-packet",
                 "archsig-analysis-packet-validation-report",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -275,6 +275,22 @@ fn cli_validates_law_policy_v1_selector_contract() {
     assert_eq!(json["summary"]["result"], "pass");
     assert_eq!(json["summary"]["policyEntryCount"], 2);
     assert_eq!(json["summary"]["packEntryCount"], 1);
+    assert_eq!(json["summary"]["expandedPolicyEntryCount"], 6);
+    assert!(json["expandedPolicies"].as_array().is_some_and(|entries| {
+        entries.len() == 6
+            && entries.iter().any(|entry| {
+                entry["law"] == "solid.single-responsibility"
+                    && entry["evaluator"] == "solid.single-responsibility@1"
+            })
+            && entries.iter().any(|entry| {
+                entry["law"] == "solid.dependency-inversion"
+                    && entry["evaluator"] == "solid.dependency-inversion@1"
+            })
+            && entries.iter().any(|entry| {
+                entry["law"] == "domain.no-direct-infra-dependency"
+                    && entry["evaluator"] == "domain.no-direct-infra-dependency@1"
+            })
+    }));
 }
 
 #[test]
@@ -303,6 +319,33 @@ fn cli_rejects_law_policy_v1_unknown_evaluator() {
             .any(|check| check["id"] == "law-policy-v1-registry-vocabulary"
                 && check["result"] == "fail"))
     );
+}
+
+#[test]
+fn cli_rejects_law_policy_v1_unknown_pack() {
+    let out_dir = temp_dir("law-policy-v1-unknown-pack");
+    let root = archmap_v1_root();
+    let report = out_dir.join("law-policy-validation.json");
+
+    let output = run_sig0_output(&[
+        "law-policy",
+        "--input",
+        root.join("law_policy_unknown_pack.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    let json = read_json(&report);
+    assert_eq!(json["schemaVersion"], "law-policy-validation-report-v1");
+    assert_eq!(json["summary"]["result"], "fail");
+    assert!(json["checks"].as_array().is_some_and(|checks| {
+        checks.iter().any(|check| {
+            check["id"] == "law-policy-v1-registry-vocabulary" && check["result"] == "fail"
+        })
+    }));
 }
 
 #[test]
@@ -3682,6 +3725,7 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
             "archmap-v1",
             "law-policy",
             "law-policy-v1",
+            "law-evaluator-registry-v1",
             "law-policy-validation-report",
             "normalized-archmap-v1",
             "archsig-analysis-packet",

--- a/tools/archsig/tests/fixtures/archmap_v1/law_policy_unknown_pack.json
+++ b/tools/archsig/tests/fixtures/archmap_v1/law_policy_unknown_pack.json
@@ -1,0 +1,12 @@
+{
+  "schema": "law-policy/v1",
+  "id": "bad-pack",
+  "policies": [
+    {
+      "pack": "freeform@1",
+      "basis": ["policy-basis:solid"],
+      "scope": ["src.app"],
+      "severity": "error"
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -145,6 +145,33 @@
       }
     },
     {
+      "artifactId": "law-evaluator-registry-v1",
+      "artifactName": "Law evaluator registry v1",
+      "schemaVersionName": "law-evaluator-registry/v1",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchMap Atom-to-AAT contract",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archmap_minimal_observation_contract_prd.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Law evaluator registry v1 owns evaluator manifests, policy pack expansion, basis refs, missing blocker rules, pass / violation criteria, typed result schema refs, distance contribution, and output refs. LawPolicy v1 selects entries from this registry.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "Evaluator registry manifest is an ArchSig computation contract, not a Lean theorem proof.",
+          "LawPolicy v1 cannot override witness rules, axis rules, distance formula, pass criteria, or violation criteria."
+        ]
+      }
+    },
+    {
       "artifactId": "law-policy-validation-report",
       "artifactName": "LawPolicy validation report",
       "schemaVersionName": "law-policy-validation-report-v0",


### PR DESCRIPTION
## 概要

Closes #1814

LawPolicy v1 を selector に保ったまま、計算 contract を所有する evaluator registry と policy pack expansion を追加しました。

- `LawEvaluatorRegistryV1` / evaluator manifest / policy pack / basis manifest schema を追加
- `solid@1` pack を SOLID 5 law entries へ registry-defined に展開
- explicit law entry と pack entry を `ExpandedLawPolicyEntryV1` として validation report に出力
- validator の pack / evaluator / basis 解決を registry 参照に移動
- unknown pack negative fixture を追加
- `law-evaluator-registry-v1` を schema catalog に追加

LawPolicy v1 は criteria、witness rule、axis rule、distance formula を持たず、entry は law / evaluator / basis / scope / severity selector に留めています。

## 証明した定理

- なし

Lean status: tooling implementation。Lean theorem / proof object は追加していない。

## 編集したドキュメント

- `tools/archsig/tests/fixtures/minimal/schema_version_catalog.json`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない