### PR TITLE
ArchSig square-free repair evaluator と NSdepth fixture を追加

### DIFF
--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -32,7 +32,9 @@ covers rather than molecule-primary ArchMaps.
 
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json`
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json`
+- `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json`
+- `tools/archsig/tests/fixtures/ag_measurement/law_policy_square_free.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_missing_profile.json`
 
 The executable lock is
@@ -41,6 +43,14 @@ witness-blind / H1-visible discriminator: classical witness counting remains
 `measured_zero`, while the finite F2 Cech evaluator emits
 `measured_nonzero` for the selected H1 obstruction and records a cocycle
 representative with mismatch support refs.
+
+The square-free repair lock is
+`cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth`. It fixes
+the B.3 / B.4 worked example path: `I_Ob^U`, minimal forbidden supports,
+`Delta_U`, Alexander dual minimal repair hitting sets, and an NSdepth
+certificate are emitted as finite measurement packet invariants. The companion
+`cli_analyze_v2_square_free_without_certificate_returns_unknown` regression
+keeps missing certificates as `unknown`, not lawful or measured zero.
 
 ## V1 Positive Fixtures
 

--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -47,8 +47,10 @@ representative with mismatch support refs.
 The square-free repair lock is
 `cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth`. It fixes
 the B.3 / B.4 worked example path: `I_Ob^U`, minimal forbidden supports,
-`Delta_U`, Alexander dual minimal repair hitting sets, and an NSdepth
-certificate are emitted as finite measurement packet invariants. The companion
+`Delta_U` faces with finite F2 reduced homology, Alexander dual minimal repair
+hitting sets, and an author-supplied NSdepth certificate reference are emitted
+as measurement packet invariants. Because the NSdepth atom is not a finite
+verifier payload, the structural verdict remains `unknown`. The companion
 `cli_analyze_v2_square_free_without_certificate_returns_unknown` regression
 keeps missing certificates as `unknown`, not lawful or measured zero.
 

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -217,6 +217,7 @@ fn evaluate_square_free_repair_v1(
             .collect(),
     );
     let delta_faces = stanley_reisner_faces(&witness_variables, &minimal_forbidden_supports);
+    let reduced_homology = reduced_simplicial_homology_f2(&delta_faces);
     let repair_hitting_sets = minimal_hitting_sets(&witness_variables, &minimal_forbidden_supports);
     let certificate = square_free_certificate(normalized, &selected_contexts)?;
     let has_obstruction = !minimal_forbidden_supports.is_empty();
@@ -233,13 +234,12 @@ fn evaluate_square_free_repair_v1(
         )
     } else if let Some(certificate) = &certificate {
         (
-            "measured_nonzero".to_string(),
+            "unknown".to_string(),
             false,
-            true,
-            "square_free_repair_certificate_computed".to_string(),
+            false,
+            "nsdepth_certificate_author_supplied_unverified".to_string(),
             Some(certificate.cert_ref.clone()),
-            "square-free obstruction ideal has selected generators and an NSdepth certificate"
-                .to_string(),
+            "square-free obstruction generators were found and an NSdepth certificate reference was supplied, but no finite NSdepth verifier payload was checked; lawfulness is not concluded".to_string(),
         )
     } else {
         (
@@ -278,16 +278,23 @@ fn evaluate_square_free_repair_v1(
             "minimalForbiddenSupports": minimal_forbidden_supports,
             "stanleyReisnerComplex": {
                 "id": "Delta_U",
-                "faces": delta_faces
+                "faces": delta_faces,
+                "reducedHomology": {
+                    "field": "F2",
+                    "method": "finite-f2-simplicial-boundary@1",
+                    "betti": reduced_homology
+                }
             },
             "alexanderDualRepair": {
                 "minimalHittingSets": repair_hitting_sets,
                 "minimality": "checked_by_finite_support_enumeration"
             },
             "nsdepthCertificate": certificate.as_ref().map(|certificate| json!({
+                "status": "author_supplied_unverified",
                 "certificateRef": certificate.cert_ref,
                 "nsdepth": certificate.nsdepth,
-                "supportAtomRefs": certificate.support_atom_refs
+                "supportAtomRefs": certificate.support_atom_refs,
+                "effect": "structural verdict remains unknown until a finite NSdepth verifier payload is checked"
             })).unwrap_or_else(|| json!({
                 "status": "missing",
                 "effect": "structural verdict remains unknown when obstruction generators are present"
@@ -314,19 +321,15 @@ fn evaluate_square_free_repair_v1(
             },
             AgAssumptionLedgerEntryV1 {
                 theorem_ref: "part3/7.2B".to_string(),
-                assumption: "NSdepth certificate supplied by ArchMap author".to_string(),
-                status: if certificate.is_some() {
-                    "checked"
-                } else {
-                    "assumed"
-                }
-                .to_string(),
-                checked_by: certificate
-                    .as_ref()
-                    .map(|certificate| certificate.cert_ref.clone()),
-                assumed_by: certificate
-                    .is_none()
-                    .then(|| format!("measurement-profile:{}", profile.profile_id)),
+                assumption: "NSdepth certificate value supplied by ArchMap author; finite verifier payload is not checked by this evaluator".to_string(),
+                status: "assumed".to_string(),
+                checked_by: None,
+                assumed_by: Some(
+                    certificate
+                        .as_ref()
+                        .map(|certificate| certificate.cert_ref.clone())
+                        .unwrap_or_else(|| format!("measurement-profile:{}", profile.profile_id)),
+                ),
             },
         ],
     })
@@ -692,7 +695,7 @@ fn square_free_certificate(
     normalized: &NormalizedArchMapV2,
     selected_contexts: &BTreeSet<String>,
 ) -> Result<Option<SquareFreeCertificateV1>, String> {
-    normalized
+    let certificates = normalized
         .atoms
         .iter()
         .filter(|atom| atom.axis == "square-free" && atom.predicate == "nsdepthCertificate")
@@ -722,8 +725,16 @@ fn square_free_certificate(
                 support_atom_refs: vec![atom.normalized_atom_id.clone()],
             })
         })
-        .next()
-        .transpose()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if certificates.len() > 1 {
+        return Err(format!(
+            "ag.square-free-repair@1 expected at most one selected NSdepth certificate, found {}",
+            certificates.len()
+        ));
+    }
+
+    Ok(certificates.into_iter().next())
 }
 
 fn atom_belongs_to_selected_context(
@@ -766,6 +777,97 @@ fn stanley_reisner_faces(
                 .any(|forbidden| is_subset(forbidden.as_slice(), face.as_slice()))
         })
         .collect()
