### PR TITLE
代数幾何的AAT本文の基礎条件を補強する

### DIFF
--- a/docs/aat/algebraic_geometric_theory/part_2_architecture_geometry_sites_sheaves.md
+++ b/docs/aat/algebraic_geometric_theory/part_2_architecture_geometry_sites_sheaves.md
@@ -299,7 +299,47 @@ W' is a local/refined readable context of W
 と置ける。この poset model は、後続の sheaf、Čech complex、affine chart gluing の
 基礎例として十分である。
 
-### 仮定 4.2 Pullback and Overlap
+### 命題 4.2 Minimal Context Finite-Meet Site
+
+最小 context model において、support、axis、observable family が finite meet を持ち、
+observable restriction が meet と整合すると仮定する。
+さらに context equality は readable identity を同一視した equivalence quotient で読み、
+任意の二つの context の間には高々一つの readable morphism があるとする。
+
+```text
+Supp(W_i) meet Supp(W_j)
+Ax(W_i)   meet Ax(W_j)
+Obs(W_i)  pullback_{Obs(W)} Obs(W_j)
+
+morphism uniqueness:
+  Hom(W', W) is either empty or contractible.
+
+antisymmetry after quotient:
+  W' <= W and W <= W'
+  implies W' = W in ArchCtx_min(A).
+```
+
+このとき、`ArchCtx_min(A)` は finite-meet poset category になる。
+恒等射は同じ context の readable identity であり、合成は restriction / refinement の合成である。
+
+equivalence quotient を取らない場合、同じ data は finite-meet preorder category として読む。
+poset category と呼ぶのは、thinness と antisymmetry を固定した後である。
+
+overlap は meet として構成される。
+
+```text
+W_i x_W W_j
+  =
+W_i meet_W W_j
+```
+
+すなわち、support と axis は共通部分または共通 refinement として読み、
+observable family は単なる集合交差ではなく、restriction diagram の pullback として読む。
+
+この命題は、一般の `ArchCtx(A)` が常に finite-meet category であるという主張ではない。
+後続の Čech complex と chart gluing を支える最小構成モデルである。
+
+### 仮定 4.3 Pullback and Overlap
 
 `ArchCtx(A)` は、cover の overlap を作るために必要な pullback を持つと仮定する。
 
@@ -313,7 +353,7 @@ W_i x_W W_j
 この pullback を context overlap と呼ぶ。
 第IV部の Čech complex は、この overlap に対して定義される。
 
