### PR TITLE
ArchSig v0.4.0フォローアップを反映

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -25,16 +25,28 @@ Current source-of-truth boundaries:
   `measured_nonzero`, `unmeasured`, `unknown`, and `not_computed`; analytic
   readings, including theorem-candidate readings, are separate from structural
   verdicts.
+- v0.4.0 non-compatibility is scoped to the AG measurement path: `archmap/v2`
+  plus `measurement-profile/v1` produces `archsig-measurement-packet/v1` and
+  does not accept or emit the v1 typed evaluator artifact chain as that path's
+  primary surface. The existing `archmap/v1` + `law-policy/v1` structural
+  analysis runtime remains available as bounded legacy compatibility until a
+  dedicated removal issue changes that surface.
 - The v0.4.0 assumption ledger records checked / assumed / violated CBI
   assumptions once at packet time. If an assumption is violated, dependent AG
   structural verdicts fall to `not_computed`; conclusion text stays
   ledger-relative and conclusion-first.
+- FieldSig validates serialized `archsig-measurement-packet/v1` handoff
+  semantics before projection. Measured structural verdict rows must carry a
+  `certRef` or matching computed invariant evidence. Because the current packet
+  does not encode row-level assumption dependencies, a violated assumption next
+  to any measured structural verdict is treated as a conservative fail-fast
+  packet-level contradiction rather than a success-looking SFT input.
 
 - ArchMap v1 starts from supplied `archmap/v1` evidence read as a source-grounded Atom map. It records only `sources`, `atoms`, and `molecules` as primary input. Removed v0 fields such as `semanticObservations`, `projectionInfo`, `operationSquareEvidence`, `concernHints`, and `observationGaps` are not v1 input surfaces.
 - ArchMap authoring should produce the source-grounded atoms and explicit molecule membership needed for the requested ArchSig measurement. Private, unavailable, and out-of-scope evidence belongs in authoring notes, CI reports, or review notes, not ArchMap primary JSON.
 - ArchMapStore is the forward storage boundary for ArchMap history. It models `ArchMapDelta`, `ArchMapCommit`, `ArchMapSnapshot`, `ArchMapIndex`, and validation reports so PR review can read ArchMap-level deltas instead of raw language diffs. Raw diffs are not ArchSig PR-review inputs.
 - LawPolicy v1 uses the `law-policy/v1` JSON schema. It is a selector over repository policies, evaluator ids, policy packs, basis refs, scope, severity, and optional `distanceProfileRef`. It does not carry witness rules, signature axes, coverage requirements, exactness assumptions, `part4DistanceProfile`, spectrum profiles, homotopy profiles, distance weights, operation costs, or distance DSLs; those calculation rules belong to the ArchSig evaluator registry / selected distance profile.
-- ArchSig reads ArchMap v1 + LawPolicy v1 and computes a typed evaluator artifact chain: `normalized-archmap/v1`, `typed-evaluator-results/v1`, `archsig-architecture-distance/v1`, `archsig-analysis-packet/v1`, `archsig-analysis-summary/v1`, and `archsig-atom-viewer-data-v1`. Positive bounded conclusions are generated from typed evaluator results, architecture distance readings, support refs, basis refs, and detail refs.
+- ArchSig's legacy v1 structural path reads ArchMap v1 + LawPolicy v1 and computes a typed evaluator artifact chain: `normalized-archmap/v1`, `typed-evaluator-results/v1`, `archsig-architecture-distance/v1`, `archsig-analysis-packet/v1`, `archsig-analysis-summary/v1`, and `archsig-atom-viewer-data-v1`. Positive bounded conclusions are generated from typed evaluator results, architecture distance readings, support refs, basis refs, and detail refs.
 - Wittgensteinian responsibility boundary: ArchSig says only what can be said from the supplied `ArchMap + LawPolicy + evidence contract`, and remains silent about what cannot be said from that input. The ArchMap author is responsible for Atom mapping and evidence correctness. The LawPolicy author is responsible for policy, evaluator, and restricted measurement profile selection. Axis, witness, coverage, and missing-blocker rules belong to the evaluator registry. ArchSig does not complete, infer, or validate the outside world; it emits a consistent bounded diagnostic conclusion within the input contract.
 - `analyze` is the primary ArchSig workflow entry point. `llm-native-workflow` / `north-star-workflow`, `archsig-analysis` / `aat-analysis`, `analysis-summary`, `codebase-inspection`, and `archmap-generate` are not current runtime surfaces. Old command behavior remains available only through Git history or historical fixtures, not through the v1 CLI contract.
 - `pr-review` is the lightweight CI / PR surface. The v1 path reads base `archmap/v1`, optional head / intermediate `archmap/v1`, PR-local `archmap-delta-v0`, and `law-policy/v1`; it reports typed evaluator status plus report-local refs to derived obstruction, spectrum, homotopy, structural reading, and architecture distance surfaces. It does not reconstruct v0 witness rules or accept raw diff / base packet inputs.

--- a/docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md
+++ b/docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md
@@ -52,10 +52,13 @@ ArchMap v2 (finite poset site observation)
   -> conclusion-first summary / viewer
 ```
 
-互換性方針: v0.4.0 は後方互換性を持たない。`archmap/v1`、`law-policy/v1`、
-`archsig-analysis-packet/v1` 系 artifact chain は v0.4.0 の入力・出力 surface から
-削除し、fixtures は v2 形式へ全面移行する。旧形式は Git history にのみ残る。
-現時点のユーザーは単一であり、migration tooling は作らない。
+互換性方針: v0.4.0 の非互換性は AG measurement path に限定する。
+`archmap/v2` + `measurement-profile/v1` は `archsig-measurement-packet/v1`
+を一次 surface とし、v1 typed evaluator artifact chain をこの path の入力・出力
+surface として扱わない。一方で、現行 CLI には `archmap/v1` + `law-policy/v1`
+の structural analysis path が bounded legacy compatibility として残る。これを
+削除する場合は、別 Issue で runtime、schema catalog、fixtures、FieldSig
+compatibility を同時に更新する。現時点では migration tooling は作らない。
 
 ## 背景
 

--- a/docs/tool/golden_corpus.md
+++ b/docs/tool/golden_corpus.md
@@ -56,28 +56,32 @@ The square-free repair lock is
 `cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth`. It fixes
 the B.3 / B.4 worked example path: `I_Ob^U`, minimal forbidden supports,
 `Delta_U` faces with finite F2 reduced homology, Alexander dual minimal repair
-hitting sets, and an author-supplied NSdepth certificate reference are emitted
-as measurement packet invariants. Because the NSdepth atom is not a finite
-verifier payload, the structural verdict remains `unknown`. The companion
+hitting sets, and a finite NSdepth verifier payload are emitted as measurement
+packet invariants. A verifier payload that matches the computed obstruction
+ideal, selected `depthRule`, and support atom refs yields `measured_nonzero`;
+missing, numeric-only, malformed, or depth-mismatched payloads remain
+`unknown`, not lawful or measured zero. The companion
 `cli_analyze_v2_square_free_without_certificate_returns_unknown` regression
 keeps missing certificates as `unknown`, not lawful or measured zero.
 
 The LawConflict Tor lock is
 `cli_analyze_v2_law_conflict_tor_outputs_conflict_classes`. It fixes the B.5
 worked example path: an explicit common ambient atom bounds the comparison,
-finite monomial law ideal generators are read under that ambient, and
-`LawConflict_1` classes record witness-variable support, context refs, and
-source refs. The companion
+finite selected law generators are read under that ambient, and the degree-1
+shared-support detector records `LawConflict_1` classes with witness-variable
+support, context refs, and source refs. It does not claim a full Taylor, Scarf,
+or free-resolution Tor computation. The companion
 `cli_analyze_v2_law_conflict_tor_without_common_ambient_is_not_computed`
 regression keeps missing ambient evidence as `not_computed` /
 `no_common_ambient`, not measured zero or conflict absence.
 
 The sheaf Laplacian lock is
 `cli_analyze_v2_sheaf_laplacian_outputs_analytic_hodge_reading`. It fixes the
-R6 analytic path: a finite cellular boundary yields a graph Laplacian, Hodge
-decomposition, harmonic mass, distance-to-flatness, spectral gap, curvature
-transfer spectrum, and essential repair lower bound. These are analytic
-readings only; near-flat analytic values are not structural lawfulness verdicts.
+R6 analytic path: a finite cellular boundary yields a graph Laplacian proxy,
+Hodge-style decomposition, harmonic mass, distance-to-flatness, spectral gap,
+curvature transfer spectrum, and essential repair lower bound. These are
+analytic readings only; near-flat analytic values are not structural lawfulness verdicts.
+The graph proxy is not a full chain-complex Hodge theorem.
 The companion regressions
 `cli_analyze_v2_sheaf_laplacian_without_boundary_is_not_computed`,
 `cli_analyze_v2_sheaf_laplacian_missing_witness_cell_is_not_computed`, and

--- a/docs/tool/guideline.md
+++ b/docs/tool/guideline.md
@@ -47,8 +47,8 @@ ArchSig analyze:
 
 ```bash
 cargo run --manifest-path tools/archsig/Cargo.toml -- analyze \