+}
+
+fn reduced_simplicial_homology_f2(faces: &[Vec<String>]) -> Vec<Value> {
+    let mut simplices_by_degree = BTreeMap::<usize, Vec<Vec<String>>>::new();
+    for face in faces.iter().filter(|face| !face.is_empty()) {
+        simplices_by_degree
+            .entry(face.len() - 1)
+            .or_default()
+            .push(face.clone());
+    }
+    for simplices in simplices_by_degree.values_mut() {
+        simplices.sort();
+        simplices.dedup();
+    }
+
+    let max_degree = simplices_by_degree.keys().next_back().copied().unwrap_or(0);
+    let mut betti = Vec::new();
+    for degree in 0..=max_degree {
+        let dim_chain = simplices_by_degree
+            .get(&degree)
+            .map_or(0, std::vec::Vec::len);
+        let boundary_rank = if degree == 0 {
+            usize::from(dim_chain > 0)
+        } else {
+            boundary_rank_f2(&simplices_by_degree, degree)
+        };
+        let next_boundary_rank = boundary_rank_f2(&simplices_by_degree, degree + 1);
+        let dimension = dim_chain.saturating_sub(boundary_rank + next_boundary_rank);
+        betti.push(json!({
+            "degree": degree,
+            "dimension": dimension
+        }));
+    }
+    betti
+}
+
+fn boundary_rank_f2(
+    simplices_by_degree: &BTreeMap<usize, Vec<Vec<String>>>,
+    degree: usize,
+) -> usize {
+    if degree == 0 {
+        return 0;
+    }
+    let Some(domain) = simplices_by_degree.get(&degree) else {
+        return 0;
+    };
+    let Some(codomain) = simplices_by_degree.get(&(degree - 1)) else {
+        return 0;
+    };
+    let row_index = codomain
+        .iter()
+        .enumerate()
+        .map(|(index, simplex)| (simplex.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let mut rows = vec![vec![0u8; domain.len()]; codomain.len()];
+    for (column, simplex) in domain.iter().enumerate() {
+        for omitted in 0..simplex.len() {
+            let mut facet = simplex.clone();
+            facet.remove(omitted);
+            if let Some(row) = row_index.get(&facet) {
+                rows[*row][column] ^= 1;
+            }
+        }
+    }
+    matrix_rank_f2(rows)
+}
+
+fn matrix_rank_f2(mut rows: Vec<Vec<u8>>) -> usize {
+    if rows.is_empty() {
+        return 0;
+    }
+    let column_count = rows[0].len();
+    let mut rank = 0;
+    for column in 0..column_count {
+        let Some(pivot) = (rank..rows.len()).find(|row| rows[*row][column] == 1) else {
+            continue;
+        };
+        rows.swap(rank, pivot);
+        for row in 0..rows.len() {
+            if row != rank && rows[row][column] == 1 {
+                for next_column in column..column_count {
+                    rows[row][next_column] ^= rows[rank][next_column];
+                }
+            }
+        }
+        rank += 1;
+        if rank == rows.len() {
+            break;
+        }
+    }
+    rank
 }
 
 fn minimal_hitting_sets(

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -16,6 +16,7 @@ const VERDICTS: [&str; 5] = [
     "unknown",
     "not_computed",
 ];
+const MAX_SQUARE_FREE_WITNESS_VARIABLES: usize = 12;
 
 pub fn selected_measurement_profile_v1(
     policy: &LawPolicyDocumentV1,
@@ -106,6 +107,27 @@ pub fn build_foundation_measurement_packet_v1(
                         .to_string()
                 }),
             });
+        } else if evaluator == "ag.square-free-repair@1" {
+            validate_square_free_profile_v1(&profile)?;
+            let measurement = evaluate_square_free_repair_v1(normalized, &profile)?;
+            computed_invariants.extend(measurement.computed_invariants);
+            assumptions.extend(measurement.assumptions);
+            structural_verdict.push(AgStructuralVerdictV1 {
+                evaluator: evaluator.to_string(),
+                law: entry
+                    .law
+                    .clone()
+                    .unwrap_or_else(|| "ag.square-free-repair".to_string()),
+                verdict: measurement.verdict,
+                verdict_data: AgVerdictDataV1 {
+                    in_scope: true,
+                    zero: measurement.zero,
+                    non_zero: measurement.non_zero,
+                    method_status: measurement.method_status,
+                    cert_ref: measurement.cert_ref,
+                },
+                reason: Some(measurement.reason),
+            });
         } else {
             structural_verdict.push(AgStructuralVerdictV1 {
                 evaluator: evaluator.to_string(),
@@ -153,6 +175,163 @@ pub fn build_foundation_measurement_packet_v1(
     })
 }
 
+#[derive(Debug, Clone)]
+struct SquareFreeMeasurementV1 {
+    verdict: String,
+    zero: bool,
+    non_zero: bool,
+    method_status: String,
+    cert_ref: Option<String>,
+    reason: String,
+    computed_invariants: Vec<Value>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct SquareFreeGeneratorV1 {
+    generator_id: String,
+    support: Vec<String>,
+    support_atom_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SquareFreeCertificateV1 {
+    cert_ref: String,
+    nsdepth: usize,
+    support_atom_refs: Vec<String>,
+}
+
+fn evaluate_square_free_repair_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> Result<SquareFreeMeasurementV1, String> {
+    let selected_contexts = selected_cover_contexts(normalized, profile)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let witness_variables = square_free_witness_variables(profile);
+    let generators = square_free_generators(normalized, &selected_contexts, &witness_variables)?;
+    let minimal_forbidden_supports = minimal_supports(
+        generators
+            .iter()
+            .map(|generator| generator.support.clone())
+            .collect(),
+    );
+    let delta_faces = stanley_reisner_faces(&witness_variables, &minimal_forbidden_supports);
+    let repair_hitting_sets = minimal_hitting_sets(&witness_variables, &minimal_forbidden_supports);
+    let certificate = square_free_certificate(normalized, &selected_contexts)?;
+    let has_obstruction = !minimal_forbidden_supports.is_empty();
+    let (verdict, zero, non_zero, method_status, cert_ref, reason) = if !has_obstruction {
+        (
+            "measured_zero".to_string(),
+            true,
+            false,
+            "square_free_ideal_computed".to_string(),
+            certificate
+                .as_ref()
+                .map(|certificate| certificate.cert_ref.clone()),
+            "square-free obstruction ideal has no selected generators".to_string(),
+        )
+    } else if let Some(certificate) = &certificate {
+        (
+            "measured_nonzero".to_string(),
+            false,
+            true,
+            "square_free_repair_certificate_computed".to_string(),
+            Some(certificate.cert_ref.clone()),
+            "square-free obstruction ideal has selected generators and an NSdepth certificate"
+                .to_string(),
+        )
+    } else {
+        (
+            "unknown".to_string(),
+            false,
+            false,
+            "nsdepth_certificate_missing".to_string(),
+            None,
+            "square-free obstruction generators were found, but no NSdepth certificate was supplied; lawfulness is not concluded".to_string(),
+        )
+    };
+
+    Ok(SquareFreeMeasurementV1 {
+        verdict,
+        zero,
+        non_zero,
+        method_status,
+        cert_ref,
+        reason,
+        computed_invariants: vec![json!({
+            "invariantId": format!("square-free-repair:{}", profile.profile_id),
+            "evaluator": "ag.square-free-repair@1",
+            "method": "finite-square-free-monomial-repair@1",
+            "selectedCoverRef": profile.cover_ref,
+            "witnessVariables": witness_variables,
+            "obstructionIdeal": {
+                "id": "I_Ob^U",
+                "generators": generators.iter().map(|generator| {
+                    json!({
+                        "generatorId": generator.generator_id,
+                        "support": generator.support,
+                        "supportAtomRefs": generator.support_atom_refs
+                    })
+                }).collect::<Vec<_>>()
+            },
+            "minimalForbiddenSupports": minimal_forbidden_supports,
+            "stanleyReisnerComplex": {
+                "id": "Delta_U",
+                "faces": delta_faces
+            },
+            "alexanderDualRepair": {
+                "minimalHittingSets": repair_hitting_sets,
+                "minimality": "checked_by_finite_support_enumeration"
+            },
+            "nsdepthCertificate": certificate.as_ref().map(|certificate| json!({
+                "certificateRef": certificate.cert_ref,
+                "nsdepth": certificate.nsdepth,
+                "supportAtomRefs": certificate.support_atom_refs
+            })).unwrap_or_else(|| json!({
+                "status": "missing",
+                "effect": "structural verdict remains unknown when obstruction generators are present"
+            }))
+        })],
+        assumptions: vec![
+            AgAssumptionLedgerEntryV1 {
+                theorem_ref: "part8/5.1".to_string(),
+                assumption: "square-free witness variables selected by MeasurementProfile"
+                    .to_string(),
+                status: "checked".to_string(),
+                checked_by: Some(format!(
+                    "measurement-profile:{}.witnessFamily",
+                    profile.profile_id
+                )),
+                assumed_by: None,
+            },
+            AgAssumptionLedgerEntryV1 {
+                theorem_ref: "part8/5.2".to_string(),
+                assumption: "finite support family for Alexander dual enumeration".to_string(),
+                status: "checked".to_string(),
+                checked_by: Some("archmap-v2-validation.contexts-finite".to_string()),
+                assumed_by: None,
+            },
+            AgAssumptionLedgerEntryV1 {
+                theorem_ref: "part3/7.2B".to_string(),
+                assumption: "NSdepth certificate supplied by ArchMap author".to_string(),
+                status: if certificate.is_some() {
+                    "checked"
+                } else {
+                    "assumed"
+                }
+                .to_string(),
+                checked_by: certificate
+                    .as_ref()
+                    .map(|certificate| certificate.cert_ref.clone()),
+                assumed_by: certificate
+                    .is_none()
+                    .then(|| format!("measurement-profile:{}", profile.profile_id)),
+            },
+        ],
+    })
+}
+
 pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Value {
     let nonzero_count = packet
         .structural_verdict
@@ -169,8 +348,13 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
             )
         })
         .count();
-    let conclusion = if nonzero_count > 0 {
+    let cech_nonzero = packet.structural_verdict.iter().any(|verdict| {
+        verdict.evaluator == "ag.cech-obstruction@1" && verdict.verdict == "measured_nonzero"
+    });
+    let conclusion = if cech_nonzero {
         "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    } else if nonzero_count > 0 {
+        "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
     } else if unmeasured_count > 0 {
         "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
     } else if nonzero_count == 0 {
@@ -383,6 +567,246 @@ fn validate_cech_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String
         ));
     }
     Ok(())
