### PR TITLE
AG版AATのAtomFamilyとclosure補題を追加する

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -1,3 +1,4 @@
 import Formal.AG.Atom.Atom
 import Formal.AG.Atom.Axioms
+import Formal.AG.Atom.Family
 import Formal.AG.Atom.Observation

--- a/Formal/AG/Atom/Family.lean
+++ b/Formal/AG/Atom/Family.lean
@@ -1,0 +1,118 @@
+import Formal.AG.Atom.Atom
+
+namespace AAT.AG
+
+universe u
+
+/-- I.定義3.1: an Atom family is a predicate selecting atoms of a carrier. -/
+structure AtomFamily (U : AtomCarrier.{u}) where
+  mem : U.Atom -> Prop
+
+namespace AtomFamily
+
+/-- Inclusion of Atom families. -/
+def Subset {U : AtomCarrier.{u}} (F G : AtomFamily U) : Prop :=
+  ∀ {atom}, F.mem atom -> G.mem atom
+
+/-- I.定義3.2: the subject support of an Atom family. -/
+def support {U : AtomCarrier.{u}} (F : AtomFamily U) (subject : U.Subject) :
+    Prop :=
+  ∃ atom, F.mem atom ∧ U.subject atom = subject
+
+/-- I.定義3.3: restrict an Atom family to a selected axis. -/
+def restrictAxis {U : AtomCarrier.{u}} (F : AtomFamily U) (axis : U.Axis) :
+    AtomFamily U where
+  mem atom := F.mem atom ∧ U.axis atom = axis
+
+/--
+I.定義3.4: compatibility is relative to a selected payload compatibility
+relation for atoms with the same subject and predicate inside a family.
+-/
+def Compatible {U : AtomCarrier.{u}} (payloadCompatible : U.Payload -> U.Payload -> Prop)
+    (F : AtomFamily U) : Prop :=
+  ∀ {a b}, F.mem a -> F.mem b ->
+    U.subject a = U.subject b -> U.predicate a = U.predicate b ->
+      payloadCompatible (U.payload a) (U.payload b)
+
+/-- I.定義3.4: equality is the strict compatibility reading. -/
+def EqCompatible {U : AtomCarrier.{u}} (F : AtomFamily U) : Prop :=
+  Compatible Eq F
+
+/-- I.定義3.5: primitive and derived origin markers for family membership. -/
+inductive AtomOrigin where
+  | primitive
+  | derived
+  deriving DecidableEq
+
+/-- I.定義3.5: an Atom family equipped with origin markers. -/
+structure OriginMarked (U : AtomCarrier.{u}) extends AtomFamily U where
+  origin : ∀ atom, mem atom -> AtomOrigin
+
+/-- I.定義3.5: a monotone inference rule family used to close Atom families. -/
+structure InferenceSystem (U : AtomCarrier.{u}) where
+  derives : AtomFamily U -> U.Atom -> Prop
+  monotone : ∀ {F G : AtomFamily U}, F.Subset G ->
+    ∀ {atom}, derives F atom -> derives G atom
+
+/-- I.定義3.5: a family is closed under an inference system. -/
+def IsClosed {U : AtomCarrier.{u}} (R : InferenceSystem U)
+    (F : AtomFamily U) : Prop :=
+  ∀ {atom}, R.derives F atom -> F.mem atom
+
+/--
+I.定義3.5: closure is the least closed family containing `F`, represented as
+the intersection of all closed supersets.
+-/
+def closure {U : AtomCarrier.{u}} (R : InferenceSystem U)
+    (F : AtomFamily U) : AtomFamily U where
+  mem atom := ∀ G : AtomFamily U, F.Subset G -> IsClosed R G -> G.mem atom
+
+/-- I.定義3.2: membership witnesses support. -/
+theorem support_of_mem {U : AtomCarrier.{u}} {F : AtomFamily U}
+    {atom : U.Atom} (h : F.mem atom) :
+    F.support (U.subject atom) :=
+  ⟨atom, h, rfl⟩
+
+/-- I.定義3.3: axis restriction is a subfamily. -/
+theorem restrictAxis_subset {U : AtomCarrier.{u}} (F : AtomFamily U)
+    (axis : U.Axis) :
+    (F.restrictAxis axis).Subset F := by
+  intro atom h
+  exact h.1
+
+/-- I.定義3.3: every restricted atom lies on the selected axis. -/
+theorem restrictAxis_axis {U : AtomCarrier.{u}} (F : AtomFamily U)
+    (axis : U.Axis) {atom : U.Atom}
+    (h : (F.restrictAxis axis).mem atom) :
+    U.axis atom = axis :=
+  h.2
+
+/-- I.定義3.5(a): every original atom is in its closure. -/
+theorem subset_closure {U : AtomCarrier.{u}} (R : InferenceSystem U)
+    (F : AtomFamily U) :
+    F.Subset (closure R F) := by
+  intro atom hAtom G hFG _hClosed
+  exact hFG hAtom
+
+/-- I.定義3.5(b): the closure is closed under the inference system. -/
+theorem closure_isClosed {U : AtomCarrier.{u}} (R : InferenceSystem U)
+    (F : AtomFamily U) :
+    IsClosed R (closure R F) := by
+  intro atom hDerives G hFG hClosed
+  apply hClosed
+  exact R.monotone (F := closure R F) (G := G)
+    (by
+      intro candidate hCandidate
+      exact hCandidate G hFG hClosed)
+    hDerives
+
+/-- I.定義3.5(c): closure is the smallest closed family containing `F`. -/
+theorem closure_minimal {U : AtomCarrier.{u}} (R : InferenceSystem U)
+    (F G : AtomFamily U) (hFG : F.Subset G) (hClosed : IsClosed R G) :
+    (closure R F).Subset G := by
+  intro atom hAtom
+  exact hAtom G hFG hClosed
+
+end AtomFamily
+
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4438,10 +4438,10 @@ completeness、FieldSig forecast calibration は結論しない。
 ## AG版AAT Lean形式化 PRD-1 bootstrap
 
 File: `Formal/AG.lean`, `Formal/AG/Atom/Atom.lean`, `Formal/AG/Atom/Axioms.lean`,
