### PR TITLE
AG数学本文の橋渡し定理とEvolution Geometryを追加

### DIFF
--- a/docs/aat/algebraic_geometric_theory/README.md
+++ b/docs/aat/algebraic_geometric_theory/README.md
@@ -44,15 +44,16 @@ Atom
   -> Singularity / monodromy / stack
   -> Representation / periods / analysis
   -> Measurement theory
+  -> Evolution geometry
   -> Claim status / finite worked example
 ```
 
 ## 位置づけ
 
 このディレクトリの本文では、AAT を純粋な数学理論として扱う。
-SFT、ArchSig、FieldSig、実コードベース抽出、tool diagnosis、empirical validation は
-本文の内部対象ではない。それらは、AAT で構成された幾何対象を読む、測る、または
-進化させる後続の理論・artifact で扱う。
+本文の内部対象は、Atom、architecture object、law universe、site、sheaf、cohomology、
+representation、measurement profile、trace category である。
+未選択の観測過程、外部過程、応用上の判定手続きについて、本文は主張しない。
 
 従来の Atom / law / obstruction / flatness / signature による AAT は、
 この理論史における古典的な有限・構成的基礎である。この本文は、その旧体系への
@@ -68,8 +69,9 @@ SFT、ArchSig、FieldSig、実コードベース抽出、tool diagnosis、empiri
 6. [第VI部 Singularity・Monodromy・Stack](part_6_singularity_monodromy_stack.md)
 7. [第VII部 Representation・Periods・Analysis](part_7_representation_periods_analysis.md)
 8. [第VIII部 Measurement Theory](part_8_measurement_theory.md)
-9. [付録 A Mathematical Ambient and Standard AG Embedding](appendix_mathematical_ambient.md)
-10. [付録 B Claim Status and Finite Worked Example](appendix_claim_status_and_worked_example.md)
+9. [第IX部 Evolution Geometry](part_9_evolution_geometry.md)
+10. [付録 A Mathematical Ambient and Standard AG Embedding](appendix_mathematical_ambient.md)
+11. [付録 B Claim Status and Finite Worked Example](appendix_claim_status_and_worked_example.md)
 
 ## 主張の読み方
 
@@ -118,9 +120,8 @@ Lean 形式化との対応は、必要に応じて
 これらの台帳に対応する Lean API または proof obligation が記載されていない theorem label は、
 本文内の数学命題であり、現在の Lean proved claim とは読まない。
 
-実コードベースからの読み取り、tooling measurement、経験的検証は、この幾何対象を別の観点から読む
-後続の営みである。AAT 本文内の measurement は、固定された数学的対象と selected profile に
-相対化された reading であり、実コード観測や empirical validation の完全性を仮定しない。
+AAT 本文内の measurement は、固定された数学的対象と selected profile に相対化された reading である。
+選ばれていない data source、観測手段、判定手続きの完全性は仮定しない。
 
 ## 強い代数幾何としての階層
 
@@ -144,6 +145,14 @@ Architecture scheme:
 Derived / stacky AAT geometry:
   lawful loci の derived intersection、Tor conflict、cotangent complex、
   monodromy representation、decomposition stack / gerbe を扱う。
+
+Finite measurement geometry:
+  finite poset site、cellular sheaf、Stanley-Reisner 複体、Tor、
+  period pairing、Laplacian、transport cost を、選ばれた profile の中で測る。
+
+Evolution geometry:
+  trace category、state transition presheaf、temporal coefficient、dissipative policy、Lyapunov reading を、
+  AAT geometry の時間方向の構造として扱う。
 ```
 
 したがって、`ringed AAT topos` は architecture scheme を作るための基礎階である。

--- a/docs/aat/algebraic_geometric_theory/appendix_claim_status_and_worked_example.md
+++ b/docs/aat/algebraic_geometric_theory/appendix_claim_status_and_worked_example.md
@@ -1,7 +1,7 @@
 # 付録 B Claim Status and Finite Worked Example
 
 この付録は、本文の主張区分を読むための台帳と、有限 regime の最小 worked example を与える。
-ここで扱うのは純数学的な AAT geometry であり、source extraction、ArchSig 実装、empirical validation ではない。
+ここで扱うのは純数学的な AAT geometry であり、選ばれていない観測過程や外部手続きではない。
 
 ## B.1 Claim Status Ledger
 
@@ -36,6 +36,27 @@
 | `NoHigherBoundaryObstruction` | future design obligation | boundary class だけで判定を完備にするための追加仮定。本文内では未証明の bounded assumption として読む。 |
 | `operation homotopy` | future design obligation | operation category / groupoid を固定した後に定義する homotopy predicate。 |
 | `trace topos` | future design obligation | temporal law を扱うための後続 ambient。AAT 本文の core site とは分けて読む。 |
+| `homotopy generator family` | defined predicate family | selected operation homotopy を生成する 2-cell relation family。採用する generator は law universe / operation family / transport profile に相対化される。 |
+| `presentation two-complex K_H` | defined object | selected operation graph に homotopy generator family の 2-cell を貼った finite / combinatorial presentation。 |
+| `measured square monodromy` | analytic reading | `K_H` の selected square boundary に沿う coefficient transport defect。all-path monodromy completeness ではない。 |
+| `Transport Descent Criterion` | certified bounded inference | edge transport が `pi_1^AAT(X,U,H,A)` へ降りることを、selected generator 2-cell 上の zero monodromy defect で検出する主張。 |
+| `Square Monodromy Nonfillability` | certified bounded inference | selected square boundary、coefficient transport、monodromy defect が固定された場合、nonzero defect が selected filler の不在を検出する主張。 |
+| `AAT-GAGA` | certified bounded inference bundle | finite measurement profile 内で Hodge / period / topological capacity / Tor を比較する束。candidate に依存する stability 条項は追加 regime の interface として読む。 |
+| `topological debt capacity` | certified bounded inference | finite cover nerve と cochain dimension から `H^1` capacity を読む。具体的な nonzero class の存在とは区別する。 |
+| `harmonic debt minimality` | certified bounded inference | finite inner-product cochain model で local adjustment 後の residual norm を harmonic representative の norm として読む。 |
+| `Finite Hodge Decomposition` | certified bounded inference | finite-dimensional inner product cochain complex と adjoint が固定された場合の直交 Hodge 分解。一般 sheaf cohomology の無条件分解ではない。 |
+| `Margin Stability` | certified bounded inference | selected metric、unsafe boundary までの margin、三角不等式、path length bound が固定された場合の safe region 不脱出。 |
+| `Hilbert series conflict accounting` | certified bounded inference | graded monomial conflict regime で Tor conflict の交代 Hilbert series を audit reading として読む。 |
+| `Repair Termination` | certified bounded inference | well-founded repair comparison profile と strictly decreasing repair step を固定した場合の有限停止。lawfulness 到達は別仮定。 |
+| `scale-stable debt` | theorem candidate / defined reading | selected aggregation family に沿って coarse side から持ち上がる `H^1` class。すべての尺度に対する絶対不変性ではない。 |
+| `discrete Morse repair reading` | analytic reading / theorem candidate | square-free complex の collapse data を combinatorial repair route として読む。operation semantics は別 profile。 |
+| `Wasserstein transfer cost` | analytic reading / theorem candidate | finite support graph 上の obstruction measure の移動距離。mass preservation と ground metric に相対化される。 |
+| `Monotone Witness Stability` | theorem candidate | monotone forbidden-support filtration、comparison map、interleaving / correspondence を固定した場合の persistence stability reading。 |
+| `state transition presheaf` | defined object | selected trace category と AAT site 上で state space / transition monoid を割り当てる presheaf。descent 条件が確認された regime で sheaf と呼ぶ。 |
+| `temporal coefficient` | defined coefficient object | temporal law data の mismatch / gluing defect を測る abelian coefficient sheaf。 |
+| `Temporal Descent Criterion` | certified bounded inference | finite trace product site、temporal coefficient、zero mismatch class のもとで local adjustment 後の replay data が大域 transition へ貼れる主張。 |
+| `Force Integrability Obstruction` | theorem candidate | force に付随する temporal mismatch class が定義され、descent 検出性が固定された場合の non-integrability criterion。 |
+| `dissipative policy` | certified bounded inference when finite | selected evolution functional を非増加にする operation family。未選択の future state や外部成功条件ではない。 |
 | `witness exactness` | certified assumption | selected witness family が selected obstruction reading に対して sound / complete であること。 |
 
 ## B.2 Label Discipline
@@ -194,7 +215,7 @@ gamma = P - Q
 
 である。この値は、選ばれた cover、coefficient sheaf、cycle representative に相対化された
 period reading である。
-この pairing は source extraction の完全性や実コード上の defect を直接主張しない。
+この pairing は、未選択の data source や外部 defect を直接主張しない。
 それは、構成済み AAT geometry の中で、local mismatch class が cycle に沿って非自明に読める、
 という有限数学モデルである。
 
