### PR TITLE
AG版AATのPresheafとSheaf条件を定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -5,3 +5,4 @@ import Formal.AG.Site.Coverage
 import Formal.AG.Site.Topology
 import Formal.AG.Site.Adequate
 import Formal.AG.Site.Geometry
+import Formal.AG.Site.Sheaf

--- a/Formal/AG/Site/Sheaf.lean
+++ b/Formal/AG/Site/Sheaf.lean
@@ -1,0 +1,169 @@
+import Formal.AG.Site.Geometry
+import Mathlib.CategoryTheory.Sites.Sheaf
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+open CategoryTheory
+
+/-- II.定義9.1: a presheaf on the architecture context category. -/
+abbrev AATPresheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) :=
+  S.categoryᵒᵖ ⥤ Type u
+
+/-- II.定義9.1: raw Atom presheaf signature. -/
+abbrev AtRaw {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) :=
+  AATPresheaf S
+
+/-- II.定義9.1: raw law presheaf signature. -/
+abbrev LawRaw {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) :=
+  AATPresheaf S
+
+/-- II.定義9.1: raw signature-axis presheaf signature. -/
+abbrev SigRaw {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) :=
+  AATPresheaf S
+
+/--
+II.定義10.1: sheaf condition for a single `J_U` cover.
+
+Mathlib's `Presieve.IsSheafFor` says every compatible family of local sections
+has a unique amalgamating global section.
+-/
+def AATSheafConditionFor {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (F : AATPresheaf S) {base : S.category}
+    (cover : Sieve base) : Prop :=
+  Presieve.IsSheafFor F (cover : Presieve base)
+
+/--
+II.定義10.1: sheaf condition for the AAT topology `J_U`.
+
+The quantification ranges exactly over covers in `S.topology`; no
+sheafification or descent object is constructed here.
+-/
+def AATSheafCondition {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (F : AATPresheaf S) : Prop :=
+  ∀ {base : S.category} (cover : Sieve base), cover ∈ S.topology base ->
+    AATSheafConditionFor S F cover
+
+namespace AATSheafCondition
+
+/-- II.定義10.1: the condition exposes the selected cover-wise gluing property. -/
+theorem cover {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S}
+    (h : AATSheafCondition S F) {base : S.category}
+    (cover : Sieve base) (hcover : cover ∈ S.topology base) :
+    AATSheafConditionFor S F cover :=
+  h cover hcover
+
+/--
+II.定義10.1 bridge: the AAT sheaf condition is exactly Mathlib's
+`Presieve.IsSheaf` condition for the topology `J_U`.
+-/
+theorem iff_presieve_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (F : AATPresheaf S) :
+    AATSheafCondition S F ↔ Presieve.IsSheaf S.topology F :=
+  Iff.rfl
+
+end AATSheafCondition
+
+/-- II.定義10.2: a sheaf on the AAT site, as a presheaf plus the `J_U` condition. -/
+structure AATSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) where
+  carrier : AATPresheaf S
+  isSheaf : AATSheafCondition S carrier
+
+namespace AATSheaf
+
+/-- II.定義10.2: read the underlying presheaf. -/
+def toPresheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : AATSheaf S) : AATPresheaf S :=
+  F.carrier
+
+/-- II.定義10.2: the underlying presheaf satisfies Mathlib's sheaf condition. -/
+theorem presieve_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : AATSheaf S) :
+    Presieve.IsSheaf S.topology F.toPresheaf :=
+  (AATSheafCondition.iff_presieve_isSheaf S F.toPresheaf).1 F.isSheaf
+
+end AATSheaf
+
+/--
+II.定義10.2: named raw presheaves and sheaves attached to an AAT site.
+
+This is a carrier package only. It records the intended names for later
+architecture sheaf surfaces, but it does not construct their sections or prove
+descent statements.
+-/
+structure ArchitectureSheafFamily {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) where
+  atRaw : AtRaw S
+  lawRaw : LawRaw S
+  sigRaw : SigRaw S
+  At : AATSheaf S
+  Law : AATSheaf S
+  Sig : AATSheaf S
+  State : AATSheaf S
+  Eff : AATSheaf S
+  Auth : AATSheaf S
+  Sem : AATSheaf S
+  Trace : AATSheaf S
+
+namespace ArchitectureSheafFamily
+
+/-- II.定義10.2: the named Atom sheaf satisfies the `J_U` sheaf condition. -/
+theorem At_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.At.toPresheaf :=
+  F.At.presieve_isSheaf
+
+/-- II.定義10.2: the named law sheaf satisfies the `J_U` sheaf condition. -/
+theorem Law_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.Law.toPresheaf :=
+  F.Law.presieve_isSheaf
+
+/-- II.定義10.2: the named signature sheaf satisfies the `J_U` sheaf condition. -/
+theorem Sig_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.Sig.toPresheaf :=
+  F.Sig.presieve_isSheaf
+
+/-- II.定義10.2: the named state sheaf satisfies the `J_U` sheaf condition. -/
+theorem State_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.State.toPresheaf :=
+  F.State.presieve_isSheaf
+
+/-- II.定義10.2: the named effect sheaf satisfies the `J_U` sheaf condition. -/
+theorem Eff_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.Eff.toPresheaf :=
+  F.Eff.presieve_isSheaf
+
+/-- II.定義10.2: the named authority sheaf satisfies the `J_U` sheaf condition. -/
+theorem Auth_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.Auth.toPresheaf :=
+  F.Auth.presieve_isSheaf
+
+/-- II.定義10.2: the named semantic sheaf satisfies the `J_U` sheaf condition. -/
+theorem Sem_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.Sem.toPresheaf :=
+  F.Sem.presieve_isSheaf
+
+/-- II.定義10.2: the named trace sheaf satisfies the `J_U` sheaf condition. -/
+theorem Trace_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : ArchitectureSheafFamily S) :
+    Presieve.IsSheaf S.topology F.Trace.toPresheaf :=
+  F.Trace.presieve_isSheaf
+
+end ArchitectureSheafFamily
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4486,15 +4486,16 @@ finite model example theorem package までを含む。第II部以降の concret
 File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
 `Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`,
 `Formal/AG/Site/Coverage.lean`, `Formal/AG/Site/Topology.lean`,