-  --archmap tools/archsig/tests/fixtures/archmap_v1/archmap.json \
-  --law-policy tools/archsig/tests/fixtures/archmap_v1/law_policy.json \
+  --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json \
+  --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json \
   --out-dir .tmp/archsig-analyze
 ```
 
@@ -56,7 +56,7 @@ FieldSig handoff:
 
 ```bash
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
-  --analysis-packet .tmp/archsig-analyze/archsig-analysis-packet.json \
+  --measurement-packet .tmp/archsig-analyze/archsig-measurement-packet.json \
   --out .tmp/fieldsig/operation-support-estimate.json
 ```
 

--- a/tools/archsig/README.md
+++ b/tools/archsig/README.md
@@ -1,8 +1,10 @@
 # ArchSig
 
-`archsig` is the ArchMap -> ArchSig structural analysis CLI. The current v1
-runtime reads supplied `archmap/v1` evidence and a selected `law-policy/v1`
-profile, then emits a typed evaluator output chain for LLM and human review.
+`archsig` is the ArchMap -> ArchSig structural analysis CLI. The current
+runtime has two explicit paths: the legacy v1 structural analysis path reads
+supplied `archmap/v1` evidence and a selected `law-policy/v1` profile, while
+the v0.4.0 AG measurement path reads `archmap/v2` plus a selected
+`measurement-profile/v1` and emits `archsig-measurement-packet/v1`.
 
 ArchSig is an LLM-native tool. The intended product interface is the bundled
 LLM skills in `tools/archsig/skills`, not a human manually reading raw AAT
@@ -42,6 +44,7 @@ are not measured zeros.
 | ArchMap validation and authoring | `archmap` | ArchMap v1 records source-grounded Atom observations and explicit molecule candidates. Removed v0 helper fields such as `semanticObservations`, `projectionInfo`, `operationSquareEvidence`, `concernHints`, and `observationGaps` are not positive input. Complete-first authoring should collect source support and molecule candidates before handoff. ArchMap does not select laws or output obstruction circuits. |
 | Interpretation profile | `law-policy` | LawPolicy v1 selects evaluator manifests, basis refs, selected laws, distance profile, and non-conclusions. It is an evaluator selector, not AAT itself. |
 | ArchSig analysis | `analyze` | `analyze` is the primary workflow from ArchMap v1 + LawPolicy v1 to validation reports, normalized ArchMap, typed evaluator results, architecture distance, `archsig-analysis-summary.json`, `archsig-atom-viewer-data.json`, and `archsig-run-manifest.json`. Raw packet, detail index, and LLM interpretation artifacts are emitted only with `--emit-raw-artifacts`. |
+| AG measurement | `analyze` | When `law-policy/v1` selects `measurementProfileRef` and the input is `archmap/v2`, `analyze` runs the v0.4.0 finite AG measurement path and emits `archsig-measurement-packet/v1`, conclusion-first summary, viewer data, and run manifest. This path is not backward-compatible with v1 ArchMap input, but the legacy v1 structural path remains a bounded compatibility runtime. |
 | Lightweight PR review | `pr-review` | Reads base `archmap/v1`, optional head / intermediate `archmap/v1`, PR-local `archmap-delta-v0`, and required `law-policy/v1`. It does not accept raw diff, ArchMapCommit, or base/head analysis packets as PR-review inputs. It internally computes report-local v1 snapshots and emits delta packet intersections, architecture-distance movement, hidden-excursion boundary, safe-change budget, and structural review focus. |
 | Schema | `schema-catalog` | The catalog lists the current ArchMap, LawPolicy, ArchSig analysis packet, and validation report artifacts. |
 

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -257,8 +257,11 @@ struct SquareFreeGeneratorV1 {
 #[derive(Debug, Clone)]
 struct SquareFreeCertificateV1 {
     cert_ref: String,
-    nsdepth: usize,
+    nsdepth: Option<usize>,
     support_atom_refs: Vec<String>,
+    verified_minimal_forbidden_supports: Vec<Vec<String>>,
+    status: String,
+    effect: String,
 }
 
 #[derive(Debug, Clone)]
@@ -405,7 +408,14 @@ fn evaluate_square_free_repair_v1(
     let delta_faces = stanley_reisner_faces(&witness_variables, &minimal_forbidden_supports);
     let reduced_homology = reduced_simplicial_homology_f2(&delta_faces);
     let repair_hitting_sets = minimal_hitting_sets(&witness_variables, &minimal_forbidden_supports);
-    let certificate = square_free_certificate(normalized, &selected_contexts)?;
+    let certificate = square_free_certificate(
+        normalized,
+        &selected_contexts,
+        &minimal_forbidden_supports,
+        &repair_hitting_sets,
+        &generators,
+        witness_variables.len(),
+    )?;
     let has_obstruction = !minimal_forbidden_supports.is_empty();
     let (verdict, zero, non_zero, method_status, cert_ref, reason) = if !has_obstruction {
         (
@@ -419,14 +429,25 @@ fn evaluate_square_free_repair_v1(
             "square-free obstruction ideal has no selected generators".to_string(),
         )
     } else if let Some(certificate) = &certificate {
-        (
-            "unknown".to_string(),
-            false,
-            false,
-            "nsdepth_certificate_author_supplied_unverified".to_string(),
-            Some(certificate.cert_ref.clone()),
-            "square-free obstruction generators were found and an NSdepth certificate reference was supplied, but no finite NSdepth verifier payload was checked; lawfulness is not concluded".to_string(),
-        )
+        if certificate.status == "verified" {
+            (
+                "measured_nonzero".to_string(),
+                false,
+                true,
+                "nsdepth_certificate_verified".to_string(),
+                Some(certificate.cert_ref.clone()),
+                "square-free obstruction generators were found and the selected finite NSdepth certificate payload matches the computed obstruction ideal".to_string(),
+            )
+        } else {
+            (
+                "unknown".to_string(),
+                false,
+                false,
+                format!("nsdepth_certificate_{}", certificate.status),
+                Some(certificate.cert_ref.clone()),
+                certificate.effect.clone(),
+            )
+        }
     } else {
         (
             "unknown".to_string(),
@@ -476,11 +497,12 @@ fn evaluate_square_free_repair_v1(
                 "minimality": "checked_by_finite_support_enumeration"
             },
             "nsdepthCertificate": certificate.as_ref().map(|certificate| json!({
-                "status": "author_supplied_unverified",
+                "status": certificate.status,
                 "certificateRef": certificate.cert_ref,
                 "nsdepth": certificate.nsdepth,
                 "supportAtomRefs": certificate.support_atom_refs,
-                "effect": "structural verdict remains unknown until a finite NSdepth verifier payload is checked"
+                "verifiedMinimalForbiddenSupports": certificate.verified_minimal_forbidden_supports,
+                "effect": certificate.effect
             })).unwrap_or_else(|| json!({
                 "status": "missing",
                 "effect": "structural verdict remains unknown when obstruction generators are present"
@@ -507,15 +529,27 @@ fn evaluate_square_free_repair_v1(
             },
             AgAssumptionLedgerEntryV1 {
                 theorem_ref: "part3/7.2B".to_string(),
-                assumption: "NSdepth certificate value supplied by ArchMap author; finite verifier payload is not checked by this evaluator".to_string(),
-                status: "assumed".to_string(),
-                checked_by: None,
-                assumed_by: Some(
-                    certificate
-                        .as_ref()
-                        .map(|certificate| certificate.cert_ref.clone())
-                        .unwrap_or_else(|| format!("measurement-profile:{}", profile.profile_id)),
-                ),
+                assumption: "NSdepth certificate payload covers the computed square-free obstruction ideal within the selected witness family".to_string(),
+                status: certificate
+                    .as_ref()
+                    .filter(|certificate| certificate.status == "verified")
+                    .map(|_| "checked")
+                    .unwrap_or("assumed")
+                    .to_string(),
+                checked_by: certificate
+                    .as_ref()
+                    .filter(|certificate| certificate.status == "verified")
+                    .map(|certificate| format!("ag.square-free-repair@1:{}", certificate.cert_ref)),
+                assumed_by: certificate
+                    .as_ref()
+                    .map(|certificate| {
+                        if certificate.status == "verified" {
+                            None
+                        } else {
+                            Some(certificate.cert_ref.clone())
+                        }
+                    })
+                    .unwrap_or_else(|| Some(format!("measurement-profile:{}", profile.profile_id))),
             },
         ],
     })
@@ -623,20 +657,21 @@ fn evaluate_law_conflict_tor_v1(
         },
         zero: !has_conflict,
         non_zero: has_conflict,
-        method_status: "finite_monomial_tor_computed".to_string(),
+        method_status: "finite_degree1_shared_support_conflict_computed".to_string(),
         cert_ref: Some(ambient.atom_ref.clone()),
         reason: if has_conflict {
-            "finite monomial Tor found LawConflict classes under the supplied common ambient"
+            "finite degree-1 shared-support detector found LawConflict classes under the supplied common ambient"
                 .to_string()
         } else {
-            "finite monomial Tor found no LawConflict class under the supplied common ambient"
+            "finite degree-1 shared-support detector found no LawConflict class under the supplied common ambient"
                 .to_string()
         },
         computed_invariants: vec![json!({
-            "invariantId": format!("law-conflict-tor:{}", profile.profile_id),
-            "evaluator": "ag.law-conflict-tor@1",
-            "method": "finite-monomial-tor@1",
-            "resolution": profile.resolution_selector,
+                "invariantId": format!("law-conflict-tor:{}", profile.profile_id),
+                "evaluator": "ag.law-conflict-tor@1",
+                "method": "finite-degree1-shared-support-conflict@1",
+                "claimScope": "degree-1 shared-support conflict detector over the selected common ambient pair",
+                "resolution": profile.resolution_selector,
             "selectedCoverRef": profile.cover_ref,
             "witnessVariables": witness_variables,
             "commonAmbient": {
@@ -649,9 +684,11 @@ fn evaluate_law_conflict_tor_v1(
             "lawConflicts": conflict_json,
             "torByDegree": [{
                 "degree": 1,
-                "classCount": conflicts.len()
+                "classCount": conflicts.len(),
+                "scope": "detected shared witness-variable support only"
             }],
             "nonConclusions": [
+                "This evaluator does not compute a full Taylor, Scarf, or free resolution Tor algebra.",
                 "Flat base change stability is a theorem-candidate reading and is not concluded by this structural verdict."
             ]
         })],
@@ -763,7 +800,8 @@ fn evaluate_sheaf_laplacian_v1(
         .collect::<Vec<_>>();
 
     let analytic_value = json!({
-        "readingKind": "cellular-sheaf-laplacian@1",
+        "readingKind": "graph-laplacian-hodge-proxy@1",
+        "modelScope": "finite graph Laplacian over selected cochain cells and boundary edges",
         "selectedCoverRef": profile.cover_ref,
         "cells": cell_ids,
         "cochain": rounded_vec(&cochain),
@@ -788,6 +826,7 @@ fn evaluate_sheaf_laplacian_v1(
             "invariantId": format!("sheaf-laplacian:{}", profile.profile_id),
             "evaluator": "ag.sheaf-laplacian@1",
             "method": "finite-graph-laplacian@1",
+            "claimScope": "graph Laplacian analytic proxy; not a full sheaf chain-complex Hodge theorem",
             "selectedCoverRef": profile.cover_ref,
             "cellRefs": cells.iter().map(|cell| json!({
                 "cell": cell.cell_id,
@@ -1281,6 +1320,7 @@ fn evaluate_cech_obstruction_v1(
                 "invariantId": format!("cech-cohomology:{}", profile.profile_id),
                 "evaluator": "ag.cech-obstruction@1",
                 "method": "finite-f2-incidence-graph-cochain@1",
+                "claimScope": "selected-cover 1-skeleton Cech cochain calculation",
                 "selectedCoverRef": profile.cover_ref,
                 "coefficient": profile.coefficient,
                 "contextCount": selected_contexts.len(),
@@ -2557,8 +2597,9 @@ fn tor_assumptions(
         },
         AgAssumptionLedgerEntryV1 {
             theorem_ref: "part5/5.5".to_string(),
-            assumption: "finite monomial law ideals selected for Taylor / Scarf Tor enumeration"
-                .to_string(),
+            assumption:
+                "finite monomial law ideals selected for degree-1 shared-support conflict detection"
+                    .to_string(),
             status: "checked".to_string(),
             checked_by: Some(format!(
                 "measurement-profile:{}.witnessFamily",
@@ -2637,6 +2678,10 @@ fn square_free_atom_variables(atom: &crate::NormalizedAtomV2) -> Vec<String> {
 fn square_free_certificate(
     normalized: &NormalizedArchMapV2,
     selected_contexts: &BTreeSet<String>,
+    minimal_forbidden_supports: &[Vec<String>],
+    repair_hitting_sets: &[Vec<String>],
+    generators: &[SquareFreeGeneratorV1],
+    witness_variable_count: usize,
 ) -> Result<Option<SquareFreeCertificateV1>, String> {
     let certificates = normalized
         .atoms
@@ -2644,31 +2689,30 @@ fn square_free_certificate(
         .filter(|atom| atom.axis == "square-free" && atom.predicate == "nsdepthCertificate")
         .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
         .map(|atom| {
-            let raw = atom.object.as_deref().ok_or_else(|| {
-                format!(
-                    "ag.square-free-repair@1 NSdepth certificate {} requires numeric object",
-                    atom.normalized_atom_id
-                )
-            })?;
-            let nsdepth = raw.parse::<usize>().map_err(|_| {
-                format!(
-                    "ag.square-free-repair@1 NSdepth certificate {} has non-numeric object {raw}",
-                    atom.normalized_atom_id
-                )
-            })?;
-            if nsdepth == 0 {
-                return Err(format!(
-                    "ag.square-free-repair@1 NSdepth certificate {} must have positive object",
-                    atom.normalized_atom_id
-                ));
-            }
-            Ok(SquareFreeCertificateV1 {
+            let raw = atom.object.as_deref();
+            let verification = verify_square_free_nsdepth_certificate(
+                raw,
+                minimal_forbidden_supports,
+                repair_hitting_sets,
+                generators,
+                witness_variable_count,
+            );
+            let support_atom_refs = if verification.support_atom_refs.is_empty() {
+                vec![atom.normalized_atom_id.clone()]
+            } else {
+                verification.support_atom_refs.clone()
+            };
+            SquareFreeCertificateV1 {
                 cert_ref: atom.normalized_atom_id.clone(),
-                nsdepth,
-                support_atom_refs: vec![atom.normalized_atom_id.clone()],
-            })
+                nsdepth: verification.nsdepth,
+                support_atom_refs,
+                verified_minimal_forbidden_supports: verification
+                    .verified_minimal_forbidden_supports,
+                status: verification.status,
+                effect: verification.effect,
+            }
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Vec<_>>();
 
     if certificates.len() > 1 {
         return Err(format!(
@@ -2678,6 +2722,226 @@ fn square_free_certificate(
     }
 
     Ok(certificates.into_iter().next())
+}
+
+#[derive(Debug, Clone)]
+struct SquareFreeCertificateVerificationV1 {
+    nsdepth: Option<usize>,
+    support_atom_refs: Vec<String>,
+    verified_minimal_forbidden_supports: Vec<Vec<String>>,
+    status: String,
+    effect: String,
+}
+
+fn verify_square_free_nsdepth_certificate(
+    raw: Option<&str>,
+    minimal_forbidden_supports: &[Vec<String>],
+    repair_hitting_sets: &[Vec<String>],
+    generators: &[SquareFreeGeneratorV1],
+    witness_variable_count: usize,
+) -> SquareFreeCertificateVerificationV1 {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return square_free_certificate_unverified(
+            None,
+            "invalid_payload",
+            "NSdepth certificate object is missing; structural verdict remains unknown",
+        );
+    };
+
+    if let Ok(nsdepth) = raw.parse::<usize>() {
+        if nsdepth == 0 {
+            return square_free_certificate_unverified(
+                None,
+                "invalid_payload",
+                "NSdepth certificate numeric object must be positive; structural verdict remains unknown",
+            );
+        }
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "author_supplied_unverified",
+            "NSdepth certificate only supplies a numeric value, not a finite verifier payload; structural verdict remains unknown",
+        );
+    }
+
+    let fields = match parse_square_free_certificate_fields(raw) {
+        Ok(fields) => fields,
+        Err(reason) => {
+            return square_free_certificate_unverified(
+                None,
+                "invalid_payload",
+                &format!("{reason}; structural verdict remains unknown"),
+            );
+        }
+    };
+    let nsdepth = match fields
+        .get("nsdepth")
+        .and_then(|value| value.as_str().parse::<usize>().ok())
+    {
+        Some(nsdepth) if nsdepth > 0 => nsdepth,
+        _ => {
+            return square_free_certificate_unverified(
+                None,
+                "invalid_payload",
+                "NSdepth verifier payload requires positive nsdepth field; structural verdict remains unknown",
+            );
+        }
+    };
+    if nsdepth > witness_variable_count {
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "invalid_payload",
+            "NSdepth verifier payload exceeds selected witness family size; structural verdict remains unknown",
+        );
+    }
+    let Some(depth_rule) = fields.get("depthRule") else {
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "invalid_payload",
+            "NSdepth verifier payload requires depthRule field; structural verdict remains unknown",
+        );
+    };
+    if depth_rule != "alexanderDualMaxMinimalHittingSet@1" {
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "invalid_payload",
+            "NSdepth verifier payload uses unsupported depthRule; structural verdict remains unknown",
+        );
+    }
+    let expected_nsdepth = repair_hitting_sets.iter().map(Vec::len).max().unwrap_or(0);
+    if nsdepth != expected_nsdepth {
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "invalid_payload",
+            "NSdepth verifier payload value does not match the selected finite depthRule; structural verdict remains unknown",
+        );
+    }
+
+    let payload_supports = fields
+        .get("minimalForbiddenSupports")
+        .map(|value| parse_square_free_support_payload(value.as_str()))
+        .unwrap_or_default();
+    let support_atom_refs = fields
+        .get("supportAtomRefs")
+        .map(|value| parse_csv_values(value.as_str()))
+        .unwrap_or_default();
+    let expected_atom_refs = generators
+        .iter()
+        .map(|generator| generator.generator_id.clone())
+        .collect::<Vec<_>>();
+    if payload_supports != minimal_forbidden_supports {
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "invalid_payload",
+            "NSdepth verifier payload minimalForbiddenSupports does not match the computed obstruction ideal; structural verdict remains unknown",
+        );
+    }
+    if support_atom_refs != expected_atom_refs {
+        return square_free_certificate_unverified(
+            Some(nsdepth),
+            "invalid_payload",
+            "NSdepth verifier payload supportAtomRefs does not match selected obstruction generator atoms; structural verdict remains unknown",
+        );
+    }
+
+    SquareFreeCertificateVerificationV1 {
+        nsdepth: Some(nsdepth),
+        support_atom_refs,
+        verified_minimal_forbidden_supports: payload_supports,
+        status: "verified".to_string(),
+        effect:
+            "finite verifier payload matched selected obstruction generators, minimal forbidden supports, and depthRule-derived NSdepth; structural verdict is measured_nonzero"
+                .to_string(),
+    }
+}
+
+fn parse_square_free_certificate_fields(raw: &str) -> Result<BTreeMap<String, String>, String> {
+    let mut fields = BTreeMap::new();
+    let allowed = BTreeSet::from([
+        "nsdepth",
+        "minimalForbiddenSupports",
+        "supportAtomRefs",
+        "depthRule",
+    ]);
+    for segment in raw.split(';') {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            return Err("NSdepth verifier payload contains an empty segment".to_string());
+        }
+        let Some((key, value)) = segment.split_once('=') else {
+            return Err(format!(
+                "NSdepth verifier payload segment {segment} must be key=value"
+            ));
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() || value.is_empty() {
+            return Err("NSdepth verifier payload contains empty key or value".to_string());
+        }
+        if !allowed.contains(key) {
+            return Err(format!(
+                "NSdepth verifier payload contains unsupported field {key}"
+            ));
+        }
+        if fields.insert(key.to_string(), value.to_string()).is_some() {
+            return Err(format!(
+                "NSdepth verifier payload contains duplicate field {key}"
+            ));
+        }
+    }
+    Ok(fields)
+}
+
+fn square_free_certificate_unverified(
+    nsdepth: Option<usize>,
+    status: &str,
+    effect: &str,
+) -> SquareFreeCertificateVerificationV1 {
+    SquareFreeCertificateVerificationV1 {
+        nsdepth,
+        support_atom_refs: Vec::new(),
+        verified_minimal_forbidden_supports: Vec::new(),
+        status: status.to_string(),
+        effect: effect.to_string(),
+    }
+}
+
+fn parse_square_free_support_payload(raw: &str) -> Vec<Vec<String>> {
+    let mut supports = raw
+        .split('|')
+        .map(parse_plus_values)
+        .filter(|support| !support.is_empty())
+        .collect::<Vec<_>>();
+    for support in &mut supports {
+        support.sort();
+        support.dedup();
+    }
+    supports.sort();
+    supports.dedup();
+    supports
+}
+
+fn parse_plus_values(raw: &str) -> Vec<String> {
+    let mut values = raw
+        .split('+')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn parse_csv_values(raw: &str) -> Vec<String> {
+    let mut values = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    values.sort();
+    values.dedup();
+    values
 }
 
 fn atom_belongs_to_selected_context(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -208,6 +208,10 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
         true
     );
     let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    assert_eq!(
+        cech["claimScope"],
+        "selected-cover 1-skeleton Cech cochain calculation"
+    );
     assert_eq!(cech["observedCocycle"]["classNonzero"], true);
     assert_eq!(
         cech["observedCocycle"]["representative"]
@@ -359,10 +363,13 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
         packet["structuralVerdict"][0]["evaluator"],
         "ag.square-free-repair@1"
     );
-    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdict"],
+        "measured_nonzero"
+    );
     assert_eq!(
         packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
-        "nsdepth_certificate_author_supplied_unverified"
+        "nsdepth_certificate_verified"
     );
     assert_eq!(
         packet["structuralVerdict"][0]["verdictData"]["certRef"],
@@ -385,16 +392,17 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
             {"degree": 1, "dimension": 0}
         ])
     );
-    assert_eq!(
-        repair["nsdepthCertificate"]["status"],
-        "author_supplied_unverified"
-    );
+    assert_eq!(repair["nsdepthCertificate"]["status"], "verified");
     assert_eq!(repair["nsdepthCertificate"]["nsdepth"], Value::from(2));
+    assert_eq!(
+        repair["nsdepthCertificate"]["verifiedMinimalForbiddenSupports"],
+        serde_json::json!([["x_checkout", "x_inventory"], ["x_inventory", "x_payment"]])
+    );
 
     let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
     assert_eq!(
         summary["conclusion"],
-        "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
+        "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
     );
 }
 
@@ -480,11 +488,11 @@ fn cli_analyze_v2_square_free_requires_matching_witness_family() {
 }
 
 #[test]
-fn cli_analyze_v2_square_free_rejects_malformed_nsdepth_certificate() {
+fn cli_analyze_v2_square_free_malformed_nsdepth_certificate_returns_unknown() {
     let out_dir = temp_dir("ag-measurement-square-free-bad-cert");
     let root = ag_measurement_root();
     let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
-    archmap["atoms"][5]["object"] = Value::String("not-a-number".to_string());
+    archmap["atoms"][5]["object"] = Value::String("not-a-verifier-payload".to_string());
     let archmap_path = out_dir.join("archmap_v2_square_free_bad_cert.json");
     fs::write(
         &archmap_path,
@@ -492,40 +500,110 @@ fn cli_analyze_v2_square_free_rejects_malformed_nsdepth_certificate() {
     )
     .expect("archmap fixture can be written");
 
-    run_sig0_expect_code(
-        &[
-            "analyze",
-            "--archmap",
-            archmap_path.to_str().expect("path is utf-8"),
-            "--law-policy",
-            root.join("law_policy_square_free.json")
-                .to_str()
-                .expect("path is utf-8"),
-            "--out-dir",
-            out_dir.to_str().expect("path is utf-8"),
-        ],
-        2,
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "nsdepth_certificate_invalid_payload"
     );
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(repair["nsdepthCertificate"]["status"], "invalid_payload");
 }
 
 #[test]
-fn cli_analyze_v2_square_free_rejects_any_malformed_nsdepth_certificate() {
+fn cli_analyze_v2_square_free_wrong_nsdepth_value_returns_unknown() {
+    let out_dir = temp_dir("ag-measurement-square-free-wrong-nsdepth");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    archmap["atoms"][5]["object"] = Value::String(
+        "nsdepth=1;depthRule=alexanderDualMaxMinimalHittingSet@1;minimalForbiddenSupports=x_checkout+x_inventory|x_inventory+x_payment;supportAtomRefs=atom:ob-checkout-inventory,atom:ob-inventory-payment"
+            .to_string(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_square_free_wrong_nsdepth.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "nsdepth_certificate_invalid_payload"
+    );
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(repair["nsdepthCertificate"]["status"], "invalid_payload");
+}
+
+#[test]
+fn cli_analyze_v2_square_free_junk_nsdepth_segment_returns_unknown() {
+    let out_dir = temp_dir("ag-measurement-square-free-junk-nsdepth");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
+    archmap["atoms"][5]["object"] = Value::String(
+        "nsdepth=2;depthRule=alexanderDualMaxMinimalHittingSet@1;unexpected-segment;minimalForbiddenSupports=x_checkout+x_inventory|x_inventory+x_payment;supportAtomRefs=atom:ob-checkout-inventory,atom:ob-inventory-payment"
+            .to_string(),
+    );
+    let archmap_path = out_dir.join("archmap_v2_square_free_junk_nsdepth.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "nsdepth_certificate_invalid_payload"
+    );
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(repair["nsdepthCertificate"]["status"], "invalid_payload");
+}
+
+#[test]
+fn cli_analyze_v2_square_free_numeric_only_certificate_returns_unknown() {
     let out_dir = temp_dir("ag-measurement-square-free-extra-bad-cert");
     let root = ag_measurement_root();
     let mut archmap = read_json(&root.join("archmap_v2_square_free_repair.json"));
-    let mut bad_cert = archmap["atoms"][5].clone();
-    bad_cert["id"] = Value::String("atom:nsdepth-certificate-malformed".to_string());
-    bad_cert["object"] = Value::String("not-a-number".to_string());
-    archmap["atoms"]
-        .as_array_mut()
-        .expect("atoms is array")
-        .push(bad_cert);
-    archmap["contexts"][0]["atoms"]
-        .as_array_mut()
-        .expect("context atoms is array")
-        .push(Value::String(
-            "atom:nsdepth-certificate-malformed".to_string(),
-        ));
+    archmap["atoms"][5]["object"] = Value::String("2".to_string());
     let archmap_path = out_dir.join("archmap_v2_square_free_extra_bad_cert.json");
     fs::write(
         &archmap_path,
@@ -533,19 +611,28 @@ fn cli_analyze_v2_square_free_rejects_any_malformed_nsdepth_certificate() {
     )
     .expect("archmap fixture can be written");
 
-    run_sig0_expect_code(
-        &[
-            "analyze",
-            "--archmap",
-            archmap_path.to_str().expect("path is utf-8"),
-            "--law-policy",
-            root.join("law_policy_square_free.json")
-                .to_str()
-                .expect("path is utf-8"),
-            "--out-dir",
-            out_dir.to_str().expect("path is utf-8"),
-        ],
-        2,
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_square_free.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
+    assert_eq!(
+        packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
+        "nsdepth_certificate_author_supplied_unverified"
+    );
+    let repair = invariant_by_id(&packet, "square-free-repair:profile:ag-square-free@1");
+    assert_eq!(
+        repair["nsdepthCertificate"]["status"],
+        "author_supplied_unverified"
     );
 }
 
@@ -705,13 +792,18 @@ fn cli_analyze_v2_law_conflict_tor_outputs_conflict_classes() {
     );
     assert_eq!(
         packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
-        "finite_monomial_tor_computed"
+        "finite_degree1_shared_support_conflict_computed"
     );
     assert_eq!(
         packet["structuralVerdict"][0]["verdictData"]["certRef"],
         "atom:tor-common-ambient"
     );
     let tor = invariant_by_id(&packet, "law-conflict-tor:profile:ag-law-conflict-tor@1");
+    assert_eq!(tor["method"], "finite-degree1-shared-support-conflict@1");
+    assert_eq!(
+        tor["claimScope"],
+        "degree-1 shared-support conflict detector over the selected common ambient pair"
+    );
     assert_eq!(
         tor["commonAmbient"]["ambientRef"],
         "ambient:checkout-inventory"
@@ -733,7 +825,11 @@ fn cli_analyze_v2_law_conflict_tor_outputs_conflict_classes() {
     );
     assert_eq!(
         tor["torByDegree"],
-        serde_json::json!([{"degree": 1, "classCount": 1}])
+        serde_json::json!([{
+            "degree": 1,
+            "classCount": 1,
+            "scope": "detected shared witness-variable support only"
+        }])
     );
 
     let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
@@ -1049,6 +1145,10 @@ fn cli_analyze_v2_sheaf_laplacian_outputs_analytic_hodge_reading() {
     );
     let invariant = invariant_by_id(&packet, "sheaf-laplacian:profile:ag-sheaf-laplacian@1");
     assert_eq!(
+        invariant["claimScope"],
+        "graph Laplacian analytic proxy; not a full sheaf chain-complex Hodge theorem"
+    );
+    assert_eq!(
         invariant["laplacianMatrix"],
         serde_json::json!([[1.0, -1.0], [-1.0, 1.0]])
     );
@@ -1060,6 +1160,14 @@ fn cli_analyze_v2_sheaf_laplacian_outputs_analytic_hodge_reading() {
         .expect("laplacian analytic reading exists");
     assert_eq!(reading["structuralVerdictRef"], Value::Null);
     assert_eq!(reading["regime"], "analytic-measurement");
+    assert_eq!(
+        reading["value"]["readingKind"],
+        "graph-laplacian-hodge-proxy@1"
+    );
+    assert_eq!(
+        reading["value"]["modelScope"],
+        "finite graph Laplacian over selected cochain cells and boundary edges"
+    );
     assert_eq!(
         reading["value"]["hodgeDecomposition"]["harmonic"],
         serde_json::json!([0.5, 0.5])

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json
@@ -83,7 +83,7 @@
       "id": "atom:nsdepth-certificate",
       "kind": "semantic",
       "subject": "cert:nsdepth-square-free",
-      "object": "2",
+      "object": "nsdepth=2;depthRule=alexanderDualMaxMinimalHittingSet@1;minimalForbiddenSupports=x_checkout+x_inventory|x_inventory+x_payment;supportAtomRefs=atom:ob-checkout-inventory,atom:ob-inventory-payment",
       "axis": "square-free",
       "predicate": "nsdepthCertificate",
       "refs": ["src:certificate"]

--- a/tools/fieldsig/README.md
+++ b/tools/fieldsig/README.md
@@ -8,7 +8,7 @@ FieldSig artifacts are measurement and workflow evidence. They do not prove fore
 
 ```bash
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- archsig-analysis-sft-input \
-  --measurement-packet .tmp/archsig-analyze-e2e/archsig-raw/archsig-measurement-packet.json \
+  --measurement-packet .tmp/archsig-analyze/archsig-measurement-packet.json \
   --out .fieldsig/operation-support-estimate.json
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- software-field-measurement --fixture --out .fieldsig/software-field-measurement.json
 cargo run --manifest-path tools/fieldsig/Cargo.toml -- software-field-measurement --input .fieldsig/software-field-measurement.json --out .fieldsig/software-field-measurement-validation.json

--- a/tools/fieldsig/src/archmap.rs
+++ b/tools/fieldsig/src/archmap.rs
@@ -826,6 +826,15 @@ fn json_path_string(packet: &serde_json::Value, path: &[&str], key: &str) -> Opt
 fn validate_archsig_measurement_packet_handoff_shape(
     packet: &serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = packet
+        .get("schema")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if schema != "archsig-measurement-packet/v1" {
+        return Err(
+            "FieldSig ArchSig measurement handoff requires archsig-measurement-packet/v1".into(),
+        );
+    }
     let packet_id = packet
         .get("packetId")
         .and_then(|value| value.as_str())
@@ -857,7 +866,219 @@ fn validate_archsig_measurement_packet_handoff_shape(
             );
         }
     }
+    validate_archsig_measurement_packet_structural_verdicts(packet)?;
+    validate_archsig_measurement_packet_assumptions(packet)?;
     Ok(())
+}
+
+fn validate_archsig_measurement_packet_structural_verdicts(
+    packet: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for (index, row) in packet
+        .get("structuralVerdict")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        let evaluator = required_string(row, "evaluator").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        required_string(row, "law").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        let verdict = required_string(row, "verdict").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        if !matches!(
+            verdict,
+            "measured_zero" | "measured_nonzero" | "unmeasured" | "unknown" | "not_computed"
+        ) {
+            return Err(format!(
+                "FieldSig ArchSig measurement handoff structuralVerdict[{index}] has unsupported verdict {verdict}"
+            )
+            .into());
+        }
+        let data = row
+            .get("verdictData")
+            .and_then(|value| value.as_object())
+            .ok_or_else(|| {
+                format!(
+                    "FieldSig ArchSig measurement handoff structuralVerdict[{index}] requires verdictData object"
+                )
+            })?;
+        let zero = required_bool(data, "zero").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        let non_zero = required_bool(data, "nonZero").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        required_bool(data, "inScope").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        required_object_string(data, "methodStatus").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff structuralVerdict[{index}] {message}")
+        })?;
+        if zero && non_zero {
+            return Err(format!(
+                "FieldSig ArchSig measurement handoff structuralVerdict[{index}] for {evaluator} marks both zero and nonZero"
+            )
+            .into());
+        }
+        match verdict {
+            "measured_zero" if !zero || non_zero => {
+                return Err(format!(
+                    "FieldSig ArchSig measurement handoff structuralVerdict[{index}] measured_zero requires zero=true and nonZero=false"
+                )
+                .into());
+            }
+            "measured_nonzero" if zero || !non_zero => {
+                return Err(format!(
+                    "FieldSig ArchSig measurement handoff structuralVerdict[{index}] measured_nonzero requires zero=false and nonZero=true"
+                )
+                .into());
+            }
+            "unknown" | "unmeasured" | "not_computed" if zero || non_zero => {
+                return Err(format!(
+                    "FieldSig ArchSig measurement handoff structuralVerdict[{index}] {verdict} must not carry zero/nonZero measured flags"
+                )
+                .into());
+            }
+            _ => {}
+        }
+        if matches!(verdict, "measured_zero" | "measured_nonzero")
+            && !archsig_measurement_verdict_has_evidence(packet, row, evaluator)
+        {
+            return Err(format!(
+                "FieldSig ArchSig measurement handoff structuralVerdict[{index}] {verdict} requires certRef or matching computed invariant evidence"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn archsig_measurement_verdict_has_evidence(
+    packet: &serde_json::Value,
+    row: &serde_json::Value,
+    evaluator: &str,
+) -> bool {
+    if row
+        .get("verdictData")
+        .and_then(|data| data.get("certRef"))
+        .and_then(|value| value.as_str())
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return true;
+    }
+    packet
+        .get("computedInvariants")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .any(|invariant| {
+            invariant
+                .get("evaluator")
+                .and_then(|value| value.as_str())
+                .is_some_and(|value| value == evaluator)
+                && ["invariantId", "readingId", "id"].iter().any(|key| {
+                    invariant
+                        .get(*key)
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|value| !value.trim().is_empty())
+                })
+        })
+}
+
+fn validate_archsig_measurement_packet_assumptions(
+    packet: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let measured_structural_verdict = packet
+        .get("structuralVerdict")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .any(|row| {
+            row.get("verdict")
+                .and_then(|value| value.as_str())
+                .is_some_and(|verdict| matches!(verdict, "measured_zero" | "measured_nonzero"))
+        });
+    for (index, row) in packet
+        .get("assumptions")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        let theorem_ref = required_string(row, "theoremRef").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff assumptions[{index}] {message}")
+        })?;
+        required_string(row, "assumption").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff assumptions[{index}] {message}")
+        })?;
+        let status = required_string(row, "status").map_err(|message| {
+            format!("FieldSig ArchSig measurement handoff assumptions[{index}] {message}")
+        })?;
+        match status {
+            "checked" => {
+                required_string(row, "checkedBy").map_err(|message| {
+                    format!("FieldSig ArchSig measurement handoff assumptions[{index}] {message}")
+                })?;
+            }
+            "assumed" => {
+                required_string(row, "assumedBy").map_err(|message| {
+                    format!("FieldSig ArchSig measurement handoff assumptions[{index}] {message}")
+                })?;
+            }
+            "violated" => {
+                if measured_structural_verdict {
+                    return Err(format!(
+                        "FieldSig ArchSig measurement handoff assumption {theorem_ref} is violated while structural verdicts contain measured rows"
+                    )
+                    .into());
+                }
+            }
+            _ => {
+                return Err(format!(
+                    "FieldSig ArchSig measurement handoff assumptions[{index}] has unsupported status {status}"
+                )
+                .into());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn required_string<'a>(
+    object: &'a serde_json::Value,
+    key: &str,
+) -> Result<&'a str, Box<dyn std::error::Error>> {
+    object
+        .get(key)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("requires non-empty {key}").into())
+}
+
+fn required_bool(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    object
+        .get(key)
+        .and_then(|value| value.as_bool())
+        .ok_or_else(|| format!("requires boolean verdictData.{key}").into())
+}
+
+fn required_object_string<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<&'a str, Box<dyn std::error::Error>> {
+    object
+        .get(key)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("requires non-empty verdictData.{key}").into())
 }
 
 fn archsig_measurement_packet_sft_source_refs(
@@ -1188,7 +1409,8 @@ fn archsig_measurement_packet_unknown_remainders(
             .and_then(|value| value.as_array())
             .into_iter()
             .flatten()
-            .filter_map(|assumption| {
+            .enumerate()
+            .filter_map(|(index, assumption)| {
                 let status = assumption.get("status")?.as_str()?;
                 if status == "checked" {
                     return None;
@@ -1201,10 +1423,11 @@ fn archsig_measurement_packet_unknown_remainders(
                     .get("assumption")
                     .and_then(|value| value.as_str())
                     .unwrap_or("assumption");
+                let assumption_key = format!("{index}:{theorem_ref}:{assumption_text}:{status}");
                 Some(OperationSupportUnknownRemainderV0 {
                     remainder_id: format!(
                         "unknown:archsig-measurement:assumption:{}",
-                        stable_id(theorem_ref)
+                        stable_id(&assumption_key)
                     ),
                     affected_family_ids: family_ids.to_vec(),
                     source_ref_ids: source_ref_ids.to_vec(),

--- a/tools/fieldsig/tests/cli.rs
+++ b/tools/fieldsig/tests/cli.rs
@@ -624,6 +624,11 @@ fn cli_projects_archsig_measurement_packet_to_sft_input_boundary() {
             "assumption": "transfer_lower_bound",
             "status": "assumed",
             "assumedBy": "measurement-profile author"
+        }, {
+            "theoremRef": "part8/10.4",
+            "assumption": "second transfer boundary",
+            "status": "assumed",
+            "assumedBy": "measurement-profile author"
         }],
         "nonConclusions": [
             "ArchSig measurement packet is a computation artifact, not a Lean proof object."
@@ -736,6 +741,36 @@ fn cli_projects_archsig_measurement_packet_to_sft_input_boundary() {
             }),
         "assumed theorem-candidate boundaries must remain unknown remainder"
     );
+    let duplicate_theorem_remainders = estimate_json["unknownRemainder"]
+        .as_array()
+        .expect("unknown remainder is array")
+        .iter()
+        .filter(|entry| {
+            entry["reason"]
+                .as_str()
+                .expect("reason is string")
+                .contains("part8/10.4")
+        })
+        .map(|entry| {
+            entry["remainderId"]
+                .as_str()
+                .expect("remainder id is string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    let unique_duplicate_theorem_remainders = duplicate_theorem_remainders
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        duplicate_theorem_remainders.len(),
+        2,
+        "fixture should contain two same-theorem assumed rows"
+    );
+    assert_eq!(
+        unique_duplicate_theorem_remainders.len(),
+        duplicate_theorem_remainders.len(),
+        "same theoremRef assumption rows must still produce distinct unknown remainder IDs"
+    );
     assert!(
         estimate_json["unknownRemainder"]
             .as_array()
@@ -840,6 +875,127 @@ fn cli_rejects_invalid_measurement_packet_handoff_inputs() {
         String::from_utf8_lossy(&both.stderr)
             .contains("--measurement-packet and --analysis-packet are mutually exclusive"),
         "handoff inputs must be explicit and mutually exclusive"
+    );
+
+    let valid_measurement_packet = serde_json::json!({
+        "schema": "archsig-measurement-packet/v1",
+        "packetId": "measurement:semantic-validation",
+        "profile": {
+            "schema": "measurement-profile/v1",
+            "profileId": "profile:semantic-validation"
+        },
+        "structuralVerdict": [{
+            "evaluator": "ag.square-free-repair@1",
+            "law": "ag.square-free-repair",
+            "verdict": "measured_nonzero",
+            "verdictData": {
+                "inScope": true,
+                "zero": false,
+                "nonZero": true,
+                "methodStatus": "nsdepth_certificate_verified",
+                "certRef": "computedInvariants/square-free-repair:profile:semantic-validation"
+            }
+        }],
+        "computedInvariants": [],
+        "analyticReadings": [],
+        "assumptions": [{
+            "theoremRef": "part3/7.2B",
+            "assumption": "finite certificate verified",
+            "status": "checked",
+            "checkedBy": "ag.square-free-repair@1"
+        }],
+        "nonConclusions": []
+    });
+
+    let invalid_verdict_packet = out_dir.join("invalid-verdict-measurement-packet.json");
+    let mut invalid_verdict_json = valid_measurement_packet.clone();
+    invalid_verdict_json["structuralVerdict"][0]["verdict"] = serde_json::json!("measured_unknown");
+    fs::write(
+        &invalid_verdict_packet,
+        serde_json::to_string_pretty(&invalid_verdict_json)
+            .expect("invalid verdict packet serializes"),
+    )
+    .expect("invalid verdict packet fixture is written");
+    let invalid_verdict = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        invalid_verdict_packet
+            .to_str()
+            .expect("invalid verdict packet path is utf-8"),
+        "--out",
+        out_dir
+            .join("invalid-verdict.json")
+            .to_str()
+            .expect("invalid verdict output path is utf-8"),
+    ]);
+    assert!(!invalid_verdict.status.success());
+    assert!(
+        String::from_utf8_lossy(&invalid_verdict.stderr)
+            .contains("unsupported verdict measured_unknown"),
+        "measurement-packet handoff must reject unsupported structural verdicts"
+    );
+
+    let violated_assumption_packet = out_dir.join("violated-assumption-measurement-packet.json");
+    let mut violated_assumption_json = valid_measurement_packet.clone();
+    violated_assumption_json["assumptions"][0]["status"] = serde_json::json!("violated");
+    violated_assumption_json["assumptions"][0]
+        .as_object_mut()
+        .expect("assumption row is object")
+        .remove("checkedBy");
+    fs::write(
+        &violated_assumption_packet,
+        serde_json::to_string_pretty(&violated_assumption_json)
+            .expect("violated assumption packet serializes"),
+    )
+    .expect("violated assumption packet fixture is written");
+    let violated_assumption = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        violated_assumption_packet
+            .to_str()
+            .expect("violated assumption packet path is utf-8"),
+        "--out",
+        out_dir
+            .join("violated-assumption.json")
+            .to_str()
+            .expect("violated assumption output path is utf-8"),
+    ]);
+    assert!(!violated_assumption.status.success());
+    assert!(
+        String::from_utf8_lossy(&violated_assumption.stderr)
+            .contains("is violated while structural verdicts contain measured rows"),
+        "measurement-packet handoff must reject violated assumptions paired with measured structural verdicts"
+    );
+
+    let missing_evidence_packet = out_dir.join("missing-evidence-measurement-packet.json");
+    let mut missing_evidence_json = valid_measurement_packet.clone();
+    missing_evidence_json["structuralVerdict"][0]["verdictData"]
+        .as_object_mut()
+        .expect("verdictData is object")
+        .remove("certRef");
+    fs::write(
+        &missing_evidence_packet,
+        serde_json::to_string_pretty(&missing_evidence_json)
+            .expect("missing evidence packet serializes"),
+    )
+    .expect("missing evidence packet fixture is written");
+    let missing_evidence = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        missing_evidence_packet
+            .to_str()
+            .expect("missing evidence packet path is utf-8"),
+        "--out",
+        out_dir
+            .join("missing-evidence.json")
+            .to_str()
+            .expect("missing evidence output path is utf-8"),
+    ]);
+    assert!(!missing_evidence.status.success());
+    assert!(
+        String::from_utf8_lossy(&missing_evidence.stderr)
+            .contains("requires certRef or matching computed invariant evidence"),
+        "measurement-packet handoff must reject measured verdicts without evidence linkage"
     );
 }
 


### PR DESCRIPTION
## 概要

Closes #1987
Closes #1988
Closes #1989
Closes #1990
Closes #1991
Closes #1992

ArchSig v0.4.0 PRD 完了レビューで見つかった Rust / docs drift をまとめて解消します。

- NSdepth certificate payload を finite depthRule 付きで検証し、値・support・generator refs が一致した場合だけ measured_nonzero に昇格
- AG evaluator の Cech / Tor / Laplacian 出力に実装深度に沿った claimScope / modelScope を追加
- FieldSig measurement-packet handoff に semantic validation を追加し、measured verdict の evidence linkage と assumption / verdict 整合を検査
- v0.4.0 AG measurement path と legacy v1 structural path の runtime surface を docs で分離し、FieldSig primary handoff を measurement-packet に統一

## 証明した定理

- なし

## 編集したドキュメント

- docs/tool/README.md
- docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md
- docs/tool/golden_corpus.md
- docs/tool/guideline.md
- tools/archsig/README.md
- tools/fieldsig/README.md

## 実施したテスト

- [ ] lake build（Lean 変更なしのため未実施）
- [x] cargo test --manifest-path tools/archsig/Cargo.toml
- [x] cargo test --manifest-path tools/fieldsig/Cargo.toml
- [x] git diff --check
- [x] hidden / bidirectional Unicode scan
- [ ] axiom / admit / sorry / unsafe scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を Closes #N 形式で本文に記載した
- [x] Lean status を明確にした: tooling implementation follow-up / Lean 変更なし
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに axiom, admit, sorry, unsafe を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない