### PR TITLE
FieldSig handoff を measurement packet v1 に更新

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -55,8 +55,9 @@ jobs:
           out_dir=".tmp/archsig-analyze-e2e"
           archsig_dir="$out_dir/archsig"
           archsig_raw_dir="$out_dir/archsig-raw"
+          archsig_measurement_dir="$out_dir/archsig-measurement"
           fieldsig_dir="$out_dir/fieldsig"
-          mkdir -p "$archsig_dir" "$archsig_raw_dir" "$fieldsig_dir"
+          mkdir -p "$archsig_dir" "$archsig_raw_dir" "$archsig_measurement_dir" "$fieldsig_dir"
 
           cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
             --archmap tools/archsig/tests/fixtures/archmap_v1/archmap.json \
@@ -190,6 +191,36 @@ jobs:
             echo "FieldSig accepted raw ArchMap as ArchSig analysis packet" >&2
             exit 1
           fi
+
+          cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
+            --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json \
+            --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_transfer.json \
+            --out-dir "$archsig_measurement_dir"
+
+          test -s "$archsig_measurement_dir/archsig-measurement-packet.json"
+
+          jq -e '
+            .schema == "archsig-measurement-packet/v1"
+            and .packetId == "measurement:ag-measurement-support-transfer-fixture"
+            and (.profile.profileId == "profile:ag-support-transfer@1")
+            and ((.computedInvariants | length) > 0)
+            and ((.analyticReadings | length) > 0)
+            and ([.assumptions[]? | select(.assumption == "transfer_lower_bound" and .status == "assumed")] | length == 1)
+          ' "$archsig_measurement_dir/archsig-measurement-packet.json"
+
+          cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
+            --measurement-packet "$archsig_measurement_dir/archsig-measurement-packet.json" \
+            --out "$fieldsig_dir/operation-support-estimate-measurement.json"
+
+          jq -e '
+            .schemaVersion == "operation-support-estimate-v0"
+            and .descriptorRef.artifactKind == "archsig-measurement-packet"
+            and ([.candidateOperationFamilies[]?.supportKind] | index("measurement-packet-analytic-reading") != null)
+            and ([.descriptorRef.sourceRefIds[]? | startswith("archsigMeasurementPacket:")] | any)
+            and ([.evidenceBoundary.measurementBoundaryRefs[]? | startswith("archsigMeasurementAnalytic:")] | any)
+            and ([.knownForbiddenSupport[]?.operationFamily] | index("raw-archmap-truth-promotion") != null)
+            and ([.unknownRemainder[]?.reason | contains("transfer_lower_bound")] | any)
+          ' "$fieldsig_dir/operation-support-estimate-measurement.json"
 
       - name: Upload ArchSig analyze e2e artifacts
         uses: actions/upload-artifact@v4

--- a/docs/tool/llm_native_e2e_workflow.md
+++ b/docs/tool/llm_native_e2e_workflow.md
@@ -100,7 +100,27 @@ packet is the compact `llmInterpretationPacket` reading surface from the raw
 analysis packet; it is intentionally not a byte-for-byte copy of the full
 analysis packet. For large ArchMaps, run the workflow with `cargo run --release`.
 