-`Formal/AG/Site/Adequate.lean`, `Formal/AG/Site/Geometry.lean`.
+`Formal/AG/Site/Adequate.lean`, `Formal/AG/Site/Geometry.lean`,
+`Formal/AG/Site/Sheaf.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6 に対応する site/context entrypoint である。現時点では
+AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6、AC11/R7 に対応する site/context entrypoint である。現時点では
 PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
 §5 の射 role predicate、命題4.2 の finite-meet preorder / quotient-poset package、
 仮定4.3 の pullback lifting package、coverage family、admissible cover の5条件までを Lean 上に置き、
 admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge までを Lean 上に置く。
-U-adequate cover、補題7.2A、AAT Site、Architecture Geometry も Lean 上に置く。sheaf category は後続 Issue の対象として残す。
+U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、名前付き sheaf family も Lean 上に置く。descent は後続 Issue の対象として残す。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4505,14 +4506,15 @@ U-adequate cover、補題7.2A、AAT Site、Architecture Geometry も Lean 上に
 | `II.定義7.1後半 / R4` | `AAT.AG.Site.ContextCategoryObject`, `ContextCategoryObject.of`, `AAT.AG.Site.AATCoverageFamily`, `AATCoverageFamily.toCoverageFamily`, `AATCoverageFamily.presieve`, `AATCoverageFamily.admissibleCover`, `AAT.AG.Site.admissiblePrecoverage`, `AAT.AG.Site.AATGrothendieckTopology`, `AATGrothendieckTopology.top_mem`, `AATGrothendieckTopology.pullback_stable`, `AATGrothendieckTopology.transitive`, `AATGrothendieckTopology.generate_mem`, `AATGrothendieckTopology.eq_coverage_toGrothendieck` | `structure` / `def` / `theorem` | context preorder を Mathlib の thin preorder category に包み、admissible cover family を presieve として生成 precoverage に入れ、その `toGrothendieck` を `J_U` として定義する。Mathlib `Coverage.toGrothendieck` との一致は、admissible precoverage が pullback と base-change stability を持つことを明示前提にした bridge theorem。 | `defined only` / `proved` |
 | `II.定義7.2 / 補題7.2A` | `AAT.AG.Site.UAdequacyRequirements`, `AAT.AG.Site.UAdequateCover`, `UAdequateCover.isCover`, `UAdequateCover.support`, `UAdequateCover.witness`, `UAdequateCover.axis`, `UAdequateCover.boundary`, `UAdequateCover.witnessIdeal`, `AAT.AG.Site.RequiredWitnessSubtype`, `AAT.AG.Site.WitnessClosureIndex`, `WitnessClosureIndex.patch`, `AAT.AG.Site.WitnessClosureCover`, `WitnessClosureCover.ClosedIndex`, `WitnessClosureCover.patch`, `WitnessClosureCover.inclusion`, `WitnessClosureCover.toAATCoverageFamily`, `AAT.AG.Site.witnessClosureCover_uAdequate` | `abbrev` / `structure` / `def` / `theorem` | `J_U` cover に required support / witness / axis / boundary visibility と selected reading 上の witness ideal predicate の restriction 保存を追加した `U`-adequate cover。補題7.2A は seed patch、局所有限な required witness subtype、required witness support、seed-boundary overlap branch から生成される closed index を持つ witness-closure cover construction package を明示引数に取り、その package から admissible family を構成する。admissibility と adequacy の boundary 条件は明示された boundary visibility field から得る。 | `defined only` / `proved under explicit WitnessClosureCover package assumptions` |
 | `II.定義8.1 / 定義2.1` | `AAT.AG.Site.AATSite`, `AATSite.architectureObject`, `AATSite.category`, `AATSite.topology`, `AATSite.topology_eq`, `AATSite.top_mem`, `AAT.AG.Site.ArchitectureGeometry`, `ArchitectureGeometry.generatedObject`, `ArchitectureGeometry.generatedObject_eq_core`, `ArchitectureGeometry.contextPreorder`, `ArchitectureGeometry.category`, `ArchitectureGeometry.topology`, `ArchitectureGeometry.topology_eq_site` | `structure` / `abbrev` / `def` / `theorem` | `ArchCtx(A)` と `J_U` を束ねる AAT Site package、および PRD-1 の `PartIPrerequisites` / `AATCorePackage` 由来 object に site を載せる Architecture Geometry package。第III部以降の sheaf 群の置き場はコメントに留める。 | `defined only` / `proved` |
+| `II.定義9.1 / 定義10.1 / 定義10.2` | `AAT.AG.Site.AATPresheaf`, `AAT.AG.Site.AtRaw`, `AAT.AG.Site.LawRaw`, `AAT.AG.Site.SigRaw`, `AAT.AG.Site.AATSheafConditionFor`, `AAT.AG.Site.AATSheafCondition`, `AATSheafCondition.cover`, `AATSheafCondition.iff_presieve_isSheaf`, `AAT.AG.Site.AATSheaf`, `AATSheaf.toPresheaf`, `AATSheaf.presieve_isSheaf`, `AAT.AG.Site.ArchitectureSheafFamily`, `ArchitectureSheafFamily.At_isSheaf`, `ArchitectureSheafFamily.Law_isSheaf`, `ArchitectureSheafFamily.Sig_isSheaf`, `ArchitectureSheafFamily.State_isSheaf`, `ArchitectureSheafFamily.Eff_isSheaf`, `ArchitectureSheafFamily.Auth_isSheaf`, `ArchitectureSheafFamily.Sem_isSheaf`, `ArchitectureSheafFamily.Trace_isSheaf` | `abbrev` / `structure` / `def` / `theorem` | `ArchCtx(A)^op` 上の Type-valued presheaf、代表的 raw presheaf signature、compatible local sections が一意の global section へ貼り合う sheaf condition、Mathlib `Presieve.IsSheaf` bridge、および `At / Law / Sig / State / Eff / Auth / Sem / Trace` の名前付き sheaf family carrier package。 | `defined only` / `proved` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
 PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate、
 命題4.2 と仮定4.3 の明示仮定 package と pullback lifting property、
 coverage family と admissible cover の5条件、admissible cover から生成される `J_U`、
 明示された pullback / base-change 前提下の Mathlib coverage bridge、U-adequate cover、
-補題7.2A の十分条件、AAT Site、Architecture Geometry だけを示す。
-Presheaf / Sheaf、
+補題7.2A の十分条件、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、
+および名前付き sheaf family carrier package だけを示す。
 Descent、Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -628,6 +628,8 @@ Issue [#1972](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では U-adequate cover と補題7.2A Witness-Closure Cover を追加した。
 Issue [#1974](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1974)
 では AAT Site と Architecture Geometry package を追加した。
+Issue [#1976](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1976)
+では presheaf、sheaf condition bridge、名前付き sheaf family package を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -638,6 +640,7 @@ Issue [#1974](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
 | `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
 | `II.定義8.1 / 定義2.1` AAT Site と Architecture Geometry | `defined only` / `proved`. `Formal/AG/Site/Geometry.lean` が `AATSite`、`AATSite.topology`、`ArchitectureGeometry`、PRD-1 core object との accessor theorem を持つ。 | Presheaf / Sheaf、Descent、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