@@ -213,4 +234,180 @@ finite context cover
 ```
 
 すべての構成は、選ばれた finite site、coefficient sheaf、witness variables、law ideals に相対化される。
-未選択の law、axis、runtime trace、source observation については何も主張しない。
+未選択の law、axis、trace、data source については何も主張しない。
+
+## B.8 Atom-Family-To-Geometry Toy Reading
+
+第I部 例1.4 の finite Atom family を、固定された Atom vocabulary と reading doctrine の下で読む。
+ここで使うのは、本文が明示した Atom family である。
+
+```text
+component(C)
+component(D)
+relation_imports(C, D)
+state(C, x : X)
+relation_calls(m, D.read)
+relation_writes(m, x)
+effect(e)
+relation_emits(m, e)
+authority(a, act, r)
+contract(m, P -> Q)
+semantic(q(y), denotes result-of-m)
+```
+
+### B.8.1 Finite Context Cover
+
+この Atom family から、三つの chart を持つ finite cover を固定する。
+
+```text
+W_dep:
+  component / dependency reading.
+
+W_state:
+  state transition reading.
+
+W_effect:
+  effect / authority reading.
+```
+
+overlap component を次のように置く。
+
+```text
+P = W_dep intersection W_state
+Q = W_state intersection W_effect
+R = W_dep intersection W_effect
+```
+
+coefficient sheaf は constant abelian sheaf `Z` とし、restriction はこの toy model では恒等とする。
+三重 overlap `W_dep intersection W_state intersection W_effect` は空、または selected cover nerve の
+2-face として採用しない。
+したがって nerve は埋まった 2-simplex ではなく、三つの edge からなる 1-cycle である。
+
+### B.8.2 Cech Mismatch
+
+local lawful section の mismatch を
+
+```text
+g = (1, 0, 0) in Z_P + Z_Q + Z_R
+```
+
+と置く。
+orientation を
+
+```text
+P : W_dep -> W_state
+Q : W_state -> W_effect
+R : W_dep -> W_effect
+```
+
+と取ると、0-cochain `s = (s_dep,s_state,s_effect)` の coboundary は
+
+```text
+d s = (s_state - s_dep, s_effect - s_state, s_effect - s_dep).
+```
+
+したがって `im d^0` は
+
+```text
+{(u,v,u+v)}
+```
+
+であり、class を検出する functional は
+
+```text
+g_P + g_Q - g_R.
+```
+
+この例では
+
+```text
+1 + 0 - 0 = 1
+```
+
+なので、`g` は `H^1` の nonzero class を与える。
+これは、dependency、state、effect の局所 reading が、それぞれ単独では整合していても、
+三者を同時に貼ると mismatch class が残ることを読む toy model である。
+
+### B.8.3 Obstruction Ideal
+
+witness variables を次で置く。
+
+```text
+p = dependency-state mismatch witness
+q = state-effect mismatch witness
+r = dependency-effect mismatch witness
+```
+
+forbidden supports を
+
+```text
+{p,q}
+{q,r}
+```
+
+とすると、
+
+```text
+I_Ob = <p q, q r> subset k[p,q,r]
+```
+
+を得る。
+これは B.4 と同じ Stanley-Reisner chart であり、selected Atom family 由来の witness names を
+割り当てた例である。
+
+### B.8.4 Tor and Period
+
+law universes を
+
+```text
+U = dependency-state law
+V = state-effect law
+```
+
+として、同じ ambient ring 上で
+
+```text
+I_U = <p q>
+I_V = <q r>
+```
+
+と読む。
+共有 witness factor `q` により、
+
+```text
+Tor_1^R(R/I_U, R/I_V)
+```
+
+は `q` support に沿う derived conflict residue を持つ。
+
+また、cycle
+
+```text
+gamma = P + Q - R
+```
+
+に対する period pairing は、
+
+```text
+<g, gamma> = g_P + g_Q - g_R = 1
+```
+
+である。
+これは Cech class を検出する functional と一致し、state transition chart を挟んだ
+dependency/effect mismatch の reading になる。
+
+### B.8.5 Verdict Boundary
+
+この toy reading が示すのは次である。
+
+```text
+given selected Atom family
+  -> finite cover
+  -> Cech mismatch
+  -> square-free obstruction ideal
+  -> Tor conflict
+  -> period reading.
+```
+
+これは、未選択の trace completeness や外部 authority model の正しさを主張しない。
+本文内で構成済みの Atom family を入力にした、finite AAT geometry の worked example である。

--- a/docs/aat/algebraic_geometric_theory/part_4_obstruction_cohomology.md
+++ b/docs/aat/algebraic_geometric_theory/part_4_obstruction_cohomology.md
@@ -1375,7 +1375,263 @@ vanishing in one projection != total vanishing
 AAT は、固定された cover、coefficient sheaf、witness family、exactness assumption の範囲で
 cohomological conclusion を述べる。
 
-## 12. Part4 の結論
+## 12. Topological Debt Theorem
+
+### 定義 12.1 Cover Nerve
+
+有限 cover
+
+```text
+U = {W_i -> W}
+```
+
+に対して、overlap component を明示した nerve 複体を `N(U)` と書く。
+頂点は chart `W_i`、辺は二重 overlap component、面は三重 overlap component である。
+overlap が複数成分を持つ場合、`N(U)` は多重グラフまたは多重複体として読む。
+
+```text
+vertices:
+  charts
+
+edges:
+  connected components of W_i intersection W_j
+
+faces:
+  connected components of triple overlaps
+```
+
+### 定理 12.2 Topological Debt Capacity [Certified bounded inference]
+
+有限 poset regime で、cochain groups が finite-dimensional `k`-vector spaces であるとする。
+このとき、rank-nullity により次の容量下界を得る。
+
+```text
+dim_k H^1(U,F)
+  >=
+  dim C^1(U,F) - dim C^0(U,F) - dim C^2(U,F).
+```
+
+証明の読みは有限次元線形代数である。
+`H^1 = ker d_1 / im d_0` なので
+
+```text
+dim H^1 = dim ker d_1 - dim im d_0.
+```
+
+rank-nullity から `dim ker d_1 >= dim C^1 - dim C^2` であり、
+また `dim im d_0 <= dim C^0` であるため、上の不等式が従う。
+
+特に stalk dimension が overlap component ごとに固定されている場合、この右辺は
+`N(U)` の chart、edge、face と stalk dimension だけから読める。
+
+これは、具体的な obstruction class が存在することを直ちに主張しない。
+言うのは、選ばれた cover の形が `H^1` の容量をどこまで許すかである。
+
+### 系 12.3 Constant Coefficient Nerve Reading
+
+係数 sheaf が定数層 `k` であり、restriction が標準的であるとき、
+
+```text
+H^1(U,k) ≅ H^1(N(U),k)
+```
+
+と読める。
+したがって、
+
+```text
+dim_k H^1(U,k) = b_1(N(U)).
+```
+
+`b_1(N(U))` は、選ばれた nerve complex が持つ独立 loop の数である。
+三重 overlap などの face が選ばれて loop を埋める場合、その face を含む複体の Betti 数として読む。
+これは、大域 section への貼り合わせで追加条件が必要になりうる構造的余地を示す。
+
+### 定理 12.4 Local Gluing Sufficiency [Certified bounded inference]
+
+次を仮定する。
+
+```text
+N(U) is a forest.
+there are no triple overlap faces.
+all restriction maps F(W_i) -> F(W_e) are surjective.
+```
+
+このとき、
+
+```text
+H^1(U,F) = 0.
+```
+
+したがって、この regime では任意の mismatch cocycle は coboundary である。
+特に定理 11.1 の effective torsor regime では、local adjustment を選べば local lawful family は
+大域 section へ貼り合う。
+
+証明の読みは次である。
+forest-shaped cover では 1-cycle がなく、surjective restriction により edge 上の mismatch は
+vertex 上の local adjustment で逐次吸収できる。
+したがって `C^1` の cocycle は `im d^0` に入り、`H^1(U,F)=0` となる。
+
+この定理は、non-abelian torsor、stacky descent、gerbe obstruction を排除しない。
+主張は、選ばれた abelian coefficient sheaf と forest-shaped cover に相対化される。
+
+### 系 12.5 Euler Accounting
+
+有限 cochain complex に対し、
+
+```text
+chi(U,F) = sum_n (-1)^n dim C^n(U,F)
+```
+
+は、cochain group の次元だけから決まる。
+cover の shape と stalk dimension を保つ refactor は、obstruction mass を次数間で移動させても、
+この交代和を変えない。
+
+これは、負債が消えたことではなく、選ばれた cochain accounting における保存則である。
+
+## 13. Period Stokes Accounting
+
+### 定義 13.1 Cochain-Chain Pairing
+
+有限 poset / Cech homology model で、orientation を固定し、cochain と chain の pairing を固定する。
+
+```text
+< -, - > : C^n(U,F) x C_n(U,F^*) -> k
+```
+
+標準的には、basis simplex `sigma` と dual basis cochain `sigma^*` について
+
+```text
+<sigma^*, sigma> = 1
+```
+
+とし、線形に拡張する。
+boundary と coboundary がこの pairing に関して随伴であるとき、Stokes-compatible pairing と呼ぶ。
+
+### 定理 13.2 Period Stokes Identity [Certified bounded inference]
+
+有限 poset / Cech model の標準的な交代符号 convention で上の pairing を取る。
+このとき、任意の cochain `omega` と chain `gamma` について、
+
+```text
+<d omega, gamma> = <omega, boundary gamma>.
+```
+
+証明は basis simplex 上で確認すればよい。
+`d` の交代符号は `boundary` の交代符号と同じ face incidence number を持つため、
+両辺は同じ incidence contribution の和になる。
+
+さらに、feature extension cover から来る boundary mismatch section `b` と
+connecting homomorphism
+
+```text
+delta : H^0(boundary, Ob_U) -> H^1(U, Ob_U)
+```
+
+が固定されている場合、
+
+```text
+<delta(b), gamma> = <b, boundary gamma>
+```
+
+が成り立つ。
+
+これは connecting homomorphism が boundary restriction の coboundary representative として構成される場合、
+上の Stokes identity をその representative に適用したものである。
+
+これは、release loop や feature boundary に沿って測った period が、境界 mismatch の符号付き会計と
+一致することを意味する。
+
+### 原則 13.3 Stokes Accounting Boundary
+
+Stokes identity は、構成済み AAT geometry 内部の数学である。
+未選択の data source や外部手続きが pairing を保存することは主張しない。
+
+```text
+accounting identity in geometry
+  !=
+external procedure correctness.
+```
+
+### 定義 13.4 Extension Holonomy Accounting Reading
+
+feature extension
+
+```text
+A -> B
+```
+
+と extension interface `f`、boundary mismatch section `b_f`、boundary holonomy `Hol_U(boundary f)` が
+同じ Mayer-Vietoris / boundary residue regime で定義されているとする。
+selected obstruction accounting の加法性を次の形で固定する。
+
+```text
+kappa_U(B)
+  =
+  kappa_U(A)
+  +
+  kappa_U(f)
+  +
+  Hol_U(boundary f).
+```
+
+ここで `Hol_U(boundary f)` は、この等式が成り立つように選ばれた boundary residue / correction term である。
+したがってこれは定理 13.2 から自動的に出る系ではなく、Mayer-Vietoris / boundary residue regime 上の
+accounting convention である。
+`kappa_U` の値域、加法性、boundary residue の検出性を別途固定した場合にのみ、定理として昇格できる。
+
+この式は、`NoHigherBoundaryObstruction` などの追加仮定なしに、boundary class だけで
+lawfulness を完全判定するとは主張しない。
+
+## 14. Scale-Stable Debt
+
+### 定義 14.1 Aggregation Morphism
+
+fine site から coarse site への尺度変更を、有限 site の射として表す。
+
+```text
+pi : X_fine -> X_coarse
+```
+
+`pi_* Ob` は coarse site 上で見える obstruction coefficient であり、
+`R^q pi_* Ob` は coarse cell の内部に残る高次 obstruction を読む。
+
+### 定理候補 14.2 Leray Five-Term Debt Sequence
+
+有限 site 射 `pi` と coefficient object `Ob` に対して、Leray spectral sequence が構成できる regime では、
+低次に次の五項完全列を期待する。
+
+```text
+0 -> H^1(X_coarse, pi_* Ob)
+  -> H^1(X_fine, Ob)
+  -> H^0(X_coarse, R^1 pi_* Ob)
+  -> H^2(X_coarse, pi_* Ob)
+  -> H^2(X_fine, Ob)
+```
+
+この列は、fine scale の hidden coupling class が、
+coarse scale でも見える成分と、集約単位の内部に局在する成分へ分配されることを読む。
+
+### 定義 14.3 Scale-Stable Debt
+
+selected aggregation family `Pi` に対して、obstruction class `alpha in H^1(X_fine,Ob)` が
+すべての `pi in Pi` で coarse 側から来るとき、`alpha` を scale-stable debt と呼ぶ。
+
+```text
+alpha is scale-stable
+  iff
+for all pi in Pi,
+alpha lies in image(H^1(X_coarse, pi_* Ob) -> H^1(X_fine, Ob)).
+```
+
+scale-stable debt は、単なる粒度の取り方で現れた artifact ではなく、選ばれた集約族を通じて
+持続する obstruction class である。
+
+### 原則 14.4 Scale Relativity
+
+尺度安定性は、選ばれた aggregation family に相対化される。
+すべての分解、すべての module boundary、すべての runtime grouping に対する不変性を主張しない。
+
+## 15. Part4 の結論
 
 第IV部では、Part3 で定義した lawful locus の局所-大域問題を obstruction cohomology として定式化した。
 
@@ -1415,6 +1671,11 @@ global obstruction remains
 ```
 
 この現象は、経験的な複雑性ではなく、cohomological obstruction である。
+
+さらに、有限 cover の形そのものが `H^1` の容量を制御し、
+period pairing は境界 mismatch の会計恒等式として読める。
+尺度変更に対しては、fine / coarse の間でどの obstruction class が持続するかを
+Leray 型の低次列として追跡する。
 
 次の問いは、複数の lawful loci を同時に満たそうとするとき、
 その交差が古典的には正しく見えても、導来的には余剰 obstruction を持つ場合をどう読むかである。

--- a/docs/aat/algebraic_geometric_theory/part_5_derived_law_geometry_repair.md
+++ b/docs/aat/algebraic_geometric_theory/part_5_derived_law_geometry_repair.md
@@ -1322,7 +1322,166 @@ refactoring is controlled deformation of architecture geometry.
 
 このため、refactoring は Part5 の自然な対象である。
 
-## 12. Part5 の結論
+## 12. Hilbert Series Conflict Accounting
+
+### 定義 12.1 Graded Monomial Conflict Regime
+
+common ambient ring
+
+```text
+R = k[x_1, ..., x_n]
+```
+
+を標準次数付き多項式環とし、law universes `U`、`V` の lawful loci が homogeneous monomial ideals
+
+```text
+I_U, I_V subset R
+```
+
+で定義されるとき、graded monomial conflict regime と呼ぶ。
+
+この regime では、各 `LawConflict_i(U,V)` は graded module として読む。
+
+```text
+LawConflict_i(U,V)
+  =
+  Tor_i^R(R/I_U, R/I_V)
+```
+
+### 定理 12.2 Hilbert Series Conflict Identity [Certified bounded inference]
+
+graded monomial conflict regime で、各 Tor module の Hilbert series が定義されるとする。
+このとき、graded free resolution の Euler characteristic により、
+
+```text
+H_{R/I_U}(t) * H_{R/I_V}(t) / H_R(t)
+  =
+  sum_i (-1)^i H_{LawConflict_i(U,V)}(t)
+```
+
+が成り立つ。
+ここで
+
+```text
+LawConflict_0(U,V) = Tor_0^R(R/I_U,R/I_V) = R/(I_U + I_V).
+```
+
+証明の読みは、`R/I_U` の graded free resolution に `R/I_V` を tensor し、
+Euler characteristic を Hilbert series に適用することである。
+free module の Hilbert series は shift を除いて `H_R(t)` の和であり、tensor 後の homology が
+`Tor_i^R(R/I_U,R/I_V)` であるため、上の交代和が得られる。
+
+したがって、干渉級数
+
+```text
+Int_{U,V}(t)
+  =
+  H_{R/(I_U + I_V)}(t)
+  -
+  H_{R/I_U}(t) * H_{R/I_V}(t) / H_R(t)
+```
+
+は、独立に交わった場合の期待値からのずれを、Tor 質量の交代和として会計する。
+付録 B の finite worked example では、この `Tor_0` 表示により
+`R/(I_U+I_V)` の Hilbert series が干渉級数の基準項として現れる。
+
+### 原則 12.3 Hilbert Series Is an Audit Reading
+
+Hilbert series conflict は、law universes の derived non-transversality を次数別に読む audit reading である。
+これは、どちらの law が重要であるか、どの repair が実務的に望ましいかを自動的に決めない。
+
+```text
+degree-k interference
+  =
+selected witness size / grading level reading,
+not total policy priority.
+```
+
+## 13. Well-Founded Repair
+
+### 定義 13.1 Well-Founded Repair Comparison Profile
+
+repair comparison profile は、architecture state の集合 `S` と、well-founded order
+
+```text
+<_{rep}
+```
+
+および repair step relation
+
+```text
+A ->_r B
+```
+
+を含む。
+すべての repair step が
+
+```text
+B <_{rep} A
+```
+
+を満たすとき、profile は well-founded repair comparison profile である。
+
+### 定義 13.2 Sound Repair Step
+
+repair step `A ->_r B` が sound であるとは、選ばれた target obstruction predicate について
+次のいずれかを満たすことである。
+
+```text
+target obstruction strictly decreases.
+target obstruction is cleared.
+selected certificate records why no target repair exists.
+```
+
+soundness は、selected target と selected certificate に相対化される。
+全 obstruction の除去や最短 repair を意味しない。
+
+### 定理 13.3 Repair Termination [Certified bounded inference]
+
+well-founded repair comparison profile を固定し、すべての selected repair step が
+`<_{rep}` に関して減少するとする。
+このとき、無限 repair sequence は存在しない。
+
+```text
+A_0 ->_r A_1 ->_r A_2 ->_r ...
+```
+
+は finite length で停止する。
+
+証明は well-foundedness の定義による。
+無限列が存在すれば
+
+```text
+A_0 >_{rep} A_1 >_{rep} A_2 >_{rep} ...
+```
+
+という無限下降列を与え、`<_{rep}` が well-founded であることに反する。
+
+### 定理 13.4 Sound Repair Synthesis [Certified bounded inference]
+
+次を仮定する。
+
+```text
+repair comparison profile is well-founded.
+each selected step is sound for the target obstruction.
+the synthesis rule only emits selected sound steps or a selected no-solution certificate.
+```
+
+このとき、synthesis は finite sequence として停止し、その出力は次のどちらかである。
+
+```text
+target obstruction cleared in the selected profile.
+selected no-solution certificate returned.
+```
+
+証明の読みは定理 13.3 と出力規則の合成である。
+規則が repair step を出す限り `<_{rep}` は下降するため、無限には続かない。
+停止時には、規則の定義により target obstruction cleared または selected no-solution certificate の
+どちらかだけが出力される。
+
+この定理は、solver completeness、global repair optimality、全 law universe の同時改善を主張しない。
+
+## 14. Part5 の結論
 
 第V部では、複数の lawful loci の交差を derived geometry として扱った。
 
