### PR TITLE
ArchSig Čech H1 evaluator と H1-visible fixture を追加

### DIFF
--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -22,6 +22,26 @@ homotopy, structural reading, FieldSig handoff, removed-field-only,
 label-only, schema-only, missing-support, blocked-molecule, strict-distance,
 and stale success artifact suppression cases.
 
+## AG v0.4.0 Measurement Fixtures
+
+The AG measurement corpus is the current v0.4.0 fixture surface for
+`archmap/v2`, `measurement-profile/v1`, and
+`archsig-measurement-packet/v1`. It is intentionally separate from the v1
+output replacement corpus because v0.4.0 reads finite poset sites and selected
+covers rather than molecule-primary ArchMaps.
+
+- `tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json`
+- `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json`
+- `tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json`
+- `tools/archsig/tests/fixtures/ag_measurement/law_policy_missing_profile.json`
+
+The executable lock is
+`cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero`. It fixes the
+witness-blind / H1-visible discriminator: classical witness counting remains
+`measured_zero`, while the finite F2 Cech evaluator emits
+`measured_nonzero` for the selected H1 obstruction and records a cocycle
+representative with mismatch support refs.
+
 ## V1 Positive Fixtures
 
 - `tools/archsig/tests/fixtures/archmap_v1/archmap.json`

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::{Value, json};
 
