### PR TITLE
AG版AATの命題A9観測不完全性を追加する

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -1,2 +1,3 @@
 import Formal.AG.Atom.Atom
 import Formal.AG.Atom.Axioms
+import Formal.AG.Atom.Observation

--- a/Formal/AG/Atom/Observation.lean
+++ b/Formal/AG/Atom/Observation.lean
@@ -1,0 +1,159 @@
+import Formal.AG.Atom.Axioms
+
+namespace AAT.AG
+
+universe u
+
+/-- I.命題A9: an observation map from a family carrier to observations. -/
+structure ObservationModel (Family Observation : Type u) where
+  observe : Family -> Observation
+
+namespace ObservationModel
+
+/-- I.命題A9: observations can collapse distinct families. -/
+def NonInjective {Family Observation : Type u}
+    (M : ObservationModel Family Observation) : Prop :=
+  ∃ F G, F ≠ G ∧ M.observe F = M.observe G
+
+end ObservationModel
+
+/-- I.命題A9: a coarse projection used by an observation reading. -/
+structure ObservationProjection (Family CoarseFamily : Type u) where
+  project : Family -> CoarseFamily
+
+/-- I.命題A9: a reconstruction attempt from observations back to families. -/
+structure ReconstructionAttempt (Observation Family : Type u) where
+  reconstruct : Observation -> Family
+
+/--
+I.命題A9: a non-injective observation map admits no exact reconstruction for
+all families.
+-/
+theorem no_exact_reconstruction_of_nonInjective {Family Observation : Type u}
+    (M : ObservationModel Family Observation)
+    (R : ReconstructionAttempt Observation Family)
+    (hM : M.NonInjective) :
+    ¬ ∀ F, R.reconstruct (M.observe F) = F := by
+  intro hExact
+  rcases hM with ⟨F, G, hne, hobs⟩
+  apply hne
+  calc
+    F = R.reconstruct (M.observe F) := (hExact F).symm
+    _ = R.reconstruct (M.observe G) := by rw [hobs]
+    _ = G := hExact G
+
+namespace A9Example
+
+inductive Atom where
+  | observed
+  | hidden
+  deriving DecidableEq
+
+inductive Family where
+  | canonical
+  | alternative
+  deriving DecidableEq
+
+inductive Source where
+  | source
+
+inductive Observation where
+  | collapsed
+  deriving DecidableEq
+
+/-- I.命題A9: a tiny carrier with one observed atom and one hidden atom. -/
+def carrier : AtomCarrier where
+  AtomKind := Unit
+  Axis := Unit
+  Subject := Unit
+  Predicate := Unit
+  Payload := Unit
+  Atom := Atom
+  kind := fun _ => ()
+  axis := fun _ => ()
+  subject := fun _ => ()
+  predicate := fun _ => ()
+  payload := fun _ => ()
+
+/-- I.命題A9: a constant observation collapses all example atoms. -/
+def observeAtom (_atom : Atom) : Observation := Observation.collapsed
+
+/-- I.命題A9: the selected atom read from a collapsed observation. -/
+def observedAtom? : Observation -> Option Atom
+  | Observation.collapsed => some Atom.observed
+
+/-- I.命題A9: a constant observation collapses two different atoms. -/
+theorem noninjective_atom_observation :
+    ∃ a b : Atom, a ≠ b ∧ observeAtom a = observeAtom b := by
+  refine ⟨Atom.observed, Atom.hidden, ?_, rfl⟩
+  intro h
+  cases h
+
+/-- I.命題A9: which atoms are recovered from the selected observation surface. -/
+def AppearsInObservation (atom : Atom) : Prop :=
+  observedAtom? (observeAtom atom) = some atom
+
+/-- I.命題A9: an atom can exist without appearing in the observation surface. -/
+theorem unobserved_atom_exists :
+    ∃ atom : Atom, ¬ AppearsInObservation atom := by
+  exact ⟨Atom.hidden, by simp [AppearsInObservation, observedAtom?]⟩
+
+/-- I.命題A9: the example family observation collapses all families. -/
+def familyObservation : ObservationModel Family Observation where
+  observe := fun _ => Observation.collapsed
+
+/-- I.命題A9: the family observation is non-injective. -/
+theorem noninjective_family_observation :
+    familyObservation.NonInjective := by
+  refine ⟨Family.canonical, Family.alternative, ?_, rfl⟩
+  intro h
+  cases h
+
+/-- I.命題A9: the associated coarse projection. -/
+def projection : ObservationProjection Family Observation where
+  project := familyObservation.observe
+
+/-- I.命題A9: a reconstruction attempt that chooses the canonical family. -/
+def reconstruction : ReconstructionAttempt Observation Family where
+  reconstruct := fun _ => Family.canonical
+
+/-- I.命題A9: the non-injective example has no exact reconstruction. -/
+theorem reconstruction_not_exact :
+    ¬ ∀ F, reconstruction.reconstruct (familyObservation.observe F) = F :=
+  no_exact_reconstruction_of_nonInjective familyObservation reconstruction
+    noninjective_family_observation
+
+/-- I.命題A9 / A8: a doctrine whose canonical family is independent of observation. -/
+def doctrine : ExtractionDoctrine carrier Family where
+  Source := Source
+  Vocabulary := Unit
+  SemanticReading := Unit
+  Resolution := Unit
+  sourceSemantics := fun _ => Unit
+  normalize := fun src => src
+  atomize := fun _ => Family.canonical
+
+/-- I.命題A9 / A8: canonical family uniqueness follows from the doctrine. -/
+theorem canonical_family_unique {F G : Family}
+    (hF : F = doctrine.atomize Source.source)
+    (hG : G = doctrine.atomize Source.source) : F = G :=
+  ExtractionDoctrine.atomize_unique doctrine Source.source hF hG
+
+/--
+I.命題A9: observation incompleteness and A8 canonical-family uniqueness are
+separate facts in the same finite example.
+-/
+theorem observation_incompleteness_coexists_with_a8 :
+    familyObservation.NonInjective ∧
+      (∀ {F G : Family},
+        F = doctrine.atomize Source.source ->
+        G = doctrine.atomize Source.source ->
+        F = G) := by
+  constructor
+  · exact noninjective_family_observation
+  · intro F G hF hG
+    exact canonical_family_unique hF hG
+
+end A9Example
+
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4437,12 +4437,13 @@ completeness、FieldSig forecast calibration は結論しない。
 
 ## AG版AAT Lean形式化 PRD-1 bootstrap
 