+| `II.定義9.1 / 定義10.1 / 定義10.2` Presheaf と sheaf condition | `defined only` / `proved`. `Formal/AG/Site/Sheaf.lean` が `AATPresheaf`、raw presheaf signature、`AATSheafCondition`、Mathlib `Presieve.IsSheaf` bridge、`AATSheaf`、`At / Law / Sig / State / Eff / Auth / Sem / Trace` の `ArchitectureSheafFamily` を持つ。 | Descent、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 
@@ -650,7 +653,7 @@ Issue [#1974](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.補題7.2A` | `proved under explicit WitnessClosureCover package assumptions` |
 | `II.定義8.1 AAT Site` | `defined only` / `proved` |
 | `II.定義2.1 Architecture Geometry` | `defined only` / `proved` |
-| `II.定義10.1 sheaf condition bridge` | `future proof obligation` |
+| `II.定義10.1 sheaf condition bridge` | `proved` |
 | `II.定義11.1-12.1 sheaf-descent` | `future proof obligation` |
 | `II.命題7.2C` | `future proof obligation` |
 | `II.R11 finite model examples` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #1976

PRD-2 R7 / AC11 として、AG 版 AAT の presheaf、sheaf condition bridge、名前付き sheaf family package を `Formal/AG/Site` に追加した。

- `AATPresheaf` を `ArchCtx(A)^op` 上の Type-valued Mathlib functor として定義
- `AtRaw` / `LawRaw` / `SigRaw` の raw presheaf signature を追加
- `AATSheafCondition` を `J_U` cover 上の Mathlib `Presieve.IsSheaf` 条件として定義し、bridge theorem を追加
- `AATSheaf` と `At / Law / Sig / State / Eff / Auth / Sem / Trace` の named sheaf family carrier package を追加
- theorem index と proof obligations を AC11/R7 の実体に同期

## 証明した定理

- `AATSheafCondition.cover`
- `AATSheafCondition.iff_presieve_isSheaf`
- `AATSheaf.presieve_isSheaf`
- `ArchitectureSheafFamily.At_isSheaf`
- `ArchitectureSheafFamily.Law_isSheaf`
- `ArchitectureSheafFamily.Sig_isSheaf`
- `ArchitectureSheafFamily.State_isSheaf`
- `ArchitectureSheafFamily.Eff_isSheaf`
- `ArchitectureSheafFamily.Auth_isSheaf`
- `ArchitectureSheafFamily.Sem_isSheaf`
- `ArchitectureSheafFamily.Trace_isSheaf`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Site/Sheaf.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan in `Formal/AG`

`lake build` は成功。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
