### PR TITLE
ArchSig Part IV距離coverage ledgerを追加

### DIFF
--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -124,6 +124,7 @@ and validation report generated from
 require the validation report to pass the first-class Part IV checks for:
 
 - `part4DistanceFoundation`
+- `part4DistanceCoverageLedger`
 - `atomDistanceReadings`
 - `configurationDistanceReadings`
 - `signatureDistanceReadings`
@@ -140,6 +141,10 @@ It must keep measured / zero values tied to provenance refs, evaluator-basis
 refs, coverage refs, selected `DistanceProfile`, and selected
 `DiagnosticScope`. Blocked, unmeasured, unavailable, incomparable, or infinite
 values must carry blocker refs. A missing measurement is not a measured zero.
+`part4DistanceCoverageLedger` must enumerate the Part IV definition families
+covered by the packet and point each family back to its primary artifacts, raw
+packet rows, supporting distance rows, blockers, and follow-up implementation
+Issues.
 The raw packet `part4DistanceFoundation.diagnosticScope`, compact
 `distanceDiagnosis`, Atom Viewer report pane, and LLM
 `distanceDiagnosisSummary` must agree on post-evaluator axis status. In

--- a/tools/archsig/src/analysis/distance/foundation.rs
+++ b/tools/archsig/src/analysis/distance/foundation.rs
@@ -140,6 +140,408 @@ fn build_part4_distance_foundation(
     }
 }
 
+fn build_part4_distance_coverage_ledger(
+    foundation: &ArchSigPart4DistanceFoundationV0,
+    atom_distance_readings: &[ArchSigAtomDistanceReadingV0],
+    configuration_distance_readings: &[ArchSigConfigurationDistanceReadingV0],
+    signature_distance_readings: &[ArchSigSignatureDistanceReadingV0],
+    operation_distance_readings: &[ArchSigOperationDistanceReadingV0],
+    obstruction_measure_readings: &[ArchSigObstructionMeasureReadingV0],
+    curvature_mass_readings: &[ArchSigCurvatureMassReadingV0],
+    homotopy_distance_readings: &[ArchSigHomotopyDistanceReadingV0],
+    representation_metric_readings: &[ArchSigRepresentationMetricReadingV0],
+) -> Vec<ArchSigPart4DistanceCoverageLedgerEntryV0> {
+    vec![
+        part4_ledger_entry(
+            "part4-ledger:distance-aat",
+            "definition:1.1",
+            "DistanceAAT",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:35",
+            "foundation",
+            "primary",
+            foundation_status(foundation),
+            foundation.supporting_distances.len(),
+            &["archsig-analysis-packet.json#/part4DistanceFoundation"],
+            &["/part4DistanceFoundation"],
+            supporting_distance_refs(foundation, &[
+                "atomGeometry",
+                "configurationGeometry",
+                "signatureGeometry",
+                "operationGeometry",
+                "curvatureGeometry",
+                "homotopyFillingGeometry",
+                "representationMetric",
+            ]),
+            foundation.diagnostic_scope.blocker_refs.clone(),
+            &[],
+            "DistanceAAT is represented as the Part IV foundation, profile, diagnostic scope, supporting distances, and non-conclusion boundary.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:atom-geometry",
+            "definitions:2.1-2.5",
+            "Fiber / Carrier / Valence / Semantic Anchor / Atom Layout distance",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:140",
+            "atomGeometry",
+            coverage_status_for_family(
+                foundation,
+                "atomGeometry",
+                atom_distance_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "atomGeometry"),
+            atom_distance_readings.len(),
+            &[
+                "architecture-distance.json#/atomDistanceReadings",
+                "archsig-analysis-summary.json#/distanceDiagnosis/topMovedAtoms",
+                "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis",
+            ],
+            &["/atomDistanceReadings", "/viewerDistanceInputs"],
+            supporting_distance_refs(foundation, &["atomGeometry"]),
+            supporting_blockers(foundation, "atomGeometry"),
+            &["#1859"],
+            "Atom geometry is expected to expose each Part IV atom-distance component without treating viewer layout distance as diagnostic distance.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:configuration-context",
+            "definitions:3.1-3.2",
+            "Configuration-indexed distance and Context distance",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:275",
+            "configurationGeometry",
+            coverage_status_for_family(
+                foundation,
+                "configurationGeometry",
+                configuration_distance_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "configurationGeometry"),
+            configuration_distance_readings.len(),
+            &[
+                "architecture-distance.json#/configurationDistanceReadings",
+                "archsig-analysis-summary.json#/distanceDiagnosis",
+                "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis",
+            ],
+            &["/configurationDistanceReadings"],
+            supporting_distance_refs(foundation, &["configurationGeometry"]),
+            supporting_blockers(foundation, "configurationGeometry"),
+            &["#1859"],
+            "Configuration distance must stay typed-hypergraph and context based; molecule size alone is not complete Part IV coverage.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:signature-geometry",
+            "definitions:4.1-4.4",
+            "Axis distance, Signature distance, Safe margin, and Signature drift",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:344",
+            "signatureGeometry",
+            coverage_status_for_family(
+                foundation,
+                "signatureGeometry",
+                signature_distance_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "signatureGeometry"),
+            signature_distance_readings.len(),
+            &[
+                "architecture-distance.json#/signatureDistanceReadings",
+                "archsig-analysis-summary.json#/distanceDiagnosis/topMovedAxes",
+                "llm-interpretation-packet.json#/distanceDiagnosisSummary",
+            ],
+            &["/signatureDistanceReadings", "/signatureAxes"],
+            supporting_distance_refs(foundation, &["signatureGeometry"]),
+            supporting_blockers(foundation, "signatureGeometry"),
+            &["#1861"],
+            "Signature geometry is LawPolicy-relative and must preserve measured, blocked, unmeasured, and incomparable axis states.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:operation-geometry",
+            "definitions:5.1-5.5",
+            "Operation cost, Operation distance, Flatness distance, Repair route, and Side-effect bound",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:490",
+            "operationGeometry",
+            coverage_status_for_family(
+                foundation,
+                "operationGeometry",
+                operation_distance_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "operationGeometry"),
+            operation_distance_readings.len(),
+            &[
+                "architecture-distance.json#/operationDistanceReadings",
+                "archsig-analysis-summary.json#/distanceDiagnosis/repairDistance",
+            ],
+            &[
+                "/operationDistanceReadings",
+                "/repairOperationCandidates",
+                "/operationDeltas",
+            ],
+            supporting_distance_refs(foundation, &["operationGeometry"]),
+            supporting_blockers(foundation, "operationGeometry"),
+            &["#1860"],
+            "Operation geometry must be profile-driven and blocked when operation costs, preconditions, or side-effect evidence are missing.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:obstruction-curvature",
+            "definitions:6.1-6.3",
+            "Obstruction measure, Curvature mass, and Curvature transport",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:599",
+            "curvatureGeometry",
+            coverage_status_for_family(
+                foundation,
+                "curvatureGeometry",
+                curvature_mass_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "curvatureGeometry"),
+            obstruction_measure_readings.len() + curvature_mass_readings.len(),
+            &[
+                "archsig-analysis-summary.json#/distanceDiagnosis/curvatureDistance",
+                "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis",
+            ],
+            &[
+                "/obstructionMeasureReadings",
+                "/curvatureMassReadings",
+                "/curvatureTransferReadings",
+            ],
+            supporting_distance_refs(foundation, &["curvatureGeometry"]),
+            supporting_blockers(foundation, "curvatureGeometry"),
+            &["#1864"],
+            "Curvature geometry must expose obstruction-measure support and transport state, not just raw packet rows.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:homotopy-filling",
+            "definitions:7.1-7.4",
+            "Homotopy distance, Filling cost, Observation gap lower bound, and Architectural Dehn function",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:674",
+            "homotopyFillingGeometry",
+            coverage_status_for_family(
+                foundation,
+                "homotopyFillingGeometry",
+                homotopy_distance_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "homotopyFillingGeometry"),
+            homotopy_distance_readings.len(),
+            &[
+                "archsig-analysis-summary.json#/distanceDiagnosis/homotopyDistance",
+                "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis",
+            ],
+            &[
+                "/homotopyDistanceReadings",
+                "/architectureHomotopyReport",
+                "/homotopyHolonomyReadings",
+            ],
+            supporting_distance_refs(foundation, &["homotopyFillingGeometry"]),
+            supporting_blockers(foundation, "homotopyFillingGeometry"),
+            &["#1867"],
+            "Homotopy and filling readings must make missing filler evidence an actionable blocker, not a hidden non-conclusion.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:representation-metric",
+            "definitions:8.1-8.2",
+            "Representation stability and Representation faithfulness",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:746",
+            "representationMetric",
+            coverage_status_for_family(
+                foundation,
+                "representationMetric",
+                representation_metric_readings.len(),
+                true,
+            ),
+            supporting_status(foundation, "representationMetric"),
+            representation_metric_readings.len(),
+            &[
+                "archsig-analysis-summary.json#/distanceDiagnosis/representationMetric",
+                "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis",
+            ],
+            &[
+                "/representationMetricReadings",
+                "/analyticRepresentations",
+                "/representationStrengthReadings",
+            ],
+            supporting_distance_refs(foundation, &["representationMetric"]),
+            supporting_blockers(foundation, "representationMetric"),
+            &["#1865"],
+            "Representation metrics must distinguish measured structural distance, bounded proxy telemetry, blocked Lipschitz evidence, and faithfulness blockers.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:measurement-boundary",
+            "definitions:9.1-9.3",
+            "DistanceValue, unmeasured-is-not-zero, and DistanceProfile",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:784",
+            "measurementBoundary",
+            "primary",
+            foundation_status(foundation),
+            foundation.supporting_distances.len(),
+            &[
+                "archsig-run-manifest.json#/validationResultSummary",
+                "archsig-analysis-summary.json#/measurementStatusSummary",
+            ],
+            &[
+                "/part4DistanceFoundation/profile",
+                "/part4DistanceFoundation/statusSummary",
+                "/part4DistanceFoundation/diagnosticScope",
+            ],
+            supporting_distance_refs(foundation, &[
+                "atomGeometry",
+                "configurationGeometry",
+                "signatureGeometry",
+                "operationGeometry",
+                "curvatureGeometry",
+                "homotopyFillingGeometry",
+                "representationMetric",
+            ]),
+            foundation.diagnostic_scope.blocker_refs.clone(),
+            &["#1861", "#1866"],
+            "Measurement boundary rows record that blocked and unmeasured values remain first-class states and are not aggregated as measured zero.",
+        ),
+        part4_ledger_entry(
+            "part4-ledger:bounded-diagnostic-conclusion",
+            "definitions:10.1-10.2",
+            "Diagnostic scope and Bounded diagnostic conclusion",
+            "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:852",
+            "boundedDiagnosticConclusion",
+            "partial",
+            foundation_status(foundation),
+            foundation.supporting_distances.len(),
+            &[
+                "archsig-analysis-summary.json#/conclusion",
+                "archsig-analysis-summary.json#/distanceDiagnosis",
+                "llm-interpretation-packet.json#/distanceDiagnosisSummary",
+            ],
+            &[
+                "/part4DistanceFoundation/diagnosticScope",
+                "/boundedJudgements",
+                "/llmInterpretationPacket",
+            ],
+            Vec::new(),
+            foundation.diagnostic_scope.blocker_refs.clone(),
+            &["#1863", "#1866"],
+            "Bounded diagnostic conclusion is partially covered until distanceInsights and full-output docs make the distance reading actionable.",
+        ),
+    ]
+}
+
+fn part4_ledger_entry(
+    ledger_entry_id: &str,
+    part4_definition_ref: &str,
+    definition_title: &str,
+    theory_section_ref: &str,
+    distance_family: &str,
+    coverage_status: impl Into<String>,
+    measurement_status: impl Into<String>,
+    reading_count: usize,
+    primary_artifact_refs: &[&str],
+    raw_packet_refs: &[&str],
+    supporting_distance_refs: Vec<String>,
+    blocker_refs: Vec<String>,
+    follow_up_issue_refs: &[&str],
+    evidence_boundary: &str,
+) -> ArchSigPart4DistanceCoverageLedgerEntryV0 {
+    ArchSigPart4DistanceCoverageLedgerEntryV0 {
+        ledger_entry_id: ledger_entry_id.to_string(),
+        part4_definition_ref: part4_definition_ref.to_string(),
+        definition_title: definition_title.to_string(),
+        theory_section_ref: theory_section_ref.to_string(),
+        distance_family: distance_family.to_string(),
+        coverage_status: coverage_status.into(),
+        measurement_status: measurement_status.into(),
+        reading_count,
+        primary_artifact_refs: primary_artifact_refs
+            .iter()
+            .map(|entry| (*entry).to_string())
+            .collect(),
+        raw_packet_refs: raw_packet_refs.iter().map(|entry| (*entry).to_string()).collect(),
+        supporting_distance_refs,
+        blocker_refs,
+        follow_up_issue_refs: follow_up_issue_refs
+            .iter()
+            .map(|entry| (*entry).to_string())
+            .collect(),
+        evidence_boundary: evidence_boundary.to_string(),
+        non_conclusions: strings(&REQUIRED_NON_CONCLUSIONS),
+    }
+}
+
+fn coverage_status_for_family(
+    foundation: &ArchSigPart4DistanceFoundationV0,
+    family: &str,
+    reading_count: usize,
+    has_primary_refs: bool,
+) -> String {
+    let status = supporting_status(foundation, family);
+    if reading_count == 0 {
+        return match status.as_str() {
+            "unavailable" => "not-applicable".to_string(),
+            "unmeasured" => "missing-readings".to_string(),
+            "blocked" => "blocked-without-readings".to_string(),
+            _ => "missing-readings".to_string(),
+        };
+    }
+    if !has_primary_refs {
+        return "raw-packet-only".to_string();
+    }
+    match status.as_str() {
+        "measured" | "zero" => "primary".to_string(),
+        "blocked" => "primary-blocked".to_string(),
+        "unmeasured" => "raw-packet-only".to_string(),
+        _ => status,
+    }
+}
+
+fn foundation_status(foundation: &ArchSigPart4DistanceFoundationV0) -> String {
+    if foundation.status_summary.blocked_count > 0 {
+        "blocked".to_string()
+    } else if foundation.status_summary.unmeasured_count > 0 {
+        "partial".to_string()
+    } else if foundation.status_summary.measured_count > 0
+        || foundation.status_summary.zero_count > 0
+    {
+        "measured".to_string()
+    } else {
+        "unmeasured".to_string()
+    }
+}
+
+fn supporting_status(foundation: &ArchSigPart4DistanceFoundationV0, family: &str) -> String {
+    foundation
+        .supporting_distances
+        .iter()
+        .find(|distance| distance.distance_family == family)
+        .map(|distance| distance.value.status.clone())
+        .unwrap_or_else(|| "missing".to_string())
+}
+
+fn supporting_distance_refs(
+    foundation: &ArchSigPart4DistanceFoundationV0,
+    families: &[&str],
+) -> Vec<String> {
+    foundation
+        .supporting_distances
+        .iter()
+        .enumerate()
+        .filter_map(|(index, distance)| {
+            families
+                .iter()
+                .any(|family| distance.distance_family == *family)
+                .then(|| {
+                    format!(
+                        "/part4DistanceFoundation/supportingDistances/{index}#{}",
+                        distance.distance_id
+                    )
+                })
+        })
+        .collect()
+}
+
+fn supporting_blockers(foundation: &ArchSigPart4DistanceFoundationV0, family: &str) -> Vec<String> {
+    foundation
+        .supporting_distances
+        .iter()
+        .find(|distance| distance.distance_family == family)
+        .map(|distance| distance.value.blocker_refs.clone())
+        .unwrap_or_default()
+}
+
 fn selected_part4_distance_profile(
     law_policy: &LawPolicyDocumentV0,
     default_coverage_refs: &[String],

--- a/tools/archsig/src/analysis/validation/mod.rs
+++ b/tools/archsig/src/analysis/validation/mod.rs
@@ -22,6 +22,7 @@ pub fn validate_archsig_analysis_packet_report(
         check_transfer_bridge_surface(packet),
         check_generated_middle_layer_surface(packet),
         check_part4_distance_foundation_surface(packet),
+        check_part4_distance_coverage_ledger_surface(packet),
         check_atom_distance_reading_surface(packet),
         check_configuration_distance_reading_surface(packet),
         check_signature_distance_reading_surface(packet),
@@ -5956,6 +5957,328 @@ fn check_part4_distance_foundation_surface(packet: &ArchSigAnalysisPacketV0) -> 
     check_from_examples(
         "archsig-analysis-packet-part4-distance-foundation",
         "packet exposes Part IV DistanceValue, DistanceProfile, DiagnosticScope, and anti-proxy distance provenance",
+        examples,
+        "fail",
+    )
+}
+
+fn check_part4_distance_coverage_ledger_surface(
+    packet: &ArchSigAnalysisPacketV0,
+) -> ValidationCheck {
+    let mut examples = Vec::new();
+    let ledger = &packet.part4_distance_coverage_ledger;
+    if ledger.is_empty() {
+        examples.push(generic_validation_example(
+            "part4DistanceCoverageLedger",
+            "empty",
+            "Part IV distance coverage ledger must enumerate the definition families covered by the packet",
+        ));
+    }
+    examples.extend(duplicate_examples(
+        "part4DistanceCoverageLedger.ledgerEntryId",
+        duplicates(ledger.iter().map(|entry| entry.ledger_entry_id.as_str())),
+    ));
+
+    let expected_entries = BTreeMap::from([
+        ("part4-ledger:distance-aat", ("definition:1.1", "foundation")),
+        (
+            "part4-ledger:atom-geometry",
+            ("definitions:2.1-2.5", "atomGeometry"),
+        ),
+        (
+            "part4-ledger:configuration-context",
+            ("definitions:3.1-3.2", "configurationGeometry"),
+        ),
+        (
+            "part4-ledger:signature-geometry",
+            ("definitions:4.1-4.4", "signatureGeometry"),
+        ),
+        (
+            "part4-ledger:operation-geometry",
+            ("definitions:5.1-5.5", "operationGeometry"),
+        ),
+        (
+            "part4-ledger:obstruction-curvature",
+            ("definitions:6.1-6.3", "curvatureGeometry"),
+        ),
+        (
+            "part4-ledger:homotopy-filling",
+            ("definitions:7.1-7.4", "homotopyFillingGeometry"),
+        ),
+        (
+            "part4-ledger:representation-metric",
+            ("definitions:8.1-8.2", "representationMetric"),
+        ),
+        (
+            "part4-ledger:measurement-boundary",
+            ("definitions:9.1-9.3", "measurementBoundary"),
+        ),
+        (
+            "part4-ledger:bounded-diagnostic-conclusion",
+            ("definitions:10.1-10.2", "boundedDiagnosticConclusion"),
+        ),
+    ]);
+    let ledger_by_id = ledger
+        .iter()
+        .map(|entry| (entry.ledger_entry_id.as_str(), entry))
+        .collect::<BTreeMap<_, _>>();
+    for (entry_id, (definition_ref, distance_family)) in &expected_entries {
+        match ledger_by_id.get(entry_id) {
+            Some(entry) => {
+                if entry.part4_definition_ref != *definition_ref {
+                    examples.push(generic_validation_example(
+                        &entry.ledger_entry_id,
+                        &entry.part4_definition_ref,
+                        "coverage ledger entry must keep the expected Part IV definition ref",
+                    ));
+                }
+                if entry.distance_family != *distance_family {
+                    examples.push(generic_validation_example(
+                        &entry.ledger_entry_id,
+                        &entry.distance_family,
+                        "coverage ledger entry must keep the expected Part IV distance family",
+                    ));
+                }
+            }
+            None => examples.push(generic_validation_example(
+                "part4DistanceCoverageLedger",
+                entry_id,
+                "coverage ledger must include every first-class Part IV definition family",
+            )),
+        }
+    }
+
+    let supporting_by_family = packet
+        .part4_distance_foundation
+        .supporting_distances
+        .iter()
+        .map(|distance| (distance.distance_family.as_str(), distance))
+        .collect::<BTreeMap<_, _>>();
+    let foundation_status = if packet.part4_distance_foundation.status_summary.blocked_count > 0 {
+        "blocked"
+    } else if packet
+        .part4_distance_foundation
+        .status_summary
+        .unmeasured_count
+        > 0
+    {
+        "partial"
+    } else if packet
+        .part4_distance_foundation
+        .status_summary
+        .measured_count
+        > 0
+        || packet.part4_distance_foundation.status_summary.zero_count > 0
+    {
+        "measured"
+    } else {
+        "unmeasured"
+    };
+    let allowed_coverage = BTreeSet::from([
+        "primary",
+        "partial",
+        "primary-blocked",
+        "raw-packet-only",
+        "missing-readings",
+        "blocked-without-readings",
+        "not-applicable",
+    ]);
+    let allowed_measurement = BTreeSet::from([
+        "measured",
+        "zero",
+        "unmeasured",
+        "unavailable",
+        "incomparable",
+        "infinite",
+        "blocked",
+        "partial",
+    ]);
+
+    for entry in ledger {
+        push_blank(
+            &mut examples,
+            "part4DistanceCoverageLedger.ledgerEntryId",
+            &entry.ledger_entry_id,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} definitionTitle", entry.ledger_entry_id),
+            &entry.definition_title,
+        );
+        push_blank(
+            &mut examples,
+            &format!("{} theorySectionRef", entry.ledger_entry_id),
+            &entry.theory_section_ref,
+        );
+        if !entry
+            .theory_section_ref
+            .contains("part_4_distance_measure_geometry.md")
+        {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                &entry.theory_section_ref,
+                "coverage ledger theory refs must point back to the Part IV source text",
+            ));
+        }
+        if !allowed_coverage.contains(entry.coverage_status.as_str())
+            || entry.coverage_status == "schemaFoundationOnly"
+        {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                &entry.coverage_status,
+                "coverageStatus must be a bounded ledger status and never schemaFoundationOnly",
+            ));
+        }
+        if !allowed_measurement.contains(entry.measurement_status.as_str())
+            || entry.measurement_status == "schemaFoundationOnly"
+        {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                &entry.measurement_status,
+                "measurementStatus must mirror the foundation/supporting distance state and never schemaFoundationOnly",
+            ));
+        }
+        if entry.primary_artifact_refs.is_empty() || has_blank(&entry.primary_artifact_refs) {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                "primaryArtifactRefs",
+                "coverage ledger entries must point to primary output artifacts",
+            ));
+        }
+        if entry.raw_packet_refs.is_empty() || has_blank(&entry.raw_packet_refs) {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                "rawPacketRefs",
+                "coverage ledger entries must point to raw packet rows",
+            ));
+        }
+        if entry.evidence_boundary.trim().is_empty()
+            || entry
+                .evidence_boundary
+                .to_ascii_lowercase()
+                .contains("prove")
+        {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                "evidenceBoundary",
+                "coverage ledger evidenceBoundary must be non-empty and avoid proof-style claims",
+            ));
+        }
+        if !entry
+            .non_conclusions
+            .iter()
+            .any(|non_conclusion| non_conclusion.contains("not a Lean theorem proof"))
+        {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                "nonConclusions",
+                "coverage ledger entries must preserve ArchSig/Lean boundary language",
+            ));
+        }
+        for follow_up in &entry.follow_up_issue_refs {
+            if !follow_up.starts_with('#') {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    follow_up,
+                    "follow-up issue refs must use repo-local # issue refs",
+                ));
+            }
+        }
+
+        if let Some(supporting_distance) = supporting_by_family.get(entry.distance_family.as_str()) {
+            if entry.measurement_status != supporting_distance.value.status {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    &entry.measurement_status,
+                    "measurementStatus must match the selected supporting distance status for this Part IV family",
+                ));
+            }
+            if entry.supporting_distance_refs.is_empty() {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    "supportingDistanceRefs",
+                    "families backed by supporting distances must point to those distance rows",
+                ));
+            }
+        } else if matches!(
+            entry.distance_family.as_str(),
+            "foundation" | "measurementBoundary" | "boundedDiagnosticConclusion"
+        ) && entry.measurement_status != foundation_status
+        {
+            examples.push(generic_validation_example(
+                &entry.ledger_entry_id,
+                &entry.measurement_status,
+                "foundation-level ledger rows must mirror the Part IV foundation status summary",
+            ));
+        }
+
+        for support_ref in &entry.supporting_distance_refs {
+            let Some((pointer, distance_id)) = support_ref.split_once('#') else {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    support_ref,
+                    "supportingDistanceRefs must include a packet pointer and distance id",
+                ));
+                continue;
+            };
+            let Some(index) = pointer
+                .strip_prefix("/part4DistanceFoundation/supportingDistances/")
+                .and_then(|raw_index| raw_index.parse::<usize>().ok())
+            else {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    support_ref,
+                    "supportingDistanceRefs must resolve inside part4DistanceFoundation.supportingDistances",
+                ));
+                continue;
+            };
+            let Some(distance) = packet
+                .part4_distance_foundation
+                .supporting_distances
+                .get(index)
+            else {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    support_ref,
+                    "supportingDistanceRefs index is out of range",
+                ));
+                continue;
+            };
+            if distance.distance_id != distance_id {
+                examples.push(generic_validation_example(
+                    &entry.ledger_entry_id,
+                    support_ref,
+                    "supportingDistanceRefs distance id must match the referenced supporting distance row",
+                ));
+            }
+        }
+
+        match entry.measurement_status.as_str() {
+            "measured" | "zero" => {
+                if entry.supporting_distance_refs.is_empty() {
+                    examples.push(generic_validation_example(
+                        &entry.ledger_entry_id,
+                        "supportingDistanceRefs",
+                        "measured or zero ledger rows must retain supporting distance refs",
+                    ));
+                }
+            }
+            "blocked" | "unmeasured" | "unavailable" | "incomparable" | "infinite" => {
+                if entry.blocker_refs.is_empty() {
+                    examples.push(generic_validation_example(
+                        &entry.ledger_entry_id,
+                        "blockerRefs",
+                        "blocked, unmeasured, unavailable, incomparable, or infinite ledger rows must retain blocker refs",
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    check_from_examples(
+        "archsig-analysis-packet-part4-distance-coverage-ledger",
+        "packet maps Part IV definition families to primary artifacts, raw rows, supporting distances, blockers, and follow-up issues",
         examples,
         "fail",
     )

--- a/tools/archsig/src/archsig_analysis_packet.rs
+++ b/tools/archsig/src/archsig_analysis_packet.rs
@@ -54,20 +54,20 @@ use crate::{
     ArchSigOperationCalculusLawReadingV0, ArchSigOperationDeltaReadingV0,
     ArchSigOperationDistanceReadingV0, ArchSigOperationInvariantGaloisReadingV0,
     ArchSigOperationLawEvidenceV0, ArchSigOperationPreconditionReadinessReadingV0,
-    ArchSigOperationSquareCandidateV0, ArchSigPart4DistanceFoundationV0,
-    ArchSigPathContinuationTraceV0, ArchSigPathHomotopyDiagramReadingV0,
-    ArchSigPathMultiplicityLossReadingV0, ArchSigPathPairCandidateV0,
-    ArchSigPathSignatureTrajectoryReadingV0, ArchSigProjectionCoordinateV0,
-    ArchSigProjectionNonInjectivityCandidateV0, ArchSigProjectionReconstructionBlockerV0,
-    ArchSigRecurrentObstructionModeV0, ArchSigRepairAxisDeltaReadingV0,
-    ArchSigRepairOperationCandidateV0, ArchSigRepairTransferRiskRankV0,
-    ArchSigRepresentationMetricReadingV0, ArchSigRepresentationStrengthReadingV0,
-    ArchSigSignatureAxisDistanceV0, ArchSigSignatureAxisReadingV0,
-    ArchSigSignatureDistanceReadingV0, ArchSigSignatureTrajectoryHomotopyRefutationReadingV0,
-    ArchSigSpectralAnalysisReadingV0, ArchSigSpectralDominantComponentV0,
-    ArchSigSpectralDrilldownReadingV0, ArchSigSpectralMatrixShapeV0,
-    ArchSigSpectralModeComponentV0, ArchSigSpectralModeReadingV0, ArchSigSpectralValueV0,
-    ArchSigSplitReadinessReadingV0, ArchSigStateTransitionAlgebraReadingV0,
+    ArchSigOperationSquareCandidateV0, ArchSigPart4DistanceCoverageLedgerEntryV0,
+    ArchSigPart4DistanceFoundationV0, ArchSigPathContinuationTraceV0,
+    ArchSigPathHomotopyDiagramReadingV0, ArchSigPathMultiplicityLossReadingV0,
+    ArchSigPathPairCandidateV0, ArchSigPathSignatureTrajectoryReadingV0,
+    ArchSigProjectionCoordinateV0, ArchSigProjectionNonInjectivityCandidateV0,
+    ArchSigProjectionReconstructionBlockerV0, ArchSigRecurrentObstructionModeV0,
+    ArchSigRepairAxisDeltaReadingV0, ArchSigRepairOperationCandidateV0,
+    ArchSigRepairTransferRiskRankV0, ArchSigRepresentationMetricReadingV0,
+    ArchSigRepresentationStrengthReadingV0, ArchSigSignatureAxisDistanceV0,
+    ArchSigSignatureAxisReadingV0, ArchSigSignatureDistanceReadingV0,
+    ArchSigSignatureTrajectoryHomotopyRefutationReadingV0, ArchSigSpectralAnalysisReadingV0,
+    ArchSigSpectralDominantComponentV0, ArchSigSpectralDrilldownReadingV0,
+    ArchSigSpectralMatrixShapeV0, ArchSigSpectralModeComponentV0, ArchSigSpectralModeReadingV0,
+    ArchSigSpectralValueV0, ArchSigSplitReadinessReadingV0, ArchSigStateTransitionAlgebraReadingV0,
     ArchSigStateTransitionLawEvaluationV0, ArchSigStateTransitionRelationInputV0,
     ArchSigStokesStyleReadingV0, ArchSigStructuralReadingReviewSurfaceV0,
     ArchSigSubjectFamilySpreadV0, ArchSigSupportingDistanceV0, ArchSigSynthesisBlockageReadingV0,
@@ -454,6 +454,17 @@ pub fn build_archsig_analysis_packet(
         &operation_distance_readings,
         &curvature_mass_readings,
     );
+    let part4_distance_coverage_ledger = build_part4_distance_coverage_ledger(
+        &part4_distance_foundation,
+        &atom_distance_readings,
+        &configuration_distance_readings,
+        &signature_distance_readings,
+        &operation_distance_readings,
+        &obstruction_measure_readings,
+        &curvature_mass_readings,
+        &homotopy_distance_readings,
+        &representation_metric_readings,
+    );
     let ami_aggregate_readings =
         build_ami_aggregate_readings(law_policy, &axis_wise_monodromy_defects);
     let nonzero_monodromy_witnesses = build_nonzero_monodromy_witnesses(
@@ -626,6 +637,7 @@ pub fn build_archsig_analysis_packet(
         generated_repair_targets,
         viewer_distance_inputs,
         part4_distance_foundation,
+        part4_distance_coverage_ledger,
         atom_distance_readings,
         configuration_distance_readings,
         signature_distance_readings,
@@ -14355,6 +14367,179 @@ mod tests {
                         .target
                         .as_deref()
                         .is_some_and(|target| target.starts_with("unmeasuredAxis:"))
+                })
+        }));
+    }
+
+    #[test]
+    fn part4_distance_coverage_ledger_covers_all_part4_definition_families() {
+        let packet = static_archsig_analysis_packet();
+        let ledger_by_id = packet
+            .part4_distance_coverage_ledger
+            .iter()
+            .map(|entry| (entry.ledger_entry_id.as_str(), entry))
+            .collect::<BTreeMap<_, _>>();
+        let expected_entries = [
+            ("part4-ledger:distance-aat", "definition:1.1", "foundation"),
+            (
+                "part4-ledger:atom-geometry",
+                "definitions:2.1-2.5",
+                "atomGeometry",
+            ),
+            (
+                "part4-ledger:configuration-context",
+                "definitions:3.1-3.2",
+                "configurationGeometry",
+            ),
+            (
+                "part4-ledger:signature-geometry",
+                "definitions:4.1-4.4",
+                "signatureGeometry",
+            ),
+            (
+                "part4-ledger:operation-geometry",
+                "definitions:5.1-5.5",
+                "operationGeometry",
+            ),
+            (
+                "part4-ledger:obstruction-curvature",
+                "definitions:6.1-6.3",
+                "curvatureGeometry",
+            ),
+            (
+                "part4-ledger:homotopy-filling",
+                "definitions:7.1-7.4",
+                "homotopyFillingGeometry",
+            ),
+            (
+                "part4-ledger:representation-metric",
+                "definitions:8.1-8.2",
+                "representationMetric",
+            ),
+            (
+                "part4-ledger:measurement-boundary",
+                "definitions:9.1-9.3",
+                "measurementBoundary",
+            ),
+            (
+                "part4-ledger:bounded-diagnostic-conclusion",
+                "definitions:10.1-10.2",
+                "boundedDiagnosticConclusion",
+            ),
+        ];
+
+        assert_eq!(ledger_by_id.len(), expected_entries.len());
+        for (entry_id, definition_ref, distance_family) in expected_entries {
+            let entry = ledger_by_id
+                .get(entry_id)
+                .unwrap_or_else(|| panic!("missing ledger entry {entry_id}"));
+            assert_eq!(entry.part4_definition_ref, definition_ref);
+            assert_eq!(entry.distance_family, distance_family);
+            assert!(!entry.definition_title.is_empty());
+            assert!(
+                entry
+                    .theory_section_ref
+                    .contains("part_4_distance_measure_geometry.md")
+            );
+            assert!(!entry.coverage_status.is_empty());
+            assert_ne!(entry.coverage_status, "schemaFoundationOnly");
+            assert!(!entry.measurement_status.is_empty());
+            assert_ne!(entry.measurement_status, "schemaFoundationOnly");
+            assert!(!entry.primary_artifact_refs.is_empty());
+            assert!(!entry.raw_packet_refs.is_empty());
+            assert!(!entry.evidence_boundary.is_empty());
+            assert!(
+                entry
+                    .non_conclusions
+                    .iter()
+                    .any(|non_conclusion| non_conclusion.contains("not a Lean theorem proof"))
+            );
+        }
+
+        for support_ref in packet
+            .part4_distance_coverage_ledger
+            .iter()
+            .flat_map(|entry| entry.supporting_distance_refs.iter())
+        {
+            let Some((pointer, distance_id)) = support_ref.split_once('#') else {
+                panic!(
+                    "supporting distance ref must include pointer and distance id: {support_ref}"
+                );
+            };
+            assert!(
+                distance_id.starts_with("part4-distance:"),
+                "distance id must remain visible in {support_ref}"
+            );
+            let index = pointer
+                .strip_prefix("/part4DistanceFoundation/supportingDistances/")
+                .and_then(|raw_index| raw_index.parse::<usize>().ok())
+                .unwrap_or_else(|| panic!("invalid supporting distance pointer: {support_ref}"));
+            let distance = packet
+                .part4_distance_foundation
+                .supporting_distances
+                .get(index)
+                .unwrap_or_else(|| {
+                    panic!("supporting distance pointer out of range: {support_ref}")
+                });
+            assert_eq!(distance.distance_id, distance_id);
+        }
+    }
+
+    #[test]
+    fn part4_distance_coverage_ledger_negative_fixture_status_drift_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        let entry = packet
+            .part4_distance_coverage_ledger
+            .iter_mut()
+            .find(|entry| entry.distance_family == "atomGeometry")
+            .expect("static fixture has atom geometry ledger row");
+        entry.measurement_status = "measured".to_string();
+        entry.blocker_refs.clear();
+
+        let report = validate_archsig_analysis_packet_report(
+            &packet,
+            "negative-fixture-part4-distance-coverage-ledger-status-drift.json",
+        );
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-part4-distance-coverage-ledger"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example
+                        .target
+                        .as_deref()
+                        .is_some_and(|target| target == "measured")
+                })
+        }));
+    }
+
+    #[test]
+    fn part4_distance_coverage_ledger_negative_fixture_bad_support_ref_fails_validation() {
+        let mut packet = static_archsig_analysis_packet();
+        let entry = packet
+            .part4_distance_coverage_ledger
+            .iter_mut()
+            .find(|entry| entry.distance_family == "signatureGeometry")
+            .expect("static fixture has signature geometry ledger row");
+        entry.supporting_distance_refs = vec![
+            "/part4DistanceFoundation/supportingDistances/99#part4-distance:missing".to_string(),
+        ];
+
+        let report = validate_archsig_analysis_packet_report(
+            &packet,
+            "negative-fixture-part4-distance-coverage-ledger-bad-support-ref.json",
+        );
+
+        assert_eq!(report.summary.result, "fail");
+        assert!(report.checks.iter().any(|check| {
+            check.id == "archsig-analysis-packet-part4-distance-coverage-ledger"
+                && check.result == "fail"
+                && check.examples.iter().any(|example| {
+                    example
+                        .evidence
+                        .as_deref()
+                        .is_some_and(|evidence| evidence.contains("out of range"))
                 })
         }));
     }