-### 原則 4.3 Context Non-Generation
+### 原則 4.4 Context Non-Generation
 
 ```text
 context does not create atoms

--- a/docs/aat/algebraic_geometric_theory/part_3_law_algebra_obstruction_ideal_lawful_locus.md
+++ b/docs/aat/algebraic_geometric_theory/part_3_law_algebra_obstruction_ideal_lawful_locus.md
@@ -605,6 +605,53 @@ resolution ρ
 
 であっても、選ばれていない reading について zero を主張しない。
 
+### 原則 5.8 Law Condition Types
+
+第III部の核は、closed equational law を ideal の零点集合として読むことである。
+しかし、すべての architecture law を無条件に closed ideal へ押し込めるわけではない。
+
+law condition には少なくとも次の型がある。
+
+```text
+Closed equational law:
+  selected witness ideal I_L の vanishing として読む law。
+
+Open / inequational law:
+  nonzero capability, enabled provider, available path など、
+  D(f) 型の open condition として読む law。
+
+Constructible law:
+  closed condition と open condition の boolean combination として読む law。
+
+Descent law:
+  local lawful sections が cover と gluing data に沿って貼り合うことを要求する law。
+
+Temporal / trace law:
+  runtime trace sheaf、state transition、automata、temporal predicate に相対化される law。
+
+Higher / stacky law:
+  decomposition、semantic identification、refactor equivalence など、
+  groupoid-valued または stack-valued data に相対化される law。
+```
+
+したがって本文の slogan は次のように読む。
+
+```text
+closed law is equation.
+general law is a geometric condition.
+obstruction ideal is the closed defect envelope
+of selected witnesses.
+```
+
+`I_Ob^U` は、選ばれた witness family のうち closed equational envelope として読める部分を集める。
+open、constructible、descent、temporal、stacky な law は、必要な追加構造を固定した上で、
+open subobject、locally closed subobject、descent condition、trace condition、
+または stack condition として扱う。
+
+この分類は law-as-equation の核を弱めるものではない。
+closed defect を ideal として扱える場所を正確に固定し、それ以外の law を不自然に ideal 化しないための
+claim boundary である。
+
 ## 6. Obstruction Ideal Sheaf
 
 ### 定義 6.1 Local Obstruction Ideal
@@ -788,7 +835,102 @@ Spec_AAT(O_X^U(W))
 selected law reading、signature axis reading を付加した affine spectrum として読む。
 基礎となる可換環の spectrum は通常の `Spec` である。
 
-### 定義 8.2 Local Lawful Chart
+### 定義 8.2 R-Valued Local Configuration Functor
+
+context `W` と law universe `U` に対して、`R`-valued local architecture configuration functor を
+次で表す。
+
+```text
+h_W^U : CommAlg_k -> Set
+```
+
+`h_W^U(R)` は、`W` 上で読める typed architecture coordinates に `R`-value を与え、
+structural relations を満たす局所 architecture configuration の集合である。
+
+```text
+h_W^U(R)
+  =
+{ R-valued W-local architecture configurations
+  satisfying structural relations }
+```
+
+この段階では selected law witness ideals をすべて zero にするとは限らない。
+lawful locus は、後で `I_Ob^U` の vanishing によって切り出す。
+
+### 定理 8.3 Raw Affine Chart Representability
+
+context `W` が有限表示の coordinate family と structural relation family を持ち、
+restriction が typed coordinate と structural relation を保つと仮定する。
+このとき、
+
+```text
+A_{raw,W}^U := O_raw^U(W)
+```
+
+は `h_W^U` を表現する。
+
+```text
+h_W^U(R)
+  ≅
+Hom_{k-Alg}(A_{raw,W}^U, R)
+```
+
+したがって、
+
+```text
+AffAAT_raw(W,U)
+  =
+Spec_AAT(A_{raw,W}^U)
+```
+
+は、`W` 上の typed local architecture configurations の moduli functor を表現する affine scheme に
+AAT の label と selected reading を載せた chart である。
+
+この raw representability は、自由可換環を structural relation ideal で割った presentation の
+普遍性から読む。
+
+### 仮定 8.4 Sheafified Chart Presentation
+
+sheafification 後の structure sheaf section
+
+```text
+O_X^U(W)
+```
+
+を同じ local configuration functor の coordinate algebra として使うには、追加の presentation-preservation
+仮定を固定する。
+
+```text
+A_W^U := O_X^U(W)
+
+presentation preservation:
+  O_raw^U(W) -> O_X^U(W)
+  preserves the selected finite presentation for h_W^U,
+  or induces an isomorphism on the represented local functor.
+```
+
+この仮定の下でのみ、
+
+```text
+h_W^U(R)
+  ≅
+Hom_{k-Alg}(A_W^U, R)
+```
+
+と読み、
+
+```text
+AffAAT(W,U)
+  =
+Spec_AAT(A_W^U)
+```
+
+を sheafified affine AAT chart と呼ぶ。
+
+したがって、`Spec_AAT(O_X^U(W))` は無条件に raw moduli functor を表現するのではない。
+raw chart representability と、sheafified chart がその presentation を保つ条件を分けて読む。
+
+### 定義 8.5 Local Lawful Chart
 
 context `W` 上の local lawful chart を次で定義する。
 
@@ -807,7 +949,7 @@ Flat_U(W)
   { p in Spec_AAT(O_X^U(W)) | I_Ob^U(W) subset p }
 ```
 
-### 例 8.3 Boundary Chart
+### 例 8.6 Boundary Chart
 
 boundary context `W_boundary` では、次の coordinate が現れる。
 

