### PR TITLE
AG版AATのArchitecture Contextを定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -1,1 +1,2 @@
 import Formal.AG.Site.Basic
+import Formal.AG.Site.Context

--- a/Formal/AG/Site/Context.lean
+++ b/Formal/AG/Site/Context.lean
@@ -1,0 +1,159 @@
+import Formal.AG.Site.Basic
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+/--
+II.定義3.1: the minimal Architecture Context model over an architecture object.
+
+The minimal reading records the carrier types for support, selected axes, and
+observable data, together with the predicates that say which atoms, axes, and
+observables are visible in the context.
+-/
+structure MinimalContext {U : AtomCarrier.{u}} (A : ArchitectureObject U) where
+  Support : Type u
+  Axis : Type u
+  Observable : Type u
+  supportReads : Support -> U.Atom -> Prop
+  axisReads : Axis -> Prop
+  observableReads : Observable -> Prop
+
+/--
+II.定義3.1: a general Architecture Context is an extension of the minimal
+support / axis / observable reading.
+-/
+structure ArchitectureContext {U : AtomCarrier.{u}} (A : ArchitectureObject U) where
+  minimal : MinimalContext A
+  Extension : Type u
+  extension : Extension
+
+namespace ArchitectureContext
+
+/-- II.定義3.1: read the minimal support carrier of a context. -/
+def Support {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (W : ArchitectureContext A) : Type u :=
+  W.minimal.Support
+
+/-- II.定義3.1: read the minimal axis carrier of a context. -/
+def Axis {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (W : ArchitectureContext A) : Type u :=
+  W.minimal.Axis
+
+/-- II.定義3.1: read the minimal observable carrier of a context. -/
+def Observable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (W : ArchitectureContext A) : Type u :=
+  W.minimal.Observable
+
+end ArchitectureContext
+
+/--
+II.定義4.1 / §5: a readable context morphism from a local context to the
+context it reads into.
+
+The morphism keeps the minimal data explicit: local support and axes map into
+the target reading, while target observables restrict back to local
+observables. The proposition fields record the selected role assumptions used
+by later category, coverage, and sheaf constructions.
+-/
+structure ContextMorphism {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (source target : ArchitectureContext A) where
+  supportMap : source.Support -> target.Support
+  axisMap : source.Axis -> target.Axis
+  observableRestrict : target.Observable -> source.Observable
+  supportReadable : Prop
+  axisReadable : Prop
+  observableFunctorial : Prop
+  nonGenerating : Prop
+  axisForgetting : Prop
+  supportRefinement : Prop
+  axisRefinement : Prop
+  baseChangeCompatible : Prop
+
+namespace ContextMorphism
+
+/-- II.§5.1: restriction preserves readable support, axes, and observables. -/
+def IsRestriction {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {source target : ArchitectureContext A}
+    (f : ContextMorphism source target) : Prop :=
+  f.supportReadable ∧ f.axisReadable ∧ f.observableFunctorial ∧ f.nonGenerating
+
+/-- II.§5.2: projection is restriction plus selected axis forgetting. -/
+def IsProjection {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {source target : ArchitectureContext A}
+    (f : ContextMorphism source target) : Prop :=
+  f.IsRestriction ∧ f.axisForgetting
+
+/-- II.§5.3: refinement is restriction plus support and axis refinement. -/
+def IsRefinement {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {source target : ArchitectureContext A}
+    (f : ContextMorphism source target) : Prop :=
+  f.IsRestriction ∧ f.supportRefinement ∧ f.axisRefinement
+
+/-- II.§5.4: base change is restriction compatible with the selected pullback reading. -/
+def IsBaseChange {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {source target : ArchitectureContext A}
+    (f : ContextMorphism source target) : Prop :=
+  f.IsRestriction ∧ f.baseChangeCompatible
+
+/-- II.§5.1: a restriction morphism records support readability. -/
+theorem supportReadable_of_restriction {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsRestriction) :
+    f.supportReadable :=
+  h.1
+
+/-- II.§5.1: a restriction morphism records axis readability. -/
+theorem axisReadable_of_restriction {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsRestriction) :
+    f.axisReadable :=
+  h.2.1
+
+/-- II.§5.1: a restriction morphism records functorial observable restriction. -/
+theorem observableFunctorial_of_restriction {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsRestriction) :
+    f.observableFunctorial :=
+  h.2.2.1
+
+/-- II.§5.1 / 5.2 / 5.3: context morphisms do not create atoms. -/
+theorem nonGenerating_of_restriction {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsRestriction) :
+    f.nonGenerating :=
+  h.2.2.2
+
+/-- II.§5.2: projection records that hidden axes are forgotten, not zero. -/
+theorem axisForgetting_of_projection {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsProjection) :
+    f.axisForgetting :=
+  h.2
+
+/-- II.§5.3: refinement records support refinement. -/
+theorem supportRefinement_of_refinement {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsRefinement) :
+    f.supportRefinement :=
+  h.2.1
+
+/-- II.§5.3: refinement records axis refinement. -/
+theorem axisRefinement_of_refinement {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsRefinement) :
+    f.axisRefinement :=
+  h.2.2
+
+/-- II.§5.4: base change records compatibility with the selected pullback reading. -/
+theorem baseChangeCompatible_of_baseChange {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {source target : ArchitectureContext A}
+    {f : ContextMorphism source target} (h : f.IsBaseChange) :
+    f.baseChangeCompatible :=
+  h.2
+
+end ContextMorphism
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4483,20 +4483,23 @@ finite model example theorem package までを含む。第II部以降の concret
 
 ## AG版AAT Lean形式化 PRD-2 / 第II部 Architecture Geometry・Site・Sheaf
 
-File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`.
+File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
+`Formal/AG/Site/Context.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0 に対応する初期 site entrypoint である。現時点では PRD-1 の
-`AATCorePackage` に依存することだけを Lean 上に置き、Architecture Context、
-coverage、Grothendieck topology、sheaf category は後続 Issue の対象として残す。
+AC1/R0 と AC2/R1 に対応する site/context entrypoint である。現時点では
+PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
+§5 の射 role predicate までを Lean 上に置き、Context Category、coverage、
+Grothendieck topology、sheaf category は後続 Issue の対象として残す。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
 | `II.R0` | `AAT.AG.Site.PartIPrerequisites`, `PartIPrerequisites.architectureObject`, `PartIPrerequisites.lawUniverse`, `PartIPrerequisites.signature`, `PartIPrerequisites.architectureObject_configuration` | `structure` / `def` / `theorem` | 第II部 site tower が PRD-1 の `AATCorePackage` から architecture object / law universe / signature を読むための prerequisite package と accessor。 | `defined only` / `proved` |
+| `II.定義3.1 / §5.1-5.4` | `AAT.AG.Site.MinimalContext`, `AAT.AG.Site.ArchitectureContext`, `ArchitectureContext.Support`, `ArchitectureContext.Axis`, `ArchitectureContext.Observable`, `AAT.AG.Site.ContextMorphism`, `ContextMorphism.IsRestriction`, `ContextMorphism.IsProjection`, `ContextMorphism.IsRefinement`, `ContextMorphism.IsBaseChange`, `ContextMorphism.supportReadable_of_restriction`, `ContextMorphism.axisReadable_of_restriction`, `ContextMorphism.observableFunctorial_of_restriction`, `ContextMorphism.nonGenerating_of_restriction`, `ContextMorphism.axisForgetting_of_projection`, `ContextMorphism.supportRefinement_of_refinement`, `ContextMorphism.axisRefinement_of_refinement`, `ContextMorphism.baseChangeCompatible_of_baseChange` | `structure` / `def` / `theorem` | 最小 context model `(Supp, Ax, Obs)`、最小読みを含む一般 context、local context から target context への readable morphism、および restriction / projection / refinement / base change の role predicate と accessor。 | `defined only` / `proved` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
-PRD-1 依存の入口だけを示す。定義3.1 Architecture Context、命題4.2、
-admissible cover、`J_U`、Mathlib bridge、sheaf condition、Cech complex、
+PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate だけを示す。
+命題4.2、pullback / overlap、admissible cover、`J_U`、Mathlib bridge、sheaf condition、Cech complex、
 `AATSh`、有限 poset site example はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -615,10 +615,13 @@ PRD-2 は `docs/aat/lean_ag_part_2_sites_sheaves_prd.md` で管理する。
 Issue [#1962](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1962)
 では `Formal/AG/Site` の初期 entrypoint を追加し、PRD-1 の
 `AATCorePackage` に依存する prerequisite package を置いた。
+Issue [#1964](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1964)
+では Architecture Context の最小モデルと §5 の context morphism role predicate を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | Architecture Context、Coverage、Grothendieck topology、AAT Site、Presheaf / Sheaf、Descent、Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | Coverage、Grothendieck topology、AAT Site、Presheaf / Sheaf、Descent、Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | Context Category、finite-meet poset category、pullback / overlap、coverage family、Grothendieck topology は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 


### PR DESCRIPTION
## 概要

Closes #1964

PRD-2 第II部の AC2/R1 として、Architecture Context の最小モデルと §5 の context morphism role predicate を追加した。`MinimalContext` は `(Supp, Ax, Obs)` を Lean 上の support / axis / observable carrier と読み取り述語として持ち、`ArchitectureContext` はその最小読みを含む拡張として置く。`ContextMorphism` には support / axis map と observable restriction を置き、restriction / projection / refinement / base change は role predicate と accessor theorem として切った。

local-review では docs の PRD-2 概要文が AC1/R0 時点のまま残っている指摘があり、`lean_theorem_index.md` と `proof_obligations.md` を R1 反映後の境界へ更新した。PRD checklist への反映提案もあったが、`prd-loop` 規律で PRD は不変条件のため、この PR では編集していない。

## 証明した定理

- `AAT.AG.Site.ContextMorphism.supportReadable_of_restriction`
- `AAT.AG.Site.ContextMorphism.axisReadable_of_restriction`
- `AAT.AG.Site.ContextMorphism.observableFunctorial_of_restriction`
- `AAT.AG.Site.ContextMorphism.nonGenerating_of_restriction`
- `AAT.AG.Site.ContextMorphism.axisForgetting_of_projection`
- `AAT.AG.Site.ContextMorphism.supportRefinement_of_refinement`
- `AAT.AG.Site.ContextMorphism.axisRefinement_of_refinement`
- `AAT.AG.Site.ContextMorphism.baseChangeCompatible_of_baseChange`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
  - 成功。既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ。
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