-File: `Formal/AG.lean`, `Formal/AG/Atom/Atom.lean`, `Formal/AG/Atom/Axioms.lean`.
+File: `Formal/AG.lean`, `Formal/AG/Atom/Atom.lean`, `Formal/AG/Atom/Axioms.lean`,
+`Formal/AG/Atom/Observation.lean`.
 
 PRD-1 [第I部 Atom・対象・法則](lean_ag_part_1_atoms_objects_laws_prd.md) の
-AC1/R0 と AC2/R1 に対応する初期 Atom entrypoint である。`Formal/Arch` は import せず、
+AC1/R0、AC2/R1、AC3/R1 に対応する初期 Atom entrypoint である。`Formal/Arch` は import せず、
 AG 版 AAT の namespace を `AAT.AG` として分離する。この節は Part I の最下層索引であり、
-命題A9、定理9.3、定理10.5 の完了宣言ではない。
+定理9.3、定理10.5 の完了宣言ではない。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4452,9 +4453,10 @@ AG 版 AAT の namespace を `AAT.AG` として分離する。この節は Part 
 | `I.公理A0-A8` | `AAT.AG.AtomAxiomSystem` | `structure` | AG Atom carrier 上で A0-A8 を structure field として束ねる package。 | `defined only` |
 | `I.公理A3` | `AAT.AG.SameCoordinates`, `AAT.AG.AtomAxiomSystem.eq_iff_sameCoordinates`, `AAT.AG.AtomAxiomSystem.ext` | `def` / `theorem` | 五成分一致と Atom 同一性の同値、ならびに ext 補題。 | `proved` |
 | `I.公理A8` | `AAT.AG.ExtractionDoctrine`, `AAT.AG.ExtractionDoctrine.atomize_unique`, `AAT.AG.CoarseProjection`, `AAT.AG.AtomAxiomSystem.doctrine_family_unique` | `structure` / `theorem` | extraction doctrine と、`atomize` が関数であることから得る canonical Atom family の一意性。 | `defined only` / `proved` |
+| `I.命題A9` | `AAT.AG.ObservationModel`, `ObservationModel.NonInjective`, `ObservationProjection`, `ReconstructionAttempt`, `no_exact_reconstruction_of_nonInjective`, `A9Example.projection`, `A9Example.reconstruction`, `A9Example.noninjective_atom_observation`, `A9Example.unobserved_atom_exists`, `A9Example.noninjective_family_observation`, `A9Example.reconstruction_not_exact`, `A9Example.canonical_family_unique`, `A9Example.observation_incompleteness_coexists_with_a8` | `structure` / `def` / `theorem` | 観測写像、projection、reconstruction、非単射観測、未観測 Atom、A8 一意性との分離を有限例で示す。 | `defined only` / `proved` |
 
 Non-conclusions: この bootstrap は `Formal/AG` の Atom carrier と A0-A8 package の