--- a/docs/aat/algebraic_geometric_theory/part_4_obstruction_cohomology.md
+++ b/docs/aat/algebraic_geometric_theory/part_4_obstruction_cohomology.md
@@ -178,7 +178,91 @@ Gerbe / stack layer:
 第二層と第三層は、第VI部の stack / gerbe 構造に持ち上げて扱う。
 この分離により、abelian cohomology の計算可能性と、non-abelian gluing の強さを混同しない。
 
-### 原則 2.4 Obstruction Sheaf Relativity
+### 定義 2.4 Canonical Obstruction Package
+
+`Ob_U` は、問題に応じて選ばれる coefficient sheaf である。
+ただし、lawful locus
+
+```text
+i : Flat_U(X) -> X
+```
+
+が obstruction ideal
+
+```text
+I_U = I_Ob^U subset O_X^U
+```
+
+によって切り出されている場合、標準的な obstruction package を次で置く。
+ここでは、`I_U/I_U^2` は lawful locus 上の conormal sheaf として読む。
+すなわち、係数圏は `O_{Flat_U(X)}`-modules である。
+
+```text
+Def_U
+  :=
+I_U
+
+ConDef_U
+  :=
+(I_U / I_U^2) on Flat_U(X)
+  as an O_{Flat_U(X)}-module
+
+DerOb_U(M)
+  :=
+Ext^1(L_{Flat_U(X)/X}, M)
+  for M in Mod(O_{Flat_U(X)})
+```
+
+`Def_U` は見えている closed defect ideal である。
+`ConDef_U` は lawful locus から見た first-order defect residue である。
+`DerOb_U(M)` は、deformation module `M` に相対化された derived obstruction space である。
+
+`ConDef_U` を `X` 上で比較したい場合は、包含 `i` に沿った pushforward を明示して
+
+```text
+i_* ConDef_U
+```
+
+として読む。lawful locus 上へ制限して読む場合は、`i^* I_U / i^* I_U^2` ではなく、
+closed immersion の conormal sheaf としての `(I_U/I_U^2)|_{Flat_U(X)}` を使う。
+どちらの圏で扱うかを固定せずに cohomology group を書かない。
+
+この package により、`Ob_U` は次のいずれか、またはその functorial extension として選ばれる。
+
+```text
+Ob_U = Def_U
+Ob_U = ConDef_U
+Ob_U = a module derived from L_{Flat_U(X)/X}
+Ob_U = an abelianization of torsor / stack obstruction data
+```
+
+したがって、
+
+```text
+H^0(X, Def_U):
+  visible closed defect sections.
+
+H^1(X, ConDef_U):
+  first-order gluing residue of closed defect data.
+
+Ext^1(L_{Flat_U(X)/X}, M):
+  deformation obstruction for selected module M.
+```
+
+と読むことができる。
+ただし `ConDef_U` を lawful locus 上の sheaf として扱う場合、cohomology は
+
+```text
+H^1(Flat_U(X), ConDef_U)
+```
+
+であり、`X` 上で読む場合は `H^1(X, i_* ConDef_U)` と書く。
+
+これは `Ob_U` を一種類に固定する定義ではない。
+cohomology を語るときに、どの obstruction coefficient を使っているかを明示するための
+canonical reference package である。
+
+### 原則 2.5 Obstruction Sheaf Relativity
 
 `Ob_U` は次に相対化される。
 

--- a/docs/aat/algebraic_geometric_theory/part_5_derived_law_geometry_repair.md
+++ b/docs/aat/algebraic_geometric_theory/part_5_derived_law_geometry_repair.md
@@ -326,7 +326,31 @@ LawConflict_1(U,V)
 
 である。
 
-### 原則 5.2 Conflict Is Structural
+### 定義 5.2 Higher Law Conflict Sheaves
+
+一次 conflict だけでなく、derived intersection は高次の非横断性を持ちうる。
+law universe `U` と `V` に対して、高次 law conflict sheaf を次で定義する。
+
+```text
+LawConflict_i(U,V)
+  =
+Tor_i^{O_X}(O_X/I_U, O_X/I_V)
+for i > 0
+```
+
+`LawConflict_1(U,V)` はその低次成分であり、first-order non-transversality を読む。
+`LawConflict_i(U,V)` は、高次の coherence、multi-boundary、derived repair obstruction を読む。
+
+derived intersection 全体を読む場合は、
+
+```text
+O_X/I_U tensor^L_{O_X} O_X/I_V
+```
+
+を基本対象とし、`LawConflict_i` はその homology sheaf / cohomology sheaf の選ばれた grading convention に
+よる成分として読む。
+
+### 原則 5.3 Conflict Is Structural
 
 `LawConflict_1(U,V)` は、単なる defect count ではない。
 また、`U` と `V` の両方に違反があるというだけでもない。
@@ -405,7 +429,7 @@ derived-transversely compatible
 
 ### 定義 7.1 Transverse Law Universes
 
-law universe `U` と `V` が横断的に交わるとは、次が消えることをいう。
+law universe `U` と `V` が一次横断的に交わるとは、次が消えることをいう。
 
 ```text
 LawConflict_1(U,V) = 0
@@ -419,12 +443,56 @@ transverse law intersection
 no first derived law conflict
 ```
 
-### 定義 7.2 Non-Transverse Law Universes
+### 定義 7.2 Derived-Transverse Law Universes
+
+law universe `U` と `V` が derived-transverse に交わるとは、すべての正次数 conflict が消えることをいう。
+
+```text
+LawConflict_i(U,V) = 0
+for all i > 0
+```
+
+同値に、局所的には derived tensor product が古典的 tensor product と同じ情報だけを持つ。
+
+```text
+O_X/I_U tensor^L_{O_X} O_X/I_V
+  has no higher Tor residue.
+```
+
+この条件は `LawConflict_1 = 0` より強い。
+一次 conflict が消えていても、高次 conflict が残る場合は derived-transverse とは呼ばない。
+
+### 定理 7.3 Derived Transversality Criterion
+
+次を仮定する。
+
+```text
+O_X is a commutative structure sheaf
+I_U and I_V define the selected lawful loci
+derived tensor product is defined in the chosen category
+the grading convention for Tor is fixed
+```
+
+このとき、`Flat_U(X)` と `Flat_V(X)` は、選ばれた derived reading において、
+
+```text
+Tor_i^{O_X}(O_X/I_U, O_X/I_V) = 0
+for all i > 0
+```
+
+なら derived-transversely compatible である。
+逆に、正次数 Tor が残るなら、その次数に対応する derived law conflict を持つ。
+
+この定理は、classical joint lawful locus の存在を否定しない。
+古典的な共通零点が存在しても、正次数 Tor が非零なら、交差の仕方に derived residue が残る。
+
+### 定義 7.4 Non-Transverse Law Universes
 
 law universe `U` と `V` が非横断的に交わるとは、次が非零であることをいう。
 
 ```text
-LawConflict_1(U,V) != 0
+LawConflict_i(U,V) != 0
+for some i > 0
 ```
 
 このとき、二つの law universe の同時実現には derived law conflict がある。
