### PR TITLE
ArchSig support-localized transfer evaluator を追加

### DIFF
--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -36,11 +36,13 @@ covers rather than molecule-primary ArchMaps.
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_law_conflict_tor.json`
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_sheaf_laplacian.json`
 - `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_period_stokes.json`
+- `tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_square_free.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_tor.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_laplacian.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_period.json`
+- `tools/archsig/tests/fixtures/ag_measurement/law_policy_transfer.json`
 - `tools/archsig/tests/fixtures/ag_measurement/law_policy_missing_profile.json`
 
 The executable lock is
@@ -94,6 +96,17 @@ lawfulness. The companion regressions
 `cli_analyze_v2_period_stokes_rejects_unknown_cycle` keep audit mismatches,
 missing finite period evidence, and witness mismatches from becoming measured
 zero.
+
+The support-localized transfer lock is
+`cli_analyze_v2_support_transfer_outputs_residue_and_wasserstein_cost`. It
+fixes the R8 analytic path: finite transfer pairing atoms and explicit ground
+cost atoms yield a transfer measurement pairing, transfer residue, and
+Wasserstein transfer cost. These transfer readings do not prove absence of side
+effects or global repair safety. The companion regressions
+`cli_analyze_v2_support_transfer_missing_pairing_cell_is_not_computed`,
+`cli_analyze_v2_support_transfer_missing_ground_cost_is_not_computed`, and
+`cli_analyze_v2_support_transfer_rejects_unknown_target` keep incomplete
+transfer evidence and witness mismatches from becoming measured zero.
 
 ## V1 Positive Fixtures
 

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -20,6 +20,7 @@ const MAX_SQUARE_FREE_WITNESS_VARIABLES: usize = 12;
 const MAX_TOR_WITNESS_VARIABLES: usize = 12;
 const MAX_LAPLACIAN_CELLS: usize = 16;
 const MAX_PERIOD_CYCLES: usize = 16;
+const MAX_TRANSFER_TARGETS: usize = 16;
 
 pub fn selected_measurement_profile_v1(
     policy: &LawPolicyDocumentV1,
@@ -190,6 +191,12 @@ pub fn build_foundation_measurement_packet_v1(
             computed_invariants.extend(measurement.computed_invariants);
             analytic_readings.extend(measurement.analytic_readings);
             assumptions.extend(measurement.assumptions);
+        } else if evaluator == "ag.support-transfer@1" {
+            validate_transfer_profile_v1(&profile)?;
+            let measurement = evaluate_support_transfer_v1(normalized, &profile)?;
+            computed_invariants.extend(measurement.computed_invariants);
+            analytic_readings.extend(measurement.analytic_readings);
+            assumptions.extend(measurement.assumptions);
         } else {
             structural_verdict.push(AgStructuralVerdictV1 {
                 evaluator: evaluator.to_string(),
@@ -345,6 +352,37 @@ struct StokesAuditValueV1 {
     form_id: String,
     chain_id: String,
     value: f64,
+    atom_ref: String,
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TransferMeasurementV1 {
+    computed_invariants: Vec<Value>,
+    analytic_readings: Vec<AgAnalyticReadingV1>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct TransferPairingV1 {
+    path_id: String,
+    target_id: String,
+    value: f64,
+    atom_ref: String,
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TransferRepairPathV1 {
+    path_id: String,
+    atom_ref: String,
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TransferGroundCostV1 {
+    target_id: String,
+    cost: f64,
     atom_ref: String,
     source_refs: Vec<String>,
 }
@@ -926,6 +964,208 @@ fn evaluate_period_stokes_v1(
     })
 }
 
+fn evaluate_support_transfer_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> Result<TransferMeasurementV1, String> {
+    let selected_contexts = selected_cover_contexts(normalized, profile)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let targets = transfer_witness_targets(profile);
+    let repair_paths = transfer_repair_paths(normalized, &selected_contexts)?;
+    let pairings = transfer_pairings(normalized, &selected_contexts, &targets)?;
+    let ground_costs = transfer_ground_costs(normalized, &selected_contexts, &targets)?;
+    let observed_targets = pairings
+        .iter()
+        .map(|pairing| pairing.target_id.clone())
+        .collect::<BTreeSet<_>>();
+    let missing_targets = targets
+        .iter()
+        .filter(|target| !observed_targets.contains(*target))
+        .cloned()
+        .collect::<Vec<_>>();
+    let cost_targets = ground_costs
+        .iter()
+        .map(|cost| cost.target_id.clone())
+        .collect::<BTreeSet<_>>();
+    let missing_costs = targets
+        .iter()
+        .filter(|target| !cost_targets.contains(*target))
+        .cloned()
+        .collect::<Vec<_>>();
+    if repair_paths.is_empty()
+        || pairings.is_empty()
+        || ground_costs.is_empty()
+        || !missing_targets.is_empty()
+        || !missing_costs.is_empty()
+    {
+        let mut reasons = Vec::new();
+        if repair_paths.is_empty() || pairings.is_empty() || ground_costs.is_empty() {
+            reasons.push("transfer_model_missing".to_string());
+        }
+        if !missing_targets.is_empty() {
+            reasons.push(format!("missing_pairings:{}", missing_targets.join(",")));
+        }
+        if !missing_costs.is_empty() {
+            reasons.push(format!("missing_ground_costs:{}", missing_costs.join(",")));
+        }
+        return Ok(TransferMeasurementV1 {
+            computed_invariants: vec![json!({
+                "invariantId": format!("support-transfer:{}", profile.profile_id),
+                "evaluator": "ag.support-transfer@1",
+                "status": "not_computed",
+                "reason": reasons.join(";")
+            })],
+            analytic_readings: Vec::new(),
+            assumptions: transfer_assumptions(profile, "violated"),
+        });
+    }
+
+    let paths = repair_paths
+        .iter()
+        .map(|path| path.path_id.clone())
+        .collect::<Vec<_>>();
+    let path_set = paths.iter().cloned().collect::<BTreeSet<_>>();
+    let outside_paths = pairings
+        .iter()
+        .filter(|pairing| !path_set.contains(&pairing.path_id))
+        .map(|pairing| pairing.path_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !outside_paths.is_empty() {
+        return Err(format!(
+            "ag.support-transfer@1 transfer pairings reference paths outside selected repair path model: {}",
+            outside_paths.join(",")
+        ));
+    }
+    let observed_pairings = pairings
+        .iter()
+        .map(|pairing| (pairing.path_id.clone(), pairing.target_id.clone()))
+        .collect::<BTreeSet<_>>();
+    let mut missing_pairings = Vec::new();
+    for path in &paths {
+        for target in &targets {
+            if !observed_pairings.contains(&(path.clone(), target.clone())) {
+                missing_pairings.push(format!("{path}/{target}"));
+            }
+        }
+    }
+    if !missing_pairings.is_empty() {
+        return Ok(TransferMeasurementV1 {
+            computed_invariants: vec![json!({
+                "invariantId": format!("support-transfer:{}", profile.profile_id),
+                "evaluator": "ag.support-transfer@1",
+                "status": "not_computed",
+                "reason": format!("transfer_model_missing:{}", missing_pairings.join(","))
+            })],
+            analytic_readings: Vec::new(),
+            assumptions: transfer_assumptions(profile, "violated"),
+        });
+    }
+
+    let path_index = paths
+        .iter()
+        .enumerate()
+        .map(|(index, path)| (path.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let target_index = targets
+        .iter()
+        .enumerate()
+        .map(|(index, target)| (target.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let mut matrix = vec![vec![0.0; targets.len()]; paths.len()];
+    for pairing in &pairings {
+        matrix[path_index[&pairing.path_id]][target_index[&pairing.target_id]] = pairing.value;
+    }
+    let cost_by_target = ground_costs
+        .iter()
+        .map(|cost| (cost.target_id.clone(), cost.cost))
+        .collect::<BTreeMap<_, _>>();
+    let transfer_residue = matrix
+        .iter()
+        .flatten()
+        .map(|value| value * value)
+        .sum::<f64>()
+        .sqrt();
+    let wasserstein_cost = pairings
+        .iter()
+        .map(|pairing| pairing.value.abs() * cost_by_target[&pairing.target_id])
+        .sum::<f64>();
+    let source_refs = pairings
+        .iter()
+        .flat_map(|pairing| pairing.source_refs.iter())
+        .chain(repair_paths.iter().flat_map(|path| path.source_refs.iter()))
+        .chain(ground_costs.iter().flat_map(|cost| cost.source_refs.iter()))
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    let analytic_value = json!({
+        "readingKind": "support-localized-transfer@1",
+        "selectedCoverRef": profile.cover_ref,
+        "modelRelative": true,
+        "repairPaths": paths,
+        "transferTargets": targets,
+        "transferMeasurementPairing": rounded_matrix(&matrix),
+        "transferResidue": round_f64(transfer_residue),
+        "wassersteinTransferCost": round_f64(wasserstein_cost),
+        "groundCosts": ground_costs.iter().map(|cost| json!({
+            "target": cost.target_id,
+            "cost": round_f64(cost.cost),
+            "atomRef": cost.atom_ref
+        })).collect::<Vec<_>>(),
+        "nonConclusion": "transfer readings do not prove absence of side effects or global repair safety"
+    });
+
+    Ok(TransferMeasurementV1 {
+        computed_invariants: vec![json!({
+            "invariantId": format!("support-transfer:{}", profile.profile_id),
+            "evaluator": "ag.support-transfer@1",
+            "method": "finite-support-localized-transfer@1",
+            "selectedCoverRef": profile.cover_ref,
+            "repairPathAtomRefs": repair_paths.iter().map(|path| json!({
+                "repairPath": path.path_id,
+                "atomRef": path.atom_ref
+            })).collect::<Vec<_>>(),
+            "pairingAtomRefs": pairings.iter().map(|pairing| json!({
+                "repairPath": pairing.path_id,
+                "target": pairing.target_id,
+                "atomRef": pairing.atom_ref
+            })).collect::<Vec<_>>(),
+            "transferMeasurementPairing": rounded_matrix(&matrix),
+            "transferResidue": round_f64(transfer_residue),
+            "wassersteinTransferCost": round_f64(wasserstein_cost),
+            "sourceRefs": source_refs
+        })],
+        analytic_readings: vec![
+            AgAnalyticReadingV1 {
+                reading_id: format!("analytic:support-transfer:{}", profile.profile_id),
+                evaluator: "ag.support-transfer@1".to_string(),
+                value: analytic_value,
+                regime: Some("analytic-measurement".to_string()),
+                structural_verdict_ref: None,
+            },
+            AgAnalyticReadingV1 {
+                reading_id: format!(
+                    "theorem-candidate:transfer-lower-bound:{}",
+                    profile.profile_id
+                ),
+                evaluator: "ag.foundation@1".to_string(),
+                value: json!({
+                    "readingKind": "transfer-lower-bound-candidate@1",
+                    "transferLowerBound": round_f64(wasserstein_cost),
+                    "reason": "transfer lower bound remains theorem-candidate and cannot generate a structural verdict"
+                }),
+                regime: Some("theorem-candidate".to_string()),
+                structural_verdict_ref: None,
+            },
+        ],
+        assumptions: transfer_assumptions(profile, "checked"),
+    })
+}
+
 pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Value {
     let nonzero_count = packet
         .structural_verdict
@@ -1388,6 +1628,56 @@ fn validate_period_profile_v1(profile: &MeasurementProfileV1) -> Result<(), Stri
     Ok(())
 }
 
+fn validate_transfer_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        ("coefficient", profile.coefficient.as_str(), "R"),
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "finite-linear-algebra@1",
+        ),
+        (
+            "resolutionSelector",
+            profile.resolution_selector.as_str(),
+            "support-localized-transfer@1",
+        ),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "analytic-zero@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "analytic-positive@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "analytic-reading@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.support-transfer@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if transfer_witness_targets(profile).is_empty() {
+        return Err(format!(
+            "ag.support-transfer@1 requires MeasurementProfile {} witnessFamily law ag.support-transfer",
+            profile.profile_id
+        ));
+    }
+    if transfer_witness_targets(profile).len() > MAX_TRANSFER_TARGETS {
+        return Err(format!(
+            "ag.support-transfer@1 supports at most {MAX_TRANSFER_TARGETS} witness targets for finite transfer enumeration"
+        ));
+    }
+    Ok(())
+}
+
 fn laplacian_witness_variables(profile: &MeasurementProfileV1) -> Vec<String> {
     profile
         .witness_family
@@ -1404,6 +1694,17 @@ fn period_witness_cycles(profile: &MeasurementProfileV1) -> Vec<String> {
         .witness_family
         .iter()
         .filter(|witness| witness.law == "ag.period-stokes")
+        .map(|witness| witness.variable.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn transfer_witness_targets(profile: &MeasurementProfileV1) -> Vec<String> {
+    profile
+        .witness_family
+        .iter()
+        .filter(|witness| witness.law == "ag.support-transfer")
         .map(|witness| witness.variable.clone())
         .collect::<BTreeSet<_>>()
         .into_iter()
@@ -1674,6 +1975,147 @@ fn stokes_audit_report(
     }))
 }
 
+fn transfer_pairings(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+    targets: &[String],
+) -> Result<Vec<TransferPairingV1>, String> {
+    let target_set = targets.iter().cloned().collect::<BTreeSet<_>>();
+    let mut pairings = Vec::new();
+    for atom in normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "transfer" && atom.predicate == "transferPairing")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+    {
+        let raw = atom.object.as_deref().ok_or_else(|| {
+            format!(
+                "ag.support-transfer@1 transfer pairing {} requires object target=value",
+                atom.normalized_atom_id
+            )
+        })?;
+        let (target_id, value) = parse_numeric_assignment(
+            raw,
+            "ag.support-transfer@1 transfer pairing",
+            &atom.normalized_atom_id,
+        )?;
+        if !target_set.contains(&target_id) {
+            return Err(format!(
+                "ag.support-transfer@1 transfer pairing {} uses target outside witnessFamily: {}",
+                atom.normalized_atom_id, target_id
+            ));
+        }
+        if pairings.iter().any(|pairing: &TransferPairingV1| {
+            pairing.path_id == atom.subject && pairing.target_id == target_id
+        }) {
+            return Err(format!(
+                "ag.support-transfer@1 duplicate transfer pairing for path {} and target {}",
+                atom.subject, target_id
+            ));
+        }
+        pairings.push(TransferPairingV1 {
+            path_id: atom.subject.clone(),
+            target_id,
+            value,
+            atom_ref: atom.normalized_atom_id.clone(),
+            source_refs: atom.source_refs.clone(),
+        });
+    }
+    pairings.sort_by(|left, right| {
+        left.path_id
+            .cmp(&right.path_id)
+            .then_with(|| left.target_id.cmp(&right.target_id))
+    });
+    Ok(pairings)
+}
+
+fn transfer_repair_paths(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+) -> Result<Vec<TransferRepairPathV1>, String> {
+    let mut paths = Vec::new();
+    for atom in normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "transfer" && atom.predicate == "repairPath")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+    {
+        if paths
+            .iter()
+            .any(|path: &TransferRepairPathV1| path.path_id == atom.subject)
+        {
+            return Err(format!(
+                "ag.support-transfer@1 duplicate repair path {}",
+                atom.subject
+            ));
+        }
+        paths.push(TransferRepairPathV1 {
+            path_id: atom.subject.clone(),
+            atom_ref: atom.normalized_atom_id.clone(),
+            source_refs: atom.source_refs.clone(),
+        });
+    }
+    paths.sort_by(|left, right| left.path_id.cmp(&right.path_id));
+    Ok(paths)
+}
+
+fn transfer_ground_costs(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+    targets: &[String],
+) -> Result<Vec<TransferGroundCostV1>, String> {
+    let target_set = targets.iter().cloned().collect::<BTreeSet<_>>();
+    let mut costs = Vec::new();
+    for atom in normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "transfer" && atom.predicate == "groundCost")
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+    {
+        if !target_set.contains(&atom.subject) {
+            return Err(format!(
+                "ag.support-transfer@1 ground cost {} uses target outside witnessFamily: {}",
+                atom.normalized_atom_id, atom.subject
+            ));
+        }
+        let raw = atom.object.as_deref().ok_or_else(|| {
+            format!(
+                "ag.support-transfer@1 ground cost {} requires numeric object",
+                atom.normalized_atom_id
+            )
+        })?;
+        let cost = raw.parse::<f64>().map_err(|_| {
+            format!(
+                "ag.support-transfer@1 ground cost {} has non-numeric object {raw}",
+                atom.normalized_atom_id
+            )
+        })?;
+        if !cost.is_finite() || cost < 0.0 {
+            return Err(format!(
+                "ag.support-transfer@1 ground cost {} requires finite non-negative object",
+                atom.normalized_atom_id
+            ));
+        }
+        if costs
+            .iter()
+            .any(|cost_entry: &TransferGroundCostV1| cost_entry.target_id == atom.subject)
+        {
+            return Err(format!(
+                "ag.support-transfer@1 duplicate ground cost for target {}",
+                atom.subject
+            ));
+        }
+        costs.push(TransferGroundCostV1 {
+            target_id: atom.subject.clone(),
+            cost,
+            atom_ref: atom.normalized_atom_id.clone(),
+            source_refs: atom.source_refs.clone(),
+        });
+    }
+    costs.sort_by(|left, right| left.target_id.cmp(&right.target_id));
+    Ok(costs)
+}
+
 fn graph_laplacian(
     cell_ids: &[String],
     cell_index: &BTreeMap<String, usize>,
@@ -1879,6 +2321,41 @@ fn period_assumptions(
         AgAssumptionLedgerEntryV1 {
             theorem_ref: "part7/5.2A".to_string(),
             assumption: "period_comparison".to_string(),
+            status: "assumed".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+    ]
+}
+
+fn transfer_assumptions(
+    profile: &MeasurementProfileV1,
+    transfer_model_status: &str,
+) -> Vec<AgAssumptionLedgerEntryV1> {
+    vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/10.1".to_string(),
+            assumption: "finite support-localized transfer model selected by MeasurementProfile"
+                .to_string(),
+            status: transfer_model_status.to_string(),
+            checked_by: (transfer_model_status == "checked")
+                .then(|| format!("measurement-profile:{}.witnessFamily", profile.profile_id)),
+            assumed_by: (transfer_model_status != "checked")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/10.6".to_string(),
+            assumption: "finite Wasserstein transfer cost computed on supplied ground costs"
+                .to_string(),
+            status: transfer_model_status.to_string(),
+            checked_by: (transfer_model_status == "checked")
+                .then(|| "finite-support-localized-transfer@1".to_string()),
+            assumed_by: (transfer_model_status != "checked")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/10.4".to_string(),
+            assumption: "transfer_lower_bound".to_string(),
             status: "assumed".to_string(),
             checked_by: None,
             assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -819,9 +819,26 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                     ["nonTerminalCount"]
                     .as_u64()
                     .unwrap_or(0);
-                if strict_distance && non_terminal_count > 0 {
+                let analytic_not_computed_count = measurement_packet
+                    .computed_invariants
+                    .iter()
+                    .filter(|invariant| {
+                        invariant["status"]
+                            .as_str()
+                            .is_some_and(|status| status == "not_computed")
+                    })
+                    .count();
+                let violated_assumption_count =
+                    measurement_summary["assumptionSummary"]["violatedCount"]
+                        .as_u64()
+                        .unwrap_or(0);
+                if strict_distance
+                    && (non_terminal_count > 0
+                        || analytic_not_computed_count > 0
+                        || violated_assumption_count > 0)
+                {
                     eprintln!(
-                        "--strict-distance rejected v2 measurement foundation with unmeasured, unknown, or not_computed structural verdict rows"
+                        "--strict-distance rejected v2 measurement foundation with unmeasured structural verdict rows, not_computed analytic invariants, or violated assumptions"
                     );
                     return Ok(ExitCode::from(1));
                 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1725,6 +1725,447 @@ fn cli_analyze_v2_period_stokes_missing_witness_cycle_is_not_computed() {
 }
 
 #[test]
+fn cli_analyze_v2_support_transfer_outputs_residue_and_wasserstein_cost() {
+    let out_dir = temp_dir("ag-measurement-support-transfer");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2_support_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"]
+            .as_array()
+            .expect("structural verdict is array")
+            .len(),
+        0,
+        "transfer readings are analytic-only and must not generate structural verdict rows"
+    );
+    let invariant = invariant_by_id(&packet, "support-transfer:profile:ag-support-transfer@1");
+    assert_eq!(
+        invariant["transferMeasurementPairing"],
+        serde_json::json!([[0.25, 0.75]])
+    );
+    assert_eq!(invariant["transferResidue"], Value::from(0.790569));
+    assert_eq!(invariant["wassersteinTransferCost"], Value::from(3.5));
+    let reading = packet["analyticReadings"]
+        .as_array()
+        .expect("analytic readings is array")
+        .iter()
+        .find(|reading| reading["evaluator"] == "ag.support-transfer@1")
+        .expect("transfer analytic reading exists");
+    assert_eq!(reading["structuralVerdictRef"], Value::Null);
+    assert_eq!(reading["regime"], "analytic-measurement");
+    assert_eq!(
+        reading["value"]["transferMeasurementPairing"],
+        serde_json::json!([[0.25, 0.75]])
+    );
+    assert_eq!(reading["value"]["transferResidue"], Value::from(0.790569));
+    assert_eq!(
+        reading["value"]["wassersteinTransferCost"],
+        Value::from(3.5)
+    );
+    assert_eq!(
+        reading["value"]["nonConclusion"],
+        "transfer readings do not prove absence of side effects or global repair safety"
+    );
+    let candidate = packet["analyticReadings"]
+        .as_array()
+        .expect("analytic readings is array")
+        .iter()
+        .find(|reading| {
+            reading["readingId"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("theorem-candidate:transfer-lower-bound:"))
+        })
+        .expect("transfer lower bound theorem-candidate reading exists");
+    assert_eq!(candidate["regime"], "theorem-candidate");
+    assert_eq!(candidate["value"]["transferLowerBound"], Value::from(3.5));
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .expect("assumptions is array")
+            .iter()
+            .any(|entry| {
+                entry["assumption"] == "transfer_lower_bound" && entry["status"] == "assumed"
+            })
+    );
+
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    assert_eq!(
+        summary["conclusion"],
+        "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_missing_pairing_cell_is_not_computed() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-missing-cell");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(serde_json::json!({
+            "id": "atom:transfer-repair-path-secondary",
+            "kind": "semantic",
+            "subject": "repair:path:secondary",
+            "object": "selected",
+            "axis": "transfer",
+            "predicate": "repairPath",
+            "refs": ["src:repair-path"]
+        }));
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(serde_json::json!({
+            "id": "atom:transfer-secondary-api",
+            "kind": "semantic",
+            "subject": "repair:path:secondary",
+            "object": "support:api=0.5",
+            "axis": "transfer",
+            "predicate": "transferPairing",
+            "refs": ["src:transfer-api"]
+        }));
+    archmap["contexts"][0]["atoms"]
+        .as_array_mut()
+        .expect("context atoms is array")
+        .push(Value::String(
+            "atom:transfer-repair-path-secondary".to_string(),
+        ));
+    archmap["contexts"][0]["atoms"]
+        .as_array_mut()
+        .expect("context atoms is array")
+        .push(Value::String("atom:transfer-secondary-api".to_string()));
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_missing_cell.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let invariant = invariant_by_id(&packet, "support-transfer:profile:ag-support-transfer@1");
+    assert_eq!(invariant["status"], "not_computed");
+    assert_eq!(
+        invariant["reason"],
+        "transfer_model_missing:repair:path:secondary/support:data"
+    );
+    assert!(
+        packet["analyticReadings"]
+            .as_array()
+            .expect("analytic readings is array")
+            .iter()
+            .all(|reading| reading["evaluator"] != "ag.support-transfer@1"),
+        "missing transfer pairing cells must not synthesize zero analytic readings"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_missing_repair_path_row_is_not_computed() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-missing-row");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(serde_json::json!({
+            "id": "atom:transfer-repair-path-secondary",
+            "kind": "semantic",
+            "subject": "repair:path:secondary",
+            "object": "selected",
+            "axis": "transfer",
+            "predicate": "repairPath",
+            "refs": ["src:repair-path"]
+        }));
+    archmap["contexts"][0]["atoms"]
+        .as_array_mut()
+        .expect("context atoms is array")
+        .push(Value::String(
+            "atom:transfer-repair-path-secondary".to_string(),
+        ));
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_missing_row.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let invariant = invariant_by_id(&packet, "support-transfer:profile:ag-support-transfer@1");
+    assert_eq!(invariant["status"], "not_computed");
+    assert_eq!(
+        invariant["reason"],
+        "transfer_model_missing:repair:path:secondary/support:api,repair:path:secondary/support:data"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_rejects_unknown_target() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-unknown-target");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    archmap["atoms"][1]["object"] = Value::String("support:missing=0.25".to_string());
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_unknown_target.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_transfer.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_strict_distance_rejects_not_computed_analytic_invariants() {
+    let out_dir = temp_dir("ag-measurement-strict-transfer-missing-cost");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    archmap["atoms"] = Value::Array(
+        archmap["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .filter(|atom| atom["id"] != "atom:transfer-ground-data")
+            .cloned()
+            .collect(),
+    );
+    archmap["contexts"][0]["atoms"] = Value::Array(
+        archmap["contexts"][0]["atoms"]
+            .as_array()
+            .expect("context atoms is array")
+            .iter()
+            .filter(|atom| atom.as_str() != Some("atom:transfer-ground-data"))
+            .cloned()
+            .collect(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_missing_cost.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+        "--strict-distance",
+    ]);
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not_computed analytic invariants")
+            && stderr.contains("violated assumptions"),
+        "strict-distance must reject incomplete analytic-only transfer evidence\n{stderr}"
+    );
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let invariant = invariant_by_id(&packet, "support-transfer:profile:ag-support-transfer@1");
+    assert_eq!(invariant["status"], "not_computed");
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_rejects_duplicate_pairings() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-duplicate");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    let mut duplicate = archmap["atoms"][1].clone();
+    duplicate["id"] = Value::String("atom:transfer-path-api-duplicate".to_string());
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(duplicate);
+    archmap["contexts"][0]["atoms"]
+        .as_array_mut()
+        .expect("context atoms is array")
+        .push(Value::String(
+            "atom:transfer-path-api-duplicate".to_string(),
+        ));
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_duplicate.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_transfer.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_rejects_non_finite_values() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-nan");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    archmap["atoms"][1]["object"] = Value::String("support:api=NaN".to_string());
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_nan.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--law-policy",
+            root.join("law_policy_transfer.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_rejects_malformed_profile_selector() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-bad-profile");
+    let root = ag_measurement_root();
+    let mut policy = read_json(&root.join("law_policy_transfer.json"));
+    policy["measurementProfiles"][0]["resolutionSelector"] =
+        Value::String("unsupported@1".to_string());
+    let policy_path = out_dir.join("law_policy_transfer_bad_profile.json");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            root.join("archmap_v2_support_transfer.json")
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            policy_path.to_str().expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ],
+        2,
+    );
+}
+
+#[test]
+fn cli_analyze_v2_support_transfer_missing_ground_cost_is_not_computed() {
+    let out_dir = temp_dir("ag-measurement-support-transfer-missing-cost");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_support_transfer.json"));
+    archmap["atoms"] = Value::Array(
+        archmap["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .filter(|atom| atom["id"] != "atom:transfer-ground-data")
+            .cloned()
+            .collect(),
+    );
+    archmap["contexts"][0]["atoms"] = Value::Array(
+        archmap["contexts"][0]["atoms"]
+            .as_array()
+            .expect("context atoms is array")
+            .iter()
+            .filter(|atom| atom.as_str() != Some("atom:transfer-ground-data"))
+            .cloned()
+            .collect(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_support_transfer_missing_cost.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let invariant = invariant_by_id(&packet, "support-transfer:profile:ag-support-transfer@1");
+    assert_eq!(invariant["status"], "not_computed");
+    assert_eq!(invariant["reason"], "missing_ground_costs:support:data");
+}
+
+#[test]
 fn cli_analyze_v2_sheaf_laplacian_rejects_unknown_cell() {
     let out_dir = temp_dir("ag-measurement-sheaf-laplacian-unknown-cell");
     let root = ag_measurement_root();
@@ -1923,49 +2364,73 @@ fn cli_locks_ag_measurement_period_stokes_golden_fixture() {
 }
 
 #[test]
-fn cli_analyze_v2_strict_distance_rejects_unmeasured_foundation_rows() {
-    let out_dir = temp_dir("ag-measurement-strict");
-    let root = ag_measurement_root();
-    let mut policy = read_json(&root.join("law_policy_ag.json"));
-    policy["policies"]
-        .as_array_mut()
-        .expect("policies is array")
-        .push(serde_json::json!({
-            "law": "ag.support-transfer",
-            "evaluator": "ag.support-transfer@1",
-            "basis": ["policy-basis:layering"],
-            "scope": ["src/"],
-            "severity": "medium"
-        }));
-    let policy_path = out_dir.join("law_policy_ag_with_unmeasured.json");
-    fs::write(
-        &policy_path,
-        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
-    )
-    .expect("policy fixture can be written");
-
-    run_sig0_expect_code(
-        &[
-            "analyze",
-            "--archmap",
-            root.join("archmap_v2.json")
-                .to_str()
-                .expect("path is utf-8"),
-            "--law-policy",
-            policy_path.to_str().expect("path is utf-8"),
-            "--out-dir",
-            out_dir.to_str().expect("path is utf-8"),
-            "--strict-distance",
-        ],
-        1,
+fn cli_locks_ag_measurement_support_transfer_golden_fixture() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate root is tools/archsig inside repo");
+    let fixture = read_json(&ag_measurement_root().join("archmap_v2_support_transfer.json"));
+    assert_eq!(fixture["schema"], "archmap/v2");
+    assert_eq!(fixture["id"], "ag-measurement-support-transfer-fixture");
+    assert!(
+        fixture["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .any(|atom| atom["axis"] == "transfer" && atom["predicate"] == "groundCost"),
+        "AG Transfer fixture must contain explicit transfer ground-cost atoms"
     );
+
+    let golden_corpus = fs::read_to_string(repo_root.join("docs/tool/golden_corpus.md"))
+        .expect("golden corpus docs are readable");
+    for snippet in [
+        "archmap_v2_support_transfer.json",
+        "law_policy_transfer.json",
+        "cli_analyze_v2_support_transfer_outputs_residue_and_wasserstein_cost",
+        "global repair safety",
+    ] {
+        assert!(
+            golden_corpus.contains(snippet),
+            "AG golden corpus docs must mention {snippet}"
+        );
+    }
+}
+
+#[test]
+fn cli_analyze_v2_strict_distance_allows_implemented_analytic_only_evaluators() {
+    let out_dir = temp_dir("ag-measurement-strict-analytic-only");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2_support_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_transfer.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+        "--strict-distance",
+    ]);
 
     let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
     assert_eq!(
         summary["conclusion"],
         "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
     );
-    assert_eq!(summary["structuralVerdictSummary"]["nonTerminalCount"], 1);
+    assert_eq!(summary["structuralVerdictSummary"]["rowCount"], 0);
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert!(
+        packet["analyticReadings"]
+            .as_array()
+            .expect("analytic readings is array")
+            .iter()
+            .any(|reading| reading["evaluator"] == "ag.support-transfer@1")
+    );
 }
 
 #[test]

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json
@@ -1,0 +1,108 @@
+{
+  "schema": "archmap/v2",
+  "id": "ag-measurement-support-transfer-fixture",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:ag-fixture@1",
+    "fingerprint": "sha256:ag-fixture-doctrine",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
+  "sources": {
+    "src:transfer-api": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R8-transfer-api"
+    },
+    "src:transfer-data": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R8-transfer-data"
+    },
+    "src:ground-api": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R8-ground-api"
+    },
+    "src:ground-data": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R8-ground-data"
+    },
+    "src:repair-path": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R8-repair-path"
+    },
+    "src:cover": {
+      "kind": "policy",
+      "path": "docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md",
+      "section": "R8"
+    }
+  },
+  "atoms": [
+    {
+      "id": "atom:transfer-repair-path-core",
+      "kind": "semantic",
+      "subject": "repair:path:core",
+      "object": "selected",
+      "axis": "transfer",
+      "predicate": "repairPath",
+      "refs": ["src:repair-path"]
+    },
+    {
+      "id": "atom:transfer-path-api",
+      "kind": "semantic",
+      "subject": "repair:path:core",
+      "object": "support:api=0.25",
+      "axis": "transfer",
+      "predicate": "transferPairing",
+      "refs": ["src:transfer-api"]
+    },
+    {
+      "id": "atom:transfer-path-data",
+      "kind": "semantic",
+      "subject": "repair:path:core",
+      "object": "support:data=0.75",
+      "axis": "transfer",
+      "predicate": "transferPairing",
+      "refs": ["src:transfer-data"]
+    },
+    {
+      "id": "atom:transfer-ground-api",
+      "kind": "semantic",
+      "subject": "support:api",
+      "object": "2",
+      "axis": "transfer",
+      "predicate": "groundCost",
+      "refs": ["src:ground-api"]
+    },
+    {
+      "id": "atom:transfer-ground-data",
+      "kind": "semantic",
+      "subject": "support:data",
+      "object": "4",
+      "axis": "transfer",
+      "predicate": "groundCost",
+      "refs": ["src:ground-data"]
+    }
+  ],
+  "contexts": [
+    {
+      "id": "ctx:support-transfer-local",
+      "atoms": [
+        "atom:transfer-repair-path-core",
+        "atom:transfer-path-api",
+        "atom:transfer-path-data",
+        "atom:transfer-ground-api",
+        "atom:transfer-ground-data"
+      ],
+      "refs": ["src:cover"]
+    }
+  ],
+  "covers": [
+    {
+      "id": "cover:support-transfer",
+      "contexts": ["ctx:support-transfer-local"],
+      "refs": ["src:cover"]
+    }
+  ]
+}

--- a/tools/archsig/tests/fixtures/ag_measurement/law_policy_transfer.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/law_policy_transfer.json
@@ -1,0 +1,40 @@
+{
+  "schema": "law-policy/v1",
+  "id": "ag-support-transfer-policy",
+  "measurementProfileRef": "profile:ag-support-transfer@1",
+  "measurementProfiles": [
+    {
+      "schema": "measurement-profile/v1",
+      "profileId": "profile:ag-support-transfer@1",
+      "siteRef": "archmap:/contexts",
+      "coverRef": "cover:support-transfer",
+      "coefficient": "R",
+      "effCoeff": "finite-linear-algebra@1",
+      "witnessFamily": [
+        {
+          "law": "ag.support-transfer",
+          "variable": "support:api"
+        },
+        {
+          "law": "ag.support-transfer",
+          "variable": "support:data"
+        }
+      ],
+      "resolutionSelector": "support-localized-transfer@1",
+      "domain": "finite-poset-site",
+      "zeroPredicate": "analytic-zero@1",
+      "nonZeroPredicate": "analytic-positive@1",
+      "certSelector": "analytic-reading@1",
+      "verdictDiscipline": "five-valued-structural-verdict@1"
+    }
+  ],
+  "policies": [
+    {
+      "law": "ag.support-transfer",
+      "evaluator": "ag.support-transfer@1",
+      "basis": ["policy-basis:layering"],
+      "scope": ["src/"],
+      "severity": "medium"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1940
Part of #1907

## 概要
- ag.support-transfer@1 evaluator を追加し、finite support-localized transfer model から transfer measurement pairing を出力する
- transfer residue と Wasserstein transfer cost を analytic reading として出力する
- transfer lower bound は theorem-candidate reading に分離し、structural verdict を生成しない
- selected repair path universe を repairPath atom から読み、欠損 matrix cell / 欠損 row / 欠損 ground cost を 0 合成せず not_computed に落とす
- --strict-distance が analytic-only evaluator の not_computed invariant / violated assumption も reject するようにする
- R8 fixture と golden corpus lock を追加する

## 検証
- cargo test --manifest-path tools/archsig/Cargo.toml --test cli support_transfer
- cargo test --manifest-path tools/archsig/Cargo.toml --test cli strict_distance_rejects_not_computed
- cargo test --manifest-path tools/archsig/Cargo.toml
- git diff --check
- hidden/bidi Unicode scan over changed files
- local review: initial findings fixed, final review No major findings

Lean / FieldSig は今回の変更対象外。