### PR TITLE
AG版AATの有限poset Čech計算を定義

### DIFF
--- a/Formal/AG/Site.lean
+++ b/Formal/AG/Site.lean
@@ -7,3 +7,4 @@ import Formal.AG.Site.Adequate
 import Formal.AG.Site.Geometry
 import Formal.AG.Site.Sheaf
 import Formal.AG.Site.Descent
+import Formal.AG.Site.FinitePoset

--- a/Formal/AG/Site/FinitePoset.lean
+++ b/Formal/AG/Site/FinitePoset.lean
@@ -1,0 +1,175 @@
+import Formal.AG.Site.Descent
+
+namespace AAT.AG
+namespace Site
+
+universe u
+
+/--
+II.定義7.2B: finite poset AAT site regime.
+
+This is the finite, cover-relative regime used by the Čech computation
+surface. It records finiteness of contexts and of the selected cover index, the
+finite-meet overlap structure, the witness-closure adequacy boundary, and a
+coefficient presheaf on the selected AAT site.
+-/
+structure FinitePosetAATSiteRegime {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} (S : AATSite A) where
+  finiteContexts : Finite (ArchCtx A)
+  finiteMeet : ContextFiniteMeet S.contextPreorder
+  base : S.category
+  cover : AATCoverageFamily S.requirements S.overlap base
+  finiteCoverIndex : Finite cover.Index
+  nerveSimplex : Nat -> Type u
+  finiteNerveSimplex : ∀ n : Nat, Finite (nerveSimplex n)
+  simplexIndices : ∀ n : Nat, nerveSimplex n -> Fin (n + 1) -> cover.Index
+  simplexOverlap : ∀ n : Nat, nerveSimplex n -> ArchCtx A
+  simplexOverlap_le_patch :
+    ∀ (n : Nat) (simplex : nerveSimplex n) (k : Fin (n + 1)),
+      S.contextPreorder.le (simplexOverlap n simplex)
+        (cover.patch (simplexIndices n simplex k))
+  adequacyRequirements : UAdequacyRequirements S.contextPreorder S.requirements
+  coverAdequate : UAdequateCover adequacyRequirements cover
+  coefficient : AATPresheaf S
+
+namespace FinitePosetAATSiteRegime
+
+/-- II.定義7.2B: the selected cover is finite. -/
+theorem cover_index_finite {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) :
+    Finite K.cover.Index :=
+  K.finiteCoverIndex
+
+/-- II.定義7.2B: the regime remembers a `U`-adequate cover. -/
+theorem cover_is_uAdequate {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) :
+    UAdequateCover K.adequacyRequirements K.cover :=
+  K.coverAdequate
+
+end FinitePosetAATSiteRegime
+
+/--
+II.定義7.2B / 7.2C: an `n`-simplex of the cover nerve.
+
+The simplex is represented by `n+1` selected cover indices and an explicit
+overlap context mapping to every selected patch.
+-/
+abbrev FinitePosetCechSimplex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) (n : Nat) :=
+  K.nerveSimplex n
+
+namespace FinitePosetCechSimplex
+
+/-- II.定義7.2B: the cover indices selected by a simplex. -/
+def indices {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {K : FinitePosetAATSiteRegime S} {n : Nat}
+    (simplex : FinitePosetCechSimplex K n) :
+    Fin (n + 1) -> K.cover.Index :=
+  K.simplexIndices n simplex
+
+/-- II.定義7.2B: the explicit overlap context of a simplex. -/
+def overlap {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {K : FinitePosetAATSiteRegime S} {n : Nat}
+    (simplex : FinitePosetCechSimplex K n) : ArchCtx A :=
+  K.simplexOverlap n simplex
+
+/-- II.定義7.2B: the overlap context maps to every selected patch. -/
+theorem overlap_le_patch {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} {K : FinitePosetAATSiteRegime S} {n : Nat}
+    (simplex : FinitePosetCechSimplex K n) (k : Fin (n + 1)) :
+    S.contextPreorder.le simplex.overlap (K.cover.patch (simplex.indices k)) :=
+  K.simplexOverlap_le_patch n simplex k
+
+/-- II.命題7.2C: the finite cover regime has finitely many selected simplices. -/
+theorem finite {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) (n : Nat) :
+    Finite (FinitePosetCechSimplex K n) := by
+  exact K.finiteNerveSimplex n
+
+end FinitePosetCechSimplex
+
+/-- II.定義7.2C: finite-poset cover-relative Čech `n`-cochains. -/
+abbrev FinitePosetCechCochain {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) (M : Type u) (n : Nat) :=
+  FinitePosetCechSimplex K n -> M
+
+/-- II.定義7.2C: the zero cochain in a coefficient type with zero. -/
+def FinitePosetCechZeroCochain {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) (M : Type u) [Zero M]
+    (n : Nat) : FinitePosetCechCochain K M n :=
+  fun _ => 0
+
+/--
+II.定義7.2C: finite-poset cover-relative Čech complex vocabulary.
+
+The differential is explicit data. This file does not assert that this
+cover-relative complex computes sheaf cohomology.
+-/
+structure FinitePosetCechComplex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) (M : Type u) [Zero M] where
+  differential :
+    ∀ n : Nat, FinitePosetCechCochain K M n -> FinitePosetCechCochain K M (n + 1)
+  differential_zero :
+    ∀ n : Nat, differential n (FinitePosetCechZeroCochain K M n) =
+      FinitePosetCechZeroCochain K M (n + 1)
+
+/--
+II.定義7.2C: `C^n = 0` in the finite cover-relative vocabulary.
+
+Because the present R9 surface is type-valued and cover-relative, vanishing is
+recorded as subsingleton cochains in the selected degree.
+-/
+def FinitePosetCechCochainsVanish {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : AATSite A}
+    (K : FinitePosetAATSiteRegime S) (M : Type u) (n : Nat) : Prop :=
+  Subsingleton (FinitePosetCechCochain K M n)
+
+/-- II.定義7.2C: `H^n = 0` in the same finite cover-relative vocabulary. -/
+def FinitePosetCechCohomologyVanishes {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : AATSite A}
+    (K : FinitePosetAATSiteRegime S) (M : Type u) (n : Nat) : Prop :=
+  FinitePosetCechCochainsVanish K M n
+
+/--
+II.定義7.2C: the cover nerve has dimension at most `d`.
+
+This is the finite-poset form of the dimension bound: no selected `n`-simplex
+exists for `d < n`.
+-/
+def FinitePosetNerveDimension {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : AATSite A} (K : FinitePosetAATSiteRegime S) (d : Nat) : Prop :=
+  ∀ {n : Nat}, d < n -> IsEmpty (FinitePosetCechSimplex K n)
+
+/-- II.命題7.2C: the finite Čech complex has finitely many degree-`n` summands. -/
+theorem finitePosetCechComplex_finite {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : AATSite A}
+    (K : FinitePosetAATSiteRegime S) (n : Nat) :
+    Finite (FinitePosetCechSimplex K n) :=
+  FinitePosetCechSimplex.finite K n
+
+/--
+II.命題7.2C: above the nerve dimension, the selected Čech cochains vanish.
+-/
+theorem finitePosetCechCochains_vanish_above_nerveDimension
+    {U : AtomCarrier.{u}} {A : ArchitectureObject U} {S : AATSite A}
+    (K : FinitePosetAATSiteRegime S) (M : Type u) {d n : Nat}
+    (hdim : FinitePosetNerveDimension K d) (hn : d < n) :
+    FinitePosetCechCochainsVanish K M n := by
+  letI : IsEmpty (FinitePosetCechSimplex K n) := hdim hn
+  change Subsingleton (FinitePosetCechCochain K M n)
+  exact inferInstance
+
+/--
+II.命題7.2C: above the nerve dimension, the finite cover-relative
+cohomology vocabulary vanishes.
+-/
+theorem finitePosetCechCohomology_vanishes_above_nerveDimension
+    {U : AtomCarrier.{u}} {A : ArchitectureObject U} {S : AATSite A}
+    (K : FinitePosetAATSiteRegime S) (M : Type u) [Zero M]
+    (_complex : FinitePosetCechComplex K M) {d n : Nat}
+    (hdim : FinitePosetNerveDimension K d) (hn : d < n) :
+    FinitePosetCechCohomologyVanishes K M n :=
+  finitePosetCechCochains_vanish_above_nerveDimension K M hdim hn
+
+end Site
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4487,15 +4487,16 @@ File: `Formal/AG/Site.lean`, `Formal/AG/Site/Basic.lean`,
 `Formal/AG/Site/Context.lean`, `Formal/AG/Site/ContextCategory.lean`,
 `Formal/AG/Site/Coverage.lean`, `Formal/AG/Site/Topology.lean`,
 `Formal/AG/Site/Adequate.lean`, `Formal/AG/Site/Geometry.lean`,
-`Formal/AG/Site/Sheaf.lean`, `Formal/AG/Site/Descent.lean`.
+`Formal/AG/Site/Sheaf.lean`, `Formal/AG/Site/Descent.lean`,
+`Formal/AG/Site/FinitePoset.lean`.
 
 PRD-2 [第II部 Architecture Geometry・Site・Sheaf](lean_ag_part_2_sites_sheaves_prd.md) の
-AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6、AC11/R7、AC12/R8 に対応する site/context entrypoint である。現時点では
+AC1/R0、AC2/R1、AC3-AC4/R2、AC5/R3、AC6-AC7/R4、AC8-AC9/R5、AC10/R6、AC11/R7、AC12/R8、AC13-AC14/R9 に対応する site/context entrypoint である。現時点では
 PRD-1 の `AATCorePackage` に依存する入口、Architecture Context の最小モデル、
 §5 の射 role predicate、命題4.2 の finite-meet preorder / quotient-poset package、
 仮定4.3 の pullback lifting package、coverage family、admissible cover の5条件までを Lean 上に置き、
 admissible cover から生成される `J_U` と Mathlib `Coverage.toGrothendieck` bridge までを Lean 上に置く。
-U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、名前付き sheaf family、gluing / descent、sheafification comparison / gap も Lean 上に置く。
+U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、名前付き sheaf family、gluing / descent、sheafification comparison / gap、finite poset Čech regime と高次消滅も Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4508,6 +4509,7 @@ U-adequate cover、補題7.2A、AAT Site、Architecture Geometry、presheaf、sh
 | `II.定義8.1 / 定義2.1` | `AAT.AG.Site.AATSite`, `AATSite.architectureObject`, `AATSite.category`, `AATSite.topology`, `AATSite.topology_eq`, `AATSite.top_mem`, `AAT.AG.Site.ArchitectureGeometry`, `ArchitectureGeometry.generatedObject`, `ArchitectureGeometry.generatedObject_eq_core`, `ArchitectureGeometry.contextPreorder`, `ArchitectureGeometry.category`, `ArchitectureGeometry.topology`, `ArchitectureGeometry.topology_eq_site` | `structure` / `abbrev` / `def` / `theorem` | `ArchCtx(A)` と `J_U` を束ねる AAT Site package、および PRD-1 の `PartIPrerequisites` / `AATCorePackage` 由来 object に site を載せる Architecture Geometry package。第III部以降の sheaf 群の置き場はコメントに留める。 | `defined only` / `proved` |
 | `II.定義9.1 / 定義10.1 / 定義10.2` | `AAT.AG.Site.AATPresheaf`, `AAT.AG.Site.AtRaw`, `AAT.AG.Site.LawRaw`, `AAT.AG.Site.SigRaw`, `AAT.AG.Site.AATSheafConditionFor`, `AAT.AG.Site.AATSheafCondition`, `AATSheafCondition.cover`, `AATSheafCondition.iff_presieve_isSheaf`, `AAT.AG.Site.AATSheaf`, `AATSheaf.toPresheaf`, `AATSheaf.presieve_isSheaf`, `AAT.AG.Site.ArchitectureSheafFamily`, `ArchitectureSheafFamily.At_isSheaf`, `ArchitectureSheafFamily.Law_isSheaf`, `ArchitectureSheafFamily.Sig_isSheaf`, `ArchitectureSheafFamily.State_isSheaf`, `ArchitectureSheafFamily.Eff_isSheaf`, `ArchitectureSheafFamily.Auth_isSheaf`, `ArchitectureSheafFamily.Sem_isSheaf`, `ArchitectureSheafFamily.Trace_isSheaf` | `abbrev` / `structure` / `def` / `theorem` | `ArchCtx(A)^op` 上の Type-valued presheaf、代表的 raw presheaf signature、compatible local sections が一意の global section へ貼り合う sheaf condition、Mathlib `Presieve.IsSheaf` bridge、および `At / Law / Sig / State / Eff / Auth / Sem / Trace` の名前付き sheaf family carrier package。 | `defined only` / `proved` |
 | `II.定義11.1 / 定義11.2 / 定義12.1` | `AAT.AG.Site.AATLocalSectionFamily`, `AAT.AG.Site.AATOverlapAgreement`, `AAT.AG.Site.AATCocycleCondition`, `AAT.AG.Site.AATGluingData`, `AATGluingData.cocycle`, `AAT.AG.Site.AATGlobalSectionRealizes`, `AAT.AG.Site.AATDescent`, `AATDescent.exists_global`, `AATSheafConditionFor.descent`, `AATSheafCondition.descent`, `AATSheaf.descent`, `AAT.AG.Site.AATSheafificationComparison`, `AATSheafificationComparison.plus_isSheaf`, `AAT.AG.Site.AATSheafificationGap` | `abbrev` / `structure` / `def` / `theorem` | cover 上の局所 section family、overlap agreement / cocycle condition、gluing data、compatible gluing data が一意の global section から来る descent、sheaf condition から descent を読む補題、および canonical map `F_raw -> F_raw^+` に相対化した sheafification comparison / gap。 | `defined only` / `proved` |
+| `II.定義7.2B / 命題7.2C` | `AAT.AG.Site.FinitePosetAATSiteRegime`, `FinitePosetAATSiteRegime.cover_index_finite`, `FinitePosetAATSiteRegime.cover_is_uAdequate`, `AAT.AG.Site.FinitePosetCechSimplex`, `FinitePosetCechSimplex.indices`, `FinitePosetCechSimplex.overlap`, `FinitePosetCechSimplex.overlap_le_patch`, `FinitePosetCechSimplex.finite`, `AAT.AG.Site.FinitePosetCechCochain`, `AAT.AG.Site.FinitePosetCechZeroCochain`, `AAT.AG.Site.FinitePosetCechComplex`, `AAT.AG.Site.FinitePosetCechCochainsVanish`, `AAT.AG.Site.FinitePosetCechCohomologyVanishes`, `AAT.AG.Site.FinitePosetNerveDimension`, `AAT.AG.Site.finitePosetCechComplex_finite`, `AAT.AG.Site.finitePosetCechCochains_vanish_above_nerveDimension`, `AAT.AG.Site.finitePosetCechCohomology_vanishes_above_nerveDimension` | `structure` / `abbrev` / `def` / `theorem` | finite contexts、finite meet、finite witness-closure adequate cover、coefficient presheaf、selected finite nerve simplex と overlap データを束ねる finite poset AAT site regime。cover-relative Čech cochain / complex vocabulary、各 degree の finite summand、nerve dimension `d` より上の cochain / cohomology vanishing を定義・証明する。 | `defined only` / `proved` |
 
 Non-conclusions: この entrypoint は `Formal/AG/Site` が build 対象に入ったことと
 PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predicate、
@@ -4515,8 +4517,9 @@ PRD-1 依存の入口、定義3.1 Architecture Context、§5 の射 role predica
 coverage family と admissible cover の5条件、admissible cover から生成される `J_U`、
 明示された pullback / base-change 前提下の Mathlib coverage bridge、U-adequate cover、
 補題7.2A の十分条件、AAT Site、Architecture Geometry、presheaf、sheaf condition bridge、
-名前付き sheaf family carrier package、gluing / descent、sheafification comparison / gap だけを示す。
-Cech complex、`AATSh`、有限 poset site example はまだ形式化しない。
+名前付き sheaf family carrier package、gluing / descent、sheafification comparison / gap、
+finite poset cover-relative Čech vocabulary と nerve dimension 上の高次消滅だけを示す。
+一般 site の Čech complex、sheaf cohomology 計算、`AATSh`、有限 poset site example はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -632,18 +632,21 @@ Issue [#1976](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では presheaf、sheaf condition bridge、名前付き sheaf family package を追加した。
 Issue [#1978](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1978)
 では gluing data、descent、sheaf-descent 補題、sheafification comparison / gap を追加した。
+Issue [#1980](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1980)
+では finite poset AAT site regime、cover-relative Čech complex vocabulary、命題7.2C の finite / high-degree vanishing surface を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
-| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
-| `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
-| `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | Finite Poset regime、AATSh は後続 Issue に残る。 |
-| `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | finite poset Cech regime は後続 Issue に残る。 |
-| `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | finite poset Cech regime は後続 Issue に残る。 |
-| `II.定義8.1 / 定義2.1` AAT Site と Architecture Geometry | `defined only` / `proved`. `Formal/AG/Site/Geometry.lean` が `AATSite`、`AATSite.topology`、`ArchitectureGeometry`、PRD-1 core object との accessor theorem を持つ。 | finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
-| `II.定義9.1 / 定義10.1 / 定義10.2` Presheaf と sheaf condition | `defined only` / `proved`. `Formal/AG/Site/Sheaf.lean` が `AATPresheaf`、raw presheaf signature、`AATSheafCondition`、Mathlib `Presieve.IsSheaf` bridge、`AATSheaf`、`At / Law / Sig / State / Eff / Auth / Sem / Trace` の `ArchitectureSheafFamily` を持つ。 | finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
+| `II.R0` Part I prerequisites / Formal/AG/Site entrypoint | `defined only` / `proved`. `Formal/AG/Site/Basic.lean` が `AAT.AG.Site.PartIPrerequisites` と accessor theorem を持つ。 | AATSh は後続 Issue に残る。 |
+| `II.定義3.1 / §5.1-5.4` Architecture Context と射 role | `defined only` / `proved`. `Formal/AG/Site/Context.lean` が `MinimalContext`, `ArchitectureContext`, `ContextMorphism`、restriction / projection / refinement / base change role predicate と accessor theorem を持つ。 | AATSh は後続 Issue に残る。 |
+| `II.定義4.1 / 命題4.2 / 仮定4.3` Context Category と meet-pullback | `defined only` / `proved`. `Formal/AG/Site/ContextCategory.lean` が readable morphism 付き preorder-category package、finite meet、readable equivalence quotient、quotient object 上の finite-meet poset package、pullback / overlap package、pullback lifting property、meet-overlap 補題を持つ。 | AATSh は後続 Issue に残る。 |
+| `II.定義6.1 / 定義7.1前半` Coverage Family と admissible cover | `defined only` / `proved`. `Formal/AG/Site/Coverage.lean` が coverage family `{ W_i -> W }`、selected law universe / selected reading を実引数に取る required support / witness / axis、overlap package に相対化した witness / boundary visibility、admissible cover の5条件と accessor theorem を持つ。 | AATSh は後続 Issue に残る。 |
+| `II.定義7.1後半 / R4` `J_U` と Mathlib bridge | `defined only` / `proved`. `Formal/AG/Site/Topology.lean` が context preorder の Mathlib thin category wrapper、admissible cover generated precoverage、`AATGrothendieckTopology`、identity/top cover、base-change stability、transitivity、admissible generated cover membership、明示 pullback / base-change 前提下の `Coverage.toGrothendieck` bridge theorem を持つ。 | AATSh は後続 Issue に残る。 |
+| `II.定義7.2 / 補題7.2A` U-adequate cover と witness-closure | `defined only` / `proved under explicit WitnessClosureCover package assumptions`. `Formal/AG/Site/Adequate.lean` が U-adequate cover、selected reading 上の witness ideal predicate とその restriction 保存、witness-closure cover construction package、補題7.2A `witnessClosureCover_uAdequate` を持つ。 | AATSh は後続 Issue に残る。 |
+| `II.定義8.1 / 定義2.1` AAT Site と Architecture Geometry | `defined only` / `proved`. `Formal/AG/Site/Geometry.lean` が `AATSite`、`AATSite.topology`、`ArchitectureGeometry`、PRD-1 core object との accessor theorem を持つ。 | `AATSh` は後続 Issue に残る。 |
+| `II.定義9.1 / 定義10.1 / 定義10.2` Presheaf と sheaf condition | `defined only` / `proved`. `Formal/AG/Site/Sheaf.lean` が `AATPresheaf`、raw presheaf signature、`AATSheafCondition`、Mathlib `Presieve.IsSheaf` bridge、`AATSheaf`、`At / Law / Sig / State / Eff / Auth / Sem / Trace` の `ArchitectureSheafFamily` を持つ。 | `AATSh` は後続 Issue に残る。 |
 | `II.定義11.1 / 定義11.2 / 定義12.1` Gluing / Descent / Sheafification Gap | `defined only` / `proved`. `Formal/AG/Site/Descent.lean` が `AATLocalSectionFamily`、`AATOverlapAgreement`、`AATCocycleCondition`、`AATGluingData`、`AATDescent`、`AATSheafConditionFor.descent`、`AATSheafCondition.descent`、`AATSheaf.descent`、`AATSheafificationComparison`、`AATSheafificationGap` を持つ。 | 一般 site の sheafification 構成、finite poset Cech regime、`AATSh` は後続 Issue に残る。 |
+| `II.定義7.2B / 命題7.2C` Finite Poset Regime と Čech computation | `defined only` / `proved`. `Formal/AG/Site/FinitePoset.lean` が `FinitePosetAATSiteRegime`、`FinitePosetCechSimplex`、`FinitePosetCechCochain`、`FinitePosetCechComplex`、`FinitePosetNerveDimension`、finite summand theorem、nerve dimension 上の cochain / cohomology vanishing theorem を持つ。 | 一般 site の Čech complex、sheaf cohomology 計算、Leray 条件、`AATSh` は後続 Issue に残る。 |
 
 第II部 PRD-2 の証明対象ラベルは次の状態から開始する。
 
@@ -658,7 +661,7 @@ Issue [#1978](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 | `II.定義2.1 Architecture Geometry` | `defined only` / `proved` |
 | `II.定義10.1 sheaf condition bridge` | `proved` |
 | `II.定義11.1-12.1 sheaf-descent` | `proved` |
-| `II.命題7.2C` | `future proof obligation` |
+| `II.命題7.2C` | `proved` |
 | `II.R11 finite model examples` | `future proof obligation` |
 
 ## 現在の未解決カテゴリ


### PR DESCRIPTION
## 概要

Closes #1980

AG版AAT PRD-2 の AC13-AC14/R9 として、定義7.2B Finite Poset AAT Site Regime と命題7.2C Finite Poset Computation の Lean surface を追加した。

設計判断:

- `FinitePosetAATSiteRegime` は finite contexts、finite meet、finite cover index、selected nerve simplex、overlap data、U-adequate cover、coefficient presheaf を束ねる。
- Čech complex は finite cover-relative vocabulary として `FinitePosetCechCochain` / `FinitePosetCechComplex` を定義する。
- 命題7.2C は、selected simplex が各 degree で finite であることと、nerve dimension `d` より上では cochain / cohomology vocabulary が vanishing になることを theorem として証明する。
- 一般 site の Čech complex、sheaf cohomology 計算、Leray 条件は主張しない。

## 証明した定理

- `FinitePosetAATSiteRegime.cover_index_finite`
- `FinitePosetAATSiteRegime.cover_is_uAdequate`
- `FinitePosetCechSimplex.overlap_le_patch`
- `FinitePosetCechSimplex.finite`
- `finitePosetCechComplex_finite`
- `finitePosetCechCochains_vanish_above_nerveDimension`
- `finitePosetCechCohomology_vanishes_above_nerveDimension`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Site/FinitePoset.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