@@ -435,7 +503,9 @@ non-transverse law intersection
 latent compatibility obstruction
 ```
 
-### 原則 7.3 Non-Transversality Is Not Failure Count
+一次の非横断性を特に読む場合は、`LawConflict_1(U,V) != 0` と書く。
+
+### 原則 7.5 Non-Transversality Is Not Failure Count
 
 非横断性は、失敗の数ではない。
 失敗数が少なくても、lawful loci が非横断的に交われば、repair は別 axis に obstruction を転送しうる。
@@ -506,7 +576,103 @@ X' prec^{geom}_{P_U} X
 
 と書く。
 
-### 定義 8.2 Repair Path
+### 定義 8.2 Pullback Repair Profile
+
+geometric repair
+
+```text
+r : X -> X'
+```
+
+の obstruction を比較するには、scheme morphism の反変性を明示する。
+repair comparison profile `P_U` は、必要に応じて次の比較写像を含む。
+
+```text
+r^{-1} I'_U · O_X
+  <=_{P_U}
+I_U
+```
+
+ここで `I_U subset O_X` は repair 前の obstruction ideal、
+`I'_U subset O_{X'}` は repair 後の obstruction ideal である。
+左辺は `I'_U` を `X` 側へ引き戻して比較したものである。
+
+probe family
+
+```text
+s : T -> X
+```
+
+が固定されている場合は、section-level comparison として次を使う。
+
+```text
+(r circ s)^* I'_U
+  <=_{P_U}
+s^* I_U
+```
+
+したがって repair の改善は、少なくとも次の二種類に分けて読む。
+
+```text
+Internal repair:
+  same X 上の section deformation s -> s'。
+  obstruction comparison is s'^* I_U <=_{P_U} s^* I_U.
+
+Geometric repair:
+  architecture geometry morphism r : X -> X'。
+  obstruction comparison is made after a chosen pullback / probe profile.
+```
+
+pullback profile または probe profile を固定しない限り、
+`r : X -> X'` が `U`-improving であるという theorem は立てない。
+
+### 定義 8.3 Conflict Comparison Profile
+
+repair が derived conflict を増やさないことを述べるには、obstruction ideal とは別に、
+law conflict sheaf / Tor complex の比較 profile を固定する。
+
+law universe pair `(U,V)`、degree set `D subset Nat_{>0}`、repair `r : X -> X'` に対して、
+conflict comparison profile を次の data として置く。
+
+```text
+Q_{U,V}
+```
+
+`Q_{U,V}` は少なくとも次を含む。
+
+```text
+degree profile:
+  selected positive degrees D.
+
+comparison maps:
+  cmp_i(r) :
+    pullback_r LawConflict'_i(U,V)
+      -> LawConflict_i(U,V)
+  or probe-level maps along selected s : T -> X.
+
+order / vanishing predicate:
+  <=_{Q_{U,V}} on selected conflict readings,
+  and a notion of zero / nonzero after comparison.
+```
+
+ここで `LawConflict'_i(U,V)` は repair 後の geometry `X'` 上で計算される conflict sheaf である。
+pullback、pushforward、または probe-level comparison のどれを使うかは `Q_{U,V}` の一部として固定する。
+
+repair が selected derived conflict を増やさないとは、
+
+```text
+pullback_r LawConflict'_i(U,V)
+  <=_{Q_{U,V}}
+LawConflict_i(U,V)
+for all i in D
+```
+
+または、同じ意味を持つ selected probe-level comparison が成り立つことである。
+
+`Q_{U,V}` を固定しない限り、`LawConflict_i(U,V)` が repair によって増えない、
+または新たに非零化しない、という theorem は立てない。
+
+### 定義 8.4 Repair Path
 
 repair path とは、architecture geometry 上の変形または morphism である。
 
@@ -543,7 +709,7 @@ under P_U
 以後の repair theorem は、必ず profile `P_U` と、それが section 比較なのか geometry 比較なのかに
 相対化して読む。
 
-### 原則 8.3 Repair Is Not Scalar Improvement
+### 原則 8.5 Repair Is Not Scalar Improvement
 
 repair は単一の scalar score の改善ではない。
 
@@ -696,7 +862,8 @@ derived conflict class does not increase
 transferred obstruction is zero or controlled
 ```
 
-記号的には、law universe `U,V in 𝓛` について、
+記号的には、law universe `U,V in 𝓛` について、repair comparison profile `P_U` と
+conflict comparison profile `Q_{U,V}` を固定し、
 
 ```text
 r(X) prec^{geom}_{P_U} X
@@ -705,10 +872,15 @@ r(X) prec^{geom}_{P_U} X
 かつ、
 
 ```text
-LawConflict_1(U,V)
+pullback_r LawConflict'_i(U,V)
+  <=_{Q_{U,V}}
+LawConflict_i(U,V)
+for selected i in D
 ```
 
