### PR TITLE
AG版AATのSite入口を追加

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -12,3 +12,4 @@ import Formal.AG.Atom.ThreeReading
 import Formal.AG.Atom.ObjectAlgebra
 import Formal.AG.Atom.AATCore
 import Formal.AG.Examples.FiniteModel
+import Formal.AG.Site

--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -1,0 +1,1 @@
+import Formal.AG.Site.Basic

--- a/Formal/AG/Site/Basic.lean
+++ b/Formal/AG/Site/Basic.lean
@@ -1,0 +1,47 @@
+import Formal.AG.Atom.AATCore
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+/--
+II.R0: Part I prerequisite package for the Part II site tower.
+
+The site formalization starts from the Part I `AATCorePackage`; it does not
+import `Formal/Arch` and it does not manufacture Atom, law, obstruction, or
+object data on its own.
+-/
+structure PartIPrerequisites where
+  carrier : AtomCarrier.{u}
+  core : AATCorePackage carrier
+
+namespace PartIPrerequisites
+
+/-- II.R0: read the selected ArchitectureObject supplied by Part I. -/
+def architectureObject (P : PartIPrerequisites.{u}) :
+    ArchitectureObject P.carrier :=
+  P.core.object
+
+/-- II.R0: read the selected LawUniverse supplied by Part I. -/
+def lawUniverse (P : PartIPrerequisites.{u}) :
+    LawUniverse P.carrier :=
+  P.core.lawUniverse
+
+/-- II.R0: read the selected ArchitectureSignature supplied by Part I. -/
+def signature (P : PartIPrerequisites.{u}) :
+    ArchitectureSignature P.carrier :=
+  P.core.signature
+
+/--
+II.R0: the Part I object still carries the configuration packaged by the
+selected AAT core.
+-/
+theorem architectureObject_configuration (P : PartIPrerequisites.{u}) :
+    P.architectureObject.configuration = P.core.configuration :=
+  P.core.object_configuration_eq
+
+end PartIPrerequisites
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4481,6 +4481,24 @@ Invariant / preservation、Law / Lawfulness、Obstruction / Valuation、定理9.
 Object Algebra / operation / signature / operation role predicate、定理10.5 AAT Core theorem package の入口であり、
 finite model example theorem package までを含む。第II部以降の concrete graph / category / algebra / diagram / state transition instance は後続 Issue の対象である。
 
+## AG版AAT Lean形式化 PRD-2 / 第II部 Architecture Geometry・Site・Sheaf
+
+File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`.
+
+PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
+AC1/R0 に対応する初期 site entrypoint である。現時点では PRD-1 の
+`AATCorePackage` に依存することだけを Lean 上に置き、Architecture Context、
+coverage、Grothendieck topology、sheaf category は後続 Issue の対象として残す。
+
+| 本文ラベル | Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- | --- |
+| `II.R0` | `AAT.AG.Site.PartIPrerequisites`, `PartIPrerequisites.architectureObject`, `PartIPrerequisites.lawUniverse`, `PartIPrerequisites.signature`, `PartIPrerequisites.architectureObject_configuration` | `structure` / `def` / `theorem` | 第II部 site tower が PRD-1 の `AATCorePackage` から architecture object / law universe / signature を読むための prerequisite package と accessor。 | `defined only` / `proved` |
+
+Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
+PRD-1 依存の入口だけを示す。定義3.1 Architecture Context、命題4.2、
+admissible cover、`J_U`、Mathlib bridge、sheaf condition、Cech complex、
+`AATSh`、有限 poset site example はまだ形式化しない。
+
 ## Reverse-Import Theorem Packages
 
 File: `Formal/Arch/Evolution/ReverseImportTheorems.lean`.

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -609,6 +609,31 @@ Issue [#1959](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 AC15 scan status: `rg -n "\b(axiom|admit|sorry|unsafe)\b" Formal/AG Formal/AG.lean`
 と `rg -n "Formal\.Arch|import Formal\.Arch" Formal/AG Formal/AG.lean` は no matches である。
 
+## AG版AAT PRD-2 / 第II部 Architecture Geometry・Site・Sheaf
+
+PRD-2 は `docs/aat/lean_ag_part_2_sites_sheaves_prd.md` で管理する。
+Issue [#1962](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1962)
+では `Formal/AG/Site` の初期 entrypoint を追加し、PRD-1 の
+`AATCorePackage` に依存する prerequisite package を置いた。
+
+| 対象 | 現在の扱い | 残す境界 |
+| --- | --- | --- |
+| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | Architecture Context、Coverage、Grothendieck topology、AAT Site、Presheaf / Sheaf、Descent、Finite Poset regime、AATSh は後続 Issue に残る。 |
+
+第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
+
+| 証明対象ラベル | Lean status |
+| --- | --- |
+| `II.命題4.2` | `future proof obligation` |
+| `II.仮定4.3 meet-pullback` | `future proof obligation` |
+| `II.定義7.1 J_U topology axioms` | `future proof obligation` |
+| `II.定義7.1 Coverage.toGrothendieck bridge` | `future proof obligation` |
+| `II.補題7.2A` | `future proof obligation` |
+| `II.定義10.1 sheaf condition bridge` | `future proof obligation` |
+| `II.定義11.1-12.1 sheaf-descent` | `future proof obligation` |
+| `II.命題7.2C` | `future proof obligation` |
+| `II.R11 finite model examples` | `future proof obligation` |
+
 ## 現在の未解決カテゴリ
 
 | カテゴリ | 扱い |


### PR DESCRIPTION
## 概要

Closes #1962

PRD-2 第II部の AC1/R0 として `Formal/AG/Site` の初期 entrypoint を追加した。`PartIPrerequisites` は PRD-1 の `AATCorePackage` から architecture object / law universe / signature を読むだけの薄い package であり、Architecture Context、coverage、Grothendieck topology、sheaf category は後続 Issue に残す。

local-review では 4観点で確認し、新規 Lean files 未追跡と #1961 tracking ledger 未更新の指摘が出た。前者は staging/commit 済み、後者は #1961 へ iteration 1 開始コメントを追加して解消した。

## 証明した定理

- `AAT.AG.Site.PartIPrerequisites.architectureObject_configuration`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
  - 成功。既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ。
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
