### PR TITLE
AG版AATのU-adequate coverを定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -3,3 +3,4 @@ import Formal.AG.Site.Context
 import Formal.AG.Site.ContextCategory
 import Formal.AG.Site.Coverage
 import Formal.AG.Site.Topology
+import Formal.AG.Site.Adequate

--- a/Formal/AG/Site/Adequate.lean
+++ b/Formal/AG/Site/Adequate.lean
@@ -1,0 +1,301 @@
+import Formal.AG.Site.Topology
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+open CategoryTheory
+
+/--
+II.定義7.2: extra ideal-preservation data used by `U`-adequate covers.
+
+The selected witness ideal is not built into the context category. It is an
+explicit predicate on the readable restriction maps of a chosen cover.
+-/
+structure UAdequacyRequirements {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {LU : LawUniverse U} {Sig : ArchitectureSignature U}
+    (C : ContextPreorderCategory A)
+    (R : CoverageRequirements A LU Sig) where
+  selectedWitnessIdeal : LU.SelectedReading -> ArchCtx A -> Prop
+  witnessIdealPreservedBy :
+    {source target : ArchCtx A} -> C.Hom source target ->
+      selectedWitnessIdeal R.selectedReading target ->
+        selectedWitnessIdeal R.selectedReading source
+
+/--
+II.定義7.2: `U`-adequate cover.
+
+An adequate cover is a `J_U` cover plus the selected support, witness, axis,
+boundary, and witness-ideal preservation conditions needed by later theorem
+packages.
+-/
+structure UAdequateCover {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    (Q : UAdequacyRequirements C R) {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} (F : AATCoverageFamily R P base) : Prop where
+  topologyCover :
+    Sieve.generate F.presieve ∈ AATGrothendieckTopology R P base
+  requiredSupportCovered :
+    ∀ atom : U.Atom, R.requiredSupport R.selectedReading atom ->
+      ∃ i : F.Index, R.supportVisibleOn (F.patch i) atom
+  requiredWitnessesVisible :
+    ∀ witness : LU.witnessFamily.Witness, R.requiredWitness R.selectedReading witness ->
+      (∃ i : F.Index, R.witnessVisibleOn (F.patch i) witness) ∨
+        ∃ i j : F.Index,
+          R.witnessVisibleOn (P.overlap base.ctx (F.patch i) (F.patch j)) witness
+  requiredAxesReadable :
+    ∀ axis : Sig.Axis, R.requiredAxis R.selectedReading axis ->
+      ∃ i : F.Index, R.axisReadableOn (F.patch i) axis
+  boundaryWitnessesVisible :
+    ∀ i j : F.Index,
+      R.boundaryVisibleOn (P.overlap base.ctx (F.patch i) (F.patch j)) base.ctx
+  restrictionMapsPreserveWitnessIdeals :
+    ∀ i : F.Index,
+      Q.selectedWitnessIdeal R.selectedReading base.ctx ->
+        Q.selectedWitnessIdeal R.selectedReading (F.patch i)
+
+namespace UAdequateCover
+
+/-- II.定義7.2: an adequate cover is a cover in the generated topology. -/
+theorem isCover {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} {F : AATCoverageFamily R P base}
+    (h : UAdequateCover Q F) :
+    Sieve.generate F.presieve ∈ AATGrothendieckTopology R P base :=
+  h.topologyCover
+
+/-- II.定義7.2: adequate covers expose required support. -/
+theorem support {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} {F : AATCoverageFamily R P base}
+    (h : UAdequateCover Q F) {atom : U.Atom}
+    (hreq : R.requiredSupport R.selectedReading atom) :
+    ∃ i : F.Index, R.supportVisibleOn (F.patch i) atom :=
+  h.requiredSupportCovered atom hreq
+
+/-- II.定義7.2: adequate covers expose required witnesses on patches or overlaps. -/
+theorem witness {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} {F : AATCoverageFamily R P base}
+    (h : UAdequateCover Q F) {witness : LU.witnessFamily.Witness}
+    (hreq : R.requiredWitness R.selectedReading witness) :
+    (∃ i : F.Index, R.witnessVisibleOn (F.patch i) witness) ∨
+      ∃ i j : F.Index,
+        R.witnessVisibleOn (P.overlap base.ctx (F.patch i) (F.patch j)) witness :=
+  h.requiredWitnessesVisible witness hreq
+
+/-- II.定義7.2: adequate covers make required axes readable. -/
+theorem axis {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} {F : AATCoverageFamily R P base}
+    (h : UAdequateCover Q F) {axis : Sig.Axis}
+    (hreq : R.requiredAxis R.selectedReading axis) :
+    ∃ i : F.Index, R.axisReadableOn (F.patch i) axis :=
+  h.requiredAxesReadable axis hreq
+
+/-- II.定義7.2: adequate covers keep selected boundary witnesses visible. -/
+theorem boundary {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} {F : AATCoverageFamily R P base}
+    (h : UAdequateCover Q F) (i j : F.Index) :
+    R.boundaryVisibleOn (P.overlap base.ctx (F.patch i) (F.patch j)) base.ctx :=
+  h.boundaryWitnessesVisible i j
+
+/-- II.定義7.2: adequate covers preserve selected witness ideals on restrictions. -/
+theorem witnessIdeal {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} {F : AATCoverageFamily R P base}
+    (h : UAdequateCover Q F) (i : F.Index) :
+    Q.selectedWitnessIdeal R.selectedReading base.ctx ->
+      Q.selectedWitnessIdeal R.selectedReading (F.patch i) :=
+  h.restrictionMapsPreserveWitnessIdeals i
+
+end UAdequateCover
+
+/-- II.補題7.2A: required witnesses selected by the current reading. -/
+abbrev RequiredWitnessSubtype {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {LU : LawUniverse U} {Sig : ArchitectureSignature U}
+    (R : CoverageRequirements A LU Sig) :=
+  {witness : LU.witnessFamily.Witness // R.requiredWitness R.selectedReading witness}
+
+/--
+II.補題7.2A: closed index generated by seed patches, required witness supports,
+and seed-boundary overlaps.
+-/
+abbrev WitnessClosureIndex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {LU : LawUniverse U} {Sig : ArchitectureSignature U}
+    (R : CoverageRequirements A LU Sig) (SeedIndex : Type u) :=
+  SeedIndex ⊕ (RequiredWitnessSubtype R ⊕ (SeedIndex × SeedIndex))
+
+namespace WitnessClosureIndex
+
+/-- II.補題7.2A: context selected by a closed-cover index. -/
+def patch {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {SeedIndex : Type u} (P : ContextOverlapPullback C)
+    (base : ContextCategoryObject C) (seedPatch : SeedIndex -> ArchCtx A)
+    (requiredWitnessSupport : RequiredWitnessSubtype R -> ArchCtx A) :
+    WitnessClosureIndex R SeedIndex -> ArchCtx A
+  | Sum.inl seed => seedPatch seed
+  | Sum.inr (Sum.inl witness) => requiredWitnessSupport witness
+  | Sum.inr (Sum.inr pair) => P.overlap base.ctx (seedPatch pair.1) (seedPatch pair.2)
+
+end WitnessClosureIndex
+
+/--
+II.補題7.2A: witness-closure cover construction package.
+
+The closed index set is generated from seed patches, one representable support
+context for every required witness, and the selected seed-boundary overlaps.
+The visibility and preservation fields are the explicit hypotheses that remain
+after the closure construction has supplied those contexts.
+-/
+structure WitnessClosureCover {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    (Q : UAdequacyRequirements C R) (P : ContextOverlapPullback C)
+    (base : ContextCategoryObject C) where
+  SeedIndex : Type u
+  seedPatch : SeedIndex -> ArchCtx A
+  seedInclusion : ∀ i : SeedIndex, C.Hom (seedPatch i) base.ctx
+  localFiniteRequiredWitnesses :
+    Finite (RequiredWitnessSubtype R)
+  RequiredWitnessSupport :
+    RequiredWitnessSubtype R -> ArchCtx A
+  requiredWitnessSupport_inclusion :
+    ∀ witness, C.Hom (RequiredWitnessSupport witness) base.ctx
+  requiredWitnessSupport_visible :
+    ∀ witness, R.witnessVisibleOn (RequiredWitnessSupport witness) witness.1
+  requiredSupportCovered :
+    ∀ atom : U.Atom, R.requiredSupport R.selectedReading atom ->
+      ∃ i : WitnessClosureIndex R SeedIndex,
+        R.supportVisibleOn
+          (WitnessClosureIndex.patch P base seedPatch RequiredWitnessSupport i) atom
+  readableRequiredAxes :
+    ∀ axis : Sig.Axis, R.requiredAxis R.selectedReading axis ->
+      ∃ i : WitnessClosureIndex R SeedIndex,
+        R.axisReadableOn
+          (WitnessClosureIndex.patch P base seedPatch RequiredWitnessSupport i) axis
+  visibleBoundaryWitnesses :
+    ∀ i j : WitnessClosureIndex R SeedIndex,
+      R.boundaryVisibleOn
+        (P.overlap base.ctx
+          (WitnessClosureIndex.patch P base seedPatch RequiredWitnessSupport i)
+          (WitnessClosureIndex.patch P base seedPatch RequiredWitnessSupport j)) base.ctx
+
+namespace WitnessClosureCover
+
+/-- II.補題7.2A: index set of the closed cover. -/
+abbrev ClosedIndex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} (K : WitnessClosureCover Q P base) :=
+  WitnessClosureIndex R K.SeedIndex
+
+/-- II.補題7.2A: context carried by a closed-cover index. -/
+def patch {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} (K : WitnessClosureCover Q P base) :
+    K.ClosedIndex -> ArchCtx A :=
+  WitnessClosureIndex.patch P base K.seedPatch K.RequiredWitnessSupport
+
+/-- II.補題7.2A: each closed-cover context reads into the base. -/
+def inclusion {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} (K : WitnessClosureCover Q P base) :
+    ∀ i : K.ClosedIndex, C.Hom (K.patch i) base.ctx
+  | Sum.inl seed => K.seedInclusion seed
+  | Sum.inr (Sum.inl witness) => K.requiredWitnessSupport_inclusion witness
+  | Sum.inr (Sum.inr pair) =>
+      P.overlap_le_base (K.seedInclusion pair.1) (K.seedInclusion pair.2)
+
+/-- II.補題7.2A: the witness-closure construction as an admissible family. -/
+def toAATCoverageFamily {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {C : ContextPreorderCategory A} {LU : LawUniverse U}
+    {Sig : ArchitectureSignature U} {R : CoverageRequirements A LU Sig}
+    {Q : UAdequacyRequirements C R} {P : ContextOverlapPullback C}
+    {base : ContextCategoryObject C} (K : WitnessClosureCover Q P base) :
+    AATCoverageFamily R P base where
+  Index := K.ClosedIndex
+  patch := K.patch
+  inclusion := K.inclusion
+  admissible := {
+    atomSupportCoverage := fun atom hreq =>
+      let ⟨i, hi⟩ := K.requiredSupportCovered atom hreq
+      ⟨i, by
+        change R.supportVisibleOn (K.patch i) atom
+        simpa [WitnessClosureCover.patch] using hi⟩
+    lawWitnessCoverage := fun witness hreq =>
+      let required : {witness : LU.witnessFamily.Witness //
+          R.requiredWitness R.selectedReading witness} := ⟨witness, hreq⟩
+      Or.inl ⟨Sum.inr (Sum.inl required), K.requiredWitnessSupport_visible required⟩
+    signatureAxisCoverage := fun axis hreq =>
+      let ⟨i, hi⟩ := K.readableRequiredAxes axis hreq
+      ⟨i, by
+        change R.axisReadableOn (K.patch i) axis
+        simpa [WitnessClosureCover.patch] using hi⟩
+    boundaryCoverage := fun i j => by
+      change R.boundaryVisibleOn (P.overlap base.ctx (K.patch i) (K.patch j)) base.ctx
+      simpa [WitnessClosureCover.patch] using K.visibleBoundaryWitnesses i j
+    nonGeneration := fun i =>
+      ContextMorphism.nonGenerating_of_restriction (C.morphism_isRestriction (K.inclusion i))
+  }
+
+end WitnessClosureCover
+
+/--
+II.補題7.2A: under the explicit witness-closure assumptions, the closed cover
+is `U`-adequate.
+-/
+theorem witnessClosureCover_uAdequate {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {C : ContextPreorderCategory A}
+    {LU : LawUniverse U} {Sig : ArchitectureSignature U}
+    {R : CoverageRequirements A LU Sig} {Q : UAdequacyRequirements C R}
+    {P : ContextOverlapPullback C} {base : ContextCategoryObject C}
+    (K : WitnessClosureCover Q P base) :
+    UAdequateCover Q K.toAATCoverageFamily where
+  topologyCover := AATGrothendieckTopology.generate_mem K.toAATCoverageFamily
+  requiredSupportCovered := fun atom hreq =>
+    let ⟨i, hi⟩ := K.requiredSupportCovered atom hreq
+    ⟨i, by
+      change R.supportVisibleOn (K.patch i) atom
+      simpa [WitnessClosureCover.patch] using hi⟩
+  requiredWitnessesVisible := fun witness hreq =>
+    let required : {witness : LU.witnessFamily.Witness //
+        R.requiredWitness R.selectedReading witness} := ⟨witness, hreq⟩
+    Or.inl ⟨Sum.inr (Sum.inl required), by
+      change R.witnessVisibleOn (K.patch (Sum.inr (Sum.inl required))) witness
+      exact K.requiredWitnessSupport_visible required⟩
+  requiredAxesReadable := fun axis hreq =>
+    let ⟨i, hi⟩ := K.readableRequiredAxes axis hreq
+    ⟨i, by
+      change R.axisReadableOn (K.patch i) axis
+      simpa [WitnessClosureCover.patch] using hi⟩
+  boundaryWitnessesVisible := fun i j => by
+    change R.boundaryVisibleOn (P.overlap base.ctx (K.patch i) (K.patch j)) base.ctx
+    simpa [WitnessClosureCover.patch] using K.visibleBoundaryWitnesses i j
+  restrictionMapsPreserveWitnessIdeals := fun i hbase =>
+    Q.witnessIdealPreservedBy (K.inclusion i) hbase
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4485,15 +4485,16 @@ finite model example theorem package までを含む。第II部以降の concret
 
 File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
 `Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`,
-`Formal/AG/Site/Coverage.lean`, `Formal/AG/Site/Topology.lean`.
+`Formal/AG/Site/Coverage.lean`, `Formal/AG/Site/Topology.lean`,
+`Formal/AG/Site/Adequate.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4 に対応する site/context entrypoint である。現時点では
+AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5 に対応する site/context entrypoint である。現時点では
 PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
 §5 の射 role predicate、命題4.2 の finite-meet preorder / quotient-poset package、
 仮定4.3 の pullback lifting package、coverage family、admissible cover の5条件までを Lean 上に置き、
 admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge までを Lean 上に置く。
-sheaf category は後続 Issue の対象として残す。
+U-adequate cover と補題7.2A も Lean 上に置く。sheaf category は後続 Issue の対象として残す。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4502,12 +4503,14 @@ sheaf category は後続 Issue の対象として残す。
 | `II.定義4.1 / 命題4.2 / 仮定4.3` | `AAT.AG.Site.ArchCtx`, `ContextPreorderCategory`, `ContextPreorderCategory.Hom`, `ContextPreorderCategory.hom_subsingleton`, `ContextPreorderCategory.id`, `ContextPreorderCategory.comp`, `ContextPreorderCategory.morphism`, `ContextPreorderCategory.morphism_isRestriction`, `ContextFiniteMeet`, `ReadableEquivalent`, `ReadableEquivalent.refl`, `ReadableEquivalent.symm`, `ReadableEquivalent.trans`, `readableSetoid`, `QuotientArchCtx`, `ContextFiniteMeetPreorderCategory`, `ContextFiniteMeetPosetCategory`, `QuotientFiniteMeetPosetCategory`, `finiteMeetPreorderCategoryOf`, `finiteMeetPosetCategoryOf`, `minimalContextFiniteMeetPreorderCategory`, `minimalContextFiniteMeetPosetCategory`, `minimalContextQuotientFiniteMeetPosetCategory`, `ContextOverlapPullback`, `ContextOverlapPullback.left`, `ContextOverlapPullback.right`, `ContextOverlapPullback.base`, `ContextOverlapPullback.lift`, `meetOverlapPullback`, `minimalMeetPullback` | `abbrev` / `structure` / `def` / `theorem` | `ArchCtx(A)` の readable morphism 付き preorder-category reading、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap 仮定 package と lifting property、および meet が overlap を実現する補題。 | `defined only` / `proved` |
 | `II.定義6.1 / 定義7.1前半` | `AAT.AG.Site.CoverageFamily`, `CoverageFamily.inclusionMorphism`, `CoverageFamily.inclusion_isRestriction`, `CoverageFamily.inclusion_nonGenerating`, `AAT.AG.Site.CoverageRequirements`, `AAT.AG.Site.AdmissibleCover`, `AdmissibleCover.support`, `AdmissibleCover.witness`, `AdmissibleCover.axis`, `AdmissibleCover.boundary`, `AdmissibleCover.nonGenerating`, `AdmissibleCover.nonGenerating_from_inclusions` | `structure` / `def` / `theorem` | coverage family `{ W_i -> W }`、law universe と selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、および admissible cover の5条件と accessor。 | `defined only` / `proved` |
 | `II.定義7.1後半 / R4` | `AAT.AG.Site.ContextCategoryObject`, `ContextCategoryObject.of`, `AAT.AG.Site.AATCoverageFamily`, `AATCoverageFamily.toCoverageFamily`, `AATCoverageFamily.presieve`, `AATCoverageFamily.admissibleCover`, `AAT.AG.Site.admissiblePrecoverage`, `AAT.AG.Site.AATGrothendieckTopology`, `AATGrothendieckTopology.top_mem`, `AATGrothendieckTopology.pullback_stable`, `AATGrothendieckTopology.transitive`, `AATGrothendieckTopology.generate_mem`, `AATGrothendieckTopology.eq_coverage_toGrothendieck` | `structure` / `def` / `theorem` | context preorder を Mathlib の thin preorder category に包み、admissible cover family を presieve として生成 precoverage に入れ、その `toGrothendieck` を `J_U` として定義する。Mathlib `Coverage.toGrothendieck` との一致は、admissible precoverage が pullback と base-change stability を持つことを明示前提にした bridge theorem。 | `defined only` / `proved` |
+| `II.定義7.2 / 補題7.2A` | `AAT.AG.Site.UAdequacyRequirements`, `AAT.AG.Site.UAdequateCover`, `UAdequateCover.isCover`, `UAdequateCover.support`, `UAdequateCover.witness`, `UAdequateCover.axis`, `UAdequateCover.boundary`, `UAdequateCover.witnessIdeal`, `AAT.AG.Site.RequiredWitnessSubtype`, `AAT.AG.Site.WitnessClosureIndex`, `WitnessClosureIndex.patch`, `AAT.AG.Site.WitnessClosureCover`, `WitnessClosureCover.ClosedIndex`, `WitnessClosureCover.patch`, `WitnessClosureCover.inclusion`, `WitnessClosureCover.toAATCoverageFamily`, `AAT.AG.Site.witnessClosureCover_uAdequate` | `abbrev` / `structure` / `def` / `theorem` | `J_U` cover に required support / witness / axis / boundary visibility と selected reading 上の witness ideal predicate の restriction 保存を追加した `U`-adequate cover。補題7.2A は seed patch、局所有限な required witness subtype、required witness support、seed-boundary overlap branch から生成される closed index を持つ witness-closure cover construction package を明示引数に取り、その package から admissible family を構成する。admissibility と adequacy の boundary 条件は明示された boundary visibility field から得る。 | `defined only` / `proved under explicit WitnessClosureCover package assumptions` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
 PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate、
 命題4.2 と仮定4.3 の明示仮定 package と pullback lifting property、
 coverage family と admissible cover の5条件、admissible cover から生成される `J_U`、
-および明示された pullback / base-change 前提下の Mathlib coverage bridge だけを示す。
+明示された pullback / base-change 前提下の Mathlib coverage bridge、U-adequate cover、
+および補題7.2A の十分条件だけを示す。
 AAT Site、Presheaf / Sheaf、
 Descent、Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -624,6 +624,8 @@ Issue [#1968](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では Coverage Family と admissible cover の5条件を追加した。
 Issue [#1970](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1970)
 では admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge を追加した。
+Issue [#1972](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1972)
+では U-adequate cover と補題7.2A Witness-Closure Cover を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -632,6 +634,7 @@ Issue [#1970](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
 | `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
 | `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
+| `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 
@@ -641,7 +644,7 @@ Issue [#1970](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.仮定4.3 meet-pullback` | `proved` |
 | `II.定義7.1 J_U topology axioms` | `proved` |
 | `II.定義7.1 Coverage.toGrothendieck bridge` | `proved under explicit pullback / base-change stability assumptions` |
-| `II.補題7.2A` | `future proof obligation` |
+| `II.補題7.2A` | `proved under explicit WitnessClosureCover package assumptions` |
 | `II.定義10.1 sheaf condition bridge` | `future proof obligation` |
 | `II.定義11.1-12.1 sheaf-descent` | `future proof obligation` |
 | `II.命題7.2C` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #1972

PRD-2 R5 / AC8-AC9 として、AG 版 AAT の `U`-adequate cover と補題7.2A Witness-Closure Cover を `Formal/AG/Site` に追加した。

- `UAdequacyRequirements` / `UAdequateCover` で `J_U` cover、required support / witness / axis / boundary visibility、selected witness ideal の restriction 保存を定義
- `WitnessClosureIndex` / `WitnessClosureCover` で seed patch、required witness support、seed-boundary overlap branch からなる closed index を定義
- `WitnessClosureCover.toAATCoverageFamily` と `witnessClosureCover_uAdequate` で、明示 `WitnessClosureCover` package 前提下の補題7.2A を sorry なしで証明
- theorem index と proof obligations を `proved under explicit WitnessClosureCover package assumptions` として同期

## 証明した定理

- `UAdequateCover.isCover`
- `UAdequateCover.support`
- `UAdequateCover.witness`
- `UAdequateCover.axis`
- `UAdequateCover.boundary`
- `UAdequateCover.witnessIdeal`
- `witnessClosureCover_uAdequate`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Site/Adequate.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan in `Formal/AG`

`lake build` は成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
