### PR TITLE
ArchSig v1 packet summaryをtyped evaluator化

### DIFF
--- a/docs/tool/archsig_analysis_packet.md
+++ b/docs/tool/archsig_analysis_packet.md
@@ -1,6 +1,32 @@
 # ArchSig Analysis Packet
 
-`archsig-analysis-packet-v0` is the North Star ArchSig output artifact.
+For `archmap/v1` and `law-policy/v1`, ArchSig now uses a typed evaluator
+artifact chain:
+
+```text
+ArchMap v1
+  -> normalized-archmap/v1
+  -> typed-evaluator-results/v1
+  -> archsig-analysis-packet/v1
+  -> archsig-analysis-summary/v1
+  -> archsig-atom-viewer-data-v1
+```
+
+The v1 packet / summary / viewer path is computed from normalized atoms,
+generated molecule candidates, LawPolicy-selected evaluator manifests, typed
+evaluator statuses, support atom refs, support molecule refs, basis refs, and
+detail refs. `blocked`, `unknown`, and `unmeasured` statuses remain non-zero
+blocking states; they are not collapsed into measured zero.
+
+The v1 path does not read v0 helper fields such as `semanticObservations`,
+`projectionInfo`, `operationSquareEvidence`, `concernHints`, or
+`observationGaps` as positive readings. It also does not call Lean or require a
+Lean proof object. `--emit-raw-artifacts` writes v1 raw packet,
+detail-index, and LLM interpretation artifacts; without it, summary / viewer /
+manifest remain the primary reading surface.
+
+`archsig-analysis-packet-v0` is the legacy ArchSig output artifact for
+`archmap-observation-map-v0` / `law-policy-v0`.
 It reads a source-grounded ArchMap together with one selected interpretation
 profile and records AAT-based, bounded analysis for LLM and human review.
 

--- a/tools/archsig/src/cli/analyze.rs
+++ b/tools/archsig/src/cli/analyze.rs
@@ -159,6 +159,83 @@ pub(crate) fn build_analyze_run_manifest(
         ],
     }
 }
+
+pub(crate) fn build_analyze_run_manifest_v1(
+    archmap: &Path,
+    law_policy: &Path,
+    emit_raw_artifacts: bool,
+    archmap_validation_result: &str,
+    law_policy_validation_result: &str,
+    analysis_validation_result: &str,
+) -> serde_json::Value {
+    let mut generated_artifacts = vec![
+        "archmap-validation.json",
+        "law-policy-validation.json",
+        "normalized-archmap.json",
+        "typed-evaluator-results.json",
+        "archsig-analysis-validation.json",
+        "archsig-analysis-summary.json",
+        "archsig-atom-viewer-data.json",
+        "archsig-run-manifest.json",
+    ];
+    let mut omitted_artifacts = Vec::new();
+    if emit_raw_artifacts {
+        generated_artifacts.extend([
+            "archsig-analysis-packet.json",
+            "archsig-analysis-detail-index.json",
+            "llm-interpretation-packet.json",
+        ]);
+    } else {
+        omitted_artifacts.extend([
+            "archsig-analysis-packet.json",
+            "archsig-analysis-detail-index.json",
+            "llm-interpretation-packet.json",
+        ]);
+    }
+
+    serde_json::json!({
+        "schemaVersion": "archsig-run-manifest-v1",
+        "commandName": "analyze",
+        "archmapInputPath": archmap.display().to_string(),
+        "lawPolicyInputPath": law_policy.display().to_string(),
+        "outputMode": if emit_raw_artifacts {
+            "v1-summary-viewer-manifest-with-raw-artifacts"
+        } else {
+            "v1-summary-viewer-manifest"
+        },
+        "rawArtifactRetention": if emit_raw_artifacts { "full" } else { "omitted" },
+        "generatedArtifacts": generated_artifacts,
+        "omittedArtifacts": omitted_artifacts,
+        "summaryPath": "archsig-analysis-summary.json",
+        "atomViewerDataPath": "archsig-atom-viewer-data.json",
+        "typedEvaluatorResultsPath": "typed-evaluator-results.json",
+        "validationReports": {
+            "archmap": "archmap-validation.json",
+            "lawPolicy": "law-policy-validation.json",
+            "analysis": "archsig-analysis-validation.json"
+        },
+        "rawArtifactPaths": if emit_raw_artifacts {
+            serde_json::json!({
+                "analysisPacket": "archsig-analysis-packet.json",
+                "analysisDetailIndex": "archsig-analysis-detail-index.json",
+                "llmInterpretationPacket": "llm-interpretation-packet.json"
+            })
+        } else {
+            serde_json::Value::Null
+        },
+        "validationResultSummary": {
+            "archmap": { "result": archmap_validation_result },
+            "lawPolicy": { "result": law_policy_validation_result },
+            "analysis": { "result": analysis_validation_result }
+        },
+        "nonConclusions": [
+            "v1 run manifest records generated and omitted typed evaluator artifacts for this ArchSig analyze run",
+            "manifest paths are artifact navigation aids, not source completeness proof",
+            "ArchSig v1 run manifest does not claim Lean theorem discharge"
+        ]
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn resolve_archmap_sidecar_path(archmap_path: &Path, sidecar_path: &str) -> Option<PathBuf> {
     let raw_path = PathBuf::from(sidecar_path);

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -46,4 +46,8 @@ pub use schema::{
     TypedEvaluatorResultsV1,
 };
 pub use schema_catalog::static_schema_version_catalog;
-pub use typed_evaluator::evaluate_typed_v1;
+pub use typed_evaluator::{
+    build_typed_analysis_packet_v1, build_typed_analysis_summary_v1,
+    build_typed_analysis_validation_v1, build_typed_atom_viewer_data_v1,
+    build_typed_detail_index_v1, build_typed_llm_interpretation_packet_v1, evaluate_typed_v1,
+};

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -6,7 +6,10 @@ use archsig::{
     ARCHMAP_V1_SCHEMA, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ArchMapDocumentV0,
     ArchMapDocumentV1, ArchMapSourceInventoryInput, ArchMapSourceInventoryV0,
     ArchMapValidationReportV0, LAW_POLICY_V1_SCHEMA, LawPolicyDocumentV0, LawPolicyDocumentV1,
-    SchemaVersionCatalogV0, build_archsig_analysis_packet, evaluate_typed_v1, normalize_archmap_v1,
+    SchemaVersionCatalogV0, build_archsig_analysis_packet, build_typed_analysis_packet_v1,
+    build_typed_analysis_summary_v1, build_typed_analysis_validation_v1,
+    build_typed_atom_viewer_data_v1, build_typed_detail_index_v1,
+    build_typed_llm_interpretation_packet_v1, evaluate_typed_v1, normalize_archmap_v1,
     static_law_evaluator_registry_v1, static_law_policy, static_schema_version_catalog,
     validate_archmap_report, validate_archmap_v1_report, validate_archsig_analysis_packet_report,
     validate_law_policy_report, validate_law_policy_v1_report,
@@ -306,6 +309,10 @@ fn json_schema(document: &serde_json::Value) -> Option<&str> {
         .get("schema")
         .or_else(|| document.get("schemaVersion"))
         .and_then(|value| value.as_str())
+}
+
+fn summary_result(document: &serde_json::Value) -> &str {
+    document["summary"]["result"].as_str().unwrap_or("fail")
 }
 
 fn run() -> Result<ExitCode, Box<dyn Error>> {
@@ -609,11 +616,56 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                     &law_policy.display().to_string(),
                 );
                 write_json(Some(typed_evaluator_results_path), &typed_results)?;
-                eprintln!(
-                    "archsig analyze wrote v1 validation, normalized ArchMap, and typed evaluator artifacts to {} but the v1 packet pipeline is not implemented yet",
-                    out_dir.display()
+                let analysis_packet =
+                    build_typed_analysis_packet_v1(&normalized_archmap, &typed_results);
+                let analysis_summary =
+                    build_typed_analysis_summary_v1(&normalized_archmap, &typed_results);
+                let atom_viewer_data = build_typed_atom_viewer_data_v1(
+                    &normalized_archmap,
+                    &typed_results,
+                    &analysis_summary,
                 );
-                return Ok(ExitCode::from(1));
+                let analysis_validation =
+                    build_typed_analysis_validation_v1(&analysis_packet, &typed_results);
+                write_json(Some(analysis_validation_path), &analysis_validation)?;
+                write_json(Some(analysis_summary_path.clone()), &analysis_summary)?;
+                write_json(Some(atom_viewer_data_path.clone()), &atom_viewer_data)?;
+                if emit_raw_artifacts {
+                    write_json(Some(analysis_packet_path), &analysis_packet)?;
+                    write_json(
+                        Some(out_dir.join("archsig-analysis-detail-index.json")),
+                        &build_typed_detail_index_v1(&typed_results),
+                    )?;
+                    write_json(
+                        Some(llm_interpretation_path),
+                        &build_typed_llm_interpretation_packet_v1(&typed_results),
+                    )?;
+                }
+                write_json(
+                    Some(run_manifest_path),
+                    &build_analyze_run_manifest_v1(
+                        &archmap,
+                        &law_policy,
+                        emit_raw_artifacts,
+                        summary_result(&archmap_preflight),
+                        summary_result(&law_policy_preflight),
+                        analysis_validation["summary"]["result"]
+                            .as_str()
+                            .unwrap_or("fail"),
+                    ),
+                )?;
+                if strict_distance
+                    && typed_results.summary.blocked_count
+                        + typed_results.summary.unknown_count
+                        + typed_results.summary.unmeasured_count
+                        > 0
+                {
+                    return Err(
+                        "--strict-distance rejected v1 typed evaluator results with blocked, unknown, or unmeasured distance statuses"
+                            .into(),
+                    );
+                }
+                return Ok(ExitCode::SUCCESS);
             }
 
             let archmap_document: ArchMapDocumentV0 = read_json(&archmap)?;

--- a/tools/archsig/src/typed_evaluator.rs
+++ b/tools/archsig/src/typed_evaluator.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use serde_json::json;
+
 use crate::{
     LawEvaluatorRegistryV1, LawPolicyDocumentV1, NormalizedArchMapV1,
     TYPED_EVALUATOR_RESULTS_V1_SCHEMA, TypedEvaluatorResultV1, TypedEvaluatorResultsSummaryV1,
@@ -7,6 +9,7 @@ use crate::{
 };
 
 const PIPELINE_ID: &str = "archsig-v1-typed-evaluator-pipeline@1";
+const ANALYSIS_PIPELINE_ID: &str = "archsig-v1-typed-analysis-pipeline@1";
 
 pub fn evaluate_typed_v1(
     normalized: &NormalizedArchMapV1,
@@ -85,6 +88,236 @@ pub fn evaluate_typed_v1(
             "Typed evaluator results are ArchSig computation artifacts, not Lean proof objects.".to_string(),
         ],
     }
+}
+
+pub fn build_typed_analysis_packet_v1(
+    normalized: &NormalizedArchMapV1,
+    typed_results: &TypedEvaluatorResultsV1,
+) -> serde_json::Value {
+    let detail_refs = typed_results
+        .results
+        .iter()
+        .flat_map(|result| result.detail_refs.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    json!({
+        "schema": "archsig-analysis-packet/v1",
+        "analysisId": format!("analysis:{}", normalized.source_archmap_id),
+        "pipelineId": ANALYSIS_PIPELINE_ID,
+        "inputRefs": {
+            "normalizedArchMap": typed_results.normalized_archmap_ref,
+            "lawPolicy": typed_results.law_policy_ref,
+            "typedEvaluatorResults": "typed-evaluator-results.json"
+        },
+        "typedEvaluatorResults": typed_results.results,
+        "distanceDiagnosis": typed_distance_diagnosis(typed_results),
+        "positiveBoundedConclusions": typed_results.positive_bounded_conclusions,
+        "detailRefs": detail_refs,
+        "nonConclusions": [
+            "ArchSig v1 packet is computed from Normalized ArchMap v1 and TypedEvaluatorResults v1.",
+            "ArchSig v1 packet does not read v0 semanticObservations, projectionInfo, operationSquareEvidence, concernHints, or observationGaps.",
+            "Blocked, unknown, and unmeasured evaluator results are not measured zero.",
+            "ArchSig v1 packet is a computation artifact, not a Lean proof object."
+        ]
+    })
+}
+
+pub fn build_typed_analysis_summary_v1(
+    normalized: &NormalizedArchMapV1,
+    typed_results: &TypedEvaluatorResultsV1,
+) -> serde_json::Value {
+    let verdict = if typed_results.summary.measured_violation_count > 0 {
+        "SELECTED_VIOLATION_MEASURED_UNDER_EVIDENCE_CONTRACT"
+    } else if typed_results.summary.measured_pass_count > 0
+        && typed_results.summary.blocked_count == 0
+        && typed_results.summary.unknown_count == 0
+        && typed_results.summary.unmeasured_count == 0
+    {
+        "ACCEPTABLE_UNDER_EVIDENCE_CONTRACT"
+    } else {
+        "BOUNDED_MEASUREMENT_INCOMPLETE"
+    };
+    json!({
+        "schema": "archsig-analysis-summary/v1",
+        "summaryKind": "typed-evaluator-summary",
+        "verdict": verdict,
+        "pipelineId": ANALYSIS_PIPELINE_ID,
+        "measurementBasis": {
+            "normalizedArchMap": typed_results.normalized_archmap_ref,
+            "lawPolicy": typed_results.law_policy_ref,
+            "typedEvaluatorResults": "typed-evaluator-results.json",
+            "normalizedAtomCount": normalized.summary.normalized_atom_count,
+            "generatedMoleculeCandidateCount": normalized.summary.generated_molecule_candidate_count
+        },
+        "measurementStatusSummary": typed_results.summary,
+        "distanceDiagnosis": typed_distance_diagnosis(typed_results),
+        "dominantFindings": typed_dominant_findings(typed_results),
+        "actionQueue": typed_action_queue(typed_results),
+        "positiveBoundedConclusions": typed_results.positive_bounded_conclusions,
+        "metadata": {
+            "boundary": "ArchSig v1 summary reads typed evaluator results only",
+            "leanDependency": "none"
+        },
+        "nonConclusions": [
+            "Summary does not promote missing support to measured zero.",
+            "Summary does not use v0 concern-only, projection-only, square-only, or gap-only inputs as positive readings.",
+            "Summary is not a Lean proof certificate."
+        ]
+    })
+}
+
+pub fn build_typed_atom_viewer_data_v1(
+    normalized: &NormalizedArchMapV1,
+    typed_results: &TypedEvaluatorResultsV1,
+    summary: &serde_json::Value,
+) -> serde_json::Value {
+    let atom_nodes = normalized
+        .atoms
+        .iter()
+        .map(|atom| {
+            json!({
+                "nodeId": atom.normalized_atom_id,
+                "sourceAtomId": atom.source_atom_id,
+                "atomKind": atom.atom_kind,
+                "axis": atom.axis,
+                "predicate": atom.predicate,
+                "normalizationStatus": atom.normalization_status,
+                "moleculeMemberships": atom.molecule_memberships
+            })
+        })
+        .collect::<Vec<_>>();
+    let molecule_groups = normalized
+        .molecules
+        .iter()
+        .map(|molecule| {
+            json!({
+                "groupId": molecule.normalized_molecule_id,
+                "sourceMoleculeId": molecule.source_molecule_id,
+                "atomIds": molecule.atom_ids,
+                "generatedMoleculeCandidateStatus": molecule.generated_molecule_candidate_status,
+                "requiredPortStatus": molecule.required_port_status,
+                "compositionStatus": molecule.composition_status
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "schemaVersion": "archsig-atom-viewer-data-v1",
+        "dataKind": "typed-evaluator-viewer-projection",
+        "sourceArtifactRefs": {
+            "normalizedArchMap": "normalized-archmap.json",
+            "typedEvaluatorResults": "typed-evaluator-results.json",
+            "summary": "archsig-analysis-summary.json",
+            "manifest": "archsig-run-manifest.json"
+        },
+        "atomNodes": atom_nodes,
+        "moleculeGroups": molecule_groups,
+        "analysisOverlays": {
+            "typedEvaluatorResults": typed_results.results,
+            "distanceDiagnosis": summary["distanceDiagnosis"],
+            "actionQueue": summary["actionQueue"]
+        },
+        "reportPane": {
+            "overview": {
+                "summaryVerdict": summary["verdict"],
+                "measurementStatusSummary": summary["measurementStatusSummary"]
+            },
+            "distanceDiagnosis": summary["distanceDiagnosis"],
+            "topFindings": summary["dominantFindings"],
+            "actionQueue": summary["actionQueue"],
+            "artifacts": {
+                "summary": "archsig-analysis-summary.json",
+                "typedEvaluatorResults": "typed-evaluator-results.json",
+                "rawArtifacts": "see archsig-run-manifest.json rawArtifactRetention"
+            }
+        },
+        "nonConclusions": [
+            "Viewer data is a bounded projection over normalized atoms, generated molecule candidates, and typed evaluator results.",
+            "Viewer data does not embed raw source content or Lean proof objects."
+        ]
+    })
+}
+
+pub fn build_typed_detail_index_v1(typed_results: &TypedEvaluatorResultsV1) -> serde_json::Value {
+    let ref_dictionary = typed_results
+        .results
+        .iter()
+        .flat_map(|result| result.detail_refs.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let entries = typed_results
+        .results
+        .iter()
+        .map(|result| {
+            json!({
+                "resultRef": format!("typedEvaluatorResults:{}", result.law),
+                "status": result.status,
+                "supportAtomRefs": result.support_atom_refs,
+                "supportMoleculeRefs": result.support_molecule_refs,
+                "basisRefs": result.basis_refs,
+                "detailRefs": result.detail_refs
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "schemaVersion": "archsig-analysis-detail-index-v1",
+        "indexKind": "typed-evaluator-support-index",
+        "refDictionary": ref_dictionary,
+        "entries": entries,
+        "nonConclusions": [
+            "detail index records typed evaluator support refs only",
+            "detail refs are evidence navigation aids, not proof objects"
+        ]
+    })
+}
+
+pub fn build_typed_llm_interpretation_packet_v1(
+    typed_results: &TypedEvaluatorResultsV1,
+) -> serde_json::Value {
+    json!({
+        "schema": "llm-interpretation-packet/v1",
+        "interpretationKind": "typed-evaluator-bounded-reading",
+        "distanceDiagnosisSummary": typed_distance_diagnosis(typed_results),
+        "typedEvaluatorSummary": typed_results.summary,
+        "positiveBoundedConclusions": typed_results.positive_bounded_conclusions,
+        "nonConclusions": [
+            "LLM interpretation packet summarizes typed evaluator results and does not add new findings.",
+            "Blocked, unknown, and unmeasured are preserved as non-measured statuses."
+        ]
+    })
+}
+
+pub fn build_typed_analysis_validation_v1(
+    packet: &serde_json::Value,
+    typed_results: &TypedEvaluatorResultsV1,
+) -> serde_json::Value {
+    let result = if packet["schema"] == "archsig-analysis-packet/v1"
+        && typed_results.summary.result_count == typed_results.results.len()
+    {
+        "pass"
+    } else {
+        "fail"
+    };
+    json!({
+        "schemaVersion": "archsig-analysis-validation-report-v1",
+        "summary": {
+            "result": result,
+            "failedCheckCount": if result == "pass" { 0 } else { 1 },
+            "warningCheckCount": 0,
+            "proxyRegressionCheckCount": 0
+        },
+        "checks": [
+            {
+                "checkId": "archsig.v1.typedEvaluatorResultCount",
+                "result": result,
+                "message": "typed evaluator result count matches summary"
+            }
+        ],
+        "nonConclusions": [
+            "v1 analysis validation checks typed evaluator artifact consistency, not Lean theorem discharge"
+        ]
+    })
 }
 
 fn typed_result(
@@ -179,4 +412,122 @@ fn positive_bounded_conclusions(results: &[TypedEvaluatorResultV1]) -> Vec<Strin
         "ACCEPTABLE_UNDER_EVIDENCE_CONTRACT for measured evaluator set: {}",
         measured_passes.into_iter().collect::<Vec<_>>().join(", ")
     )]
+}
+
+fn typed_distance_diagnosis(typed_results: &TypedEvaluatorResultsV1) -> serde_json::Value {
+    let status_summary = &typed_results.summary;
+    let measured_distance = status_summary.measured_violation_count;
+    let blocked_distance = status_summary.blocked_count
+        + status_summary.unknown_count
+        + status_summary.unmeasured_count;
+    let top_moved_axes = typed_results
+        .results
+        .iter()
+        .filter(|result| result.status == "measuredViolation")
+        .map(|result| {
+            json!({
+                "law": result.law,
+                "evaluator": result.evaluator,
+                "status": result.status,
+                "axisDistance": {
+                    "status": "measured",
+                    "measuredValue": 1,
+                    "basisRefs": result.basis_refs,
+                    "detailRefs": result.detail_refs
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    let blocked_results = typed_results
+        .results
+        .iter()
+        .filter(|result| {
+            result.status == "blocked"
+                || result.status == "unknown"
+                || result.status == "unmeasured"
+        })
+        .map(|result| {
+            json!({
+                "law": result.law,
+                "evaluator": result.evaluator,
+                "status": result.status,
+                "blockerReason": result.blocker_reason
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "schema": "archsig-distance-diagnosis/v1",
+        "basis": "typedEvaluatorResults",
+        "verdict": if measured_distance > 0 {
+            "SELECTED_VIOLATION_MEASURED_UNDER_EVIDENCE_CONTRACT"
+        } else if blocked_distance > 0 {
+            "BOUNDED_DISTANCE_PARTIALLY_BLOCKED"
+        } else {
+            "NO_SELECTED_OBSTRUCTION"
+        },
+        "distanceValue": {
+            "status": if blocked_distance > 0 { "partial" } else { "measured" },
+            "measuredViolationCount": measured_distance,
+            "blockedOrUnmeasuredCount": blocked_distance
+        },
+        "topMovedAxes": top_moved_axes,
+        "blockedResults": blocked_results,
+        "detailRefs": typed_results
+            .results
+            .iter()
+            .flat_map(|result| result.detail_refs.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>(),
+        "nonConclusions": [
+            "Blocked, unknown, and unmeasured evaluator results are not zero distance.",
+            "Distance contribution is read from evaluator registry owned typed results, not LawPolicy-authored witness formulas.",
+            "Distance diagnosis is an ArchSig computation artifact, not a Lean theorem."
+        ]
+    })
+}
+
+fn typed_dominant_findings(typed_results: &TypedEvaluatorResultsV1) -> Vec<serde_json::Value> {
+    typed_results
+        .results
+        .iter()
+        .filter(|result| result.status == "measuredViolation" || result.status == "blocked")
+        .map(|result| {
+            json!({
+                "findingId": format!("finding:{}", result.law),
+                "law": result.law,
+                "evaluator": result.evaluator,
+                "status": result.status,
+                "summary": result.summary,
+                "supportAtomRefs": result.support_atom_refs,
+                "supportMoleculeRefs": result.support_molecule_refs,
+                "basisRefs": result.basis_refs,
+                "detailRefs": result.detail_refs
+            })
+        })
+        .collect()
+}
+
+fn typed_action_queue(typed_results: &TypedEvaluatorResultsV1) -> Vec<serde_json::Value> {
+    typed_results
+        .results
+        .iter()
+        .filter(|result| result.status != "measuredPass")
+        .map(|result| {
+            let action_kind = if result.status == "measuredViolation" {
+                "reviewSelectedViolation"
+            } else {
+                "collectRequiredSupport"
+            };
+            json!({
+                "actionId": format!("action:{}", result.law),
+                "actionKind": action_kind,
+                "law": result.law,
+                "status": result.status,
+                "basisRefs": result.basis_refs,
+                "detailRefs": result.detail_refs,
+                "blockerReason": result.blocker_reason
+            })
+        })
+        .collect()
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -93,10 +93,7 @@ fn cli_analyze_v1_writes_normalized_archmap_for_valid_input() {
         out_dir.to_str().expect("path is utf-8"),
     ]);
 
-    assert!(
-        !output.status.success(),
-        "v1 analyze stops before the evaluator pipeline is implemented"
-    );
+    assert!(output.status.success());
     let json = read_json(&out_dir.join("normalized-archmap.json"));
     assert_eq!(json["schema"], "normalized-archmap/v1");
     assert_eq!(json["normalizerId"], "archmap-v1-aat-presentation@1");
@@ -133,10 +130,7 @@ fn cli_analyze_v1_writes_typed_evaluator_results() {
         out_dir.to_str().expect("path is utf-8"),
     ]);
 
-    assert!(
-        !output.status.success(),
-        "v1 analyze stops before packet replacement is implemented"
-    );
+    assert!(output.status.success());
     let json = read_json(&out_dir.join("typed-evaluator-results.json"));
     assert_eq!(json["schema"], "typed-evaluator-results/v1");
     assert_eq!(json["summary"]["resultCount"], 6);
@@ -192,7 +186,7 @@ fn cli_analyze_v1_marks_incomplete_molecule_candidate_blocked() {
         out_dir.to_str().expect("path is utf-8"),
     ]);
 
-    assert!(!output.status.success());
+    assert!(output.status.success());
     let json = read_json(&out_dir.join("normalized-archmap.json"));
     assert_eq!(json["summary"]["blockedMoleculeCandidateCount"], 1);
     assert!(
@@ -463,7 +457,7 @@ fn cli_rejects_law_policy_v1_dsl_field() {
 }
 
 #[test]
-fn cli_analyze_v1_writes_validation_artifacts_and_stops_before_packet() {
+fn cli_analyze_v1_writes_summary_viewer_and_manifest_artifacts() {
     let out_dir = temp_dir("analyze-v1-preflight");
     let root = archmap_v1_root();
     for stale_artifact in [
@@ -489,7 +483,7 @@ fn cli_analyze_v1_writes_validation_artifacts_and_stops_before_packet() {
         out_dir.to_str().expect("path is utf-8"),
     ]);
 
-    assert!(!output.status.success());
+    assert!(output.status.success());
     assert_eq!(
         read_json(&out_dir.join("archmap-validation.json"))["schemaVersion"],
         "archmap-validation-report-v1"
@@ -506,20 +500,102 @@ fn cli_analyze_v1_writes_validation_artifacts_and_stops_before_packet() {
         read_json(&out_dir.join("typed-evaluator-results.json"))["schema"],
         "typed-evaluator-results/v1"
     );
+    assert_eq!(
+        read_json(&out_dir.join("archsig-analysis-summary.json"))["schema"],
+        "archsig-analysis-summary/v1"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("archsig-atom-viewer-data.json"))["schemaVersion"],
+        "archsig-atom-viewer-data-v1"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("archsig-analysis-validation.json"))["schemaVersion"],
+        "archsig-analysis-validation-report-v1"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("archsig-run-manifest.json"))["schemaVersion"],
+        "archsig-run-manifest-v1"
+    );
     assert!(
         !out_dir.join("archsig-analysis-packet.json").exists(),
-        "v1 input must not be silently converted into a v0 analysis packet"
+        "raw v1 packet is omitted unless --emit-raw-artifacts is passed"
     );
-    for stale_artifact in [
-        "archsig-analysis-summary.json",
-        "archsig-atom-viewer-data.json",
-        "archsig-run-manifest.json",
-    ] {
-        assert!(
-            !out_dir.join(stale_artifact).exists(),
-            "v1 preflight failure must remove stale success artifact {stale_artifact}"
-        );
-    }
+}
+
+#[test]
+fn cli_analyze_v1_emit_raw_artifacts_writes_typed_packet_detail_and_handoff() {
+    let out_dir = temp_dir("analyze-v1-raw-artifacts");
+    let root = archmap_v1_root();
+
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap.json").to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+        "--emit-raw-artifacts",
+    ]);
+
+    assert!(output.status.success());
+    let packet = read_json(&out_dir.join("archsig-analysis-packet.json"));
+    assert_eq!(packet["schema"], "archsig-analysis-packet/v1");
+    assert_eq!(
+        packet["inputRefs"]["typedEvaluatorResults"],
+        "typed-evaluator-results.json"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("archsig-analysis-detail-index.json"))["schemaVersion"],
+        "archsig-analysis-detail-index-v1"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("llm-interpretation-packet.json"))["schema"],
+        "llm-interpretation-packet/v1"
+    );
+    assert!(
+        packet["nonConclusions"].as_array().is_some_and(|items| {
+            items.iter().any(|item| {
+                item.as_str()
+                    .is_some_and(|text| text.contains("does not read v0 semanticObservations"))
+            })
+        }),
+        "v1 packet must not promote removed v0 helper fields into positive readings"
+    );
+}
+
+#[test]
+fn cli_analyze_v1_strict_distance_rejects_blocked_typed_results() {
+    let out_dir = temp_dir("analyze-v1-strict-distance-blocked");
+    let root = archmap_v1_root();
+
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_blocked_molecule.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+        "--strict-distance",
+    ]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("blocked, unknown, or unmeasured distance statuses"),
+        "--strict-distance must reject incomplete v1 typed distance support"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("typed-evaluator-results.json"))["summary"]["blockedCount"],
+        6
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要
- v1 analyze path を normalized ArchMap + typed evaluator result 起点で packet / summary / viewer / detail-index 生成まで進める
- blocked / unknown / unmeasured を measured zero にせず distanceDiagnosis と strict-distance に反映
- --emit-raw-artifacts で v1 packet / detail-index / LLM interpretation packet を出力
- docs/tool/archsig_analysis_packet.md に v1 typed evaluator artifact chain を追記

## 検証
- cargo test --manifest-path tools/archsig/Cargo.toml
- cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v1 --test cli
- git diff --check
- hidden / bidi Unicode scan

Closes #1816