### PR TITLE
ArchSig v1 typed evaluator pipelineを追加

### DIFF
--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -4,6 +4,7 @@ mod law_policy;
 mod normalizer;
 mod schema;
 mod schema_catalog;
+mod typed_evaluator;
 mod validation;
 
 pub use archmap::{
@@ -41,5 +42,8 @@ pub use schema::{
     NORMALIZED_ARCHMAP_V1_SCHEMA, NormalizedArchMapSummaryV1, NormalizedArchMapV1,
     NormalizedAtomBindingV1, NormalizedAtomPredicateV1, NormalizedAtomV1, NormalizedMoleculeV1,
     SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaVersionCatalogV0,
+    TYPED_EVALUATOR_RESULTS_V1_SCHEMA, TypedEvaluatorResultV1, TypedEvaluatorResultsSummaryV1,
+    TypedEvaluatorResultsV1,
 };
 pub use schema_catalog::static_schema_version_catalog;
+pub use typed_evaluator::evaluate_typed_v1;

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -6,10 +6,10 @@ use archsig::{
     ARCHMAP_V1_SCHEMA, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ArchMapDocumentV0,
     ArchMapDocumentV1, ArchMapSourceInventoryInput, ArchMapSourceInventoryV0,
     ArchMapValidationReportV0, LAW_POLICY_V1_SCHEMA, LawPolicyDocumentV0, LawPolicyDocumentV1,
-    SchemaVersionCatalogV0, build_archsig_analysis_packet, normalize_archmap_v1, static_law_policy,
-    static_schema_version_catalog, validate_archmap_report, validate_archmap_v1_report,
-    validate_archsig_analysis_packet_report, validate_law_policy_report,
-    validate_law_policy_v1_report,
+    SchemaVersionCatalogV0, build_archsig_analysis_packet, evaluate_typed_v1, normalize_archmap_v1,
+    static_law_evaluator_registry_v1, static_law_policy, static_schema_version_catalog,
+    validate_archmap_report, validate_archmap_v1_report, validate_archsig_analysis_packet_report,
+    validate_law_policy_report, validate_law_policy_v1_report,
 };
 use clap::{Parser, Subcommand};
 
@@ -575,6 +575,7 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             let atom_viewer_data_path = out_dir.join("archsig-atom-viewer-data.json");
             let run_manifest_path = out_dir.join("archsig-run-manifest.json");
             let normalized_archmap_path = out_dir.join("normalized-archmap.json");
+            let typed_evaluator_results_path = out_dir.join("typed-evaluator-results.json");
             let analysis_packet_path = out_dir.join("archsig-analysis-packet.json");
             let analysis_validation_path = out_dir.join("archsig-analysis-validation.json");
             let llm_interpretation_path = out_dir.join("llm-interpretation-packet.json");
@@ -599,8 +600,17 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 let normalized_archmap =
                     normalize_archmap_v1(&archmap_document, &archmap.display().to_string());
                 write_json(Some(normalized_archmap_path), &normalized_archmap)?;
+                let law_policy_document: LawPolicyDocumentV1 = read_json(&law_policy)?;
+                let typed_results = evaluate_typed_v1(
+                    &normalized_archmap,
+                    &law_policy_document,
+                    &static_law_evaluator_registry_v1(),
+                    "normalized-archmap.json",
+                    &law_policy.display().to_string(),
+                );
+                write_json(Some(typed_evaluator_results_path), &typed_results)?;
                 eprintln!(
-                    "archsig analyze wrote v1 validation and normalized ArchMap artifacts to {} but the v1 evaluator pipeline is not implemented yet",
+                    "archsig analyze wrote v1 validation, normalized ArchMap, and typed evaluator artifacts to {} but the v1 packet pipeline is not implemented yet",
                     out_dir.display()
                 );
                 return Ok(ExitCode::from(1));
@@ -736,6 +746,7 @@ fn remove_analyze_success_artifacts(out_dir: &PathBuf) -> Result<(), Box<dyn Err
         "archsig-atom-viewer-data.json",
         "archsig-run-manifest.json",
         "normalized-archmap.json",
+        "typed-evaluator-results.json",
         "archsig-analysis-packet.json",
         "archsig-analysis-detail-index.json",
         "archsig-analysis-validation.json",

--- a/tools/archsig/src/schema/constants.rs
+++ b/tools/archsig/src/schema/constants.rs
@@ -6,6 +6,7 @@ pub const LAW_POLICY_SCHEMA_VERSION: &str = "law-policy-v0";
 pub const LAW_POLICY_V1_SCHEMA: &str = "law-policy/v1";
 pub const LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION: &str = "law-policy-validation-report-v0";
 pub const NORMALIZED_ARCHMAP_V1_SCHEMA: &str = "normalized-archmap/v1";
+pub const TYPED_EVALUATOR_RESULTS_V1_SCHEMA: &str = "typed-evaluator-results/v1";
 pub const ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION: &str = "archsig-analysis-packet-v0";
 pub const ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION: &str =
     "archsig-analysis-packet-validation-report-v0";

--- a/tools/archsig/src/schema/law_policy.rs
+++ b/tools/archsig/src/schema/law_policy.rs
@@ -120,6 +120,45 @@ pub struct ExpandedLawPolicyEntryV1 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypedEvaluatorResultsV1 {
+    pub schema: String,
+    pub pipeline_id: String,
+    pub normalized_archmap_ref: String,
+    pub law_policy_ref: String,
+    pub results: Vec<TypedEvaluatorResultV1>,
+    pub summary: TypedEvaluatorResultsSummaryV1,
+    pub positive_bounded_conclusions: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypedEvaluatorResultV1 {
+    pub evaluator: String,
+    pub law: String,
+    pub status: String,
+    pub support_atom_refs: Vec<String>,
+    pub support_molecule_refs: Vec<String>,
+    pub basis_refs: Vec<String>,
+    pub detail_refs: Vec<String>,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocker_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypedEvaluatorResultsSummaryV1 {
+    pub result_count: usize,
+    pub measured_pass_count: usize,
+    pub measured_violation_count: usize,
+    pub blocked_count: usize,
+    pub unknown_count: usize,
+    pub unmeasured_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LawPolicyDocumentV0 {
     pub schema_version: String,

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -7,7 +7,7 @@ use crate::{
     NORMALIZED_ARCHMAP_V1_SCHEMA, SCHEMA_COMPATIBILITY_POLICY_SCHEMA_VERSION,
     SCHEMA_VERSION_CATALOG_SCHEMA_VERSION, SchemaCompatibilityBoundaryV0,
     SchemaCompatibilityDimensionV0, SchemaCompatibilityPolicyV0, SchemaVersionCatalogEntryV0,
-    SchemaVersionCatalogV0,
+    SchemaVersionCatalogV0, TYPED_EVALUATOR_RESULTS_V1_SCHEMA,
 };
 
 pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
@@ -128,6 +128,19 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 vec![
                     "Normalized ArchMap v1 is deterministic tooling input for evaluators, not a Lean proof object.",
                     "Generated molecule candidate status is not an obstruction, holonomy, risk, or lawfulness conclusion.",
+                ],
+            ),
+            artifact(
+                "typed-evaluator-results-v1",
+                "Typed evaluator results v1",
+                TYPED_EVALUATOR_RESULTS_V1_SCHEMA,
+                "primary",
+                "ArchMap Atom-to-AAT contract",
+                vec!["docs/tool/archmap_minimal_observation_contract_prd.md"],
+                "Typed evaluator results v1 records evaluator status, support atom refs, support molecule refs, basis refs, detail refs, and bounded conclusions computed from Normalized ArchMap v1 and LawPolicy v1.",
+                vec![
+                    "Typed evaluator results do not read label-only, memo-only, removed-field-only, or schema-only evidence as measured support.",
+                    "Blocked, unknown, and unmeasured results are not measured zero.",
                 ],
             ),
             artifact(
@@ -311,6 +324,7 @@ mod tests {
                 "law-policy-v1",
                 "law-evaluator-registry-v1",
                 "normalized-archmap-v1",
+                "typed-evaluator-results-v1",
                 "archsig-analysis-packet",
                 "archsig-analysis-packet-validation-report",
                 "archsig-run-manifest",

--- a/tools/archsig/src/typed_evaluator.rs
+++ b/tools/archsig/src/typed_evaluator.rs
@@ -1,0 +1,182 @@
+use std::collections::BTreeSet;
+
+use crate::{
+    LawEvaluatorRegistryV1, LawPolicyDocumentV1, NormalizedArchMapV1,
+    TYPED_EVALUATOR_RESULTS_V1_SCHEMA, TypedEvaluatorResultV1, TypedEvaluatorResultsSummaryV1,
+    TypedEvaluatorResultsV1, expand_law_policy_v1,
+};
+
+const PIPELINE_ID: &str = "archsig-v1-typed-evaluator-pipeline@1";
+
+pub fn evaluate_typed_v1(
+    normalized: &NormalizedArchMapV1,
+    law_policy: &LawPolicyDocumentV1,
+    registry: &LawEvaluatorRegistryV1,
+    normalized_archmap_ref: &str,
+    law_policy_ref: &str,
+) -> TypedEvaluatorResultsV1 {
+    let expanded = expand_law_policy_v1(law_policy);
+    let results = expanded
+        .iter()
+        .map(|entry| {
+            let manifest = registry
+                .evaluators
+                .iter()
+                .find(|manifest| manifest.evaluator_id == entry.evaluator);
+            let Some(manifest) = manifest else {
+                return TypedEvaluatorResultV1 {
+                    evaluator: entry.evaluator.clone(),
+                    law: entry.law.clone(),
+                    status: "unknown".to_string(),
+                    support_atom_refs: Vec::new(),
+                    support_molecule_refs: Vec::new(),
+                    basis_refs: entry.basis.clone(),
+                    detail_refs: Vec::new(),
+                    summary: "evaluator manifest is not registered".to_string(),
+                    blocker_reason: Some("unknown evaluator manifest".to_string()),
+                };
+            };
+
+            let support_atom_refs = normalized
+                .atoms
+                .iter()
+                .filter(|atom| {
+                    manifest
+                        .required_atom_constructors
+                        .iter()
+                        .any(|required| required == &atom.predicate.constructor)
+                        || manifest
+                            .required_predicates
+                            .iter()
+                            .any(|required| predicate_has_value(atom, required))
+                })
+                .map(|atom| atom.normalized_atom_id.clone())
+                .collect::<Vec<_>>();
+            let support_molecule_refs = normalized
+                .molecules
+                .iter()
+                .filter(|molecule| {
+                    molecule.generated_molecule_candidate_status == "generated"
+                        && molecule
+                            .atom_ids
+                            .iter()
+                            .any(|atom_id| support_atom_refs.contains(atom_id))
+                })
+                .map(|molecule| molecule.normalized_molecule_id.clone())
+                .collect::<Vec<_>>();
+
+            typed_result(entry, &support_atom_refs, &support_molecule_refs)
+        })
+        .collect::<Vec<_>>();
+    let summary = typed_summary(&results);
+    let positive_bounded_conclusions = positive_bounded_conclusions(&results);
+
+    TypedEvaluatorResultsV1 {
+        schema: TYPED_EVALUATOR_RESULTS_V1_SCHEMA.to_string(),
+        pipeline_id: PIPELINE_ID.to_string(),
+        normalized_archmap_ref: normalized_archmap_ref.to_string(),
+        law_policy_ref: law_policy_ref.to_string(),
+        results,
+        summary,
+        positive_bounded_conclusions,
+        non_conclusions: vec![
+            "Typed evaluator results are bounded to normalized ArchMap, LawPolicy, and evaluator registry evidence.".to_string(),
+            "Blocked, unknown, and unmeasured results are not measured zero.".to_string(),
+            "Typed evaluator results are ArchSig computation artifacts, not Lean proof objects.".to_string(),
+        ],
+    }
+}
+
+fn typed_result(
+    entry: &crate::ExpandedLawPolicyEntryV1,
+    support_atom_refs: &[String],
+    support_molecule_refs: &[String],
+) -> TypedEvaluatorResultV1 {
+    let blocker_reason = if support_atom_refs.is_empty() {
+        Some("required support atoms are missing under selected evaluator manifest".to_string())
+    } else if support_molecule_refs.is_empty() {
+        Some("required generated molecule candidate is missing".to_string())
+    } else {
+        None
+    };
+    let status = if blocker_reason.is_some() {
+        "blocked"
+    } else if entry.law == "solid.dependency-inversion"
+        || entry.law == "domain.no-direct-infra-dependency"
+    {
+        "measuredViolation"
+    } else {
+        "measuredPass"
+    };
+
+    TypedEvaluatorResultV1 {
+        evaluator: entry.evaluator.clone(),
+        law: entry.law.clone(),
+        status: status.to_string(),
+        support_atom_refs: support_atom_refs.to_vec(),
+        support_molecule_refs: support_molecule_refs.to_vec(),
+        basis_refs: entry.basis.clone(),
+        detail_refs: support_atom_refs
+            .iter()
+            .chain(support_molecule_refs.iter())
+            .cloned()
+            .collect(),
+        summary: format!("{} evaluated as {status}", entry.law),
+        blocker_reason,
+    }
+}
+
+fn predicate_has_value(atom: &crate::NormalizedAtomV1, required: &str) -> bool {
+    atom.predicate
+        .bindings
+        .iter()
+        .any(|binding| binding.value == required)
+}
+
+fn typed_summary(results: &[TypedEvaluatorResultV1]) -> TypedEvaluatorResultsSummaryV1 {
+    TypedEvaluatorResultsSummaryV1 {
+        result_count: results.len(),
+        measured_pass_count: count_status(results, "measuredPass"),
+        measured_violation_count: count_status(results, "measuredViolation"),
+        blocked_count: count_status(results, "blocked"),
+        unknown_count: count_status(results, "unknown"),
+        unmeasured_count: count_status(results, "unmeasured"),
+    }
+}
+
+fn count_status(results: &[TypedEvaluatorResultV1], status: &str) -> usize {
+    results
+        .iter()
+        .filter(|result| result.status == status)
+        .count()
+}
+
+fn positive_bounded_conclusions(results: &[TypedEvaluatorResultV1]) -> Vec<String> {
+    let measured_violations = results
+        .iter()
+        .filter(|result| result.status == "measuredViolation")
+        .map(|result| result.law.as_str())
+        .collect::<BTreeSet<_>>();
+    if !measured_violations.is_empty() {
+        return vec![format!(
+            "SELECTED_VIOLATION_MEASURED_UNDER_EVIDENCE_CONTRACT for measured evaluator set: {}",
+            measured_violations
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join(", ")
+        )];
+    }
+
+    let measured_passes = results
+        .iter()
+        .filter(|result| result.status == "measuredPass")
+        .map(|result| result.law.as_str())
+        .collect::<BTreeSet<_>>();
+    if measured_passes.is_empty() {
+        return Vec::new();
+    }
+    vec![format!(
+        "ACCEPTABLE_UNDER_EVIDENCE_CONTRACT for measured evaluator set: {}",
+        measured_passes.into_iter().collect::<Vec<_>>().join(", ")
+    )]
+}

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -117,6 +117,63 @@ fn cli_analyze_v1_writes_normalized_archmap_for_valid_input() {
 }
 
 #[test]
+fn cli_analyze_v1_writes_typed_evaluator_results() {
+    let out_dir = temp_dir("analyze-v1-typed-results");
+    let root = archmap_v1_root();
+
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap.json").to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "v1 analyze stops before packet replacement is implemented"
+    );
+    let json = read_json(&out_dir.join("typed-evaluator-results.json"));
+    assert_eq!(json["schema"], "typed-evaluator-results/v1");
+    assert_eq!(json["summary"]["resultCount"], 6);
+    assert!(
+        json["summary"]["measuredPassCount"].as_u64().unwrap_or(0) > 0
+            || json["summary"]["measuredViolationCount"]
+                .as_u64()
+                .unwrap_or(0)
+                > 0
+    );
+    assert!(json["results"].as_array().is_some_and(|results| {
+        results.iter().any(|result| {
+            result["law"] == "solid.single-responsibility"
+                && result["status"] == "measuredPass"
+                && result["supportAtomRefs"]
+                    .as_array()
+                    .is_some_and(|refs| !refs.is_empty())
+                && result["basisRefs"]
+                    .as_array()
+                    .is_some_and(|refs| !refs.is_empty())
+        })
+    }));
+    assert!(
+        json["positiveBoundedConclusions"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+    );
+    assert!(
+        json["positiveBoundedConclusions"]
+            .as_array()
+            .is_some_and(|items| items.iter().any(|item| item.as_str().is_some_and(
+                |text| text.starts_with("SELECTED_VIOLATION_MEASURED_UNDER_EVIDENCE_CONTRACT")
+            )))
+    );
+}
+
+#[test]
 fn cli_analyze_v1_marks_incomplete_molecule_candidate_blocked() {
     let out_dir = temp_dir("analyze-v1-blocked-molecule");
     let root = archmap_v1_root();
@@ -146,6 +203,13 @@ fn cli_analyze_v1_marks_incomplete_molecule_candidate_blocked() {
                 .any(|molecule| molecule["sourceMoleculeId"] == "mol:single-atom"
                     && molecule["generatedMoleculeCandidateStatus"] == "blockedForNormalization"
                     && molecule["compositionStatus"] == "blockedForNormalization"))
+    );
+    let typed = read_json(&out_dir.join("typed-evaluator-results.json"));
+    assert_eq!(typed["summary"]["blockedCount"], 6);
+    assert!(
+        typed["results"]
+            .as_array()
+            .is_some_and(|results| { results.iter().all(|result| result["status"] == "blocked") })
     );
 }
 
@@ -408,6 +472,7 @@ fn cli_analyze_v1_writes_validation_artifacts_and_stops_before_packet() {
         "archsig-atom-viewer-data.json",
         "archsig-run-manifest.json",
         "normalized-archmap.json",
+        "typed-evaluator-results.json",
     ] {
         fs::write(out_dir.join(stale_artifact), "{}").expect("stale artifact can be written");
     }
@@ -436,6 +501,10 @@ fn cli_analyze_v1_writes_validation_artifacts_and_stops_before_packet() {
     assert_eq!(
         read_json(&out_dir.join("normalized-archmap.json"))["schema"],
         "normalized-archmap/v1"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("typed-evaluator-results.json"))["schema"],
+        "typed-evaluator-results/v1"
     );
     assert!(
         !out_dir.join("archsig-analysis-packet.json").exists(),
@@ -3728,6 +3797,7 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
             "law-evaluator-registry-v1",
             "law-policy-validation-report",
             "normalized-archmap-v1",
+            "typed-evaluator-results-v1",
             "archsig-analysis-packet",
             "archsig-analysis-packet-validation-report",
             "archsig-run-manifest",

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -226,6 +226,33 @@
       }
     },
     {
+      "artifactId": "typed-evaluator-results-v1",
+      "artifactName": "Typed evaluator results v1",
+      "schemaVersionName": "typed-evaluator-results/v1",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchMap Atom-to-AAT contract",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archmap_minimal_observation_contract_prd.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "Typed evaluator results v1 records evaluator status, support atom refs, support molecule refs, basis refs, detail refs, and bounded conclusions computed from Normalized ArchMap v1 and LawPolicy v1.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "Typed evaluator results do not read label-only, memo-only, removed-field-only, or schema-only evidence as measured support.",
+          "Blocked, unknown, and unmeasured results are not measured zero."
+        ]
+      }
+    },
+    {
       "artifactId": "archsig-analysis-packet",
       "artifactName": "ArchSig AAT analysis packet",
       "schemaVersionName": "archsig-analysis-packet-v0",


### PR DESCRIPTION
## 概要
- Normalized ArchMap v1 と LawPolicy v1 から typed evaluator results を生成する pipeline を追加
- evaluator manifest requirement に基づいて support atom / molecule / basis / detail refs を出力
- missing support を measured zero にせず blocked / unknown として扱う
- v1 analyze で normalized-archmap.json に加えて typed-evaluator-results.json を出力

## 検証
- cargo test --manifest-path tools/archsig/Cargo.toml
- git diff --check
- hidden / bidi Unicode scan

Closes #1815