-Project the ArchSig analysis packet into FieldSig:
+Project the primary v0.4.0 ArchSig measurement packet into FieldSig:
+
+```bash
+cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
+  --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json \
+  --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_transfer.json \
+  --out-dir .tmp/archsig-analyze-e2e/archsig-measurement
+
+cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
+  --measurement-packet .tmp/archsig-analyze-e2e/archsig-measurement/archsig-measurement-packet.json \
+  --out .tmp/archsig-analyze-e2e/fieldsig/operation-support-estimate-measurement.json
+```
+
+The output must be `operation-support-estimate-v0` with
+`descriptorRef.artifactKind = "archsig-measurement-packet"`. FieldSig preserves
+structural verdict rows, computed invariants, analytic readings, assumption
+ledger refs, and non-conclusions as bounded current AG measurement state. It
+does not promote raw ArchMap observations, analytic readings, theorem-candidate
+readings, or assumed boundaries to forecast truth.
+
+Legacy analysis packet compatibility handoff:
 
 ```bash
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \

--- a/tools/fieldsig/README.md
+++ b/tools/fieldsig/README.md
@@ -1,6 +1,6 @@
 # FieldSig
 
-`fieldsig` is the SFT-based software evolution measurement layer. It is separate from ArchSig: ArchSig produces current AAT structural telemetry and review cues, while FieldSig consumes raw `archsig-analysis-packet/v1` handoff artifacts together with PRD, SPEC, Issue, CI, test, review, runtime, ownership, history, calibration, and AI proposal policy evidence to study PR / diff / change-vector evolution over that state.
+`fieldsig` is the SFT-based software evolution measurement layer. It is separate from ArchSig: ArchSig produces current AG measurement state and review cues, while FieldSig consumes serialized `archsig-measurement-packet/v1` handoff artifacts together with PRD, SPEC, Issue, CI, test, review, runtime, ownership, history, calibration, and AI proposal policy evidence to study PR / diff / change-vector evolution over that state.
 
 FieldSig artifacts are measurement and workflow evidence. They do not prove forecast correctness, assign probabilities by default, establish causal correctness, provide global safety, or replace CI, tests, and human review.
 
@@ -8,19 +8,21 @@ FieldSig artifacts are measurement and workflow evidence. They do not prove fore
 
 ```bash
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
-  --analysis-packet .tmp/archsig-analyze-e2e/archsig-raw/archsig-analysis-packet.json \
+  --measurement-packet .tmp/archsig-analyze-e2e/archsig-raw/archsig-measurement-packet.json \
   --out .fieldsig/operation-support-estimate.json
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- software-field-measurement --fixture --out .fieldsig/software-field-measurement.json
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- software-field-measurement --input .fieldsig/software-field-measurement.json --out .fieldsig/software-field-measurement-validation.json
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- fieldsig-run-manifest --fixture --out .fieldsig/fieldsig-run-manifest.json
 ```
 
-`archsig-analysis-sft-input` is the current ArchSig handoff. It rejects raw
-ArchMap JSON when supplied as the analysis packet and preserves v1 typed
-evaluator results, generated packet refs, spectrum readings, homotopy readings,
-structural review boundaries, detail refs, and coverage gaps as bounded SFT
-input refs / unknown remainder. It does not treat ArchSig current-state
-telemetry as forecast correctness or causal truth.
+`archsig-analysis-sft-input` is the current ArchSig handoff command. Its primary
+input is `--measurement-packet archsig-measurement-packet/v1`; legacy
+`--analysis-packet archsig-analysis-packet/v1` and `archsig-analysis-packet-v0`
+remain accepted as bounded compatibility inputs. The command rejects raw ArchMap
+JSON and preserves structural verdicts, computed invariants, analytic readings,
+assumption ledger entries, and legacy packet refs as bounded SFT input refs /
+unknown remainder. It does not treat ArchSig current-state telemetry as forecast
+correctness or causal truth.
 
 ## Migrated surface
 

--- a/tools/fieldsig/docs/artifacts-and-boundaries.md
+++ b/tools/fieldsig/docs/artifacts-and-boundaries.md
@@ -11,7 +11,7 @@ non-conclusions を落とさない。
 
 | Surface | Artifact families | Boundary |
 | --- | --- | --- |
-| ArchSig handoff | `archsig-analysis-packet-v0` から生成する `operation-support-estimate-v0`。 | ArchSig analysis state を current AAT structural state として読む。raw ArchMap observation、PR diff analysis、forecast truth、causal proof ではない。 |
+| ArchSig handoff | `archsig-measurement-packet/v1` から生成する `operation-support-estimate-v0`。 | ArchSig measurement packet を current AG measurement state として読む。raw ArchMap observation、PR diff analysis、forecast truth、causal proof ではない。 |
 | Adapter / review refs | Sig0、validation report、snapshot、signature diff、AIR、Feature Extension Report、AAT Observable Bundle。 | historical / bounded review refs として読めるが、FieldSig の現行 handoff source of truth ではない。 |
 | FieldSig SFT | ArtifactDescriptor、OperationSupportEstimate、ForecastConeSkeleton、ConsequenceEnvelope、ForecastCalibrationHook と validation report。 | bounded forecast report projection であり、point prediction、causal proof、forecast correctness ではない。 |
 | FieldSig Operational | PR history dataset、feature extension dataset、outcome linkage、daily ledger、calibration、threshold、ownership、repair adoption、incident correlation、hypothesis refresh。 | empirical / operational feedback であり、correlation を causal theorem にしない。 |
@@ -27,7 +27,8 @@ non-conclusions を落とさない。
 | AIR | `aat-air-v0` | Signature artifact layer を claim / evidence / coverage / extension boundary へ正規化した中間表現。 |
 | ArchMap observation map | `archmap-observation-map-v0` | ArchSig 入力の source-grounded Atom observation map。FieldSig はこれを現行 handoff として直接読まない。 |
 | LawPolicy | `law-policy-v0` | ArchSig analysis 用 selected law / witness / signature-axis policy artifact。AAT theory そのものではない。 |
-| ArchSig analysis packet | `archsig-analysis-packet-v0` | FieldSig の現行 ArchSig handoff。obstruction circuits、signature axes、repair candidates、v0.3.0 measurement expansion readings、structural review boundary、current-state/evolution boundary、coverage gaps、non-conclusions を bounded SFT input として読む。 |
+| ArchSig measurement packet | `archsig-measurement-packet/v1` | FieldSig の現行 ArchSig handoff。structural verdict、computed invariants、analytic readings、assumption ledger、non-conclusions を bounded SFT input として読む。 |
+| ArchSig analysis packet | `archsig-analysis-packet/v1`, `archsig-analysis-packet-v0` | Legacy compatibility handoff。typed evaluator / obstruction / signature / repair / structural review refs を bounded SFT input として読むが、v0.4.0 の primary handoff ではない。 |
 | ArchMap validation report | `archmap-validation-report-v0` | ArchMap の source refs、claim boundary、semantic coverage、conflict、formal promotion guardrail、atomic observation checks / summary の検査結果。 |
 | AIR validation report | `aat-air-validation-report-v0` | AIR の dangling refs、claim boundary、measured evidence traceability の検査結果。 |
 | Theorem precondition check report | `theorem-precondition-check-report-v0` | AIR claim が `FORMAL_PROVED` へ昇格できるかの検査結果。 |
@@ -101,11 +102,13 @@ non-conclusions を落とさない。
 | AI Proposal Governance validation report | `ai-proposal-governance-validation-report-v0` | support category、shortcut witness、review / CI / posterior boundary、AI safety / forecast correctness / lawfulness non-conclusions を検査する。 |
 | Lifecycle Decision Report | planned `lifecycle-decision-report-v0` | repair / migration / contraction / deletion の selected inputs、field capacity impact、runtime / ownership boundary、non-conclusions を保持する将来候補。 |
 
-`archsig-analysis-sft-input` は `archsig-analysis-packet-v0` を
-`operation-support-estimate-v0` へ射影する現行 handoff command である。obstruction circuits、
-signature axes、repair candidates、v0.3.0 measurement expansion readings、structural review boundary、
-current-state/evolution boundary、coverage gaps は bounded refs / unknown remainder として残る。これは certified universal atoms、
-zero curvature proof、PR diff analysis、forecast correctness、future outcome probability ではない。
+`archsig-analysis-sft-input` は `archsig-measurement-packet/v1` を
+`operation-support-estimate-v0` へ射影する現行 handoff command である。structural verdict、
+computed invariants、analytic readings、assumption ledger、non-conclusions は bounded refs /
+unknown remainder として残る。analytic readings や theorem-candidate readings は structural verdict
+へ変換しない。これは certified universal atoms、zero curvature proof、PR diff analysis、
+forecast correctness、future outcome probability ではない。`archsig-analysis-packet/v1` と
+`archsig-analysis-packet-v0` は legacy bounded compatibility input としてのみ読む。
 `archmap-sft-input` は legacy bounded projection であり、raw ArchMap observation を forecast truth へ
 昇格してはならない。
 

--- a/tools/fieldsig/docs/commands.md
+++ b/tools/fieldsig/docs/commands.md
@@ -1,6 +1,6 @@
 # FieldSig Commands
 
-FieldSig owns SFT software evolution measurement and workflow-evidence artifacts. The current ArchSig handoff is the serialized `archsig-analysis-packet-v0`: FieldSig reads it as current AAT structural state, not as forecast truth, causal correctness, global safety, or PR diff analysis. `archsig-analysis-sft-input` projects that packet into `operation-support-estimate-v0` while preserving obstruction circuits, signature axes, repair candidates, v0.3.0 measurement expansion readings, structural review boundaries, and coverage gaps as bounded refs. `archmap-sft-input` remains a legacy bounded projection and must not promote raw ArchMap observations to forecast truth. FieldSig does not share Rust types with ArchSig as a contract; the stable boundary is the serialized artifact ref.
+FieldSig owns SFT software evolution measurement and workflow-evidence artifacts. The current ArchSig handoff is the serialized `archsig-measurement-packet/v1`: FieldSig reads it as current AG measurement state, not as forecast truth, causal correctness, global safety, or PR diff analysis. `archsig-analysis-sft-input` projects that packet into `operation-support-estimate-v0` while preserving structural verdicts, computed invariants, analytic readings, assumption ledger entries, and non-conclusions as bounded refs / unknown remainder. Legacy `archsig-analysis-packet/v1` and `archsig-analysis-packet-v0` remain accepted as bounded compatibility inputs. `archmap-sft-input` remains a legacy bounded projection and must not promote raw ArchMap observations to forecast truth. FieldSig does not share Rust types with ArchSig as a contract; the stable boundary is the serialized artifact ref.
 
 ## Measurement
 
@@ -11,16 +11,18 @@ FieldSig owns SFT software evolution measurement and workflow-evidence artifacts
 
 Use `artifact-descriptor`, `intent-map`, `intent-archmap-alignment`, `intent-forecast`, `operation-support-estimate`, `forecast-cone-skeleton`, `consequence-envelope`, `sft-review-summary`, `forecast-calibration-hook`, `intent-calibration-record`, and `sft-forecast` for bounded SFT forecast artifacts. These commands preserve missing evidence and unknown remainder; they do not create probability or causal-correctness claims.
 
-ArchSig analysis packet handoff:
+ArchSig measurement packet handoff:
 
 ```bash
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
-  --analysis-packet tools/fieldsig/tests/fixtures/minimal/llm_native_handoff/archsig_analysis_packet.json \
+  --measurement-packet .tmp/archsig-analyze/archsig-measurement-packet.json \
   --out .fieldsig/operation-support-estimate.json
 ```
 
-This command rejects raw ArchMap JSON when it is supplied as the analysis-packet
-input. The accepted boundary is `archsig-analysis-packet-v0`.
+This command rejects raw ArchMap JSON when it is supplied as the
+measurement-packet input. The primary accepted boundary is
+`archsig-measurement-packet/v1`. `--analysis-packet` is retained only for legacy
+bounded analysis packet handoff.
 
 The end-to-end command transcript is fixed in
 [`docs/tool/llm_native_e2e_workflow.md`](../../../docs/tool/llm_native_e2e_workflow.md).

--- a/tools/fieldsig/src/archmap.rs
+++ b/tools/fieldsig/src/archmap.rs
@@ -17,6 +17,20 @@ use crate::{
     ValidationCheck,
 };
 
+const OPERATION_SUPPORT_REQUIRED_NON_CONCLUSIONS: [&str; 5] = [
+    "operation support estimate is a bounded tooling estimate, not accepted PR history",
+    "operation support estimate is not actual future support",
+    "unknown support is not measured zero",
+    "policy constraints do not prove global policy safety",
+    "operation support estimate does not prove future trajectory safety",
+];
+
+const OPERATION_SUPPORT_EVIDENCE_BOUNDARY_NON_CONCLUSIONS: [&str; 3] = [
+    "confidence is relative to retained descriptor source refs",
+    "evidence boundary does not complete extractor coverage",
+    "unsupported constructs remain forecast boundary items",
+];
+
 pub struct ArchMapSourceInventoryInput<'a> {
     pub path: &'a str,
     pub document: Option<&'a ArchMapSourceInventoryV0>,
@@ -257,6 +271,118 @@ pub fn build_operation_support_estimate_from_archsig_analysis_packet(
             non_conclusions,
         },
         non_conclusions: archsig_packet_sft_non_conclusions(packet),
+    })
+}
+
+pub fn build_operation_support_estimate_from_archsig_measurement_packet(
+    packet: &serde_json::Value,
+    input_path: &str,
+) -> Result<OperationSupportEstimateV0, Box<dyn std::error::Error>> {
+    let schema_version = packet
+        .get("schema")
+        .or_else(|| packet.get("schemaVersion"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if schema_version != "archsig-measurement-packet/v1" {
+        return Err(format!(
+            "FieldSig ArchSig measurement handoff requires archsig-measurement-packet/v1, got {schema_version}"
+        )
+        .into());
+    }
+    validate_archsig_measurement_packet_handoff_shape(packet)?;
+
+    let packet_id = packet
+        .get("packetId")
+        .and_then(|value| value.as_str())
+        .unwrap_or("archsig-measurement-packet");
+    let source_ref_ids = archsig_measurement_packet_sft_source_refs(packet, input_path);
+    let action_class_candidate_ids = archsig_measurement_packet_action_candidate_ids(packet);
+    let candidate_operation_families = archsig_measurement_packet_candidate_families(
+        packet,
+        &source_ref_ids,
+        &action_class_candidate_ids,
+    );
+    let family_ids = candidate_operation_families
+        .iter()
+        .map(|family| family.family_id.clone())
+        .collect::<Vec<_>>();
+    let non_conclusions = archsig_measurement_packet_sft_non_conclusions(packet);
+
+    Ok(OperationSupportEstimateV0 {
+        schema_version: OPERATION_SUPPORT_ESTIMATE_SCHEMA_VERSION.to_string(),
+        estimate_id: format!("estimate:archsig-measurement:{}", stable_id(packet_id)),
+        descriptor_ref: OperationSupportDescriptorRefV0 {
+            descriptor_schema_version: ARTIFACT_DESCRIPTOR_SCHEMA_VERSION.to_string(),
+            descriptor_id: format!("descriptor:archsig-measurement:{packet_id}"),
+            artifact_kind: "archsig-measurement-packet".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            action_class_candidate_ids: action_class_candidate_ids.clone(),
+            non_conclusions: non_conclusions.clone(),
+        },
+        candidate_operation_families,
+        policy_constraints: vec![OperationSupportPolicyConstraintV0 {
+            constraint_id: "constraint:archsig-measurement:no-forecast-truth-promotion"
+                .to_string(),
+            constraint_kind: "claim-boundary".to_string(),
+            applies_to_family_ids: family_ids.clone(),
+            source_ref_ids: source_ref_ids.clone(),
+            rule: "ArchSig measurement packet is current AG measurement state for SFT evolution input, not forecast truth".to_string(),
+            safety_claim_boundary:
+                "SFT consumes selected structural verdict, computed invariant, analytic reading, and assumption refs as bounded coordinates only"
+                    .to_string(),
+            policy_refs: vec!["policy:archsig-measurement-sft-boundary".to_string()],
+            support_disposition: "conditionallyAllowed".to_string(),
+            governance_action_refs: vec![
+                "governance:review-archsig-measurement-handoff".to_string(),
+            ],
+            non_conclusions: non_conclusions.clone(),
+        }],
+        known_forbidden_support: vec![KnownForbiddenOperationSupportV0 {
+            forbidden_id: "forbidden:raw-archmap-forecast-truth".to_string(),
+            operation_family: "raw-archmap-truth-promotion".to_string(),
+            source_ref_ids: source_ref_ids.clone(),
+            constraint_refs: vec![
+                "constraint:archsig-measurement:no-forecast-truth-promotion".to_string(),
+            ],
+            reason: "ArchSig measurement packets do not assert SFT forecast correctness or raw ArchMap truth".to_string(),
+            boundary: "FieldSig must keep measurement packet refs as bounded current AG structural state, not ground truth, causal proof, or diff analysis".to_string(),
+            non_conclusions: non_conclusions.clone(),
+        }],
+        unknown_remainder: archsig_measurement_packet_unknown_remainders(
+            packet,
+            &family_ids,
+            &source_ref_ids,
+        ),
+        evidence_boundary: OperationSupportEvidenceBoundaryV0 {
+            boundary_id: format!("boundary:archsig-measurement:{}:sft-input", stable_id(packet_id)),
+            source_ref_ids,
+            measurement_boundary_refs: archsig_measurement_packet_measurement_boundary_refs(packet),
+            confidence_boundary:
+                "ArchSig measurement packet statuses are selected finite-measurement evidence, not probability"
+                    .to_string(),
+            evidence_kinds: vec![
+                "archsig-measurement-packet/v1".to_string(),
+                "measurement-profile/v1".to_string(),
+                "structural-verdict".to_string(),
+                "computed-invariant".to_string(),
+                "analytic-reading".to_string(),
+                "assumption-ledger".to_string(),
+            ],
+            unsupported_constructs: vec![
+                "raw ArchMap observation completeness".to_string(),
+                "SFT forecast correctness".to_string(),
+                "causal repair safety".to_string(),
+                "global architecture safety".to_string(),
+            ],
+            assumptions: vec![
+                "FieldSig reads ArchSig measurement packet refs as current AG measurement state".to_string(),
+                "PR, diff, change-vector, forecast, governance, and operational evolution remain FieldSig readings".to_string(),
+                "analytic readings and theorem-candidate readings are retained as analytic state, not structural verdicts".to_string(),
+                "not_computed verdicts and violated assumptions remain unknown remainder, not measured zero".to_string(),
+            ],
+            non_conclusions: archsig_measurement_packet_evidence_boundary_non_conclusions(packet),
+        },
+        non_conclusions: archsig_measurement_packet_sft_non_conclusions(packet),
     })
 }
 
@@ -695,6 +821,526 @@ fn json_path_string(packet: &serde_json::Value, path: &[&str], key: &str) -> Opt
         current = current.get(*segment)?;
     }
     current.get(key)?.as_str().map(ToOwned::to_owned)
+}
+
+fn validate_archsig_measurement_packet_handoff_shape(
+    packet: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let packet_id = packet
+        .get("packetId")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if packet_id.trim().is_empty() {
+        return Err("FieldSig ArchSig measurement handoff requires non-empty packetId".into());
+    }
+    let profile = packet
+        .get("profile")
+        .and_then(|value| value.as_object())
+        .ok_or("FieldSig ArchSig measurement handoff requires profile object")?;
+    let profile_id = profile
+        .get("profileId")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if profile_id.trim().is_empty() {
+        return Err("FieldSig ArchSig measurement handoff requires profile.profileId".into());
+    }
+    for key in [
+        "structuralVerdict",
+        "computedInvariants",
+        "analyticReadings",
+        "assumptions",
+        "nonConclusions",
+    ] {
+        if !packet.get(key).is_some_and(|value| value.is_array()) {
+            return Err(
+                format!("FieldSig ArchSig measurement handoff requires {key} array").into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn archsig_measurement_packet_sft_source_refs(
+    packet: &serde_json::Value,
+    input_path: &str,
+) -> Vec<String> {
+    let mut refs = vec![format!("source:archsig-measurement-packet:{input_path}")];
+    if let Some(packet_id) = packet.get("packetId").and_then(|value| value.as_str()) {
+        refs.push(format!("archsigMeasurementPacket:{packet_id}"));
+    }
+    if let Some(profile_id) = json_path_string(packet, &["profile"], "profileId") {
+        refs.push(format!("archsigMeasurementProfile:{profile_id}"));
+    }
+    refs.extend(
+        packet
+            .get("structuralVerdict")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .flat_map(|verdict| {
+                let mut refs = Vec::new();
+                if let Some(evaluator) = verdict.get("evaluator").and_then(|value| value.as_str()) {
+                    refs.push(format!("archsigMeasurementStructuralEvaluator:{evaluator}"));
+                }
+                if let Some(law) = verdict.get("law").and_then(|value| value.as_str()) {
+                    refs.push(format!("archsigMeasurementStructuralLaw:{law}"));
+                }
+                if let Some(cert_ref) = verdict
+                    .get("verdictData")
+                    .and_then(|data| data.get("certRef"))
+                    .and_then(|value| value.as_str())
+                {
+                    refs.push(format!("archsigMeasurementCert:{cert_ref}"));
+                }
+                refs
+            }),
+    );
+    refs.extend(
+        packet
+            .get("computedInvariants")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .flat_map(|invariant| {
+                let mut refs = Vec::new();
+                for key in ["invariantId", "readingId", "id"] {
+                    if let Some(id) = invariant.get(key).and_then(|value| value.as_str()) {
+                        refs.push(format!("archsigMeasurementComputedInvariant:{id}"));
+                    }
+                }
+                if let Some(evaluator) = invariant.get("evaluator").and_then(|value| value.as_str())
+                {
+                    refs.push(format!("archsigMeasurementComputedEvaluator:{evaluator}"));
+                }
+                refs
+            }),
+    );
+    refs.extend(
+        packet
+            .get("analyticReadings")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .flat_map(|reading| {
+                let mut refs = Vec::new();
+                if let Some(id) = reading.get("readingId").and_then(|value| value.as_str()) {
+                    refs.push(format!("archsigMeasurementAnalyticReading:{id}"));
+                }
+                if let Some(evaluator) = reading.get("evaluator").and_then(|value| value.as_str()) {
+                    refs.push(format!("archsigMeasurementAnalyticEvaluator:{evaluator}"));
+                }
+                refs
+            }),
+    );
+    refs.extend(
+        packet
+            .get("assumptions")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|assumption| {
+                let theorem_ref = assumption.get("theoremRef")?.as_str()?;
+                let status = assumption
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown");
+                Some(format!(
+                    "archsigMeasurementAssumption:{theorem_ref}:{status}"
+                ))
+            }),
+    );
+    unique_strings(refs)
+}
+
+fn archsig_measurement_packet_action_candidate_ids(packet: &serde_json::Value) -> Vec<String> {
+    let mut ids = json_object_string_array(packet, &["structuralVerdict"], "evaluator");
+    ids.extend(json_object_string_array(
+        packet,
+        &["structuralVerdict"],
+        "law",
+    ));
+    ids.extend(json_object_string_array(
+        packet,
+        &["computedInvariants"],
+        "evaluator",
+    ));
+    ids.extend(json_object_string_array(
+        packet,
+        &["analyticReadings"],
+        "evaluator",
+    ));
+    ids.extend(json_object_string_array(
+        packet,
+        &["computedInvariants"],
+        "invariantId",
+    ));
+    ids.extend(json_object_string_array(
+        packet,
+        &["analyticReadings"],
+        "readingId",
+    ));
+    if ids.is_empty() {
+        ids.push(
+            packet
+                .get("packetId")
+                .and_then(|value| value.as_str())
+                .unwrap_or("archsig-measurement-packet")
+                .to_string(),
+        );
+    }
+    unique_strings(ids)
+}
+
+fn archsig_measurement_packet_candidate_families(
+    packet: &serde_json::Value,
+    source_ref_ids: &[String],
+    action_class_candidate_ids: &[String],
+) -> Vec<CandidateOperationFamilyV0> {
+    let non_conclusions = archsig_measurement_packet_sft_non_conclusions(packet);
+    let mut families = packet
+        .get("structuralVerdict")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .enumerate()
+        .map(|(index, row)| {
+            let evaluator = row
+                .get("evaluator")
+                .and_then(|value| value.as_str())
+                .unwrap_or("ag-structural-evaluator");
+            let law = row
+                .get("law")
+                .and_then(|value| value.as_str())
+                .unwrap_or("selected-ag-law");
+            let verdict = row
+                .get("verdict")
+                .and_then(|value| value.as_str())
+                .unwrap_or("not_computed");
+            let row_key = archsig_measurement_structural_row_key(index, row);
+            CandidateOperationFamilyV0 {
+                family_id: format!("family:archsig-measurement:{}", stable_id(&row_key)),
+                operation_family: format!("review-ag-structural-{verdict}"),
+                support_kind: "measurement-packet-structural-verdict".to_string(),
+                action_class_candidate_ids: vec![evaluator.to_string(), law.to_string()],
+                source_ref_ids: source_ref_ids.to_vec(),
+                confidence: if matches!(verdict, "measured_zero" | "measured_nonzero") {
+                    "medium"
+                } else {
+                    "low"
+                }
+                .to_string(),
+                rationale:
+                    "structural verdict is read from ArchSig measurement packet as current AG measurement state"
+                        .to_string(),
+                assumptions: Vec::new(),
+                non_conclusions: non_conclusions.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+    families.extend(
+        packet
+            .get("analyticReadings")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|reading| {
+                let reading_id = reading.get("readingId")?.as_str()?;
+                let evaluator = reading
+                    .get("evaluator")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("ag-analytic-evaluator");
+                let regime = reading
+                    .get("regime")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("analytic");
+                Some(CandidateOperationFamilyV0 {
+                    family_id: format!(
+                        "family:archsig-measurement-analytic:{}",
+                        stable_id(reading_id)
+                    ),
+                    operation_family: format!("review-ag-analytic-{regime}"),
+                    support_kind: "measurement-packet-analytic-reading".to_string(),
+                    action_class_candidate_ids: vec![reading_id.to_string(), evaluator.to_string()],
+                    source_ref_ids: source_ref_ids.to_vec(),
+                    confidence: "low".to_string(),
+                    rationale:
+                        "analytic reading is retained as bounded measurement state, not converted into a structural verdict"
+                            .to_string(),
+                    assumptions: Vec::new(),
+                    non_conclusions: non_conclusions.clone(),
+                })
+            }),
+    );
+    if families.is_empty() {
+        families.push(CandidateOperationFamilyV0 {
+            family_id: "family:archsig-measurement-review-only".to_string(),
+            operation_family: "review-selected-archsig-measurement".to_string(),
+            support_kind: "measurement-packet-review-boundary".to_string(),
+            action_class_candidate_ids: action_class_candidate_ids.to_vec(),
+            source_ref_ids: source_ref_ids.to_vec(),
+            confidence: "low".to_string(),
+            rationale:
+                "no structural verdict or analytic reading is present; FieldSig keeps the packet as review input"
+                    .to_string(),
+            assumptions: vec!["selected MeasurementProfile may not cover all future SFT axes"
+                .to_string()],
+            non_conclusions,
+        });
+    }
+    families
+}
+
+fn archsig_measurement_structural_row_key(index: usize, row: &serde_json::Value) -> String {
+    let evaluator = row
+        .get("evaluator")
+        .and_then(|value| value.as_str())
+        .unwrap_or("ag-structural-evaluator");
+    let law = row
+        .get("law")
+        .and_then(|value| value.as_str())
+        .unwrap_or("selected-ag-law");
+    let verdict = row
+        .get("verdict")
+        .and_then(|value| value.as_str())
+        .unwrap_or("not_computed");
+    let cert_ref = row
+        .get("verdictData")
+        .and_then(|value| value.get("certRef"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("no-cert");
+    format!("{index}:{evaluator}:{law}:{verdict}:{cert_ref}")
+}
+
+fn archsig_measurement_packet_unknown_remainders(
+    packet: &serde_json::Value,
+    family_ids: &[String],
+    source_ref_ids: &[String],
+) -> Vec<OperationSupportUnknownRemainderV0> {
+    let mut remainders = Vec::new();
+    remainders.extend(
+        packet
+        .get("structuralVerdict")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .enumerate()
+        .filter_map(|(index, row)| {
+            let verdict = row.get("verdict")?.as_str()?;
+            if !matches!(verdict, "not_computed" | "unknown" | "unmeasured") {
+                return None;
+            }
+                let evaluator = row
+                    .get("evaluator")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("ag-structural-evaluator");
+                let reason = row
+                .get("reason")
+                .and_then(|value| value.as_str())
+                .unwrap_or("structural verdict is outside the selected finite measurement boundary");
+            let row_key = archsig_measurement_structural_row_key(index, row);
+            Some(OperationSupportUnknownRemainderV0 {
+                remainder_id: format!(
+                    "unknown:archsig-measurement:structural:{}",
+                    stable_id(&row_key)
+                ),
+                    affected_family_ids: family_ids.to_vec(),
+                    source_ref_ids: source_ref_ids.to_vec(),
+                    unknown_axes: vec![verdict.to_string()],
+                    reason: format!("ArchSig measurement evaluator {evaluator} returned {verdict}: {reason}"),
+                    treatment: "carry as unknown remainder; do not round to absence, zero-valued support, forecast truth, or repair safety".to_string(),
+                    non_conclusions: archsig_measurement_packet_sft_non_conclusions(packet),
+                })
+            }),
+    );
+    remainders.extend(
+        packet
+            .get("computedInvariants")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|invariant| {
+                let status = invariant.get("status")?.as_str()?;
+                if status != "not_computed" {
+                    return None;
+                }
+                let id = invariant
+                    .get("invariantId")
+                    .or_else(|| invariant.get("id"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("computed-invariant");
+                Some(OperationSupportUnknownRemainderV0 {
+                    remainder_id: format!(
+                        "unknown:archsig-measurement:computed:{}",
+                        stable_id(id)
+                    ),
+                    affected_family_ids: family_ids.to_vec(),
+                    source_ref_ids: source_ref_ids.to_vec(),
+                    unknown_axes: vec!["computedInvariant:not_computed".to_string()],
+                    reason: format!("ArchSig measurement computed invariant {id} is not_computed"),
+                    treatment: "carry as unknown remainder; do not synthesize zero analytic or structural support".to_string(),
+                    non_conclusions: archsig_measurement_packet_sft_non_conclusions(packet),
+                })
+            }),
+    );
+    remainders.extend(
+        packet
+            .get("assumptions")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|assumption| {
+                let status = assumption.get("status")?.as_str()?;
+                if status == "checked" {
+                    return None;
+                }
+                let theorem_ref = assumption
+                    .get("theoremRef")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("assumption");
+                let assumption_text = assumption
+                    .get("assumption")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("assumption");
+                Some(OperationSupportUnknownRemainderV0 {
+                    remainder_id: format!(
+                        "unknown:archsig-measurement:assumption:{}",
+                        stable_id(theorem_ref)
+                    ),
+                    affected_family_ids: family_ids.to_vec(),
+                    source_ref_ids: source_ref_ids.to_vec(),
+                    unknown_axes: vec![format!("assumption:{status}")],
+                    reason: format!("ArchSig measurement assumption {theorem_ref} is {status}: {assumption_text}"),
+                    treatment: "retain assumption status as boundary data; do not promote it to proof, forecast truth, or repair safety".to_string(),
+                    non_conclusions: archsig_measurement_packet_sft_non_conclusions(packet),
+                })
+            }),
+    );
+    remainders.push(OperationSupportUnknownRemainderV0 {
+        remainder_id: "unknown:archsig-measurement:fieldsig-evolution-boundary".to_string(),
+        affected_family_ids: family_ids.to_vec(),
+        source_ref_ids: source_ref_ids.to_vec(),
+        unknown_axes: vec![
+            "PR diff evidence".to_string(),
+            "workflow history".to_string(),
+            "operational outcome".to_string(),
+            "unselected laws outside MeasurementProfile".to_string(),
+        ],
+        reason:
+            "ArchSig measurement packet records current AG measurement state, not FieldSig evolution evidence"
+                .to_string(),
+        treatment:
+            "retain as FieldSig-side unknown remainder; require separate workflow evidence before forecast or governance readings"
+                .to_string(),
+        non_conclusions: archsig_measurement_packet_sft_non_conclusions(packet),
+    });
+    remainders
+}
+
+fn archsig_measurement_packet_measurement_boundary_refs(packet: &serde_json::Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    if let Some(profile_id) = json_path_string(packet, &["profile"], "profileId") {
+        refs.push(format!("archsigMeasurementProfile:{profile_id}"));
+    }
+    refs.extend(
+        packet
+            .get("structuralVerdict")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let evaluator = row.get("evaluator")?.as_str()?;
+                let verdict = row
+                    .get("verdict")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown");
+                Some(format!("archsigMeasurementVerdict:{evaluator}:{verdict}"))
+            }),
+    );
+    refs.extend(
+        packet
+            .get("computedInvariants")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|invariant| {
+                let id = invariant
+                    .get("invariantId")
+                    .or_else(|| invariant.get("id"))?
+                    .as_str()?;
+                let status = invariant
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("computed");
+                Some(format!("archsigMeasurementInvariant:{id}:{status}"))
+            }),
+    );
+    refs.extend(
+        packet
+            .get("analyticReadings")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|reading| {
+                let id = reading.get("readingId")?.as_str()?;
+                let regime = reading
+                    .get("regime")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("analytic");
+                Some(format!("archsigMeasurementAnalytic:{id}:{regime}"))
+            }),
+    );
+    refs.extend(
+        packet
+            .get("assumptions")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|assumption| {
+                let theorem_ref = assumption.get("theoremRef")?.as_str()?;
+                let status = assumption
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown");
+                Some(format!(
+                    "archsigMeasurementAssumptionBoundary:{theorem_ref}:{status}"
+                ))
+            }),
+    );
+    unique_strings(refs)
+}
+
+fn archsig_measurement_packet_sft_non_conclusions(packet: &serde_json::Value) -> Vec<String> {
+    let mut values = json_string_array(packet, &["nonConclusions"]);
+    values.extend(
+        OPERATION_SUPPORT_REQUIRED_NON_CONCLUSIONS
+            .iter()
+            .map(|value| value.to_string()),
+    );
+    values.extend([
+        "ArchSig measurement packet is FieldSig input state, not forecast correctness".to_string(),
+        "raw ArchMap observations are not promoted to SFT ground truth".to_string(),
+        "analytic readings are not converted into structural verdicts".to_string(),
+        "not_computed measurements and violated assumptions are unknown remainder, not measured zero".to_string(),
+        "FieldSig handoff does not prove causal correctness, repair safety, or global architecture safety".to_string(),
+    ]);
+    unique_strings(values)
+}
+
+fn archsig_measurement_packet_evidence_boundary_non_conclusions(
+    packet: &serde_json::Value,
+) -> Vec<String> {
+    let mut values = json_string_array(packet, &["nonConclusions"]);
+    values.extend(
+        OPERATION_SUPPORT_EVIDENCE_BOUNDARY_NON_CONCLUSIONS
+            .iter()
+            .map(|value| value.to_string()),
+    );
+    values.extend([
+        "ArchSig measurement packet evidence boundary does not complete ArchMap observation coverage".to_string(),
+        "FieldSig handoff evidence boundary does not prove forecast correctness".to_string(),
+        "unsupported constructs remain outside the selected measurement profile".to_string(),
+    ]);
+    unique_strings(values)
 }
 
 fn archsig_v1_packet_sft_non_conclusions(packet: &serde_json::Value) -> Vec<String> {

--- a/tools/fieldsig/src/lib.rs
+++ b/tools/fieldsig/src/lib.rs
@@ -73,7 +73,8 @@ pub use architecture_policy::{
 pub use archmap::{
     ArchMapSourceInventoryInput, build_air_from_archmap,
     build_operation_support_estimate_from_archmap,
-    build_operation_support_estimate_from_archsig_analysis_packet, validate_archmap_report,
+    build_operation_support_estimate_from_archsig_analysis_packet,
+    build_operation_support_estimate_from_archsig_measurement_packet, validate_archmap_report,
 };
 pub use artifact_descriptor::{
     build_artifact_descriptor_from_ai_proposal_json,

--- a/tools/fieldsig/src/main.rs
+++ b/tools/fieldsig/src/main.rs
@@ -51,6 +51,7 @@ use fieldsig::{
     build_feature_extension_report, build_forecast_cone_skeleton_from_operation_support,
     build_law_violation_report, build_operation_support_estimate_from_archmap,
     build_operation_support_estimate_from_archsig_analysis_packet,
+    build_operation_support_estimate_from_archsig_measurement_packet,
     build_operation_support_estimate_from_descriptor,
     build_operation_support_estimate_from_intent_alignment,
     build_outcome_linkage_dataset_from_files, build_policy_decision_report,
@@ -554,11 +555,15 @@ enum Command {
         out: Option<PathBuf>,
     },
 
-    /// Project an ArchSig analysis packet into SFT operation-support input.
+    /// Project an ArchSig measurement packet into SFT operation-support input.
     ArchsigAnalysisSftInput {
-        /// Input archsig-analysis-packet/v1 or archsig-analysis-packet-v0 JSON path.
+        /// Input archsig-measurement-packet/v1 JSON path.
+        #[arg(long = "measurement-packet")]
+        measurement_packet: Option<PathBuf>,
+
+        /// Legacy input archsig-analysis-packet/v1 or archsig-analysis-packet-v0 JSON path.
         #[arg(long = "analysis-packet")]
-        analysis_packet: PathBuf,
+        analysis_packet: Option<PathBuf>,
 
         /// Output operation-support-estimate-v0 JSON path. If omitted, JSON is written to stdout.
         #[arg(long)]
@@ -1664,14 +1669,37 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             Ok(ExitCode::SUCCESS)
         }
         Some(Command::ArchsigAnalysisSftInput {
+            measurement_packet,
             analysis_packet,
             out,
         }) => {
-            let packet: serde_json::Value = read_json(&analysis_packet)?;
-            let estimate = build_operation_support_estimate_from_archsig_analysis_packet(
-                &packet,
-                &analysis_packet.display().to_string(),
-            )?;
+            let estimate = match (measurement_packet, analysis_packet) {
+                (Some(measurement_packet), None) => {
+                    let packet: serde_json::Value = read_json(&measurement_packet)?;
+                    build_operation_support_estimate_from_archsig_measurement_packet(
+                        &packet,
+                        &measurement_packet.display().to_string(),
+                    )?
+                }
+                (None, Some(analysis_packet)) => {
+                    let packet: serde_json::Value = read_json(&analysis_packet)?;
+                    build_operation_support_estimate_from_archsig_analysis_packet(
+                        &packet,
+                        &analysis_packet.display().to_string(),
+                    )?
+                }
+                (Some(_), Some(_)) => {
+                    return Err(
+                        "--measurement-packet and --analysis-packet are mutually exclusive".into(),
+                    );
+                }
+                (None, None) => {
+                    return Err(
+                        "archsig-analysis-sft-input requires --measurement-packet or --analysis-packet"
+                            .into(),
+                    );
+                }
+            };
             write_json(out, &estimate)?;
             Ok(ExitCode::SUCCESS)
         }

--- a/tools/fieldsig/tests/cli.rs
+++ b/tools/fieldsig/tests/cli.rs
@@ -555,6 +555,295 @@ fn cli_projects_archsig_analysis_packet_to_sft_input_boundary() {
 }
 
 #[test]
+fn cli_projects_archsig_measurement_packet_to_sft_input_boundary() {
+    let out_dir = temp_dir("archsig-measurement-sft-input");
+    let packet = out_dir.join("archsig-measurement-packet.json");
+    let estimate = out_dir.join("operation-support-estimate.json");
+    let estimate_validation = out_dir.join("operation-support-estimate-validation.json");
+    let packet_json = serde_json::json!({
+        "schema": "archsig-measurement-packet/v1",
+        "packetId": "measurement:test-handoff",
+        "profile": {
+            "schema": "measurement-profile/v1",
+            "profileId": "profile:test-handoff",
+            "siteRef": "archmap:/contexts",
+            "coverRef": "cover:test",
+            "coefficient": "F2",
+            "effCoeff": "finite-linear-algebra@1",
+            "witnessFamily": [],
+            "resolutionSelector": "cech@1",
+            "domain": "finite-poset-site",
+            "zeroPredicate": "rank-zero@1",
+            "nonZeroPredicate": "rank-positive@1",
+            "certSelector": "finite-certificate@1",
+            "verdictDiscipline": "five-valued-structural-verdict@1"
+        },
+        "structuralVerdict": [{
+            "evaluator": "ag.cech-obstruction@1",
+            "law": "ag.cech-obstruction",
+            "verdict": "measured_nonzero",
+            "verdictData": {
+                "inScope": true,
+                "zero": false,
+                "nonZero": true,
+                "methodStatus": "computed",
+                "certRef": "computedInvariants/cech-cohomology:profile:test-handoff"
+            }
+        }, {
+            "evaluator": "ag.cech-obstruction@1",
+            "law": "ag.cech-obstruction",
+            "verdict": "unknown",
+            "reason": "certificate boundary is outside the selected profile",
+            "verdictData": {
+                "inScope": true,
+                "zero": false,
+                "nonZero": false,
+                "methodStatus": "certificate_missing"
+            }
+        }],
+        "computedInvariants": [{
+            "invariantId": "cech-cohomology:profile:test-handoff",
+            "evaluator": "ag.cech-obstruction@1",
+            "status": "computed",
+            "dimensions": {"H0": 1, "H1": 1}
+        }],
+        "analyticReadings": [{
+            "readingId": "theorem-candidate:transfer-lower-bound:test",
+            "evaluator": "ag.foundation@1",
+            "value": {"transferLowerBound": 3.5},
+            "regime": "theorem-candidate",
+            "structuralVerdictRef": null
+        }],
+        "assumptions": [{
+            "theoremRef": "part8/4.2",
+            "assumption": "finite site",
+            "status": "checked",
+            "checkedBy": "finite-linear-algebra@1"
+        }, {
+            "theoremRef": "part8/10.4",
+            "assumption": "transfer_lower_bound",
+            "status": "assumed",
+            "assumedBy": "measurement-profile author"
+        }],
+        "nonConclusions": [
+            "ArchSig measurement packet is a computation artifact, not a Lean proof object."
+        ]
+    });
+    fs::write(
+        &packet,
+        serde_json::to_string_pretty(&packet_json).expect("measurement packet serializes"),
+    )
+    .expect("measurement packet fixture is written");
+
+    run_sig0(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        packet.to_str().expect("measurement packet path is utf-8"),
+        "--out",
+        estimate.to_str().expect("estimate path is utf-8"),
+    ]);
+    run_sig0(&[
+        "operation-support-estimate",
+        "--input",
+        estimate.to_str().expect("estimate path is utf-8"),
+        "--out",
+        estimate_validation
+            .to_str()
+            .expect("estimate validation path is utf-8"),
+    ]);
+
+    let estimate_json = read_json(&estimate);
+    assert_eq!(
+        estimate_json["schemaVersion"],
+        "operation-support-estimate-v0"
+    );
+    assert_eq!(
+        estimate_json["descriptorRef"]["artifactKind"],
+        "archsig-measurement-packet"
+    );
+    assert!(
+        estimate_json["descriptorRef"]["sourceRefIds"]
+            .as_array()
+            .expect("source refs are array")
+            .iter()
+            .any(|source| source == "archsigMeasurementPacket:measurement:test-handoff"),
+        "FieldSig must retain the measurement packet id as a handoff source ref"
+    );
+    assert!(
+        estimate_json["candidateOperationFamilies"]
+            .as_array()
+            .expect("candidate families are array")
+            .iter()
+            .any(|family| family["supportKind"] == "measurement-packet-structural-verdict"),
+        "FieldSig must project measurement-packet structural verdict rows into bounded candidate families"
+    );
+    let structural_family_ids = estimate_json["candidateOperationFamilies"]
+        .as_array()
+        .expect("candidate families are array")
+        .iter()
+        .filter(|family| family["supportKind"] == "measurement-packet-structural-verdict")
+        .map(|family| {
+            family["familyId"]
+                .as_str()
+                .expect("family id is string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    let unique_structural_family_ids = structural_family_ids
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        structural_family_ids.len(),
+        2,
+        "fixture should contain duplicate evaluator structural rows"
+    );
+    assert_eq!(
+        unique_structural_family_ids.len(),
+        structural_family_ids.len(),
+        "duplicate evaluator structural rows must still produce distinct family IDs"
+    );
+    assert!(
+        estimate_json["candidateOperationFamilies"]
+            .as_array()
+            .expect("candidate families are array")
+            .iter()
+            .any(|family| family["supportKind"] == "measurement-packet-analytic-reading"),
+        "FieldSig must retain analytic readings without turning them into structural verdicts"
+    );
+    assert!(
+        estimate_json["evidenceBoundary"]["measurementBoundaryRefs"]
+            .as_array()
+            .expect("measurement boundary refs are array")
+            .iter()
+            .any(|source| source
+                == "archsigMeasurementVerdict:ag.cech-obstruction@1:measured_nonzero"),
+        "FieldSig must carry measurement packet verdict boundaries"
+    );
+    assert!(
+        estimate_json["unknownRemainder"]
+            .as_array()
+            .expect("unknown remainder is array")
+            .iter()
+            .any(|entry| {
+                entry["reason"]
+                    .as_str()
+                    .expect("reason is string")
+                    .contains("part8/10.4")
+                    && entry["treatment"]
+                        .as_str()
+                        .expect("treatment is string")
+                        .contains("do not promote it to proof")
+            }),
+        "assumed theorem-candidate boundaries must remain unknown remainder"
+    );
+    assert!(
+        estimate_json["unknownRemainder"]
+            .as_array()
+            .expect("unknown remainder is array")
+            .iter()
+            .any(|entry| {
+                entry["reason"]
+                    .as_str()
+                    .expect("reason is string")
+                    .contains("ag.cech-obstruction@1 returned unknown")
+                    && entry["unknownAxes"]
+                        .as_array()
+                        .expect("unknown axes are array")
+                        .iter()
+                        .any(|axis| axis == "unknown")
+            }),
+        "unknown structural verdicts must remain unknown remainder"
+    );
+    assert!(
+        estimate_json["knownForbiddenSupport"]
+            .as_array()
+            .expect("forbidden support entries are array")
+            .iter()
+            .any(|entry| entry["operationFamily"] == "raw-archmap-truth-promotion"),
+        "raw ArchMap observation must not be promoted to forecast truth"
+    );
+    let validation_json = read_json(&estimate_validation);
+    assert_eq!(validation_json["summary"]["result"], "pass");
+}
+
+#[test]
+fn cli_rejects_invalid_measurement_packet_handoff_inputs() {
+    let out_dir = temp_dir("archsig-measurement-sft-input-rejected");
+    let schema_only = out_dir.join("schema-only-measurement-packet.json");
+    fs::write(
+        &schema_only,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": "archsig-measurement-packet/v1"
+        }))
+        .expect("schema-only packet serializes"),
+    )
+    .expect("schema-only packet fixture is written");
+
+    let malformed = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        schema_only
+            .to_str()
+            .expect("schema-only packet path is utf-8"),
+        "--out",
+        out_dir
+            .join("malformed.json")
+            .to_str()
+            .expect("malformed path is utf-8"),
+    ]);
+    assert!(!malformed.status.success());
+    assert!(
+        String::from_utf8_lossy(&malformed.stderr).contains("requires non-empty packetId"),
+        "schema-only measurement packet must be rejected before writing a handoff estimate"
+    );
+
+    let rejected = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        fixture_root()
+            .join("archmap.json")
+            .to_str()
+            .expect("archmap path is utf-8"),
+        "--out",
+        out_dir
+            .join("rejected.json")
+            .to_str()
+            .expect("rejected path is utf-8"),
+    ]);
+    assert!(!rejected.status.success());
+    assert!(
+        String::from_utf8_lossy(&rejected.stderr)
+            .contains("requires archsig-measurement-packet/v1"),
+        "raw ArchMap input must be rejected by the measurement-packet handoff"
+    );
+
+    let both = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        fixture_root()
+            .join("llm_native_handoff/archsig_analysis_packet.json")
+            .to_str()
+            .expect("analysis packet path is utf-8"),
+        "--analysis-packet",
+        fixture_root()
+            .join("llm_native_handoff/archsig_analysis_packet.json")
+            .to_str()
+            .expect("analysis packet path is utf-8"),
+        "--out",
+        out_dir
+            .join("both.json")
+            .to_str()
+            .expect("both path is utf-8"),
+    ]);
+    assert!(!both.status.success());
+    assert!(
+        String::from_utf8_lossy(&both.stderr)
+            .contains("--measurement-packet and --analysis-packet are mutually exclusive"),
+        "handoff inputs must be explicit and mutually exclusive"
+    );
+}
+
+#[test]
 fn cli_projects_archsig_v1_packet_refs_and_schema_compatibility() {
     let out_dir = temp_dir("archsig-v1-analysis-sft-input");
     let packet = out_dir.join("archsig-analysis-packet-v1.json");


### PR DESCRIPTION
## 概要

Closes #1946

FieldSig の ArchSig handoff を `archsig-measurement-packet/v1` primary に更新しました。既存の `archsig-analysis-packet/v1` / `archsig-analysis-packet-v0` は legacy bounded compatibility input として残し、`--measurement-packet` と `--analysis-packet` は排他にしています。

主な設計判断:

- FieldSig は serialized `archsig-measurement-packet/v1` だけを読み、ArchSig の Rust 型へ依存しない。
- structural verdict / computed invariant / analytic reading / assumption ledger を `operation-support-estimate-v0` の bounded refs / unknown remainder へ写す。
- analytic reading と theorem-candidate reading は structural verdict に昇格しない。
- raw ArchMap observation は forecast truth / causal proof / repair safety に昇格しない。
- malformed schema-only packet は成功 artifact を書かず fail-fast する。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/fieldsig/README.md`
- `tools/fieldsig/docs/commands.md`
- `tools/fieldsig/docs/artifacts-and-boundaries.md`
- `docs/tool/llm_native_e2e_workflow.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml --test cli support_transfer`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] ArchSig 実生成 `archsig-measurement-packet.json` → FieldSig `--measurement-packet` → `operation-support-estimate` validation

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: empirical hypothesis / tooling output。Lean theorem は追加していません。