-入口であり、命題A9、AtomFamily、Configuration、Lawfulness-Zero Obstruction、
+入口であり、AtomFamily、Configuration、Lawfulness-Zero Obstruction、
 AAT Core、有限モデルは後続 Issue の対象である。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -542,13 +542,15 @@ Issue [#1913](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では `Formal/AG` の bootstrap と `I.定義1.1` の Atom carrier entrypoint を追加した。
 Issue [#1918](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1918)
 では A0-A8 を structure field として束ね、A3 ext 補題と A8 一意性 theorem を追加した。
+Issue [#1922](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1922)
+では命題A9の観測不完全性と存在一意性の分離を有限例 theorem として追加した。
 これは定理9.3 / 定理10.5 の証明済み主張ではない。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `I.定義1.1` Atom carrier | `defined only`. `Formal/AG/Atom/Atom.lean` が `AAT.AG.AtomRecord`, `AAT.AG.AtomCarrier`, `AAT.AG.AtomCarrier.record` を持つ。 | 命題A9、AtomFamily、Configuration、Lawfulness-Zero Obstruction、AAT Core、有限モデルはまだ proved claim ではない。 |
-| `I.公理A0-A8` Atom system package | `defined only` / `proved` for A3 and A8 accessors. `Formal/AG/Atom/Axioms.lean` が `AAT.AG.AtomAxiomSystem`, `AAT.AG.AtomAxiomSystem.ext`, `AAT.AG.ExtractionDoctrine.atomize_unique`, `AAT.AG.AtomAxiomSystem.doctrine_family_unique` を持つ。 | A4/R3 との具体接続、命題A9 の観測不完全性 example theorem、R2 以降の AtomFamily / Configuration 実装は後続 Issue に残る。 |
-| 命題A9 観測不完全性と存在一意性 | `future proof obligation`. | 観測写像、projection、非単射観測 example theorem、canonical family の存在一意性との分離を後続 Issue で証明する。 |
+| `I.定義1.1` Atom carrier | `defined only`. `Formal/AG/Atom/Atom.lean` が `AAT.AG.AtomRecord`, `AAT.AG.AtomCarrier`, `AAT.AG.AtomCarrier.record` を持つ。 | AtomFamily、Configuration、Lawfulness-Zero Obstruction、AAT Core、有限モデルはまだ proved claim ではない。 |
+| `I.公理A0-A8` Atom system package | `defined only` / `proved` for A3 and A8 accessors. `Formal/AG/Atom/Axioms.lean` が `AAT.AG.AtomAxiomSystem`, `AAT.AG.AtomAxiomSystem.ext`, `AAT.AG.ExtractionDoctrine.atomize_unique`, `AAT.AG.AtomAxiomSystem.doctrine_family_unique` を持つ。 | A4/R3 との具体接続、R2 以降の AtomFamily / Configuration 実装は後続 Issue に残る。 |
+| `I.命題A9` 観測不完全性と存在一意性 | `defined only` / `proved`. `Formal/AG/Atom/Observation.lean` が `ObservationModel`, `ObservationProjection`, `ReconstructionAttempt`, `no_exact_reconstruction_of_nonInjective`, `A9Example.projection`, `A9Example.reconstruction`, `A9Example.noninjective_atom_observation`, `A9Example.unobserved_atom_exists`, `A9Example.noninjective_family_observation`, `A9Example.reconstruction_not_exact`, `A9Example.canonical_family_unique`, `A9Example.observation_incompleteness_coexists_with_a8` を持つ。 | R2 以降の本格的な AtomFamily / closure / Configuration API との接続は後続 Issue に残る。 |
 | 命題5.3 Atom-Origin | `future proof obligation`. | ArchitectureObject / Generated Object の定義が入った後で、生成関係から証明する。 |
 | 例8.3 / 例8.4 obstruction example theorem | `future proof obligation`. | R7 と R10 の有限モデルが入るまで proved claim として扱わない。 |
 | 定理9.3 Lawfulness-Zero Obstruction | `future proof obligation`. | soundness、completeness、zero-reflecting aggregation、三読み一致の明示仮定が入るまで proved claim として扱わない。 |


### PR DESCRIPTION
## 概要

Closes #1922

AG版AAT PRD-1 / AC3/R1 に対応して、命題A9の観測不完全性を Formal/AG に追加します。

- `ObservationModel` / `ObservationProjection` / `ReconstructionAttempt` を追加
- 非単射観測、未観測 Atom、非単射観測から exact reconstruction が成り立たない theorem を追加
- A8 canonical family uniqueness と観測不完全性が同じ有限例で同時に成立することを theorem として分離
- `lean_theorem_index.md` / `proof_obligations.md` の Lean status を同期

## 証明した定理

- `AAT.AG.no_exact_reconstruction_of_nonInjective`
- `AAT.AG.A9Example.noninjective_atom_observation`
- `AAT.AG.A9Example.unobserved_atom_exists`
- `AAT.AG.A9Example.noninjective_family_observation`
- `AAT.AG.A9Example.reconstruction_not_exact`
- `AAT.AG.A9Example.canonical_family_unique`
- `AAT.AG.A9Example.observation_incompleteness_coexists_with_a8`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Atom/Observation.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build Formal.AG`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan

`lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ再表示されました。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている（対象外: ArchSig 変更なし）
- [x] ArchSig と FieldSig の責務を混同していない（対象外: ArchSig / FieldSig 変更なし）