### PR TITLE
AG第III部のLawAlgebra入口を追加

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -13,3 +13,4 @@ import Formal.AG.Atom.ObjectAlgebra
 import Formal.AG.Atom.AATCore
 import Formal.AG.Examples.FiniteModel
 import Formal.AG.Site
+import Formal.AG.LawAlgebra

--- a/Formal/AG/LawAlgebra.lean
+++ b/Formal/AG/LawAlgebra.lean
@@ -1,0 +1,2 @@
+import Formal.AG.LawAlgebra.Coordinate
+import Formal.AG.LawAlgebra.AmbientAlgebra

--- a/Formal/AG/LawAlgebra/AmbientAlgebra.lean
+++ b/Formal/AG/LawAlgebra/AmbientAlgebra.lean
@@ -1,0 +1,55 @@
+import Formal.AG.LawAlgebra.Coordinate
+import Mathlib.Algebra.MvPolynomial.Basic
+
+namespace AAT.AG
+namespace LawAlgebra
+
+universe u v
+
+/--
+III.定義4.1: free typed commutative algebra over a coordinate type.
+
+This is a definitional bridge to Mathlib's `MvPolynomial`. Later structural
+relations quotient this algebra; law witness equations are not quotiented out
+at the ambient stage.
+-/
+abbrev FreeCommAlg (Coord : Type u) (k : Type v) [CommSemiring k] : Type (max u v) :=
+  MvPolynomial Coord k
+
+/--
+III.定義4.1: `FreeCommAlg_k(Coord_X(W))` for a selected coordinate family.
+
+The bridge is intentionally definitional, so Mathlib's polynomial API is
+available without a new free-algebra theory.
+-/
+abbrev FreeTypedCommAlg {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W)
+    (k : Type v) [CommSemiring k] : Type (max u v) :=
+  FreeCommAlg F.CoordX k
+
+namespace FreeTypedCommAlg
+
+/-- III.定義4.1 bridge: the selected free algebra is exactly `MvPolynomial`. -/
+theorem eq_mvPolynomial {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W)
+    (k : Type v) [CommSemiring k] :
+    FreeTypedCommAlg F k = MvPolynomial F.CoordX k :=
+  rfl
+
+/-- III.定義4.1: the polynomial variable attached to a coordinate. -/
+noncomputable def coordVar {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W)
+    (k : Type v) [CommSemiring k] (c : F.CoordX) : FreeTypedCommAlg F k :=
+  MvPolynomial.X c
+
+/-- III.定義4.1: variables are Mathlib `MvPolynomial.X`. -/
+theorem coordVar_eq_X {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W)
+    (k : Type v) [CommSemiring k] (c : F.CoordX) :
+    coordVar F k c = MvPolynomial.X c :=
+  rfl
+
+end FreeTypedCommAlg
+
+end LawAlgebra
+end AAT.AG

