### PR TITLE
AG版AATのadmissible coverを定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -1,3 +1,4 @@
 import Formal.AG.Site.Basic
 import Formal.AG.Site.Context
 import Formal.AG.Site.ContextCategory
+import Formal.AG.Site.Coverage

--- a/Formal/AG/Site/Coverage.lean
+++ b/Formal/AG/Site/Coverage.lean
@@ -1,0 +1,157 @@
+import Formal.AG.Site.ContextCategory
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+/--
+II.定義6.1: a coverage family `{ W_i -> W }` in `ArchCtx(A)`.
+
+Each patch is a readable local context of the selected base context. The
+underlying morphism data is still supplied by the chosen context preorder; this
+definition does not generate new Atom data or infer additional observations.
+-/
+structure CoverageFamily {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (C : ContextPreorderCategory A) where
+  base : ArchCtx A
+  Index : Type u
+  patch : Index -> ArchCtx A
+  inclusion : ∀ i : Index, C.Hom (patch i) base
+
+namespace CoverageFamily
+
+/-- II.定義6.1: the readable morphism represented by a patch inclusion. -/
+def inclusionMorphism {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} (F : CoverageFamily C) (i : F.Index) :
+    ContextMorphism (F.patch i) F.base :=
+  C.morphism (F.inclusion i)
+
+/-- II.定義6.1: each patch inclusion is a readable restriction. -/
+theorem inclusion_isRestriction {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} (F : CoverageFamily C) (i : F.Index) :
+    (F.inclusionMorphism i).IsRestriction :=
+  C.morphism_isRestriction (F.inclusion i)
+
+/-- II.定義7.1: readable patch inclusions do not generate atoms. -/
+theorem inclusion_nonGenerating {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} (F : CoverageFamily C) (i : F.Index) :
+    (F.inclusionMorphism i).nonGenerating :=
+  ContextMorphism.nonGenerating_of_restriction (F.inclusion_isRestriction i)
+
+end CoverageFamily
+
+/--
+II.定義7.1 前半: selected requirements read by admissible covers.
+
+The required support, witness, and signature axes are explicit parameters of
+the selected law universe and selected reading. Visibility predicates are kept
+separate from the context data so later topology and adequacy layers can choose
+the intended reading without changing the context category itself.
+-/
+structure CoverageRequirements {U : AtomCarrier.{u}} (A : ArchitectureObject U)
+    (LU : LawUniverse U) (Sig : ArchitectureSignature U) where
+  selectedReading : LU.SelectedReading
+  requiredSupport : LU.SelectedReading -> U.Atom -> Prop
+  requiredWitness : LU.SelectedReading -> LU.witnessFamily.Witness -> Prop
+  requiredAxis : LU.SelectedReading -> Sig.Axis -> Prop
+  supportVisibleOn : ArchCtx A -> U.Atom -> Prop
+  witnessVisibleOn : ArchCtx A -> LU.witnessFamily.Witness -> Prop
+  axisReadableOn : ArchCtx A -> Sig.Axis -> Prop
+  boundaryVisibleOn : ArchCtx A -> ArchCtx A -> Prop
+
+/--
+II.定義7.1 前半: admissible cover conditions for a coverage family.
+
+The five fields are exactly the R3 admissibility clauses: Atom support
+coverage, law witness coverage, signature axis coverage, boundary coverage,
+and context non-generation.
+-/
+structure AdmissibleCover {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} (R : CoverageRequirements A LU Sig)
+    (P : ContextOverlapPullback C) (F : CoverageFamily C) : Prop where
+  atomSupportCoverage :
+    ∀ atom : U.Atom, R.requiredSupport R.selectedReading atom ->
+      ∃ i : F.Index, R.supportVisibleOn (F.patch i) atom
+  lawWitnessCoverage :
+    ∀ witness : LU.witnessFamily.Witness, R.requiredWitness R.selectedReading witness ->
+      (∃ i : F.Index, R.witnessVisibleOn (F.patch i) witness) ∨
+        ∃ i j : F.Index,
+          R.witnessVisibleOn (P.overlap F.base (F.patch i) (F.patch j)) witness
+  signatureAxisCoverage :
+    ∀ axis : Sig.Axis, R.requiredAxis R.selectedReading axis ->
+      ∃ i : F.Index, R.axisReadableOn (F.patch i) axis
+  boundaryCoverage :
+    ∀ i j : F.Index,
+      R.boundaryVisibleOn (P.overlap F.base (F.patch i) (F.patch j)) F.base
+  nonGeneration :
+    ∀ i : F.Index, (F.inclusionMorphism i).nonGenerating
+
+namespace AdmissibleCover
+
+/-- II.定義7.1: admissible covers expose required Atom support on patches. -/
+theorem support {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {P : ContextOverlapPullback C} {F : CoverageFamily C} (h : AdmissibleCover R P F)
+    {atom : U.Atom} (hreq : R.requiredSupport R.selectedReading atom) :
+    ∃ i : F.Index, R.supportVisibleOn (F.patch i) atom :=
+  h.atomSupportCoverage atom hreq
+
+/--
+II.定義7.1: admissible covers expose required law witnesses on patches or
+their selected overlaps.
+-/
+theorem witness {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {P : ContextOverlapPullback C} {F : CoverageFamily C} (h : AdmissibleCover R P F)
+    {witness : LU.witnessFamily.Witness}
+    (hreq : R.requiredWitness R.selectedReading witness) :
+    (∃ i : F.Index, R.witnessVisibleOn (F.patch i) witness) ∨
+      ∃ i j : F.Index,
+        R.witnessVisibleOn (P.overlap F.base (F.patch i) (F.patch j)) witness :=
+  h.lawWitnessCoverage witness hreq
+
+/-- II.定義7.1: admissible covers expose required signature axes on patches. -/
+theorem axis {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {P : ContextOverlapPullback C} {F : CoverageFamily C} (h : AdmissibleCover R P F)
+    {axis : Sig.Axis} (hreq : R.requiredAxis R.selectedReading axis) :
+    ∃ i : F.Index, R.axisReadableOn (F.patch i) axis :=
+  h.signatureAxisCoverage axis hreq
+
+/-- II.定義7.1: admissible covers expose boundary readings on overlaps. -/
+theorem boundary {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {P : ContextOverlapPullback C} {F : CoverageFamily C} (h : AdmissibleCover R P F)
+    (i j : F.Index) :
+    R.boundaryVisibleOn (P.overlap F.base (F.patch i) (F.patch j)) F.base :=
+  h.boundaryCoverage i j
+
+/-- II.定義7.1: admissible covers do not generate atoms along inclusions. -/
+theorem nonGenerating {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {P : ContextOverlapPullback C} {F : CoverageFamily C} (h : AdmissibleCover R P F)
+    (i : F.Index) :
+    (F.inclusionMorphism i).nonGenerating :=
+  h.nonGeneration i
+
+/--
+II.定義7.1: any coverage family whose non-generation clause is inherited from
+the context preorder satisfies the fifth admissibility condition.
+-/
+theorem nonGenerating_from_inclusions {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {C : ContextPreorderCategory A}
+    {F : CoverageFamily C} :
+    (∀ i : F.Index, (F.inclusionMorphism i).nonGenerating) :=
+  F.inclusion_nonGenerating
+
+end AdmissibleCover
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4484,26 +4484,29 @@ finite model example theorem package までを含む。第II部以降の concret
 ## AG版AAT Lean形式化 PRD-2 / 第II部 Architecture Geometry・Site・Sheaf
 
 File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
-`Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`.
+`Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`,
+`Formal/AG/Site/Coverage.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0、AC2/R1、AC3-AC4/R2 に対応する site/context entrypoint である。現時点では
+AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3 に対応する site/context entrypoint である。現時点では
 PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
 §5 の射 role predicate、命題4.2 の finite-meet preorder / quotient-poset package、
-仮定4.3 の pullback lifting package までを Lean 上に置き、coverage、Grothendieck topology、
-sheaf category は後続 Issue の対象として残す。
+仮定4.3 の pullback lifting package、coverage family、admissible cover の5条件までを Lean 上に置き、
+Grothendieck topology、Mathlib bridge、sheaf category は後続 Issue の対象として残す。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
 | `II.R0` | `AAT.AG.Site.PartIPrerequisites`, `PartIPrerequisites.architectureObject`, `PartIPrerequisites.lawUniverse`, `PartIPrerequisites.signature`, `PartIPrerequisites.architectureObject_configuration` | `structure` / `def` / `theorem` | 第II部 site tower が PRD-1 の `AATCorePackage` から architecture object / law universe / signature を読むための prerequisite package と accessor。 | `defined only` / `proved` |
 | `II.定義3.1 / §5.1-5.4` | `AAT.AG.Site.MinimalContext`, `AAT.AG.Site.ArchitectureContext`, `ArchitectureContext.Support`, `ArchitectureContext.Axis`, `ArchitectureContext.Observable`, `AAT.AG.Site.ContextMorphism`, `ContextMorphism.IsRestriction`, `ContextMorphism.IsProjection`, `ContextMorphism.IsRefinement`, `ContextMorphism.IsBaseChange`, `ContextMorphism.supportReadable_of_restriction`, `ContextMorphism.axisReadable_of_restriction`, `ContextMorphism.observableFunctorial_of_restriction`, `ContextMorphism.nonGenerating_of_restriction`, `ContextMorphism.axisForgetting_of_projection`, `ContextMorphism.supportRefinement_of_refinement`, `ContextMorphism.axisRefinement_of_refinement`, `ContextMorphism.baseChangeCompatible_of_baseChange` | `structure` / `def` / `theorem` | 最小 context model `(Supp, Ax, Obs)`、最小読みを含む一般 context、local context から target context への readable morphism、および restriction / projection / refinement / base change の role predicate と accessor。 | `defined only` / `proved` |
 | `II.定義4.1 / 命題4.2 / 仮定4.3` | `AAT.AG.Site.ArchCtx`, `ContextPreorderCategory`, `ContextPreorderCategory.Hom`, `ContextPreorderCategory.hom_subsingleton`, `ContextPreorderCategory.id`, `ContextPreorderCategory.comp`, `ContextPreorderCategory.morphism`, `ContextPreorderCategory.morphism_isRestriction`, `ContextFiniteMeet`, `ReadableEquivalent`, `ReadableEquivalent.refl`, `ReadableEquivalent.symm`, `ReadableEquivalent.trans`, `readableSetoid`, `QuotientArchCtx`, `ContextFiniteMeetPreorderCategory`, `ContextFiniteMeetPosetCategory`, `QuotientFiniteMeetPosetCategory`, `finiteMeetPreorderCategoryOf`, `finiteMeetPosetCategoryOf`, `minimalContextFiniteMeetPreorderCategory`, `minimalContextFiniteMeetPosetCategory`, `minimalContextQuotientFiniteMeetPosetCategory`, `ContextOverlapPullback`, `ContextOverlapPullback.left`, `ContextOverlapPullback.right`, `ContextOverlapPullback.base`, `ContextOverlapPullback.lift`, `meetOverlapPullback`, `minimalMeetPullback` | `abbrev` / `structure` / `def` / `theorem` | `ArchCtx(A)` の readable morphism 付き preorder-category reading、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap 仮定 package と lifting property、および meet が overlap を実現する補題。 | `defined only` / `proved` |
+| `II.定義6.1 / 定義7.1前半` | `AAT.AG.Site.CoverageFamily`, `CoverageFamily.inclusionMorphism`, `CoverageFamily.inclusion_isRestriction`, `CoverageFamily.inclusion_nonGenerating`, `AAT.AG.Site.CoverageRequirements`, `AAT.AG.Site.AdmissibleCover`, `AdmissibleCover.support`, `AdmissibleCover.witness`, `AdmissibleCover.axis`, `AdmissibleCover.boundary`, `AdmissibleCover.nonGenerating`, `AdmissibleCover.nonGenerating_from_inclusions` | `structure` / `def` / `theorem` | coverage family `{ W_i -> W }`、law universe と selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、および admissible cover の5条件と accessor。 | `defined only` / `proved` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
 PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate、
-命題4.2 と仮定4.3 の明示仮定 package と pullback lifting property だけを示す。
-admissible cover、`J_U`、Mathlib bridge、sheaf condition、Cech complex、
-`AATSh`、有限 poset site example はまだ形式化しない。
+命題4.2 と仮定4.3 の明示仮定 package と pullback lifting property、
+coverage family と admissible cover の5条件だけを示す。
+`J_U`、Grothendieck topology、Mathlib bridge、AAT Site、Presheaf / Sheaf、
+Descent、Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -620,12 +620,15 @@ Issue [#1964](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 Issue [#1966](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1966)
 では Context Category、finite-meet preorder / quotient-poset package、readable equivalence quotient、
 pullback / overlap 仮定 package、pullback lifting property、meet-pullback 補題を追加した。
+Issue [#1968](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1968)
+では Coverage Family と admissible cover の5条件を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | Coverage、Grothendieck topology、AAT Site、Presheaf / Sheaf、Descent、Finite Poset regime、AATSh は後続 Issue に残る。 |
-| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | Coverage family、Grothendieck topology は後続 Issue に残る。 |
-| `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | Coverage family、admissible cover、Grothendieck topology、Mathlib bridge は後続 Issue に残る。 |
+| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | `J_U`、Grothendieck topology、AAT Site、Presheaf / Sheaf、Descent、Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | `J_U`、Grothendieck topology、AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
+| `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | `J_U`、Grothendieck topology、Mathlib bridge は後続 Issue に残る。 |
+| `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | `J_U`、Grothendieck topology、Mathlib bridge は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 


### PR DESCRIPTION
## 概要

Closes #1968

PRD-2 R3 / AC5 として、第II部の Coverage Family と admissible cover の5条件を `Formal/AG/Site` に追加した。

- `CoverageFamily` で `{ W_i -> W }` を readable context inclusion として定義
- `CoverageRequirements` で law universe と selected reading を実引数に取る required support / witness / axis を明示
- `AdmissibleCover` で Atom support、law witness、signature axis、boundary、non-generation の5条件を定義
- law witness / boundary coverage は `ContextOverlapPullback` に相対化し、本文の overlap 条件を保持

## 証明した定理

- `CoverageFamily.inclusion_isRestriction`
- `CoverageFamily.inclusion_nonGenerating`
- `AdmissibleCover.support`
- `AdmissibleCover.witness`
- `AdmissibleCover.axis`
- `AdmissibleCover.boundary`
- `AdmissibleCover.nonGenerating`
- `AdmissibleCover.nonGenerating_from_inclusions`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Site/Coverage.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

注: `lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ再表示された。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
