### PR TITLE
AG版AATのAAT SiteとGeometryを定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -4,3 +4,4 @@ import Formal.AG.Site.ContextCategory
 import Formal.AG.Site.Coverage
 import Formal.AG.Site.Topology
 import Formal.AG.Site.Adequate
+import Formal.AG.Site.Geometry

--- a/Formal/AG/Site/Geometry.lean
+++ b/Formal/AG/Site/Geometry.lean
@@ -1,0 +1,101 @@
+import Formal.AG.Site.Adequate
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+open CategoryTheory
+
+/--
+II.定義8.1: the AAT site attached to an architecture object.
+
+This packages the context preorder `ArchCtx(A)` together with the selected
+coverage requirements and overlap package whose generated topology is `J_U`.
+It does not construct presheaves, sheaves, descent data, or Cech complexes.
+-/
+structure AATSite {U : AtomCarrier.{u}} (A : ArchitectureObject U) where
+  contextPreorder : ContextPreorderCategory A
+  lawUniverse : LawUniverse U
+  signature : ArchitectureSignature U
+  requirements : CoverageRequirements A lawUniverse signature
+  overlap : ContextOverlapPullback contextPreorder
+
+namespace AATSite
+
+/-- II.定義8.1: the object whose contexts form the site category. -/
+def architectureObject {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (_S : AATSite A) : ArchitectureObject U :=
+  A
+
+/-- II.定義8.1: the Mathlib category of architecture contexts. -/
+abbrev category {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) :=
+  ContextCategoryObject S.contextPreorder
+
+/-- II.定義8.1: the AAT Grothendieck topology `J_U` on `ArchCtx(A)`. -/
+def topology {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) : GrothendieckTopology S.category :=
+  AATGrothendieckTopology S.requirements S.overlap
+
+/-- II.定義8.1: the topology component is definitionally the generated `J_U`. -/
+theorem topology_eq {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) :
+    S.topology = AATGrothendieckTopology S.requirements S.overlap :=
+  rfl
+
+/-- II.定義8.1: the generated topology contains the top cover. -/
+theorem top_mem {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (base : S.category) :
+    (⊤ : Sieve base) ∈ S.topology base :=
+  AATGrothendieckTopology.top_mem S.requirements S.overlap base
+
+end AATSite
+
+/--
+II.定義2.1: architecture geometry built from the Part I generated object.
+
+The object component is exactly the `AATCorePackage` object supplied by
+`PartIPrerequisites`; the site component is the selected `AATSite` on that
+object. Later sheaf surfaces such as `O_X^U`, `I_Ob^U`, and `Flat_U(X)` should
+be added in the presheaf/sheaf layer, not in this package.
+-/
+structure ArchitectureGeometry (P : PartIPrerequisites.{u}) where
+  site : AATSite P.architectureObject
+
+namespace ArchitectureGeometry
+
+/-- II.定義2.1: the generated architecture object `A_S^V` of the geometry. -/
+def generatedObject {P : PartIPrerequisites.{u}}
+    (_X : ArchitectureGeometry P) : ArchitectureObject P.carrier :=
+  P.architectureObject
+
+/-- II.定義2.1: the generated object is the object supplied by the Part I core. -/
+theorem generatedObject_eq_core {P : PartIPrerequisites.{u}}
+    (X : ArchitectureGeometry P) :
+    X.generatedObject = P.core.object :=
+  rfl
+
+/-- II.定義2.1: the context preorder of `X_S^{V,U,J}`. -/
+def contextPreorder {P : PartIPrerequisites.{u}} (X : ArchitectureGeometry P) :
+    ContextPreorderCategory X.generatedObject :=
+  X.site.contextPreorder
+
+/-- II.定義2.1: the context category `ArchCtx(A_S^V)` of the geometry. -/
+abbrev category {P : PartIPrerequisites.{u}} (X : ArchitectureGeometry P) :=
+  X.site.category
+
+/-- II.定義2.1: the selected topology `J_U` of the geometry. -/
+def topology {P : PartIPrerequisites.{u}} (X : ArchitectureGeometry P) :
+    GrothendieckTopology X.category :=
+  X.site.topology
+
+/-- II.定義2.1: the geometry topology is the site topology. -/
+theorem topology_eq_site {P : PartIPrerequisites.{u}} (X : ArchitectureGeometry P) :
+    X.topology = X.site.topology :=
+  rfl
+
+end ArchitectureGeometry
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4486,15 +4486,15 @@ finite model example theorem package までを含む。第II部以降の concret
 File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
 `Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`,
 `Formal/AG/Site/Coverage.lean`, `Formal/AG/Site/Topology.lean`,
-`Formal/AG/Site/Adequate.lean`.
+`Formal/AG/Site/Adequate.lean`, `Formal/AG/Site/Geometry.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5 に対応する site/context entrypoint である。現時点では
+AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6 に対応する site/context entrypoint である。現時点では
 PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
 §5 の射 role predicate、命題4.2 の finite-meet preorder / quotient-poset package、
 仮定4.3 の pullback lifting package、coverage family、admissible cover の5条件までを Lean 上に置き、
 admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge までを Lean 上に置く。
-U-adequate cover と補題7.2A も Lean 上に置く。sheaf category は後続 Issue の対象として残す。
+U-adequate cover、補題7.2A、AAT Site、Architecture Geometry も Lean 上に置く。sheaf category は後続 Issue の対象として残す。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4504,14 +4504,15 @@ U-adequate cover と補題7.2A も Lean 上に置く。sheaf category は後続 
 | `II.定義6.1 / 定義7.1前半` | `AAT.AG.Site.CoverageFamily`, `CoverageFamily.inclusionMorphism`, `CoverageFamily.inclusion_isRestriction`, `CoverageFamily.inclusion_nonGenerating`, `AAT.AG.Site.CoverageRequirements`, `AAT.AG.Site.AdmissibleCover`, `AdmissibleCover.support`, `AdmissibleCover.witness`, `AdmissibleCover.axis`, `AdmissibleCover.boundary`, `AdmissibleCover.nonGenerating`, `AdmissibleCover.nonGenerating_from_inclusions` | `structure` / `def` / `theorem` | coverage family `{ W_i -> W }`、law universe と selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、および admissible cover の5条件と accessor。 | `defined only` / `proved` |
 | `II.定義7.1後半 / R4` | `AAT.AG.Site.ContextCategoryObject`, `ContextCategoryObject.of`, `AAT.AG.Site.AATCoverageFamily`, `AATCoverageFamily.toCoverageFamily`, `AATCoverageFamily.presieve`, `AATCoverageFamily.admissibleCover`, `AAT.AG.Site.admissiblePrecoverage`, `AAT.AG.Site.AATGrothendieckTopology`, `AATGrothendieckTopology.top_mem`, `AATGrothendieckTopology.pullback_stable`, `AATGrothendieckTopology.transitive`, `AATGrothendieckTopology.generate_mem`, `AATGrothendieckTopology.eq_coverage_toGrothendieck` | `structure` / `def` / `theorem` | context preorder を Mathlib の thin preorder category に包み、admissible cover family を presieve として生成 precoverage に入れ、その `toGrothendieck` を `J_U` として定義する。Mathlib `Coverage.toGrothendieck` との一致は、admissible precoverage が pullback と base-change stability を持つことを明示前提にした bridge theorem。 | `defined only` / `proved` |
 | `II.定義7.2 / 補題7.2A` | `AAT.AG.Site.UAdequacyRequirements`, `AAT.AG.Site.UAdequateCover`, `UAdequateCover.isCover`, `UAdequateCover.support`, `UAdequateCover.witness`, `UAdequateCover.axis`, `UAdequateCover.boundary`, `UAdequateCover.witnessIdeal`, `AAT.AG.Site.RequiredWitnessSubtype`, `AAT.AG.Site.WitnessClosureIndex`, `WitnessClosureIndex.patch`, `AAT.AG.Site.WitnessClosureCover`, `WitnessClosureCover.ClosedIndex`, `WitnessClosureCover.patch`, `WitnessClosureCover.inclusion`, `WitnessClosureCover.toAATCoverageFamily`, `AAT.AG.Site.witnessClosureCover_uAdequate` | `abbrev` / `structure` / `def` / `theorem` | `J_U` cover に required support / witness / axis / boundary visibility と selected reading 上の witness ideal predicate の restriction 保存を追加した `U`-adequate cover。補題7.2A は seed patch、局所有限な required witness subtype、required witness support、seed-boundary overlap branch から生成される closed index を持つ witness-closure cover construction package を明示引数に取り、その package から admissible family を構成する。admissibility と adequacy の boundary 条件は明示された boundary visibility field から得る。 | `defined only` / `proved under explicit WitnessClosureCover package assumptions` |
+| `II.定義8.1 / 定義2.1` | `AAT.AG.Site.AATSite`, `AATSite.architectureObject`, `AATSite.category`, `AATSite.topology`, `AATSite.topology_eq`, `AATSite.top_mem`, `AAT.AG.Site.ArchitectureGeometry`, `ArchitectureGeometry.generatedObject`, `ArchitectureGeometry.generatedObject_eq_core`, `ArchitectureGeometry.contextPreorder`, `ArchitectureGeometry.category`, `ArchitectureGeometry.topology`, `ArchitectureGeometry.topology_eq_site` | `structure` / `abbrev` / `def` / `theorem` | `ArchCtx(A)` と `J_U` を束ねる AAT Site package、および PRD-1 の `PartIPrerequisites` / `AATCorePackage` 由来 object に site を載せる Architecture Geometry package。第III部以降の sheaf 群の置き場はコメントに留める。 | `defined only` / `proved` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
 PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate、
 命題4.2 と仮定4.3 の明示仮定 package と pullback lifting property、
 coverage family と admissible cover の5条件、admissible cover から生成される `J_U`、
 明示された pullback / base-change 前提下の Mathlib coverage bridge、U-adequate cover、
-および補題7.2A の十分条件だけを示す。
-AAT Site、Presheaf / Sheaf、
+補題7.2A の十分条件、AAT Site、Architecture Geometry だけを示す。
+Presheaf / Sheaf、
 Descent、Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -626,6 +626,8 @@ Issue [#1970](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge を追加した。
 Issue [#1972](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1972)
 では U-adequate cover と補題7.2A Witness-Closure Cover を追加した。
+Issue [#1974](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1974)
+では AAT Site と Architecture Geometry package を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -635,6 +637,7 @@ Issue [#1972](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
 | `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
 | `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
+| `II.定義8.1 / 定義2.1` AAT Site と Architecture Geometry | `defined only` / `proved`. `Formal/AG/Site/Geometry.lean` が `AATSite`、`AATSite.topology`、`ArchitectureGeometry`、PRD-1 core object との accessor theorem を持つ。 | Presheaf / Sheaf、Descent、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 
@@ -645,6 +648,8 @@ Issue [#1972](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.定義7.1 J_U topology axioms` | `proved` |
 | `II.定義7.1 Coverage.toGrothendieck bridge` | `proved under explicit pullback / base-change stability assumptions` |
 | `II.補題7.2A` | `proved under explicit WitnessClosureCover package assumptions` |
+| `II.定義8.1 AAT Site` | `defined only` / `proved` |
+| `II.定義2.1 Architecture Geometry` | `defined only` / `proved` |
 | `II.定義10.1 sheaf condition bridge` | `future proof obligation` |
 | `II.定義11.1-12.1 sheaf-descent` | `future proof obligation` |
 | `II.命題7.2C` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #1974

PRD-2 R6 / AC10 として、AG 版 AAT の AAT Site と Architecture Geometry package を `Formal/AG/Site` に追加した。

- `AATSite` で `ArchCtx(A)` の context preorder、coverage requirements、overlap package、生成 topology `J_U` を束ねる
- `ArchitectureGeometry` で PRD-1 `PartIPrerequisites` / `AATCorePackage` 由来 object に `AATSite` を載せる
- sheaf 群 (`O_X^U`, `I_Ob^U`, `Flat_U(X)` など) は後続 layer の置き場コメントに留める
- theorem index と proof obligations を AC10/R6 の実体に同期

## 証明した定理

- `AATSite.topology_eq`
- `AATSite.top_mem`
- `ArchitectureGeometry.generatedObject_eq_core`
- `ArchitectureGeometry.topology_eq_site`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Site/Geometry.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan in `Formal/AG`

`lake build` は成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