+}
+
+fn validate_square_free_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        ("coefficient", profile.coefficient.as_str(), "F2"),
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "finite-linear-algebra@1",
+        ),
+        (
+            "resolutionSelector",
+            profile.resolution_selector.as_str(),
+            "taylor@1",
+        ),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "rank-zero@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "rank-positive@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "finite-certificate@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.square-free-repair@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if square_free_witness_variables(profile).is_empty() {
+        return Err(format!(
+            "ag.square-free-repair@1 requires MeasurementProfile {} witnessFamily law ag.square-free-repair",
+            profile.profile_id
+        ));
+    }
+    if square_free_witness_variables(profile).len() > MAX_SQUARE_FREE_WITNESS_VARIABLES {
+        return Err(format!(
+            "ag.square-free-repair@1 supports at most {MAX_SQUARE_FREE_WITNESS_VARIABLES} witness variables for finite support enumeration"
+        ));
+    }
+    Ok(())
+}
+
+fn square_free_witness_variables(profile: &MeasurementProfileV1) -> Vec<String> {
+    profile
+        .witness_family
+        .iter()
+        .filter(|witness| witness.law == "ag.square-free-repair")
+        .map(|witness| witness.variable.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn square_free_generators(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+    witness_variables: &[String],
+) -> Result<Vec<SquareFreeGeneratorV1>, String> {
+    let witness_set = witness_variables.iter().cloned().collect::<BTreeSet<_>>();
+    let mut generators = Vec::new();
+    for atom in normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "square-free" && atom.predicate == "obstructionGenerator")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+    {
+        let raw_variables = square_free_atom_variables(atom);
+        let unknown = raw_variables
+            .iter()
+            .filter(|variable| !witness_set.contains(*variable))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !unknown.is_empty() {
+            return Err(format!(
+                "ag.square-free-repair@1 generator {} contains variables outside witnessFamily: {}",
+                atom.normalized_atom_id,
+                unknown.join(",")
+            ));
+        }
+        if raw_variables.is_empty() {
+            return Err(format!(
+                "ag.square-free-repair@1 generator {} has no square-free witness variables",
+                atom.normalized_atom_id
+            ));
+        }
+        generators.push(SquareFreeGeneratorV1 {
+            generator_id: atom.normalized_atom_id.clone(),
+            support: raw_variables,
+            support_atom_refs: vec![atom.normalized_atom_id.clone()],
+        });
+    }
+    generators.sort_by(|left, right| left.generator_id.cmp(&right.generator_id));
+    Ok(generators)
+}
+
+fn square_free_atom_variables(atom: &crate::NormalizedAtomV2) -> Vec<String> {
+    let mut support = Vec::new();
+    for value in std::iter::once(atom.subject.as_str()).chain(atom.object.as_deref()) {
+        for variable in value
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            support.push(variable.to_string());
+        }
+    }
+    support.sort();
+    support.dedup();
+    support
+}
+
+fn square_free_certificate(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+) -> Result<Option<SquareFreeCertificateV1>, String> {
+    normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "square-free" && atom.predicate == "nsdepthCertificate")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+        .map(|atom| {
+            let raw = atom.object.as_deref().ok_or_else(|| {
+                format!(
+                    "ag.square-free-repair@1 NSdepth certificate {} requires numeric object",
+                    atom.normalized_atom_id
+                )
+            })?;
+            let nsdepth = raw.parse::<usize>().map_err(|_| {
+                format!(
+                    "ag.square-free-repair@1 NSdepth certificate {} has non-numeric object {raw}",
+                    atom.normalized_atom_id
+                )
+            })?;
+            if nsdepth == 0 {
+                return Err(format!(
+                    "ag.square-free-repair@1 NSdepth certificate {} must have positive object",
+                    atom.normalized_atom_id
+                ));
+            }
+            Ok(SquareFreeCertificateV1 {
+                cert_ref: atom.normalized_atom_id.clone(),
+                nsdepth,
+                support_atom_refs: vec![atom.normalized_atom_id.clone()],
+            })
+        })
+        .next()
+        .transpose()
+}
+
+fn atom_belongs_to_selected_context(
+    atom: &crate::NormalizedAtomV2,
+    selected_contexts: &BTreeSet<String>,
+) -> bool {
+    atom.context_memberships
+        .iter()
+        .any(|membership| selected_contexts.contains(membership))
+}
+
+fn minimal_supports(mut supports: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    for support in &mut supports {
+        support.sort();
+        support.dedup();
+    }
+    supports.sort();
+    supports.dedup();
+    supports
+        .iter()
+        .filter(|support| {
+            !supports.iter().any(|candidate| {
+                candidate.len() < support.len()
+                    && is_subset(candidate.as_slice(), support.as_slice())
+            })
+        })
+        .cloned()
+        .collect()
+}
+
+fn stanley_reisner_faces(
+    witness_variables: &[String],
+    minimal_forbidden_supports: &[Vec<String>],
+) -> Vec<Vec<String>> {
+    all_subsets(witness_variables)
+        .into_iter()
+        .filter(|face| {
+            !minimal_forbidden_supports
+                .iter()
+                .any(|forbidden| is_subset(forbidden.as_slice(), face.as_slice()))
+        })
+        .collect()
+}
+
+fn minimal_hitting_sets(
+    witness_variables: &[String],
+    minimal_forbidden_supports: &[Vec<String>],
+) -> Vec<Vec<String>> {
+    if minimal_forbidden_supports.is_empty() {
+        return Vec::new();
+    }
+    let hitting_sets = all_subsets(witness_variables)
+        .into_iter()
+        .filter(|candidate| !candidate.is_empty())
+        .filter(|candidate| {
+            minimal_forbidden_supports
+                .iter()
+                .all(|support| candidate.iter().any(|variable| support.contains(variable)))
+        })
+        .collect::<Vec<_>>();
+    let mut minimal = minimal_supports(hitting_sets);
+    minimal.sort_by(|left, right| left.len().cmp(&right.len()).then_with(|| left.cmp(right)));
+    minimal
+}
+
+fn all_subsets(items: &[String]) -> Vec<Vec<String>> {
+    let mut subsets = Vec::new();
+    let limit = 1usize << items.len();
+    for mask in 0..limit {
+        let mut subset = Vec::new();
+        for (index, item) in items.iter().enumerate() {
+            if mask & (1usize << index) != 0 {
+                subset.push(item.clone());
+            }
+        }
+        subsets.push(subset);
+    }
+    subsets.sort();
+    subsets
+}
+
+fn is_subset(left: &[String], right: &[String]) -> bool {
+    left.iter().all(|item| right.contains(item))
 }
 
 fn cech_edges(normalized: &NormalizedArchMapV2, selected_contexts: &[String]) -> Vec<CechEdgeV1> {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -336,6 +336,293 @@ fn cli_analyze_v2_cech_ignores_unanchored_mismatch_support() {
 }
 
 #[test]
+fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
+    let out_dir = temp_dir("ag-measurement-square-free-repair");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2_square_free_repair.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"][0]["evaluator"],
+        "ag.square-free-repair@1"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdict"],
+        "measured_nonzero"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["certRef"],
+        "atom:nsdepth-certificate"
+    );
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(repair["obstructionIdeal"]["id"], "I_Ob^U");
+    assert_eq!(
+        repair["minimalForbiddenSupports"],
+        serde_json::json!([["x_checkout", "x_inventory"], ["x_inventory", "x_payment"]])
+    );
+    assert_eq!(
+        repair["alexanderDualRepair"]["minimalHittingSets"],
+        serde_json::json!([["x_inventory"], ["x_checkout", "x_payment"]])
+    );
+    assert_eq!(repair["nsdepthCertificate"]["nsdepth"], Value::from(2));
+
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    assert_eq!(
+        summary["conclusion"],
+        "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_square_free_without_certificate_returns_unknown() {
+    let out_dir = temp_dir("ag-measurement-square-free-no-cert");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    archmap["atoms"] = Value::Array(
+        archmap["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .filter(|atom| atom["id"] != "atom:nsdepth-certificate")
+            .cloned()
+            .collect(),
+    );
+    archmap["contexts"][0]["atoms"] = Value::Array(
+        archmap["contexts"][0]["atoms"]
+            .as_array()
+            .expect("context atoms is array")
+            .iter()
+            .filter(|atom| atom.as_str() != Some("atom:nsdepth-certificate"))
+            .cloned()
+            .collect(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_square_free_no_cert.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "nsdepth_certificate_missing"
+    );
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(repair["nsdepthCertificate"]["status"], "missing");
+}
+
+#[test]
+fn cli_analyze_v2_square_free_requires_matching_witness_family() {
+    let out_dir = temp_dir("ag-measurement-square-free-witness-family");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_square_free.json"));
+    policy["measurementProfiles"][0]["witnessFamily"] = Value::Array(vec![]);
+    let policy_path = out_dir.join("law_policy_square_free_missing_witness.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_square_free_repair.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_square_free_rejects_malformed_nsdepth_certificate() {
+    let out_dir = temp_dir("ag-measurement-square-free-bad-cert");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    archmap["atoms"][5]["object"] = Value::String("not-a-number".to_string());
+    let archmap_path = out_dir.join("archmap_v2_square_free_bad_cert.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_square_free.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_square_free_rejects_generator_outside_witness_family() {
+    let out_dir = temp_dir("ag-measurement-square-free-unknown-variable");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    archmap["atoms"][3]["subject"] = Value::String("x_unknown".to_string());
+    let archmap_path = out_dir.join("archmap_v2_square_free_unknown_variable.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_square_free.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_square_free_rejects_too_many_witness_variables() {
+    let out_dir = temp_dir("ag-measurement-square-free-too-many-witnesses");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_square_free.json"));
+    policy["measurementProfiles"][0]["witnessFamily"] = Value::Array(
+        (0..13)
+            .map(|index| {
+                serde_json::json!({
+                    "law": "ag.square-free-repair",
+                    "variable": format!("x_{index}")
+                })
+            })
+            .collect(),
+    );
+    let policy_path = out_dir.join("law_policy_square_free_too_many_witnesses.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_square_free_repair.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_square_free_without_generators_returns_measured_zero() {
+    let out_dir = temp_dir("ag-measurement-square-free-zero");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    archmap["atoms"] = Value::Array(
+        archmap["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .filter(|atom| atom["predicate"] != "obstructionGenerator")
+            .cloned()
+            .collect(),
+    );
+    archmap["contexts"][0]["atoms"] = Value::Array(
+        archmap["contexts"][0]["atoms"]
+            .as_array()
+            .expect("context atoms is array")
+            .iter()
+            .filter(|atom| {
+                !matches!(
+                    atom.as_str(),
+                    Some("atom:ob-checkout-inventory" | "atom:ob-inventory-payment")
+                )
+            })
+            .cloned()
+            .collect(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_square_free_zero.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(
+        repair["obstructionIdeal"]["generators"]
+            .as_array()
+            .expect("generators is array")
+            .len(),
+        0
+    );
+}
+
+#[test]
 fn cli_locks_ag_measurement_cech_h1_visible_golden_fixture() {
     let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let repo_root = crate_root
@@ -369,6 +656,40 @@ fn cli_locks_ag_measurement_cech_h1_visible_golden_fixture() {
 }
 
 #[test]
+fn cli_locks_ag_measurement_square_free_golden_fixture() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate root is tools/archsig inside repo");
+    let fixture = read_json(&ag_measurement_root().join("archmap_v2_square_free_repair.json"));
+    assert_eq!(fixture["schema"], "archmap/v2");
+    assert_eq!(fixture["id"], "ag-measurement-square-free-repair-fixture");
+    assert!(
+        fixture["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .any(|atom| atom["axis"] == "square-free" && atom["predicate"] == "nsdepthCertificate"),
+        "AG square-free fixture must contain an explicit NSdepth certificate atom"
+    );
+
+    let golden_corpus = fs::read_to_string(repo_root.join("docs/tool/golden_corpus.md"))
+        .expect("golden corpus docs are readable");
+    for snippet in [
+        "archmap_v2_square_free_repair.json",
+        "law_policy_square_free.json",
+        "cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth",
+        "cli_analyze_v2_square_free_without_certificate_returns_unknown",
+    ] {
+        assert!(
+            golden_corpus.contains(snippet),
+            "AG golden corpus docs must mention {snippet}"
+        );
+    }
+}
+
+#[test]
 fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
     let out_dir = temp_dir("ag-measurement-strict");
     let root = ag_measurement_root();
@@ -377,8 +698,8 @@ fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
         .as_array_mut()
         .expect("policies is array")
         .push(serde_json::json!({
-            "law": "ag.square-free-repair",
-            "evaluator": "ag.square-free-repair@1",
+            "law": "ag.law-conflict-tor",
+            "evaluator": "ag.law-conflict-tor@1",
             "basis": ["policy-basis:layering"],
             "scope": ["src/"],
             "severity": "medium"

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -359,9 +359,10 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
         packet["structuralVerdict"][0]["evaluator"],
         "ag.square-free-repair@1"
     );
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
     assert_eq!(
-        packet["structuralVerdict"][0]["verdict"],
-        "measured_nonzero"
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "nsdepth_certificate_author_supplied_unverified"
     );
     assert_eq!(
         packet["structuralVerdict"][0]["verdictData"]["certRef"],
@@ -377,12 +378,23 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
         repair["alexanderDualRepair"]["minimalHittingSets"],
         serde_json::json!([["x_inventory"], ["x_checkout", "x_payment"]])
     );
+    assert_eq!(
+        repair["stanleyReisnerComplex"]["reducedHomology"]["betti"],
+        serde_json::json!([
+            {"degree": 0, "dimension": 1},
+            {"degree": 1, "dimension": 0}
+        ])
+    );
+    assert_eq!(
+        repair["nsdepthCertificate"]["status"],
+        "author_supplied_unverified"
+    );
     assert_eq!(repair["nsdepthCertificate"]["nsdepth"], Value::from(2));
 
     let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
     assert_eq!(
         summary["conclusion"],
-        "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
+        "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
     );
 }
 
@@ -474,6 +486,47 @@ fn cli_analyze_v2_square_free_rejects_malformed_nsdepth_certificate() {
     let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
     archmap["atoms"][5]["object"] = Value::String("not-a-number".to_string());
     let archmap_path = out_dir.join("archmap_v2_square_free_bad_cert.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_square_free.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_square_free_rejects_any_malformed_nsdepth_certificate() {
+    let out_dir = temp_dir("ag-measurement-square-free-extra-bad-cert");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    let mut bad_cert = archmap["atoms"][5].clone();
+    bad_cert["id"] = Value::String("atom:nsdepth-certificate-malformed".to_string());
+    bad_cert["object"] = Value::String("not-a-number".to_string());
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(bad_cert);
+    archmap["contexts"][0]["atoms"]
+        .as_array_mut()
+        .expect("context atoms is array")
+        .push(Value::String(
+            "atom:nsdepth-certificate-malformed".to_string(),
+        ));
+    let archmap_path = out_dir.join("archmap_v2_square_free_extra_bad_cert.json");
     fs::write(
         &archmap_path,
         serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json
@@ -1,0 +1,113 @@
+{
+  "schema": "archmap/v2",
+  "id": "ag-measurement-square-free-repair-fixture",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:ag-fixture@1",
+    "fingerprint": "sha256:ag-fixture-doctrine",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
+  "sources": {
+    "src:checkout": {
+      "kind": "rust",
+      "path": "src/checkout.rs",
+      "symbol": "CheckoutContext",
+      "line": 1
+    },
+    "src:inventory": {
+      "kind": "rust",
+      "path": "src/inventory.rs",
+      "symbol": "InventoryContext",
+      "line": 1
+    },
+    "src:payment": {
+      "kind": "rust",
+      "path": "src/payment.rs",
+      "symbol": "PaymentContext",
+      "line": 1
+    },
+    "src:certificate": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.3-B.4"
+    },
+    "src:cover": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R4"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:checkout",
+      "kind": "component",
+      "subject": "src:checkout",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:checkout"]
+    },
+    {
+      "id": "atom:inventory",
+      "kind": "component",
+      "subject": "src:inventory",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:inventory"]
+    },
+    {
+      "id": "atom:payment",
+      "kind": "component",
+      "subject": "src:payment",
+      "axis": "static",
+      "predicate": "component",
+      "refs": ["src:payment"]
+    },
+    {
+      "id": "atom:ob-checkout-inventory",
+      "kind": "relation",
+      "subject": "x_checkout",
+      "object": "x_inventory",
+      "axis": "square-free",
+      "predicate": "obstructionGenerator",
+      "refs": ["src:checkout", "src:inventory"]
+    },
+    {
+      "id": "atom:ob-inventory-payment",
+      "kind": "relation",
+      "subject": "x_inventory",
+      "object": "x_payment",
+      "axis": "square-free",
+      "predicate": "obstructionGenerator",
+      "refs": ["src:inventory", "src:payment"]
+    },
+    {
+      "id": "atom:nsdepth-certificate",
+      "kind": "semantic",
+      "subject": "cert:nsdepth-square-free",
+      "object": "2",
+      "axis": "square-free",
+      "predicate": "nsdepthCertificate",
+      "refs": ["src:certificate"]
+    }
+  ],
+  "contexts": [
+    {
+      "id": "ctx:square-free-local",
+      "atoms": [
+        "atom:checkout",
+        "atom:inventory",
+        "atom:payment",
+        "atom:ob-checkout-inventory",
+        "atom:ob-inventory-payment",
+        "atom:nsdepth-certificate"
+      ],
+      "refs": ["src:cover"]
+    }
+  ],
+  "covers": [
+    {
+      "id": "cover:square-free-repair",
+      "contexts": ["ctx:square-free-local"],
+      "refs": ["src:cover"]
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/ag_measurement/law_policy_square_free.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/law_policy_square_free.json
@@ -1,0 +1,44 @@
+{
+  "schema": "law-policy/v1",
+  "id": "ag-square-free-policy",
+  "measurementProfileRef": "profile:ag-square-free@1",
+  "measurementProfiles": [
+    {
+      "schema": "measurement-profile/v1",
+      "profileId": "profile:ag-square-free@1",
+      "siteRef": "archmap:/contexts",
+      "coverRef": "cover:square-free-repair",
+      "coefficient": "F2",
+      "effCoeff": "finite-linear-algebra@1",
+      "witnessFamily": [
+        {
+          "law": "ag.square-free-repair",
+          "variable": "x_checkout"
+        },
+        {
+          "law": "ag.square-free-repair",
+          "variable": "x_inventory"
+        },
+        {
+          "law": "ag.square-free-repair",
+          "variable": "x_payment"
+        }
+      ],
+      "resolutionSelector": "taylor@1",
+      "domain": "finite-poset-site",
+      "zeroPredicate": "rank-zero@1",
+      "nonZeroPredicate": "rank-positive@1",
+      "certSelector": "finite-certificate@1",
+      "verdictDiscipline": "five-valued-structural-verdict@1"
+    }
+  ],
+  "policies": [
+    {
+      "law": "ag.square-free-repair",
+      "evaluator": "ag.square-free-repair@1",
+      "basis": ["policy-basis:layering"],
+      "scope": ["src/"],
+      "severity": "high"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1917
Part of #1907

ArchSig v0.4.0 PRD の square-free repair 測定面として、`ag.square-free-repair@1` evaluator と NSdepth fixture を追加しました。

- `profile:ag-square-free@1` に対して、有限 square-free monomial obstruction から `I_Ob^U`、minimal forbidden supports、`Delta_U`、finite F2 reduced homology、Alexander dual repair の minimal hitting sets を計算する
- `nsdepthCertificate` atom は author-supplied reference として packet に残すが、finite verifier payload ではないため verdict は `unknown` に留める
- certificate 不在時も `unknown` に落とし、測定主張をしない
- malformed certificate、複数 certificate、witness family 外の generator、過大な witness variable set は fail-closed にする
- golden corpus に square-free repair fixture と lock test を追加する

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/golden_corpus.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
