### PR TITLE
AG版AATの三読み一致を証明

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -8,3 +8,4 @@ import Formal.AG.Atom.Invariant
 import Formal.AG.Atom.Law
 import Formal.AG.Atom.Obstruction
 import Formal.AG.Atom.LawfulnessZero
+import Formal.AG.Atom.ThreeReading

--- a/Formal/AG/Atom/ThreeReading.lean
+++ b/Formal/AG/Atom/ThreeReading.lean
@@ -1,0 +1,81 @@
+import Formal.AG.Atom.Law
+
+namespace AAT.AG
+
+universe u
+
+/--
+I.定理9.3 後段: explicit assumptions under which the semantic, witness, and
+signature-axis readings agree.
+-/
+structure ThreeReadingAgreementAssumptions {U : AtomCarrier.{u}}
+    (A : ArchitectureObject U) (LU : LawUniverse U)
+    (W : LawWitnessFamily U) (S : SignatureAxes U) where
+  witnessCompleteness : Prop
+  axisExactness : Prop
+  coverage : Prop
+  selectedReadingExactness : Prop
+  witnessCompleteness_holds : witnessCompleteness
+  axisExactness_holds : axisExactness
+  coverage_holds : coverage
+  selectedReadingExactness_holds : selectedReadingExactness
+  semantic_noObstruction :
+    witnessCompleteness -> coverage -> selectedReadingExactness ->
+      (SemanticLawful A LU ↔ NoRequiredObstruction A W)
+  noObstruction_axesZero :
+    axisExactness -> coverage -> selectedReadingExactness ->
+      (NoRequiredObstruction A W ↔ RequiredSignatureAxesZero A S)
+
+namespace ThreeReadingAgreementAssumptions
+
+/--
+I.定理9.3 後段: semantic lawfulness agrees with no required obstruction under
+explicit witness-completeness, coverage, and selected-reading exactness.
+-/
+theorem semanticLawful_iff_noRequiredObstruction {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {LU : LawUniverse U}
+    {W : LawWitnessFamily U} {S : SignatureAxes U}
+    (h : ThreeReadingAgreementAssumptions A LU W S) :
+    SemanticLawful A LU ↔ NoRequiredObstruction A W :=
+  h.semantic_noObstruction h.witnessCompleteness_holds h.coverage_holds
+    h.selectedReadingExactness_holds
+
+/--
+I.定理9.3 後段: no required obstruction agrees with selected signature axes
+zero under explicit axis-exactness, coverage, and selected-reading exactness.
+-/
+theorem noRequiredObstruction_iff_requiredSignatureAxesZero
+    {U : AtomCarrier.{u}} {A : ArchitectureObject U} {LU : LawUniverse U}
+    {W : LawWitnessFamily U} {S : SignatureAxes U}
+    (h : ThreeReadingAgreementAssumptions A LU W S) :
+    NoRequiredObstruction A W ↔ RequiredSignatureAxesZero A S :=
+  h.noObstruction_axesZero h.axisExactness_holds h.coverage_holds
+    h.selectedReadingExactness_holds
+
+/--
+I.定理9.3 後段: semantic lawfulness agrees directly with selected signature axes
+zero under the explicit three-reading assumptions.
+-/
+theorem semanticLawful_iff_requiredSignatureAxesZero {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {LU : LawUniverse U}
+    {W : LawWitnessFamily U} {S : SignatureAxes U}
+    (h : ThreeReadingAgreementAssumptions A LU W S) :
+    SemanticLawful A LU ↔ RequiredSignatureAxesZero A S :=
+  (semanticLawful_iff_noRequiredObstruction h).trans
+    (noRequiredObstruction_iff_requiredSignatureAxesZero h)
+
+/-- I.定理9.3 後段: the three readings agree as a chain. -/
+theorem threeReadingAgreement {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {LU : LawUniverse U}
+    {W : LawWitnessFamily U} {S : SignatureAxes U}
+    (h : ThreeReadingAgreementAssumptions A LU W S) :
+    (SemanticLawful A LU ↔ NoRequiredObstruction A W) ∧
+      (NoRequiredObstruction A W ↔ RequiredSignatureAxesZero A S) ∧
+        (SemanticLawful A LU ↔ RequiredSignatureAxesZero A S) :=
+  ⟨semanticLawful_iff_noRequiredObstruction h,
+    noRequiredObstruction_iff_requiredSignatureAxesZero h,
+    semanticLawful_iff_requiredSignatureAxesZero h⟩
+
+end ThreeReadingAgreementAssumptions
+
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4441,12 +4441,13 @@ File: `Formal/AG.lean`, `Formal/AG/Atom/Atom.lean`, `Formal/AG/Atom/Axioms.lean`
 `Formal/AG/Atom/Observation.lean`, `Formal/AG/Atom/Family.lean`,
 `Formal/AG/Atom/Configuration.lean`, `Formal/AG/Atom/ArchitectureObject.lean`,
 `Formal/AG/Atom/Invariant.lean`, `Formal/AG/Atom/Law.lean`,
-`Formal/AG/Atom/Obstruction.lean`, `Formal/AG/Atom/LawfulnessZero.lean`.
+`Formal/AG/Atom/Obstruction.lean`, `Formal/AG/Atom/LawfulnessZero.lean`,
+`Formal/AG/Atom/ThreeReading.lean`.
 
 PRD-1 [第I部 Atom・対象・法則](lean_ag_part_1_atoms_objects_laws_prd.md) の
-AC1/R0、AC2/R1、AC3/R1、AC4/R2、AC5/R3、AC6/R4、AC7/R5、AC8/R6、AC9/R7、AC10/R8 に対応する初期 Atom entrypoint である。`Formal/Arch` は import せず、
+AC1/R0、AC2/R1、AC3/R1、AC4/R2、AC5/R3、AC6/R4、AC7/R5、AC8/R6、AC9/R7、AC10/R8、AC11/R8 に対応する初期 Atom entrypoint である。`Formal/Arch` は import せず、
 AG 版 AAT の namespace を `AAT.AG` として分離する。この節は Part I の最下層索引であり、
-定理9.3 後段の三読み一致、定理10.5 の完了宣言ではない。
+定理10.5 の完了宣言ではない。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4464,10 +4465,11 @@ AG 版 AAT の namespace を `AAT.AG` として分離する。この節は Part 
 | `I.定義7.1-7.3` | `AAT.AG.Law`, `AAT.AG.LawRole`, `AAT.AG.LawWitnessFamily`, `AAT.AG.SignatureAxes`, `AAT.AG.LawUniverse`, `LawUniverse.Required`, `LawUniverse.Optional`, `LawUniverse.Derived`, `AAT.AG.Lawfulness`, `AAT.AG.SemanticLawful`, `AAT.AG.NoRequiredObstruction`, `AAT.AG.RequiredSignatureAxesZero`, `AAT.AG.lawfulness_required_holds`, `AAT.AG.semanticLawful_iff_lawfulness`, `AAT.AG.noRequiredObstruction_no_bad_witness`, `AAT.AG.requiredSignatureAxesZero_axis` | `structure` / `inductive` / `def` / `theorem` | ArchitectureObject 上の law predicate、required / optional / derived role を持つ law universe、witness family、selected reading、coverage / exactness assumption、required lawfulness、三述語と accessor 補題。三述語の同値は主張しない。 | `defined only` / `proved` |
 | `I.定義8.1 / 8.2 / 8.5` | `AAT.AG.Obstruction`, `AAT.AG.ObstructionCircuit`, `AAT.AG.ObstructionValueDomain`, `AAT.AG.ObstructionValuation`, `AAT.AG.ZeroReflectingAggregation`, `AAT.AG.ZeroReflectingListAggregation`, `LawUniverse.RequiredIndex`, `AAT.AG.FiniteIndexEnumeration`, `ZeroReflectingListAggregation.toIndexed`, `AAT.AG.omegaU`, `AAT.AG.omegaU_zero_iff_required`, `ObstructionCircuit.relation_supported_holds`, `ObstructionCircuit.finite_marker`, `ObstructionCircuit.law_failure_holds`, `ObstructionValueDomain.nat`, `ObstructionValueDomain.bool`, `ObstructionValueDomain.NonnegativeWeight`, `ObstructionValueDomain.NonnegativeWeight.zero`, `ObstructionValueDomain.NonnegativeWeight.sup`, `ObstructionValueDomain.nonnegativeWeight`, `ObstructionAggregation.natSum`, `ObstructionAggregation.boolOr`, `ObstructionAggregation.weightSup`, `ObstructionAggregation.natSum_eq_zero_iff`, `ObstructionAggregation.boolOr_eq_false_iff`, `ObstructionAggregation.weightSup_eq_zero_iff`, `ObstructionAggregation.natSumListAggregation`, `ObstructionAggregation.boolOrListAggregation`, `ObstructionAggregation.weightSupListAggregation` | `structure` / `def` / `theorem` | Obstruction witness、finite marker 付き obstruction circuit、zero / positive / dichotomy / no-cancellation を持つ値域、law-indexed valuation、required law index に相対化した aggregate valuation、finite-list aggregation から selected finite index aggregation への bridge、count sum / boolean disjunction / nonnegative-weight sup の finite-list zero-reflecting theorem。定理9.3 は主張しない。 | `defined only` / `proved` |
 | `I.命題9.1 / 9.2 / 定理9.3` | `AAT.AG.ObstructionSound`, `AAT.AG.ObstructionComplete`, `AAT.AG.law_holds_iff_omega_zero`, `AAT.AG.lawfulness_iff_omegaU_zero` | `def` / `theorem` | selected law valuation の soundness / completeness predicate、per-law `L(A) ↔ omega_L(A)=0`、required law universe と zero-reflecting aggregation に相対化した `Lawfulness A LU ↔ omegaU ... A = 0`。三述語一致は主張しない。 | `defined only` / `proved` |
+| `I.定理9.3 後段` | `AAT.AG.ThreeReadingAgreementAssumptions`, `ThreeReadingAgreementAssumptions.semanticLawful_iff_noRequiredObstruction`, `ThreeReadingAgreementAssumptions.noRequiredObstruction_iff_requiredSignatureAxesZero`, `ThreeReadingAgreementAssumptions.semanticLawful_iff_requiredSignatureAxesZero`, `ThreeReadingAgreementAssumptions.threeReadingAgreement` | `structure` / `theorem` | witness completeness、axis exactness、coverage、selected reading exactness を明示 field として持つ package から、`SemanticLawful(A,U)` / `NoRequiredObstruction(A,W)` / `RequiredSignatureAxesZero(A,S)` の三読み一致を取り出す。 | `defined only` / `proved` |
 
 Non-conclusions: この bootstrap は `Formal/AG` の Atom carrier、A0-A8 package、A9、
 AtomFamily / closure、Configuration / Molecule、ArchitectureObject / Atom-Origin、
-Invariant / preservation、Law / Lawfulness、Obstruction / Valuation、定理9.3 本体の入口であり、三述語一致、
+Invariant / preservation、Law / Lawfulness、Obstruction / Valuation、定理9.3 本体と後段三読み一致の入口であり、
 AAT Core、有限モデルは後続 Issue の対象である。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -562,7 +562,10 @@ Issue [#1945](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 zero-reflecting aggregation と Nat / Bool / 非負 weight の finite-list theorem を追加した。
 Issue [#1948](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1948)
 では soundness / completeness 仮定から定理9.3 Lawfulness-Zero Obstruction 本体を証明した。
-これは定理9.3 後段の三読み一致 / 定理10.5 の証明済み主張ではない。
+Issue [#1951](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1951)
+では witness completeness / axis exactness / coverage / selected reading exactness を明示仮定として、
+定理9.3 後段の三読み一致を証明した。
+これは定理10.5 の証明済み主張ではない。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -576,8 +579,8 @@ Issue [#1948](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `I.定義7.1-7.3` Law / LawUniverse / Lawfulness | `defined only` / `proved`. `Formal/AG/Atom/Law.lean` が `Law`, `LawRole`, `LawWitnessFamily`, `SignatureAxes`, `LawUniverse`, `LawUniverse.Required`, `LawUniverse.Optional`, `LawUniverse.Derived`, `Lawfulness`, `SemanticLawful`, `NoRequiredObstruction`, `RequiredSignatureAxesZero`, `lawfulness_required_holds`, `semanticLawful_iff_lawfulness`, `noRequiredObstruction_no_bad_witness`, `requiredSignatureAxesZero_axis` を持つ。 | required law satisfaction、selected witness absence、selected signature axes zero は定義として分離する。定理9.3 後段の三述語一致、AAT Core、有限モデルは後続 Issue に残る。 |
 | `I.定義8.1 / 8.2 / 8.5` Obstruction / ObstructionCircuit / ObstructionValuation | `defined only` / `proved`. `Formal/AG/Atom/Obstruction.lean` が `Obstruction`, `ObstructionCircuit`, `ObstructionValueDomain`, `ObstructionValuation`, `ZeroReflectingAggregation`, `ZeroReflectingListAggregation`, `LawUniverse.RequiredIndex`, `FiniteIndexEnumeration`, `ZeroReflectingListAggregation.toIndexed`, `omegaU`, `omegaU_zero_iff_required`, `ObstructionCircuit.relation_supported_holds`, `ObstructionCircuit.finite_marker`, `ObstructionCircuit.law_failure_holds`, `ObstructionValueDomain.nat`, `ObstructionValueDomain.bool`, `ObstructionValueDomain.NonnegativeWeight`, `ObstructionValueDomain.nonnegativeWeight`, `ObstructionAggregation.natSum_eq_zero_iff`, `ObstructionAggregation.boolOr_eq_false_iff`, `ObstructionAggregation.weightSup_eq_zero_iff`, `ObstructionAggregation.natSumListAggregation`, `ObstructionAggregation.boolOrListAggregation`, `ObstructionAggregation.weightSupListAggregation` を持つ。 | obstruction valuation は required law / selected aggregation に相対化される。finite-list aggregation は explicit covering enumeration により selected finite index aggregation へ持ち上げる。定理9.3 後段の三述語一致、AAT Core、有限モデルは後続 Issue に残る。 |
 | `I.命題9.1 / 9.2 / 定理9.3` Lawfulness-Zero Obstruction 本体 | `defined only` / `proved`. `Formal/AG/Atom/LawfulnessZero.lean` が `ObstructionSound`, `ObstructionComplete`, `law_holds_iff_omega_zero`, `lawfulness_iff_omegaU_zero` を持つ。 | soundness / completeness / zero-reflecting aggregation は theorem 引数として明示される。定理9.3 後段の `SemanticLawful` / `NoRequiredObstruction` / `RequiredSignatureAxesZero` 三述語一致、AAT Core、有限モデルは後続 Issue に残る。 |
+| `I.定理9.3 後段` 三読み一致 | `defined only` / `proved`. `Formal/AG/Atom/ThreeReading.lean` が `ThreeReadingAgreementAssumptions`, `ThreeReadingAgreementAssumptions.semanticLawful_iff_noRequiredObstruction`, `ThreeReadingAgreementAssumptions.noRequiredObstruction_iff_requiredSignatureAxesZero`, `ThreeReadingAgreementAssumptions.semanticLawful_iff_requiredSignatureAxesZero`, `ThreeReadingAgreementAssumptions.threeReadingAgreement` を持つ。 | witness completeness、axis exactness、coverage、selected reading exactness は package field として明示される。AAT Core、有限モデルは後続 Issue に残る。 |
 | 例8.3 / 例8.4 obstruction example theorem | `future proof obligation`. | R7 と R10 の有限モデルが入るまで proved claim として扱わない。 |
-| 定理9.3 後段の三読み一致 | `future proof obligation`. | witness completeness、axis exactness、coverage、selected reading exactness を明示仮定として入れるまで proved claim として扱わない。 |
 | 定理10.5 AAT Core | `future proof obligation`. | A0-A8 と R1-R7 の塔がそろうまで proved claim として扱わない。 |
 
 ## 現在の未解決カテゴリ


### PR DESCRIPTION
## 概要

Closes #1951

AG 版 AAT PRD-1 の AC11/R8 として、定理9.3 後段の三読み一致を `Formal/AG` に追加する。

- `ThreeReadingAgreementAssumptions` に witness completeness / axis exactness / coverage / selected reading exactness を明示 field として追加
- `SemanticLawful(A,U) ↔ NoRequiredObstruction(A,W)` を証明
- `NoRequiredObstruction(A,W) ↔ RequiredSignatureAxesZero(A,S)` を証明
- `SemanticLawful(A,U) ↔ RequiredSignatureAxesZero(A,S)` と三者 chain theorem を追加
- R9 AAT Core、finite model、具体 law interpretation は主張しない
- `Formal/Arch` は import しない

## 証明した定理

- `ThreeReadingAgreementAssumptions.semanticLawful_iff_noRequiredObstruction`
- `ThreeReadingAgreementAssumptions.noRequiredObstruction_iff_requiredSignatureAxesZero`
- `ThreeReadingAgreementAssumptions.semanticLawful_iff_requiredSignatureAxesZero`
- `ThreeReadingAgreementAssumptions.threeReadingAgreement`

Lean status: theorem package `proved`。`ThreeReadingAgreementAssumptions` は `defined only`。

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Atom/ThreeReading.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
  - 既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207` の linter warning のみ
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