-`Formal/AG/Atom/Observation.lean`.
+`Formal/AG/Atom/Observation.lean`, `Formal/AG/Atom/Family.lean`.
 
 PRD-1 [第I部 Atom・対象・法則](lean_ag_part_1_atoms_objects_laws_prd.md) の
-AC1/R0、AC2/R1、AC3/R1 に対応する初期 Atom entrypoint である。`Formal/Arch` は import せず、
+AC1/R0、AC2/R1、AC3/R1、AC4/R2 に対応する初期 Atom entrypoint である。`Formal/Arch` は import せず、
 AG 版 AAT の namespace を `AAT.AG` として分離する。この節は Part I の最下層索引であり、
 定理9.3、定理10.5 の完了宣言ではない。
 
@@ -4454,9 +4454,10 @@ AG 版 AAT の namespace を `AAT.AG` として分離する。この節は Part 
 | `I.公理A3` | `AAT.AG.SameCoordinates`, `AAT.AG.AtomAxiomSystem.eq_iff_sameCoordinates`, `AAT.AG.AtomAxiomSystem.ext` | `def` / `theorem` | 五成分一致と Atom 同一性の同値、ならびに ext 補題。 | `proved` |
 | `I.公理A8` | `AAT.AG.ExtractionDoctrine`, `AAT.AG.ExtractionDoctrine.atomize_unique`, `AAT.AG.CoarseProjection`, `AAT.AG.AtomAxiomSystem.doctrine_family_unique` | `structure` / `theorem` | extraction doctrine と、`atomize` が関数であることから得る canonical Atom family の一意性。 | `defined only` / `proved` |
 | `I.命題A9` | `AAT.AG.ObservationModel`, `ObservationModel.NonInjective`, `ObservationProjection`, `ReconstructionAttempt`, `no_exact_reconstruction_of_nonInjective`, `A9Example.projection`, `A9Example.reconstruction`, `A9Example.noninjective_atom_observation`, `A9Example.unobserved_atom_exists`, `A9Example.noninjective_family_observation`, `A9Example.reconstruction_not_exact`, `A9Example.canonical_family_unique`, `A9Example.observation_incompleteness_coexists_with_a8` | `structure` / `def` / `theorem` | 観測写像、projection、reconstruction、非単射観測、未観測 Atom、A8 一意性との分離を有限例で示す。 | `defined only` / `proved` |