@@ -1365,6 +1524,8 @@ law conflict is derived non-transversality.
 repair is controlled movement through lawful loci.
 bad repair transfers obstruction.
 refactoring is derived-geometric deformation.
+Hilbert series accounts for graded conflict mass.
+well-founded repair terminates under selected comparison profile.
 ```
 
 これにより、AAT は次を扱える。

--- a/docs/aat/algebraic_geometric_theory/part_6_singularity_monodromy_stack.md
+++ b/docs/aat/algebraic_geometric_theory/part_6_singularity_monodromy_stack.md
@@ -690,7 +690,7 @@ A' ~_ref A
 operation loop の homotopy class の集合を、architecture fundamental group と呼ぶ。
 
 ```text
-pi_1^AAT(X,U)
+pi_1^AAT(X,U; chosen homotopy data)
 ```
 
 これは、operation history の loop structure を表す。
@@ -707,11 +707,86 @@ operation groupoid:
 homotopy category / fundamental groupoid:
   selected operation homotopy under refactor equivalence is quotiented.
 
-pi_1^AAT(X,U):
+pi_1^AAT(X,U; chosen homotopy data):
   chosen base architecture at a component of the fundamental groupoid.
 ```
 
 この構成を固定して初めて、operation loop が sheaf に作用するかどうかを問える。
+
+### 定義 9.3 Homotopy Generator Family
+
+operation category `Op_U(X)` に対し、selected operation homotopy を生成する関係族を
+homotopy generator family と呼ぶ。
+
+```text
+H_U(X)
+```
+
+代表的な generator は次である。
+
+```text
+independent square:
+  独立な二つの operation の交換。
+
+same contract replacement:
+  同じ contract を保つ replacement。
+
+repair filler:
+  repair path と direct path の間の filling。
+
+identity insertion / deletion:
+  恒等 operation の挿入と除去。
+
+associativity reassociation:
+  合成括弧の付け替え。
+```
+
+どの generator を採用するかは、law universe、operation family、refactor equivalence、
+coefficient transport に相対化される。
+
+### 定義 9.4 Presentation Two-Complex
+
+operation graph の 1-skeleton を取り、`H_U(X)` の各 generator を 2-cell として貼った 2-complex を
+presentation two-complex と呼ぶ。
+
+```text
+K_H(X,U)
+```
+
+edge は selected operation、2-cell は selected operation homotopy relation である。
+
+### 定義 9.5 Presented Architecture Fundamental Group
+
+base architecture state `A` を固定する。
+presentation two-complex `K_H(X,U)` の edge-path group を、`H` に相対化された
+architecture fundamental group と呼ぶ。
+
+```text
+pi_1^AAT(X,U,H,A)
+  =
+  pi_1(K_H(X,U), A).
+```
+
+base point が文脈から明らかな場合は、`A` を省略する。
+
+```text
+pi_1^AAT(X,U,H)
+```
+
+この定義は、operation homotopy を未指定の商として扱わず、generator family `H` に相対化して
+明示する。
+edge-path group では edge を形式的に可逆化する。
+逆向き edge は、対応する逆 operation が architecture operation として存在することを主張しない。
+
+### 原則 9.6 Homotopy Presentation Boundary
+
+`pi_1^AAT(X,U,H)` は、選ばれた operation graph と homotopy generator family の fundamental group である。
+未選択の operation、未選択の semantic equivalence、未構成の path は含まない。
+
+```text
+different H
+  -> different pi_1^AAT reading.
+```
 
 ## 10. Monodromy
 
@@ -720,15 +795,15 @@ pi_1^AAT(X,U):
 operation loop
 
 ```text
-gamma in pi_1^AAT(X,U)
+gamma in pi_1^AAT(X,U,H,A)
 ```
 
 に対して、monodromy representation が与えられていると仮定する。
 
 ```text
-rho_U
+rho_{U,H,A}
   :
-  pi_1^AAT(X,U)
+  pi_1^AAT(X,U,H,A)
   -> Aut(Ob_U) x Aut(Sem_U) x Aut(Eff_U)
 ```
 
@@ -743,7 +818,7 @@ Mon_gamma(Eff_U) : Eff_U -> Eff_U
 ここで、
 
 ```text
-Mon_gamma := rho_U(gamma)
+Mon_gamma := rho_{U,H,A}(gamma)
 ```
 
 である。
@@ -836,6 +911,101 @@ but
 different obstruction sheaf state
 ```
 
+### 定義 10.4 Measured Square Monodromy
+
+`K_H(X,U)` の selected 2-cell `sigma` を取る。
+その境界 loop を
+
+```text
+boundary sigma : gamma_sigma
+```
+
+と書く。
+coefficient transport が `gamma_sigma` に沿って定義され、selected axis `x` に comparison reading があるとき、
+square-level monodromy defect を次で表す。
+
+```text
+mu_x(sigma)
+  =
+  d_x(Transport(gamma_sigma), id)
+```
+
+ここで `d_x` は selected axis 上の distance または equality-defect reading である。
+この値は、2-cell が selected coefficient reading をどれだけ恒等的に transport するかを測る。
+
+### 定理 10.5 Transport Descent Criterion [Certified bounded inference]
+
+`K_H(X,U)`、base architecture `A`、coefficient transport functor、selected detecting axis family `X_axis` を固定する。
+operation graph の edge transport が与えられているとする。
+この edge transport が表示群
+
+```text
+pi_1^AAT(X,U,H,A)
+```
+
+へ降りるための十分必要条件は、各 homotopy generator 2-cell `sigma` について、
+その boundary transport が恒等として検出されることである。
+
+```text
+for all sigma in H_U(X),
+for all x in X_axis,
+  mu_x(sigma) = 0
+
+iff
+
+edge transport descends to
+  rho_{U,H,A} : pi_1^AAT(X,U,H,A) -> Aut(Coeff_U)
+```
+
+ここで `X_axis` は transport equality を反映する selected detecting family である。
+証明の読みは表示群の普遍性である。
+free path groupoid 上の transport は edge によって定まり、`H` の 2-cell は関係式である。
+すべての関係式の boundary transport が恒等なら transport は quotient group へ因子化する。
+逆に quotient group へ因子化するなら、各関係式は単位元へ送られるため、すべての `mu_x(sigma)` は zero になる。
+
+### 定義 10.6 Architectural Monodromy Index
+
+finite measured square family
+
+```text
+Sigma = {sigma_1, ..., sigma_n}
+```
+
+と positive weights `w_i` を固定する。
+Architectural Monodromy Index を次で読む。
+
+```text
+AMI_x(Sigma)
+  =
+  sum_i w_i * mu_x(sigma_i).
+```
+
+複数 axis を束ねる場合は、axis aggregation policy を measurement profile に含める。
+
+### 定理 10.7 Square Monodromy Nonfillability [Certified bounded inference]
+
+次を仮定する。
+
+```text
+K_H(X,U) is fixed.
+sigma is a selected 2-cell or selected square boundary.
+coefficient transport along boundary sigma is defined.
+selected axis x detects transport equality.
+mu_x(sigma) != 0.
+```
+
+このとき、`sigma` の境界 loop は、selected axis `x` に関して恒等 transport を持つ
+filling としては読めない。
+
+```text
+mu_x(sigma) != 0
+  =>
+selected x-axis filling is refuted.
+```
+
+これは、すべての homotopy filling の不存在を主張しない。
+主張は、固定された `K_H(X,U)`、transport、axis exactness に相対化される。
+
 ## 11. Monodromy Debt Theorem
 
 ### 定理 11.1 Monodromy Debt
@@ -924,6 +1094,51 @@ different presentation
 ```
 
 この違いを潰さずに保持するため、AAT は stack 的な対象へ進む。
+
+### 定義 12.3 Operation-Invariant Galois Data
+
+refactor groupoid `Ref_U(X)` の部分 groupoid の族を `SubGpd(Ref_U(X))` とし、
+selected invariant family の族を `InvFam_U(X)` とする。
+
+operation family `G` が保存する invariant を
+
+```text
+Inv(G)
+```
+
+と書き、invariant family `I` を保存する operation を
+
+```text
+Ops(I)
+```
+
+と書く。
+
+### 定理 12.4 Operation-Invariant Galois Correspondence [Certified bounded inference]
+
+次を仮定する。
+
+```text
+Ref_U(X) is fixed.
+invariant preservation predicate is fixed.
+SubGpd(Ref_U(X)) and InvFam_U(X) are ordered by inclusion.
+```
+
+このとき、次は Galois connection をなす。
+
+```text
+G <= Ops(I)
+  iff
+I <= Inv(G).
+```
+
+この対応は、operation family を増やすほど保存される invariant family が小さくなり、
+invariant requirement を増やすほど許される operation family が小さくなることを読む。
+
+### 原則 12.5 Galois Relativity
+
+この Galois connection は、選ばれた invariant predicate と refactor groupoid に相対化される。
+すべての設計原則、すべての semantic property、すべての未選択 behavior を含むものではない。
 
 ## 13. Architecture Stack
 

--- a/docs/aat/algebraic_geometric_theory/part_7_representation_periods_analysis.md
+++ b/docs/aat/algebraic_geometric_theory/part_7_representation_periods_analysis.md
@@ -211,6 +211,64 @@ effect representation:
 
 これらは、同じ architecture geometry を異なる方向から読む period family の成分である。
 
+### 定義 3.3 Graph Representation
+
+graph representation は、AAT geometry の selected relation data を graph category へ送る functor である。
+
+```text
+R_graph : AATGeometry -> Graph
+```
+
+代表的な edge は、dependency、call、ownership、authority、state transition、effect relation である。
+どの relation を edge とするかは representation profile の一部である。
+
+### 命題 3.4 Acyclicity Preservation [Certified bounded inference]
+
+次を仮定する。
+
+```text
+R_graph is selected for dependency-axis reading.
+cycle obstruction witness is exact for the selected graph edges.
+structural dependency obstruction is zero.
+```
+
+このとき、`R_graph(X)` は selected dependency graph として acyclic である。
+
+逆に、`R_graph(X)` が acyclic であっても、semantic、effect、state transition の obstruction が
+消えるとは限らない。
+
+### 定義 3.5 Matrix Representation
+
+finite graph representation が与えられたとき、その adjacency / incidence / transition matrix を
+matrix representation と呼ぶ。
+
+```text
+R_matrix(X)
+```
+
+`R_matrix` は graph reading の線形代数化であり、walk count、rank、nilpotence、spectral radius などを読む。
+
+### 命題 3.6 Matrix Walk Reading [Certified bounded inference]
+
+finite adjacency matrix `A_X = R_matrix(X)` を固定する。
+このとき、`(A_X^n)_{ij}` は selected graph representation における length `n` walk count を読む。
+
+さらに、selected graph が finite directed acyclic graph である場合、ある `N` について
+
+```text
+A_X^N = 0
+```
+
+となる。
+
+この命題は、graph representation の有限 relation structure についての reading であり、
+全 architecture lawfulness や semantic flatness を主張しない。
+
+### 原則 3.7 Graph / Matrix Boundary
+
+graph と matrix は、AAT geometry の selected relation を読む representation である。
+それらは有用な analytic reading を与えるが、選ばれていない coefficient、law、semantic axis を自動的には読まない。
+
 ## 4. Preservation and Reflection
 
 ### 定義 4.1 Preservation Properties