-が repair によって新たに非零化しないことを要求する。
+が成り立つことを要求する。
+低次だけを読む repair criterion では `i = 1` に制限してよい。
+高次 coherence まで含める場合は、選ばれた conflict degree profile を明示する。
 
 ### 原則 11.2 Repair Preserves Geometry
 
@@ -761,13 +933,25 @@ LawConflict_1(U,V)
   Tor_1^{O_X}(O_X/I_U, O_X/I_V)
 ```
 
-cohomological grading を固定した場合、この sheaf は derived intersection の負次数として読める。
+さらに、正次数全体の conflict sheaf を次で定義した。
+
+```text
+LawConflict_i(U,V)
+  =
+Tor_i^{O_X}(O_X/I_U, O_X/I_V)
+for i > 0
+```
+
+cohomological grading を固定した場合、一次 conflict sheaf は derived intersection の負次数として読める。
 
 ```text
 LawConflict_1(U,V)
   ≅
   H^{-1}(O_{Flat_U intersection^R Flat_V})
 ```
+
+すべての `i > 0` で `LawConflict_i(U,V) = 0` なら、選ばれた derived reading において
+`U` と `V` は derived-transverse である。
 
 第V部の核心は次である。
 

--- a/docs/aat/algebraic_geometric_theory/part_6_singularity_monodromy_stack.md
+++ b/docs/aat/algebraic_geometric_theory/part_6_singularity_monodromy_stack.md
@@ -8,6 +8,10 @@ Flat_U(X) intersection^R Flat_V(X)
 LawConflict_1(U,V)
   =
   Tor_1^{O_X}(O_X/I_U, O_X/I_V)
+LawConflict_i(U,V)
+  =
+  Tor_i^{O_X}(O_X/I_U, O_X/I_V)
+  for i > 0
 ```
 
 また、repair や refactoring を、lawful loci の間を動く derived-geometric deformation として定式化した。
@@ -49,10 +53,12 @@ stack:
 Part5 の derived law geometry は、lawful loci の交差に残る latent conflict を扱った。
 
 ```text
-LawConflict_1(U,V) != 0
+LawConflict_i(U,V) != 0
+for some selected i > 0
 ```
 
 この非零性は、law universe `U` と `V` の同時実現に潜在的な incompatibility があることを示す。
+一次 conflict に注目する場合は、特に `LawConflict_1(U,V) != 0` と書く。
 
 しかし、次の問いが残る。
 
@@ -723,6 +729,41 @@ stack:
 architecture では、refactor、decomposition、semantic-preserving rewrite が本質的な同型として現れるため、
 stack 的な扱いが自然である。
 
+### 定義 13.3 Algebraic Architecture Stack
+
+architecture stack は、任意の AAT site 上の groupoid-valued sheaf である。
+これを algebraic stack と呼ぶには、さらに代数幾何的な representability 条件が必要である。
+
+architecture stack `𝓧` が algebraic architecture stack であるとは、次を満たすことをいう。
+
+```text
+representable diagonal:
+  diagonal 𝓧 -> 𝓧 x 𝓧 is representable by ArchitectureSchemes.
+
+atlas:
+  there exists an atlas class AtlasClass
+  and an admissible atlas
+  X_0 -> 𝓧
+  from an ArchitectureScheme X_0.
+
+descent of structure:
+  obstruction ideals, law sheaves, signature sheaves,
+  and selected structure sheaves descend along the atlas.
+```
+
+したがって、本文で単に stack と呼ぶときは groupoid-valued descent object を意味する。
+`algebraic architecture stack` と呼ぶときだけ、diagonal、atlas、descent of structure を備えた
+強い対象を意味する。
+
+```text
+stack
+  !=
+algebraic stack
+```
+
+この分離により、decomposition や refactor equivalence を stack として扱うことと、
+それが scheme atlas を持つ algebraic stack であることを混同しない。
+
 ## 14. Codebase Essence as Quotient Stack
 
 ### 定義 14.1 Codebase Essence
