### PR TITLE
ArchSig LawConflict Tor evaluator と common ambient fixture を追加

### DIFF
--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -33,8 +33,10 @@ covers rather than molecule-primary ArchMaps.
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json`
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json`
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json`
+- `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_law_conflict_tor.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_square_free.json`
+- `tools/archsig/tests/fixtures/ag_measurement/law_policy_tor.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_missing_profile.json`
 
 The executable lock is
@@ -53,6 +55,16 @@ as measurement packet invariants. Because the NSdepth atom is not a finite
 verifier payload, the structural verdict remains `unknown`. The companion
 `cli_analyze_v2_square_free_without_certificate_returns_unknown` regression
 keeps missing certificates as `unknown`, not lawful or measured zero.
+
+The LawConflict Tor lock is
+`cli_analyze_v2_law_conflict_tor_outputs_conflict_classes`. It fixes the B.5
+worked example path: an explicit common ambient atom bounds the comparison,
+finite monomial law ideal generators are read under that ambient, and
+`LawConflict_1` classes record witness-variable support, context refs, and
+source refs. The companion
+`cli_analyze_v2_law_conflict_tor_without_common_ambient_is_not_computed`
+regression keeps missing ambient evidence as `not_computed` /
+`no_common_ambient`, not measured zero or conflict absence.
 
 ## V1 Positive Fixtures
 

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -17,6 +17,7 @@ const VERDICTS: [&str; 5] = [
     "not_computed",
 ];
 const MAX_SQUARE_FREE_WITNESS_VARIABLES: usize = 12;
+const MAX_TOR_WITNESS_VARIABLES: usize = 12;
 
 pub fn selected_measurement_profile_v1(
     policy: &LawPolicyDocumentV1,
@@ -128,6 +129,27 @@ pub fn build_foundation_measurement_packet_v1(
                 },
                 reason: Some(measurement.reason),
             });
+        } else if evaluator == "ag.law-conflict-tor@1" {
+            validate_tor_profile_v1(&profile)?;
+            let measurement = evaluate_law_conflict_tor_v1(normalized, &profile)?;
+            computed_invariants.extend(measurement.computed_invariants);
+            assumptions.extend(measurement.assumptions);
+            structural_verdict.push(AgStructuralVerdictV1 {
+                evaluator: evaluator.to_string(),
+                law: entry
+                    .law
+                    .clone()
+                    .unwrap_or_else(|| "ag.law-conflict-tor".to_string()),
+                verdict: measurement.verdict,
+                verdict_data: AgVerdictDataV1 {
+                    in_scope: true,
+                    zero: measurement.zero,
+                    non_zero: measurement.non_zero,
+                    method_status: measurement.method_status,
+                    cert_ref: measurement.cert_ref,
+                },
+                reason: Some(measurement.reason),
+            });
         } else {
             structural_verdict.push(AgStructuralVerdictV1 {
                 evaluator: evaluator.to_string(),
@@ -199,6 +221,49 @@ struct SquareFreeCertificateV1 {
     cert_ref: String,
     nsdepth: usize,
     support_atom_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TorMeasurementV1 {
+    verdict: String,
+    zero: bool,
+    non_zero: bool,
+    method_status: String,
+    cert_ref: Option<String>,
+    reason: String,
+    computed_invariants: Vec<Value>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct TorCommonAmbientV1 {
+    ambient_ref: String,
+    atom_ref: String,
+    law_pair: Vec<String>,
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TorIdealGeneratorV1 {
+    law: String,
+    generator_id: String,
+    support: Vec<String>,
+    context_refs: Vec<String>,
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TorConflictClassV1 {
+    conflict_id: String,
+    degree: usize,
+    support: Vec<String>,
+    shared_support: Vec<String>,
+    left_law: String,
+    left_generator_ref: String,
+    right_law: String,
+    right_generator_ref: String,
+    context_refs: Vec<String>,
+    source_refs: Vec<String>,
 }
 
 fn evaluate_square_free_repair_v1(
@@ -332,6 +397,144 @@ fn evaluate_square_free_repair_v1(
                 ),
             },
         ],
+    })
+}
+
+fn evaluate_law_conflict_tor_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> Result<TorMeasurementV1, String> {
+    let selected_contexts = selected_cover_contexts(normalized, profile)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let witness_variables = tor_witness_variables(profile);
+    let ambient = tor_common_ambient(normalized, &selected_contexts)?;
+    let Some(ambient) = ambient else {
+        return Ok(TorMeasurementV1 {
+            verdict: "not_computed".to_string(),
+            zero: false,
+            non_zero: false,
+            method_status: "no_common_ambient".to_string(),
+            cert_ref: None,
+            reason: "common ambient pair is not supplied; no LawConflict comparison is computed"
+                .to_string(),
+            computed_invariants: vec![json!({
+                "invariantId": format!("law-conflict-tor:{}", profile.profile_id),
+                "evaluator": "ag.law-conflict-tor@1",
+                "method": "finite-monomial-tor@1",
+                "selectedCoverRef": profile.cover_ref,
+                "status": "not_computed",
+                "reason": "no_common_ambient"
+            })],
+            assumptions: tor_assumptions(profile, None, "violated"),
+        });
+    };
+
+    let generators = tor_ideal_generators(normalized, &selected_contexts, &witness_variables)?;
+    let law_order = ambient.law_pair.clone();
+    let selected_laws = generators
+        .iter()
+        .map(|generator| generator.law.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let ambient_laws = law_order.iter().cloned().collect::<BTreeSet<_>>();
+    let outside_ambient = selected_laws
+        .iter()
+        .filter(|law| !ambient_laws.contains(*law))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !outside_ambient.is_empty() {
+        return Err(format!(
+            "ag.law-conflict-tor@1 selected law generators outside common ambient pair: {}",
+            outside_ambient.join(",")
+        ));
+    }
+    if selected_laws.len() != 2 || selected_laws != law_order {
+        return Err(format!(
+            "ag.law-conflict-tor@1 requires generators for exactly the common ambient law pair {}, found {}",
+            law_order.join(","),
+            selected_laws.join(",")
+        ));
+    }
+    let conflicts = tor_conflict_classes(&generators, &law_order[0], &law_order[1]);
+    let has_conflict = !conflicts.is_empty();
+    let law_ideals = law_order
+        .iter()
+        .map(|law| {
+            json!({
+                "law": law,
+                "generators": generators.iter()
+                    .filter(|generator| &generator.law == law)
+                    .map(|generator| json!({
+                        "generatorId": generator.generator_id,
+                        "support": generator.support,
+                        "contextRefs": generator.context_refs,
+                        "sourceRefs": generator.source_refs
+                    }))
+                    .collect::<Vec<_>>()
+            })
+        })
+        .collect::<Vec<_>>();
+    let conflict_json = conflicts
+        .iter()
+        .map(|conflict| {
+            json!({
+                "conflictId": conflict.conflict_id,
+                "degree": conflict.degree,
+                "support": conflict.support,
+                "sharedSupport": conflict.shared_support,
+                "leftLaw": conflict.left_law,
+                "leftGeneratorRef": conflict.left_generator_ref,
+                "rightLaw": conflict.right_law,
+                "rightGeneratorRef": conflict.right_generator_ref,
+                "contextRefs": conflict.context_refs,
+                "sourceRefs": conflict.source_refs
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(TorMeasurementV1 {
+        verdict: if has_conflict {
+            "measured_nonzero".to_string()
+        } else {
+            "measured_zero".to_string()
+        },
+        zero: !has_conflict,
+        non_zero: has_conflict,
+        method_status: "finite_monomial_tor_computed".to_string(),
+        cert_ref: Some(ambient.atom_ref.clone()),
+        reason: if has_conflict {
+            "finite monomial Tor found LawConflict classes under the supplied common ambient"
+                .to_string()
+        } else {
+            "finite monomial Tor found no LawConflict class under the supplied common ambient"
+                .to_string()
+        },
+        computed_invariants: vec![json!({
+            "invariantId": format!("law-conflict-tor:{}", profile.profile_id),
+            "evaluator": "ag.law-conflict-tor@1",
+            "method": "finite-monomial-tor@1",
+            "resolution": profile.resolution_selector,
+            "selectedCoverRef": profile.cover_ref,
+            "witnessVariables": witness_variables,
+            "commonAmbient": {
+                "ambientRef": ambient.ambient_ref,
+                "atomRef": ambient.atom_ref,
+                "lawPair": ambient.law_pair,
+                "sourceRefs": ambient.source_refs
+            },
+            "lawIdeals": law_ideals,
+            "lawConflicts": conflict_json,
+            "torByDegree": [{
+                "degree": 1,
+                "classCount": conflicts.len()
+            }],
+            "nonConclusions": [
+                "Flat base change stability is a theorem-candidate reading and is not concluded by this structural verdict."
+            ]
+        })],
+        assumptions: tor_assumptions(profile, Some(&ambient), "checked"),
     })
 }
 
@@ -631,6 +834,281 @@ fn square_free_witness_variables(profile: &MeasurementProfileV1) -> Vec<String> 
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+fn validate_tor_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        ("coefficient", profile.coefficient.as_str(), "F2"),
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "finite-linear-algebra@1",
+        ),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "rank-zero@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "rank-positive@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "finite-certificate@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.law-conflict-tor@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if !matches!(profile.resolution_selector.as_str(), "taylor@1" | "scarf@1") {
+        return Err(format!(
+            "ag.law-conflict-tor@1 requires MeasurementProfile resolutionSelector=taylor@1 or scarf@1, found {}",
+            profile.resolution_selector
+        ));
+    }
+    if tor_witness_variables(profile).is_empty() {
+        return Err(format!(
+            "ag.law-conflict-tor@1 requires MeasurementProfile {} witnessFamily law ag.law-conflict-tor",
+            profile.profile_id
+        ));
+    }
+    if tor_witness_variables(profile).len() > MAX_TOR_WITNESS_VARIABLES {
+        return Err(format!(
+            "ag.law-conflict-tor@1 supports at most {MAX_TOR_WITNESS_VARIABLES} witness variables for finite monomial enumeration"
+        ));
+    }
+    Ok(())
+}
+
+fn tor_witness_variables(profile: &MeasurementProfileV1) -> Vec<String> {
+    profile
+        .witness_family
+        .iter()
+        .filter(|witness| witness.law == "ag.law-conflict-tor")
+        .map(|witness| witness.variable.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn tor_common_ambient(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+) -> Result<Option<TorCommonAmbientV1>, String> {
+    let ambients = normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "tor" && atom.predicate == "commonAmbient")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+        .map(|atom| {
+            let raw_pair = atom.object.as_deref().ok_or_else(|| {
+                format!(
+                    "ag.law-conflict-tor@1 common ambient {} requires object law pair",
+                    atom.normalized_atom_id
+                )
+            })?;
+            let law_pair = raw_pair
+                .split(',')
+                .map(str::trim)
+                .filter(|law| !law.is_empty())
+                .map(ToString::to_string)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            if law_pair.len() != 2 {
+                return Err(format!(
+                    "ag.law-conflict-tor@1 common ambient {} requires exactly two laws in object",
+                    atom.normalized_atom_id
+                ));
+            }
+            Ok(TorCommonAmbientV1 {
+                ambient_ref: atom.subject.clone(),
+                atom_ref: atom.normalized_atom_id.clone(),
+                law_pair,
+                source_refs: atom.source_refs.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if ambients.len() > 1 {
+        return Err(format!(
+            "ag.law-conflict-tor@1 expected at most one selected common ambient, found {}",
+            ambients.len()
+        ));
+    }
+
+    Ok(ambients.into_iter().next())
+}
+
+fn tor_ideal_generators(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+    witness_variables: &[String],
+) -> Result<Vec<TorIdealGeneratorV1>, String> {
+    let witness_set = witness_variables.iter().cloned().collect::<BTreeSet<_>>();
+    let mut generators = Vec::new();
+    for atom in normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "tor" && atom.predicate == "lawIdealGenerator")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+    {
+        let support = tor_atom_variables(atom);
+        let unknown = support
+            .iter()
+            .filter(|variable| !witness_set.contains(*variable))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !unknown.is_empty() {
+            return Err(format!(
+                "ag.law-conflict-tor@1 generator {} contains variables outside witnessFamily: {}",
+                atom.normalized_atom_id,
+                unknown.join(",")
+            ));
+        }
+        if support.is_empty() {
+            return Err(format!(
+                "ag.law-conflict-tor@1 generator {} has no Tor witness variables",
+                atom.normalized_atom_id
+            ));
+        }
+        generators.push(TorIdealGeneratorV1 {
+            law: atom.subject.clone(),
+            generator_id: atom.normalized_atom_id.clone(),
+            support,
+            context_refs: atom.context_memberships.clone(),
+            source_refs: atom.source_refs.clone(),
+        });
+    }
+    generators.sort_by(|left, right| {
+        left.law
+            .cmp(&right.law)
+            .then_with(|| left.generator_id.cmp(&right.generator_id))
+    });
+    Ok(generators)
+}
+
+fn tor_atom_variables(atom: &crate::NormalizedAtomV2) -> Vec<String> {
+    atom.object
+        .as_deref()
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn tor_conflict_classes(
+    generators: &[TorIdealGeneratorV1],
+    left_law: &str,
+    right_law: &str,
+) -> Vec<TorConflictClassV1> {
+    let left_generators = generators
+        .iter()
+        .filter(|generator| generator.law == left_law)
+        .collect::<Vec<_>>();
+    let right_generators = generators
+        .iter()
+        .filter(|generator| generator.law == right_law)
+        .collect::<Vec<_>>();
+    let mut classes = Vec::new();
+    for left in &left_generators {
+        for right in &right_generators {
+            let shared_support = left
+                .support
+                .iter()
+                .filter(|variable| right.support.contains(*variable))
+                .cloned()
+                .collect::<Vec<_>>();
+            if shared_support.is_empty() {
+                continue;
+            }
+            let mut support = left
+                .support
+                .iter()
+                .chain(right.support.iter())
+                .cloned()
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            support.sort();
+            let context_refs = left
+                .context_refs
+                .iter()
+                .chain(right.context_refs.iter())
+                .cloned()
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let source_refs = left
+                .source_refs
+                .iter()
+                .chain(right.source_refs.iter())
+                .cloned()
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            classes.push(TorConflictClassV1 {
+                conflict_id: format!("LawConflict_1:{}", classes.len() + 1),
+                degree: 1,
+                support,
+                shared_support,
+                left_law: left.law.clone(),
+                left_generator_ref: left.generator_id.clone(),
+                right_law: right.law.clone(),
+                right_generator_ref: right.generator_id.clone(),
+                context_refs,
+                source_refs,
+            });
+        }
+    }
+    classes
+}
+
+fn tor_assumptions(
+    profile: &MeasurementProfileV1,
+    ambient: Option<&TorCommonAmbientV1>,
+    ambient_status: &str,
+) -> Vec<AgAssumptionLedgerEntryV1> {
+    vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/9.1".to_string(),
+            assumption: "common ambient pair supplied by ArchMap under MeasurementProfile"
+                .to_string(),
+            status: ambient_status.to_string(),
+            checked_by: ambient.map(|ambient| ambient.atom_ref.clone()),
+            assumed_by: (ambient_status != "checked")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part5/5.5".to_string(),
+            assumption: "finite monomial law ideals selected for Taylor / Scarf Tor enumeration"
+                .to_string(),
+            status: "checked".to_string(),
+            checked_by: Some(format!(
+                "measurement-profile:{}.witnessFamily",
+                profile.profile_id
+            )),
+            assumed_by: None,
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/9.2".to_string(),
+            assumption: "flat base change stability is theorem-candidate only".to_string(),
+            status: "assumed".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+    ]
 }
 
 fn square_free_generators(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -676,6 +676,349 @@ fn cli_analyze_v2_square_free_without_generators_returns_measured_zero() {
 }
 
 #[test]
+fn cli_analyze_v2_law_conflict_tor_outputs_conflict_classes() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2_law_conflict_tor.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_tor.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"][0]["evaluator"],
+        "ag.law-conflict-tor@1"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdict"],
+        "measured_nonzero"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "finite_monomial_tor_computed"
+    );
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["certRef"],
+        "atom:tor-common-ambient"
+    );
+    let tor = invariant_by_id(&packet, "law-conflict-tor:profile:ag-law-conflict-tor@1");
+    assert_eq!(
+        tor["commonAmbient"]["ambientRef"],
+        "ambient:checkout-inventory"
+    );
+    assert_eq!(
+        tor["lawConflicts"],
+        serde_json::json!([{
+            "conflictId": "LawConflict_1:1",
+            "degree": 1,
+            "support": ["x_checkout", "x_inventory", "x_payment"],
+            "sharedSupport": ["x_inventory"],
+            "leftLaw": "law:checkout",
+            "leftGeneratorRef": "atom:checkout-law-generator",
+            "rightLaw": "law:inventory",
+            "rightGeneratorRef": "atom:inventory-law-generator",
+            "contextRefs": ["ctx:tor-common-ambient"],
+            "sourceRefs": ["src:checkout-policy", "src:inventory-policy"]
+        }])
+    );
+    assert_eq!(
+        tor["torByDegree"],
+        serde_json::json!([{"degree": 1, "classCount": 1}])
+    );
+
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    assert_eq!(
+        summary["conclusion"],
+        "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_disjoint_supports_are_measured_zero() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-disjoint");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"][1]["object"] = Value::String("x_checkout".to_string());
+    archmap["atoms"][2]["object"] = Value::String("x_payment".to_string());
+    let archmap_path = out_dir.join("archmap_v2_law_conflict_tor_disjoint.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_tor.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
+    let tor = invariant_by_id(&packet, "law-conflict-tor:profile:ag-law-conflict-tor@1");
+    assert_eq!(
+        tor["lawConflicts"]
+            .as_array()
+            .expect("conflicts is array")
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_nested_common_factor_is_nonzero() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-nested");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"][1]["object"] = Value::String("x_inventory".to_string());
+    archmap["atoms"][2]["object"] = Value::String("x_inventory,x_payment".to_string());
+    let archmap_path = out_dir.join("archmap_v2_law_conflict_tor_nested.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_tor.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdict"],
+        "measured_nonzero"
+    );
+    let tor = invariant_by_id(&packet, "law-conflict-tor:profile:ag-law-conflict-tor@1");
+    assert_eq!(
+        tor["lawConflicts"][0]["sharedSupport"],
+        serde_json::json!(["x_inventory"])
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_rejects_generators_outside_ambient_pair() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-ambient-mismatch");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"][2]["subject"] = Value::String("law:shipping".to_string());
+    let archmap_path = out_dir.join("archmap_v2_law_conflict_tor_ambient_mismatch.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_tor.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_without_common_ambient_is_not_computed() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-no-ambient");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"] = Value::Array(
+        archmap["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .filter(|atom| atom["predicate"] != "commonAmbient")
+            .cloned()
+            .collect(),
+    );
+    archmap["contexts"][0]["atoms"] = Value::Array(
+        archmap["contexts"][0]["atoms"]
+            .as_array()
+            .expect("context atoms is array")
+            .iter()
+            .filter(|atom| atom.as_str() != Some("atom:tor-common-ambient"))
+            .cloned()
+            .collect(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_law_conflict_tor_no_ambient.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_tor.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "not_computed");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "no_common_ambient"
+    );
+    let tor = invariant_by_id(&packet, "law-conflict-tor:profile:ag-law-conflict-tor@1");
+    assert_eq!(tor["status"], "not_computed");
+    assert_eq!(tor["reason"], "no_common_ambient");
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_requires_matching_witness_family() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-witness-family");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_tor.json"));
+    policy["measurementProfiles"][0]["witnessFamily"] = Value::Array(vec![]);
+    let policy_path = out_dir.join("law_policy_tor_missing_witness.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_law_conflict_tor.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_rejects_unsupported_resolution_selector() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-bad-resolution");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_tor.json"));
+    policy["measurementProfiles"][0]["resolutionSelector"] =
+        Value::String("unsupported@1".to_string());
+    let policy_path = out_dir.join("law_policy_tor_bad_resolution.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_law_conflict_tor.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_rejects_malformed_common_ambient_pair() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-bad-ambient");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"][0]["object"] = Value::String("law:checkout".to_string());
+    let archmap_path = out_dir.join("archmap_v2_law_conflict_tor_bad_ambient.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_tor.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_law_conflict_tor_rejects_generator_outside_witness_family() {
+    let out_dir = temp_dir("ag-measurement-law-conflict-tor-unknown-variable");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"][1]["object"] = Value::String("x_unknown,x_inventory".to_string());
+    let archmap_path = out_dir.join("archmap_v2_law_conflict_tor_unknown_variable.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_tor.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
 fn cli_locks_ag_measurement_cech_h1_visible_golden_fixture() {
     let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let repo_root = crate_root
@@ -743,6 +1086,40 @@ fn cli_locks_ag_measurement_square_free_golden_fixture() {
 }
 
 #[test]
+fn cli_locks_ag_measurement_law_conflict_tor_golden_fixture() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate root is tools/archsig inside repo");
+    let fixture = read_json(&ag_measurement_root().join("archmap_v2_law_conflict_tor.json"));
+    assert_eq!(fixture["schema"], "archmap/v2");
+    assert_eq!(fixture["id"], "ag-measurement-law-conflict-tor-fixture");
+    assert!(
+        fixture["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .any(|atom| atom["axis"] == "tor" && atom["predicate"] == "commonAmbient"),
+        "AG Tor fixture must contain an explicit common ambient atom"
+    );
+
+    let golden_corpus = fs::read_to_string(repo_root.join("docs/tool/golden_corpus.md"))
+        .expect("golden corpus docs are readable");
+    for snippet in [
+        "archmap_v2_law_conflict_tor.json",
+        "law_policy_tor.json",
+        "cli_analyze_v2_law_conflict_tor_outputs_conflict_classes",
+        "cli_analyze_v2_law_conflict_tor_without_common_ambient_is_not_computed",
+    ] {
+        assert!(
+            golden_corpus.contains(snippet),
+            "AG golden corpus docs must mention {snippet}"
+        );
+    }
+}
+
+#[test]
 fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
     let out_dir = temp_dir("ag-measurement-strict");
     let root = ag_measurement_root();
@@ -751,8 +1128,8 @@ fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
         .as_array_mut()
         .expect("policies is array")
         .push(serde_json::json!({
-            "law": "ag.law-conflict-tor",
-            "evaluator": "ag.law-conflict-tor@1",
+            "law": "ag.sheaf-laplacian",
+            "evaluator": "ag.sheaf-laplacian@1",
             "basis": ["policy-basis:layering"],
             "scope": ["src/"],
             "severity": "medium"

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_law_conflict_tor.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_law_conflict_tor.json
@@ -1,0 +1,78 @@
+{
+  "schema": "archmap/v2",
+  "id": "ag-measurement-law-conflict-tor-fixture",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:ag-fixture@1",
+    "fingerprint": "sha256:ag-fixture-doctrine",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
+  "sources": {
+    "src:checkout-policy": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.5-checkout"
+    },
+    "src:inventory-policy": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "B.5-inventory"
+    },
+    "src:ambient": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R5"
+    },
+    "src:cover": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R5"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:tor-common-ambient",
+      "kind": "semantic",
+      "subject": "ambient:checkout-inventory",
+      "object": "law:checkout,law:inventory",
+      "axis": "tor",
+      "predicate": "commonAmbient",
+      "refs": ["src:ambient"]
+    },
+    {
+      "id": "atom:checkout-law-generator",
+      "kind": "relation",
+      "subject": "law:checkout",
+      "object": "x_checkout,x_inventory",
+      "axis": "tor",
+      "predicate": "lawIdealGenerator",
+      "refs": ["src:checkout-policy"]
+    },
+    {
+      "id": "atom:inventory-law-generator",
+      "kind": "relation",
+      "subject": "law:inventory",
+      "object": "x_inventory,x_payment",
+      "axis": "tor",
+      "predicate": "lawIdealGenerator",
+      "refs": ["src:inventory-policy"]
+    }
+  ],
+  "contexts": [
+    {
+      "id": "ctx:tor-common-ambient",
+      "atoms": [
+        "atom:tor-common-ambient",
+        "atom:checkout-law-generator",
+        "atom:inventory-law-generator"
+      ],
+      "refs": ["src:cover"]
+    }
+  ],
+  "covers": [
+    {
+      "id": "cover:law-conflict-tor",
+      "contexts": ["ctx:tor-common-ambient"],
+      "refs": ["src:cover"]
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/ag_measurement/law_policy_tor.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/law_policy_tor.json
@@ -1,0 +1,44 @@
+{
+  "schema": "law-policy/v1",
+  "id": "ag-law-conflict-tor-policy",
+  "measurementProfileRef": "profile:ag-law-conflict-tor@1",
+  "measurementProfiles": [
+    {
+      "schema": "measurement-profile/v1",
+      "profileId": "profile:ag-law-conflict-tor@1",
+      "siteRef": "archmap:/contexts",
+      "coverRef": "cover:law-conflict-tor",
+      "coefficient": "F2",
+      "effCoeff": "finite-linear-algebra@1",
+      "witnessFamily": [
+        {
+          "law": "ag.law-conflict-tor",
+          "variable": "x_checkout"
+        },
+        {
+          "law": "ag.law-conflict-tor",
+          "variable": "x_inventory"
+        },
+        {
+          "law": "ag.law-conflict-tor",
+          "variable": "x_payment"
+        }
+      ],
+      "resolutionSelector": "taylor@1",
+      "domain": "finite-poset-site",
+      "zeroPredicate": "rank-zero@1",
+      "nonZeroPredicate": "rank-positive@1",
+      "certSelector": "finite-certificate@1",
+      "verdictDiscipline": "five-valued-structural-verdict@1"
+    }
+  ],
+  "policies": [
+    {
+      "law": "ag.law-conflict-tor",
+      "evaluator": "ag.law-conflict-tor@1",
+      "basis": ["policy-basis:layering"],
+      "scope": ["src/"],
+      "severity": "high"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

Closes #1923
Part of #1907

ArchSig v0.4.0 PRD の R5 として、`ag.law-conflict-tor@1` evaluator と B.5 fixture を追加しました。

- explicit `commonAmbient` atom が宣言する law pair の内側でだけ LawConflict を計算する
- common ambient がない場合は `not_computed` / `no_common_ambient` に落とし、conflict absence や measured zero として読まない
- principal monomial pair の shared support を finite Tor conflict support として `LawConflict_1` に出力する
- disjoint supports は measured zero、nested/common-factor supports は measured nonzero として回帰固定する
- ambient law-pair mismatch、malformed ambient、unsupported resolution selector、unknown witness variable は fail-closed にする
- golden corpus に Tor fixture と lock test を追加する

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/golden_corpus.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