--- a/tools/archsig/src/reports/detail_index.rs
+++ b/tools/archsig/src/reports/detail_index.rs
@@ -4,6 +4,7 @@ fn detail_index(packet: &serde_json::Value) -> serde_json::Value {
         "sections": [
             detail_index_section("signatureAxes", "/signatureAxes", array_len(packet, "signatureAxes")),
             detail_index_section("part4DistanceFoundation", "/part4DistanceFoundation", object_key_count(packet, "part4DistanceFoundation")),
+            detail_index_section("part4DistanceCoverageLedger", "/part4DistanceCoverageLedger", array_len(packet, "part4DistanceCoverageLedger")),
             detail_index_section("atomDistanceReadings", "/atomDistanceReadings", array_len(packet, "atomDistanceReadings")),
             detail_index_section("configurationDistanceReadings", "/configurationDistanceReadings", array_len(packet, "configurationDistanceReadings")),
             detail_index_section("signatureDistanceReadings", "/signatureDistanceReadings", array_len(packet, "signatureDistanceReadings")),

--- a/tools/archsig/src/schema/analysis_packet.rs
+++ b/tools/archsig/src/schema/analysis_packet.rs
@@ -36,6 +36,8 @@ pub struct ArchSigAnalysisPacketV0 {
     #[serde(default)]
     pub part4_distance_foundation: ArchSigPart4DistanceFoundationV0,
     #[serde(default)]
+    pub part4_distance_coverage_ledger: Vec<ArchSigPart4DistanceCoverageLedgerEntryV0>,
+    #[serde(default)]
     pub atom_distance_readings: Vec<ArchSigAtomDistanceReadingV0>,
     #[serde(default)]
     pub configuration_distance_readings: Vec<ArchSigConfigurationDistanceReadingV0>,
@@ -732,6 +734,26 @@ pub struct ArchSigPart4DistanceFoundationV0 {
     pub status_summary: ArchSigDistanceStatusSummaryV0,
     pub measurement_boundary: String,
     pub proxy_guardrails: Vec<String>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchSigPart4DistanceCoverageLedgerEntryV0 {
+    pub ledger_entry_id: String,
+    pub part4_definition_ref: String,
+    pub definition_title: String,
+    pub theory_section_ref: String,
+    pub distance_family: String,
+    pub coverage_status: String,
+    pub measurement_status: String,
+    pub reading_count: usize,
+    pub primary_artifact_refs: Vec<String>,
+    pub raw_packet_refs: Vec<String>,
+    pub supporting_distance_refs: Vec<String>,
+    pub blocker_refs: Vec<String>,
+    pub follow_up_issue_refs: Vec<String>,
+    pub evidence_boundary: String,
     pub non_conclusions: Vec<String>,
 }
 

--- a/tools/archsig/src/typed_evaluator.rs
+++ b/tools/archsig/src/typed_evaluator.rs
@@ -151,6 +151,12 @@ pub fn build_typed_analysis_packet_v1(
         &spectrum,
         &homotopy,
     );
+    let part4_distance_coverage_ledger = typed_part4_distance_coverage_ledger_v1(
+        architecture_distance,
+        &spectrum,
+        &homotopy,
+        &structural,
+    );
     let detail_refs = typed_results
         .results
         .iter()
@@ -177,6 +183,7 @@ pub fn build_typed_analysis_packet_v1(
         "typedEvaluatorDiagnosis": typed_evaluator_diagnosis(typed_results),
         "architectureDistance": architecture_distance,
         "distanceDiagnosis": architecture_distance["distanceDiagnosis"],
+        "part4DistanceCoverageLedger": part4_distance_coverage_ledger,
         "generatedLawInputs": generated_law_inputs,
         "signatureAxes": signature_axes,
         "generatedObstructions": generated_obstructions,
@@ -232,7 +239,8 @@ pub fn build_typed_analysis_packet_v1(
             "operationPreconditionReadinessReadings": "/operationPreconditionReadinessReadings",
             "pathMultiplicityLossReadings": "/pathMultiplicityLossReadings",
             "typedEvaluatorResults": "/typedEvaluatorResults",
-            "architectureDistanceSignatureReadings": "/architectureDistance/signatureDistanceReadings"
+            "architectureDistanceSignatureReadings": "/architectureDistance/signatureDistanceReadings",
+            "part4DistanceCoverageLedger": "/part4DistanceCoverageLedger"
         },
         "positiveBoundedConclusions": typed_results.positive_bounded_conclusions,
         "detailRefs": detail_refs,
@@ -247,6 +255,209 @@ pub fn build_typed_analysis_packet_v1(
             "ArchSig v1 packet is a computation artifact, not a Lean proof object."
         ]
     })
+}
+
+fn typed_part4_distance_coverage_ledger_v1(
+    architecture_distance: &Value,
+    spectrum: &Value,
+    homotopy: &Value,
+    structural: &Value,
+) -> Vec<Value> {
+    let architecture_status = architecture_distance["summary"]["status"]
+        .as_str()
+        .unwrap_or("partial");
+    vec![
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:distance-aat",
+            "definition:1.1",
+            "DistanceAAT",
+            "foundation",
+            architecture_status,
+            packet_refs(&["/architectureDistance", "/distanceDiagnosis"]),
+            vec!["architecture-distance.json#/summary"],
+            1,
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:atom-geometry",
+            "definitions:2.1-2.5",
+            "Fiber / Carrier / Valence / Semantic Anchor / Atom Layout distance",
+            "atomGeometry",
+            architecture_status,
+            packet_refs(&["/architectureDistance/atomDistanceReadings"]),
+            vec!["architecture-distance.json#/atomDistanceReadings"],
+            packet_array_len(architecture_distance, "atomDistanceReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:configuration-context",
+            "definitions:3.1-3.2",
+            "Configuration-indexed distance and Context distance",
+            "configurationGeometry",
+            architecture_status,
+            packet_refs(&["/architectureDistance/configurationDistanceReadings"]),
+            vec!["architecture-distance.json#/configurationDistanceReadings"],
+            packet_array_len(architecture_distance, "configurationDistanceReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:signature-geometry",
+            "definitions:4.1-4.4",
+            "Axis distance, Signature distance, Safe margin, and Signature drift",
+            "signatureGeometry",
+            architecture_status,
+            packet_refs(&[
+                "/architectureDistance/signatureDistanceReadings",
+                "/signatureAxes",
+            ]),
+            vec![
+                "architecture-distance.json#/signatureDistanceReadings",
+                "archsig-analysis-summary.json#/distanceDiagnosis/topMovedAxes",
+            ],
+            packet_array_len(architecture_distance, "signatureDistanceReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:operation-geometry",
+            "definitions:5.1-5.5",
+            "Operation cost, Operation distance, Flatness distance, Repair route, and Side-effect bound",
+            "operationGeometry",
+            architecture_status,
+            packet_refs(&["/architectureDistance/operationDistanceReadings"]),
+            vec![
+                "architecture-distance.json#/operationDistanceReadings",
+                "archsig-analysis-summary.json#/distanceDiagnosis",
+            ],
+            packet_array_len(architecture_distance, "operationDistanceReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:obstruction-curvature",
+            "definitions:6.1-6.3",
+            "Obstruction measure, Curvature mass, and Curvature transport",
+            "curvatureGeometry",
+            architecture_status,
+            packet_refs(&[
+                "/curvatureSupportReadings",
+                "/curvatureTransferReadings",
+                "/curvatureMassReadings",
+            ]),
+            vec![
+                "archsig-analysis-packet.json#/curvatureSupportReadings",
+                "archsig-analysis-packet.json#/curvatureTransferReadings",
+                "archsig-analysis-packet.json#/curvatureMassReadings",
+            ],
+            packet_array_len(spectrum, "curvatureMassReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:homotopy-filling",
+            "definitions:7.1-7.4",
+            "Homotopy distance, Filling cost, Observation gap lower bound, and Architectural Dehn function",
+            "homotopyFillingGeometry",
+            architecture_status,
+            packet_refs(&[
+                "/homotopyDistanceReadings",
+                "/architectureHomotopyReport",
+                "/homotopyHolonomyReadings",
+            ]),
+            vec![
+                "archsig-analysis-packet.json#/homotopyDistanceReadings",
+                "archsig-analysis-packet.json#/architectureHomotopyReport",
+            ],
+            packet_array_len(homotopy, "homotopyDistanceReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:representation-metric",
+            "definitions:8.1-8.2",
+            "Representation stability and Representation faithfulness",
+            "representationMetric",
+            architecture_status,
+            packet_refs(&["/representationMetricReadings"]),
+            vec!["archsig-analysis-packet.json#/representationMetricReadings"],
+            packet_array_len(structural, "representationMetricReadings"),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:measurement-boundary",
+            "definitions:9.1-9.3",
+            "DistanceValue, unmeasured-is-not-zero, and DistanceProfile",
+            "measurementBoundary",
+            architecture_status,
+            packet_refs(&[
+                "/architectureDistance/profile",
+                "/architectureDistance/summary",
+                "/architectureDistance/distanceDiagnosis",
+            ]),
+            vec![
+                "architecture-distance.json#/profile",
+                "architecture-distance.json#/summary",
+                "archsig-analysis-summary.json#/distanceDiagnosis",
+            ],
+            architecture_distance["summary"]["readingCounts"]
+                .as_object()
+                .map(|counts| counts.len())
+                .unwrap_or_default(),
+        ),
+        typed_part4_ledger_entry_v1(
+            "part4-ledger:bounded-diagnostic-conclusion",
+            "definitions:10.1-10.2",
+            "Diagnostic scope and Bounded diagnostic conclusion",
+            "boundedDiagnosticConclusion",
+            architecture_status,
+            packet_refs(&["/distanceDiagnosis", "/structuralReadingReviewSurface"]),
+            vec![
+                "archsig-analysis-summary.json#/conclusion",
+                "archsig-analysis-summary.json#/distanceDiagnosis",
+                "llm-interpretation-packet.json#/distanceDiagnosisSummary",
+            ],
+            1,
+        ),
+    ]
+}
+
+fn typed_part4_ledger_entry_v1(
+    ledger_entry_id: &str,
+    part4_definition_ref: &str,
+    definition_title: &str,
+    distance_family: &str,
+    measurement_status: &str,
+    raw_packet_refs: Vec<String>,
+    primary_artifact_refs: Vec<&str>,
+    reading_count: usize,
+) -> Value {
+    let coverage_status = if reading_count == 0 {
+        "missing-readings"
+    } else {
+        "primary"
+    };
+    let measurement_status = if reading_count == 0 {
+        "unmeasured"
+    } else {
+        measurement_status
+    };
+    let blocker_refs = if reading_count == 0 {
+        vec![format!("noTypedReadings:{distance_family}")]
+    } else {
+        Vec::new()
+    };
+    json!({
+        "ledgerEntryId": ledger_entry_id,
+        "part4DefinitionRef": part4_definition_ref,
+        "definitionTitle": definition_title,
+        "distanceFamily": distance_family,
+        "coverageStatus": coverage_status,
+        "measurementStatus": measurement_status,
+        "readingCount": reading_count,
+        "primaryArtifactRefs": primary_artifact_refs,
+        "rawPacketRefs": raw_packet_refs,
+        "blockerRefs": blocker_refs,
+        "evidenceBoundary": "typed v1 ledger records where the selected Part IV distance family is exposed in ArchSig outputs; it is not a proof object",
+        "nonConclusions": [
+            "ArchSig distance coverage is relative to the supplied ArchMap, selected LawPolicy, typed evaluator results, and distance profile.",
+            "Unmeasured or blocked distance is not measured zero.",
+            "Part IV distance coverage ledger is an output navigation contract, not a Lean theorem proof."
+        ]
+    })
+}
+
+fn packet_refs(refs: &[&str]) -> Vec<String> {
+    refs.iter()
+        .map(|reference| format!("packet:{reference}"))
+        .collect()
 }
 
 pub fn build_typed_analysis_summary_v1(
@@ -470,6 +681,7 @@ pub fn build_typed_detail_index_v1(
         "indexKind": "typed-evaluator-support-index",
         "sections": [
             detail_index_section_v1("typedEvaluatorResults", "/typedEvaluatorResults", packet_array_len(packet, "typedEvaluatorResults")),
+            detail_index_section_v1("part4DistanceCoverageLedger", "/part4DistanceCoverageLedger", packet_array_len(packet, "part4DistanceCoverageLedger")),
             detail_index_section_v1("generatedLawInputs", "/generatedLawInputs", packet_array_len(packet, "generatedLawInputs")),
             detail_index_section_v1("signatureAxes", "/signatureAxes", packet_array_len(packet, "signatureAxes")),
             detail_index_section_v1("generatedObstructions", "/generatedObstructions", packet_array_len(packet, "generatedObstructions")),
@@ -3927,6 +4139,7 @@ fn packet_nested_array_len(packet: &Value, path: &[&str]) -> usize {
 fn derived_packet_refs(packet: &Value) -> Vec<String> {
     [
         "generatedLawInputs",
+        "part4DistanceCoverageLedger",
         "signatureAxes",
         "generatedObstructions",
         "generatedRepairTargets",
@@ -3961,6 +4174,12 @@ fn derived_packet_refs(packet: &Value) -> Vec<String> {
 
 fn derived_detail_index_entries(packet: &Value) -> Vec<Value> {
     let mut entries = Vec::new();
+    entries.extend(derived_detail_entries_for_field(
+        packet,
+        "part4DistanceCoverageLedger",
+        "ledgerEntryId",
+        "part4DistanceCoverageLedger",
+    ));
     entries.extend(derived_detail_entries_for_field(
         packet,
         "generatedLawInputs",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1812,6 +1812,7 @@ fn cli_analyze_v1_emit_raw_artifacts_writes_typed_packet_detail_and_handoff() {
         detail_index["sections"].as_array().is_some_and(|sections| {
             [
                 "generatedLawInputs",
+                "part4DistanceCoverageLedger",
                 "signatureAxes",
                 "generatedObstructions",
                 "generatedRepairTargets",
@@ -1849,6 +1850,9 @@ fn cli_analyze_v1_emit_raw_artifacts_writes_typed_packet_detail_and_handoff() {
     assert!(
         detail_index["entries"].as_array().is_some_and(|entries| {
             entries.iter().any(|entry| {
+                entry["packetRef"] == "packet:/part4DistanceCoverageLedger/0"
+                    && entry["resultRef"] == "part4DistanceCoverageLedger:part4-ledger:distance-aat"
+            }) && entries.iter().any(|entry| {
                 entry["packetRef"] == "packet:/generatedLawInputs/0"
                     && entry["typedEvaluatorResultRef"] == "/typedEvaluatorResults/0"
             }) && entries.iter().any(|entry| {

--- a/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
+++ b/tools/archsig/tests/fixtures/minimal/archsig_analysis_packet.json
@@ -1699,6 +1699,415 @@
       "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
     ]
   },
+  "part4DistanceCoverageLedger": [
+    {
+      "ledgerEntryId": "part4-ledger:distance-aat",
+      "part4DefinitionRef": "definition:1.1",
+      "definitionTitle": "DistanceAAT",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:35",
+      "distanceFamily": "foundation",
+      "coverageStatus": "primary",
+      "measurementStatus": "blocked",
+      "readingCount": 7,
+      "primaryArtifactRefs": [
+        "archsig-analysis-packet.json#/part4DistanceFoundation"
+      ],
+      "rawPacketRefs": [
+        "/part4DistanceFoundation"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/0#part4-distance:atom-geometry",
+        "/part4DistanceFoundation/supportingDistances/1#part4-distance:configuration-geometry",
+        "/part4DistanceFoundation/supportingDistances/2#part4-distance:signature-geometry",
+        "/part4DistanceFoundation/supportingDistances/3#part4-distance:operation-geometry",
+        "/part4DistanceFoundation/supportingDistances/4#part4-distance:curvature-geometry",
+        "/part4DistanceFoundation/supportingDistances/5#part4-distance:homotopy-filling-geometry",
+        "/part4DistanceFoundation/supportingDistances/6#part4-distance:representation-metric"
+      ],
+      "blockerRefs": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "followUpIssueRefs": [],
+      "evidenceBoundary": "DistanceAAT is represented as the Part IV foundation, profile, diagnostic scope, supporting distances, and non-conclusion boundary.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:atom-geometry",
+      "part4DefinitionRef": "definitions:2.1-2.5",
+      "definitionTitle": "Fiber / Carrier / Valence / Semantic Anchor / Atom Layout distance",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:140",
+      "distanceFamily": "atomGeometry",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 10,
+      "primaryArtifactRefs": [
+        "architecture-distance.json#/atomDistanceReadings",
+        "archsig-analysis-summary.json#/distanceDiagnosis/topMovedAtoms",
+        "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis"
+      ],
+      "rawPacketRefs": [
+        "/atomDistanceReadings",
+        "/viewerDistanceInputs"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/0#part4-distance:atom-geometry"
+      ],
+      "blockerRefs": [
+        "missing semantic anchor evidence for atom:capability:create-user",
+        "missing semantic anchor evidence for atom:component:route-users",
+        "missing semantic anchor evidence for atom:component:service-user"
+      ],
+      "followUpIssueRefs": [
+        "#1859"
+      ],
+      "evidenceBoundary": "Atom geometry is expected to expose each Part IV atom-distance component without treating viewer layout distance as diagnostic distance.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:configuration-context",
+      "part4DefinitionRef": "definitions:3.1-3.2",
+      "definitionTitle": "Configuration-indexed distance and Context distance",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:275",
+      "distanceFamily": "configurationGeometry",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 10,
+      "primaryArtifactRefs": [
+        "architecture-distance.json#/configurationDistanceReadings",
+        "archsig-analysis-summary.json#/distanceDiagnosis",
+        "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis"
+      ],
+      "rawPacketRefs": [
+        "/configurationDistanceReadings"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/1#part4-distance:configuration-geometry"
+      ],
+      "blockerRefs": [
+        "observationGap:gap-runtime-user-db-trace:runtime-trace-was-requested-but-not-supplied"
+      ],
+      "followUpIssueRefs": [
+        "#1859"
+      ],
+      "evidenceBoundary": "Configuration distance must stay typed-hypergraph and context based; molecule size alone is not complete Part IV coverage.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:signature-geometry",
+      "part4DefinitionRef": "definitions:4.1-4.4",
+      "definitionTitle": "Axis distance, Signature distance, Safe margin, and Signature drift",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:344",
+      "distanceFamily": "signatureGeometry",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 1,
+      "primaryArtifactRefs": [
+        "architecture-distance.json#/signatureDistanceReadings",
+        "archsig-analysis-summary.json#/distanceDiagnosis/topMovedAxes",
+        "llm-interpretation-packet.json#/distanceDiagnosisSummary"
+      ],
+      "rawPacketRefs": [
+        "/signatureDistanceReadings",
+        "/signatureAxes"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/2#part4-distance:signature-geometry"
+      ],
+      "blockerRefs": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied"
+      ],
+      "followUpIssueRefs": [
+        "#1861"
+      ],
+      "evidenceBoundary": "Signature geometry is LawPolicy-relative and must preserve measured, blocked, unmeasured, and incomparable axis states.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:operation-geometry",
+      "part4DefinitionRef": "definitions:5.1-5.5",
+      "definitionTitle": "Operation cost, Operation distance, Flatness distance, Repair route, and Side-effect bound",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:490",
+      "distanceFamily": "operationGeometry",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 1,
+      "primaryArtifactRefs": [
+        "architecture-distance.json#/operationDistanceReadings",
+        "archsig-analysis-summary.json#/distanceDiagnosis/repairDistance"
+      ],
+      "rawPacketRefs": [
+        "/operationDistanceReadings",
+        "/repairOperationCandidates",
+        "/operationDeltas"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/3#part4-distance:operation-geometry"
+      ],
+      "blockerRefs": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "followUpIssueRefs": [
+        "#1860"
+      ],
+      "evidenceBoundary": "Operation geometry must be profile-driven and blocked when operation costs, preconditions, or side-effect evidence are missing.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:obstruction-curvature",
+      "part4DefinitionRef": "definitions:6.1-6.3",
+      "definitionTitle": "Obstruction measure, Curvature mass, and Curvature transport",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:599",
+      "distanceFamily": "curvatureGeometry",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 5,
+      "primaryArtifactRefs": [
+        "archsig-analysis-summary.json#/distanceDiagnosis/curvatureDistance",
+        "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis"
+      ],
+      "rawPacketRefs": [
+        "/obstructionMeasureReadings",
+        "/curvatureMassReadings",
+        "/curvatureTransferReadings"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/4#part4-distance:curvature-geometry"
+      ],
+      "blockerRefs": [
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "unmeasuredAxis:axis:layer-violation",
+        "unmeasuredAxis:axis:semantic-inconsistency"
+      ],
+      "followUpIssueRefs": [
+        "#1864"
+      ],
+      "evidenceBoundary": "Curvature geometry must expose obstruction-measure support and transport state, not just raw packet rows.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:homotopy-filling",
+      "part4DefinitionRef": "definitions:7.1-7.4",
+      "definitionTitle": "Homotopy distance, Filling cost, Observation gap lower bound, and Architectural Dehn function",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:674",
+      "distanceFamily": "homotopyFillingGeometry",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 3,
+      "primaryArtifactRefs": [
+        "archsig-analysis-summary.json#/distanceDiagnosis/homotopyDistance",
+        "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis"
+      ],
+      "rawPacketRefs": [
+        "/homotopyDistanceReadings",
+        "/architectureHomotopyReport",
+        "/homotopyHolonomyReadings"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/5#part4-distance:homotopy-filling-geometry"
+      ],
+      "blockerRefs": [
+        "gap-runtime-user-db-trace"
+      ],
+      "followUpIssueRefs": [
+        "#1867"
+      ],
+      "evidenceBoundary": "Homotopy and filling readings must make missing filler evidence an actionable blocker, not a hidden non-conclusion.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:representation-metric",
+      "part4DefinitionRef": "definitions:8.1-8.2",
+      "definitionTitle": "Representation stability and Representation faithfulness",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:746",
+      "distanceFamily": "representationMetric",
+      "coverageStatus": "primary-blocked",
+      "measurementStatus": "blocked",
+      "readingCount": 14,
+      "primaryArtifactRefs": [
+        "archsig-analysis-summary.json#/distanceDiagnosis/representationMetric",
+        "archsig-atom-viewer-data.json#/reportPane/distanceDiagnosis"
+      ],
+      "rawPacketRefs": [
+        "/representationMetricReadings",
+        "/analyticRepresentations",
+        "/representationStrengthReadings"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/6#part4-distance:representation-metric"
+      ],
+      "blockerRefs": [
+        "coverage-completeness:selected-representation-not-global",
+        "gap-runtime-user-db-trace",
+        "witness-completeness:selected-LawPolicy-not-certified"
+      ],
+      "followUpIssueRefs": [
+        "#1865"
+      ],
+      "evidenceBoundary": "Representation metrics must distinguish measured structural distance, bounded proxy telemetry, blocked Lipschitz evidence, and faithfulness blockers.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:measurement-boundary",
+      "part4DefinitionRef": "definitions:9.1-9.3",
+      "definitionTitle": "DistanceValue, unmeasured-is-not-zero, and DistanceProfile",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:784",
+      "distanceFamily": "measurementBoundary",
+      "coverageStatus": "primary",
+      "measurementStatus": "blocked",
+      "readingCount": 7,
+      "primaryArtifactRefs": [
+        "archsig-run-manifest.json#/validationResultSummary",
+        "archsig-analysis-summary.json#/measurementStatusSummary"
+      ],
+      "rawPacketRefs": [
+        "/part4DistanceFoundation/profile",
+        "/part4DistanceFoundation/statusSummary",
+        "/part4DistanceFoundation/diagnosticScope"
+      ],
+      "supportingDistanceRefs": [
+        "/part4DistanceFoundation/supportingDistances/0#part4-distance:atom-geometry",
+        "/part4DistanceFoundation/supportingDistances/1#part4-distance:configuration-geometry",
+        "/part4DistanceFoundation/supportingDistances/2#part4-distance:signature-geometry",
+        "/part4DistanceFoundation/supportingDistances/3#part4-distance:operation-geometry",
+        "/part4DistanceFoundation/supportingDistances/4#part4-distance:curvature-geometry",
+        "/part4DistanceFoundation/supportingDistances/5#part4-distance:homotopy-filling-geometry",
+        "/part4DistanceFoundation/supportingDistances/6#part4-distance:representation-metric"
+      ],
+      "blockerRefs": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "followUpIssueRefs": [
+        "#1861",
+        "#1866"
+      ],
+      "evidenceBoundary": "Measurement boundary rows record that blocked and unmeasured values remain first-class states and are not aggregated as measured zero.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    },
+    {
+      "ledgerEntryId": "part4-ledger:bounded-diagnostic-conclusion",
+      "part4DefinitionRef": "definitions:10.1-10.2",
+      "definitionTitle": "Diagnostic scope and Bounded diagnostic conclusion",
+      "theorySectionRef": "docs/aat/mathematical_theory/part_4_distance_measure_geometry.md:852",
+      "distanceFamily": "boundedDiagnosticConclusion",
+      "coverageStatus": "partial",
+      "measurementStatus": "blocked",
+      "readingCount": 7,
+      "primaryArtifactRefs": [
+        "archsig-analysis-summary.json#/conclusion",
+        "archsig-analysis-summary.json#/distanceDiagnosis",
+        "llm-interpretation-packet.json#/distanceDiagnosisSummary"
+      ],
+      "rawPacketRefs": [
+        "/part4DistanceFoundation/diagnosticScope",
+        "/boundedJudgements",
+        "/llmInterpretationPacket"
+      ],
+      "supportingDistanceRefs": [],
+      "blockerRefs": [
+        "coverage:layer-atoms: report observation gap and block signature-zero reflection",
+        "coverage:semantic-contract-atoms: report observation gap and block signature-zero reflection",
+        "gap-runtime-user-db-trace: runtime trace was requested but not supplied",
+        "may transfer obstruction into runtime behavior, ownership, or idempotency boundary"
+      ],
+      "followUpIssueRefs": [
+        "#1863",
+        "#1866"
+      ],
+      "evidenceBoundary": "Bounded diagnostic conclusion is partially covered until distanceInsights and full-output docs make the distance reading actionable.",
+      "nonConclusions": [
+        "ArchSig analysis packet is not a Lean theorem proof",
+        "ArchSig analysis packet is not global architecture truth",
+        "ArchSig analysis packet does not prove source extraction completeness",
+        "signature axes are law-policy-relative, not universal quality scores",
+        "flatness reading is blocked by coverage gaps and exactness assumptions",
+        "repair operation candidates are not automatic safe refactorings",
+        "ArchSig reads current architecture state and does not replace FieldSig evolution analysis"
+      ]
+    }
+  ],
   "atomDistanceReadings": [
     {
       "atomDistanceReadingId": "atom-distance:atom-capability-create-user:atom-component-route-users",


### PR DESCRIPTION
## 概要

Closes #1862

AAT Part IV の距離定義 family が ArchSig output のどこに反映されているかを確認できる `part4DistanceCoverageLedger` を追加しました。v0 analysis packet では `part4DistanceFoundation` / raw packet rows / primary artifacts / blocker / follow-up Issue を対応付け、v1 typed packet でも detail index から ledger を辿れるようにしています。

local-review で出た指摘を反映し、ledger を validation report の first-class check に追加し、`measurementStatus` の drift や壊れた supporting distance ref を fail にする negative test も追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/golden_corpus.md`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] practical example analyze:
  `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/examples/practical-rust-service/archmap/archmap.json --law-policy tools/archsig/examples/practical-rust-service/law_policy/law_policy.json --out-dir .tmp/archsig-practical-issue-1862 --emit-raw-artifacts --strict-distance`
- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