+| `I.定義3.1-3.5` | `AAT.AG.AtomFamily`, `AtomFamily.Subset`, `AtomFamily.support`, `AtomFamily.restrictAxis`, `AtomFamily.Compatible`, `AtomFamily.EqCompatible`, `AtomFamily.AtomOrigin`, `AtomFamily.OriginMarked`, `AtomFamily.InferenceSystem`, `AtomFamily.IsClosed`, `AtomFamily.closure`, `AtomFamily.support_of_mem`, `AtomFamily.restrictAxis_subset`, `AtomFamily.restrictAxis_axis`, `AtomFamily.subset_closure`, `AtomFamily.closure_isClosed`, `AtomFamily.closure_minimal` | `structure` / `def` / `inductive` / `theorem` | Atom family、subset、support、axis restriction、選択された payload compatibility relation に相対化された compatibility、origin marker、monotone 推論規則族 closure と support/restriction 補題および closure 3補題。 | `defined only` / `proved` |
 
-Non-conclusions: この bootstrap は `Formal/AG` の Atom carrier と A0-A8 package の
-入口であり、AtomFamily、Configuration、Lawfulness-Zero Obstruction、
+Non-conclusions: この bootstrap は `Formal/AG` の Atom carrier、A0-A8 package、A9、
+AtomFamily / closure の入口であり、Configuration、Lawfulness-Zero Obstruction、
 AAT Core、有限モデルは後続 Issue の対象である。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -544,13 +544,18 @@ Issue [#1918](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では A0-A8 を structure field として束ね、A3 ext 補題と A8 一意性 theorem を追加した。
 Issue [#1922](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1922)
 では命題A9の観測不完全性と存在一意性の分離を有限例 theorem として追加した。
+Issue [#1926](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1926)
+では AtomFamily、support、axis restriction、payload compatibility relation に相対化された
+compatibility、origin marker、monotone inference closure と
+closure 特徴付け3補題を追加した。
 これは定理9.3 / 定理10.5 の証明済み主張ではない。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `I.定義1.1` Atom carrier | `defined only`. `Formal/AG/Atom/Atom.lean` が `AAT.AG.AtomRecord`, `AAT.AG.AtomCarrier`, `AAT.AG.AtomCarrier.record` を持つ。 | AtomFamily、Configuration、Lawfulness-Zero Obstruction、AAT Core、有限モデルはまだ proved claim ではない。 |
-| `I.公理A0-A8` Atom system package | `defined only` / `proved` for A3 and A8 accessors. `Formal/AG/Atom/Axioms.lean` が `AAT.AG.AtomAxiomSystem`, `AAT.AG.AtomAxiomSystem.ext`, `AAT.AG.ExtractionDoctrine.atomize_unique`, `AAT.AG.AtomAxiomSystem.doctrine_family_unique` を持つ。 | A4/R3 との具体接続、R2 以降の AtomFamily / Configuration 実装は後続 Issue に残る。 |
-| `I.命題A9` 観測不完全性と存在一意性 | `defined only` / `proved`. `Formal/AG/Atom/Observation.lean` が `ObservationModel`, `ObservationProjection`, `ReconstructionAttempt`, `no_exact_reconstruction_of_nonInjective`, `A9Example.projection`, `A9Example.reconstruction`, `A9Example.noninjective_atom_observation`, `A9Example.unobserved_atom_exists`, `A9Example.noninjective_family_observation`, `A9Example.reconstruction_not_exact`, `A9Example.canonical_family_unique`, `A9Example.observation_incompleteness_coexists_with_a8` を持つ。 | R2 以降の本格的な AtomFamily / closure / Configuration API との接続は後続 Issue に残る。 |
+| `I.定義1.1` Atom carrier | `defined only`. `Formal/AG/Atom/Atom.lean` が `AAT.AG.AtomRecord`, `AAT.AG.AtomCarrier`, `AAT.AG.AtomCarrier.record` を持つ。 | Configuration、Lawfulness-Zero Obstruction、AAT Core、有限モデルはまだ proved claim ではない。 |
+| `I.公理A0-A8` Atom system package | `defined only` / `proved` for A3 and A8 accessors. `Formal/AG/Atom/Axioms.lean` が `AAT.AG.AtomAxiomSystem`, `AAT.AG.AtomAxiomSystem.ext`, `AAT.AG.ExtractionDoctrine.atomize_unique`, `AAT.AG.AtomAxiomSystem.doctrine_family_unique` を持つ。 | A4/R3 との具体接続、R3 以降の Configuration 実装は後続 Issue に残る。 |
+| `I.命題A9` 観測不完全性と存在一意性 | `defined only` / `proved`. `Formal/AG/Atom/Observation.lean` が `ObservationModel`, `ObservationProjection`, `ReconstructionAttempt`, `no_exact_reconstruction_of_nonInjective`, `A9Example.projection`, `A9Example.reconstruction`, `A9Example.noninjective_atom_observation`, `A9Example.unobserved_atom_exists`, `A9Example.noninjective_family_observation`, `A9Example.reconstruction_not_exact`, `A9Example.canonical_family_unique`, `A9Example.observation_incompleteness_coexists_with_a8` を持つ。 | R3 以降の Configuration / ArchitectureObject API との接続は後続 Issue に残る。 |
+| `I.定義3.1-3.5` AtomFamily / closure | `defined only` / `proved`. `Formal/AG/Atom/Family.lean` が `AtomFamily`, `AtomFamily.Subset`, `AtomFamily.support`, `AtomFamily.restrictAxis`, `AtomFamily.Compatible`, `AtomFamily.EqCompatible`, `AtomFamily.AtomOrigin`, `AtomFamily.OriginMarked`, `AtomFamily.InferenceSystem`, `AtomFamily.IsClosed`, `AtomFamily.closure`, `AtomFamily.support_of_mem`, `AtomFamily.restrictAxis_subset`, `AtomFamily.restrictAxis_axis`, `AtomFamily.subset_closure`, `AtomFamily.closure_isClosed`, `AtomFamily.closure_minimal` を持つ。 | compatibility は選択された payload compatibility relation に相対化され、closure 3補題は monotone inference system に相対化される。R3 Configuration / Molecule、R4 ArchitectureObject、Lawfulness-Zero Obstruction、AAT Core、有限モデルは後続 Issue に残る。 |
 | 命題5.3 Atom-Origin | `future proof obligation`. | ArchitectureObject / Generated Object の定義が入った後で、生成関係から証明する。 |
 | 例8.3 / 例8.4 obstruction example theorem | `future proof obligation`. | R7 と R10 の有限モデルが入るまで proved claim として扱わない。 |
 | 定理9.3 Lawfulness-Zero Obstruction | `future proof obligation`. | soundness、completeness、zero-reflecting aggregation、三読み一致の明示仮定が入るまで proved claim として扱わない。 |


### PR DESCRIPTION
## 概要

Closes #1926

AG版AAT PRD-1 / AC4/R2 に対応して、AtomFamily と closure 特徴付けを `Formal/AG` に追加します。

- `AtomFamily` / `Subset` / `support` / `restrictAxis` を追加
- payload compatibility relation に相対化した `Compatible` と strict equality 版 `EqCompatible` を追加
- primitive / derived の `AtomOrigin` と origin-marked family を追加
- monotone `InferenceSystem` に相対化した closure と3補題を追加
- `lean_theorem_index.md` / `proof_obligations.md` の Lean status を同期

## 証明した定理

- `AAT.AG.AtomFamily.support_of_mem`
- `AAT.AG.AtomFamily.restrictAxis_subset`
- `AAT.AG.AtomFamily.restrictAxis_axis`
- `AAT.AG.AtomFamily.subset_closure`
- `AAT.AG.AtomFamily.closure_isClosed`
- `AAT.AG.AtomFamily.closure_minimal`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Atom/Family.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build Formal.AG`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan

`lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ再表示されました。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている（対象外: ArchSig 変更なし）
- [x] ArchSig と FieldSig の責務を混同していない（対象外: ArchSig / FieldSig 変更なし）