@@ -736,6 +777,24 @@ Ref_U ⇉ X^U
 ```
 
 が `X^U` に作用していると仮定する。
+すなわち、少なくとも次の data が与えられている。
+
+```text
+source, target:
+  s,t : Ref_U -> X^U
+
+identity:
+  e : X^U -> Ref_U
+
+inverse:
+  inv : Ref_U -> Ref_U
+
+composition:
+  Ref_U x_{X^U} Ref_U -> Ref_U
+```
+
+これらは groupoid identities を満たし、さらに selected law、obstruction、signature、
+structure sheaf と整合するものとする。
 このとき、codebase essence は quotient stack として定義される。
 
 ```text

--- a/docs/aat/algebraic_geometric_theory/part_7_representation_periods_analysis.md
+++ b/docs/aat/algebraic_geometric_theory/part_7_representation_periods_analysis.md
@@ -263,36 +263,101 @@ faithful reading
 
 ## 5. Period Family
 
-### 定義 5.1 Period
+### 定義 5.1 Representation Reading
 
-representation `R` に対して、architecture geometry `X` の period を次で定義する。
+representation `R` に対して、architecture geometry `X` の reading を次で定義する。
 
 ```text
-Period_R(X)
+Read_R(X)
   =
   R(X)
 ```
 
-period は、`X` を特定の representation で読んだ値である。
+これは、`X` を特定の representation で読んだ値である。
+従来の広い意味では、この reading を broad period と呼んでもよい。
 
 ```text
-graph period
-matrix period
-signature period
-curvature period
-semantic period
-effect period
-runtime period
+Period_R^{broad}(X)
+  :=
+Read_R(X)
+
+Period_R(X)
+  may be used as shorthand
+  only when broad-period convention is fixed.
 ```
 
-### 定義 5.2 Period Family
+代表例は次である。
+
+```text
+graph reading
+matrix reading
+signature reading
+curvature reading
+semantic reading
+effect reading
+runtime reading
+```
+
+### 定義 5.2 Strict Period
+
+狭義の period は、単なる representation value ではなく、cohomology class、cycle、trace、
+operation loop などとの pairing として定義する。
+
+たとえば obstruction cohomology class
+
+```text
+omega in H^n(X, Ob_U)
+```
+
+と cycle または test object
+
+```text
+gamma in H_n(X, Z)
+```
+
+が固定されているとき、strict obstruction period を次で表す。
+
+```text
+Per_{omega,gamma}(X)
+  :=
+< omega, gamma >
+```
+
+monodromy representation
+
+```text
+rho_U : pi_1^{op}(X) -> Aut(F)
+```
+
+が固定されている場合、operation loop `gamma` に沿う trace period を次で表す。
+
+```text
+Per_rho(gamma)
+  :=
+Tr(rho_U(gamma))
+```
+
+したがって、本文では次を区別する。
+
+```text
+reading:
+  R(X), representation による値。
+
+broad period:
+  reading を period family の成分として読む広義の用法。
+
+strict period:
+  cohomology / cycle / trace / loop との pairing。
+```
+
+### 定義 5.3 Period Family
 
 period family を次で定義する。
 
 ```text
 Per(X)
   =
-  { Period_R(X) | R in Rep(AAT) }
+  { Read_R(X) | R in Rep(AAT) }
 ```
 
 `Per(X)` は、architecture geometry `X` の多面的な analytic reading である。
@@ -313,25 +378,25 @@ Per(X)
 
 ### 定理 6.1 Period Separation
 