@@ -966,6 +1024,97 @@ metric improvement
 ```
 
 repair cost は、metric reading と derived geometry の両方に相対化される。
+
+### 定義 12.4 Margin
+
+metric profile `P` の下で、architecture state `A` が selected unsafe boundary まで持つ余裕を
+margin と呼ぶ。
+
+```text
+margin_P(A)
+```
+
+margin は、selected measured axes、metric、selected unsafe predicate に相対化される。
+具体的には、selected safe region `Safe_P` とその boundary `BoundaryUnsafe_P` に対し、
+
+```text
+margin_P(A) = dist_P(A, BoundaryUnsafe_P)
+```
+
+として読む。
+
+### 定理 12.5 Margin Stability [Certified bounded inference]
+
+次を仮定する。
+
+```text
+operation path p : A -> B is measured in P.
+length_P(p) < margin_P(A).
+dist_P satisfies the triangle inequality on the selected measured axes.
+path endpoint distance satisfies dist_P(A,B) <= length_P(p).
+margin_P(A) is the distance to the selected unsafe boundary.
+```
+
+このとき、`B` は selected unsafe boundary を越えない。
+
+```text
+length_P(p) < margin_P(A)
+  =>
+B remains inside the selected safe region.
+```
+
+これは、未測定 axis や未選択 law universe の安全性を主張しない。
+証明は三角不等式による。
+もし `B` が selected unsafe boundary 上またはその外側にあれば、
+`dist_P(A,B) >= margin_P(A)` でなければならない。
+一方 `dist_P(A,B) <= length_P(p) < margin_P(A)` なので矛盾する。
+
+### 定義 12.6 Architectural Dehn Function
+
+presentation two-complex `K_H(X,U)` と filling area reading を固定する。
+loop `ell` の boundary length を `|ell|` とし、minimal filling area を `FillArea(ell)` と書く。
+Architectural Dehn function を次で定義する。
+
+```text
+Dehn_{X,U,H}(n)
+  =
+  max { FillArea(ell) | |ell| <= n }
+```
+
+この関数は、selected homotopy presentation の中で、loop を埋めるために必要な 2-cell area の増大を読む。
+
+### 定理 12.7 Observation Gap Lower Bound [Certified bounded inference]
+
+次を仮定する。
+
+```text
+O is L-Lipschitz with respect to selected filling generator cost.
+two operation paths P,Q have observation gap delta:
+  d_obs(O(P), O(Q)) = delta.
+```
+
+このとき、loop `P . Q^{-1}` の filling cost について、
+
+```text
+fill_cost(P . Q^{-1}) >= delta / L.
+```
+
+この下界は、selected observation reading と Lipschitz constant に相対化される。
+observation gap が未測定の axis では、この結論は使えない。
+
+### 定義 12.8 Bi-Lipschitz Representation
+
+representation `R` が metric profile `P` と `Q` の間で bi-Lipschitz であるとは、
+定数 `c,C > 0` が存在して、selected comparable state pair について
+
+```text
+c * d_P(A,B) <= d_Q(R(A),R(B)) <= C * d_P(A,B)
+```
+
+が成り立つことである。
+
+bi-Lipschitz representation は、selected metric geometry を粗く潰さずに読む。
+ただし、comparable pair、coverage、witness completeness は profile に含める。
 
 ## 13. Analytic Reading of Singularity and Monodromy
 

--- a/docs/aat/algebraic_geometric_theory/part_8_measurement_theory.md
+++ b/docs/aat/algebraic_geometric_theory/part_8_measurement_theory.md
@@ -10,8 +10,8 @@ representation、metric enrichment を構成した。
 When is this geometry measurably readable?
 ```
 
-ここでいう measurement は、実コード抽出 profile や tooling validation ではない。
-すでに構成された AAT geometry の中で、どの有限条件、係数条件、安定性条件の下なら
+ここでいう measurement は、すでに構成された AAT geometry の内部で行う bounded reading である。
+どの有限条件、係数条件、安定性条件の下なら
 obstruction、cohomology、Tor、distance、repair residue を計算可能な不変量として読めるかを述べる。
 
 ```text
@@ -95,7 +95,7 @@ Measured_M(alpha)
 選ばれた predicate と certificate に相対化された verdict であり、
 arbitrary coefficient regime 上の自動決定可能性ではない。
 
-### 原則 2.2 Measurement Is Not Extraction
+### 原則 2.2 Measurement Is Internal
 
 Part VIII の measurement は、AAT geometry 内部の数学的 reading である。
 
@@ -104,13 +104,12 @@ measurement in Part VIII:
   finite computation over selected AAT geometry.
 
 not asserted here:
-  source extraction completeness.
-  ArchSig implementation correctness.
-  empirical validation over codebases.
+  completeness of unselected data.
+  correctness of unselected procedures.
+  validity outside the selected profile.
 ```
 
-ArchSig、FieldSig、source observation、empirical validation へ接続する場合は、
-Part VIII の下流 surface で、別の artifact contract として扱う。
+未選択の観測過程、外部手続き、応用上の判定は Part VIII の数学的主張ではない。
 
 ## 3. Measurement Verdict Discipline
 
@@ -335,7 +334,7 @@ minimal generators of I_{Delta_U^vee}:
 ### 原則 5.3 Repair Hitting Set Is Not Repair Semantics
 
 Alexander dual は、obstruction pattern を打つ最小 witness set を与える。
-しかし、それは実コード操作や architecture operation の意味論を自動的には与えない。
+しかし、それは architecture operation の意味論を自動的には与えない。
 
 ```text
 minimal hitting set:
@@ -344,6 +343,27 @@ minimal hitting set:
 actual repair operation:
   requires operation semantics, legality, cost, and side-effect profile.
 ```
+
+### 定義 5.4 Discrete Morse Repair Reading
+
+square-free repair regime の simplicial complex `Delta_U` に acyclic matching または discrete Morse function を
+選ぶ。
+
+```text
+Morse_U(Delta_U)
+```
+
+critical cells は、chosen collapse sequence では消えない obstruction pattern を読む。
+matching に沿う collapse sequence は、`Delta_U` を簡約する selected combinatorial repair route として読む。
+
+### 定理候補 5.5 Morse Lower Bound for Structural Repair
+
+`Delta_U`、acyclic matching、repair operation semantics が compatible である regime では、
+critical cell の数は、selected collapse-style structural repair route の手数に対する下界を与えると期待する。
+
+この主張は theorem candidate である。
+Morse matching は repair target の組合せ reading であり、実際の operation legality や side-effect control は
+別途 repair profile に含める。
 
 ## 6. Cech Stability
 