@@ -37,12 +37,77 @@ pub fn build_foundation_measurement_packet_v1(
         .ok_or_else(|| "AG measurement packet requires measurementProfileRef".to_string())?
         .clone();
     validate_profile_refs(&profile, normalized)?;
-    let structural_verdict = policy
-        .policies
-        .iter()
-        .filter_map(|entry| {
-            let evaluator = entry.evaluator.as_deref()?;
-            evaluator.starts_with("ag.").then(|| AgStructuralVerdictV1 {
+    let mut structural_verdict = Vec::new();
+    let mut computed_invariants = vec![json!({
+        "invariantId": "finite-poset-site-shape",
+        "archmapRef": archmap_ref,
+        "atomCount": normalized.summary.atom_count,
+        "contextCount": normalized.summary.context_count,
+        "coverCount": normalized.summary.cover_count,
+        "doctrineFingerprint": normalized.summary.doctrine_fingerprint
+    })];
+    let mut assumptions = vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/4.2".to_string(),
+            assumption: "finite site".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some("archmap-v2-validation.contexts-finite".to_string()),
+            assumed_by: None,
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/4.2".to_string(),
+            assumption: "U-adequate cover".to_string(),
+            status: "assumed".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!(
+                "measurement-profile:{}",
+                policy
+                    .measurement_profile_ref
+                    .as_deref()
+                    .unwrap_or_default()
+            )),
+        },
+    ];
+
+    for entry in policy.policies.iter().filter(|entry| {
+        entry
+            .evaluator
+            .as_deref()
+            .is_some_and(|evaluator| evaluator.starts_with("ag."))
+    }) {
+        let evaluator = entry.evaluator.as_deref().unwrap_or_default();
+        if evaluator == "ag.cech-obstruction@1" {
+            validate_cech_profile_v1(&profile)?;
+            let measurement = evaluate_cech_obstruction_v1(normalized, &profile);
+            computed_invariants.extend(measurement.computed_invariants);
+            assumptions.extend(measurement.assumptions);
+            structural_verdict.push(AgStructuralVerdictV1 {
+                evaluator: evaluator.to_string(),
+                law: entry
+                    .law
+                    .clone()
+                    .unwrap_or_else(|| "ag.cech-obstruction".to_string()),
+                verdict: if measurement.h1_class_nonzero {
+                    "measured_nonzero".to_string()
+                } else {
+                    "measured_zero".to_string()
+                },
+                verdict_data: AgVerdictDataV1 {
+                    in_scope: true,
+                    zero: !measurement.h1_class_nonzero,
+                    non_zero: measurement.h1_class_nonzero,
+                    method_status: "finite_f2_cech_computed".to_string(),
+                    cert_ref: Some(measurement.cert_ref),
+                },
+                reason: Some(if measurement.h1_class_nonzero {
+                    "finite F2 Cech 1-cocycle is not a coboundary on the selected cover".to_string()
+                } else {
+                    "finite F2 Cech 1-cocycle is zero or a coboundary on the selected cover"
+                        .to_string()
+                }),
+            });
+        } else {
+            structural_verdict.push(AgStructuralVerdictV1 {
                 evaluator: evaluator.to_string(),
                 law: entry.law.clone().unwrap_or_else(|| evaluator.to_string()),
                 verdict: "unmeasured".to_string(),
@@ -56,23 +121,16 @@ pub fn build_foundation_measurement_packet_v1(
                 reason: Some(
                     "AG evaluator schema is registered; mathematical computation is implemented by follow-up evaluator issues".to_string(),
                 ),
-            })
-        })
-        .collect::<Vec<_>>();
+            });
+        }
+    }
 
     Ok(ArchSigMeasurementPacketV1 {
         schema: ARCHSIG_MEASUREMENT_PACKET_V1_SCHEMA.to_string(),
         packet_id: format!("measurement:{}", normalized.source_archmap_id),
         profile,
         structural_verdict,
-        computed_invariants: vec![json!({
-            "invariantId": "finite-poset-site-shape",
-            "archmapRef": archmap_ref,
-            "atomCount": normalized.summary.atom_count,
-            "contextCount": normalized.summary.context_count,
-            "coverCount": normalized.summary.cover_count,
-            "doctrineFingerprint": normalized.summary.doctrine_fingerprint
-        })],
+        computed_invariants,
         analytic_readings: vec![AgAnalyticReadingV1 {
             reading_id: "candidate-regime:stability-placeholder".to_string(),
             evaluator: "ag.foundation@1".to_string(),
@@ -83,28 +141,7 @@ pub fn build_foundation_measurement_packet_v1(
             regime: Some("theorem-candidate".to_string()),
             structural_verdict_ref: None,
         }],
-        assumptions: vec![
-            AgAssumptionLedgerEntryV1 {
-                theorem_ref: "part8/4.2".to_string(),
-                assumption: "finite site".to_string(),
-                status: "checked".to_string(),
-                checked_by: Some("archmap-v2-validation.contexts-finite".to_string()),
-                assumed_by: None,
-            },
-            AgAssumptionLedgerEntryV1 {
-                theorem_ref: "part8/4.2".to_string(),
-                assumption: "U-adequate cover".to_string(),
-                status: "assumed".to_string(),
-                checked_by: None,
-                assumed_by: Some(format!(
-                    "measurement-profile:{}",
-                    policy
-                        .measurement_profile_ref
-                        .as_deref()
-                        .unwrap_or_default()
-                )),
-            },
-        ],
+        assumptions,
         non_conclusions: vec![
             format!(
                 "ArchSig v0.4.0 foundation packet is computed from {archmap_ref} and {law_policy_ref}; it is not a Lean proof object."
@@ -132,12 +169,14 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
             )
         })
         .count();
-    let conclusion = if unmeasured_count > 0 {
+    let conclusion = if nonzero_count > 0 {
+        "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    } else if unmeasured_count > 0 {
         "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
     } else if nonzero_count == 0 {
         "NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
     } else {
-        "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+        "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
     };
     json!({
         "schema": "archsig-analysis-summary/v2",
@@ -160,6 +199,391 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
             "Schema foundation rows do not claim completed AG invariant computation."
         ]
     })
+}
+
+#[derive(Debug, Clone)]
+struct CechMeasurementV1 {
+    h1_class_nonzero: bool,
+    cert_ref: String,
+    computed_invariants: Vec<Value>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct CechEdgeV1 {
+    edge_id: String,
+    source_context: String,
+    target_context: String,
+    value: u8,
+    support_atom_refs: Vec<String>,
+}
+
+fn evaluate_cech_obstruction_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> CechMeasurementV1 {
+    let selected_contexts = selected_cover_contexts(normalized, profile);
+    let edges = cech_edges(normalized, &selected_contexts);
+    let component_count = graph_component_count(&selected_contexts, &edges);
+    let h0_dimension = component_count;
+    let h1_dimension = edges
+        .len()
+        .saturating_add(component_count)
+        .saturating_sub(selected_contexts.len());
+    let h1_class_nonzero = !edge_cochain_is_coboundary(&selected_contexts, &edges);
+    let representative = edges
+        .iter()
+        .filter(|edge| edge.value == 1)
+        .map(|edge| {
+            json!({
+                "edge": edge.edge_id,
+                "sourceContext": edge.source_context,
+                "targetContext": edge.target_context,
+                "value": 1,
+                "supportAtomRefs": edge.support_atom_refs
+            })
+        })
+        .collect::<Vec<_>>();
+    let mismatch_support_refs = edges
+        .iter()
+        .flat_map(|edge| edge.support_atom_refs.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let witness_support_refs = witness_violation_support_refs(normalized);
+    let witness_violation_count = witness_support_refs.len();
+
+    CechMeasurementV1 {
+        h1_class_nonzero,
+        cert_ref: format!("computedInvariants/cech-cohomology:{}", profile.profile_id),
+        computed_invariants: vec![
+            json!({
+                "invariantId": format!("cech-cohomology:{}", profile.profile_id),
+                "evaluator": "ag.cech-obstruction@1",
+                "method": "finite-f2-incidence-graph-cochain@1",
+                "selectedCoverRef": profile.cover_ref,
+                "coefficient": profile.coefficient,
+                "contextCount": selected_contexts.len(),
+                "restrictionEdgeCount": edges.len(),
+                "rankD0": selected_contexts.len().saturating_sub(component_count),
+                "dimensions": {
+                    "H0": h0_dimension,
+                    "H1": h1_dimension
+                },
+                "selectedH2": {
+                    "dimension": 0,
+                    "status": "computed_for_selected_1_skeleton",
+                    "reason": "no selected 2-simplices are present in the finite incidence graph complex"
+                },
+                "observedCocycle": {
+                    "classNonzero": h1_class_nonzero,
+                    "representative": representative,
+                    "mismatchSupportRefs": mismatch_support_refs
+                }
+            }),
+            json!({
+                "invariantId": format!("witness-counting:{}", profile.profile_id),
+                "evaluator": "witness-counting@1",
+                "verdict": if witness_violation_count == 0 {
+                    "measured_zero"
+                } else {
+                    "measured_nonzero"
+                },
+                "violationCount": witness_violation_count,
+                "supportAtomRefs": witness_support_refs,
+                "nonConclusion": "Witness counting is reported as a fixture discriminator and does not determine Cech H1."
+            }),
+        ],
+        assumptions: vec![
+            AgAssumptionLedgerEntryV1 {
+                theorem_ref: "part8/B.8.2".to_string(),
+                assumption: "F2 finite coefficient field".to_string(),
+                status: "checked".to_string(),
+                checked_by: Some(format!(
+                    "measurement-profile:{}.coefficient={}",
+                    profile.profile_id, profile.coefficient
+                )),
+                assumed_by: None,
+            },
+            AgAssumptionLedgerEntryV1 {
+                theorem_ref: "part8/B.8.2".to_string(),
+                assumption: "cover-relative Cech reading".to_string(),
+                status: "checked".to_string(),
+                checked_by: Some(format!(
+                    "measurement-profile:{}.coverRef",
+                    profile.profile_id
+                )),
+                assumed_by: None,
+            },
+            AgAssumptionLedgerEntryV1 {
+                theorem_ref: "part8/B.8.2".to_string(),
+                assumption: "Leray / acyclicity comparison to sheaf cohomology".to_string(),
+                status: "assumed".to_string(),
+                checked_by: None,
+                assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+            },
+        ],
+    }
+}
+
+fn selected_cover_contexts(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> Vec<String> {
+    normalized
+        .covers
+        .iter()
+        .find(|cover| {
+            cover.normalized_cover_id == profile.cover_ref
+                || cover.source_cover_id == profile.cover_ref
+        })
+        .map(|cover| cover.context_ids.clone())
+        .unwrap_or_default()
+}
+
+fn validate_cech_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        ("coefficient", profile.coefficient.as_str(), "F2"),
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "finite-linear-algebra@1",
+        ),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "rank-zero@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "rank-positive@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "finite-certificate@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.cech-obstruction@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if !profile
+        .witness_family
+        .iter()
+        .any(|witness| witness.law == "ag.cech-obstruction")
+    {
+        return Err(format!(
+            "ag.cech-obstruction@1 requires MeasurementProfile {} witnessFamily law ag.cech-obstruction",
+            profile.profile_id
+        ));
+    }
+    Ok(())
+}
+
+fn cech_edges(normalized: &NormalizedArchMapV2, selected_contexts: &[String]) -> Vec<CechEdgeV1> {
+    let selected = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    let marker_atoms = normalized
+        .atoms
+        .iter()
+        .filter(|atom| {
+            atom.axis == "cech"
+                && matches!(
+                    atom.predicate.as_str(),
+                    "mismatch" | "cechMismatch" | "residue"
+                )
+        })
+        .collect::<Vec<_>>();
+    let mut seen_edges = BTreeSet::new();
+    let mut edges = Vec::new();
+    for context in &normalized.contexts {
+        if !selected.contains(&context.normalized_context_id) {
+            continue;
+        }
+        for target in context
+            .restricts_to
+            .iter()
+            .filter(|target| selected.contains(*target))
+        {
+            let edge_key = if context.normalized_context_id < *target {
+                (
+                    context.normalized_context_id.clone(),
+                    target.clone(),
+                    context.normalized_context_id.clone(),
+                    target.clone(),
+                )
+            } else {
+                (
+                    target.clone(),
+                    context.normalized_context_id.clone(),
+                    context.normalized_context_id.clone(),
+                    target.clone(),
+                )
+            };
+            if !seen_edges.insert((edge_key.0.clone(), edge_key.1.clone())) {
+                continue;
+            }
+            let support_atom_refs = marker_atoms
+                .iter()
+                .filter(|atom| marker_atom_marks_edge(atom, &edge_key.2, &edge_key.3))
+                .map(|atom| atom.normalized_atom_id.clone())
+                .collect::<Vec<_>>();
+            edges.push(CechEdgeV1 {
+                edge_id: format!("{}->{}", edge_key.2, edge_key.3),
+                source_context: edge_key.2,
+                target_context: edge_key.3,
+                value: (support_atom_refs.len() % 2) as u8,
+                support_atom_refs,
+            });
+        }
+    }
+    edges.sort_by(|left, right| left.edge_id.cmp(&right.edge_id));
+    edges
+}
+
+fn marker_atom_marks_edge(
+    atom: &crate::NormalizedAtomV2,
+    source_context: &str,
+    target_context: &str,
+) -> bool {
+    let source_matches =
+        atom.subject == source_context || atom.subject == unprefixed(source_context);
+    let object_matches = atom
+        .object
+        .as_deref()
+        .is_some_and(|object| object == target_context || object == unprefixed(target_context));
+    let target_matches = atom
+        .source_refs
+        .iter()
+        .any(|value| value == target_context || value == unprefixed(target_context));
+    let source_ref_matches = atom
+        .source_refs
+        .iter()
+        .any(|value| value == source_context || value == unprefixed(source_context));
+    let context_membership_matches = atom.context_memberships.iter().any(|membership| {
+        membership == source_context
+            || membership == target_context
+            || membership == unprefixed(source_context)
+            || membership == unprefixed(target_context)
+    });
+    source_matches
+        && object_matches
+        && source_ref_matches
+        && target_matches
+        && context_membership_matches
+}
+
+fn unprefixed(value: &str) -> &str {
+    value
+        .split_once(':')
+        .map(|(_, suffix)| suffix)
+        .unwrap_or(value)
+}
+
+fn graph_component_count(selected_contexts: &[String], edges: &[CechEdgeV1]) -> usize {
+    let adjacency = adjacency_map(selected_contexts, edges);
+    let mut visited = BTreeSet::new();
+    let mut components = 0usize;
+    for context in selected_contexts {
+        if visited.contains(context) {
+            continue;
+        }
+        components += 1;
+        let mut stack = vec![context.clone()];
+        while let Some(current) = stack.pop() {
+            if !visited.insert(current.clone()) {
+                continue;
+            }
+            for next in adjacency.get(&current).into_iter().flatten() {
+                if !visited.contains(next) {
+                    stack.push(next.clone());
+                }
+            }
+        }
+    }
+    components
+}
+
+fn edge_cochain_is_coboundary(selected_contexts: &[String], edges: &[CechEdgeV1]) -> bool {
+    let adjacency = valued_adjacency_map(selected_contexts, edges);
+    let mut potentials: BTreeMap<String, u8> = BTreeMap::new();
+    for context in selected_contexts {
+        if potentials.contains_key(context) {
+            continue;
+        }
+        potentials.insert(context.clone(), 0);
+        let mut stack = vec![context.clone()];
+        while let Some(current) = stack.pop() {
+            let current_value = *potentials.get(&current).unwrap_or(&0);
+            for (next, edge_value) in adjacency.get(&current).into_iter().flatten() {
+                let expected = current_value ^ *edge_value;
+                match potentials.get(next) {
+                    Some(existing) if *existing != expected => return false,
+                    Some(_) => {}
+                    None => {
+                        potentials.insert(next.clone(), expected);
+                        stack.push(next.clone());
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+fn adjacency_map(
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+) -> BTreeMap<String, Vec<String>> {
+    let mut adjacency = selected_contexts
+        .iter()
+        .map(|context| (context.clone(), Vec::new()))
+        .collect::<BTreeMap<_, _>>();
+    for edge in edges {
+        adjacency
+            .entry(edge.source_context.clone())
+            .or_default()
+            .push(edge.target_context.clone());
+        adjacency
+            .entry(edge.target_context.clone())
+            .or_default()
+            .push(edge.source_context.clone());
+    }
+    adjacency
+}
+
+fn valued_adjacency_map(
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+) -> BTreeMap<String, Vec<(String, u8)>> {
+    let mut adjacency = selected_contexts
+        .iter()
+        .map(|context| (context.clone(), Vec::new()))
+        .collect::<BTreeMap<_, _>>();
+    for edge in edges {
+        adjacency
+            .entry(edge.source_context.clone())
+            .or_default()
+            .push((edge.target_context.clone(), edge.value));
+        adjacency
+            .entry(edge.target_context.clone())
+            .or_default()
+            .push((edge.source_context.clone(), edge.value));
+    }
+    adjacency
+}
+
+fn witness_violation_support_refs(normalized: &NormalizedArchMapV2) -> Vec<String> {
+    normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "witness" && atom.predicate == "violation")
+        .map(|atom| atom.normalized_atom_id.clone())
+        .collect()
 }
 
 pub fn build_measurement_viewer_data_v1(

--- a/tools/archsig/src/normalizer.rs
+++ b/tools/archsig/src/normalizer.rs
@@ -162,6 +162,7 @@ pub fn normalize_archmap_v2(document: &ArchMapDocumentV2, input_path: &str) -> N
                 subject: atom.subject.clone(),
                 axis: atom.axis.clone(),
                 predicate: atom.predicate.clone().unwrap_or_else(|| atom.kind.clone()),
+                object: atom.object.clone(),
                 source_refs: refs,
                 context_memberships: context_memberships
                     .get(&atom.id)

--- a/tools/archsig/src/schema/archmap.rs
+++ b/tools/archsig/src/schema/archmap.rs
@@ -230,6 +230,8 @@ pub struct NormalizedAtomV2 {
     pub subject: String,
     pub axis: String,
     pub predicate: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<String>,
     pub source_refs: Vec<String>,
     pub context_memberships: Vec<String>,
     pub normalization_status: String,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -152,7 +152,10 @@ fn cli_analyze_v2_writes_measurement_packet_foundation() {
     assert!(packet["analyticReadings"].is_array());
     assert!(packet["assumptions"].is_array());
     assert!(packet["nonConclusions"].is_array());
-    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unmeasured");
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
+    let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    assert_eq!(cech["dimensions"]["H1"], Value::from(0));
+    assert_eq!(cech["selectedH2"]["dimension"], Value::from(0));
     assert_eq!(packet["analyticReadings"][0]["regime"], "theorem-candidate");
 
     let validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
@@ -168,14 +171,224 @@ fn cli_analyze_v2_writes_measurement_packet_foundation() {
     let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
     assert_eq!(
         summary["conclusion"],
-        "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
+        "NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
     );
+}
+
+#[test]
+fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
+    let out_dir = temp_dir("ag-measurement-cech-h1-visible");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2_cech_h1_visible.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"][0]["evaluator"],
+        "ag.cech-obstruction@1"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdict"],
+        "measured_nonzero"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["nonZero"],
+        true
+    );
+    let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    assert_eq!(cech["observedCocycle"]["classNonzero"], true);
+    assert_eq!(
+        cech["observedCocycle"]["representative"]
+            .as_array()
+            .expect("representative is array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        cech["observedCocycle"]["mismatchSupportRefs"][0],
+        "atom:left-bottom-cech-mismatch"
+    );
+    assert_eq!(
+        cech["selectedH2"]["status"],
+        "computed_for_selected_1_skeleton"
+    );
+    let witness_counting = invariant_by_id(&packet, "witness-counting:profile:ag-default@1");
+    assert_eq!(
+        witness_counting["invariantId"],
+        "witness-counting:profile:ag-default@1"
+    );
+    assert_eq!(witness_counting["verdict"], "measured_zero");
+
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    assert_eq!(
+        summary["conclusion"],
+        "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_cech_rejects_unsupported_measurement_profile_selectors() {
+    let out_dir = temp_dir("ag-measurement-cech-bad-profile");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_ag.json"));
+    policy["measurementProfiles"][0]["coefficient"] = Value::String("Z".to_string());
+    let policy_path = out_dir.join("law_policy_bad_cech_selector.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_cech_h1_visible.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_cech_requires_matching_witness_family() {
+    let out_dir = temp_dir("ag-measurement-cech-witness-family");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_ag.json"));
+    policy["measurementProfiles"][0]["witnessFamily"] = Value::Array(vec![]);
+    let policy_path = out_dir.join("law_policy_missing_cech_witness.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_cech_h1_visible.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_cech_ignores_unanchored_mismatch_support() {
+    let out_dir = temp_dir("ag-measurement-cech-unanchored-support");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_cech_h1_visible.json"));
+    archmap["atoms"][4]["object"] = Value::String("ctx:right".to_string());
+    let archmap_path = out_dir.join("archmap_v2_unanchored_cech.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
+    let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    assert_eq!(cech["dimensions"]["H1"], Value::from(1));
+    assert_eq!(cech["observedCocycle"]["classNonzero"], false);
+    assert_eq!(
+        cech["observedCocycle"]["mismatchSupportRefs"]
+            .as_array()
+            .expect("mismatch support refs is array")
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn cli_locks_ag_measurement_cech_h1_visible_golden_fixture() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate root is tools/archsig inside repo");
+    let fixture = read_json(&ag_measurement_root().join("archmap_v2_cech_h1_visible.json"));
+    assert_eq!(fixture["schema"], "archmap/v2");
+    assert_eq!(fixture["id"], "ag-measurement-cech-h1-visible-fixture");
+    assert!(
+        fixture["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .any(|atom| atom["axis"] == "cech" && atom["predicate"] == "mismatch"),
+        "AG golden fixture must contain an explicit Cech mismatch atom"
+    );
+
+    let golden_corpus = fs::read_to_string(repo_root.join("docs/tool/golden_corpus.md"))
+        .expect("golden corpus docs are readable");
+    for snippet in [
+        "archmap_v2_cech_h1_visible.json",
+        "cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero",
+        "witness-blind / H1-visible",
+    ] {
+        assert!(
+            golden_corpus.contains(snippet),
+            "AG golden corpus docs must mention {snippet}"
+        );
+    }
 }
 
 #[test]
 fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
     let out_dir = temp_dir("ag-measurement-strict");
     let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_ag.json"));
+    policy["policies"]
+        .as_array_mut()
+        .expect("policies is array")
+        .push(serde_json::json!({
+            "law": "ag.square-free-repair",
+            "evaluator": "ag.square-free-repair@1",
+            "basis": ["policy-basis:layering"],
+            "scope": ["src/"],
+            "severity": "medium"
+        }));
+    let policy_path = out_dir.join("law_policy_ag_with_unmeasured.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
 
     run_sig0_expect_code(
         &[
@@ -185,9 +398,7 @@ fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
                 .to_str()
                 .expect("path is utf-8"),
             "--law-policy",
-            root.join("law_policy_ag.json")
-                .to_str()
-                .expect("path is utf-8"),
+            policy_path.to_str().expect("path is utf-8"),
             "--out-dir",
             out_dir.to_str().expect("path is utf-8"),
             "--strict-distance",
@@ -7511,6 +7722,15 @@ fn run_sig0_output(args: &[&str]) -> std::process::Output {
 fn read_json(path: &Path) -> Value {
     serde_json::from_slice(&fs::read(path).expect("json fixture can be read"))
         .expect("json fixture parses")
+}
+
+fn invariant_by_id<'a>(packet: &'a Value, invariant_id: &str) -> &'a Value {
+    packet["computedInvariants"]
+        .as_array()
+        .expect("computedInvariants is array")
+        .iter()
+        .find(|invariant| invariant["invariantId"] == invariant_id)
+        .unwrap_or_else(|| panic!("missing computed invariant {invariant_id}"))
 }
 
 fn assert_public_artifact_omits_part4(label: &str, value: &Value) {

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json
@@ -1,0 +1,135 @@
+{
+  "schema": "archmap/v2",
+  "id": "ag-measurement-cech-h1-visible-fixture",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:ag-fixture@1",
+    "fingerprint": "sha256:ag-fixture-doctrine",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
+  "sources": {
+    "src:top": {
+      "kind": "rust",
+      "path": "src/top.rs",
+      "symbol": "TopContext",
+      "line": 1
+    },
+    "src:left": {
+      "kind": "rust",
+      "path": "src/left.rs",
+      "symbol": "LeftContext",
+      "line": 1
+    },
+    "src:right": {
+      "kind": "rust",
+      "path": "src/right.rs",
+      "symbol": "RightContext",
+      "line": 1
+    },
+    "src:bottom": {
+      "kind": "rust",
+      "path": "src/bottom.rs",
+      "symbol": "BottomContext",
+      "line": 1
+    },
+    "src:cover": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.8.2"
+    },
+    "ctx:top": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.8.2"
+    },
+    "ctx:left": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.8.2"
+    },
+    "ctx:right": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.8.2"
+    },
+    "ctx:bottom": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.8.2"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:top",
+      "kind": "component",
+      "subject": "src:top",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:top"]
+    },
+    {
+      "id": "atom:left",
+      "kind": "component",
+      "subject": "src:left",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:left"]
+    },
+    {
+      "id": "atom:right",
+      "kind": "component",
+      "subject": "src:right",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:right"]
+    },
+    {
+      "id": "atom:bottom",
+      "kind": "component",
+      "subject": "src:bottom",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:bottom"]
+    },
+    {
+      "id": "atom:left-bottom-cech-mismatch",
+      "kind": "relation",
+      "subject": "ctx:left",
+      "object": "ctx:bottom",
+      "axis": "cech",
+      "predicate": "mismatch",
+      "refs": ["ctx:left", "ctx:bottom", "src:cover"]
+    }
+  ],
+  "contexts": [
+    {
+      "id": "ctx:top",
+      "atoms": ["atom:top"],
+      "restrictsTo": ["ctx:left", "ctx:right"],
+      "refs": ["ctx:top"]
+    },
+    {
+      "id": "ctx:left",
+      "atoms": ["atom:left", "atom:left-bottom-cech-mismatch"],
+      "restrictsTo": ["ctx:bottom"],
+      "refs": ["ctx:left"]
+    },
+    {
+      "id": "ctx:right",
+      "atoms": ["atom:right"],
+      "restrictsTo": ["ctx:bottom"],
+      "refs": ["ctx:right"]
+    },
+    {
+      "id": "ctx:bottom",
+      "atoms": ["atom:bottom"],
+      "refs": ["ctx:bottom"]
+    }
+  ],
+  "covers": [
+    {
+      "id": "cover:order-inventory",
+      "contexts": ["ctx:top", "ctx:left", "ctx:right", "ctx:bottom"],
+      "refs": ["src:cover"]
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1910
Part of #1907

ArchSig v0.4.0 の AG measurement chain に `ag.cech-obstruction@1` の finite F2 Čech evaluator を追加しました。`archmap/v2` の selected cover / finite context poset から `H0`, `H1`, selected `H2` boundary を measurement packet に出し、nonzero `H1` では `measured_nonzero`、zero/coboundary では `measured_zero` を出します。

あわせて witness-blind / H1-visible fixture を追加し、witness counting は `measured_zero` のまま Čech H1 が `measured_nonzero` になるケースを golden corpus に固定しました。unsupported profile selector、witnessFamily 不一致、unanchored mismatch support は fail/zero 側に倒す regression も追加しています。

## 証明した定理

- なし

Lean status: tooling implementation / PRD acceptance tracking。Lean 形式化との接続は扱っていません。

## 編集したドキュメント

- `docs/tool/golden_corpus.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