-architecture geometries `X` と `Y` について、ある representation では同じ period を持ち、
-別の representation では異なる period を持つことがある。
+architecture geometries `X` と `Y` について、ある representation では同じ broad period / reading を持ち、
+別の representation では異なる broad period / reading を持つことがある。
 
 たとえば、
 
 ```text
-Period_graph(X) = Period_graph(Y)
+Period_graph^{broad}(X) = Period_graph^{broad}(Y)
 ```
 
 であっても、
 
 ```text
-Period_semantic(X) != Period_semantic(Y)
+Period_semantic^{broad}(X) != Period_semantic^{broad}(Y)
 ```
 
 または、
 
 ```text
-Period_effect(X) != Period_effect(Y)
+Period_effect^{broad}(X) != Period_effect^{broad}(Y)
 ```
 
 となりうる。
@@ -343,20 +408,21 @@ semantic representation は language game と use-rule に相対化された mea
 effect representation は authority、state、runtime effect の reading を与える。
 
 これらは異なる coordinate family を読む。
-したがって、graph period が一致しても、semantic period や effect period が異なることがある。
+したがって、graph broad period / reading が一致しても、semantic broad period や
+effect broad period が異なることがある。
 
 ```text
-same graph period
-different semantic period
-different effect period
+same graph broad period
+different semantic broad period
+different effect broad period
 ```
 
-この定理は、graph period の位置を明確にする。
+この定理は、graph broad period / reading の位置を明確にする。
 
 ```text
-graph is a legitimate period.
-semantic is another period.
-effect is another period.
+graph is a legitimate broad period.
+semantic is another broad period.
+effect is another broad period.
 ```
 
 ## 7. Signature and Curvature Readings
@@ -761,7 +827,8 @@ complete for selected purpose
 ```
 
 ある representation は graph structure には faithful でも、semantic structure には coarse でありうる。
-別の representation は semantic period をよく分離しても、runtime interaction を読まないことがある。
+別の representation は semantic reading / broad period をよく分離しても、
+runtime interaction を読まないことがある。
 
 ### 原則 15.2 Choose a Representation Family
 
@@ -769,16 +836,16 @@ complete for selected purpose
 
 ```text
 dependency questions:
-  graph and matrix periods.
+  graph and matrix readings.
 
 semantic questions:
-  semantic and contract periods.
+  semantic and contract readings.
 
 effect questions:
-  authority and effect periods.
+  authority and effect readings.
 
 runtime questions:
-  trace and state periods.
+  trace and state readings.
 
 repair questions:
   distance, normal cone, derived conflict, monodromy readings.


### PR DESCRIPTION
## 概要

AAT代数幾何版の数学本文レビューを受けて、次点以上の補強項目を本文へ反映した。

Issue: なし（レビュー反映のため `Closes #N` なし）

主な設計判断:

- `ArchCtx_min(A)` を finite-meet poset category と呼ぶ条件として、morphism uniqueness、antisymmetry、equivalence quotient を明示した。
- `Spec_AAT` の representability を raw affine chart と sheafified chart presentation に分けた。
- `Ob_U` の canonical obstruction package で、`ConDef_U` と `DerOb_U(M)` の係数圏を明示した。
- `LawConflict_i` と derived-transverse 条件を追加し、repair 側には `ConflictComparisonProfile` を導入した。
- stack / algebraic stack、broad period / strict period の用語境界を整理した。

## 証明した定理

- なし（Lean theorem の追加なし）

## 編集したドキュメント

- `docs/aat/algebraic_geometric_theory/part_2_architecture_geometry_sites_sheaves.md`
- `docs/aat/algebraic_geometric_theory/part_3_law_algebra_obstruction_ideal_lawful_locus.md`
- `docs/aat/algebraic_geometric_theory/part_4_obstruction_cohomology.md`
- `docs/aat/algebraic_geometric_theory/part_5_derived_law_geometry_repair.md`
- `docs/aat/algebraic_geometric_theory/part_6_singularity_monodromy_stack.md`
- `docs/aat/algebraic_geometric_theory/part_7_representation_periods_analysis.md`

## 実施したテスト

- [ ] `lake build`（docs-only 変更で Lean source 変更なしのため未実行）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `$local-review` 実施、指摘を反映済み

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Issue なしのレビュー反映）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean theorem 追加なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている（該当変更なし）
- [x] ArchSig と FieldSig の責務を混同していない