--- a/Formal/AG/LawAlgebra/Coordinate.lean
+++ b/Formal/AG/LawAlgebra/Coordinate.lean
@@ -1,0 +1,115 @@
+import Formal.AG.Site.Context
+
+namespace AAT.AG
+namespace LawAlgebra
+
+universe u v
+
+/--
+III.定義3.1: coordinate namespace for architecture coordinates.
+
+These labels classify the source of a coordinate reading. They are labels only:
+the coordinate family below supplies the actual local data read on a context.
+-/
+inductive CoordinateLabel where
+  | atom
+  | signature
+  | state
+  | effect
+  | authority
+  | semantic
+  | runtime
+  | boundary
+  deriving DecidableEq, Repr
+
+/--
+III.定義3.1: a single architecture coordinate on a context.
+
+The coordinate reads selected local data on `W` into a coefficient carrier `R`.
+No algebraic equation is imposed at this layer.
+-/
+structure ArchitectureCoordinate {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (_W : Site.ArchitectureContext A) (R : Type v) where
+  label : CoordinateLabel
+  LocalData : Type u
+  read : LocalData -> R
+
+namespace ArchitectureCoordinate
+
+/-- III.定義3.1: evaluate a coordinate on its local datum. -/
+def eval {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} {R : Type v}
+    (c : ArchitectureCoordinate W R) (x : c.LocalData) : R :=
+  c.read x
+
+/-- III.定義3.1: evaluation is the stored reading function. -/
+theorem eval_eq_read {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} {R : Type v}
+    (c : ArchitectureCoordinate W R) :
+    c.eval = c.read :=
+  rfl
+
+end ArchitectureCoordinate
+
+/--
+III.定義3.1: a context-indexed family of architecture coordinates.
+
+`Coord` is the Lean form of `Coord_X(W)`. Each coordinate has a namespace label
+and a type of local data that later structural relations can reference.
+-/
+structure CoordinateFamily {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (_W : Site.ArchitectureContext A) where
+  Coord : Type u
+  label : Coord -> CoordinateLabel
+  LocalData : Coord -> Type u
+
+namespace CoordinateFamily
+
+/-- III.定義3.1: the coordinate type `Coord_X(W)` of a selected family. -/
+abbrev CoordX {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W) : Type u :=
+  F.Coord
+
+/-- III.定義3.1: the label attached to a coordinate. -/
+def namespaceLabel {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W)
+    (c : F.CoordX) : CoordinateLabel :=
+  F.label c
+
+/-- III.定義3.1: the local data type read by a coordinate. -/
+def localData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W)
+    (c : F.CoordX) : Type u :=
+  F.LocalData c
+
+end CoordinateFamily
+
+/--
+III.定義3.1: a coefficient-valued reading of all coordinates in a family.
+
+This is the abstract `Coord_X(W)`-indexed reading function used before law
+equations or structural quotienting are imposed.
+-/
+structure CoordinateReading {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} (F : CoordinateFamily W) (R : Type v) where
+  read : (c : F.CoordX) -> F.localData c -> R
+
+namespace CoordinateReading
+
+/-- III.定義3.1: evaluate the reading attached to one coordinate. -/
+def eval {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} {F : CoordinateFamily W} {R : Type v}
+    (rho : CoordinateReading F R) (c : F.CoordX) (x : F.localData c) : R :=
+  rho.read c x
+
+/-- III.定義3.1: evaluation is the stored family reading. -/
+theorem eval_eq_read {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {W : Site.ArchitectureContext A} {F : CoordinateFamily W} {R : Type v}
+    (rho : CoordinateReading F R) :
+    rho.eval = rho.read :=
+  rfl
+
+end CoordinateReading
+
+end LawAlgebra
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4525,6 +4525,28 @@ finite poset cover-relative Čech section product / face restriction differentia
 PRD-1 finite model 上の singleton site example だけを示す。
 一般 site の Čech complex、sheaf cohomology 計算、law algebra sheaf の具体構成、非 singleton の finite poset site example はまだ形式化しない。
 
+## AG版AAT Lean形式化 PRD-3 / 第III部 Law Algebra・Obstruction Ideal・Lawful Locus
+
+File: `Formal/AG/LawAlgebra.lean`, `Formal/AG/LawAlgebra/Coordinate.lean`,
+`Formal/AG/LawAlgebra/AmbientAlgebra.lean`.
+
+PRD-3 [第III部 Law Algebra・Obstruction Ideal・Lawful Locus](lean_ag_part_3_law_algebra_lawful_locus_prd.md) の
+R0/R1、AC1-AC2 に対応する初期 entrypoint である。現時点では
+`Formal/AG/LawAlgebra` を build 対象へ追加し、context に相対化された coordinate
+family と、`FreeCommAlg_k(Coord_X(W))` を Mathlib `MvPolynomial` として読む
+definitional bridge までを Lean 上に置く。
+
+| 本文ラベル | Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- | --- |
+| `III.R0` | `Formal.AG.LawAlgebra` entrypoint | `import` | 第III部 LawAlgebra module を `Formal/AG.lean` から import し、PRD-1 `Formal/AG/Atom` と PRD-2 `Formal/AG/Site` の成果物上に立ち上げる。 | `defined only` |
+| `III.定義3.1` | `AAT.AG.LawAlgebra.CoordinateLabel`, `AAT.AG.LawAlgebra.ArchitectureCoordinate`, `ArchitectureCoordinate.eval`, `ArchitectureCoordinate.eval_eq_read`, `AAT.AG.LawAlgebra.CoordinateFamily`, `CoordinateFamily.CoordX`, `CoordinateFamily.namespaceLabel`, `CoordinateFamily.localData`, `AAT.AG.LawAlgebra.CoordinateReading`, `CoordinateReading.eval`, `CoordinateReading.eval_eq_read` | `inductive` / `structure` / `abbrev` / `def` / `theorem` | context `W` に相対化された coordinate label、単一 coordinate、coordinate family、係数値 reading。coordinate は局所データから係数 carrier への読みとして扱い、structural relation や law equation はまだ課さない。 | `defined only` / `proved` |
+| `III.定義4.1` | `AAT.AG.LawAlgebra.FreeCommAlg`, `AAT.AG.LawAlgebra.FreeTypedCommAlg`, `FreeTypedCommAlg.eq_mvPolynomial`, `FreeTypedCommAlg.coordVar`, `FreeTypedCommAlg.coordVar_eq_X` | `abbrev` / `def` / `theorem` | `FreeCommAlg_k(Coord_X(W))` を `MvPolynomial F.CoordX k` として読む bridge。law witness equation は ambient stage では quotient しない。 | `defined only` / `proved` |
+
+Non-conclusions: この entrypoint は coordinate と free typed commutative algebra の
+bridge だけを示す。structural relation、`J_struct`、quotient `O_raw^U`、
+restriction descent、law witness ideal、obstruction ideal、lawful locus、
+Nullstellensatz、affine chart、scheme、定理11.1 はまだ形式化しない。
+
 ## Reverse-Import Theorem Packages
 
 File: `Formal/Arch/Evolution/ReverseImportTheorems.lean`.

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -680,6 +680,37 @@ cohomology、nerve dimension 上の高次 cochain / cohomology vanishing surface
 | `II.命題7.2C` | `proved` |
 | `II.R11 finite model examples` | `proved` |
 
+## AG版AAT PRD-3 / 第III部 Law Algebra・Obstruction Ideal・Lawful Locus
+
+Tracking Issue [#1998](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1998)。
+Issue [#1999](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/1999)
+では `Formal/AG/LawAlgebra` entrypoint、context 相対 coordinate family、
+coefficient-valued coordinate reading、`FreeCommAlg_k(Coord_X(W))` から
+Mathlib `MvPolynomial` への definitional bridge を追加した。
+
+| 対象 | 現在の扱い | 残す境界 |
+| --- | --- | --- |
+| `III.R0` Formal/AG/LawAlgebra entrypoint | `defined only`. `Formal/AG/LawAlgebra.lean` が `Coordinate` と `AmbientAlgebra` を束ね、`Formal/AG.lean` から import される。 | R2 以降の structural quotient、law witness ideal、obstruction ideal、lawful locus はまだ扱わない。 |
+| `III.定義3.1` Coordinate | `defined only` / `proved`. `Formal/AG/LawAlgebra/Coordinate.lean` が `CoordinateLabel`, `ArchitectureCoordinate`, `CoordinateFamily`, `CoordinateReading` と accessor theorem を持つ。 | coordinate は abstract local data reading であり、source observation completeness や concrete runtime coordinate の全列挙は主張しない。 |
+| `III.定義4.1` Free Typed Commutative Algebra | `defined only` / `proved`. `Formal/AG/LawAlgebra/AmbientAlgebra.lean` が `FreeCommAlg`, `FreeTypedCommAlg`, `FreeTypedCommAlg.eq_mvPolynomial`, `FreeTypedCommAlg.coordVar`, `FreeTypedCommAlg.coordVar_eq_X` を持つ。 | ambient stage では law witness equation を quotient しない。`J_struct` quotient と restriction descent は後続 R2 に残る。 |
+
+第III部 PRD-3 の証明対象ラベルは次の現在状態である。
+
+| 証明対象ラベル | Lean status |
+| --- | --- |
+| `III.R0` | `defined only` |
+| `III.定義3.1` | `defined only` / `proved` |
+| `III.定義4.1` | `defined only` / `proved` |
+| `III.条件4.4` | `future proof obligation` |
+| `III.補題5.6A` | `future proof obligation` |
+| `III.定理5.6C` | `future proof obligation` |
+| `III.系5.6D` | `future proof obligation` |
+| `III.定理候補7.2A` | `future proof obligation` |
+| `III.命題7.2C` | `future proof obligation` |
+| `III.定理8.3` | `future proof obligation` |
+| `III.定理11.1` | `future proof obligation` |
+| `III.R13 finite model examples` | `future proof obligation` |
+
 ## 現在の未解決カテゴリ
 
 | カテゴリ | 扱い |


### PR DESCRIPTION
## 概要

Closes #1999

PRD-3 第III部 Law Algebra / Obstruction Ideal / Lawful Locus の R0/R1 と AC1/AC2 に対応して、`Formal/AG/LawAlgebra` の最初の entrypoint を追加しました。

- `Formal/AG/LawAlgebra` を `Formal/AG.lean` から import し、build 対象へ接続
- context 相対の `CoordinateLabel` / `ArchitectureCoordinate` / `CoordinateFamily` / `CoordinateReading` を定義
- `FreeCommAlg_k(Coord_X(W))` を Mathlib `MvPolynomial` として読む `FreeCommAlg` / `FreeTypedCommAlg` bridge を追加
- `lean_theorem_index.md` と `proof_obligations.md` に PRD-3 R0/R1 の現在状態と残る future proof obligation を同期

R2 以降の `J_struct`、quotient、restriction descent、law witness ideal、obstruction ideal、lawful locus、定理11.1 はこの PR では扱いません。

## 証明した定理

- `ArchitectureCoordinate.eval_eq_read`
- `CoordinateReading.eval_eq_read`
- `FreeTypedCommAlg.eq_mvPolynomial`
- `FreeTypedCommAlg.coordVar_eq_X`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/LawAlgebra/Coordinate.lean`
- [x] `lake env lean Formal/AG/LawAlgebra/AmbientAlgebra.lean`
- [x] `lake env lean Formal/AG/LawAlgebra.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan for `Formal/AG`
- [x] `$local-review` 4観点レビュー。P2 指摘2件(import 軽量化、`III.定理候補7.2A` 台帳登録)を修正済み

`lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning が再表示されましたが、この PR の変更範囲外です。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
