### PR TITLE
AG第III部の代数値層bridgeを追加

### DIFF
--- a/Formal/AG/LawAlgebra.lean
+++ b/Formal/AG/LawAlgebra.lean
@@ -1,3 +1,4 @@
 import Formal.AG.LawAlgebra.Coordinate
 import Formal.AG.LawAlgebra.AmbientAlgebra
 import Formal.AG.LawAlgebra.StructuralRelation
+import Formal.AG.LawAlgebra.StructureSheaf

--- a/Formal/AG/LawAlgebra/StructureSheaf.lean
+++ b/Formal/AG/LawAlgebra/StructureSheaf.lean
@@ -1,0 +1,293 @@
+import Formal.AG.LawAlgebra.StructuralRelation
+import Formal.AG.Site.Descent
+import Mathlib.Algebra.Category.Ring.Under.Basic
+
+namespace AAT.AG
+namespace LawAlgebra
+
+universe u v
+
+noncomputable section
+
+open CategoryTheory
+open Opposite
+
+/--
+III.R3: the category of commutative `k`-algebras used for the law algebra
+sheaf.
+
+This is the Mathlib-facing target category for algebra-valued presheaves:
+objects are commutative rings equipped with the selected structure map from the
+universe-lifted coefficient ring `ULift k`.
+-/
+abbrev AATCommAlgCat (k : Type v) [CommRing k] :=
+  Under (CommRingCat.of (ULift.{max u v, v} k))
+
+/--
+III.R3: a commutative `k`-algebra-valued presheaf on an AAT site.
+
+This extends the PRD-2 Type-valued presheaf surface by changing the codomain to
+the bundled category of commutative `k`-algebras.
+-/
+abbrev AlgebraValuedAATPresheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] :=
+  S.categoryᵒᵖ ⥤ AATCommAlgCat k
+
+/-- III.定義2.1: a law algebra sheaf is a `k`-algebra-valued sheaf on `J_U`. -/
+abbrev LawAlgebraSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] :=
+  Sheaf S.topology (AATCommAlgCat k)
+
+/--
+III.R3: bridge from the R2 raw ambient algebra package to an algebra-valued
+presheaf on the selected AAT site.
+
+The raw algebra package is indexed by native contexts. The presheaf is indexed
+by the wrapped site category. `identifiesObject` records the objectwise reading
+of the site presheaf as `O_raw^U(W)`.
+-/
+structure RawAmbientAlgebraPresheafBridge {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} (S : Site.AATSite A)
+    (k : Type v) [CommRing k] where
+  rawAmbient : RawAmbientPresheafBridge (A := A) k
+  rawPresheaf : AlgebraValuedAATPresheaf S k
+  identifiesObject :
+    ∀ W : S.category,
+      rawAmbient.rawAlgebra W.ctx ≃+* (rawPresheaf.obj (op W)).right
+  restriction_naturality :
+    ∀ {source target : S.category} (h : S.contextPreorder.Hom source.ctx target.ctx)
+      (x : rawAmbient.rawAlgebra target.ctx),
+        identifiesObject source
+            (rawAmbient.res (S.contextPreorder.morphism h) x) =
+          (rawPresheaf.map (CategoryTheory.homOfLE h).op).right
+            (identifiesObject target x)
+
+namespace RawAmbientAlgebraPresheafBridge
+
+/-- III.R3: the site-indexed raw algebra presheaf. -/
+def toPresheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : RawAmbientAlgebraPresheafBridge S k) :
+    AlgebraValuedAATPresheaf S k :=
+  B.rawPresheaf
+
+/-- III.R3: the objectwise identification with the raw ambient quotient. -/
+def objectIso {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : RawAmbientAlgebraPresheafBridge S k) (W : S.category) :
+    B.rawAmbient.rawAlgebra W.ctx ≃+* (B.rawPresheaf.obj (op W)).right :=
+  B.identifiesObject W
+
+/-- III.R3: objectwise identifications commute with raw restriction maps. -/
+theorem restriction_naturality_apply {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : RawAmbientAlgebraPresheafBridge S k)
+    {source target : S.category} (h : S.contextPreorder.Hom source.ctx target.ctx)
+    (x : B.rawAmbient.rawAlgebra target.ctx) :
+    B.objectIso source
+        (B.rawAmbient.res (S.contextPreorder.morphism h) x) =
+      (B.rawPresheaf.map (CategoryTheory.homOfLE h).op).right (B.objectIso target x) :=
+  B.restriction_naturality h x
+
+end RawAmbientAlgebraPresheafBridge
+
+/--
+III.定義2.1: `O_X^U = (O_raw^U)^+` as a selected sheafification bridge.
+
+This records the AAT-facing data supplied by Mathlib's sheafification surface:
+the raw algebra-valued presheaf, the sheafified object, and the canonical map
+from raw sections to sheafified sections. It does not construct a new
+sheafification theory.
+-/
+structure LawAlgebraSheafificationBridge {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} (S : Site.AATSite A)
+    (k : Type v) [CommRing k] where
+  raw : AlgebraValuedAATPresheaf S k
+  plus : LawAlgebraSheaf S k
+  canonical : raw ⟶ plus.val
+  isSheafification :
+    ∀ (F : LawAlgebraSheaf S k) (η : raw ⟶ F.val),
+      ∃! lift : plus.val ⟶ F.val, canonical ≫ lift = η
+
+namespace LawAlgebraSheafificationBridge
+
+/-- III.定義2.1: the sheafified law algebra `O_X^U`. -/
+abbrev OX {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) : LawAlgebraSheaf S k :=
+  B.plus
+
+/-- III.定義2.1: the underlying presheaf of `O_X^U`. -/
+abbrev OXPresheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) :
+    AlgebraValuedAATPresheaf S k :=
+  B.plus.val
+
+/-- III.定義2.1: the canonical component `O_raw^U(W) -> O_X^U(W)`. -/
+def canonicalAt {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) (W : S.category) :
+    B.raw.obj (op W) ⟶ B.OXPresheaf.obj (op W) :=
+  B.canonical.app (op W)
+
+/-- III.定義2.1: the codomain of the bridge is a sheaf on `J_U`. -/
+theorem plus_isSheaf {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) :
+    Presheaf.IsSheaf S.topology B.OXPresheaf :=
+  B.plus.cond
+
+/-- III.定義2.1: the notation `O_X^U` is definitionally the selected plus object. -/
+theorem OX_eq_plus {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) :
+    B.OX = B.plus :=
+  rfl
+
+/--
+III.定義2.1: the selected plus object satisfies the sheafification universal
+property against every algebra-valued sheaf.
+-/
+theorem sheafification_lift_unique {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {k : Type v} [CommRing k] (B : LawAlgebraSheafificationBridge S k)
+    (F : LawAlgebraSheaf S k) (η : B.raw ⟶ F.val) :
+    ∃! lift : B.OXPresheaf ⟶ F.val, B.canonical ≫ lift = η :=
+  B.isSheafification F η
+
+end LawAlgebraSheafificationBridge
+
+/--
+III.条件4.5: selected presentation data at a context.
+
+The predicates are assumptions about the selected presentation, not new
+global theorems about all sheafifications. They are kept explicit so later
+affine chart work can state exactly which presentations survive passage from
+`O_raw^U` to `O_X^U`.
+-/
+structure SelectedLawAlgebraPresentation {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) (W : S.category) where
+  Generator : Type u
+  Relation : Type u
+  rawGenerator : Generator -> (B.raw.obj (op W)).right
+  sheafifiedGenerator : Generator -> (B.OXPresheaf.obj (op W)).right
+  rawRelation : Relation -> (B.raw.obj (op W)).right
+  sheafifiedRelation : Relation -> (B.OXPresheaf.obj (op W)).right
+  presentsRaw : Prop
+  presentsSheafified : Prop
+  canonical_preserves_generator :
+    ∀ g : Generator, (B.canonicalAt W).right (rawGenerator g) = sheafifiedGenerator g
+  canonical_preserves_relation :
+    ∀ r : Relation, (B.canonicalAt W).right (rawRelation r) = sheafifiedRelation r
+
+/-- III.条件4.5: presentation-stability at a single context. -/
+def PresentationStableAt {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    {B : LawAlgebraSheafificationBridge S k} {W : S.category}
+    (P : SelectedLawAlgebraPresentation B W) : Prop :=
+  P.presentsRaw ∧ P.presentsSheafified
+
+/--
+III.条件4.5: presentation-stable AAT site for the law algebra sheaf.
+
+This is an explicit assumption package: every selected context carries a
+presentation and that presentation is stable across the canonical
+`O_raw^U -> O_X^U` bridge.
+-/
+structure PresentationStableAATSite {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {k : Type v} [CommRing k]
+    (B : LawAlgebraSheafificationBridge S k) where
+  presentation :
+    ∀ W : S.category, SelectedLawAlgebraPresentation B W
+  stable :
+    ∀ W : S.category, PresentationStableAt (presentation W)
+
+namespace PresentationStableAATSite
+
+/-- III.条件4.5: expose the raw-presentation part of stability. -/
+theorem presentsRaw {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    {B : LawAlgebraSheafificationBridge S k}
+    (H : PresentationStableAATSite B) (W : S.category) :
+    (H.presentation W).presentsRaw :=
+  (H.stable W).1
+
+/-- III.条件4.5: expose preservation of selected generators by the canonical map. -/
+theorem canonicalPreservesGenerators {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {k : Type v} [CommRing k]
+    {B : LawAlgebraSheafificationBridge S k}
+    (H : PresentationStableAATSite B) (W : S.category)
+    (g : (H.presentation W).Generator) :
+    (B.canonicalAt W).right ((H.presentation W).rawGenerator g) =
+      (H.presentation W).sheafifiedGenerator g :=
+  (H.presentation W).canonical_preserves_generator g
+
+/-- III.条件4.5: expose preservation of selected relations by the canonical map. -/
+theorem canonicalPreservesRelations {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {k : Type v} [CommRing k]
+    {B : LawAlgebraSheafificationBridge S k}
+    (H : PresentationStableAATSite B) (W : S.category)
+    (r : (H.presentation W).Relation) :
+    (B.canonicalAt W).right ((H.presentation W).rawRelation r) =
+      (H.presentation W).sheafifiedRelation r :=
+  (H.presentation W).canonical_preserves_relation r
+
+/-- III.条件4.5: expose the sheafified-presentation part of stability. -/
+theorem presentsSheafified {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {k : Type v} [CommRing k]
+    {B : LawAlgebraSheafificationBridge S k}
+    (H : PresentationStableAATSite B) (W : S.category) :
+    (H.presentation W).presentsSheafified :=
+  (H.stable W).2
+
+end PresentationStableAATSite
+
+/--
+III.R3: the Law Algebra Sheaf package used by later witness-ideal and affine
+chart layers.
+
+The package ties the R2 raw ambient algebra bridge to the selected
+sheafification bridge and records condition 4.5 as an explicit assumption.
+-/
+structure LawAlgebraSheafPackage {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] where
+  rawAmbient : RawAmbientAlgebraPresheafBridge S k
+  sheafification : LawAlgebraSheafificationBridge S k
+  raw_eq : sheafification.raw = rawAmbient.rawPresheaf
+  presentationStable : PresentationStableAATSite sheafification
+
+namespace LawAlgebraSheafPackage
+
+/-- III.定義2.1: the sheafified law algebra carried by the package. -/
+abbrev OX {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (P : LawAlgebraSheafPackage S k) : LawAlgebraSheaf S k :=
+  P.sheafification.OX
+
+/-- III.R3: the package uses the R2 raw ambient algebra presheaf as its raw input. -/
+theorem raw_eq_rawAmbient {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (P : LawAlgebraSheafPackage S k) :
+    P.sheafification.raw = P.rawAmbient.rawPresheaf :=
+  P.raw_eq
+
+/-- III.条件4.5: the packaged site is presentation-stable. -/
+theorem presentationStableAt {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (P : LawAlgebraSheafPackage S k) (W : S.category) :
+    PresentationStableAt (P.presentationStable.presentation W) :=
+  P.presentationStable.stable W
+
+end LawAlgebraSheafPackage
+
+end
+
+end LawAlgebra
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4529,15 +4529,17 @@ PRD-1 finite model 上の singleton site example だけを示す。
 
 File: `Formal/AG/LawAlgebra.lean`, `Formal/AG/LawAlgebra/Coordinate.lean`,
 `Formal/AG/LawAlgebra/AmbientAlgebra.lean`,
-`Formal/AG/LawAlgebra/StructuralRelation.lean`.
+`Formal/AG/LawAlgebra/StructuralRelation.lean`,
+`Formal/AG/LawAlgebra/StructureSheaf.lean`.
 
 PRD-3 [第III部 Law Algebra・Obstruction Ideal・Lawful Locus](lean_ag_part_3_law_algebra_lawful_locus_prd.md) の
-R0-R2、AC1-AC3 に対応する entrypoint である。現時点では
+R0-R3、AC1-AC4 に対応する entrypoint である。現時点では
 `Formal/AG/LawAlgebra` を build 対象へ追加し、context に相対化された coordinate
 family と、`FreeCommAlg_k(Coord_X(W))` を Mathlib `MvPolynomial` として読む
 definitional bridge、structural relation family、`J_struct`、raw ambient quotient、
 restriction-stability 下の quotient 降下補題、明示法則付き raw ambient presheaf
-bridge までを Lean 上に置く。
+bridge、universe-lifted commutative `k`-algebra-valued presheaf /
+sheafification bridge、presentation-stability assumption package までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4545,10 +4547,11 @@ bridge までを Lean 上に置く。
 | `III.定義3.1` | `AAT.AG.LawAlgebra.CoordinateLabel`, `AAT.AG.LawAlgebra.ArchitectureCoordinate`, `ArchitectureCoordinate.eval`, `ArchitectureCoordinate.eval_eq_read`, `AAT.AG.LawAlgebra.CoordinateFamily`, `CoordinateFamily.CoordX`, `CoordinateFamily.namespaceLabel`, `CoordinateFamily.localData`, `AAT.AG.LawAlgebra.CoordinateReading`, `CoordinateReading.eval`, `CoordinateReading.eval_eq_read` | `inductive` / `structure` / `abbrev` / `def` / `theorem` | context `W` に相対化された coordinate label、単一 coordinate、coordinate family、係数値 reading。coordinate は局所データから係数 carrier への読みとして扱い、structural relation や law equation はまだ課さない。 | `defined only` / `proved` |
 | `III.定義4.1` | `AAT.AG.LawAlgebra.FreeCommAlg`, `AAT.AG.LawAlgebra.FreeTypedCommAlg`, `FreeTypedCommAlg.eq_mvPolynomial`, `FreeTypedCommAlg.coordVar`, `FreeTypedCommAlg.coordVar_eq_X` | `abbrev` / `def` / `theorem` | `FreeCommAlg_k(Coord_X(W))` を `MvPolynomial F.CoordX k` として読む bridge。law witness equation は ambient stage では quotient しない。 | `defined only` / `proved` |
 | `III.定義4.2 / 定義4.3 / 条件4.4` | `AAT.AG.LawAlgebra.StructuralRelationFamily`, `StructuralRelationFamily.RelStruct`, `StructuralRelationFamily.JStruct`, `StructuralRelationFamily.polynomial_mem_JStruct`, `StructuralRelationFamily.RawAmbientLawAlgebra`, `StructuralRelationFamily.quotientMap`, `StructuralRelationFamily.quotientMap_polynomial_eq_zero`, `AAT.AG.LawAlgebra.TypedCoordinateRestriction`, `TypedCoordinateRestriction.polynomialMap`, `TypedCoordinateRestriction.polynomialMap_X`, `AAT.AG.LawAlgebra.RestrictionStableStructuralRelations`, `RestrictionStableStructuralRelations.quotientDesc`, `RestrictionStableStructuralRelations.quotientDesc_mk`, `AAT.AG.LawAlgebra.RawAmbientPresheafBridge`, `RawAmbientPresheafBridge.rawAlgebra`, `RawAmbientPresheafBridge.res`, `RawAmbientPresheafBridge.identityLaw`, `RawAmbientPresheafBridge.compositionLaw` | `structure` / `def` / `abbrev` / `theorem` | structural relation family `Rel_struct(W)` と生成 ideal `J_struct(W)` を分離し、`O_raw^U(W)` を `FreeTypedCommAlg / J_struct` として定義する。typed coordinate restriction が `J_struct` を保存する仮定の下で quotient に降りることを証明し、identity / composition law を明示フィールドとして持つ raw ambient presheaf bridge を公開する。 | `defined only` / `proved under explicit restriction-stability and presheaf-law assumptions` |
+| `III.定義2.1 / 条件4.5` | `AAT.AG.LawAlgebra.AATCommAlgCat`, `AAT.AG.LawAlgebra.AlgebraValuedAATPresheaf`, `AAT.AG.LawAlgebra.LawAlgebraSheaf`, `AAT.AG.LawAlgebra.RawAmbientAlgebraPresheafBridge`, `RawAmbientAlgebraPresheafBridge.toPresheaf`, `RawAmbientAlgebraPresheafBridge.objectIso`, `RawAmbientAlgebraPresheafBridge.restriction_naturality_apply`, `AAT.AG.LawAlgebra.LawAlgebraSheafificationBridge`, `LawAlgebraSheafificationBridge.OX`, `LawAlgebraSheafificationBridge.OXPresheaf`, `LawAlgebraSheafificationBridge.canonicalAt`, `LawAlgebraSheafificationBridge.plus_isSheaf`, `LawAlgebraSheafificationBridge.OX_eq_plus`, `LawAlgebraSheafificationBridge.sheafification_lift_unique`, `AAT.AG.LawAlgebra.SelectedLawAlgebraPresentation`, `AAT.AG.LawAlgebra.PresentationStableAt`, `AAT.AG.LawAlgebra.PresentationStableAATSite`, `PresentationStableAATSite.presentsRaw`, `PresentationStableAATSite.canonicalPreservesGenerators`, `PresentationStableAATSite.canonicalPreservesRelations`, `PresentationStableAATSite.presentsSheafified`, `AAT.AG.LawAlgebra.LawAlgebraSheafPackage`, `LawAlgebraSheafPackage.OX`, `LawAlgebraSheafPackage.raw_eq_rawAmbient`, `LawAlgebraSheafPackage.presentationStableAt` | `abbrev` / `structure` / `def` / `theorem` | `O_X^U = (O_raw^U)^+` を、universe-lifted commutative `k`-algebra-valued presheaf、Mathlib `Sheaf` object、canonical map、sheafification universal property からなる selected sheafification bridge として定義する。raw ambient restriction と presheaf map の自然性を明示し、条件4.5 は selected generator / relation が canonical bridge で保たれる型付き仮定 package として持つ。 | `defined only` / `proved under explicit sheafification-bridge and presentation-stability assumptions` |
 
 Non-conclusions: この entrypoint は coordinate と free typed commutative algebra の
-bridge、structural quotient、restriction descent bridge だけを示す。
-law witness ideal、obstruction ideal、lawful locus、sheafification、
+bridge、structural quotient、restriction descent bridge、law algebra sheafification
+bridge だけを示す。law witness ideal、obstruction ideal、lawful locus、
 Nullstellensatz、affine chart、scheme、定理11.1 はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -691,13 +691,17 @@ Issue [#2001](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/
 では structural relation family、`J_struct`、raw ambient law algebra quotient、
 restriction-stability 仮定 package、quotient 降下補題、明示法則付き raw ambient
 presheaf bridge を追加した。
+Issue [#2003](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2003)
+では universe-lifted commutative `k`-algebra-valued presheaf、Law Algebra
+Sheaf sheafification bridge、条件4.5 presentation-stability 仮定 package を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `III.R0` Formal/AG/LawAlgebra entrypoint | `defined only`. `Formal/AG/LawAlgebra.lean` が `Coordinate`、`AmbientAlgebra`、`StructuralRelation` を束ね、`Formal/AG.lean` から import される。 | law witness ideal、obstruction ideal、lawful locus、sheafification はまだ扱わない。 |
+| `III.R0` Formal/AG/LawAlgebra entrypoint | `defined only`. `Formal/AG/LawAlgebra.lean` が `Coordinate`、`AmbientAlgebra`、`StructuralRelation`、`StructureSheaf` を束ね、`Formal/AG.lean` から import される。 | law witness ideal、obstruction ideal、lawful locus はまだ扱わない。 |
 | `III.定義3.1` Coordinate | `defined only` / `proved`. `Formal/AG/LawAlgebra/Coordinate.lean` が `CoordinateLabel`, `ArchitectureCoordinate`, `CoordinateFamily`, `CoordinateReading` と accessor theorem を持つ。 | coordinate は abstract local data reading であり、source observation completeness や concrete runtime coordinate の全列挙は主張しない。 |
 | `III.定義4.1` Free Typed Commutative Algebra | `defined only` / `proved`. `Formal/AG/LawAlgebra/AmbientAlgebra.lean` が `FreeCommAlg`, `FreeTypedCommAlg`, `FreeTypedCommAlg.eq_mvPolynomial`, `FreeTypedCommAlg.coordVar`, `FreeTypedCommAlg.coordVar_eq_X` を持つ。 | ambient stage では law witness equation を quotient しない。 |
-| `III.定義4.2 / 定義4.3 / 条件4.4` Structural Relation と Raw Ambient Algebra | `defined only` / `proved`. `Formal/AG/LawAlgebra/StructuralRelation.lean` が `StructuralRelationFamily`, `RelStruct`, `JStruct`, `RawAmbientLawAlgebra`, `TypedCoordinateRestriction`, `RestrictionStableStructuralRelations`, quotient descent lemma、明示 identity / composition law を持つ `RawAmbientPresheafBridge` を持つ。 | law witness equation は ambient stage では quotient しない。代数値層 `O_X^U`、law witness ideal、obstruction ideal、lawful locus は後続 R3/R4/R7/R8 に残る。 |
+| `III.定義4.2 / 定義4.3 / 条件4.4` Structural Relation と Raw Ambient Algebra | `defined only` / `proved`. `Formal/AG/LawAlgebra/StructuralRelation.lean` が `StructuralRelationFamily`, `RelStruct`, `JStruct`, `RawAmbientLawAlgebra`, `TypedCoordinateRestriction`, `RestrictionStableStructuralRelations`, quotient descent lemma、明示 identity / composition law を持つ `RawAmbientPresheafBridge` を持つ。 | law witness equation は ambient stage では quotient しない。law witness ideal、obstruction ideal、lawful locus は後続 R4/R7/R8 に残る。 |
+| `III.定義2.1 / 条件4.5` Law Algebra Sheaf と Presentation Stability | `defined only` / `proved`. `Formal/AG/LawAlgebra/StructureSheaf.lean` が `AATCommAlgCat`, `AlgebraValuedAATPresheaf`, `LawAlgebraSheaf`, `RawAmbientAlgebraPresheafBridge`, `LawAlgebraSheafificationBridge`, `PresentationStableAATSite`, `LawAlgebraSheafPackage` と accessor theorem を持つ。raw ambient restriction と presheaf map の自然性、canonical map の sheafification universal property、selected generator / relation の canonical preservation を明示する。 | `O_X^U = (O_raw^U)^+` は selected sheafification bridge として扱う。一般 site の algebra-valued sheafification 理論は新規証明しない。law witness ideal、obstruction ideal、lawful locus は後続 R4/R7/R8 に残る。 |
 
 第III部 PRD-3 の証明対象ラベルは次の現在状態である。
 
@@ -708,6 +712,7 @@ presheaf bridge を追加した。
 | `III.定義4.1` | `defined only` / `proved` |
 | `III.定義4.2 / 定義4.3` | `defined only` / `proved` |
 | `III.条件4.4` | `proved under explicit restriction-stability and presheaf-law assumptions` |
+| `III.定義2.1 / 条件4.5` | `proved under explicit sheafification-bridge and presentation-stability assumptions` |
 | `III.補題5.6A` | `future proof obligation` |
 | `III.定理5.6C` | `future proof obligation` |
 | `III.系5.6D` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #2003。

AG 版 AAT Lean 形式化 PRD-3 の R3 / AC4 として、代数値 presheaf / Law Algebra Sheaf bridge、`O_X^U = (O_raw^U)^+` を読む selected sheafification bridge、条件4.5 presentation-stability の仮定 package を追加しました。

## 証明した定理

- `RawAmbientAlgebraPresheafBridge.restriction_naturality_apply`
- `LawAlgebraSheafificationBridge.plus_isSheaf`
- `LawAlgebraSheafificationBridge.OX_eq_plus`
- `LawAlgebraSheafificationBridge.sheafification_lift_unique`
- `PresentationStableAATSite.presentsRaw`
- `PresentationStableAATSite.canonicalPreservesGenerators`
- `PresentationStableAATSite.canonicalPreservesRelations`
- `PresentationStableAATSite.presentsSheafified`
- `LawAlgebraSheafPackage.raw_eq_rawAmbient`
- `LawAlgebraSheafPackage.presentationStableAt`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/LawAlgebra/StructureSheaf.lean`
- [x] `lake env lean Formal/AG/LawAlgebra.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan for `Formal/AG`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
