### PR TITLE
AG版AATの後続PRDを追加

### DIFF
--- a/docs/aat/lean_ag_part_6_singularity_monodromy_stack_prd.md
+++ b/docs/aat/lean_ag_part_6_singularity_monodromy_stack_prd.md
@@ -1,0 +1,475 @@
+# AAT代数幾何版 Lean形式化 PRD-6: 第VI部 Singularity・Monodromy・Stack
+
+対象本文: [第VI部 Singularity・Monodromy・Stack](algebraic_geometric_theory/part_6_singularity_monodromy_stack.md)
+
+先行PRD:
+[PRD-1 第I部](lean_ag_part_1_atoms_objects_laws_prd.md) /
+[PRD-2 第II部](lean_ag_part_2_sites_sheaves_prd.md) /
+[PRD-3 第III部](lean_ag_part_3_law_algebra_lawful_locus_prd.md) /
+[PRD-4 第IV部](lean_ag_part_4_obstruction_cohomology_prd.md) /
+[PRD-5 第V部](lean_ag_part_5_derived_law_geometry_repair_prd.md)
+
+## 問い
+
+第V部で構成した derived law conflict と repair geometry は、どこに集中し、
+どの操作履歴で変化し、どの同型情報を保持して貼り合うのか。
+すなわち、第VI部で導入される三つの構造
+
+```text
+singularity:
+  obstruction が集中する場所。
+
+monodromy:
+  endpoint comparison では見えない経路依存 debt。
+
+stack:
+  refactor equivalence と decomposition non-uniqueness を保つ幾何。
+```
+
+を Lean 上で sorry なしに立ち上げられるか。特に、
+
+- selected obstruction class が非零になる deformation が存在すれば stratum は
+  `U`-singular であること(定理6.1 / 6.2 / 系6.5)
+- selected operation homotopy presentation に対して、transport が fundamental group へ
+  降りる条件を generator 2-cell の monodromy zero で特徴づけられること
+  (定理10.5)
+- endpoint-equivalent loop でも monodromy が非恒等なら hidden architecture debt を
+  持つこと(定理11.1)
+- refactor groupoid と invariant family が Galois connection をなすこと(定理12.4)
+- local decompositions が存在しても gerbe obstruction が非零なら global canonical
+  decomposition は存在しないこと(定理16.2)
+
+が Lean 上で機械検証できるか。
+
+採否規律: singularity / monodromy / stack の構成と、CBI 定理
+(6.1 / 6.2 / 10.5 / 10.7 / 12.4)および定理11.1・定理16.2・系6.5に寄与する
+定義・命題だけを形式化対象に採る。寄与しない要素(例、原則、標語、代表例リスト、
+God object を大きさで読む否定の自然言語説明)は対象外とする。実装中に、cotangent / Ext / stack / monodromy
+に必要な仮定が本文に不足している、または第III〜V部の形式化と接続できないことが見つかった場合、
+それは本文または本PRDの欠陥であり、ループを停止して報告する。
+
+## 中心方針
+
+PRD-1〜5 で確立した方針を引き継ぐ(塔を下から積む / 忠実性契約 /
+`Formal/AG` 新規実装 / `axiom`・`sorry` 禁止 / Mathlib 二段橋 / 台帳統合 /
+先行PRD依存の blocked 規律 / 部番号付き台帳ラベル)。
+
+本PRDで新たに加わる方針が五つある。
+
+**(1) cotangent / tangent は deformation-obstruction interface として実体化する。**
+第VI部は `L_{S/U}`、`T_{S/U}`、`Ext^i`、Kuranishi map を使うが、Illusie 型の余接複体一般論を
+このPRDで構築しない。Lean では、選ばれた stratum と law universe に対して、
+
+```text
+CotangentData
+TangentData
+DeformationObstructionTheory
+```
+
+を構造体として置き、complex、cohomology group、Ext group、obstruction map、lift/fill predicate、
+effectiveness / soundness をフィールドとして明示する。定理6.1 / 6.2 はこの interface の範囲で証明する。
+余接複体の一般構成、derived deformation theory の一般定理、`RHom` の総合的形式化は未割当の future proof obligation として台帳に残す。
+
+**(2) operation homotopy は combinatorial presentation として扱う。**
+未指定の homotopy quotient や ∞-groupoid は立てない。operation graph、homotopy generator family、
+presentation two-complex `K_H(X,U)` を一次対象とし、presented architecture fundamental group は
+edge-path free group / free groupoid を generator 2-cell の relation で quotient して定義する。
+逆向き edge は形式的逆元であり、実際の reverse architecture operation の存在を主張しない。
+
+**(3) monodromy は自動構造ではなく transport data である。**
+operation loop が obstruction / semantic / effect sheaf に作用するとは、
+coefficient transport functor または representation
+
+```text
+rho : pi_1^AAT(X,U,H,A) -> Aut(Coeff_U)
+```
+
+が与えられた場合に限る。Transport Descent Criterion は quotient group の普遍性として証明し、
+未選択の path や未構成の operation への monodromy claim は出さない。
+
+**(4) stack は groupoid-valued descent object として先に形式化し、algebraicity は predicate に分ける。**
+`ArchitectureStack` は groupoid-valued presheaf / sheaf と descent condition として定義する。
+`AlgebraicArchitectureStack` は representable diagonal、atlas、structure descent を満たす強い predicate として置く。
+Mathlib の stack / algebraic stack の一般論が不足する場合は、AAT 側のデータ構造と predicate を一次にし、
+必要な bridge theorem のみを作る。
+
+**(5) gerbe obstruction は non-abelian と banded abelian を分ける。**
+`[gerbe_U(X)] in H^2(X, Aut(Dec_U))` は一般には ordinary abelian cohomology の元ではない。
+Lean では non-abelian gerbe obstruction を abstract class として定義し、banded abelian sheaf `A` が固定された場合に限り
+PRD-4 の abelian Čech `H^2` へ橋を張る。定理16.2 は、global decomposition があれば gerbe class が zero になるという
+soundness 仮定と、concrete nonzero class を theorem 引数に取る。
+
+## 背景
+
+- PRD-5 は lawful loci の derived intersection、`LawConflict_i = Tor_i`、repair transfer、
+  Hilbert series accounting、well-founded repair を形式化対象にした。第VI部はその次段で、
+  derived obstruction が architecture geometry の中でどこに集中し、どの operation history によって
+  residue を残し、decomposition の非一意性としてどう現れるかを扱う。
+- PRD-4 は non-abelian torsor / gerbe / stack obstruction を第VI部の領分として非主張に置いていた。
+  本PRDはそのうち、groupoid-valued stack、decomposition gerbe、monodromy transport の最小構造を形式化する。
+- PRD-5 では余接複体 `L_{Flat/X}` と `Ext^1` の中身を未割当 future proof obligation とした。
+  第VI部は `L_{S/U}` と `Ext^1` を使うため、本PRDでは抽象 interface として扱い、一般構成はまだ証明対象にしない。
+- 第VII部は第VI部の singularity / monodromy を analytic representation として読むため、
+  本PRDの `SingProfile` や `MonIndex` の土台になる構造を定義する。ただし representation / metric / measurement は
+  PRD-7 / PRD-8 の範囲であり、本PRDでは構成済み geometry 内の構造に留まる。
+
+## アウトカム
+
+本PRDの完了時点で、次が成り立つ。
+
+1. architecture stratum、cotangent / tangent interface、smooth / singular predicate、normal cone reading、
+   Kuranishi data の型が Lean 上に存在する。
+2. 定理6.1 / 6.2 / 系6.5 により、selected obstruction class の非零性から singularity を結論する低次 deformation-obstruction logic が証明されている。
+3. operation category、operation path、homotopy generator family、presentation two-complex、
+   presented architecture fundamental group が構成され、Transport Descent Criterion(定理10.5)が証明されている。
+4. monodromy action、finite Gauss-Manin system、measured square monodromy、AMI が定義され、
+   square monodromy nonfillability(定理10.7)と monodromy debt theorem(定理11.1)が証明されている。
+5. refactor groupoid と operation-invariant Galois correspondence(定理12.4)が証明されている。
+6. architecture stack、algebraic architecture stack predicate、quotient stack と codebase essence、decomposition stack、
+   gerbe obstruction、No Canonical Decomposition(定理16.2)が形式化されている。
+7. 第VI部の本文ラベルと Lean 宣言の対応が両台帳で追跡できる。
+
+## 第VI部ラベルの処遇表
+
+ギャップ分析はこの表を基準に行う。
+
+| 本文ラベル | 処遇 | 備考 |
+| --- | --- | --- |
+| 定義2.1 Architecture Stratum | 定義 | `S ⊆ X` または selected subobject / locally closed subgeometry として定義(R1) |
+| 原則2.2 Stratum Relativity | 対象外 | 型パラメータとして反映 |
+| 定義3.1 Cotangent Complex | 定義(抽象 interface) | `CotangentData S U`。一般余接複体の構成は future obligation(R2) |
+| 定義3.2 Tangent Complex | 定義(抽象 interface) | `T_{S/U} = RHom(L,O)` は interface のフィールド。cohomological grading convention を docstring に記録(R2) |
+| 原則3.3 Tangent Is Not Operation List | 対象外 | 非主張に記録 |
+| 定義4.1 U-Smooth Stratum | 定義 | `DefTest_U(S)`, `LiftFill_U`, `ob_U`、effectiveness / soundness を明示(R2) |
+| 原則4.2 Smooth Does Not Mean Small | 対象外 | |
+| 定義5.1 U-Singular Stratum | 定義 | `∃ eta, ob_U eta ≠ 0` を主定義とする。`not smooth` との同値は exactness 仮定下のみ(R2) |
+| 定義5.2 Normal Cone Reading | 定義 | PRD-3 の `I_U` / `Flat_U` と接続。structural repair direction の predicate を置く(R2) |
+| 原則5.3 Singularity Is Repair Difficulty | 対象外 | |
+| 定理6.1 Architecture Singularity Criterion [CBI] | 証明 | 非零 selected obstruction class → `U`-singular(R3) |
+| 定理6.2 Square-Zero Lifting Obstruction [CBI] | 証明 | square-zero extension と obstruction class の soundness interface に相対化(R3) |
+| 定義6.3 Kuranishi Map | 定義 | `Tan`, `Obs`, `Defhat`, `kappa` のデータ構造(R3) |
+| 定理候補6.4 Kuranishi Local Model | statement のみ | local model / zero locus statement。証明しない(R3) |
+| 系6.5 Singular Boundary | 証明 | boundary stratum と `H^1(T_{B/U}) != 0` から singular boundary(R3) |
+| 定義7.1 God Object | 定義 | singular stratum + multiple law loci non-transverse。size は参照しない(R3) |
+| 原則7.2 Size Is Not Singularity | 対象外 | |
+| 定義8.1 Operation Category | 定義 | operation graph / category。selected operation family に相対化(R4) |
+| 定義8.2 Operation Path | 定義 | composable arrows / finite path(R4) |
+| 定義9.1 Refactor-Equivalent Endpoint | 定義 | endpoint equivalence relation / selected invariants preservation(R4) |
+| 定義9.2 Operation Loop | 定義 | endpoint-equivalent loop。homotopy class は R5 の presentation で扱う(R4) |
+| 定義9.3 Homotopy Generator Family | 定義 | selected 2-cell relation family(R5) |
+| 定義9.4 Presentation Two-Complex | 定義 | edge = operation、2-cell = generator relation(R5) |
+| 定義9.5 Presented Architecture Fundamental Group | 定義+証明 | free group / free groupoid quotient。relation の universal property を補題化(R5) |
+| 原則9.6 Homotopy Presentation Boundary | 対象外 | 非主張に記録 |
+| 定義10.1 Monodromy Action | 定義 | `rho : pi_1 -> Aut(Coeff_U)` と induced actions(R6) |
+| 定義10.2 Finite Gauss-Manin System | 定義 | finite operation groupoid から `Vect_k` への functor-like data(R6) |
+| 定義10.3 Monodromy Debt | 定義 | `Mon_gamma(Ob_U) != id` を debt predicate として読む(R6) |
+| 定義10.4 Measured Square Monodromy | 定義 | `mu_x(sigma)`。axis detecting equality data を含む(R6) |
+| 定理10.5 Transport Descent Criterion [CBI] | 証明 | relation boundary transport zero iff transport descends to presented group(R7) |
+| 定義10.6 Architectural Monodromy Index | 定義 | finite weighted sum。measurement は後続PRD(R6) |
+| 定理10.7 Square Monodromy Nonfillability [CBI] | 証明 | `mu_x(sigma) != 0` → selected filling refuted(R7) |
+| 定理11.1 Monodromy Debt | 証明 | endpoint-equivalent + nonidentity monodromy → hidden debt(R7) |
+| 定義12.1 Refactor Groupoid | 定義 | selected essence preserving equivalences(R8) |
+| 原則12.2 Refactor Is Equivalence, Not Equality | 対象外 | |
+| 定義12.3 Operation-Invariant Galois Data | 定義 | `Inv(G)` / `Ops(I)` as polarities(R8) |
+| 定理12.4 Operation-Invariant Galois Correspondence [CBI] | 証明 | inclusion orders で Galois connection(R8) |
+| 原則12.5 Galois Relativity | 対象外 | |
+| 定義13.1 Architecture Stack | 定義 | groupoid-valued presheaf / descent object(R9) |
+| 原則13.2 Stack Keeps Equivalences | 対象外 | |
+| 定義13.3 Algebraic Architecture Stack | 定義 | representable diagonal / atlas / descent of structure の predicate(R9) |
+| 定義14.1 Codebase Essence | 定義 | quotient stack `[X^U / Ref_U]` as action groupoid stack / predicate(R10) |
+| 原則14.2 Essence Is Not Text Identity | 対象外 | |
+| 定義15.1 Decomposition Stack | 定義 | local decomposition groupoid-valued stack(R11) |
+| 原則15.2 No Privileged Decomposition | 対象外 | 非主張に記録 |
+| 定義16.1 Gerbe Obstruction | 定義 | non-abelian gerbe class、banded abelian bridge を分離(R11) |
+| 定理16.2 No Canonical Decomposition | 証明 | nonzero gerbe class → no global canonical decomposition(R11) |
+| 原則16.3 Decomposition Failure Is Not Confusion | 対象外 | |
+| §17 Part6 の結論 | 対象外 | synthesis 文。台帳には登録しない |
+
+## 要求
+
+### R0. 前提の確認と Formal/AG/SingularityMonodromyStack の立ち上げ
+
+- 本PRDの実装は PRD-3(`Formal/AG/LawAlgebra`)、PRD-4(`Formal/AG/Cohomology`)、
+  PRD-5(`Formal/AG/Derived`)の成果物に依存する。着手時に依存宣言の存在を確認し、
+  未実装の場合は `blocked` として tracking Issue に記録する。先行PRDの実装を本PRDのループで先取りしない。
+- 第VI部のモジュールを `Formal/AG/SingularityMonodromyStack/` 以下に実装する。ファイル分割は本文の節構成に概ね対応させる。
+  例:
+  `Stratum.lean`, `CotangentInterface.lean`, `SmoothSingular.lean`,
+  `Kuranishi.lean`, `OperationCategory.lean`, `OperationHomotopy.lean`,
+  `Monodromy.lean`, `GaussManin.lean`, `RefactorGroupoid.lean`,
+  `ArchitectureStack.lean`, `QuotientStack.lean`, `DecompositionGerbe.lean`。
+- ルート import に追加し、CI の `lake build` 対象に含める。
+- PRD-5 で未割当とされた余接複体一般構成は、本PRDでは interface としてのみ扱う。
+  台帳には「interface 実装済み / general cotangent complex construction は future obligation」と明記する。
+- 完了条件: 空でない最初のモジュールが CI でビルドされ merge されている。
+
+### R1. Stratum と相対化(定義2.1)
+
+- architecture stratum `S` を、architecture scheme / geometry `X` の selected subobject、locally closed subgeometry、
+  または predicate-valued subfunctor として定義する。最初の実装では `S : Set X.Point` に decoration compatibility を添えた構造体でよい。
+- stratum の reading parameter として、Atom vocabulary、law universe、coverage topology、signature axes、coefficient structure を持たせる。
+- component / boundary / service / semantic boundary / runtime interaction などの代表例は carrier label として置けるが、実例証明は R12 に回す。
+- 完了条件: 定義が sorry なしで存在する。
+
+### R2. Cotangent / Tangent interface と smooth / singular(定義3.1、3.2、4.1、5.1、5.2)
+
+- `CotangentData(S,U)` を構造体として定義する。少なくとも次を含む。
+
+```text
+L_{S/U}:
+  selected cotangent complex object.
+
+baseMap:
+  S -> X_U or selected law-coordinate base map.
+
+pullback:
+  selected local base xi : T -> S に沿う pullback complex.
+```
+
+- `TangentData(S,U)` を定義し、`T_{S/U}`、`H^0(T_{S/U})`、`H^1(T_{S/U})`、
+  obstruction class の target を明示する。`RHom` の一般構成はフィールドとして受ける。
+- `DeformationTest_U(S)`、`LiftFill_U(eta)`、`ob_U(eta)`、effective obstruction theory
+  (`ob=0 -> LiftFill`)、soundness (`LiftFill -> ob=0` / `ob≠0 -> not LiftFill`)を構造体で定義する。
+- `USmooth(S,U)` を本文どおり `forall eta, LiftFill eta ∧ ob eta = 0` として定義する。
+  `forall eta, ob eta = 0` による smoothness criterion は effectiveness / soundness 仮定下の補題にする。
+- `USingular(S,U)` を `exists eta, ob eta != 0` として定義する。
+  `not USmooth` との同値は、selected obstruction theory の exactness 仮定がある場合に限って補題にする。
+- normal cone reading `C_{S/Flat_U}` と structural repair direction predicate
+  (`pointsTowardVanishing I_U` など)を定義する。PRD-3 の `Flat_U` / `I_U` を再利用する。
+- 完了条件: 定義群と smoothness criterion / singular-not-smooth 条件付き補題が sorry なしで存在する。
+
+### R3. Singularity 定理群・Kuranishi・God Object(定理6.1、6.2、定義6.3、定理候補6.4、系6.5、定義7.1)
+
+- 定理6.1を証明する: selected first-order deformation `eta` について `ob_U(eta) != 0` なら、
+  定義5.1により `S` は `U`-singular である。`H^1(T_{S/U})` が obstruction target を計算する仮定は theorem 引数に明示する。
+- 定理6.2を証明する: square-zero extension data、pullback cotangent complex、obstruction class、
+  soundness field `ob_T(xi) != 0 -> not Lift` の下で、nonzero obstruction が lift failure を与える。
+  `ob=0` の lift torsor / automorphism statement は effectiveness 仮定下の補題に分ける。
+- Kuranishi data を定義する。
+
+```text
+Tan_{S,p}
+Obs_{S,p}
+Defhat_{S,p}
+kappa_{S,p} : Defhat -> Obs
+```
+
+- 定理候補6.4を statement として形式化する。`lawful deformation germ = zero locus of kappa` と
+  `kappa(v) != 0 -> v does not lift` を Prop としてコンパイル可能にする。証明はしない。
+- 系6.5を証明する: boundary stratum `B` について、selected obstruction class family に `H^1(T_{B/U})` の
+  nonzero class が与えられれば `B` は `U`-singular boundary` である。
+- God object を `USingular(S,U)` と multiple law loci non-transverse predicate(PRD-5 の `NonTransverse`)の組として定義する。
+- 完了条件: 定理6.1 / 6.2 / 系6.5 が sorry なしで証明され、定理候補6.4 が statement としてコンパイルされている。
+
+### R4. Operation Category・Path・Endpoint Equivalence(定義8.1、8.2、9.1、9.2)
+
+- selected architecture states / sections を object、selected operation を morphism とする `Op_U(X)` を定義する。
+  Mathlib `Category` に載せられる場合は bridge instance を作る。難しい場合はまず finite operation graph と composable path を一次にする。
+- operation path を finite list of composable operations として定義し、identity path、path concatenation、associativity 補題を証明する。
+- refactor-equivalent endpoint `A ~_ref B` を、selected invariant / essence preservation predicate に相対化して定義する。
+- operation loop を `gamma : A -> A'` と `A' ~_ref A` の組として定義する。
+- 完了条件: 定義と path concatenation 補題が sorry なしで存在する。
+
+### R5. Operation Homotopy Presentation と `pi_1^AAT`(定義9.3–9.5)
+
+- homotopy generator family `H_U(X)` を、operation path pairs / loop relators の finite family として定義する。
+- presentation two-complex `K_H(X,U)` を、vertices = architecture states、edges = selected operations、
+  2-cells = homotopy generators として定義する。
+- presented architecture fundamental groupを、base state `A` を固定した edge-path free group / free groupoid の quotient として定義する。
+  Mathlib の `FreeGroup`、`PresentedGroup`、または quotient group API を橋として使う。
+- quotient universal property を補題として証明する: free transport が relators を identity へ送る iff quotient group への homomorphism に因子化する。
+- edge の形式的逆元は operation の逆操作を主張しないことを docstring に記録する。
+- 完了条件: `pi_1^AAT(X,U,H,A)` と universal property 補題が sorry なしで存在する。
+
+### R6. Monodromy Action・Gauss-Manin・Measured Square(定義10.1–10.4、10.6)
+
+- coefficient object `Coeff_U` と automorphism group `Aut(Coeff_U)` を定義する。
+  obstruction / semantic / effect sheaf への product action は、必要なら product group として扱う。
+- monodromy representation
+
+```text
+rho_{U,H,A} : pi_1^AAT(X,U,H,A) -> Aut(Coeff_U)
+```
+
+を定義し、`Mon_gamma` を評価として定義する。
+- finite Gauss-Manin system を、finite operation groupoid から finite-dimensional `k`-vector spaces への functor-like data として定義する。
+  `GM_id = id`、`GM_{β ∘ α} = GM_β ∘ GM_α` をフィールドにする。
+- monodromy debt predicate `Mon_gamma(Ob_U) != id` を定義する。
+- measured square monodromy `mu_x(sigma)` を、boundary loop transport と selected axis equality-defect reading から定義する。
+- AMI を finite measured square family と positive weights の weighted sum として定義する。
+  `DistanceValue` / measurement verdict への接続は PRD-8 に回す。
+- 完了条件: 定義群と basic functoriality 補題が sorry なしで存在する。
+
+### R7. Transport Descent・Square Nonfillability・Monodromy Debt(定理10.5、10.7、11.1)
+
+- 定理10.5を証明する: R5 の quotient universal property を使い、edge transport が relation boundary を
+  selected detecting axes ですべて zero にする iff `pi_1^AAT` への representation に降りる。
+  detecting axis family が equality-reflecting であることを theorem 引数に明示する。
+- 定理10.7を証明する: selected axis `x` が transport equality を検出し、`mu_x(sigma) != 0` なら、
+  `sigma` の boundary loop は selected x-axis filling として読めない。
+- 定理11.1を証明する: endpoint-equivalent loop、monodromy action defined、`Mon_gamma(Ob_U) != id` の下で、
+  hidden architecture debt predicate が成立する。debt predicate が nonidentity monodromy を含むように定義されていることを明示する。
+- 完了条件: 定理10.5 / 10.7 / 11.1 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R8. Refactor Groupoid と Galois Correspondence(定義12.1、12.3、定理12.4)
+
+- refactor groupoid `Ref_U(X)` を定義する。対象は selected essence を持つ architecture objects / schemes、
+  射は selected invariants を保存する refactor equivalence とする。
+- groupoid laws(identity / inverse / composition)を構造体フィールドとして持たせ、Mathlib `Groupoid` へ bridge できる場合は instance を作る。
+- `SubGpd(Ref_U(X))`、`InvFam_U(X)`、operation family が保存する invariant `Inv(G)`、
+  invariant family を保存する operation `Ops(I)` を定義する。
+- 定理12.4を証明する: preservation relation `Preserves(g, i)` に対して、
+
+```text
+Inv(G) = { i | forall g in G, Preserves(g,i) }
+Ops(I) = { g | forall i in I, Preserves(g,i) }
+```
+
+と定義すると、inclusion order 上で
+
+```text
+G <= Ops(I) iff I <= Inv(G)
+```
+
+が成り立つ。Mathlib `GaloisConnection` への bridge theorem を作る。
+- 完了条件: 定理12.4 が sorry なしで証明されている。
+
+### R9. Architecture Stack と Algebraic Architecture Stack predicate(定義13.1、13.3)
+
+- base category `AATBase` を固定し、groupoid-valued presheaf
+
+```text
+Arch_U : AATBase^op -> Groupoids
+```
+
+を定義する。
+- local objects、overlap isomorphisms、cocycle condition、effective descent をまとめた `ArchitectureStack` predicate を定義する。
+- `AlgebraicArchitectureStack` を、以下の predicate を持つ強い構造として定義する。
+
+```text
+representable diagonal
+atlas from an ArchitectureScheme
+descent of obstruction ideals / law sheaves / signature sheaves / structure sheaves
+```
+
+- algebraic stack の一般理論は開発せず、representability / atlas / descent of structure はデータと仮定として明示する。
+- 完了条件: 定義と descent predicate が sorry なしで存在する。
+
+### R10. Codebase Essence as Quotient Stack(定義14.1)
+
+- refactor groupoid object `Ref_U ⇉ X^U` の action data を定義する。
+
+```text
+source, target
+identity
+inverse
+composition
+action compatibility with law / obstruction / signature / structure sheaf
+```
+
+- quotient stack / action groupoid stack `[X^U / Ref_U]` を `Ess_U(X)` として定義する。
+  Mathlib の quotient stack 一般論に依存しない場合は、action groupoid の groupoid-valued presheaf と descent predicate として置く。
+- `Ess_U(X)` が text identity や graph isomorphism ではなく、selected geometry modulo refactor equivalence であることを docstring に記録する。
+- 完了条件: 定義が sorry なしで存在する。
+
+### R11. Decomposition Stack・Gerbe・No Canonical Decomposition(定義15.1、16.1、定理16.2)
+
+- decomposition stack `Dec_U(X)` を、local context `W` に admissible decomposition groupoid を返す groupoid-valued stack として定義する。
+- decomposition equivalence(refactor equivalence / semantic equivalence / boundary-preserving equivalence)を groupoid の射として保持する。
+- gerbe obstruction を定義する。
+  - non-abelian gerbe class: abstract pointed obstruction type / nonzero predicate。
+  - banded abelian gerbe: abelian sheaf `A` と PRD-4 の `H^2(X,A)` への bridge。
+- `globalCanonicalDecomposition` と `localDecompositionsExist` を定義し、
+  `globalCanonicalDecomposition -> gerbeClass = 0` を soundness hypothesis として明示する。
+- 定理16.2を証明する: local decompositions、`Aut(Dec_U)`、gerbe class、soundness、`[gerbe_U(X)] != 0` の下で、
+  global canonical decomposition は存在しない。
+- 完了条件: 定理16.2 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R12. 有限モデルの拡張
+
+- PRD-1〜5 の有限モデル(`Formal/AG/Examples/`)を第VI部の水準へ拡張する。
+  (a) singular boundary toy model: boundary stratum `B` と selected obstruction class を構成し、系6.5 を example theorem として検証する。
+  (b) operation square toy model: commuting square と nonzero `mu_x` を持つ square を構成し、定理10.7 により filling refutation を検証する。
+  (c) transport descent toy model: relator の boundary transport が zero の場合に representation が quotient へ降りること、
+      nonzero の場合に降りないことを example theorem として検証する。
+  (d) refactor Galois toy model: 2〜3個の operation と invariant から Galois connection を計算する。
+  (e) decomposition gerbe toy model: local decompositions は存在するが selected obstruction class が nonzero で global canonical decomposition が存在しない例を検証する。
+- これらは第VII部の singularity profile / monodromy index の golden examples として再利用できる形を保つ。
+- 完了条件: (a)–(e) が sorry なしで存在する。
+
+### R13. 台帳整備
+
+- `lean_theorem_index.md` の AG 節に第VI部の宣言を追加する(本文ラベル列は `VI.` 付き)。
+- `proof_obligations.md` に第VI部の証明対象ラベル(定理6.1、6.2、系6.5、定理10.5、10.7、11.1、12.4、16.2、
+  Kuranishi Local Model statement、example theorem 群)を登録し、進行に応じて status を更新する。
+- `CotangentComplexGeneralConstruction`、`RHomGeneralConstruction`、`AlgebraicStackGeneralTheory`、
+  `NonAbelianGerbeCohomologyGeneralTheory` を未割当の future proof obligation として明記する。
+- 処遇表で「対象外」のラベルは台帳に登録しない。
+- 完了条件: 両台帳が最終実装と一致している。
+
+## 非主張(claim boundary)
+
+- 本PRDは余接複体の一般構成、`RHom` の一般構成、Ext の一般的導来関手理論を形式化しない。
+  `L_{S/U}`、`T_{S/U}`、`Ext^i` は selected deformation-obstruction interface に相対化される。
+- Kuranishi Local Model(定理候補6.4)は statement のみであり、本PRDの完了は Kuranishi 理論の一般証明を含まない。
+- `H^1(T_{S/U}) != 0` は obstruction space が非自明であること、または selected obstruction class の存在可能性を読む。
+  すべての deformation が obstructed であるとは主張しない。
+- God object は大きさ、line count、method count、dependency count では定義しない。
+  それらは representation / metric reading になりうるが、singularity そのものではない。
+- `pi_1^AAT(X,U,H,A)` は選ばれた operation graph と homotopy generator family に相対化される。
+  未選択の operation、未選択の semantic equivalence、未構成の path は含まない。
+  形式的逆元は reverse architecture operation の存在を主張しない。
+- monodromy は AAT geometry が自動的に持つ構造ではない。coefficient transport / representation が与えられた場合だけ定義される。
+- `AMI_x` は measured square family に対する analytic / measurement-facing reading であり、measurement verdict は PRD-8 の範囲である。
+- `ArchitectureStack` は groupoid-valued descent object であり、`AlgebraicArchitectureStack` と呼ぶには representable diagonal / atlas / descent of structure を別途仮定する。
+  本PRDは algebraic stack 一般論を構築しない。
+- non-abelian gerbe obstruction は ordinary abelian cohomology class ではない。
+  banded abelian sheaf が固定された場合に限り、PRD-4 の abelian `H^2` へ橋を張る。
+- No Canonical Decomposition は、選ばれた `U`、coverage、decomposition stack、gerbe obstruction に相対化される。
+  すべての decomposition notion について唯一分解がないとは主張しない。
+- 第VII部の representation / period / metric / analysis、第VIII部の measurement verdict、第IX部の temporal evolution は扱わない。
+
+## 完了条件(Acceptance Criteria)
+
+- [ ] AC1. `Formal/AG/SingularityMonodromyStack` が新設され、CI の `lake build` でビルドされる。
+      先行PRD依存の blocked 判定が運用されている(R0)
+- [ ] AC2. Architecture stratum と reading parameter が形式化されている(R1)
+- [ ] AC3. Cotangent / tangent deformation-obstruction interface が形式化され、smooth / singular / normal cone reading が定義されている(R2)
+- [ ] AC4. smoothness criterion と singular-not-smooth 条件付き補題が sorry なしで証明されている(R2)
+- [ ] AC5. 定理6.1 Architecture Singularity Criterion が sorry なしで証明されている(R3)
+- [ ] AC6. 定理6.2 Square-Zero Lifting Obstruction が sorry なしで証明されている(R3)
+- [ ] AC7. Kuranishi data が定義され、定理候補6.4 が statement としてコンパイルされている(R3)
+- [ ] AC8. 系6.5 Singular Boundary と GodObject 定義が形式化されている(R3)
+- [ ] AC9. Operation category / path / endpoint equivalence / operation loop が形式化されている(R4)
+- [ ] AC10. Homotopy generator family、presentation two-complex、`pi_1^AAT`、quotient universal property が形式化されている(R5)
+- [ ] AC11. Monodromy action、finite Gauss-Manin system、measured square monodromy、AMI が形式化されている(R6)
+- [ ] AC12. 定理10.5 Transport Descent Criterion が sorry なしで証明されている(R7)
+- [ ] AC13. 定理10.7 Square Monodromy Nonfillability が sorry なしで証明されている(R7)
+- [ ] AC14. 定理11.1 Monodromy Debt が sorry なしで証明されている(R7)
+- [ ] AC15. Refactor groupoid と定理12.4 Operation-Invariant Galois Correspondence が sorry なしで証明されている(R8)
+- [ ] AC16. Architecture stack と AlgebraicArchitectureStack predicate が形式化されている(R9)
+- [ ] AC17. Codebase essence `Ess_U(X) = [X^U / Ref_U]` が形式化されている(R10)
+- [ ] AC18. Decomposition stack、gerbe obstruction、banded abelian bridge が形式化されている(R11)
+- [ ] AC19. 定理16.2 No Canonical Decomposition が sorry なしで証明されている(R11)
+- [ ] AC20. 有限モデル拡張((a) singular boundary、(b) square monodromy、(c) transport descent、
+      (d) refactor Galois、(e) decomposition gerbe)が検証されている(R12)
+- [ ] AC21. `Formal/AG` 全体に `axiom` / `admit` / `sorry` / `unsafe` が存在しない
+- [ ] AC22. `lean_theorem_index.md` の AG 節が第VI部の宣言を `VI.` 付き本文ラベルで含み、最終実装と一致している(R13)
+- [ ] AC23. `proof_obligations.md` に第VI部の証明対象ラベルが登録され、証明済み分が `proved`、
+      Kuranishi Local Model と一般余接複体 / stack / gerbe 理論が future proof obligation として明記されている(R13)
+
+## 実行順序の指針
+
+prd-loop のギャップ分析で対象を選ぶ際は、次の依存順を推奨する。
+
+```text
+R0 -> R1 -> R2 -> R3
+   -> R4 -> R5 -> R6 -> R7
+   -> R8 -> R9 -> R10 -> R11
+   -> R12 -> R13
+```
+
+R8(refactor Galois)は集合・順序論に近いため、R4〜R7の monodromy 実装を待たずに並行着手できる。
+R9〜R11(stack / gerbe)も、最初は groupoid-valued presheaf と abstract gerbe class で閉じられるため、
+operation homotopy 実装と並行可能である。R3 の Kuranishi statement は、R2 の deformation-obstruction interface が固まった時点で
+早めに台帳へ登録する。R12 の有限モデルは各ブロックが閉じるたびに増分追加してよい。

--- a/docs/aat/lean_ag_part_7_representation_periods_analysis_prd.md
+++ b/docs/aat/lean_ag_part_7_representation_periods_analysis_prd.md
@@ -1,0 +1,530 @@
+# AAT代数幾何版 Lean形式化 PRD-7: 第VII部 Representation・Periods・Analysis
+
+対象本文: [第VII部 Representation・Periods・Analysis](algebraic_geometric_theory/part_7_representation_periods_analysis.md)
+
+先行PRD:
+[PRD-1 第I部](lean_ag_part_1_atoms_objects_laws_prd.md) /
+[PRD-2 第II部](lean_ag_part_2_sites_sheaves_prd.md) /
+[PRD-3 第III部](lean_ag_part_3_law_algebra_lawful_locus_prd.md) /
+[PRD-4 第IV部](lean_ag_part_4_obstruction_cohomology_prd.md) /
+[PRD-5 第V部](lean_ag_part_5_derived_law_geometry_repair_prd.md) /
+[PRD-6 第VI部](lean_ag_part_6_singularity_monodromy_stack_prd.md)
+
+## 問い
+
+第I部から第VI部までで構成した architecture geometry は、どのように読める対象になるか。
+すなわち、構成済みの幾何
+
+```text
+ArchitectureScheme
+  -> LawfulLocus
+  -> ObstructionCohomology
+  -> DerivedLawGeometry
+  -> Singularity / Monodromy / Stack
+```
+
+の上に、次の reading layer を Lean 上で sorry なしに立ち上げられるか。
+
+```text
+architecture geometry
+  -> representation family
+  -> period family
+  -> metric enrichment
+  -> bounded analytic interpretation
+```
+
+特に、
+
+- graph / matrix representation が selected relation data を正しく読むこと
+  (命題3.4 / 3.6)
+- broad period と strict period を分離し、strict period は cohomology class、cycle、
+  trace map、period target を固定した pairing としてだけ定義すること
+  (定義5.2 / 5.2A / 例5.2B)
+- 同じ graph reading を持っても semantic / effect reading が分離しうること
+  (定理6.1 / 例6.2)
+- metric enrichment は lawfulness を定義せず、距離・mass・repair cost を bounded reading として扱うこと
+  (定義8.1〜12.8)
+- margin と observation gap の下界が、固定された metric / Lipschitz profile の中で証明できること
+  (定理12.5 / 12.7)
+- representation family が detecting / adequacy / exactness を満たすときだけ、
+  selected obstruction の消滅を反映できること
+  (定理15.4)
+
+が機械検証できるか。
+
+採否規律: representation / period / metric / bounded analytic interpretation の構成と、
+CBI 命題・定理(3.4 / 3.6 / 12.5 / 12.7)、定理6.1、定理15.4、定理16.1に寄与する
+定義・命題だけを形式化対象に採る。寄与しない要素(例、原則、標語、代表 reading の自然言語リスト)は対象外とする。
+実装中に、representation reflection、period pairing、metric bound、conservativity に必要な仮定が本文に不足している、
+または第III〜VI部の形式化と接続できないことが見つかった場合、それは本文または本PRDの欠陥であり、
+ループを停止して報告する。
+
+## 中心方針
+
+PRD-1〜6 で確立した方針を引き継ぐ(塔を下から積む / 忠実性契約 /
+`Formal/AG` 新規実装 / `axiom`・`sorry` 禁止 / Mathlib 二段橋 / 台帳統合 /
+先行PRD依存の blocked 規律 / 部番号付き台帳ラベル)。
+
+本PRDで新たに加わる方針が五つある。
+
+**(1) representation は functor / reading interface として扱う。**
+第VII部は graph、matrix、signature、curvature、state、trace、semantic、effect などの target を使うが、
+各 target の大規模理論を新規構築しない。Lean では、まず
+
+```text
+AATSch_p
+AnalyticRepresentation p Target
+RepresentationFamily p
+```
+
+を定義し、target 側は必要な構造だけを持つ interface とする。
+Graph は finite directed graph、Matrix は Mathlib `Matrix`、Signature / Curvature / Trace / Semantic / Effect は
+carrier と zero / equality / preservation predicate を持つ読みとして始める。
+
+**(2) broad period と strict period を型で分ける。**
+`Read_R(X) = R(X)` は broad period として扱えるが、strict period は scalar value ではない。
+strict period には、cohomology class、homology model、cycle、period target `Λ`、係数評価 `tr_U` または `epsilon` が必要である。
+この data を持たない expression は Lean 上で strict period として型が付かないようにする。
+
+**(3) finite poset / Čech homology は PRD-4 の Stokes accounting と接続する。**
+第VII部の strict period は、標準 realization がない場合に finite context poset の order complex、
+または chosen cover の Čech nerve を homology model として使う。
+PRD-4 の cochain-chain pairing / Stokes identity を再利用し、ここでは homology model と period pairing の interface を整備する。
+一般の singular homology や analytic realization の理論は新規開発しない。
+
+**(4) metric は enrichment であり、lawfulness とは別物として実装する。**
+`DistanceValue` は measured zero、unmeasured、unavailable、incomparable、infinite を区別する enriched value object として定義する。
+`dist_flat_U(A)`、`Mass_U(A)`、repair cost は analytic reading であり、`s^* I_U = 0` や `Flat_U` への factorization を置き換えない。
+aggregation が `unmeasured` を `0` に潰さないことを型と predicate で反映する。
+
+**(5) reflection / conservativity は detecting profile と adequacy の下でだけ証明する。**
+representation は原則として reading であり、構造を自動的に反映しない。
+`UDetecting(Rep, Obs_U)`、`U`-adequate cover、witness exactness、axis exactness、coefficient discipline を theorem 引数に明示した場合に限り、
+定理15.4として selected obstruction vanishing を結論する。
+単一 graph、単一 metric、単一 scalar score の完全性は主張しない。
+
+## 背景
+
+- PRD-6 は singularity、monodromy、stack を形式化対象にし、operation history と decomposition non-uniqueness を保持する構造を導入した。
+  第VII部はそれらを analytic representation、singularity profile、monodromy index として読む層である。
+- PRD-4 は Čech cohomology、boundary holonomy、period Stokes identity を形式化対象にした。
+  第VII部の strict period は、PRD-4 の cochain-chain pairing と finite Čech nerve を読みの土台として再利用する。
+- PRD-5 は derived conflict、transfer pairing、Hilbert series accounting、repair route を形式化対象にした。
+  第VII部の repair cost、normal cone / derived conflict / monodromy を含む stable repair reading は、PRD-5 / PRD-6 の構造に依存する。
+- 第VIII部は measurement profile、verdict discipline、finite computability を扱う。
+  本PRDは measurement そのものではなく、measurement に渡す representation / period / metric / analytic reading の型を整える。
+
+## アウトカム
+
+本PRDの完了時点で、次が成り立つ。
+
+1. `AATSch_p`、analytic representation、representation family、preservation / reflection / conservative / faithful predicate が Lean 上に存在する。
+2. graph representation と matrix representation が定義され、acyclicity preservation(命題3.4)と matrix walk reading(命題3.6)が証明されている。
+3. representation reading、broad period、strict period、finite poset / Čech homology model、period family が形式化され、擬円周 strict period の計算が example theorem として検証されている。
+4. Period Separation(定理6.1)が、同一 graph reading だが semantic / effect reading が異なる有限例で証明されている。
+5. signature / curvature reading が、第I部の signature、第III部の lawful locus、第IV部の obstruction class、第V部の law conflict に接続されている。
+6. Metric AAT、DistanceValue、operation distance、distance to flatness、obstruction measure / mass、repair route、margin、architectural Dehn function、bi-Lipschitz representation が Lean 上に存在する。
+7. Margin Stability(定理12.5)と Observation Gap Lower Bound(定理12.7)が、仮定を明示した theorem として証明されている。
+8. SingularityProfile と MonodromyIndex が、PRD-6 の singularity / monodromy data を analytic reading として束ねる構造として存在する。
+9. `U`-detecting representation family と Representation Conservativity under Adequacy(定理15.4)が証明されている。
+10. Algebraic-Geometric AAT Synthesis(定理16.1)が、PRD-1〜7 の構成済み tower と reading layer を束ねる theorem package として存在する。
+11. 第VII部の本文ラベルと Lean 宣言の対応が両台帳で追跡できる。
+
+## 第VII部ラベルの処遇表
+
+ギャップ分析はこの表を基準に行う。
+
+| 本文ラベル | 処遇 | 備考 |
+| --- | --- | --- |
+| 定義2.1 Analytic Representation | 定義 | `R : AATSch_p -> Target`。AAT decoration preservation 付き射の圏を PRD-3/6 から受ける(R1) |
+| 原則2.2 Representation Is a Reading | 対象外 | 相対化は reading parameter と representation profile の型で反映 |
+| 定義3.1 Representation Family | 定義 | functor family / indexed family として定義(R2) |
+| 例3.2 Main Representations | 対象外 | 代表 target は R2/R3/R6 で必要分だけ interface 化 |
+| 定義3.3 Graph Representation | 定義 | selected relation data から finite directed graph への functor / reading(R3) |
+| 命題3.4 Acyclicity Preservation [CBI] | 証明 | cycle witness exactness + structural dependency obstruction zero → selected graph acyclic(R3) |
+| 定義3.5 Matrix Representation | 定義 | finite graph の adjacency / incidence / transition matrix(R3) |
+| 命題3.6 Matrix Walk Reading [CBI] | 証明 | `(A^n)_{ij}` が length `n` walk count。DAG ならある `N` で `A^N = 0`(R3) |
+| 原則3.7 Graph / Matrix Boundary | 対象外 | 非主張に記録 |
+| 定義4.1 Preservation Properties | 定義 | `ZeroPreserving`, `ObstructionPreserving`(R2) |
+| 定義4.2 Reflection Properties | 定義 | `ZeroReflecting`, `ObstructionReflecting`。仮定付き predicate として定義(R2) |
+| 定義4.3 Conservative and Faithful | 定義 | selected iso / zero / obstruction / morphism に相対化(R2) |
+| 定義5.1 Representation Reading | 定義 | `Read_R(X) = R(X)` と broad period alias(R4) |
+| 定義5.2 Strict Period | 定義 | cohomology class、cycle、period target、trace map / coefficient evaluation が必要(R4) |
+| 定義5.2A Finite Poset / Čech Homology Model | 定義+証明 | order complex / Čech nerve chain complex、`∂²=0`、pairing well-definedness(R4) |
+| 例5.2B 擬円周 Strict Period | 例 theorem | `gamma = e_sync - e_async`、`<omega,gamma> = r_sync-r_async`(R13) |
+| 定義5.3 Period Family | 定義 | representation readings の family(R4) |
+| 定理6.1 Period Separation | 証明 | 同一 graph broad period でも semantic / effect broad period が異なる有限例で証明(R5) |
+| 例6.2 Same Graph, Different Semantic / Effect Reading | 例 theorem | R5/R13 の有限例として実装 |
+| 定義7.1 Signature Reading | 定義 | PRD-1 の selected signature axes と接続(R6) |
+| 定義7.2 Curvature Reading | 定義+証明 | obstruction valuation の representation。exactness 下の zero curvature → lawful factorization 補題(R6) |
+| 原則7.3 Curvature as Reading | 対象外 | 非主張に記録 |
+| 定義8.1 Metric AAT | 定義 | geometry + metric enrichment data(R7) |
+| 原則8.2 Metric Discipline | 対象外 | 非主張に記録 |
+| 定義9.1 Distance Value | 定義 | measured / zero / unmeasured / unavailable / incomparable / infinite を区別(R7) |
+| 原則9.2 Aggregation Discipline | 定義+証明 | aggregation profile を定義し、unmeasured が zero に潰れない補題を証明(R7) |
+| 定義10.1 Operation Distance | 定義 | operation path cost / path length / filling cost からの interface(R8) |
+| 定義10.2 Distance to Flatness | 定義 | `inf { d_op(A,F) | F in Flat_U(X) }`。infimum は cost domain 仮定(R8) |
+| 原則10.3 Near Flat Is Not Flat | 対象外 | 非主張に記録 |
+| 定義11.1 Obstruction Measure | 定義 | `Ob_U` または `I_U` への measure reading(R8) |
+| 定義11.2 Obstruction Mass | 定義 | selected support / integral interface として定義(R8) |
+| 原則11.3 Mass Is Support-Relative | 対象外 | 非主張に記録 |
+| 定義12.1 Repair Route | 定義 | `A -> Flat_U` へ向かう operation path family(R9) |
+| 定義12.2 Repair Profiles | 定義 | shortest / safest / structural / stable repair predicate(R9) |
+| 原則12.3 Shortest Need Not Be Best | 対象外 | 非主張に記録 |
+| 定義12.4 Margin | 定義 | selected safe region と unsafe boundary までの距離(R9) |
+| 定理12.5 Margin Stability [CBI] | 証明 | triangle inequality による safe region 不脱出(R9) |
+| 定義12.6 Architectural Dehn Function | 定義 | PRD-6 の `K_H` と filling area reading に相対化(R9) |
+| 定理12.7 Observation Gap Lower Bound [CBI] | 証明 | Lipschitz observation gap → filling cost 下界(R9) |
+| 定義12.8 Bi-Lipschitz Representation | 定義 | selected comparable state pair に相対化(R9) |
+| 定義13.1 Singularity Profile | 定義 | PRD-6 の tangent / normal cone / lifting failure / derived conflict を reading として束ねる(R10) |
+| 定義13.2 Monodromy Index | 定義 | PRD-6 の monodromy action / period change / residue を bounded reading として束ねる(R10) |
+| 定義14.1 Analytic Reading Context | 定義 | reading parameter package(R11) |
+| 原則14.2 Read Within the Chosen Geometry | 対象外 | 非主張に記録 |
+| 定義15.1 Completeness Spectrum | 定義 | reading / preserving / reflecting / conservative / faithful / complete-for-purpose の段階(R11) |
+| 原則15.2 Choose a Representation Family | 対象外 | 非主張に記録 |
+| 定義15.3 U-Detecting Representation Family | 定義 | selected obstruction family の readings vanishing が witness zero を検出(R11) |
+| 定理15.4 Representation Conservativity under Adequacy | 証明 | detecting + adequacy + witness / axis exactness + coefficient discipline → selected obstruction vanishes(R11) |
+| 定理16.1 Algebraic-Geometric AAT Synthesis | 証明 | PRD-1〜7 の tower と reading layer を束ねる theorem package(R12) |
+| 原則16.2 Geometry Becomes Readable | 対象外 | synthesis 文。非主張と docstring に反映 |
+
+## 要求
+
+### R0. 前提の確認と Formal/AG/RepresentationAnalysis の立ち上げ
+
+- 本PRDの実装は PRD-3(`Formal/AG/LawAlgebra`)、PRD-4(`Formal/AG/Cohomology`)、
+  PRD-5(`Formal/AG/Derived`)、PRD-6(`Formal/AG/SingularityMonodromyStack`)の成果物に依存する。
+  着手時に依存宣言の存在を確認し、未実装の場合は `blocked` として tracking Issue に記録する。
+  先行PRDの実装を本PRDのループで先取りしない。
+- 第VII部のモジュールを `Formal/AG/RepresentationAnalysis/` 以下に実装する。
+  ファイル分割は本文の節構成に概ね対応させる。例:
+  `AATSch.lean`, `Representation.lean`, `GraphMatrix.lean`, `PreservationReflection.lean`,
+  `Period.lean`, `FiniteHomology.lean`, `PeriodSeparation.lean`, `SignatureCurvature.lean`,
+  `Metric.lean`, `Distance.lean`, `Mass.lean`, `RepairCost.lean`, `SingularityMonodromyReading.lean`,
+  `AnalyticContext.lean`, `Conservativity.lean`, `Synthesis.lean`。
+- ルート import に追加し、CI の `lake build` 対象に含める。
+- PRD-8 で扱う measurement verdict は導入しない。第VII部は measurement に渡す reading layer までに留める。
+- 完了条件: 空でない最初のモジュールが CI でビルドされ merge されている。
+
+### R1. AATSch と Analytic Representation(定義2.1)
+
+- fixed reading parameter `p` を持つ decorated architecture scheme の圏 `AATSch p` を定義する。
+  対象は PRD-3 の architecture scheme / `Spec_AAT` chart に decoration を付けたもの、射は underlying scheme morphism と
+  typed Atom labels、law reading、obstruction ideal、signature reading、interpretation map の compatibility data からなる。
+- fiber product は、underlying 側で存在し decoration pullback が整合する場合の optional structure として定義する。
+- analytic representation を functor-like data として定義する。
+
+```text
+AnalyticRepresentation p Target
+  := AATSch p -> Target
+     + morphism action
+     + identity / composition law
+```
+
+- Mathlib `CategoryTheory.Functor` に橋を張れる場合は bridge theorem / instance を作る。
+  難しい場合は functor-like structure を一次対象にして、identity / composition law をフィールドに持たせる。
+- 完了条件: `AATSch p` と `AnalyticRepresentation` が sorry なしで存在する。
+
+### R2. Representation Family と preservation / reflection(定義3.1、4.1–4.3)
+
+- representation family を indexed family として定義する。
+
+```text
+RepresentationFamily p
+  := index type I
+     + target family Target i
+     + representation R_i : AnalyticRepresentation p (Target i)
+```
+
+- `Read_R(X)`、selected zero、selected obstruction、selected isomorphism、selected morphism equality に対する
+  preservation / reflection predicate を定義する。
+- `Conservative(R)` と `Faithful(R)` を、選ばれた structural notion に相対化して定義する。
+- reflection は、coverage、witness completeness、axis exactness、coefficient discipline などの assumption package を引数に取る predicate として設計する。
+- 完了条件: 定義群が sorry なしで存在する。
+
+### R3. Graph / Matrix Representation と命題3.4・3.6
+
+- finite directed graph target を定義する。頂点、辺、source / target、selected relation label を持つ構造体でよい。
+- graph representation `R_graph` を、selected relation data と graph profile に相対化して定義する。
+- cycle witness exactness を定義する。
+
+```text
+cycle witness exactness:
+  graph cycle exists iff selected cycle obstruction witness exists
+```
+
+  または、定理3.4に必要な片方向を theorem 引数として明示する。
+- 命題3.4を証明する: dependency-axis graph reading が選択され、cycle witness exactness があり、
+  structural dependency obstruction が zero なら、`R_graph(X)` は acyclic である。
+- finite graph の adjacency matrix `A_X` を Mathlib `Matrix` で定義する。
+- 命題3.6を証明する: `(A_X^n) i j` が length `n` walk count を読む。
+  DAG の場合、有限頂点数 `N = card V` などを用いて `A_X^N = 0` を証明する。
+- 完了条件: 命題3.4 / 3.6 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R4. Period Reading・Strict Period・Finite Homology(定義5.1–5.3、5.2A)
+
+- `Read_R(X)` と broad period alias を定義する。broad period convention が固定された場合だけ `Period_R(X)` と略記できるよう、
+  convention structure を持たせる。
+- strict period data を定義する。
+
+```text
+StrictPeriodData:
+  coefficient object Ob_U
+  class omega in H^n(..., Ob_U)
+  homology model H_n
+  cycle gamma
+  additive target Lambda
+  trace / evaluation tr_U or epsilon
+  compatibility with boundary / coboundary
+```
+
+- strict obstruction period `Per_{omega,gamma}^{tr_U}` を、cohomology class と homology class の pairing として定義する。
+- finite context poset の order complex、finite cover の Čech nerve、chain complex、boundary mapを定義し、`∂ ∘ ∂ = 0` を証明する。
+- PRD-4 の cochain-chain pairing と整合する finite Čech pairing を定義し、cocycle / cycle / coefficient compatibility の下で代表元の取り替えに不変であることを補題として証明する。
+- period family `Per(X) = { Read_R(X) | R in Rep }` を定義する。
+- 完了条件: 定義群、`∂²=0`、strict period well-definedness 補題が sorry なしで存在する。
+
+### R5. Period Separation(定理6.1、例6.2)
+
+- graph / semantic / effect target を持つ小さな representation family を構成する。
+- 同一 graph reading を持つ `X`、`Y` を構成し、semantic reading または effect reading が異なることを example theorem として証明する。
+- 定理6.1を証明する: ある representation では同じ broad period / reading を持ち、別の representation では異なる broad period / reading を持つ architecture geometries が存在する。
+- 証明は例6.2の有限 model を witness とする。
+- 完了条件: 定理6.1 と例6.2 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R6. Signature / Curvature Reading(定義7.1、7.2)
+
+- signature reading `Sig_U(X)` を PRD-1 の `RequiredSignatureAxesZero` / selected signature axes と接続して定義する。
+- curvature reading `kappa_U(X)` を PRD-1 の obstruction valuation `omega_U`、PRD-3 の `I_U`、PRD-4 の obstruction class と接続できる representation として定義する。
+- zero curvature と lawful factorization の対応を、soundness、completeness、coverage、axis exactness、witness exactness を theorem 引数に取る補題として証明する。
+
+```text
+kappa_U(X) = 0
+  -> selected obstruction valuation zero
+  -> X factors through Flat_U
+```
+
+- 逆向きが必要な場合は soundness / preservation 仮定を別補題として置く。
+- 完了条件: 定義と zero-curvature / lawful-factorization 補題が sorry なしで存在する。
+
+### R7. Metric AAT と DistanceValue(定義8.1、9.1、原則9.2)
+
+- `MetricAAT` を、AAT geometry に以下の metric enrichment data を載せた構造として定義する。
+
+```text
+AtomMetricBundle
+ConfigurationMetric
+SignatureMetric
+OperationCost
+PathLength
+HomotopyFillingCost
+ObstructionMeasure
+RepresentationMetric
+```
+
+- `DistanceValue` を partially ordered enriched value object として定義する。
+
+```text
+measured value
+measured zero
+unmeasured
+unavailable
+incomparable
+infinite
+```
+
+- `measured zero` と `unmeasured` が definitional に区別されること、aggregation profile が `unmeasured` を zero に潰さないことを補題として証明する。
+- scalar aggregation を使う場合は、measured subset と unmeasured support report を別フィールドとして保持する。
+- 完了条件: 定義群と aggregation discipline 補題が sorry なしで存在する。
+
+### R8. Distance to Flatness・Obstruction Mass(定義10.1、10.2、11.1、11.2)
+
+- operation distance `d_op(A,B)` を operation path cost / path length / homotopy filling cost の profile に相対化して定義する。
+- cost domain が infimum を持つ仮定を明示し、distance to flatness を定義する。
+
+```text
+dist_flat_U(A) = inf { d_op(A,F) | F in Flat_U(X) }
+```
+
+- `dist_flat_U(A) = 0` から lawfulness を結論する定理は置かない。
+  必要な場合は「distance zero reflects factorization」という別仮定を持つ reflection predicate として定義する。
+- obstruction measure `mu_Ob` / `mu_I` と obstruction mass `Mass_U(A)` を、selected support、measure value、finite sum / integral interface に相対化して定義する。
+  一般 measure theory は開発せず、finite support model を一次にする。
+- 完了条件: 定義群が sorry なしで存在する。
+
+### R9. Repair Cost・Margin・Dehn・Observation Gap(定義12.1–12.8、定理12.5、12.7)
+
+- repair route `RepairRoute(A, Flat_U)` を、PRD-6 の operation path と PRD-3 の lawful locus に接続して定義する。
+- shortest / safest / structural / stable repair profile を predicate として定義する。
+  structural repair は PRD-6 の normal cone reading、stable repair は PRD-4/5/6 の cohomology / derived conflict / monodromy debt を参照する。
+- margin を selected safe region と unsafe boundary までの距離として定義する。
+- 定理12.5を証明する: path length、endpoint distance bound、triangle inequality、margin definition の下で、endpoint は selected unsafe boundary を越えない。
+- architectural Dehn function を、PRD-6 の presentation two-complex `K_H(X,U)` と filling area reading に相対化して定義する。
+- 定理12.7を証明する: observation map `O` が filling generator cost に関して `L`-Lipschitz であり、paths `P,Q` の observation gap が `δ` なら、
+  `fill_cost(P . Q^{-1}) >= δ / L`。
+- bi-Lipschitz representation を、selected comparable state pair と metric profiles に相対化して定義する。
+- 完了条件: 定理12.5 / 12.7 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R10. Singularity Profile と Monodromy Index(定義13.1、13.2)
+
+- `SingProfile_U(S)` を、PRD-6 の stratum / tangent interface / normal cone / lifting failure / derived conflict concentration / repair difficulty reading を束ねる record として定義する。
+- `MonIndex_U(gamma)` を、PRD-6 の monodromy action、obstruction / semantic / effect action、period change、loop residue を束ねる bounded reading として定義する。
+- これらは analytic reading であり、measurement verdict は PRD-8 に渡すための field として reserved にする。
+- 完了条件: 定義群が sorry なしで存在する。
+
+### R11. Analytic Context・Completeness Spectrum・Conservativity(定義14.1、15.1、15.3、定理15.4)
+
+- analytic reading context を定義する。
+
+```text
+AnalyticReadingContext:
+  AtomVocabulary V
+  LawUniverse U
+  CoverageTopology J
+  coefficient sheaf
+  representation family Rep
+  distance profile P
+  obstruction measure / mass profile Mu
+  selected witness family
+  selected signature axes
+```
+
+- completeness spectrum を inductive / enum として定義する。
+
+```text
+reading
+preserving
+reflecting
+conservative
+faithful
+complete_for_selected_purpose
+```
+
+- `UDetecting(Rep, Obs_U)` を定義する。
+
+```text
+forall alpha in Obs_U,
+  (forall R in Rep, R(alpha) = 0)
+  -> WitnessZero_U(alpha)
+```
+
+- 定理15.4を証明する: `Rep` が `U`-detecting、cover が `U`-adequate、witness exactness、axis exactness、coefficient discipline が固定されているなら、
+  selected obstruction class `alpha` について `forall R in Rep, R(alpha)=0` から `alpha=0` が従う。
+  `WitnessZero_U(alpha) -> alpha=0` は exactness assumption として theorem 引数に明示する。
+- 完了条件: 定理15.4 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R12. Algebraic-Geometric AAT Synthesis(定理16.1)
+
+- PRD-1〜7 の構成を束ねる theorem package を定義する。
+
+```text
+AATSynthesisPackage:
+  Atom
+  AtomFamily
+  ArchitectureObject
+  ArchitectureGeometry
+  AATSite
+  RingedAATTopos
+  AffineAATCharts
+  ArchitectureScheme
+  LawfulLocus
+  ObstructionCohomology
+  DerivedLawGeometry
+  SingularityMonodromyStack
+  RepresentationPeriodMetricAnalysis
+```
+
+- 定理16.1を証明する: 先行PRDの仮定パッケージと本PRDの reading context が与えられたとき、
+  上記 synthesis package が構成できる。
+- この定理は「外部コードベースの全性質を測定できる」主張ではなく、構成済み AAT geometry を disciplined readings へ開く tower の存在を述べる。
+- 完了条件: 定理16.1 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R13. 有限モデルの拡張
+
+- PRD-1〜6 の有限モデル(`Formal/AG/Examples/`)を第VII部の水準へ拡張する。
+  (a) graph / matrix toy model: dependency graph と adjacency matrix を作り、命題3.6 の walk count と DAG nilpotence を example theorem として検証する。
+  (b) period separation toy model: 同じ graph reading、異なる semantic / effect reading を持つ `X,Y` を作り、定理6.1 を example theorem として検証する。
+  (c) pseudo-circle strict period: PRD-4 の擬円周 boundary modelで `Per((1,0), e_sync-e_async)=1` を検証する。
+  (d) margin stability toy model: 有限距離空間で定理12.5 の安全境界不脱出を検証する。
+  (e) observation gap toy model: finite presentation two-complex と Lipschitz observation mapで定理12.7 の下界を検証する。
+  (f) detecting representation toy model: 2〜3個の obstruction class と representation readings で定理15.4 の仮定と結論を検証する。
+- これらは第VIII部 measurement profile の golden examples として再利用できる形を保つ。
+- 完了条件: (a)–(f) が sorry なしで存在する。
+
+### R14. 台帳整備
+
+- `lean_theorem_index.md` の AG 節に第VII部の宣言を追加する(本文ラベル列は `VII.` 付き)。
+- `proof_obligations.md` に第VII部の証明対象ラベル(命題3.4、命題3.6、定理6.1、定理12.5、定理12.7、定理15.4、定理16.1、
+  finite homology `∂²=0` / strict period well-definedness、example theorem 群)を登録し、進行に応じて status を更新する。
+- 処遇表で「対象外」のラベルは台帳に登録しない。
+- `GeneralSingularHomologyRealization`、`GeneralMeasureTheoryForObstructionMass`、`CompleteMetricReflectionFromDistanceZero` は、
+  本PRDでは未実装の future proof obligation または explicit non-goal として明記する。
+- 完了条件: 両台帳が最終実装と一致している。
+
+## 非主張(claim boundary)
+
+- 本PRDは representation / period / metric / analysis の reading layer を形式化する。
+  第VIII部の measurement profile、measurement verdict、finite computability、stability theorem は扱わない。
+- representation は reading であり、geometry の代替ではない。graph / matrix / metric が zero に見えても、
+  detecting / adequacy / exactness なしに structural zero や lawfulness を主張しない。
+- graph と matrix は selected relation data の representation であり、semantic、effect、state、runtime、unselected law axis を自動的には読まない。
+- broad period は representation value である。strict period は cohomology class、cycle、target、trace / evaluation、homology model が固定された場合に限り定義される。
+- finite poset / Čech homology model は selected finite context / cover に相対化される。
+  一般 topological realization や singular homology の無条件構成は本PRDでは行わない。
+- metric は ontology ではなく enrichment である。distance は Atom を生成せず、lawfulness を定義せず、obstruction cohomology を消さず、unmeasured を zero にしない。
+- `dist_flat_U(A)` が小さいこと、または zero に見えることだけから、`A` が `Flat_U(X)` を factor through するとは主張しない。
+  その反映には別の exactness / reflection 仮定が必要である。
+- obstruction mass は support / measure / coefficient / selected axes に相対化される。
+  未測定 region や unselected axis を zero mass とみなさない。
+- shortest repair は best repair とは限らない。repair cost の主張は selected cost profile と derived / monodromy / singularity data に相対化される。
+- Margin Stability と Observation Gap Lower Bound は、selected metric、triangle inequality、endpoint distance bound、Lipschitz constant、observation support の範囲に限る。
+- SingularityProfile と MonodromyIndex は analytic readings であり、PRD-6 の singularity / monodromy structure が与えられている場合に定義される。
+- 定理15.4は固定された `Rep`、`Obs_U`、coverage、witness exactness、axis exactness、coefficient discipline の範囲だけで conservativity を主張する。
+  任意の単一 metric、単一 graph reading、単一 scalar score の完全性は主張しない。
+- 定理16.1は AAT の構成済み tower と reading layer の synthesis であり、外部手続き、実コード抽出、実務的評価、将来状態の正しさを主張しない。
+
+## 完了条件(Acceptance Criteria)
+
+- [ ] AC1. `Formal/AG/RepresentationAnalysis` が新設され、CI の `lake build` でビルドされる。
+      先行PRD依存の blocked 判定が運用されている(R0)
+- [ ] AC2. `AATSch p` と `AnalyticRepresentation` が形式化されている(R1)
+- [ ] AC3. Representation family と preservation / reflection / conservative / faithful predicate が形式化されている(R2)
+- [ ] AC4. Graph representation と Matrix representation が形式化されている(R3)
+- [ ] AC5. 命題3.4 Acyclicity Preservation が sorry なしで証明されている(R3)
+- [ ] AC6. 命題3.6 Matrix Walk Reading が sorry なしで証明されている(R3)
+- [ ] AC7. Representation reading、broad period、strict period、period family が形式化されている(R4)
+- [ ] AC8. Finite poset / Čech homology model が形式化され、`∂²=0` と strict period well-definedness が証明されている(R4)
+- [ ] AC9. 定理6.1 Period Separation と例6.2 が sorry なしで証明されている(R5)
+- [ ] AC10. Signature reading と curvature reading が形式化され、zero-curvature / lawful-factorization 補題が証明されている(R6)
+- [ ] AC11. Metric AAT と DistanceValue が形式化され、aggregation discipline 補題が証明されている(R7)
+- [ ] AC12. Operation distance、distance to flatness、obstruction measure、obstruction mass が形式化されている(R8)
+- [ ] AC13. Repair route / repair profiles / margin / Dehn function / bi-Lipschitz representation が形式化されている(R9)
+- [ ] AC14. 定理12.5 Margin Stability が sorry なしで証明されている(R9)
+- [ ] AC15. 定理12.7 Observation Gap Lower Bound が sorry なしで証明されている(R9)
+- [ ] AC16. SingularityProfile と MonodromyIndex が形式化されている(R10)
+- [ ] AC17. AnalyticReadingContext、CompletenessSpectrum、UDetecting representation family が形式化されている(R11)
+- [ ] AC18. 定理15.4 Representation Conservativity under Adequacy が sorry なしで証明されている(R11)
+- [ ] AC19. 定理16.1 Algebraic-Geometric AAT Synthesis が theorem package として sorry なしで証明されている(R12)
+- [ ] AC20. 有限モデル拡張((a) graph/matrix、(b) period separation、(c) pseudo-circle strict period、
+      (d) margin stability、(e) observation gap、(f) detecting representation)が検証されている(R13)
+- [ ] AC21. `Formal/AG` 全体に `axiom` / `admit` / `sorry` / `unsafe` が存在しない
+- [ ] AC22. `lean_theorem_index.md` の AG 節が第VII部の宣言を `VII.` 付き本文ラベルで含み、最終実装と一致している(R14)
+- [ ] AC23. `proof_obligations.md` に第VII部の証明対象ラベルが登録され、証明済み分が `proved`、
+      一般 singular homology / 一般 measure theory / distance-zero reflection などが future obligation または non-goal として明記されている(R14)
+
+## 実行順序の指針
+
+prd-loop のギャップ分析で対象を選ぶ際は、次の依存順を推奨する。
+
+```text
+R0 -> R1 -> R2 -> R3
+   -> R4 -> R5
+   -> R6 -> R7 -> R8 -> R9
+   -> R10 -> R11 -> R12
+   -> R13 -> R14
+```
+
+R3(graph / matrix)は比較的独立しているため、R1/R2の minimal representation interface が固まった時点で早めに着手できる。
+R4(period)は PRD-4 の Čech / Stokes 実装に依存するため、PRD-4成果物の存在確認を先に行う。
+R7〜R9(metric / distance / repair cost)は、一般 metric theory を広げすぎず、finite / selected profile から閉じる。
+R11(conservativity)は R2 の preservation / reflection predicate と PRD-2/3 の adequacy / exactness assumptions を束ねるため、後半で theorem package 化する。
+R13 の有限モデルは各ブロックが閉じるたびに増分追加してよい。

--- a/docs/aat/lean_ag_part_8_measurement_theory_prd.md
+++ b/docs/aat/lean_ag_part_8_measurement_theory_prd.md
@@ -1,0 +1,673 @@
+# AAT代数幾何版 Lean形式化 PRD-8: 第VIII部 Measurement Theory
+
+対象本文: [第VIII部 Measurement Theory](algebraic_geometric_theory/part_8_measurement_theory.md)
+
+先行PRD:
+[PRD-1 第I部](lean_ag_part_1_atoms_objects_laws_prd.md) /
+[PRD-2 第II部](lean_ag_part_2_sites_sheaves_prd.md) /
+[PRD-3 第III部](lean_ag_part_3_law_algebra_lawful_locus_prd.md) /
+[PRD-4 第IV部](lean_ag_part_4_obstruction_cohomology_prd.md) /
+[PRD-5 第V部](lean_ag_part_5_derived_law_geometry_repair_prd.md) /
+[PRD-6 第VI部](lean_ag_part_6_singularity_monodromy_stack_prd.md) /
+[PRD-7 第VII部](lean_ag_part_7_representation_periods_analysis_prd.md)
+
+## 問い
+
+第VII部までで readable になった AAT geometry は、どの条件の下で measurably readable になるか。
+すなわち、構成済みの geometry / reading layer の上に、次の measurement layer を Lean 上で
+sorry なしに立ち上げられるか。
+
+```text
+AATGeometry
+  -> representation / period / metric reading
+  -> MeasurementProfile M
+  -> FiniteMeasurementRegime M
+  -> MeasurementVerdict_M(alpha)
+  -> MeasurementPacket_M
+```
+
+特に、次を機械検証できるか。
+
+- `measured_zero`、`measured_nonzero`、`unmeasured`、`unknown`、`not_computed` を
+  型として分離し、`unmeasured != zero`、`unknown != nonzero` を崩さないこと
+  (定義3.1 / 原則3.2 / 定義3.3)。
+- finite measurement regime の下で、Čech cohomology、obstruction cocycle、
+  Stanley-Reisner complex、monomial Tor、support of conflict class が、有限線形代数・有限表示加群計算・
+  有限組合せ計算へ落ちること(定理4.2)。
+- finite square-free regime で、obstruction ideal が Stanley-Reisner ideal として読め、
+  Alexander dual が minimal repair hitting set を与えること(定理5.2)。
+- refactor equivalence が finite site、ringed ambient、coefficient、law ideal、witness / axis reading を
+  同型的に保存する場合、selected obstruction class の zero verdict が保存されること(定理7.3)。
+- finite inner-product cochain model で Hodge decomposition、harmonic representative、harmonic debt minimality、
+  essential repair lower bound が証明できること(定理8.5 / 8.6 / 系8.7)。
+- common ambient と support-localized pairing を固定した場合、repair direction が transferred residue を持つ
+  sufficient condition を証明できること(定理10.3)。
+- 第VIII部の selected measurement packet が bounded mathematical measurement として synthesis でき、
+  AAT-GAGA finite measurement comparison が certified 部分と theorem-candidate interface を分離して束ねられること
+  (定理12.1 / 定理12.3)。
+
+採否規律: measurement profile / verdict / finite computability / finite combinatorial repair / refactor transport /
+cellular sheaf Laplacian / LawConflict measurement / support-localized transfer / measurement packet の構成と、
+CBI 定理(4.2 / 5.2 / 7.3 / 8.5 / 8.6 / 10.3 / 12.1 / 12.3)および系8.7に寄与する定義・命題だけを
+形式化対象に採る。寄与しない要素(例、原則、自然言語の警句、未選択の外部手続き)は対象外とする。
+実装中に、finite computability、verdict discipline、Hodge decomposition、transfer measurement、AAT-GAGA comparison に
+必要な仮定が本文に不足している、または第II〜VII部の形式化と接続できないことが見つかった場合、
+それは本文または本PRDの欠陥であり、ループを停止して報告する。
+
+## 中心方針
+
+PRD-1〜7 で確立した方針を引き継ぐ(塔を下から積む / 忠実性契約 /
+`Formal/AG` 新規実装 / `axiom`・`admit`・`sorry`・`unsafe` 禁止 /
+Mathlib 二段橋 / 台帳統合 / 先行PRD依存の blocked 規律 / 部番号付き台帳ラベル)。
+
+本PRDで新たに加わる方針が五つある。
+
+**(1) measurement は profile に相対化された record discipline として実装する。**
+
+第VIII部は「何でも測れる」ことを主張しない。Lean では、まず
+
+```text
+MeasurementProfile M
+FiniteMeasurementRegime M
+MeasurementPacket M
+```
+
+を定義し、どの site、cover、coefficient、law universe、witness variables、representation family、
+zero / nonzero predicate、certificate selector の範囲で測るのかを record として固定する。
+`Measured_M(alpha)` は `alpha` が `M` の domain に入っていることを含む bounded statement として扱う。
+
+**(2) verdict は enum ではなく依存データ付きの構造として扱う。**
+
+`measured_zero` と `measured_nonzero` は、それぞれ selected predicate と certificate によって支えられる。
+`unmeasured` は scope 外、`unknown` は scope 内 undecided、`not_computed` は未実行または unavailable である。
+Lean では constructors の disjointness だけでなく、各 verdict の payload を明示し、
+`Zero_M` と `NonZero_M` が論理補集合でないことを設計として保つ。
+
+**(3) finite computability は algorithm completeness ではなく effective interface への reduction である。**
+
+第VIII部の計算可能性は、`EffCoeff_M` が提供する有限線形代数・有限表示加群・ideal-membership・resolution 選択に
+相対化される。Lean 上では、任意の coefficient category の決定可能性を主張せず、
+
+```text
+EffCoeff_M supplies exactly the procedures used by M.
+```
+
+という interface を仮定として持つ。定理4.2は、selected invariants をその interface が扱える有限 object へ落とす
+certified bounded inference として証明する。
+
+**(4) stability / base change / lower bound / spectral hotspot は theorem-candidate として statement-only に分ける。**
+
+第VIII部には、Finite Čech Stability、Monotone Witness Stability、Morse Lower Bound、Flat Base Change、
+Transfer Lower Bound、Spectral Hotspot、Wasserstein lower bound などの theorem candidate が含まれる。
+これらは Prop / structure statement としてコンパイルが通る形で形式化し、証明しない。
+証明済みの CBI theorem と candidate-dependent interface が混ざらないよう、theorem package の field で明示的に分ける。
+
+**(5) AAT-GAGA は finite profile 内の比較 interface であり、外部忠実性ではない。**
+
+定理12.3は、Hodge comparison、period accounting、topological capacity、derived conflict accounting などを
+selected finite measurement profile の中で束ねる。名前の `GAGA` は比喩であり、未選択の data source、
+外部 procedure、全 law universe、任意の analytic smallness から lawfulness を結論しない。
+Lean では certified components と candidate-regime components を別フィールドに持つ comparison package として実装する。
+
+## 背景
+
+- PRD-7 は、AAT geometry を representation、period、metric、mass、repair cost として読む analytic layer を定義した。
+  第VIII部は、その reading が finite / effective / verdict-disciplined profile の下で measurement になる条件を与える。
+- PRD-2 の finite poset AAT site regime と有限 Čech 計算、PRD-4 の obstruction cohomology / Stokes accounting / topological debt、
+  PRD-5 の LawConflict / Tor / Hilbert series / transfer pairing、PRD-7 の metric / distance / representation reading が、
+  本PRDの主要依存先である。
+- 第VIII部の theorem 4.2 は、finite site、finite cover、effective coefficient、finite witness variables、selected finite resolutions を
+  一つの measurement profile に束ねる。これは後続の ArchSig 型 proof-carrying measurement ledger に相当する Lean 側の理論アンカーになる。
+- 第IX部は evolution geometry に進む。第VIII部は静的な selected profile の measurement に留まり、temporal law / trace category / state transition presheaf は扱わない。
+
+## アウトカム
+
+本PRDの完了時点で、次が成り立つ。
+
+1. `MeasurementProfile`、`FiniteMeasurementRegime`、`MeasurementVerdict`、`VerdictData`、`StructuralVerdict`、`AnalyticReading` が Lean 上に存在する。
+2. `measured_zero` / `measured_nonzero` / `unmeasured` / `unknown` / `not_computed` の区別が型と補題で保証され、`unmeasured` を zero として扱う経路が存在しない。
+3. Finite AAT Computability(定理4.2)が theorem package として存在し、selected invariants が finite linear algebra / finite presented module / finite combinatorics / finite resolution computation へ落ちることが証明されている。
+4. Stanley-Reisner / Alexander Dual Repair Theorem(定理5.2)が証明され、minimal forbidden supports、minimal vertex covers、minimal repair hitting sets の対応が機械検証されている。
+5. persistence / zigzag / Morse / monotone witness stability の statement-only interface が存在し、証明済み measurement theorem と混同されない。
+6. Refactor Invariance under Equivalence(定理7.3)が証明され、measurement profile equivalence の下で selected zero verdict が保存される。
+7. Cellular sheaf Laplacian、finite Hodge decomposition、harmonic debt minimality、essential repair lower bound が Lean 上に存在する。
+8. Common ambient LawConflict measurement、flat base change candidate、support-localized transfer measurement、Wasserstein transfer cost reading が形式化されている。
+9. Finite Measurement Synthesis(定理12.1)と AAT-GAGA Finite Measurement Comparison(定理12.3)が theorem package として存在する。
+10. PRD-1〜7 の有限モデルが measurement profile の golden examples へ拡張され、pseudo-circle、square-free hitting set、Hodge toy model、transfer toy model、measurement packet の実例が検証されている。
+11. 第VIII部の本文ラベルと Lean 宣言の対応が両台帳で追跡できる。
+
+## 第VIII部ラベルの処遇表
+
+ギャップ分析はこの表を基準に行う。
+
+| 本文ラベル | 処遇 | 備考 |
+| --- | --- | --- |
+| 定義2.1 AAT Measurement Profile | 定義 | `M` の record。finite site / cover / coefficient / EffCoeff / Ob / law universe / witness / ideal / Rep / Dom / Zero / NonZero / Cert / Verdict を持つ(R1) |
+| 原則2.2 Measurement Is Internal | 対象外 | 非主張に記録。profile 内部の bounded reading として設計に反映 |
+| 定義3.1 Measurement Verdict | 定義+証明 | 5 verdict と `VerdictData_M(alpha)`。constructors の disjointness と payload 条件を補題化(R1) |
+| 原則3.2 Verdict Boundary | 定義+証明 | `unmeasured != measured_zero`、`unknown != measured_nonzero`、`not_computed != unmeasured` を補題にする(R1) |
+| 定義3.3 Structural Verdict and Analytic Reading | 定義 | structural verdict と analytic reading を別型に分ける(R1) |
+| 定義4.1 Finite Measurement Regime | 定義 | finite poset site、finite/effective coefficient、explicit maps、finite witnesses、finite resolutions(R2) |
+| 定理4.2 Finite AAT Computability [CBI] | 証明 | selected invariants を finite computation objects へ落とす theorem package(R2) |
+| 定義5.1 Square-Free Repair Regime | 定義 | finite witness set、`Forb_U`、`MinForb_U`、square-free obstruction ideal(R3) |
+| 定理5.2 Stanley-Reisner / Alexander Dual Repair Theorem [CBI] | 証明 | PRD-3 の SR theorem を再利用し、Alexander dual / hitting set 対応を追加(R3) |
+| 原則5.3 Repair Hitting Set Is Not Repair Semantics | 対象外 | 非主張に記録。operation semantics は別 profile |
+| 定義5.4 Discrete Morse Repair Reading | 定義 | acyclic matching / discrete Morse function を selected combinatorial repair route として読む(R3) |
+| 定理候補5.5 Morse Lower Bound for Structural Repair | statement のみ | critical cells が collapse-style repair steps の下界になる candidate。operation semantics compatibility を仮定(R3) |
+| 定義6.1 Witness Perturbation Distance | 定義 | forbidden support family の対称差距離、single update(R4) |
+| 定義6.2 Persistence / Zigzag Reading | 定義 | monotone persistence module と finite zigzag module の interface(R4) |
+| 定理候補6.3 Finite Čech Stability | statement のみ | finite zigzag / persistence stability distance に対する Lipschitz 型 candidate(R4) |
+| 原則6.4 Stability Is a Measurement Assumption | 対象外 | 非主張に記録 |
+| 定理候補6.5 Monotone Witness Stability | statement のみ | monotone forbidden-support filtration の bottleneck stability candidate(R4) |
+| 定義7.1 Refactor Morphism of Measurement Profiles | 定義 | finite/ringed site morphism、law compatibility、coefficient comparison、witness / axis compatibility(R5) |
+| 定義7.2 Pullback of Obstruction Classes | 定義 | Čech / sheaf cohomology pullback reading。pushforward は追加構造がある場合だけ(R5) |
+| 定理7.3 Refactor Invariance under Equivalence [CBI] | 証明 | site equivalence、ringed ambient iso、coefficient iso、law ideal iso、witness / axis preservation 下の zero iff(R5) |
+| 原則7.4 Monodromy Requires Functoriality | 対象外 | 非主張に記録。operation groupoid / coefficient transport がなければ monodromy measurement なし |
+| 定義8.1 Cellular Measurement Model | 定義 | finite cell / incidence category と finite-dimensional inner product coefficient sheaf(R6) |
+| 定義8.2 Sheaf Laplacian | 定義 | `L_n = d_{n-1}d_{n-1}^* + d_n^*d_n`(R6) |
+| 定義8.3 Distance-to-Flatness Reading | 定義 | residual norm と projection-defined distance reading(R6) |
+| 原則8.4 Near-Flat Is Not Lawful | 対象外 | 非主張に記録。small residual は structural zero ではない |
+| 定理8.5 Finite Hodge Decomposition [CBI] | 証明 | finite-dimensional Hilbert complex の直交分解と `ker L_n ≅ H^n`(R6) |
+| 定理8.6 Harmonic Debt Minimality [CBI] | 証明 | `min_c ||g - d_0 c|| = ||h(g)||`。直交射影で証明(R6) |
+| 系8.7 Essential Repair Lower Bound | 証明 | repair cost の Lipschitz assumption 下で `||h(g)|| / L` 下界(R6) |
+| 定義8.8 Spectral Gap Reading | 定義 | `lambda_1^+(L_1)` as analytic stability indicator(R6) |
+| 定義8.9 Curvature Transfer Spectrum | 定義 | finite weighted directed graph / adjacency operator / spectrum reading(R6) |
+| 定理候補8.10 Spectral Hotspot Reading | statement のみ | Perron-Frobenius regime の hotspot candidate(R6) |
+| 定義9.1 Common Ambient Pair | 定義 | common ringed site / ideals / compatible coefficients / witness pair(R7) |
+| 定理候補9.2 Flat Base Change Stability for LawConflict | statement のみ | flatness / finite presentation / coefficient compatibility 下の Tor base change candidate(R7) |
+| 原則9.3 No Ambient, No Conflict Comparison | 対象外 | 非主張に記録 |
+| 定義10.1 Support-Localized Repair Path | 定義 | conflict class support と repair path / direction の交差 predicate(R8) |
+| 定義10.2 Transfer Measurement Pairing | 定義 | transfer target、zero / nontrivial predicate、norm、pairing(R8) |
+| 定理10.3 Support-Localized Transfer [CBI] | 証明 | nontrivial pairing が nontrivial transferred residue を与える sufficient condition(R8) |
+| 定理候補10.4 Transfer Lower Bound | statement のみ | nondegenerate pairing / support weight / projection norm 下界 candidate(R8) |
+| 原則10.5 Transfer Non-Implications | 対象外 | 非主張に記録 |
+| 定義10.6 Wasserstein Transfer Cost | 定義 | finite support graph 上の `W_1` optimal transport reading(R8) |
+| 定理候補10.7 Transfer Cost Lower Bound | statement のみ | mass preservation と ground distance 下の `W_1` 下界 candidate(R8) |
+| 定義11.1 AAT Measurement Packet | 定義 | profile / structuralVerdict / computedInvariants / analyticReadings / assumptions / nonConclusions(R9) |
+| 原則11.2 Measurement Packet Is Bounded | 対象外 | 非主張に記録。packet fields で反映 |
+| 定理12.1 Finite Measurement Synthesis [CBI] | 証明 | finite regime + adequacy + exactness + common ambient + pairing + verdict discipline から packet を返す(R9) |
+| 原則12.2 What Part8 Adds | 対象外 | 非主張に記録 |
+| 定理12.3 AAT-GAGA Finite Measurement Comparison [CBI] | 証明 | Hodge / harmonic / Stokes / capacity / Tor-Hilbert / stability interface を finite profile 内で束ねる(R10) |
+| 原則12.4 AAT-GAGA Boundary | 対象外 | 非主張に記録 |
+
+## 要求
+
+### R0. 前提の確認と Formal/AG/Measurement の立ち上げ
+
+- 本PRDの実装は PRD-2(`Formal/AG/Site`)、PRD-3(`Formal/AG/LawAlgebra`)、
+  PRD-4(`Formal/AG/Cohomology`)、PRD-5(`Formal/AG/Derived`)、
+  PRD-6(`Formal/AG/SingularityMonodromyStack`)、PRD-7(`Formal/AG/RepresentationAnalysis`)の成果物に依存する。
+  着手時に依存宣言の存在を確認し、未実装の場合は `blocked` として tracking Issue に記録する。
+  先行PRDの実装を本PRDのループで先取りしない。
+- 第VIII部のモジュールを `Formal/AG/Measurement/` 以下に実装する。
+  ファイル分割は本文の節構成に概ね対応させる。例:
+  `Profile.lean`, `Verdict.lean`, `FiniteRegime.lean`, `Computability.lean`,
+  `SquareFreeRepair.lean`, `Stability.lean`, `RefactorTransport.lean`,
+  `CellularLaplacian.lean`, `Hodge.lean`, `LawConflictMeasurement.lean`,
+  `SupportTransfer.lean`, `Wasserstein.lean`, `Packet.lean`, `GAGA.lean`, `Examples.lean`。
+- ルート import に追加し、CI の `lake build` 対象に含める。
+- PRD-9 の trace category / temporal coefficient / evolution geometry は導入しない。
+- 完了条件: 空でない最初のモジュールが CI でビルドされ merge されている。
+
+### R1. Measurement Profile と Verdict Discipline(定義2.1、3.1、3.3、原則3.2)
+
+- `MeasurementProfile` を record として定義する。
+
+```text
+MeasurementProfile:
+  X_M              -- finite site or site candidate
+  U_M              -- selected cover / hypercover fragment
+  k_M              -- coefficient ring / field
+  EffCoeff_M       -- effective coefficient interface
+  Ob_M             -- coefficient sheaf
+  LawUniverse U
+  WitnessVariables E
+  I_Ob^U
+  Rep_M
+  Dom_M
+  Zero_M
+  NonZero_M
+  Cert_M
+  Verdict_M
+```
+
+- `Measured_M(alpha)` を、`alpha ∈ Dom_M` と selected method/certificate data を参照する bounded predicate として定義する。
+- `MeasurementVerdict_M(alpha)` を依存データ付き inductive / structure として定義する。
+
+```text
+measured_zero    : InScope_M alpha -> Zero_M alpha -> CertRef_M alpha -> MeasurementVerdict_M alpha
+measured_nonzero : InScope_M alpha -> NonZero_M alpha -> CertRef_M alpha -> MeasurementVerdict_M alpha
+unmeasured       : OutOfScope_M alpha -> MeasurementVerdict_M alpha
+unknown          : InScope_M alpha -> Undecided_M alpha -> MeasurementVerdict_M alpha
+not_computed     : NotRunOrUnavailable_M alpha -> MeasurementVerdict_M alpha
+```
+
+- constructors の disjointness を証明する。
+
+```text
+unmeasured alpha != measured_zero alpha
+unknown alpha != measured_nonzero alpha
+not_computed alpha != unmeasured alpha
+```
+
+- `Zero_M` と `NonZero_M` が補集合であるとは仮定しない。補集合として使う theorem は置かず、必要な場合は explicit decidability assumption を別 predicate にする。
+- structural verdict と analytic reading を別型として定義し、analytic value から structural verdict への暗黙変換を置かない。
+- 完了条件: 定義群と verdict boundary 補題が sorry なしで存在する。
+
+### R2. Finite Measurement Regime と定理4.2(定義4.1、定理4.2)
+
+- `FiniteMeasurementRegime M` を定義する。少なくとも次の fields / predicates を持つ。
+
+```text
+X_M is finite poset site.
+U_M is finite cover or finite hypercover fragment.
+Ob_M is finite-dimensional over explicit field, or finitely presented in EffCoeff_M.
+restriction maps are explicit matrices or finite module homomorphisms.
+EffCoeff_M supplies kernel / image / quotient / ideal-membership procedures used by M.
+zero / nonzero predicates are certificate-backed.
+E is finite.
+I_Ob^U is finitely generated.
+selected Tor computations have finite free / Koszul / Taylor / monomial resolutions.
+```
+
+- `EffCoeff_M` を、実際に使う有限手続きと証明 certificate を返す interface として定義する。
+  任意の係数圏の決定可能性を仮定しない。
+- 定理4.2を theorem package として証明する。package は、次の selected invariants について finite representation object を返す。
+
+```text
+FiniteCechComplexRepresentation
+FiniteCocycleRepresentative
+FiniteVerdictComputationObject
+FiniteSquareFreeObstructionIdeal
+FiniteStanleyReisnerComplex
+FiniteMonomialTorComplex
+FiniteConflictSupport
+```
+
+- finite-dimensional field coefficient の場合は finite linear algebra、finitely presented `EffCoeff_M` の場合は提供された algorithms に reduction する。
+- Tor は PRD-5 の finite free / Koszul / Taylor resolution interface を使う。Scarf / arbitrary minimal resolution を新規開発しない。
+- 完了条件: 定理4.2 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R3. Stanley-Reisner / Alexander Dual Repair と Discrete Morse(定義5.1、定理5.2、定義5.4、定理候補5.5)
+
+- square-free repair regime を PRD-3 の square-free witness regime から measurement profile に持ち上げる。
+
+```text
+SquareFreeRepairRegime M:
+  finite E
+  Forb_U : Finset (Finset E)
+  MinForb_U
+  I_Ob^U = < x_S | S in MinForb_U >
+  Delta_U = { T | no S in MinForb_U, S ⊆ T }
+```
+
+- Alexander dual complex `Delta_U^vee`、minimal vertex cover、minimal witness hitting set、minimal repair hitting set を定義する。
+- 定理5.2を証明する。
+
+```text
+I_Ob^U = I_{Delta_U}
+minimal generators of I_{Delta_U} <-> minimal forbidden supports
+minimal vertex covers of MinForb_U <-> minimal witness hitting sets
+minimal generators of I_{Delta_U^vee} <-> minimal repair hitting sets
+```
+
+- `repair hitting set` は operation semantics ではないことを docstring と非主張に記録する。
+- discrete Morse repair reading を、finite simplicial complex 上の acyclic matching / discrete Morse function として定義する。
+- 定理候補5.5を statement-only で形式化する。critical cell count が selected collapse-style structural repair route の手数下界になるには、
+  operation semantics compatibility、legality、side-effect profile を仮定に含める。
+- 完了条件: 定理5.2 が sorry なしで証明され、定理候補5.5 の statement がコンパイルされている。
+
+### R4. Witness Perturbation・Persistence・Stability Candidates(定義6.1、6.2、定理候補6.3、6.5)
+
+- witness perturbation distance を finite forbidden support family の対称差距離として定義する。
+
+```text
+d_wit(F,F') = |F △ F'|
+```
+
+- single update、face insertion / deletion、collapse / anticollapse の reading を finite complex の update data として定義する。
+- monotone persistence module と finite zigzag module の interface を定義する。
+
+```text
+PersistenceProfile:
+  F_0 <= F_1 <= ... <= F_m
+  complexes Delta_{F_i}
+  coefficient comparison maps
+  finite type condition
+  stability distance d_stab
+
+ZigzagProfile:
+  F_0 <-> F_1 <-> ... <-> F_m
+  oriented arrows / correspondences
+  coefficient comparison maps
+```
+
+- 定理候補6.3を statement-only で形式化する。
+
+```text
+d_stab(H^*(F), H^*(F')) <= C_M * d_wit(F,F')
+```
+
+- 定理候補6.5を statement-only で形式化する。
+
+```text
+d_bottleneck(Barcode(F), Barcode(F')) <= d_wit(F,F')
+```
+
+- stability theorem がない measurement value は stable measurement ではないことを非主張に記録する。
+- 完了条件: 定義群と statement 群がコンパイルされている。
+
+### R5. Refactor Functoriality and Class Transport(定義7.1、7.2、定理7.3)
+
+- measurement profiles `M_X`、`M_Y` の間の refactor morphism を定義する。
+
+```text
+rho : X_M -> Y_M
+rho# : O_{Y_M} -> rho_* O_{X_M}
+law compatibility : rho^{-1} I_Ob^{U,Y} -> I_Ob^{U,X}
+coefficient comparison : rho^{-1} Ob_Y -> Ob_X
+witness / axis compatibility
+```
+
+- coefficient comparison が固定されている場合に、Čech cohomology / cover-relative cohomology の pullback reading を定義する。
+
+```text
+rho^* : H^n(Y_M, Ob_Y) -> H^n(X_M, Ob_X)
+```
+
+- pushforward は finite map、trace map、aggregation rule などが追加された場合だけ別 interface として定義する。
+- 定理7.3を証明する。仮定はすべて theorem 引数として明示する。
+
+```text
+rho is equivalence of selected finite sites.
+ringed ambient comparison is iso.
+coefficient comparison is iso.
+law ideals pull back isomorphically.
+witness and axis readings are preserved.
+```
+
+結論:
+
+```text
+alpha = 0 iff rho^* alpha = 0
+```
+
+- period pairing の preservation は chosen representatives / pairings compatibility がある場合の optional corollary とする。
+- 完了条件: 定理7.3 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R6. Cellular Sheaf Laplacian・Hodge・Harmonic Debt(定義8.1–8.3、定理8.5、8.6、系8.7、定義8.8、8.9、定理候補8.10)
+
+- cellular measurement model を定義する。最小実装では finite incidence category / finite cochain complex を一次対象にしてよい。
+
+```text
+CellularMeasurementModel:
+  finite cells / incidence category
+  finite-dimensional inner product spaces F(c)
+  linear restriction maps
+  cochain groups C^n(X_M,F)
+  coboundary d_n
+  adjoints d_n^*
+```
+
+- sheaf Laplacian を定義する。
+
+```text
+L_n = d_{n-1} d_{n-1}^* + d_n^* d_n
+```
+
+- residual norm `Res_M(s) = ||d_0 s||` と projection-defined `dist_flat_M(s)` を analytic reading として定義する。
+  `dist_flat_M(s) = 0 -> lawful` の theorem は置かない。
+- 定理8.5を、finite-dimensional real / complex inner product regime の Hilbert complex theorem として証明する。
+
+```text
+C^n = im d_{n-1} ⊕ ker L_n ⊕ im d_n^*
+ker L_n ≅ H^n(X_M,F)
+```
+
+- 定理8.6を証明する。
+
+```text
+min_c || g - d_0 c || = || h(g) ||
+```
+
+- 系8.7を証明する。repair cost と cochain norm の `L`-Lipschitz 仮定、大域 lawful state への route が harmonic mismatch を解消する仮定を theorem 引数に取る。
+
+```text
+repair_cost >= ||h(g)|| / L
+```
+
+- spectral gap reading と curvature transfer spectrum を定義する。
+- 定理候補8.10を statement-only で形式化する。Perron-Frobenius theorem を必要とする場合は future proof obligation として台帳に登録する。
+- 完了条件: 定理8.5 / 8.6 / 系8.7 が sorry なしで証明され、定義8.8 / 8.9 と定理候補8.10 statement が存在する。
+
+### R7. LawConflict Measurement and Base Change(定義9.1、定理候補9.2)
+
+- common ambient pair を定義する。
+
+```text
+CommonAmbientPair(U,V):
+  (X,O_X)
+  I_U, I_V ⊆ O_X
+  compatible coefficient objects
+  selected witness pair and comparison profile
+```
+
+- common ambient があるときだけ LawConflict measurement を定義する。
+
+```text
+LawConflict_i^M(U,V) = Tor_i^{O_X}(O_X/I_U, O_X/I_V)
+```
+
+- 異なる topology / coefficient ring / ambient scheme の law ideals は comparison morphism なしに比較しないことを非主張として記録する。
+- 定理候補9.2を statement-only で形式化する。affine case と sheaf/ringed-site case の二つの statement を分けてよい。
+
+```text
+Tor_i^A(A/I_U,A/I_V) ⊗_A A'
+  ≅ Tor_i^{A'}(A'/I_U',A'/I_V')
+```
+
+仮定には flatness、finite presentation、coefficient compatibility、support pullback を含める。
+- 完了条件: common ambient 定義と base-change candidate statements がコンパイルされている。
+
+### R8. Support-Localized Transfer Measurement と Wasserstein Cost(定義10.1、10.2、定理10.3、定理候補10.4、定義10.6、定理候補10.7)
+
+- selected conflict class `kappa_{U,V}` と support `Supp(kappa_{U,V})` を持つ support-localized repair path / direction を定義する。
+
+```text
+image(r) intersects Supp(kappa)
+-- or
+support(v) intersects Supp(kappa)
+```
+
+- transfer measurement pairing を定義する。
+
+```text
+TransRes_{U,V}
+0_{TransRes}
+Nontrivial_{TransRes}
+|| - ||_{TransRes}
+< -, - >_{U,V} : T_X x LawConflict_1(U,V) -> TransRes_{U,V}
+```
+
+- 定理10.3を証明する。
+
+```text
+Nontrivial(<v,kappa>_{U,V})
+  -> selected repair direction has nontrivial transferred residue
+```
+
+これは sufficient condition であり、necessary condition には detecting pairing assumption を別途要求する。
+- 定理候補10.4を statement-only で形式化する。normed target、nondegenerate pairing、support weight、projection norm、constant `lambda_M` を仮定に含める。
+- finite support graph と ground distance に対して Wasserstein transfer cost を定義する。一般 measure theory ではなく finite optimal transport / transportation plan interface として始める。
+- 定理候補10.7を statement-only で形式化する。
+
+```text
+W_1 >= m * dist(s, Abs)
+```
+
+- 完了条件: 定理10.3 が sorry なしで証明され、Wasserstein reading と candidate statements が存在する。
+
+### R9. Measurement Packet と Finite Measurement Synthesis(定義11.1、定理12.1)
+
+- `MeasurementPacket` を record として定義する。
+
+```text
+MeasurementPacket:
+  profile
+  structuralVerdict
+  computedInvariants
+  analyticReadings
+  assumptions
+  nonConclusions
+```
+
+- `computedInvariants` は、`H^n`、`Tor_i`、generators、supports、dimensions、ranks、representatives を含む optional / dependent fields として定義する。
+- `analyticReadings` は、distance、mass、spectrum、residual norm、harmonic mass、barcode、repair cost、Wasserstein transfer cost、Morse collapse reading、monodromy index を含む。
+- `nonConclusions` に、unselected laws、unmeasured support、unprovided coefficient data、undecided predicates を明示的に持たせる。
+- 定理12.1を証明する。仮定:
+
+```text
+M is finite measurement regime.
+cover is U-adequate.
+witness and axis exactness hold where reflection is claimed.
+coefficient objects are finite/effective and explicit under EffCoeff_M.
+common ambient exists for selected LawConflict readings.
+support-localized pairing is fixed for transfer readings.
+verdict discipline distinguishes zero, nonzero, unmeasured, unknown, not_computed.
+```
+
+結論: selected measurement packet が bounded mathematical measurement として構成される。
+- theorem candidate に依存する readings は、packet 内で `candidateInterface` または `conditionalReading` として certified verdict から分離する。
+- 完了条件: 定理12.1 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R10. AAT-GAGA Finite Measurement Comparison(定理12.3)
+
+- `AATGAGAComparisonPacket` を定義する。certified fields と candidate-interface fields を分ける。
+
+Certified fields:
+
+```text
+HodgeComparison: H^n(X_M,F) ≅ ker L_n
+HarmonicDecomposition
+PeriodStokesAccounting
+TopologicalDebtCapacity
+DerivedConflictAccounting via Tor / Hilbert-series accounting
+```
+
+Candidate-interface fields:
+
+```text
+MonotoneWitnessStabilityInterface
+FiniteCechStabilityInterface
+FlatBaseChangeInterface
+SpectralHotspotInterface
+TransferLowerBoundInterface
+```
+
+- 定理12.3を証明する。finite measurement regime、finite cover、inner-product coefficient sheaf、cellular cochain model、square-free regime、common ambient、
+  stability distance / comparison maps where applicable を仮定に取る。
+- theorem candidate に依存する条項は certified conclusion ではなく、candidate regime が追加された場合の interface として返す。
+- `GAGA` が外部 data source や external procedure の忠実性を主張しないことを docstring と非主張に記録する。
+- 完了条件: 定理12.3 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R11. 有限モデルの拡張
+
+- PRD-1〜7 の有限モデル(`Formal/AG/Examples/`)を第VIII部の水準へ拡張する。
+  (a) pseudo-circle measurement profile: PRD-4 の擬円周 boundary model を `MeasurementProfile` に載せ、
+      concrete cocycle の verdict が `measured_nonzero` になり、unmeasured axes が zero と混同されないことを検証する。
+  (b) square-free hitting set example: 付録の `{p,q}` / `{q,r}` forbidden supports から、minimal repair hitting sets `{q}` と `{p,r}` を検証する。
+  (c) finite computability example: 小さい finite poset site と finite coefficient sheaf で Čech complex、kernel / image / quotient object が `FiniteMeasurementRegime` に入ることを検証する。
+  (d) refactor invariance example: finite site equivalence と coefficient iso の下で selected obstruction class の zero verdict が保存されることを検証する。
+  (e) cellular Hodge example: 低次 finite cochain complex で `ker L_1 ≅ H^1` と harmonic debt minimality を検証する。
+  (f) support-localized transfer example: finite-dimensional pairing で nontrivial residue verdict を返す例を検証する。
+  (g) measurement packet / AAT-GAGA example: certified readings と candidate-interface readings が分離された packet を構成する。
+- これらは第IX部 evolution geometry の static measurement fixtures として再利用できる形を保つ。
+- 完了条件: (a)–(g) が sorry なしで存在する。
+
+### R12. 台帳整備
+
+- `lean_theorem_index.md` の AG 節に第VIII部の宣言を追加する(本文ラベル列は `VIII.` 付き)。
+- `proof_obligations.md` に第VIII部の証明対象ラベル(定理4.2、5.2、7.3、8.5、8.6、系8.7、定理10.3、12.1、12.3、example theorem 群)を登録し、進行に応じて status を更新する。
+- 定理候補5.5 / 6.3 / 6.5 / 8.10 / 9.2 / 10.4 / 10.7 は future proof obligation として登録するが、proved に昇格しない。
+- 処遇表で「対象外」とした本文ラベルは台帳に登録しない。
+- `GeneralPersistenceStability`, `GeneralZigzagStability`, `GeneralFlatBaseChangeForLawConflict`,
+  `GeneralPerronFrobeniusHotspot`, `GeneralOptimalTransportTheory`, `AnalyticSmallnessImpliesLawfulness` は、
+  本PRDでは未実装の future proof obligation または explicit non-goal として明記する。
+- 完了条件: 両台帳が最終実装と一致している。
+
+## 非主張(claim boundary)
+
+- 本PRDは static finite measurement profile の理論を形式化する。第IX部の trace category、state transition presheaf、temporal coefficient、temporal law は扱わない。
+- Finite AAT Computability は selected finite measurement regime と `EffCoeff_M` の範囲に限る。
+  任意の site、任意の sheaf cohomology、任意の derived stack、任意の coefficient regime、任意の finitely generated module が計算可能であるとは主張しない。
+- `measured_zero` は selected zero predicate の成立であり、unselected laws / supports / axes の zero を意味しない。
+  `unmeasured` は zero ではなく、`unknown` は nonzero ではなく、`not_computed` は unmeasured と同じではない。
+- `Zero_M` と `NonZero_M` は一般には論理補集合ではない。decidable complement を使う theorem は、別途 decidability / completeness assumption を要求する。
+- analytic reading(distance、mass、rank、dimension、barcode、spectrum、residual norm、harmonic norm、Wasserstein cost)は structural verdict ではない。
+  小さい analytic value や near-flatness から lawfulness を結論しない。
+- Alexander dual の minimal hitting set は combinatorial repair target であり、actual architecture repair operation の legality、cost、side-effect、operation semantics を自動的には与えない。
+- Stability theorem candidates は statement-only であり、本PRDの完了は persistence / zigzag / Morse / monotone witness stability の証明を含まない。
+- Refactor invariance は selected measurement profile equivalence、coefficient iso、law ideal iso、witness / axis preservation に相対化される。
+  syntax-level refactor や external rewrite が自動的に measurement-preserving であるとは主張しない。
+- Cellular sheaf Laplacian、Hodge decomposition、harmonic debt minimality は finite-dimensional inner-product cochain model に相対化される。
+  一般 Hilbert complex や infinite-dimensional analytic theory は扱わない。
+- LawConflict measurement は common ambient pair がある場合だけ定義される。ambient / coefficient / topology が異なる場合、comparison morphism なしに Tor conflict を比較しない。
+- Flat base change、transfer lower bound、Wasserstein lower bound、spectral hotspot は theorem candidate であり、non-flat base change や non-detecting pairing での保存 / 下界を主張しない。
+- Support-localized transfer theorem は sufficient condition であり、すべての transfer residue を検出する necessary condition ではない。
+- AAT-GAGA は selected finite measurement profile 内の comparison reading であり、外部 data source、外部 tool、任意の law universe、実務的品質判定の忠実性を主張しない。
+
+## 完了条件(Acceptance Criteria)
+
+- [ ] AC1. `Formal/AG/Measurement` が新設され、CI の `lake build` でビルドされる。
+      先行PRD依存の blocked 判定が運用されている(R0)
+- [ ] AC2. `MeasurementProfile` と `Measured_M(alpha)` が形式化されている(R1)
+- [ ] AC3. `MeasurementVerdict`、`VerdictData`、`StructuralVerdict`、`AnalyticReading` が形式化されている(R1)
+- [ ] AC4. verdict boundary 補題(`unmeasured != measured_zero`、`unknown != measured_nonzero`、`not_computed != unmeasured`)が sorry なしで証明されている(R1)
+- [ ] AC5. `FiniteMeasurementRegime` と `EffCoeff_M` interface が形式化されている(R2)
+- [ ] AC6. 定理4.2 Finite AAT Computability が theorem package として sorry なしで証明されている(R2)
+- [ ] AC7. Square-Free Repair Regime、Alexander dual、minimal hitting set が形式化されている(R3)
+- [ ] AC8. 定理5.2 Stanley-Reisner / Alexander Dual Repair Theorem が sorry なしで証明されている(R3)
+- [ ] AC9. Discrete Morse repair reading と定理候補5.5 statement がコンパイルされている(R3)
+- [ ] AC10. Witness perturbation distance、persistence / zigzag profiles、定理候補6.3 / 6.5 statements がコンパイルされている(R4)
+- [ ] AC11. Refactor morphism of measurement profiles と pullback of obstruction classes が形式化されている(R5)
+- [ ] AC12. 定理7.3 Refactor Invariance under Equivalence が sorry なしで証明されている(R5)
+- [ ] AC13. Cellular measurement model、sheaf Laplacian、distance-to-flatness reading が形式化されている(R6)
+- [ ] AC14. 定理8.5 Finite Hodge Decomposition が sorry なしで証明されている(R6)
+- [ ] AC15. 定理8.6 Harmonic Debt Minimality と系8.7 Essential Repair Lower Bound が sorry なしで証明されている(R6)
+- [ ] AC16. Spectral gap reading、curvature transfer spectrum、定理候補8.10 statement が存在する(R6)
+- [ ] AC17. Common ambient pair と LawConflict measurement が形式化され、定理候補9.2 flat base change statements がコンパイルされている(R7)
+- [ ] AC18. Support-localized repair path、transfer measurement pairing が形式化されている(R8)
+- [ ] AC19. 定理10.3 Support-Localized Transfer が sorry なしで証明されている(R8)
+- [ ] AC20. Wasserstein transfer cost reading と定理候補10.4 / 10.7 statements が存在する(R8)
+- [ ] AC21. `MeasurementPacket` が形式化され、certified readings と candidate interfaces が分離されている(R9)
+- [ ] AC22. 定理12.1 Finite Measurement Synthesis が sorry なしで証明されている(R9)
+- [ ] AC23. `AATGAGAComparisonPacket` が形式化されている(R10)
+- [ ] AC24. 定理12.3 AAT-GAGA Finite Measurement Comparison が sorry なしで証明され、candidate-dependent fields が certified conclusions から分離されている(R10)
+- [ ] AC25. 有限モデル拡張((a) pseudo-circle measurement、(b) square-free hitting set、(c) finite computability、
+      (d) refactor invariance、(e) cellular Hodge、(f) support transfer、(g) measurement packet / AAT-GAGA)が検証されている(R11)
+- [ ] AC26. `Formal/AG` 全体に `axiom` / `admit` / `sorry` / `unsafe` が存在しない
+- [ ] AC27. `lean_theorem_index.md` の AG 節が第VIII部の宣言を `VIII.` 付き本文ラベルで含み、最終実装と一致している(R12)
+- [ ] AC28. `proof_obligations.md` に第VIII部の証明対象ラベルが登録され、証明済み分が `proved`、theorem candidates と non-goals が future obligation / explicit non-goal として明記されている(R12)
+
+## 実行順序の指針
+
+prd-loop のギャップ分析で対象を選ぶ際は、次の依存順を推奨する。
+
+```text
+R0 -> R1 -> R2
+   -> R3 -> R4
+   -> R5
+   -> R6
+   -> R7 -> R8
+   -> R9 -> R10
+   -> R11 -> R12
+```
+
+R1/R2 は Part8 全体の型境界であり、最初に閉じる。
+R3 は PRD-3 の Stanley-Reisner theorem に依存するが、Alexander dual / hitting set は有限組合せとして比較的独立に進められる。
+R4 の stability は theorem candidate statement までに留め、証明済みタスクをブロックしない。
+R6 は線形代数量が大きいため、まず finite cochain complex / adjoint / Laplacian の interface を閉じ、
+低次 toy model で theorem shape を確認してから一般 theorem へ進む。
+R7/R8 は PRD-5 の LawConflict / transfer pairing と接続するため、common ambient と support-localized predicate を先に固定する。
+R9/R10 は最後に theorem package 化し、certified conclusion と candidate interface を混ぜない。
+R11 の有限モデルは各ブロックが閉じるたびに増分追加してよい。

--- a/docs/aat/lean_ag_part_9_evolution_geometry_prd.md
+++ b/docs/aat/lean_ag_part_9_evolution_geometry_prd.md
@@ -1,0 +1,535 @@
+# AAT代数幾何版 Lean形式化 PRD-9: 第IX部 Evolution Geometry
+
+対象本文: [第IX部 Evolution Geometry](algebraic_geometric_theory/part_9_evolution_geometry.md)
+
+先行PRD:
+[PRD-1 第I部](lean_ag_part_1_atoms_objects_laws_prd.md) /
+[PRD-2 第II部](lean_ag_part_2_sites_sheaves_prd.md) /
+[PRD-3 第III部](lean_ag_part_3_law_algebra_lawful_locus_prd.md) /
+[PRD-4 第IV部](lean_ag_part_4_obstruction_cohomology_prd.md) /
+[PRD-5 第V部](lean_ag_part_5_derived_law_geometry_repair_prd.md) /
+[PRD-6 第VI部](lean_ag_part_6_singularity_monodromy_stack_prd.md) /
+[PRD-7 第VII部](lean_ag_part_7_representation_periods_analysis_prd.md) /
+[PRD-8 第VIII部](lean_ag_part_8_measurement_theory_prd.md)
+
+## 問い
+
+第VIII部までで構成・測定可能になった static AAT geometry は、選ばれた時間方向へ拡張できるか。
+すなわち、固定された trace category、state transition presheaf、temporal coefficient、law universe、
+measurement profile の中で、次の evolution layer を Lean 上で sorry なしに立ち上げられるか。
+
+```text
+static geometry:
+  X
+
+measurement profile:
+  M
+
+evolution geometry:
+  X_0 -> X_1 -> ... -> X_n
+
+trace / temporal layer:
+  Tr_E
+  St_A
+  TempCoeff_A
+  TemporalLaw
+  TemporalObstruction in H^n(Tr_E x X, TempCoeff_A)
+```
+
+特に、次を機械検証できるか。
+
+- trace category `Tr_E` と AAT site `X` から、selected product / incidence site `Tr_E x X` を固定し、
+  その上で temporal coefficient と Čech obstruction class を定義できること(定義2.1 / 3.2 / 3.4)。
+- local replay data の mismatch class `[m(r)]` が `H^1(Tr_E x X, TempCoeff_A)` で消える場合、
+  effective local adjustment と descent の下で global replay transition が得られること(定理4.2)。
+- measurement profile `M` 上の evolution functional `Phi_M` と dissipative policy を定義し、
+  finite / well-founded regime で selected evolution path が有限停止すること(定理5.3)。
+- Lyapunov reading が forecast ではなく、固定された evolution profile 内の非増加 reading であることを型境界で保つこと(定義6.1 / 原則6.2)。
+- force による temporal mismatch class が定義され、その非零性が integrability obstruction になるという theorem candidate を、
+  coefficient exactness と temporal descent detecting assumption を明示した statement として形式化できること(定理候補7.2)。
+
+採否規律: trace category / state transition presheaf / temporal coefficient / temporal law / temporal obstruction / temporal descent /
+dissipative policy / Lyapunov reading / force integrability statement の構成と、CBI 定理4.2・5.3に寄与する定義・命題だけを
+形式化対象に採る。寄与しない要素(例、原則、自然言語の警句、未選択の将来 path、外部イベント、実時間の意味論)は対象外とする。
+実装中に、temporal descent、finite stopping、force obstruction statement に必要な仮定が本文に不足している、または
+第II〜VIII部の形式化と接続できないことが見つかった場合、それは本文または本PRDの欠陥であり、ループを停止して報告する。
+
+## 中心方針
+
+PRD-1〜8 で確立した方針を引き継ぐ(塔を下から積む / 忠実性契約 /
+`Formal/AG` 新規実装 / `axiom`・`admit`・`sorry`・`unsafe` 禁止 /
+Mathlib 二段橋 / 台帳統合 / 先行PRD依存の blocked 規律 / 部番号付き台帳ラベル)。
+
+本PRDで新たに加わる方針が五つある。
+
+**(1) 時間は実時間ではなく selected trace category として実装する。**
+
+第IX部は、外部世界の任意のイベント、実時計、将来予測を扱わない。Lean では、まず
+
+```text
+EvolutionProfile E
+TraceCategory Tr_E
+```
+
+を record / category として固定し、object を selected time point、operation stage、abstract event state として扱う。
+trace category に入っていない transition について、zero、lawful、safe、dissipative を主張しない。
+
+**(2) `Tr_E x X` は finite product / incidence site を一次対象にする。**
+
+本文の `Tr_E x X` は、trace category と AAT site から作る selected product site または incidence model である。
+Lean では、一般の site product 理論を無条件に開発せず、まず finite trace category と finite AAT site の product / incidence model を定義する。
+一般 site product への橋は、Mathlib 資産が利用できる範囲で bridge theorem とする。
+
+**(3) temporal obstruction は ordinary obstruction cohomology の時間方向版として読む。**
+
+第IV部で構成した cover-relative Čech cohomology を再利用し、temporal obstruction は
+
+```text
+H^n(Tr_E x X, TempCoeff_A)
+```
+
+の concrete cocycle / class として扱う。`H^n` 非零の群だけから個別の temporal failure を主張せず、
+定理は必ず具体的 mismatch cocycle `m(r)` または `ob(F)` を仮定に取る。
+
+**(4) temporal descent は class vanishing だけでなく effective adjustment と descent を仮定に出す。**
+
+定理4.2の本文は「local adjustment の後、global replay transition が存在する」と述べる。
+Lean では、これを次の仮定に分解する。
+
+```text
+m(r) is a 1-cocycle.
+[m(r)] = 0, hence m(r) = d c for some 0-cochain c.
+local replay data admits adjustment by c.
+adjusted replay data is compatible on overlaps.
+St_A satisfies descent for the selected cover.
+```
+
+この分解により、abelian coefficient class の消滅と、state transition presheaf 側の実効的な貼り合わせを混同しない。
+
+**(5) dissipative / Lyapunov は forecast ではなく finite profile 内の停止・単調性である。**
+
+`Phi_M` は第VIII部の measurement profile に相対化された reading である。
+Lean では、finite state set、well-founded ordered value、strict decrease outside terminal states を仮定し、
+「無限に非終端 selected step を続けられない」ことを証明する。
+terminal state が lawful であることは、第III部・第IV部の obstruction vanishing / exactness / coverage assumptions を別途要求する。
+
+## 背景
+
+- PRD-8 は、static finite measurement profile の中で AAT geometry を測定する条件を定義した。
+  第IX部は、その measurement profile を時間方向に載せ、state transition、temporal law、temporal obstruction を読む最小構造を与える。
+- PRD-2 の AAT site / finite poset regime、PRD-4 の Čech obstruction cohomology、PRD-5 の repair path と well-founded repair、
+  PRD-6 の operation category / monodromy、PRD-7 の metric / Lyapunov に近い analytic reading、PRD-8 の measurement profile / harmonic mass / distance-to-flatness が、
+  本PRDの主要依存先である。
+- 第IX部は、AAT本文全体の最終層であり、static geometry から temporal / evolution geometry への橋である。
+  ただし、その主張は trace category、state transition presheaf、temporal coefficient の内部に限られる。
+- ArchSig 型の将来 ledger では、static measurement packet に temporal replay / migration / compensation の検査結果を追加する必要がある。
+  本PRDは、そのための Lean 側の理論アンカーを作るが、外部 runtime trace の収集や実システムの予測は扱わない。
+
+## アウトカム
+
+本PRDの完了時点で、次が成り立つ。
+
+1. `EvolutionProfile`、`TraceCategory`、`EvolutionGeometry`、`TemporalProductSite` が Lean 上に存在する。
+2. `StateTransitionPresheaf` と、descent 確認済みの場合の `StateTransitionSheaf` が定義されている。
+3. `TemporalCoefficient`、`TemporalLaw`、`TemporalObstruction`、`TemporalCocycle`、`TemporalClass` が、`Tr_E x X` 上の coefficient / Čech class として定義されている。
+4. `ReplayDescentData` と mismatch cocycle `m(r)` が定義され、定理4.2 Temporal Descent Criterion が theorem package として証明されている。
+5. `EvolutionFunctional`、`DissipativePolicy`、`StrictlyDissipative`、`TerminalState` が定義され、定理5.3 Finite Dissipation Stopping が証明されている。
+6. `AATLyapunovReading` が定義され、selected path に沿う非増加 / strict decrease の基本補題が証明されている。
+7. `Force`、`IntegrableForce`、`ForceMismatchClass` が定義され、定理候補7.2 Force Integrability Obstruction が statement-only でコンパイルされている。
+8. PRD-1〜8 の有限モデルが temporal examples へ拡張され、two-step trace、replay descent、dissipative stopping、force obstruction candidate の toy model が検証されている。
+9. 第IX部の本文ラベルと Lean 宣言の対応が両台帳で追跡できる。
+
+## 第IX部ラベルの処遇表
+
+ギャップ分析はこの表を基準に行う。
+
+| 本文ラベル | 処遇 | 備考 |
+| --- | --- | --- |
+| §1 Part8 から Part9 へ / Evolution geometry schema | 定義 | `EvolutionProfile` と geometry sequence `X_0 -> ... -> X_n` を定義する。static measurement profile から temporal profile へ拡張する入口(R1) |
+| 定義2.1 Trace Category | 定義 | `Tr_E` を category として定義。finite trace category instance を優先。selected transition だけを含む(R1) |
+| 原則2.2 Trace Relativity | 対象外 | 非主張に記録。未選択 event / path / external state について zero / lawful / safe を主張しない |
+| 定義3.1 State Transition Presheaf | 定義 | `St_A(W,t) = State_A(W,t) + Trans_A(W,t)`。AAT context restriction と trace restriction / transition action を持つ(R3) |
+| 定義3.2 Temporal Coefficient | 定義 | `TempCoeff_A` を `Tr_E x X` 上の abelian coefficient sheaf として定義(R2) |
+| 定義3.3 Temporal Law | 定義 | `St_A` と `Tr_E` 上の equation / commutative diagram / descent condition。closed temporal equation と descent temporal law を分ける(R3) |
+| 定義3.4 Temporal Obstruction | 定義 | concrete mismatch cocycle / class `Ob_t in H^n(Tr_E x X, TempCoeff_A)`。積構造がない場合は reading schema に留める(R4) |
+| 定義4.1 Replay Descent Data | 定義 | cover と trace arrow に沿う local replay maps、overlap mismatch cocycle `m(r)`(R5) |
+| 定理4.2 Temporal Descent Criterion [CBI] | 証明 | `[m(r)] = 0` + effective adjustment + descent -> global replay transition(R5) |
+| 定義5.1 Evolution Functional | 定義 | `Phi_M(A)`。第VIII部の measurement profile に相対化された nonnegative / ordered reading(R6) |
+| 定義5.2 Dissipative Policy | 定義 | `Phi_M(B) <= Phi_M(A)`、strict decrease outside terminal states(R6) |
+| 定理5.3 Finite Dissipation Stopping [CBI] | 証明 | finite selected state set / well-founded value / strict dissipativity から finite stopping(R7) |
+| 定義6.1 AAT Lyapunov Reading | 定義+証明 | 非増加 reading、selected obstruction zero 近傍で最小値。path monotonicity 補題を証明(R8) |
+| 原則6.2 Lyapunov Is Not Forecast | 対象外 | 非主張に記録。未選択 transition / future path への予測を主張しない |
+| 定義7.1 Force | 定義 | selected transition `F : A_t -> A_{t+1}`、integrable force の述語(R9) |
+| 定理候補7.2 Force Integrability Obstruction | statement のみ | `ob(F) != 0 -> not IntegrableForce F` の candidate。mismatch construction / exactness / detecting descent を仮定(R9) |
+| §8 Part9 の結論 | 対象外 | まとめ。台帳には登録しない |
+
+## 要求
+
+### R0. 前提の確認と Formal/AG/Evolution の立ち上げ
+
+- 本PRDの実装は PRD-2(`Formal/AG/Site`)、PRD-3(`Formal/AG/LawAlgebra`)、
+  PRD-4(`Formal/AG/Cohomology`)、PRD-5(`Formal/AG/Derived`)、
+  PRD-6(`Formal/AG/SingularityMonodromyStack`)、PRD-7(`Formal/AG/RepresentationAnalysis`)、
+  PRD-8(`Formal/AG/Measurement`)の成果物に依存する。
+  着手時に依存宣言の存在を確認し、未実装の場合は `blocked` として tracking Issue に記録する。
+  先行PRDの実装を本PRDのループで先取りしない。
+- 第IX部のモジュールを `Formal/AG/Evolution/` 以下に実装する。
+  ファイル分割は本文の節構成に概ね対応させる。例:
+  `Profile.lean`, `TraceCategory.lean`, `TemporalProductSite.lean`,
+  `StateTransition.lean`, `TemporalCoefficient.lean`, `TemporalLaw.lean`,
+  `TemporalObstruction.lean`, `ReplayDescent.lean`, `Dissipation.lean`,
+  `Lyapunov.lean`, `Force.lean`, `Examples.lean`。
+- ルート import に追加し、CI の `lake build` 対象に含める。
+- 本PRDは AAT AG 本文の最終部に対応するため、完了時には `Formal/AG` 全体の no-sorry / no-axiom audit を再実行する。
+- 完了条件: 空でない最初のモジュールが CI でビルドされ merge されている。
+
+### R1. EvolutionProfile・TraceCategory・EvolutionGeometry(§1、定義2.1)
+
+- `EvolutionProfile` を record として定義する。
+
+```text
+EvolutionProfile:
+  baseGeometry      -- static AAT geometry / architecture scheme
+  measurementProfile M
+  traceObjects
+  traceTransitions
+  selectedOperations
+  selectedStateFamily
+  selectedTemporalLaws
+  selectedCoefficientProfile
+```
+
+- trace category `Tr_E` を定義する。object は selected time point / operation stage / abstract event state、
+  arrow は selected transition とする。
+- finite trace category regime を instance / structure として定義し、identity と composition が選ばれた transition family の中で閉じることを証明する。
+- evolution geometry を、trace category から AAT geometry / architecture state への functor または finite diagram として定義する。
+
+```text
+EvolGeom_E : Tr_E -> AATGeometry
+```
+
+有限列の場合は次の special case を与える。
+
+```text
+X_0 -> X_1 -> ... -> X_n
+```
+
+- `TraceRelativity` は theorem ではなく、`EvolutionProfile` の field に入っている selected trace に相対化されることを docstring と非主張に記録する。
+- 完了条件: `EvolutionProfile`、`Tr_E`、finite trace category、`EvolGeom_E` が sorry なしで存在する。
+
+### R2. Temporal Product / Incidence Site と Temporal Coefficient(定義3.2、3.4 の ambient)
+
+- AAT site `X` と trace category `Tr_E` から、selected product / incidence site を定義する。
+
+```text
+TemporalSite(E,X) := Tr_E x X
+```
+
+最小実装では、finite trace category と finite poset AAT site の product poset / incidence category として構成する。
+- cover は、trace direction と architecture context direction の両方を持つ family として定義する。
+
+```text
+{ (t_a, W_i) -> (t, W) }
+```
+
+- PRD-4 の cover-relative Čech complex を `TemporalSite(E,X)` 上へ再利用できる bridge theorem を用意する。
+- temporal coefficient `TempCoeff_A` を、`TemporalSite(E,X)` 上の abelian group sheaf または module-valued sheaf として定義する。
+- finite coefficient regime では、PRD-8 の `FiniteMeasurementRegime` / `EffCoeff_M` と接続する。
+- 完了条件: `TemporalSite`、temporal cover、`TempCoeff_A`、Čech bridge が sorry なしで存在する。
+
+### R3. State Transition Presheaf と Temporal Law(定義3.1、3.3)
+
+- state transition presheaf を定義する。
+
+```text
+St_A : TemporalSite(E,X)^op -> Type
+St_A(W,t) = State_A(W,t) together with Trans_A(W,t)
+```
+
+実装上は、state carrier と transition monoid / category を field として持つ record でよい。
+- context restriction と trace transition に沿う map を分けて定義する。
+
+```text
+res_context : St_A(W,t) -> St_A(V,t)
+transport_trace : e : t -> t' -> State_A(W,t) -> State_A(W,t')
+```
+
+- presheaf functoriality(identity / composition)を証明する。
+- selected descent 条件がある場合の `StateTransitionSheaf` を定義する。sheaf 条件そのものは PRD-2 / PRD-4 の bridge を使い、一般 sheafification は新規開発しない。
+- temporal law を定義する。
+
+```text
+TemporalLaw:
+  closed temporal equation
+  commutative temporal square
+  replay idempotence
+  encode/decode compatibility
+  compensation compatibility
+  migration compatibility
+  descent temporal law
+```
+
+各 law は selected `St_A` と `Tr_E` に相対化された predicate / equation として置く。
+- 完了条件: `St_A`、restriction / transport、presheaf functoriality、`TemporalLaw` が sorry なしで存在する。
+
+### R4. Temporal Obstruction と Temporal Class(定義3.4)
+
+- temporal law `L_t` に対する mismatch object を定義する。
+
+```text
+TemporalMismatch(L_t) : C^n(TemporalSite(E,X), TempCoeff_A)
+```
+
+- temporal cocycle predicate と cohomology class を定義する。
+
+```text
+TemporalCocycle(m)
+TemporalClass(m) : H^n(Tr_E x X, TempCoeff_A)
+```
+
+- `Ob_t in H^n(Tr_E x X, TempCoeff_A)` は、積構造・係数・mismatch cocycle が固定された場合のみ定義されることを型で表す。
+- `nonzero group != concrete obstruction` の PRD-4 規律を引き継ぎ、temporal obstruction theorem は concrete class を引数に取る形にする。
+- 完了条件: temporal mismatch / cocycle / class が sorry なしで存在する。
+
+### R5. Replay Descent Data と定理4.2 Temporal Descent Criterion
+
+- cover `U = {W_i -> W}` と trace arrow `e : t -> t'` に対する local replay data を定義する。
+
+```text
+ReplayDescentData:
+  r_i : State_A(W_i,t) -> State_A(W_i,t')
+```
+
+- overlap 上の差を temporal coefficient の 1-cochain として定義する。
+
+```text
+m(r)_{ij} in TempCoeff_A(W_ij, e)
+```
+
+- mismatch が 1-cocycle である条件を定義し、torsor / affine action 型の replay adjustment がある場合に cocycle condition が自然に出る補題を証明する。
+- effective temporal adjustment を定義する。
+
+```text
+adjust(c, r)_i
+m(adjust(c,r)) = m(r) - d c
+```
+
+- 定理4.2を証明する。仮定:
+
+```text
+Tr_E and X are finite.
+TemporalSite(E,X) is fixed.
+TempCoeff_A is an abelian coefficient sheaf.
+local replay data r has mismatch cocycle m(r).
+[m(r)] = 0 in H^1(TemporalSite(E,X), TempCoeff_A).
+replay data admits effective adjustment by 0-cochains.
+adjusted compatible replay data descends for St_A.
+```
+
+結論:
+
+```text
+exists global replay transition r : State_A(W,t) -> State_A(W,t')
+```
+
+local adjustment 後の global transition として読む。
+- 逆向き(`global replay transition -> [m(r)] = 0`)は定理4.2の一部ではない。
+  replay mismatch construction の soundness、descent detecting、global transition が selected local replay data を生成することを
+  別仮定として持つ場合だけ、nonzero class から global replay transition 不存在を導く補題を置ける。
+- 完了条件: 定理4.2 が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R6. Evolution Functional と Dissipative Policy(定義5.1、5.2)
+
+- `EvolutionFunctional` を、measurement profile `M` と selected state space 上の ordered value reading として定義する。
+
+```text
+Phi_M : State_E -> Value
+```
+
+`Value` は少なくとも preorder / well-founded order / zero or minimum predicate を必要に応じて持つ。
+- 代表 reading との bridge を optional fields として持たせる。
+
+```text
+obstruction mass
+harmonic mass ||h(g)||
+distance-to-flatness
+transfer residue norm
+```
+
+- dissipative policy を定義する。
+
+```text
+Dissipative(F,Phi_M) := forall selected f : A -> B, Phi_M(B) <= Phi_M(A)
+StrictlyDissipativeOutsideTerminal := forall selected f : A -> B, NonTerminal A -> Phi_M(B) < Phi_M(A)
+```
+
+- terminal state predicate を定義する。terminal が lawful であることは別 predicate とし、ここでは同一視しない。
+- selected evolution path と path-wise non-increase / strict-decrease predicate を定義する。
+- 完了条件: `EvolutionFunctional`、`DissipativePolicy`、`TerminalState`、path predicates が sorry なしで存在する。
+
+### R7. 定理5.3 Finite Dissipation Stopping
+
+- finite selected state set、well-founded ordered value、strictly dissipative outside terminal states の下で、非終端 selected step の無限列が存在しないことを証明する。
+- theorem package は次を含む。
+
+```text
+no_infinite_nonterminal_path:
+  no infinite selected evolution path staying outside terminal states.
+
+maximal_path_reaches_terminal:
+  if the policy is executable from every nonterminal state and a path is maximal,
+  then it reaches a terminal state in finitely many selected steps.
+```
+
+- 本文の「任意の selected evolution path は有限時間で terminal state に到達する」は、Lean では上の二つに分解して証明する。
+- terminal state が lawful であるためには PRD-3 / PRD-4 の obstruction vanishing、exactness、coverage assumptions が別途必要であることを docstring と非主張に記録する。
+- 完了条件: 定理5.3 package が sorry なしで証明され、`proof_obligations.md` で `proved` に昇格している。
+
+### R8. AAT Lyapunov Reading(定義6.1)
+
+- `AATLyapunovReading` を定義する。
+
+```text
+AATLyapunovReading(Phi_M):
+  NonIncreasingAlongPolicy Phi_M
+  MinimalNearSelectedObstructionZero Phi_M
+  Scope = selected finite evolution profile
+```
+
+- dissipative policy がある場合、`Phi_M` は selected path に沿って非増加であることを補題として証明する。
+- strictly dissipative outside terminal states の場合、terminal 到達前の loop が存在しないことを補題として証明する。
+- `Phi_M(A) = ||h(g_A)||` のような harmonic mass 例は、PRD-8 の Hodge model がある場合の instance として与える。
+- 原則6.2は非主張に記録し、未選択 transition / 未構成 state space / 任意 future path に対する forecast theorem を作らない。
+- 完了条件: `AATLyapunovReading` と path monotonicity 補題が sorry なしで存在する。
+
+### R9. Force と Force Integrability Obstruction Statement(定義7.1、定理候補7.2)
+
+- force を selected transition として定義する。
+
+```text
+Force_E(A_t,A_{t+1})
+```
+
+または、state transition presheaf 上の morphism として読む。
+- integrable force を、local law data が global temporal law data へ descent / integration できる predicate として定義する。
+
+```text
+IntegrableForce(F)
+```
+
+- force mismatch class を定義する。
+
+```text
+ob(F) in H^1(TemporalSite(E,X), TempCoeff_A)
+```
+
+ただし、mismatch construction、coefficient exactness、trace product site、temporal descent detecting profile を record として明示する。
+- 定理候補7.2を statement-only で形式化する。
+
+```text
+ForceIntegrabilityObstructionCandidate:
+  ob(F) != 0
+  -> not IntegrableForce(F)
+```
+
+仮定には次を含める。
+
+```text
+ob(F) is the concrete temporal mismatch class of F.
+TempCoeff_A detects temporal descent failure.
+local-to-global integration is controlled by the selected temporal descent criterion.
+coefficient exactness and witness coverage hold for the temporal law family.
+```
+
+- 証明はしない。future proof obligation として台帳に登録する。
+- 完了条件: `Force`、`IntegrableForce`、`ForceMismatchClass`、定理候補7.2 statement がコンパイルされている。
+
+### R10. 有限モデルの拡張
+
+- PRD-1〜8 の有限モデル(`Formal/AG/Examples/`)を第IX部の水準へ拡張する。
+  (a) two-step trace category: `t0 -> t1` を持つ finite trace category を構成し、identity / composition を検証する。
+  (b) replay descent zero example: two-chart cover 上の local replay mismatch が coboundary であり、定理4.2により global replay transition が得られることを検証する。
+  (c) replay descent nonzero example: pseudo-circle temporal cover 上で concrete mismatch class が非零であることを検証する。
+      global replay transition が存在しないことまで示す場合は、PRD-4 の gap theorem に加えて、R5 の逆向き soundness / descent detecting 仮定を fixture に含める。
+  (d) finite dissipation example: 3状態程度の finite state set と `Phi` を置き、strictly dissipative policy が terminal state に停止することを検証する。
+  (e) non-lawful terminal example: terminal に到達しても selected obstruction vanishing がない限り lawful とは言えないことを、separate predicate として検証する。
+  (f) Lyapunov harmonic example: PRD-8 の finite Hodge toy model の harmonic mass を `Phi_M` として使い、selected path で非増加である例を作る。
+  (g) force obstruction candidate example: toy force に対し `ob(F)` class を構成し、statement-only candidate の仮定を満たす fixture を作る。
+- これらは future ArchSig temporal measurement / replay audit の golden fixtures として再利用できる形を保つ。
+- 完了条件: (a)–(g) が sorry なしで存在する。ただし (g) は theorem candidate の fixture であり、obstruction theorem の証明は要求しない。
+
+### R11. 台帳整備
+
+- `lean_theorem_index.md` の AG 節に第IX部の宣言を追加する(本文ラベル列は `IX.` 付き)。
+- `proof_obligations.md` に第IX部の証明対象ラベル(定理4.2、定理5.3、Lyapunov path monotonicity 補題、example theorem 群)を登録し、進行に応じて status を更新する。
+- 定理候補7.2は future proof obligation として登録するが、proved に昇格しない。
+- 処遇表で「対象外」とした本文ラベルは台帳に登録しない。
+- `GeneralTraceSemantics`, `ExternalRuntimeForecast`, `AllFuturePathSafety`, `UnselectedEventCompleteness`,
+  `TerminalStateImpliesLawfulWithoutObstructionAssumptions`, `GeneralForceIntegrabilityTheorem` は、
+  本PRDでは未実装の future proof obligation または explicit non-goal として明記する。
+- 完了条件: 両台帳が最終実装と一致している。
+
+## 非主張(claim boundary)
+
+- 本PRDは selected trace category の内部だけを扱う。未選択 event、未選択 operation path、外部 runtime event、実時間、任意の future state について zero / lawful / safe / dissipative を主張しない。
+- `Tr_E x X` が定義されていない場合、`H^n(Tr_E x X, TempCoeff_A)` は定義ではなく reading schema に留まる。
+  一般 site product の完全理論は本PRDの範囲外であり、finite product / incidence site を優先する。
+- temporal obstruction は concrete mismatch cocycle / class に相対化される。
+  `H^1` group が非零であるだけでは、特定の replay data や force が失敗するとは主張しない。
+- 定理4.2は `[m(r)] = 0` だけで global replay transition が得られるとは主張しない。
+  effective adjustment action と state transition presheaf の descent を明示的に仮定する。
+- temporal coefficient は abelian coefficient sheaf として扱う。non-abelian transition groupoid、gerbe 的 temporal obstruction、stacky temporal descent は扱わない。
+- terminal state は lawful state ではない。terminal が lawful であるには、第III部・第IV部の obstruction vanishing、soundness / completeness、axis exactness、witness coverage、descent assumptions が別途必要である。
+- dissipative policy と Lyapunov reading は forecast ではない。selected profile 外の transition、未構成の状態空間、外部入力、任意の将来 path に対する予測を与えない。
+- `Phi_M` の小ささ、非増加性、停止性は structural lawfulness ではない。lawfulness は lawful locus factorization / obstruction ideal vanishing / cohomological descent の仮定で読む。
+- Force Integrability Obstruction は theorem candidate であり、本PRDの完了は一般 force integrability theorem の証明を含まない。
+- migration、compensation、replay、encode/decode の代表例は temporal law schema として扱い、実プログラムや外部データの正しさを主張しない。
+
+## 完了条件(Acceptance Criteria)
+
+- [ ] AC1. `Formal/AG/Evolution` が新設され、CI の `lake build` でビルドされる。先行PRD依存の blocked 判定が運用されている(R0)
+- [ ] AC2. `EvolutionProfile`、`TraceCategory Tr_E`、finite trace category regime が形式化されている(R1)
+- [ ] AC3. `EvolGeom_E : Tr_E -> AATGeometry` または有限列 `X_0 -> ... -> X_n` の special case が形式化されている(R1)
+- [ ] AC4. `TemporalSite(E,X) = Tr_E x X` の finite product / incidence site が形式化されている(R2)
+- [ ] AC5. temporal cover と PRD-4 Čech complex への bridge が存在する(R2)
+- [ ] AC6. `TempCoeff_A` が abelian coefficient sheaf / module-valued sheaf として形式化されている(R2)
+- [ ] AC7. `StateTransitionPresheaf St_A`、context restriction、trace transport が形式化されている(R3)
+- [ ] AC8. `St_A` の presheaf functoriality(identity / composition)が sorry なしで証明されている(R3)
+- [ ] AC9. `StateTransitionSheaf` の selected descent predicate と `TemporalLaw` が形式化されている(R3)
+- [ ] AC10. `TemporalMismatch`、`TemporalCocycle`、`TemporalClass` が形式化されている(R4)
+- [ ] AC11. `ReplayDescentData` と mismatch cocycle `m(r)` が形式化されている(R5)
+- [ ] AC12. effective temporal adjustment の定義と `m(adjust(c,r)) = m(r) - d c` 型の補題が sorry なしで証明されている(R5)
+- [ ] AC13. 定理4.2 Temporal Descent Criterion が sorry なしで証明されている(R5)
+- [ ] AC14. `EvolutionFunctional Phi_M`、`DissipativePolicy`、`StrictlyDissipativeOutsideTerminal`、`TerminalState` が形式化されている(R6)
+- [ ] AC15. selected evolution path と path-wise non-increase / strict-decrease predicates が形式化されている(R6)
+- [ ] AC16. 定理5.3 Finite Dissipation Stopping package が sorry なしで証明されている(R7)
+- [ ] AC17. `AATLyapunovReading` が形式化され、selected path monotonicity 補題が sorry なしで証明されている(R8)
+- [ ] AC18. `Force`、`IntegrableForce`、`ForceMismatchClass` が形式化されている(R9)
+- [ ] AC19. 定理候補7.2 Force Integrability Obstruction statement がコンパイルされている(R9)
+- [ ] AC20. 有限モデル拡張((a) two-step trace category、(b) replay descent zero、(c) replay descent nonzero、(d) finite dissipation、
+      (e) non-lawful terminal、(f) Lyapunov harmonic、(g) force candidate fixture)が検証されている(R10)
+- [ ] AC21. `Formal/AG` 全体に `axiom` / `admit` / `sorry` / `unsafe` が存在しない
+- [ ] AC22. `lean_theorem_index.md` の AG 節が第IX部の宣言を `IX.` 付き本文ラベルで含み、最終実装と一致している(R11)
+- [ ] AC23. `proof_obligations.md` に第IX部の証明対象ラベルが登録され、証明済み分が `proved`、theorem candidate と non-goals が future obligation / explicit non-goal として明記されている(R11)
+
+## 実行順序の指針
+
+prd-loop のギャップ分析で対象を選ぶ際は、次の依存順を推奨する。
+
+```text
+R0 -> R1 -> R2
+   -> R3 -> R4
+   -> R5
+   -> R6 -> R7
+   -> R8
+   -> R9
+   -> R10 -> R11
+```
+
+R1/R2 は Part9 全体の ambient であり、trace と product / incidence site を先に閉じる。
+R3/R4 は temporal law と obstruction class の型境界であり、Temporal Descent Criterion の前提になる。
+R5 は第IX部の cohomological core なので、PRD-4 の Čech complex と toy cover を早めに接続する。
+R6/R7 は well-founded stopping の独立した有限数学として閉じやすい。
+R8 は PRD-8 の Hodge / harmonic examples と接続できる段階で追加する。
+R9 は theorem candidate statement に留め、R5 の temporal descent detecting interface を再利用する。
+R10 の有限モデルは各ブロックが閉じるたびに増分追加してよい。


### PR DESCRIPTION
## 概要

AAT代数幾何版 Lean形式化 PRD の第VI部〜第IX部を追加します。

- 第VI部: Singularity・Monodromy・Stack
- 第VII部: Representation・Periods・Analysis
- 第VIII部: Measurement Theory
- 第IX部: Evolution Geometry

数学本文との対応を保ちつつ、Lean形式化コストを考慮して selected interface、theorem candidate、future obligation、claim boundary を明示する計画にしています。

対象 Issue: なし

## 証明した定理

- なし

## 編集したドキュメント

- docs/aat/lean_ag_part_6_singularity_monodromy_stack_prd.md
- docs/aat/lean_ag_part_7_representation_periods_analysis_prd.md
- docs/aat/lean_ag_part_8_measurement_theory_prd.md
- docs/aat/lean_ag_part_9_evolution_geometry_prd.md

## 実施したテスト

- [x] lake build
- [ ] cargo test --manifest-path tools/archsig/Cargo.toml（ArchSig 変更なし）
- [ ] cargo test --manifest-path tools/fieldsig/Cargo.toml（FieldSig 変更なし）
- [x] git diff --cached --check
- [x] hidden / bidirectional Unicode scan
- [x] axiom / admit / sorry / unsafe scan（新規PRDの方針文と既存 docstring の axiom system 表記のみ。Lean source への新規導入なし）

## チェックリスト

- [ ] 対象 Issue を Closes #N 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を proved, defined only, future proof obligation, empirical hypothesis のいずれかで明確にした
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない