### PR TITLE
AG版AATのGluingとDescentを定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -6,3 +6,4 @@ import Formal.AG.Site.Topology
 import Formal.AG.Site.Adequate
 import Formal.AG.Site.Geometry
 import Formal.AG.Site.Sheaf
+import Formal.AG.Site.Descent

--- a/Formal/AG/Site/Descent.lean
+++ b/Formal/AG/Site/Descent.lean
@@ -1,0 +1,159 @@
+import Formal.AG.Site.Sheaf
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+open CategoryTheory
+open Opposite
+
+/-- II.定義11.1: local sections attached to a cover of an AAT site. -/
+abbrev AATLocalSectionFamily {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (F : AATPresheaf S) {base : S.category}
+    (cover : Sieve base) :=
+  Presieve.FamilyOfElements F (cover : Presieve base)
+
+/--
+II.定義11.1: overlap agreement for local sections.
+
+Mathlib records the usual equality after restricting two local sections to a
+common refinement as `Presieve.FamilyOfElements.Compatible`.
+-/
+def AATOverlapAgreement {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S} {base : S.category}
+    {cover : Sieve base} (localSections : AATLocalSectionFamily S F cover) : Prop :=
+  localSections.Compatible
+
+/-- II.定義11.1: the cocycle condition is the compatible overlap agreement. -/
+abbrev AATCocycleCondition {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S} {base : S.category}
+    {cover : Sieve base} (localSections : AATLocalSectionFamily S F cover) : Prop :=
+  AATOverlapAgreement localSections
+
+/--
+II.定義11.1: gluing data for a cover.
+
+The package contains the local section family and its overlap/cocycle
+agreement. The global section is not part of the data.
+-/
+structure AATGluingData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (F : AATPresheaf S) {base : S.category}
+    (cover : Sieve base) where
+  localSections : AATLocalSectionFamily S F cover
+  overlapAgreement : AATOverlapAgreement localSections
+
+namespace AATGluingData
+
+/-- II.定義11.1: the cocycle condition recorded by gluing data. -/
+theorem cocycle {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S} {base : S.category}
+    {cover : Sieve base} (data : AATGluingData S F cover) :
+    AATCocycleCondition data.localSections :=
+  data.overlapAgreement
+
+end AATGluingData
+
+/--
+II.定義11.2: a global section realizes the selected gluing data when it
+amalgamates all local sections.
+-/
+def AATGlobalSectionRealizes {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S} {base : S.category}
+    {cover : Sieve base} (data : AATGluingData S F cover)
+    (globalSection : F.obj (op base)) : Prop :=
+  data.localSections.IsAmalgamation globalSection
+
+/--
+II.定義11.2: descent for a cover.
+
+Every compatible local family has a unique global section which restricts back
+to the chosen local sections.
+-/
+def AATDescent {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) (F : AATPresheaf S) {base : S.category}
+    (cover : Sieve base) : Prop :=
+  ∀ data : AATGluingData S F cover,
+    ∃! globalSection : F.obj (op base), AATGlobalSectionRealizes data globalSection
+
+namespace AATDescent
+
+/-- II.定義11.2: descent exposes existence of the glued global section. -/
+theorem exists_global {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S} {base : S.category}
+    {cover : Sieve base} (h : AATDescent S F cover)
+    (data : AATGluingData S F cover) :
+    ∃ globalSection : F.obj (op base), AATGlobalSectionRealizes data globalSection :=
+  (h data).exists
+
+end AATDescent
+
+namespace AATSheafConditionFor
+
+/-- II.定義11.2: the sheaf condition gives descent for the selected cover. -/
+theorem descent {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S} {base : S.category}
+    {cover : Sieve base} (h : AATSheafConditionFor S F cover) :
+    AATDescent S F cover := fun data =>
+  h data.localSections data.overlapAgreement
+
+end AATSheafConditionFor
+
+namespace AATSheafCondition
+
+/-- II.定義11.2: a sheaf on `J_U` satisfies descent for every selected cover. -/
+theorem descent {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {F : AATPresheaf S}
+    (h : AATSheafCondition S F) {base : S.category}
+    (cover : Sieve base) (hcover : cover ∈ S.topology base) :
+    AATDescent S F cover :=
+  (h.cover cover hcover).descent
+
+end AATSheafCondition
+
+namespace AATSheaf
+
+/-- II.定義11.2: a packaged AAT sheaf satisfies descent for every `J_U` cover. -/
+theorem descent {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (F : AATSheaf S) {base : S.category}
+    (cover : Sieve base) (hcover : cover ∈ S.topology base) :
+    AATDescent S F.toPresheaf cover :=
+  AATSheafCondition.descent F.isSheaf cover hcover
+
+end AATSheaf
+
+/--
+II.定義12.1: a sheafification comparison relative to a chosen canonical map.
+
+This records only the AAT-facing boundary `F_raw -> F_raw^+`; it does not
+construct general sheafification for arbitrary sites.
+-/
+structure AATSheafificationComparison {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : AATSite A) where
+  raw : AATPresheaf S
+  plus : AATSheaf S
+  canonical : raw ⟶ plus.toPresheaf
+
+namespace AATSheafificationComparison
+
+/-- II.定義12.1: the codomain of the canonical map is a sheaf. -/
+theorem plus_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (comparison : AATSheafificationComparison S) :
+    Presieve.IsSheaf S.topology comparison.plus.toPresheaf :=
+  comparison.plus.presieve_isSheaf
+
+end AATSheafificationComparison
+
+/--
+II.定義12.1: the sheafification gap, relative to a chosen canonical map.
+
+The gap is recorded as failure of the canonical comparison to be pointwise
+bijective at some architecture context.
+-/
+def AATSheafificationGap {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (comparison : AATSheafificationComparison S) : Prop :=
+  ∃ base : S.category,
+    ¬ Function.Bijective (comparison.canonical.app (op base))
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4487,15 +4487,15 @@ File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
 `Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`,
 `Formal/AG/Site/Coverage.lean`, `Formal/AG/Site/Topology.lean`,
 `Formal/AG/Site/Adequate.lean`, `Formal/AG/Site/Geometry.lean`,
-`Formal/AG/Site/Sheaf.lean`.
+`Formal/AG/Site/Sheaf.lean`, `Formal/AG/Site/Descent.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6、AC11/R7 に対応する site/context entrypoint である。現時点では
+AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6、AC11/R7、AC12/R8 に対応する site/context entrypoint である。現時点では
 PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
 §5 の射 role predicate、命題4.2 の finite-meet preorder / quotient-poset package、
 仮定4.3 の pullback lifting package、coverage family、admissible cover の5条件までを Lean 上に置き、
 admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge までを Lean 上に置く。
-U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、名前付き sheaf family も Lean 上に置く。descent は後続 Issue の対象として残す。
+U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、名前付き sheaf family、gluing / descent、sheafification comparison / gap も Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4507,6 +4507,7 @@ U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sh
 | `II.定義7.2 / 補題7.2A` | `AAT.AG.Site.UAdequacyRequirements`, `AAT.AG.Site.UAdequateCover`, `UAdequateCover.isCover`, `UAdequateCover.support`, `UAdequateCover.witness`, `UAdequateCover.axis`, `UAdequateCover.boundary`, `UAdequateCover.witnessIdeal`, `AAT.AG.Site.RequiredWitnessSubtype`, `AAT.AG.Site.WitnessClosureIndex`, `WitnessClosureIndex.patch`, `AAT.AG.Site.WitnessClosureCover`, `WitnessClosureCover.ClosedIndex`, `WitnessClosureCover.patch`, `WitnessClosureCover.inclusion`, `WitnessClosureCover.toAATCoverageFamily`, `AAT.AG.Site.witnessClosureCover_uAdequate` | `abbrev` / `structure` / `def` / `theorem` | `J_U` cover に required support / witness / axis / boundary visibility と selected reading 上の witness ideal predicate の restriction 保存を追加した `U`-adequate cover。補題7.2A は seed patch、局所有限な required witness subtype、required witness support、seed-boundary overlap branch から生成される closed index を持つ witness-closure cover construction package を明示引数に取り、その package から admissible family を構成する。admissibility と adequacy の boundary 条件は明示された boundary visibility field から得る。 | `defined only` / `proved under explicit WitnessClosureCover package assumptions` |
 | `II.定義8.1 / 定義2.1` | `AAT.AG.Site.AATSite`, `AATSite.architectureObject`, `AATSite.category`, `AATSite.topology`, `AATSite.topology_eq`, `AATSite.top_mem`, `AAT.AG.Site.ArchitectureGeometry`, `ArchitectureGeometry.generatedObject`, `ArchitectureGeometry.generatedObject_eq_core`, `ArchitectureGeometry.contextPreorder`, `ArchitectureGeometry.category`, `ArchitectureGeometry.topology`, `ArchitectureGeometry.topology_eq_site` | `structure` / `abbrev` / `def` / `theorem` | `ArchCtx(A)` と `J_U` を束ねる AAT Site package、および PRD-1 の `PartIPrerequisites` / `AATCorePackage` 由来 object に site を載せる Architecture Geometry package。第III部以降の sheaf 群の置き場はコメントに留める。 | `defined only` / `proved` |
 | `II.定義9.1 / 定義10.1 / 定義10.2` | `AAT.AG.Site.AATPresheaf`, `AAT.AG.Site.AtRaw`, `AAT.AG.Site.LawRaw`, `AAT.AG.Site.SigRaw`, `AAT.AG.Site.AATSheafConditionFor`, `AAT.AG.Site.AATSheafCondition`, `AATSheafCondition.cover`, `AATSheafCondition.iff_presieve_isSheaf`, `AAT.AG.Site.AATSheaf`, `AATSheaf.toPresheaf`, `AATSheaf.presieve_isSheaf`, `AAT.AG.Site.ArchitectureSheafFamily`, `ArchitectureSheafFamily.At_isSheaf`, `ArchitectureSheafFamily.Law_isSheaf`, `ArchitectureSheafFamily.Sig_isSheaf`, `ArchitectureSheafFamily.State_isSheaf`, `ArchitectureSheafFamily.Eff_isSheaf`, `ArchitectureSheafFamily.Auth_isSheaf`, `ArchitectureSheafFamily.Sem_isSheaf`, `ArchitectureSheafFamily.Trace_isSheaf` | `abbrev` / `structure` / `def` / `theorem` | `ArchCtx(A)^op` 上の Type-valued presheaf、代表的 raw presheaf signature、compatible local sections が一意の global section へ貼り合う sheaf condition、Mathlib `Presieve.IsSheaf` bridge、および `At / Law / Sig / State / Eff / Auth / Sem / Trace` の名前付き sheaf family carrier package。 | `defined only` / `proved` |
+| `II.定義11.1 / 定義11.2 / 定義12.1` | `AAT.AG.Site.AATLocalSectionFamily`, `AAT.AG.Site.AATOverlapAgreement`, `AAT.AG.Site.AATCocycleCondition`, `AAT.AG.Site.AATGluingData`, `AATGluingData.cocycle`, `AAT.AG.Site.AATGlobalSectionRealizes`, `AAT.AG.Site.AATDescent`, `AATDescent.exists_global`, `AATSheafConditionFor.descent`, `AATSheafCondition.descent`, `AATSheaf.descent`, `AAT.AG.Site.AATSheafificationComparison`, `AATSheafificationComparison.plus_isSheaf`, `AAT.AG.Site.AATSheafificationGap` | `abbrev` / `structure` / `def` / `theorem` | cover 上の局所 section family、overlap agreement / cocycle condition、gluing data、compatible gluing data が一意の global section から来る descent、sheaf condition から descent を読む補題、および canonical map `F_raw -> F_raw^+` に相対化した sheafification comparison / gap。 | `defined only` / `proved` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
 PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate、
@@ -4514,8 +4515,8 @@ PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predica
 coverage family と admissible cover の5条件、admissible cover から生成される `J_U`、
 明示された pullback / base-change 前提下の Mathlib coverage bridge、U-adequate cover、
 補題7.2A の十分条件、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、
-および名前付き sheaf family carrier package だけを示す。
-Descent、Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
+名前付き sheaf family carrier package、gluing / descent、sheafification comparison / gap だけを示す。
+Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -630,17 +630,20 @@ Issue [#1974](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では AAT Site と Architecture Geometry package を追加した。
 Issue [#1976](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1976)
 では presheaf、sheaf condition bridge、名前付き sheaf family package を追加した。
+Issue [#1978](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1978)
+では gluing data、descent、sheaf-descent 補題、sheafification comparison / gap を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent、Finite Poset regime、AATSh は後続 Issue に残る。 |
-| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
-| `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
-| `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent は後続 Issue に残る。 |
-| `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
-| `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | AAT Site、Presheaf / Sheaf、Descent、finite poset Cech regime は後続 Issue に残る。 |
-| `II.定義8.1 / 定義2.1` AAT Site と Architecture Geometry | `defined only` / `proved`. `Formal/AG/Site/Geometry.lean` が `AATSite`、`AATSite.topology`、`ArchitectureGeometry`、PRD-1 core object との accessor theorem を持つ。 | Presheaf / Sheaf、Descent、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
-| `II.定義9.1 / 定義10.1 / 定義10.2` Presheaf と sheaf condition | `defined only` / `proved`. `Formal/AG/Site/Sheaf.lean` が `AATPresheaf`、raw presheaf signature、`AATSheafCondition`、Mathlib `Presieve.IsSheaf` bridge、`AATSheaf`、`At / Law / Sig / State / Eff / Auth / Sem / Trace` の `ArchitectureSheafFamily` を持つ。 | Descent、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
+| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
+| `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | finite poset Cech regime は後続 Issue に残る。 |
+| `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | finite poset Cech regime は後続 Issue に残る。 |
+| `II.定義8.1 / 定義2.1` AAT Site と Architecture Geometry | `defined only` / `proved`. `Formal/AG/Site/Geometry.lean` が `AATSite`、`AATSite.topology`、`ArchitectureGeometry`、PRD-1 core object との accessor theorem を持つ。 | finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
+| `II.定義9.1 / 定義10.1 / 定義10.2` Presheaf と sheaf condition | `defined only` / `proved`. `Formal/AG/Site/Sheaf.lean` が `AATPresheaf`、raw presheaf signature、`AATSheafCondition`、Mathlib `Presieve.IsSheaf` bridge、`AATSheaf`、`At / Law / Sig / State / Eff / Auth / Sem / Trace` の `ArchitectureSheafFamily` を持つ。 | finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
+| `II.定義11.1 / 定義11.2 / 定義12.1` Gluing / Descent / Sheafification Gap | `defined only` / `proved`. `Formal/AG/Site/Descent.lean` が `AATLocalSectionFamily`、`AATOverlapAgreement`、`AATCocycleCondition`、`AATGluingData`、`AATDescent`、`AATSheafConditionFor.descent`、`AATSheafCondition.descent`、`AATSheaf.descent`、`AATSheafificationComparison`、`AATSheafificationGap` を持つ。 | 一般 site の sheafification 構成、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 
@@ -654,7 +657,7 @@ Issue [#1976](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.定義8.1 AAT Site` | `defined only` / `proved` |
 | `II.定義2.1 Architecture Geometry` | `defined only` / `proved` |
 | `II.定義10.1 sheaf condition bridge` | `proved` |
-| `II.定義11.1-12.1 sheaf-descent` | `future proof obligation` |
+| `II.定義11.1-12.1 sheaf-descent` | `proved` |
 | `II.命題7.2C` | `future proof obligation` |
 | `II.R11 finite model examples` | `future proof obligation` |
 


### PR DESCRIPTION
## 概要

Closes #1978

AG版AAT PRD-2 の AC12/R8 として、定義11.1 / 11.2 / 12.1 に対応する gluing data、descent、sheafification comparison / gap を `Formal/AG/Site/Descent.lean` に追加した。

設計判断:

- gluing data は Mathlib の `Presieve.FamilyOfElements` と `Compatible` を AAT 語彙で包む。
- descent は compatible local family が一意の global section から来ることとして定義する。
- sheaf-descent 補題は既存の `AATSheafConditionFor` / `AATSheafCondition` / `AATSheaf` から取り出す。
- sheafification gap は一般 sheafification 理論を新規開発せず、選ばれた canonical map `F_raw -> F_raw^+` に相対化した comparison / pointwise gap として定義する。

## 証明した定理

- `AATGluingData.cocycle`
- `AATDescent.exists_global`
- `AATSheafConditionFor.descent`
- `AATSheafCondition.descent`
- `AATSheaf.descent`
- `AATSheafificationComparison.plus_isSheaf`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Site/Descent.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