@@ -438,6 +458,41 @@ computed value
   !=
 stable measurement
 ```
+
+### 定理候補 6.5 Monotone Witness Stability
+
+finite square-free regime で、forbidden support family が単調に増える filtration
+
+```text
+F_0 <= F_1 <= ... <= F_m
+```
+
+を固定する。
+各 step が forbidden support 一つの追加であり、対応する simplicial complex の反変的 inclusion、
+filtration value、coefficient comparison map、barcode を比較する interleaving または correspondence が
+profile に含まれるとする。
+このとき、通常の persistence stability を適用できる regime では、次を期待する。
+
+```text
+d_bottleneck(Barcode(F_i), Barcode(F_j))
+  <=
+|i - j|
+```
+
+として読む。
+
+より一般には、選ばれた witness perturbation distance に対して、
+
+```text
+d_bottleneck(Barcode(F), Barcode(F'))
+  <=
+d_wit(F,F')
+```
+
+となると読む。
+
+これは theorem candidate であり、monotone filtration と比較 map を固定した場合の安定性主張である。
+forbidden support の追加と削除が混在する場合は、定理候補 6.3 の zigzag profile に戻る。
 
 ## 7. Refactor Functoriality and Class Transport
 
@@ -595,6 +650,119 @@ lawful.
 
 structural zero を主張するには、Part III / Part IV の obstruction zero、axis exactness、
 witness coverage、coefficient exactness が必要である。
+
+### 定理 8.5 Finite Hodge Decomposition [Certified bounded inference]
+
+finite-dimensional inner product regime で、cochain complex
+
+```text
+C^n(X_M,F)
+```
+
+と adjoint `d_n^*` が定義されているとする。
+このとき、
+
+```text
+C^n
+  =
+  im d_{n-1}
+  ⊕
+  ker L_n
+  ⊕
+  im d_n^*
+```
+
+という直交分解を読む。
+さらに、
+
+```text
+ker L_n ≅ H^n(X_M,F)
+```
+
+であり、`ker L_n` の元は cohomology class の harmonic representative である。
+証明の読みは有限次元 Hilbert complex の標準分解である。
+有限次元性により
+
+```text
+C^n = im d_{n-1} ⊕ (im d_{n-1})^\perp
+```
+
+と分解でき、`(im d_{n-1})^\perp = ker d_{n-1}^*` である。
+さらに `ker d_{n-1}^*` を `ker d_n` と `im d_n^*` の直交成分に分けると、
+harmonic part は `ker d_n ∩ ker d_{n-1}^* = ker L_n` になる。
+exact component を quotient すると、各 cohomology class は一意の harmonic representative を持つ。
+
+### 定理 8.6 Harmonic Debt Minimality [Certified bounded inference]
+
+mismatch cocycle `g in C^1(X_M,F)` を固定する。
+Hodge 分解で得られる harmonic component を `h(g)` と書く。
+このとき、local adjustment `c in C^0(X_M,F)` によって消せる成分を除いた residual norm は、
+
+```text
+min_c || g - d_0 c || = || h(g) ||
+```
+
+として読む。
+
+したがって、`||h(g)|| > 0` なら、site、coefficient sheaf、law ideal を変えない local adjustment だけでは
+`g` を zero mismatch にできない。
+証明の読みは直交射影である。
+`d_0 c` で動かせる成分は `im d_0` に限られ、Hodge 分解により harmonic component は
+`im d_0` と直交する。
+したがって affine subspace `g - im d_0` の最小 norm representative は harmonic component `h(g)` である。
+
+### 系 8.7 Essential Repair Lower Bound
+
+さらに、selected repair cost が cochain norm に対して `L`-Lipschitz であり、
+大域 lawful state へ行く任意の repair route が harmonic mismatch を解消しなければならないとする。
+このとき、任意の selected repair route の cost は
+
+```text
+||h(g)|| / L
+```
+
+以上である。
+
+この下界は、selected cost model と Lipschitz assumption に相対化される。
+距離だけから lawfulness を主張するものではない。
+
+### 定義 8.8 Spectral Gap Reading
+
+`L_1` の非零最小固有値を
+
+```text
+lambda_1^+(L_1)
+```
+
+と書く。
+これは、selected cellular sheaf model において、small perturbation がどれだけ harmonic component へ
+近づきやすいかを読む analytic stability indicator である。
+
+### 定義 8.9 Curvature Transfer Spectrum
+
+support set `S` と axis set `A` を固定し、`S x A` 上の finite weighted directed graph を作る。
+edge は selected transfer relation を表す。
+その weighted adjacency operator を
+
+```text
+T_{curv}
+```
+
+と書き、spectrum を curvature transfer spectrum と呼ぶ。
+
+```text
+Spec(T_{curv})
+```
+
+spectral radius は、selected transfer relation の反復的な戻りやすさを読む。
+これは recurrence reading であり、未選択の future state や外部過程での再発を主張しない。
+
+### 定理候補 8.10 Spectral Hotspot Reading
+
+`T_{curv}` が nonnegative finite operator であり、Perron-Frobenius reading が適用できる場合、
+principal eigenvector の大きな support は selected curvature transfer hotspot として読むことができる。
+
+この主張は、support / axis graph、weight、transfer relation の選択に相対化される。
 
 ## 9. LawConflict Measurement and Base Change
 
@@ -812,6 +980,39 @@ small distance-to-flatness
 zero transferred residue.
 ```
 
+### 定義 10.6 Wasserstein Transfer Cost
+
+support graph `G_S` と ground distance `d_S` を固定する。
+obstruction measure
+
+```text
+Omega_U(A)
+```
+
+が support 上の finite nonnegative measure として与えられるとき、operation `op : A -> B` の
+transfer cost を次で読む。
+
+```text
+W_1(Omega_U(A), Omega_U(B)).
+```
+
+これは、selected support graph 上で obstruction mass がどれだけ移動したかを読む optimal transport reading である。
+
+### 定理候補 10.7 Transfer Cost Lower Bound
+
+selected profile で総 obstruction mass が保存され、mass `m` が support `s` から消え、
+吸収可能 support の集合 `Abs` へ移る必要があるとする。
+このとき、
+
+```text
+W_1 >= m * dist(s, Abs)
+```
+
+という下界を期待する。
+
+これは theorem candidate である。
+mass preservation、ground distance、吸収可能 support、axis aggregation が固定されていない場合は定義されない。
+
 ## 11. Measurement Packet
 
 ### 定義 11.1 AAT Measurement Packet
@@ -830,13 +1031,14 @@ computedInvariants:
   H^n, Tor_i, generators, supports, dimensions, ranks, representatives.
 
 analyticReadings:
-  distance, mass, spectrum, residual norm, barcode, repair cost.
+  distance, mass, spectrum, residual norm, harmonic mass, barcode, repair cost,
+  Wasserstein transfer cost, Morse collapse reading, monodromy index.
 
 assumptions:
   adequacy, exactness, finite regime, common ambient, base change, detecting profile.
 
 nonConclusions:
-  unselected laws, unmeasured support, source extraction completeness, empirical validity.
+  unselected laws, unmeasured support, unprovided coefficient data, undecided predicates.
 ```
 
 ### 原則 11.2 Measurement Packet Is Bounded
@@ -879,12 +1081,15 @@ refactor transport maps and invariance conditions
 cellular sheaf Laplacian analytic distances
 LawConflict base-change conditions
 support-localized transfer residues
+Hodge / harmonic decomposition readings
+monotone stability readings
+Wasserstein transfer cost readings
+discrete Morse repair readings
+curvature transfer spectrum readings
 measurement verdict boundary
 ```
 
-この synthesis は、実コード抽出の完全性、ArchSig 実装、FieldSig governance、
-empirical validation を主張しない。
-それらは、Part VIII の measurement packet を下流 artifact として読む別 surface の責務である。
+この synthesis は、選ばれていない data、support、coefficient、law universe に対する結論を主張しない。
 
 ### 原則 12.2 What Part VIII Adds
 
@@ -918,4 +1123,73 @@ unknown:
 ```
 
 Part VIII は、AAT 本文の純数学的側に残る。
-実際の codebase、tool execution、schema、fixture、empirical report は、この章の外側で扱う。
+選ばれていない外部過程や応用上の判定手続きは、この章の内部対象ではない。
+
+### 定理 12.3 Finite Measurement Comparison Theorem (AAT-GAGA) [Certified bounded inference]
+
+finite measurement regime `M` で、次を固定する。
+
+```text
+finite poset site X_M.
+finite cover U_M.
+abelian coefficient sheaf F with inner products.
+cellular cochain model C^n(X_M,F).
+square-free witness regime where used.
+common ambient for selected LawConflict readings.
+stability distance and comparison maps where an applicable stability theorem is fixed.
+```
+
+このとき、`M` の範囲で次の比較 reading を同時に扱える。
+
+```text
+Hodge comparison:
+  H^n(X_M,F) ≅ ker L_n.
+
+harmonic decomposition:
+  cochains split into exact, harmonic, and coexact components.
+
+period accounting:
+  <d omega, gamma> = <omega, boundary gamma>.
+
+topological capacity:
+  low-degree obstruction capacity is controlled by the selected nerve data.
+
+derived conflict accounting:
+  monomial LawConflict can be read by Tor and Hilbert-series accounting.
+
+stability candidate interface:
+  monotone witness filtrations admit persistence stability readings only
+  in the regime of theorem candidate 6.5 or another fixed stability theorem.
+```
+
+この theorem は、代数的 obstruction data と analytic / combinatorial readings を、
+明示された finite profile の中で比較するための束である。
+ただし theorem candidate に依存する条項は、この theorem の certified 結論ではなく、
+その candidate regime を追加した場合の interface として読む。
+名前の `GAGA` は、代数的対象と analytic reading の比較を表す比喩であり、
+未選択の data source や外部手続きの忠実性を主張しない。
+
+### 原則 12.4 AAT-GAGA Boundary
+
+AAT-GAGA は selected finite measurement profile の中でだけ読む。
+
+```text
+constructed AAT geometry
+  + finite profile
+  + exactness / adequacy assumptions
+  ----------------------------------
+comparison reading.
+```
+
+次は結論しない。
+
+```text
+all unselected data are complete.
+all external procedures preserve the profile.
+all law universes are measured.
+analytic smallness implies lawfulness.
+```
+
+次の第IX部では、静的な measurement profile から、trace category、state transition presheaf、
+temporal coefficient を持つ
+evolution geometry へ進む。

--- a/docs/aat/algebraic_geometric_theory/part_9_evolution_geometry.md
+++ b/docs/aat/algebraic_geometric_theory/part_9_evolution_geometry.md
@@ -1,0 +1,297 @@
+# 第IX部 Evolution Geometry
+
+## 1. Part8 から Part9 へ
+
+第VIII部では、固定された finite measurement profile の中で、AAT geometry を測定可能に読む条件を定めた。
+しかし、architecture は一つの静的対象としてだけ現れるのではない。
+selected operation、repair、migration、state transition によって、選ばれた geometry の列として現れる。
+
+第IX部の目的は、AAT 本文の純数学的範囲を保ったまま、時間方向を扱う最小の構造を定義することである。
+ここで扱うのは、時間方向の全事象ではない。固定された trace category、
+state transition presheaf、temporal coefficient、law universe、measurement profile の中で、
+時間方向の law と obstruction を読む。
+
+```text
+static geometry:
+  X
+
+evolution geometry:
+  X_0 -> X_1 -> ... -> X_n
+```
+
+この章の主張は、選ばれた trace category、state transition presheaf、temporal coefficient の内部に限られる。
+その外側の事象、遷移、状態空間については沈黙する。
+
+## 2. Trace Category
+
+### 定義 2.1 Trace Category
+
+architecture evolution profile `E` に対して、trace category を次で表す。
+
+```text
+Tr_E
+```
+
+`Tr_E` の object は selected time point、operation stage、または abstract event state である。
+射は selected transition を表す。
+
+代表的な射は次である。
+
+```text
+apply transition
+replay transition
+project state
+compensate action
+migrate state
+invert selected transition
+compose transitions
+```
+
+trace category は、実ログの完全性を主張しない。どの transition を object / arrow として採用するかは
+evolution profile の一部である。
+
+### 原則 2.2 Trace Relativity
+
+時間方向の law は、選ばれた trace category に相対化される。
+
+```text
+different trace category
+  -> different temporal law reading.
+```
+
+未選択の event、path、external state について、AAT 本文は zero / lawful / safe を主張しない。
+
+## 3. State Transition Presheaf
+
+### 定義 3.1 State Transition Presheaf
+
+AAT site `X` と trace category `Tr_E` を固定する。
+各 context `W` と trace object `t` に、`W` 上で時刻 `t` に見える state space と
+transition monoid を割り当てる presheaf を state transition presheaf と呼ぶ。
+
+```text
+St_A(W,t)
+  =
+  State_A(W,t)
+  together with
+  Trans_A(W,t)
+```
+
+ここで `State_A` は selected state presheaf であり、`Trans_A` は selected transition monoid presheaf である。
+restriction は、context restriction に沿って state と transition を制限する。
+
+```text
+res_{W,V} : St_A(W,t) -> St_A(V,t)
+```
+
+descent 条件が selected regime で確認されている場合、この presheaf を state transition sheaf と呼んでよい。
+
+### 定義 3.2 Temporal Coefficient
+
+temporal law data の差、mismatch、gluing defect を測る abelian coefficient sheaf を
+temporal coefficient と呼び、次で表す。
+
+```text
+TempCoeff_A
+```
+
+`TempCoeff_A` は state transition presheaf 全体ではない。
+state や transition の差が abelian coefficient として読める selected regime を固定したときに、
+temporal obstruction の係数として使う。
+
+### 定義 3.3 Temporal Law
+
+temporal law は、`St_A` と `Tr_E` の上の可換図式または関係式として読む。
+
+代表例は次である。
+
+```text
+replay(e, replay(e, s)) = replay(e, s)
+decode(encode(s)) ~ s
+compensate(action(s)) ~ s
+migrate(project_old(s)) = project_new(migrateEvents(s))
+```
+
+これらは slogan ではなく、選ばれた state transition presheaf 上の equation または descent condition である。
+
+### 定義 3.4 Temporal Obstruction
+
+temporal law `L_t` が selected context family 上で局所的に成立するが、trace composition や restriction と
+整合しない場合、その mismatch を temporal obstruction と呼ぶ。
+
+```text
+Ob_t in H^n(Tr_E x X, TempCoeff_A)
+```
+
+ここで `Tr_E x X` は、trace category と AAT site から作る selected product site または incidence model である。
+積構造、temporal coefficient、mismatch cocycle が固定されていない場合、上式は定義ではなく
+reading schema として扱う。
+
+## 4. Temporal Descent
+
+### 定義 4.1 Replay Descent Data
+
+cover `U = {W_i -> W}` と trace arrow `e : t -> t'` を固定する。
+各 `W_i` 上に replay data
+
+```text
+r_i : State_A(W_i,t) -> State_A(W_i,t')
+```
+
+があるとする。
+overlap 上の差が temporal coefficient の 1-cocycle `m(r)` として読めるとき、これを
+replay descent data と呼ぶ。
+
+### 定理 4.2 Temporal Descent Criterion [Certified bounded inference]
+
+次を仮定する。
+
+```text
+Tr_E and X are finite.
+selected product/incidence site Tr_E x X is fixed.
+TempCoeff_A is an abelian coefficient sheaf in the selected regime.
+local replay data has a temporal mismatch cocycle m(r).
+[m(r)] = 0 in H^1(Tr_E x X, TempCoeff_A).
+```
+
+このとき、selected regime では local adjustment の後、replay data は大域 transition として貼り合う。
+
+```text
+temporal mismatch class = 0
+  +
+adjust local replay data by a 0-cochain
+  =>
+global replay transition exists.
+```
+
+これは、全時間列の再構成を主張しない。固定された trace category と temporal coefficient の中で、
+局所 transition data の mismatch が coboundary なら大域 transition へ貼れることを読む。
+
+## 5. Dissipative Policy
+
+### 定義 5.1 Evolution Functional
+
+measurement profile `M` の中で、architecture state `A` に非負値を与える reading
+
+```text
+Phi_M(A)
+```
+
+を evolution functional と呼ぶ。
+
+代表例は次である。
+
+```text
+obstruction mass
+harmonic mass ||h(g)||
+distance-to-flatness
+transfer residue norm
+```
+
+### 定義 5.2 Dissipative Policy
+
+operation family `F` が `Phi_M` に関して dissipative であるとは、すべての selected operation
+`f : A -> B` について次が成り立つことである。
+
+```text
+Phi_M(B) <= Phi_M(A)
+```
+
+strictly dissipative であるとは、selected non-terminal state で不等号が strict になることである。
+
+### 定理 5.3 Finite Dissipation Stopping [Certified bounded inference]
+
+次を仮定する。
+
+```text
+selected state set is finite.
+Phi_M takes values in a well-founded ordered set.
+selected operation policy is strictly dissipative outside terminal states.
+```
+
+このとき、任意の selected evolution path は有限時間で terminal state に到達する。
+
+これは、terminal state が lawful であることを意味しない。terminal state が lawful であるためには、
+Part III / IV の obstruction vanishing、exactness、coverage assumptions が別途必要である。
+
+## 6. Lyapunov Reading
+
+### 定義 6.1 AAT Lyapunov Reading
+
+evolution functional `Phi_M` が dissipative policy に沿って非増加であり、selected obstruction zero の近くで
+最小値を取るとき、`Phi_M` を AAT Lyapunov reading と呼ぶ。
+
+```text
+Phi_M(A) = ||h(g_A)||
+```
+
+は、調和的負債分解がある場合の代表例である。
+
+### 原則 6.2 Lyapunov Is Not Forecast
+
+Lyapunov reading は、選ばれた finite evolution profile の中での散逸性を読む。
+未選択の transition、未構成の状態空間、将来の任意 path については主張しない。
+
+```text
+dissipative in profile
+  !=
+dissipative outside the selected trace category.
+```
+
+## 7. Force Integrability Reading
+
+### 定義 7.1 Force
+
+evolution geometry 上の force は、architecture state を次の state へ送る selected transition である。
+
+```text
+F : A_t -> A_{t+1}
+```
+
+force が local law data を大域 law data へ積分できるとき、integrable force と呼ぶ。
+
+### 定理候補 7.2 Force Integrability Obstruction
+
+force `F` により生じる temporal mismatch class
+
+```text
+ob(F) in H^1(Tr_E x X, TempCoeff_A)
+```
+
+が定義されているとする。
+このとき、
+
+```text
+ob(F) != 0
+```
+
+なら、選ばれた temporal law data は `F` に沿って大域 evolution へ積分できない、と期待する。
+
+この主張は theorem candidate である。`ob(F)` の構成、coefficient exactness、trace product site、
+temporal descent の検出性を固定して初めて定理になる。
+
+## 8. Part9 の結論
+
+第IX部では、AAT geometry の時間方向を trace category、state transition presheaf、temporal coefficient によって
+定式化した。
+
+```text
+Trace category
+  -> State transition presheaf
+  -> Temporal coefficient
+  -> Temporal law
+  -> Temporal obstruction
+  -> Dissipative policy
+  -> Lyapunov reading
+```
+
+これにより、AAT は次を純数学的に扱える。
+
+```text
+local transition laws
+but
+global temporal obstruction remains
+```
+
+この章は、未選択の trace、未構成の transition、任意の将来 path について主張しない。
+第IX部の結論は、固定された temporal / evolution geometry の内部でだけ読む。

--- a/docs/note/aat_ag_porting_bridges_grand_theorems.md
+++ b/docs/note/aat_ag_porting_bridges_grand_theorems.md
@@ -1,0 +1,428 @@
+# AAT代数幾何版 拡張考察: 旧本文からの移植・他分野への橋・大定理候補
+
+- 対象: `docs/aat/algebraic_geometric_theory/`(第I〜VIII部+付録A/B、2026-06-12 時点)
+- 比較対象: `docs/aat/mathematical_theory/`(旧数学本文、全4部)、`docs/note/` の旧体系定理ノート4本、`Formal/Arch/` の旧体系 Lean 資産
+- 実施日: 2026-06-12
+- 位置づけ: フルレビュー(`aat_algebraic_geometric_theory_full_review.md`、2026-06-11)とその反映(#1900 数学本文補強、#1901 計測理論=第VIII部追加)を前提に、次の三問に答える。
+  1. 旧数学本文から移植できる要素は何か
+  2. 代数幾何から解析などへ、実コードを効果的に解析できる橋は架けられるか
+  3. 複数分野に橋をかけ、コードベース構造に新しいインサイトを与える大定理を発見できるか
+
+本ノートの主張ラベルは本文の規律に従う。`[証明可能]` は有限 regime で標準的手法により証明が書けると判断したもの、`[輸入]` は外部分野の既知定理の decoration で得られるもの、`[候補]` は証明設計が必要なもの、`[プログラム]` は定式化自体に設計が残るものを指す。
+
+---
+
+## 0. 要旨
+
+- 移植: 旧本文には AG 版が**まだ持っていない計測の量的核**が眠っている。最重要は4点 — (P1) ホモトピー生成元族(π₁^AAT の表示を与え、第VI部の ill-defined 性を解消する)、(P2) 計測モノドロミー μ_x / AMI(Lean 形式化済み資産ごと第VI×VIII部に接続)、(P3) 状態遷移代数(AG 版に不在の temporal 層の実体)、(P4) 距離・充填幾何の量的核(margin 安定性、観測ギャップ下界、Dehn 関数、bi-Lipschitz 忠実性)。
+- 橋: 第VIII部が用意した有限 regime(有限 poset site + square-free + cellular sheaf)は**ハブ**であり、そこから Hodge 理論、最適輸送、離散 Morse 理論、スペクトル理論、力学系へ**スポーク**が架かる。どの橋も「実コードで何が新しく測れるか」を一つずつ持つ。
+- 大定理: 提案の筆頭は **G1 有限アーキテクチャ計測の基本定理**(AAT-GAGA)— 「有限 regime において、コードベースの代数的負債幾何は、数値線形代数によって忠実かつ安定に読める」を5条項(比較・分解・会計・位相・安定)に分けた束。うち4条項は今すぐ証明可能で、各条項が単独でも実務的な読みを持つ。G2(位相的負債定理)と G3(調和的負債分解)は特に、「**分解の形そのものが隠れ結合の容量を決める**」「**局所修正では消えない本質負債の質量が一意に定まる**」という、既存のどの計測ツールも出していない結論を出す。
+
+---
+
+## 1. 現状認識: 第VIII部追加後も残る弱点
+
+フルレビュー後の2コミットで、critical 6件は修正され(定理9.3 の zero-reflecting 集約化、scheme gluing の locally ringed 化、定理11.1 の abelian effective torsor 化+証明、第V部 transfer の support-localized 再構築、smooth/singular の DefTest 単一条件化)、第VIII部が計測 profile・verdict 規律・有限計算可能性・Stanley-Reisner/Alexander 双対・sheaf Laplacian・common ambient・support-localized transfer を整備した。これは大きな前進である。その上で、「実コード適用・計測がまだ弱い」原因は次の6点に特定できる。
+
+```text
+W1. 本丸の定理が candidate のまま:
+    安定性 (VIII 定理候補6.3)、LawConflict base change (9.2)、transfer 下界 (10.4)。
+    計測値のノイズ耐性は依然「証明対象が明示された」段階。
+
+W2. monodromy 経路が未開通:
+    第VI部の pi_1^AAT は構成が選択依存のまま (operation homotopy は付録B台帳で
+    future design obligation)。VIII 原則7.4 自身が
+    「no operation groupoid -> no monodromy measurement」と認めている。
+
+W3. temporal / dynamics 層の不在:
+    state transition、event sourcing、replay は AG 版に名前 (State_A, temporal law,
+    trace topos) しかない。時間発展を測る数学が本文にない。
+
+W4. 解析読みと構造判定の間の定理不足:
+    Laplacian の residual norm や distance は analytic reading として定義された
+    (VIII §8) が、構造的 verdict との間に「最小性」「下界」「分解」の定理がない。
+    near-flat != lawful という非主張だけでは、解析値を判断に使えない。
+
+W5. worked example がコード断片起点でない:
+    付録B は擬円周+抽象 witness (p,q,r) であり、第I部 例1.4 のコード断片から
+    付録B の pipeline までを貫く例がまだない (レビュー E1 の半残)。
+
+W6. 旧体系 Lean 資産が AG 台帳に未接続:
+    MonodromyMeasurement / HomotopyHolonomyStokes / CurvatureTransferSpectrum /
+    DistanceGeometry は guardrail として存在するが、AG 版の theorem label とは
+    無関係のまま。AG 有限 regime ならこれらの「仮定として持ち込まれた不等式」を
+    本物の定理に昇格できる。
+```
+
+以下、移植(§2)が W2/W3/W4/W5/W6 を、橋(§3)と大定理(§4)が W1/W4 を狙う。
+
+---
+
+## 2. 問1: 旧数学本文からの移植プラン
+
+旧本文(mathematical_theory 全4部)と AG 版の差分を取った。第I部(Atom 公理系、コード断片からの抽出例 1.4 を含む)はほぼ全量移植済み。**未移植の本体は旧第II部後半・第III部・第IV部に集中しており、それはちょうど「計算・例・距離」**、つまりユーザーが弱いと感じている部分である。これは偶然ではない: AG 化の過程で「構造の階層」(site/sheaf/ideal/cohomology)が先に運ばれ、「量の幾何」(距離・コスト・スペクトル・状態遷移)が後回しになった。
+
+### 2.1 移植インベントリ(優先度順)
+
+| # | 旧本文の要素 | 移植先 | 規模 | 何が変わるか |
+| --- | --- | --- | --- | --- |
+| P1 | ホモトピー生成元族(II 定義11.1: independent square / same contract replacement / repair filler / identity / associativity) | 第VI部 §9 | 中 | π₁^AAT を「selected generator 族による operation groupoid の表示」として再定義。レビュー指摘(π₁ が群にならない)の解消経路 |
+| P2 | 計測モノドロミー(II §12: Cont_x、μ_x、AMI、命題12.4/12.5)+ Lean 資産 | 第VI部 §10–11、第VIII部 | 中 | Mon を「測れる2-cell(square)上の有限 Gauss-Manin」として先に定義。`MonodromyMeasurement.*` の proved 定理を AG 台帳に接続 |
+| P3 | 状態遷移代数(III §7–8: transition law、replay/roundtrip/compensation/migration naturality) | 新節(第VII部付録 or 第IX部) | 大 | site 上の「遷移モノイドの層」St_A を置き、temporal law を trace category 上の law として実体化。付録A.6 の Temporal law スロットと付録B 台帳の trace topos obligation を充足 |
+| P4 | 距離・充填幾何の量的核(IV 命題4.5/4.6、定義5.5、命題7.3、定義7.4、定義8.1/8.2) | 第VII部 §8–12、第VIII部 | 中 | margin 安定性・観測ギャップ下界・Dehn 関数・bi-Lipschitz 忠実性。G3(c) のコスト接続と新不変量 Dehn_X を供給 |
+| P5 | グラフ/行列表現の定理群(III 命題1.3/2.4/3.3/3.5/4.2/4.4: 冪零性↔非巡回性、walk count、spectral radius) | 第VII部 §3 | 小 | R_graph、R_matrix を「定義済み functor + 証明済み preservation/reflection 実例」に格上げ。枠組み宣言(C判定)だった §3 に実体を入れる |
+| P6 | Operation-Invariant Galois 対応(II 定理6.9) | 第VI部 §12 | 小 | Ops ⊣ Inv の Galois 接続を refactor groupoid の部分 groupoid と保存 invariant 族の間の随伴に格上げ。橋 B4(抽象解釈)とも同じ語彙になる |
+| P7 | 修復停止性・健全性(II 命題8.3/8.4) | 第V部 §8、第VIII部 | 小 | well-founded な comparison profile の下で repair 戦略の停止性。**Lean 化候補の筆頭**(decidable・有限) |
+| P8 | 拡張公式・境界ホロノミー予想(II 定義7.5、予想7.6) | 第IV部 §8–9 の系 | 小 | κ_U(B) = κ_U(A) + κ_U(f) + Hol_U(∂) を Mayer-Vietoris 長完全列の系として読み直し、`boundary_holonomy_conjecture.md` を AG 版でクローズ |
+| P9 | ドメイン worked example(III §9–13: User model、Coupon 拡張、static-flat-semantic-obstruction、repair transfer、SOLID 反例) | 付録B §B.8 | 中 | 例1.4 のコード断片 → site → I_Ob → H¹ → Tor → period → verdict を**一気通貫**で計算(W5 解消、レビュー E1 完遂) |
+| P10 | ACTS(III 定義6.6: curvature transfer spectrum)+ `CurvatureTransferSpectrum.lean` | 第VIII部 §8 | 中 | (support × axis) グラフ上の transfer 作用素とそのスペクトル半径読み。橋 B9/B11 の足場 |
+
+### 2.2 移植の要諦4点(詳説)
+
+**P1: ホモトピー生成元族が π₁^AAT を治す。**
+第VI部の現行構成は「operation category → 可逆化 → selected operation homotopy で商 → 基点選択」だが、「selected operation homotopy」が何かを与えるデータがどこにもない。旧II部 §11 はまさにそれを持っている:
+
+```text
+homotopy generator family H:
+  independent square        (独立な2操作の交換)
+  same contract replacement (同一契約の置換)
+  repair filler             (修復の充填)
+  identity insertion/deletion
+  associativity reassociation
+```
+
+AG 版での正しい置き場所は「**表示(presentation)**」である。operation graph を 1-骨格、selected generator 族 H の各関係を 2-cell とする presentation 2-complex K_H(X,U) を作り、
+
+```text
+pi_1^AAT(X, U, H) := edge-path group of K_H(X,U)
+```
+
+と定義する。これで (i) 群であることが構成から従い、(ii) H への相対化が明示され(本文の規律と整合)、(iii) 有限 regime では有限表示群として計算対象になり、(iv) μ_x(P2)が「2-cell で埋まらない square の検出器」として位置づく。レビュー提案 T9 の具体化であり、第VI部の Monodromy Debt 定理が型1/型3病から脱出する最短路である。
+
+**P2: モノドロミーは「測れる版」を正典にする。**
+旧II部 §12 の μ_x(f,g;A) = d_x(Cont_x(g∘f), Cont_x(f∘g)) は、square という最小ループ上のモノドロミー欠陥であり、有限・計算可能・Lean guardrail 済み(`AxisDefect.observationDiff_of_nonzero` 等は proved)である。AG 版では:
+
+```text
+square = K_H の生成 2-cell の境界 loop
+mu_x(square) = その loop に沿う係数層の transport のずれの selected reading
+AMI_X = 重み付き総和 (VIII の measurement packet の analytic reading)
+```
+
+として、第VI部の Gauss-Manin 系(定義10.2)の**最小実例**に位置づける。一般の rho_U が「与えられていれば」の仮定付き対象である一方、square-level transport は P1 の表示から構成できる。これにより VIII 原則7.4 の「no groupoid → no monodromy measurement」が「P1 の groupoid があるので測れる」に転じ、W2 が解消する。旧 Lean 資産は台帳(`lean_theorem_index.md`)経由で AG ラベルに対応行を持たせる(W6)。
+
+**P3: 状態遷移代数は AG 版の「時間」になる。**
+AG 版は空間方向(context の貼り合わせ)は豊かだが、時間方向(状態と効果の発展)は名前しかない。旧III部 §7–8 の遷移代数
+
+```text
+replay(e, replay(e, s)) = replay(e, s)
+decode . encode ~= id
+compensate . action ~= id
+migrate ; project_old = project_new ; migrateEvents
+```
+
+は、site 上の層として持ち込める: 各 context W に「W 上で見える状態空間と遷移モノイド」St_A(W) を割り当て、遷移 law を St_A 上の関係式(= 可換図式)として読む。temporal law(付録A.6)は「trace category 上の subfunctor」と宣言されているが、その trace category の最小モデルが St_A の自由圏である。Event Sourcing / Saga / migration naturality が AG の言葉(naturality = 図式可換 = H⁰ 零)で読め、しかも μ_x(P2)の主要な軸(semantic / effect 軸)の実体を供給する。
+
+**P4: 距離・充填幾何は「解析読みの定理化」の素材である。**
+旧IV部には、AG 版第VII部が枠組み宣言で終わっている部分の量的中身が既にある。特に:
+
+```text
+命題4.6 Margin Stability:
+  length_signature(P) < margin(A_0) なら、測定済み軸 scope で P は Safe を出ない。
+
+命題7.3 Observation Gap Lower Bound:
+  観測 O が filling generator に対し L-Lipschitz で d_obs(O(P),O(Q)) = delta なら
+  fill_cost(P . Q^{-1}) >= delta / L。
+
+定義7.4 Architectural Dehn Function:
+  Dehn_A(n) = max { minimal filling area of loop l | boundary_length(l) <= n }。
+```
+
+Margin Stability は「安定性」という語の入った**証明可能な最初の主張**(三角不等式だけで出る)。Observation Gap Lower Bound は G3(c) の修復コスト下界の供給源。Dehn 関数は幾何学的群論からの新不変量で、「局所的なずれを局所的に直せる architecture か、大域 rewrite を要求する architecture か」を一つの増大度関数で表す — P1 の表示 2-complex K_H 上で定義でき、π₁ の語の問題・等周不等式の理論と直結する。
+
+### 2.3 移植しなくてよいもの
+
+- 旧 I 部(Atom 公理系、抽出例): 移植済み。
+- 旧 II 部 §1–5(flatness model、zero curvature、三層 flatness): AG 版第III部の lawful locus と第I部定理9.3(修正版)が上位互換。三層 flatness の「層間非含意」だけは P9 の例に残す価値がある。
+- 旧 IV 部 §9–10(DistanceValue、bounded diagnostic conclusion): 第VII部 §9・第VIII部 measurement packet として移植済み。
+
+---
+
+## 3. 問2: 他分野への橋 — ハブ&スポーク設計
+
+レビューの B1–B8 のうち、B1(組合せ可換代数)と B2(TDA)と B3(cellular sheaf Laplacian)は第VIII部が入口まで建設した。ここでは**橋の全体設計**を提案し、新しい橋 B9–B12 を加える。
+
+### 3.1 設計原理: 一つのハブ、多くのスポーク
+
+すべての橋は同じハブを通る。
+
+```text
+ハブ (第VIII部の有限 regime が既に用意):
+  cover nerve 多重グラフ N(U)        (chart = 頂点, overlap 成分 = 辺, 三重 = 面)
+  Stanley-Reisner 複体 Delta_U       (square-free witness regime)
+  monomial Tor 加群 LawConflict_i    (common ambient)
+  cellular sheaf model (C^n, d_n)    (内積付き有限線形代数)
+  presentation 2-complex K_H         (P1 が追加)
+
+スポーク (各分野が読むもの):
+  B1  組合せ可換代数   : Hochster 公式, Alexander 双対, lcm-lattice
+  B2  TDA             : persistence barcode, interleaving 安定性
+  B3+ Hodge 理論      : 調和分解, スペクトル, 距離   (→ G1, G3)
+  B9  最適輸送        : 負債移送コスト, Wasserstein 距離 (新規)
+  B10 離散 Morse 理論  : 臨界胞体, 修復 = collapse 列   (新規)
+  B11 スペクトルギャップ: Cheeger 型不等式, hotspot 局在  (新規)
+  B12 力学系 / SFT    : Lyapunov 関数, 散逸場, アトラクタ (新規)
+  B6  証明複雑性      : NSdepth = PC degree, 下界技術   (レビューどおり)
+```
+
+要点は、**抽出は一度、解析は多面**ということである。ArchSig 実験(`archsig_private_python_repo_aat_structural_readings.md`)が示したとおり、実リポジトリで高くつくのは観測(ArchMap 構築と coverage)であり、ハブの組合せ対象さえ作れば、スポーク側は既製ツール(Macaulay2、GUDHI/Ripser、LAPACK、LP ソルバ)が走る。
+
+### 3.2 B3+ Hodge 理論の橋を渡り切る `[証明可能]`
+
+第VIII部 §8 は Laplacian と residual norm を定義したが、W4 のとおり「解析値が構造について何を保証するか」の定理がない。渡り切るのに必要なのは有限次元 Hodge 理論そのもの:
+
+```text
+C^n = im d_{n-1}  ⊕  Harm^n  ⊕  im d_n^*       (直交直和)
+Harm^n = ker L_n ≅ H^n(X_M, Ob_M)
+```
+
+これが §4 の G3(調和的負債分解)に直結する。実コードで新しく測れるもの: **mismatch の「局所修正で消える成分 / 本質成分」への一意直交分解**と、本質成分のノルム(= どれだけ局所 patch を重ねても残る負債の質量)。さらにスペクトルギャップ λ_min(L_1 の非零最小固有値)は「いま H¹ が零でも、どれだけ小さな摂動で非零になりうるか」の頑健性指標になる(B11)。
+
+### 3.3 B9 最適輸送: 負債は消えない、移送される — を距離にする `[輸入]`
+
+旧IV部 §6.3 の curvature transport と第V部の transferred obstruction は「移る」ことを述べるが、「どれだけのコストで移るか」を測る距離がない。obstruction measure Ω_U(A)(support 上の非負測度)に対し、support グラフ(= N(U) または K_H の 1-骨格)上の最短路距離を ground metric とする Wasserstein 距離
+
+```text
+W_1(Omega_U(A), Omega_U(op(A)))
+```
+
+を transport cost と定義する。有限なので Kantorovich 双対は線形計画で厳密に解ける。狙う定理(候補):
+
+```text
+Transfer Cost Lower Bound:
+  repair op が axis x の負債質量 m を support s から消すとき、
+  全 axis 総質量が保存される profile では、W_1 >= m * dist(s, 最近接の吸収可能 support)。
+```
+
+実コードで測れるもの: 「この修復は負債を消したのか、隣のモジュールに 2 ホップ移しただけか」が**数値**になる。ArchSig 実験で観測された pressure chain(request-authority → transaction → domain-artifact → AI-surface)は、まさに transport 経路の観測例である。
+
+### 3.4 B10 離散 Morse 理論: 修復計画 = collapse 列 `[輸入]`
+
+第VIII部 §5 の Alexander 双対は minimal repair hitting set(どの witness を打てば良いか)を与えるが、「どの順に打つか」は与えない。Δ_U 上の離散 Morse 関数 / acyclic matching を選ぶと:
+
+- 臨界胞体 = 既約な obstruction パターン(打っても複体の型が変わらない本質部分)
+- matching に沿う collapse 列 = ホモトピー型を保ったまま複体を縮める「安全な簡約順序」
+
+が得られ、persistence 計算(B2)の前処理としても標準的に効く。狙う読み: **repair route(第VII部 §12)の組合せ的実体は Δ_U の collapse 列であり、structural repair の最小手数は臨界胞体数で下から押さえられる**。
+
+### 3.5 B12 力学系 / SFT: 進化の幾何 `[プログラム]`
+
+`Grothendieck_Derived_AAT-SFT.md` の構想(evolution family π: 𝔛 → B、field、force、ForecastCone)のうち、いま数学にできる最小核は:
+
+```text
+commit 列 = 有限力学系:  A_0 -> A_1 -> ...   (force = 射)
+CI/review policy = 散逸場: 許される force を omega 非増加に制限する場
+Phi_U = omega_U (または harmonic mass ||h(g)||) を Lyapunov 候補とする
+```
+
+P7(停止性)+ zero-reflecting 集約(定理9.3 修正版)から、「散逸場の下で軌道は有限時間で停留し、停留点で Phi が局所最小」までは初等的に出る。その先(Flat への到達可能性、ForecastCone の H¹ 障害 = Force Integrability)はプログラムとして第IX部候補に置く。実務読み: **CI ポリシー設計 = Lyapunov 関数設計**という語彙が得られる。
+
+### 3.6 橋ごとの「実コードで新しく測れるもの」一覧
+
+| 橋 | 測れるもの | 既製ツール | 前提 |
+| --- | --- | --- | --- |
+| B1 | β_{i,j}(I_Ob)(絡まり方の高次構造)、minimal repair set | Macaulay2 | square-free regime |
+| B2 | 負債の barcode(law 強度・時系列に沿う寿命) | GUDHI/Ripser | filtration 選択 |
+| B3+ | 本質負債質量、スペクトルギャップ、harmonic hotspot | LAPACK | 内積選択 |
+| B9 | 負債移送コスト W_1、修復の「移しただけ」検出 | LP ソルバ | 測度・ground metric 選択 |
+| B10 | 既約 obstruction パターン、安全な簡約順序 | 自前(小規模) | Δ_U |
+| B11 | 整合性の頑健性(near-miss 検出)、ボトルネック境界 | LAPACK | B3+ |
+| B12 | policy の散逸性、軌道の停留保証 | なし(理論) | P7 |
+| B6 | 修復不能性証明書の深さ NSdepth | Gröbner/SAT | Boolean regime |
+
+---
+
+## 4. 問3: 大定理候補
+
+方針: 「大きい」とは、(i) 複数分野を一つの主張で束ね、(ii) 実コード計測に直接降り、(iii) 既存本文の語彙(site / I_Ob / H^n / Tor / period / profile)で述べられること。誇大主張を避けるため、各定理に証明経路と状態を付す。**G2〜G6 は今すぐ証明に着手できる**。
+
+### G1. 有限アーキテクチャ計測の基本定理(AAT-GAGA)`[束: 条項ごとに証明可能〜候補]`
+
+> **主張(束)**: 有限計測 regime M(有限 poset site、module 係数、内積固定)において、コードベースの代数的負債幾何は数値線形代数によって忠実かつ安定に読める。すなわち:
+>
+> ```text
+> (1) 比較   : H^n_alg(U_M, Ob_M) ≅ Harm^n = ker L_n     [証明可能: 有限 Hodge]
+> (2) 分解   : C^n = im d ⊕ Harm^n ⊕ im d^*、調和代表元は
+>              各 cohomology 類のノルム最小元                [証明可能]
+> (3) 会計   : <delta(b), gamma> = <b, ∂gamma>             [証明可能: 随伴性]
+> (4) 位相   : dim H^1 の容量は nerve の組合せ量で制御される   [証明可能: G2]
+> (5) 安定   : d_interleaving(H^*(F), H^*(F')) <= d_wit(F,F') [単調系: 輸入で証明可能 /
+>                                                             zigzag: 候補]
+> ```
+
+名前の由来: GAGA が「代数的 = 解析的」の比較定理であるように、(1)–(2) は「代数的 obstruction 類 ↔ 調和的(解析的)代表元」の比較である。意義: 第VIII部の verdict 規律に「**解析読みが構造判定の忠実な代理になる条件と限界**」という定理的裏づけを与え、W1/W4 を一括で塞ぐ。各条項は以下 G2〜G7 として単独でも価値を持つ。
+
+### G2. 位相的負債定理(形が負債を強制する / 局所レビュー十分性)`[証明可能]`
+
+有限 poset regime で cover U = {W_i → W} を取り、overlap 成分を辺、三重 overlap 成分を面とする **nerve 多重グラフ/複体 N(U)** を作る(付録B の擬円周は頂点2・平行辺2、b_1 = 1)。
+
+> **(a) 容量下界(無条件)**:
+> ```text
+> dim_k H^1(U, F) >= Σ_辺 dim F(W_e) − Σ_頂点 dim F(W_v) − Σ_面 dim F(W_t)
+> ```
+> (rank-nullity のみ。restriction 写像の中身に依存しない。)
+>
+> **(b) 定数係数の等式**: F = 定数層 k なら H^1(U, k) ≅ H^1(N(U); k)、次元は b_1(N(U))。
+>
+> **(c) 局所レビュー十分性(消滅定理)**: N(U) が森(b_1 = 0、三重 overlap なし)で、
+> すべての restriction F(W_i) → F(W_e) が全射なら、H^1(U, F) = 0。
+> すなわち**互換な局所 lawful family は、この形の分解の下では必ず大域に貼り合う** —
+> どの module 係数読みに対しても同時に。
+>
+> **(d) χ 保存則**: χ(U, F) = Σ (−1)^n dim C^n は (nerve, stalk 次元) のみで決まる。
+> cover の形と stalk 次元を保つ refactor は、負債を次数間で動かせても
+> 交代和を変えられない。
+
+証明経路: (a)(d) は線形代数、(b) は定数係数 Čech の標準事実、(c) は木上の貪欲解法(根から伝播)。すべて有限で Lean 化候補。
+
+橋: グラフ理論(cycle rank)↔ 層係数 cohomology ↔ レビュープロセス設計。
+
+実務インパクト: **b_1(N(U)) = 「統合レビューが必要な独立ループの本数」**という、分解(モジュール境界の引き方)だけから計算できる数が得られる。b_1 = 0 + 全射 restriction なら局所レビューで大域 lawfulness が保証され、b_1 > 0 なら隠れ結合類の置き場がちょうど b_1 次元ぶん**構造的に存在する**(中身のコードと無関係に)。マイクロサービスの「境界は増えたのに統合バグが減らない」現象は、b_1 が分解で増大したことの帰結として説明できる。原則4.4(群の非零 ≠ 類の非零)とも整合する: (b) は容量、定理7.1 系は実弾、という分業になる。
+
+### G3. 調和的負債分解定理(本質修復下界)`[証明可能 + コスト接続は移植仮定付き]`
+
+cellular sheaf model(VIII §8)で mismatch 1-cocycle g(定義5.2 の gluing mismatch)を取る。
+
+> **(a) 分解**: g は一意に g = d_0 c + h(g) + d_1^* e と直交分解し、h(g) は [g] の調和代表元。
+>
+> **(b) 残差最小性**:
+> ```text
+> min_{c in C^0} || g − d_0 c || = || h(g) ||
+> ```
+> 局所調整(0-cochain の張り替え)で到達できる残差の最小値は調和部分のノルムであり、
+> 最小化子は調和代表元で達成される。
+>
+> **(c) 本質修復下界**: || h(g) || > 0 なら、profile(site・stalk・law ideal)を変えない
+> いかなる局所調整列も mismatch を消せない。さらに P4 の観測ギャップ下界
+> (cost が cochain ノルムに対し L-Lipschitz)を仮定すれば、大域 lawfulness に至る
+> 任意の修復計画の cost は || h(g) || / L 以上。
+
+証明経路: (a)(b) は有限次元 Hodge 理論(= 線形代数)。(c) 前半は (b) の系、後半は P4 移植の Lipschitz 公理を仮定に置いた certified bounded inference。
+
+橋: Hodge 理論 ↔ Čech cohomology ↔ 修復コスト幾何。
+
+実務インパクト: hotspot リストが「**局所 patch で消える成分**」と「**境界を跨ぐ作業なしには絶対に消えない本質成分**」に数値で割れる。`||h(g)||` は「本質負債質量」という単一スカラーだが、原則4.3(cohomology is not a metric)に反しない — これは類 [g] の測度であり、類そのものは保持される。第VIII部 distance-to-flatness 読み(定義8.3)に「その距離の下界は調和質量」という定理が付く。
+
+### G4. 周期Stokes会計恒等式(負債の複式簿記)`[証明可能]`
+
+有限 poset homology model(VII 定義5.2A)と Mayer-Vietoris 接続準同型 δ(IV 定義8.3)に対し:
+
+> **主張(随伴性)**: cochain-chain pairing の下で
+> ```text
+> <delta(b), gamma> = <b, ∂gamma>
+> <d omega, gamma>  = <omega, ∂gamma>
+> ```
+> 特に: feature 境界の mismatch section b の holonomy 類 δ(b) を release ループ γ で
+> 読んだ period は、γ の境界に沿って測った局所 mismatch の符号付き和に等しい。
+
+証明経路: 単体的 Stokes(随伴性)そのもの。有限なので完全に初等的。VII 例5.2B / 付録B.6 の pairing 計算(Per = r_sync − r_async)はこの恒等式の実例。旧体系 `HomotopyHolonomyStokes.lean` では Stokes 不等式が「仮定フィールド(boundedStokes)」として持ち込まれていたが、AG 有限 regime では**仮定でなく定理**に昇格する(W6 の模範例)。
+
+橋: 微分幾何の Stokes ↔ Čech/単体 cohomology ↔ 計測監査。
+
+実務インパクト: **監査恒等式**になる。「release サイクル一周で測った drift」=「期間中に記録した境界 mismatch の総和」が**恒等的に**成り立つはずなので、両辺の食い違いはそのまま witness coverage の穴の検出器になる(unmeasured ≠ zero を、規律ではなく**検算**で運用できる)。命名するなら: 負債の複式簿記(double-entry bookkeeping of architecture debt)。
+
+### G5. 法則干渉のHilbert級数恒等式(独立性監査)`[証明可能]`
+
+monomial regime(R = k[E]、graded ideal I_U, I_V)で:
+
+> **主張**: graded Hilbert 級数について
+> ```text
+> H_{R/I_U}(t) · H_{R/I_V}(t) / H_R(t)
+>   = Σ_{i>=0} (−1)^i H_{LawConflict_i(U,V)}(t)
+> ```
+> したがって干渉級数を
+> ```text
+> Int_{U,V}(t) := H_{R/(I_U+I_V)}(t) − H_{R/I_U}(t) H_{R/I_V}(t) / H_R(t)
+>              = H_{Tor_1}(t) − H_{Tor_2}(t) + ...
+> ```
+> と定義すると、「二つの law universe が独立だった場合の期待値」からの joint lawful
+> coordinate ring のずれは、**交代 Tor 質量で厳密に勘定される**。
+
+証明経路: graded 自由分解の Euler 標数(標準)。Macaulay2 で即計算可能。
+
+橋: 交叉理論(Serre 重複度の graded 版)↔ derived 代数 ↔ ポリシー監査。
+
+実務インパクト: 二つのポリシー(例: layering と authority)の「独立性からのずれ」が**次数別のスペクトル**として出る。次数 k の係数は「witness k 個の組合せサイズで起きる干渉量」を局在化する。第V部の「Tor は衝突の構造を読む」という標語が、検証可能な数値恒等式になる。
+
+### G6. 集約5項完全列(尺度安定負債)`[証明可能]`
+
+集約写像(module → package のような粒度変更)を有限 site の射 π : X_fine → X_coarse とすると、Leray 5項完全列:
+
+> ```text
+> 0 → H^1(coarse, π_* Ob) → H^1(fine, Ob) → H^0(coarse, R^1 π_* Ob)
+>   → H^2(coarse, π_* Ob) → H^2(fine, Ob)
+> ```
+> 読み: 細かい尺度の隠れ結合類は、(i) 粗い尺度でも見える成分と、(ii) 集約単位の内部に
+> 局在する成分(R^1 π_*)に**完全列の精度で**分配される。粗い尺度での修復を細かい尺度へ
+> 持ち上げる障害は H^2(coarse) に住む。
+> **尺度安定負債** := selected な集約族すべてについて H^1(coarse) 側から来る類
+> (= Leray スペクトル系列の E_∞ まで生き残る類)。
+
+証明経路: 有限 poset 射の Grothendieck/Leray スペクトル系列(標準)。`AAT_Grothendieck.md` の scale-stable debt 構想の厳密化。
+
+実務インパクト: 「この負債はズームレベルの取り方の産物か、どの粒度でも見える構造か」を完全列で判定。レビュー A.2.1 の coverage 比較射(検証材料が3件未証明のまま)に、最初の証明済みインスタンスを与える。
+
+### G7. 安定性定理(VIII 定理候補6.3 の昇格)`[単調系: 輸入で証明可能 / zigzag: 候補]`
+
+> **主張(単調系)**: 単一 forbidden support の挿入 F → F ∪ {S} は単体的包含
+> Δ_{F∪{S}} ⊆ Δ_F を誘導し、filtration step 計量での interleaving について
+> ```text
+> d_bottleneck(barcode(F), barcode(F')) <= d_wit(F, F')
+> ```
+
+証明経路: 挿入1回 = filtration の1段 = 1-interleaving、あとは persistence 安定性定理(Chazal et al.)の decoration。zigzag(挿入と削除の混在)は Botnan–Lesnick の zigzag interleaving を輸入する設計が必要で、候補のまま。
+
+実務インパクト: T1(レビュー筆頭提案)の単調ケースが定理になり、「commit 1個分の witness 変化で barcode は1ステップ以上動かない」というノイズ耐性保証が初めて立つ。
+
+### G8. SFT 力学定理(可積分性・散逸)`[プログラム]`
+
+P7(停止性)+ G3(Lyapunov 候補 ||h(g)||)+ `Grothendieck_Derived_AAT-SFT.md` の Force Integrability(ob(f) ∈ H¹ ≠ 0 なら force は大域進化に積分不可)を束ね、「CI/review 場の設計 = 散逸構造の設計」を定理群にする。第IX部(Evolution Geometry)として独立させる価値があるが、P1〜P4 と G1〜G6 の後で着手すべき(定式化の自由度がまだ大きい)。
+
+### 大定理候補の相互関係
+
+```text
+        P1 (pi_1 表示)──→ P2 (測れる monodromy)──→ G4 (Stokes 会計)
+                                                      │
+W4 ──→ B3+ (Hodge)──→ G3 (調和分解)──→ G1 (基本定理) ←┤
+                                          ↑           │
+        G2 (位相的負債) ──────────────────┘           │
+        G7 (安定性) ←── B2 (TDA) ─────────────────────┘
+        G5 (干渉級数) ←── B1 (可換代数)
+        G6 (尺度安定) ←── Leray
+        G8 (SFT) ←── P7 + G3
+```
+
+---
+
+## 5. 推奨実行順序
+
+各フェーズは独立に価値が出る。レビューのロードマップ(修正1〜10)は概ね消化済みなので、これはその次の計画である。
+
+| フェーズ | 内容 | 規模 | 充足するもの |
+| --- | --- | --- | --- |
+| 1. 即時の定理化 | G2(a)(c)(d)、G3(a)(b)、G4、G5、G6 を本文化(第IV/V/VIII部の系・新節)。証明はすべて有限線形代数・標準輸入 | 中 | W1/W4 の過半、レビュー T4/T6/T11 の一部 |
+| 2. 移植・第一波 | P7(停止性、**Lean 第1号候補**)、P5(graph/matrix 実例)、P8(境界ホロノミー予想のクローズ)、P9(coupon 一気通貫例 → 付録B.8) | 中 | W5、E1 完遂、旧予想ノート1本回収 |
+| 3. 移植・第二波 | P1 → P2(π₁ 表示と測れる monodromy、Lean 資産接続)、P4(距離核)、P10(ACTS) | 大 | W2/W6、レビュー T9、G4 の前提 |
+| 4. 安定性と輸送 | G7 単調系(T1 解決)、B9 輸送下界、B10 Morse 簡約 | 大 | W1 残り |
+| 5. 時間と進化 | P3(状態遷移代数 = temporal 層)、G8(第IX部 Evolution Geometry) | 大 | W3、SFT 接続 |
+
+Lean 化の優先順位(`proof_obligations.md` に積む順): P7 停止性 → G2(a)(d) → G4 随伴性 → G3(a)(b) → G2(c)。いずれも有限・decidable で、AG 版 theorem label が台帳に初めて載ることになる(現状 0 件)。
+
+---
+
+## 6. 非主張(claim boundary)
+
+- 本ノートの `[証明可能]` は「有限 regime で標準的手法により証明が書ける」という執筆者の判断であり、証明が書かれるまで本文の定理にはならない。
+- G1〜G8 はいずれも selected profile(site、cover、係数、内積、witness family、cost model、集約族)に相対化される。profile の外側の law・axis・尺度について zero / lawful / stable を主張しない。
+- G2(c) の「局所レビュー十分性」は選ばれた abelian 係数読みと全射 restriction の仮定の下の主張であり、non-abelian 層(torsor/gerbe、第VI部)の貼り合わせ失敗を排除しない。
+- G4 の監査恒等式は構成済み AAT geometry 内部の数学であり、source 抽出の完全性や ArchSig 実装の正しさを主張しない(VIII 原則2.2 と同じ境界)。
+- 橋 B9〜B12 の「実コードで測れるもの」は、ハブの組合せ対象が実コードから構成済みであること(= ArchMap/抽出層の責務)を前提とする。ArchSig 実験で確認された coverage gap(per-file semantic、runtime trace、permission audit 等)はこの前提側の課題であり、本ノートの定理群では解消されない。


### PR DESCRIPTION
## 概要

AAT AG 数学本文に、note で整理した bridge / grand theorem 候補を本文へ反映しました。第IV部〜第VIII部に有限 regime の bounded theorem / theorem candidate / analytic reading を追加し、新たに第IX部 Evolution Geometry を追加しています。

Issue 起点ではないため、Closes はありません。

## 証明した定理

- Topological Debt Capacity
- Local Gluing Sufficiency
- Period Stokes Identity
- Hilbert Series Conflict Identity
- Repair Termination
- Sound Repair Synthesis
- Transport Descent Criterion
- Square Monodromy Nonfillability
- Margin Stability
- Finite Hodge Decomposition
- Harmonic Debt Minimality
- Temporal Descent Criterion
- Finite Dissipation Stopping

※ theorem candidate は本文・Appendix B の status ledger で区別しています。

## 編集したドキュメント

- docs/aat/algebraic_geometric_theory/README.md
- docs/aat/algebraic_geometric_theory/part_4_obstruction_cohomology.md
- docs/aat/algebraic_geometric_theory/part_5_derived_law_geometry_repair.md
- docs/aat/algebraic_geometric_theory/part_6_singularity_monodromy_stack.md
- docs/aat/algebraic_geometric_theory/part_7_representation_periods_analysis.md
- docs/aat/algebraic_geometric_theory/part_8_measurement_theory.md
- docs/aat/algebraic_geometric_theory/part_9_evolution_geometry.md
- docs/aat/algebraic_geometric_theory/appendix_claim_status_and_worked_example.md
- docs/note/aat_ag_porting_bridges_grand_theorems.md

## 実施したテスト

- [ ] `lake build`（Lean 変更なし、今回は docs-only のため未実行）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean placeholder なし。`unsafe` は本文上の unsafe boundary 文言のみ）
- [x] review 指摘パターン再スキャン

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Issue 起点ではないため対象なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
