### PR TITLE
ArchSig insight viewer surfaceを追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -6,7 +6,8 @@ use crate::validation::{generic_validation_example, validation_check};
 use crate::{
     ARCHSIG_MEASUREMENT_PACKET_V1_SCHEMA, AgAnalyticReadingV1, AgAssumptionLedgerEntryV1,
     AgStructuralVerdictV1, AgVerdictDataV1, ArchSigMeasurementPacketV1, LawPolicyDocumentV1,
-    MeasurementProfileV1, NormalizedArchMapV2, ValidationCheck, ValidationExample,
+    MeasurementProfileV1, NormalizedArchMapV2, NormalizedAtomV2, NormalizedContextV2,
+    NormalizedCoverV2, ValidationCheck, ValidationExample,
 };
 
 const VERDICTS: [&str; 5] = [
@@ -1240,8 +1241,33 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
     json!({
         "schema": "archsig-analysis-summary/v2",
         "conclusion": conclusion,
+        "readThisFirst": {
+            "heading": "Read this first",
+            "conclusion": conclusion,
+            "whatItMeans": if cech_nonzero {
+                "Local rules are not enough to explain the selected cover; ArchSig measured a cross-context glue mismatch."
+            } else if nonzero_count > 0 {
+                "ArchSig measured a selected AG obstruction under the profile."
+            } else if unmeasured_count > 0 {
+                "ArchSig produced a profile-relative foundation result with unmeasured, unknown, or not_computed rows still visible."
+            } else {
+                "No selected H1 glue mismatch was measured under the profile."
+            },
+            "whereToLookFirst": "See archsig-insight-report.json#/insightCards/0/evidence",
+            "nextAction": "Open archsig-insight-brief.md or the viewer Insight Queue.",
+            "boundary": format!(
+                "Profile-relative. {} assumptions declared. {} non-terminal rows.",
+                packet.assumptions.iter().filter(|row| row.status == "assumed").count(),
+                unmeasured_count
+            )
+        },
         "measurementPacketSchema": packet.schema,
         "profileRef": packet.profile.profile_id,
+        "insightArtifacts": {
+            "insightReport": "archsig-insight-report.json",
+            "insightBrief": "archsig-insight-brief.md",
+            "viewerData": "archsig-atom-viewer-data.json"
+        },
         "structuralVerdictSummary": {
             "rowCount": packet.structural_verdict.len(),
             "measuredNonzeroCount": nonzero_count,
@@ -1258,6 +1284,1641 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
             "Schema foundation rows do not claim completed AG invariant computation."
         ]
     })
+}
+
+pub fn build_insight_report_v1(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    summary: &Value,
+) -> Value {
+    let boundary_digest = insight_boundary_digest(packet, summary);
+    let insight_cards = insight_cards_v1(normalized, packet, summary);
+    let action_queue = insight_action_queue_v1(&insight_cards);
+    let viewer_visual_scenes = insight_viewer_visual_scenes_v1(normalized, packet, &insight_cards);
+    let guided_tours = insight_guided_tours_v1(&insight_cards);
+    let copy_blocks = insight_copy_blocks_v1(normalized, &insight_cards, &boundary_digest);
+    let top_card = insight_cards.first().cloned().unwrap_or_else(|| {
+        json!({
+            "id": "insight:measurement-boundary:empty",
+            "kind": "measurement_boundary",
+            "severity": "info",
+            "title": "Measurement boundary recorded",
+            "oneLine": "ArchSig generated a bounded measurement projection under the selected profile.",
+            "whyItMatters": "Reviewers can inspect the selected profile, assumptions, and artifact links before reading details.",
+            "evidence": empty_insight_evidence(),
+            "nextAction": {
+                "label": "Inspect measurement boundary",
+                "kind": "inspect",
+                "targetRefs": ["boundary-digest:main"]
+            },
+            "viewerNavigation": {
+                "sceneId": "boundary-assumption",
+                "highlightRefs": empty_highlight_refs()
+            },
+            "tourRefs": ["tour:measurement-boundary:empty"],
+            "rankingBasis": ["fallback boundary reading"],
+            "nonClaims": ["This does not add a new measurement claim."]
+        })
+    });
+    json!({
+        "schema": "archsig-insight-report/v1",
+        "reportId": format!("insight:{}", packet.packet_id),
+        "sourcePacketRef": "archsig-measurement-packet.json",
+        "generatedAt": "deterministic-run-artifact",
+        "outputArtifacts": {
+            "summaryRef": "archsig-analysis-summary.json",
+            "briefRef": "archsig-insight-brief.md",
+            "viewerDataRef": "archsig-atom-viewer-data.json"
+        },
+        "headline": {
+            "conclusionCode": summary["conclusion"],
+            "title": top_card["title"],
+            "summary": top_card["oneLine"],
+            "decisionState": insight_decision_state(&top_card),
+            "primaryVerdictRefs": top_card["evidence"]["structuralVerdictRefs"],
+            "boundaryDigestRef": "boundary-digest:main"
+        },
+        "readThisFirst": {
+            "heading": "Read this first",
+            "conclusion": summary["conclusion"],
+            "whatItMeans": top_card["oneLine"],
+            "whereToLookFirst": top_card["evidence"]["sourceRefs"],
+            "nextAction": top_card["nextAction"]["label"],
+            "boundary": boundary_digest["shortText"],
+            "details": top_card["evidence"]
+        },
+        "insightCards": insight_cards,
+        "actionQueue": action_queue,
+        "boundaryDigest": boundary_digest,
+        "viewerVisualScenes": viewer_visual_scenes,
+        "guidedTours": guided_tours,
+        "copyBlocks": copy_blocks,
+        "rankingBasis": [
+            "validation_failure",
+            "measured_nonzero structural verdict",
+            "not_computed due to violated assumption",
+            "repair lower bound or minimal repair candidate",
+            "policy conflict",
+            "architecture debt mass analytic reading",
+            "measurement boundary",
+            "measured_zero confirmation"
+        ],
+        "claimValidation": {
+            "measuredClaimsRequireStructuralVerdictRefs": true,
+            "analyticReadingsDoNotPromoteLawfulOrUnlawful": true,
+            "highSeverityInsightsRequireWhereRefs": true,
+            "notComputedBlockersRequireReasonCode": true,
+            "repairCandidatesRequireNonClaims": true,
+            "theoremCandidatePromotionForbidden": true,
+            "monodromyVerdictGenerated": false
+        },
+        "nonConclusions": [
+            "Insight report is a projection of archsig-measurement-packet/v1 and does not generate new measurement claims.",
+            "Repair candidates are next inspection cues, not automatic fixes.",
+            "Viewer scenes are visual projections, not structural verdict derivations."
+        ]
+    })
+}
+
+pub fn build_insight_brief_v1(report: &Value) -> String {
+    let mut lines = Vec::new();
+    lines.push("# ArchSig Insight Brief".to_string());
+    lines.push(String::new());
+    lines.push("## Read this first".to_string());
+    lines.push(format!(
+        "Conclusion: {}",
+        string_at(report, &["readThisFirst", "conclusion"])
+    ));
+    lines.push(String::new());
+    lines.push("What it means:".to_string());
+    lines.push(string_at(report, &["readThisFirst", "whatItMeans"]));
+    lines.push(String::new());
+    lines.push("Where to look first:".to_string());
+    for item in string_array_at(report, &["readThisFirst", "whereToLookFirst"])
+        .into_iter()
+        .take(5)
+    {
+        lines.push(format!("- {item}"));
+    }
+    lines.push(String::new());
+    lines.push("Next action:".to_string());
+    lines.push(string_at(report, &["readThisFirst", "nextAction"]));
+    lines.push(String::new());
+    lines.push("Boundary:".to_string());
+    lines.push(string_at(report, &["readThisFirst", "boundary"]));
+    lines.push(String::new());
+    lines.push("## Top insights".to_string());
+    for card in report["insightCards"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .take(3)
+    {
+        lines.push(format!(
+            "- {}: {}",
+            string_field(card, "title"),
+            string_field(card, "oneLine")
+        ));
+        lines.push(format!(
+            "  Why this matters: {}",
+            string_field(card, "whyItMatters")
+        ));
+    }
+    lines.push(String::new());
+    lines.push("## Where to look".to_string());
+    for block in report["copyBlocks"]["sourceRefs"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .take(10)
+    {
+        lines.push(format!("- {}", block.as_str().unwrap_or_default()));
+    }
+    lines.push(String::new());
+    lines.push("## Suggested next inspections".to_string());
+    for action in report["actionQueue"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .take(8)
+    {
+        lines.push(format!(
+            "- {}: {}",
+            string_field(action, "title"),
+            string_field(action, "reason")
+        ));
+    }
+    lines.push(String::new());
+    lines.push("## Repair candidates".to_string());
+    for card in report["insightCards"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|card| string_field(card, "kind") == "minimal_repair_candidate")
+    {
+        lines.push(format!("- {}", string_field(card, "oneLine")));
+        lines.push("  Boundary: This is a combinatorial repair candidate, not a semantic refactor guarantee.".to_string());
+    }
+    if !lines
+        .last()
+        .is_some_and(|line| line.starts_with("  Boundary"))
+    {
+        lines.push("- No measured repair candidate was promoted by this packet.".to_string());
+    }
+    lines.push(String::new());
+    lines.push("## Measurement boundary".to_string());
+    lines.push(string_at(report, &["boundaryDigest", "shortText"]));
+    lines.push(format!(
+        "- checked: {}",
+        number_at(report, &["boundaryDigest", "checkedCount"])
+    ));
+    lines.push(format!(
+        "- assumed: {}",
+        number_at(report, &["boundaryDigest", "assumedCount"])
+    ));
+    lines.push(format!(
+        "- blocking: {}",
+        number_at(report, &["boundaryDigest", "blockingCount"])
+    ));
+    lines.push(String::new());
+    lines.push("## Artifact links".to_string());
+    for key in ["summaryRef", "briefRef", "viewerDataRef"] {
+        lines.push(format!(
+            "- {}: {}",
+            key,
+            string_at(report, &["outputArtifacts", key])
+        ));
+    }
+    lines.push(String::new());
+    lines.push("## Raw technical details".to_string());
+    lines.push(format!(
+        "- source packet: {}",
+        string_field(report, "sourcePacketRef")
+    ));
+    lines.push(
+        "- theorem-candidate readings are analytic-only and are not structural conclusions."
+            .to_string(),
+    );
+    lines.push("- holonomy-like visual modes are exploratory cover / restriction path views, not monodromy verdicts.".to_string());
+    lines.push(String::new());
+    lines.push("## LLM handoff".to_string());
+    lines.push("Use the following ArchSig result as bounded evidence.".to_string());
+    lines.push("Do not infer beyond the listed claims and boundaries.".to_string());
+    lines.push(String::new());
+    lines.push("Conclusion:".to_string());
+    lines.push(string_at(report, &["readThisFirst", "conclusion"]));
+    lines.push(String::new());
+    lines.push("Top insights:".to_string());
+    for card in report["insightCards"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .take(3)
+    {
+        lines.push(format!("- {}", string_field(card, "oneLine")));
+    }
+    lines.push(String::new());
+    lines.push("Boundary:".to_string());
+    lines.push(string_at(report, &["boundaryDigest", "shortText"]));
+    lines.push(String::new());
+    lines.push("Source refs:".to_string());
+    for source_ref in string_array_at(report, &["copyBlocks", "sourceRefs"])
+        .into_iter()
+        .take(10)
+    {
+        lines.push(format!("- {source_ref}"));
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn insight_cards_v1(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    summary: &Value,
+) -> Vec<Value> {
+    let mut cards = Vec::new();
+    for row in &packet.structural_verdict {
+        if row.evaluator == "ag.cech-obstruction@1" && row.verdict == "measured_nonzero" {
+            cards.push(insight_card(
+                "insight:h1-glue-mismatch:001",
+                "global_glue_mismatch",
+                "high",
+                "Global glue mismatch measured",
+                "Local checks do not explain the whole selected cover; ArchSig measured a cross-context H^1 mismatch.",
+                "This highlights architecture drift that can be invisible as a local law violation and gives reviewers a first seam to inspect.",
+                row,
+                packet,
+                normalized,
+                "Inspect mismatch support",
+                "cech-h1-mismatch",
+                vec![
+                    "measured_nonzero structural verdict".to_string(),
+                    "has context refs".to_string(),
+                    "has next inspection action".to_string(),
+                ],
+                vec![
+                    "This does not prove source extraction completeness.".to_string(),
+                    "This does not automatically identify a safe repair.".to_string(),
+                ],
+            ));
+        } else if row.evaluator == "ag.cech-obstruction@1" && row.verdict == "measured_zero" {
+            cards.push(insight_card(
+                "insight:h1-glue-mismatch:zero",
+                "no_measured_glue_mismatch",
+                "info",
+                "No measured H^1 glue mismatch under profile",
+                "No selected-cover H^1 glue mismatch was measured under this profile.",
+                "This lets reviewers distinguish a profile-relative zero result from unmeasured or unknown regions.",
+                row,
+                packet,
+                normalized,
+                "Inspect measurement boundary",
+                "boundary-assumption",
+                vec![
+                    "measured_zero confirmation".to_string(),
+                    "boundary digest remains visible".to_string(),
+                ],
+                vec![
+                    "This does not mean the architecture is clean.".to_string(),
+                    "This does not rule out unmeasured or unknown support.".to_string(),
+                ],
+            ));
+        } else if row.evaluator == "ag.square-free-repair@1" && row.verdict == "measured_nonzero" {
+            cards.push(insight_card(
+                "insight:repair-candidate:001",
+                "minimal_repair_candidate",
+                "high",
+                "Minimal repair candidate available",
+                "Measured forbidden supports have a combinatorial hitting-set repair candidate.",
+                "This gives refactor planning a concrete support set to inspect without claiming an automatic semantic repair.",
+                row,
+                packet,
+                normalized,
+                "Compare repair candidate with forbidden supports",
+                "repair-dual",
+                vec![
+                    "repair candidate".to_string(),
+                    "lower-bound language".to_string(),
+                    "non-claim required".to_string(),
+                ],
+                vec![
+                    "This is a combinatorial repair candidate, not a semantic refactor guarantee.".to_string(),
+                    "This does not prove repair safety.".to_string(),
+                ],
+            ));
+        } else if row.evaluator == "ag.law-conflict-tor@1" && row.verdict == "measured_nonzero" {
+            cards.push(insight_card(
+                "insight:policy-conflict:001",
+                "policy_conflict",
+                "high",
+                "Policy conflict measured",
+                "Selected law universes have a measured Tor conflict class in the common ambient.",
+                "This points reviewers to the witness/context where policy choices structurally collide.",
+                row,
+                packet,
+                normalized,
+                "Inspect policy conflict witness",
+                "law-conflict-tor",
+                vec!["policy conflict".to_string(), "measured_nonzero structural verdict".to_string()],
+                vec!["This does not prove there is no compatible refactor.".to_string()],
+            ));
+        } else if row.verdict == "not_computed" {
+            cards.push(insight_card(
+                &format!("insight:not-computed:{}", slug(&row.evaluator)),
+                "not_computed_blocker",
+                "high",
+                "Measurement blocked by reason code",
+                &format!(
+                    "{} did not compute because {}.",
+                    row.evaluator, row.verdict_data.method_status
+                ),
+                "The blocked reason belongs in the Decision Bar so reviewers do not mistake an empty scene for absence of conflict.",
+                row,
+                packet,
+                normalized,
+                "Inspect blocking reason",
+                if row.evaluator == "ag.law-conflict-tor@1" {
+                    "law-conflict-tor"
+                } else {
+                    "boundary-assumption"
+                },
+                vec![
+                    "not_computed due to reason code".to_string(),
+                    row.verdict_data.method_status.clone(),
+                ],
+                vec!["This is not a measured zero result.".to_string()],
+            ));
+        }
+    }
+    if packet
+        .analytic_readings
+        .iter()
+        .any(|reading| reading.evaluator == "ag.sheaf-laplacian@1")
+    {
+        cards.push(analytic_insight_card(
+            "insight:architecture-debt-mass:001",
+            "architecture_debt_mass",
+            "medium",
+            "Architecture debt field available",
+            "Harmonic mass and flatness distance are available as analytic readings.",
+            "This supports debt inspection as an analytic field while keeping lawful/unlawful verdicts separate.",
+            packet,
+            normalized,
+            "Inspect Hodge debt field",
+            "hodge-debt-field",
+            vec!["architecture debt mass / analytic reading".to_string()],
+            vec![
+                "Near-flat is not lawful.".to_string(),
+                "Analytic readings do not generate structural verdicts.".to_string(),
+            ],
+        ));
+    }
+    if packet
+        .assumptions
+        .iter()
+        .any(|assumption| assumption.status != "checked")
+        || summary["structuralVerdictSummary"]["nonTerminalCount"]
+            .as_u64()
+            .unwrap_or(0)
+            > 0
+    {
+        cards.push(analytic_insight_card(
+            "insight:measurement-boundary:001",
+            "measurement_boundary",
+            "medium",
+            "Measurement boundary recorded",
+            "Checked, assumed, unmeasured, unknown, and not_computed states are preserved for review.",
+            "This tells reviewers exactly where the conclusion is profile-relative and where it is blocked or unmeasured.",
+            packet,
+            normalized,
+            "Inspect measurement boundary",
+            "boundary-assumption",
+            vec!["measurement boundary".to_string(), "unknown states remain visible".to_string()],
+            vec!["Boundary visibility is not a negative conclusion by itself.".to_string()],
+        ));
+    }
+    cards.sort_by(|left, right| {
+        insight_rank(right)
+            .cmp(&insight_rank(left))
+            .then_with(|| string_field(left, "id").cmp(&string_field(right, "id")))
+    });
+    cards
+}
+
+fn insight_card(
+    id: &str,
+    kind: &str,
+    severity: &str,
+    title: &str,
+    one_line: &str,
+    why_it_matters: &str,
+    row: &AgStructuralVerdictV1,
+    packet: &ArchSigMeasurementPacketV1,
+    normalized: &NormalizedArchMapV2,
+    next_action: &str,
+    scene_id: &str,
+    ranking_basis: Vec<String>,
+    non_claims: Vec<String>,
+) -> Value {
+    let refs = insight_refs_for_row(normalized, packet, row);
+    let structural_verdict_ref = structural_verdict_ref(row);
+    let sample_refs = insight_sample_refs(normalized);
+    let evidence_resolution_status = if refs.3.is_empty() && refs.4.is_empty() && refs.5.is_empty()
+    {
+        "boundary_only"
+    } else {
+        "resolved_from_packet_support"
+    };
+    json!({
+        "id": id,
+        "kind": kind,
+        "severity": severity,
+        "title": title,
+        "oneLine": one_line,
+        "whyItMatters": why_it_matters,
+        "evidence": {
+            "structuralVerdictRefs": [structural_verdict_ref],
+            "computedInvariantRefs": refs.0,
+            "analyticReadingRefs": refs.1,
+            "assumptionRefs": refs.2,
+            "sourceRefs": refs.3,
+            "atomRefs": refs.4,
+            "contextRefs": refs.5,
+            "coverRefs": [packet.profile.cover_ref.clone()],
+            "evaluatorRefs": [row.evaluator.clone()],
+            "evidenceResolutionStatus": evidence_resolution_status
+        },
+        "sampleRefs": sample_refs,
+        "nextAction": {
+            "label": next_action,
+            "kind": if kind == "minimal_repair_candidate" { "repair_candidate" } else { "next_inspection" },
+            "targetRefs": refs.6
+        },
+        "viewerNavigation": {
+            "sceneId": scene_id,
+            "highlightRefs": {
+                "atomRefs": refs.4,
+                "contextRefs": refs.5,
+                "sourceRefs": refs.3
+            }
+        },
+        "tourRefs": [format!("tour:{}", id.trim_start_matches("insight:"))],
+        "rankingBasis": ranking_basis,
+        "nonClaims": non_claims
+    })
+}
+
+fn analytic_insight_card(
+    id: &str,
+    kind: &str,
+    severity: &str,
+    title: &str,
+    one_line: &str,
+    why_it_matters: &str,
+    packet: &ArchSigMeasurementPacketV1,
+    normalized: &NormalizedArchMapV2,
+    next_action: &str,
+    scene_id: &str,
+    ranking_basis: Vec<String>,
+    non_claims: Vec<String>,
+) -> Value {
+    let source_refs = top_source_refs(normalized);
+    let atom_refs = top_atom_refs(normalized);
+    let context_refs = top_context_refs(normalized);
+    let sample_refs = insight_sample_refs(normalized);
+    json!({
+        "id": id,
+        "kind": kind,
+        "severity": severity,
+        "title": title,
+        "oneLine": one_line,
+        "whyItMatters": why_it_matters,
+        "evidence": {
+            "structuralVerdictRefs": [],
+            "computedInvariantRefs": invariant_refs(packet),
+            "analyticReadingRefs": analytic_reading_refs(packet),
+            "assumptionRefs": assumption_refs(packet),
+            "sourceRefs": source_refs,
+            "atomRefs": atom_refs,
+            "contextRefs": context_refs,
+            "coverRefs": [packet.profile.cover_ref.clone()],
+            "evaluatorRefs": evaluator_refs(packet),
+            "evidenceResolutionStatus": "analytic_or_boundary_summary"
+        },
+        "sampleRefs": sample_refs,
+        "nextAction": {
+            "label": next_action,
+            "kind": "next_inspection",
+            "targetRefs": ["boundary-digest:main"]
+        },
+        "viewerNavigation": {
+            "sceneId": scene_id,
+            "highlightRefs": {
+                "atomRefs": atom_refs,
+                "contextRefs": context_refs,
+                "sourceRefs": source_refs
+            }
+        },
+        "tourRefs": [format!("tour:{}", id.trim_start_matches("insight:"))],
+        "rankingBasis": ranking_basis,
+        "nonClaims": non_claims
+    })
+}
+
+fn insight_boundary_digest(packet: &ArchSigMeasurementPacketV1, summary: &Value) -> Value {
+    let checked = packet
+        .assumptions
+        .iter()
+        .filter(|assumption| assumption.status == "checked")
+        .count();
+    let assumed = packet
+        .assumptions
+        .iter()
+        .filter(|assumption| assumption.status == "assumed")
+        .count();
+    let violated = packet
+        .assumptions
+        .iter()
+        .filter(|assumption| assumption.status == "violated")
+        .count();
+    let unmeasured = packet
+        .structural_verdict
+        .iter()
+        .filter(|row| row.verdict == "unmeasured")
+        .count();
+    let unknown = packet
+        .structural_verdict
+        .iter()
+        .filter(|row| row.verdict == "unknown")
+        .count();
+    let not_computed = packet
+        .structural_verdict
+        .iter()
+        .filter(|row| row.verdict == "not_computed")
+        .count();
+    let blocking = violated + not_computed;
+    json!({
+        "id": "boundary-digest:main",
+        "shortText": format!(
+            "Profile-relative. {assumed} assumptions declared. {unmeasured} supports unmeasured. {unknown} unknown. {not_computed} not_computed."
+        ),
+        "profileRef": packet.profile.profile_id,
+        "checkedCount": checked,
+        "assumedCount": assumed,
+        "violatedCount": violated,
+        "unmeasuredCount": unmeasured,
+        "unknownCount": unknown,
+        "notComputedCount": not_computed,
+        "blockingCount": blocking,
+        "conclusionRef": summary["conclusion"],
+        "checked": packet.assumptions.iter().filter(|row| row.status == "checked").map(assumption_row).collect::<Vec<_>>(),
+        "assumed": packet.assumptions.iter().filter(|row| row.status == "assumed").map(assumption_row).collect::<Vec<_>>(),
+        "blocking": packet.assumptions.iter().filter(|row| row.status == "violated").map(assumption_row).chain(packet.structural_verdict.iter().filter(|row| row.verdict == "not_computed").map(|row| json!({
+            "kind": "not_computed",
+            "evaluator": row.evaluator,
+            "reasonCode": row.verdict_data.method_status,
+            "reason": row.reason
+        }))).collect::<Vec<_>>(),
+        "nonClaims": [
+            "Boundary digest qualifies where the conclusion applies; it does not add a new negative conclusion.",
+            "Unmeasured, unknown, and not_computed are not measured zero."
+        ]
+    })
+}
+
+fn insight_action_queue_v1(cards: &[Value]) -> Vec<Value> {
+    cards
+        .iter()
+        .enumerate()
+        .map(|(index, card)| {
+            let kind = if string_field(card, "kind") == "minimal_repair_candidate" {
+                "repair_candidate"
+            } else {
+                "next_inspection"
+            };
+            json!({
+                "id": format!("action:{}:{}", kind, index + 1),
+                "kind": kind,
+                "title": string_at(card, &["nextAction", "label"]),
+                "reason": string_field(card, "oneLine"),
+                "targetRefs": card["nextAction"]["targetRefs"],
+                "expectedUserOutcome": if kind == "repair_candidate" {
+                    "Decide whether this combinatorial candidate should seed a refactor plan."
+                } else {
+                    "Decide which measured support, boundary, or source ref to inspect next."
+                },
+                "nonClaims": card["nonClaims"]
+            })
+        })
+        .collect()
+}
+
+fn insight_viewer_visual_scenes_v1(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    cards: &[Value],
+) -> Vec<Value> {
+    let overview_refs = scene_refs_for_kinds(
+        normalized,
+        packet,
+        cards,
+        &[
+            "global_glue_mismatch",
+            "minimal_repair_candidate",
+            "policy_conflict",
+            "not_computed_blocker",
+            "architecture_debt_mass",
+            "measurement_boundary",
+            "confirmed_zero",
+            "no_measured_glue_mismatch",
+        ],
+        true,
+    );
+    let cech_refs = scene_refs_for_kinds(
+        normalized,
+        packet,
+        cards,
+        &[
+            "global_glue_mismatch",
+            "confirmed_zero",
+            "no_measured_glue_mismatch",
+        ],
+        false,
+    );
+    let obstruction_refs = scene_refs_for_kinds(
+        normalized,
+        packet,
+        cards,
+        &["minimal_repair_candidate"],
+        false,
+    );
+    let law_refs = scene_refs_for_kinds(
+        normalized,
+        packet,
+        cards,
+        &["policy_conflict", "not_computed_blocker"],
+        false,
+    );
+    let hodge_refs = scene_refs_for_kinds(
+        normalized,
+        packet,
+        cards,
+        &["architecture_debt_mass"],
+        false,
+    );
+    let boundary_refs =
+        scene_refs_for_kinds(normalized, packet, cards, &["measurement_boundary"], false);
+    let source_refs = source_scene_refs(normalized, packet, cards);
+    let has_glue_mismatch = cards
+        .iter()
+        .any(|card| string_field(card, "kind") == "global_glue_mismatch");
+    let has_glue_zero = cards.iter().any(|card| {
+        matches!(
+            string_field(card, "kind").as_str(),
+            "confirmed_zero" | "no_measured_glue_mismatch"
+        )
+    });
+    let has_repair = cards
+        .iter()
+        .any(|card| string_field(card, "kind") == "minimal_repair_candidate");
+    let has_law_conflict = cards.iter().any(|card| {
+        matches!(
+            string_field(card, "kind").as_str(),
+            "policy_conflict" | "not_computed_blocker"
+        )
+    });
+    let has_debt = cards
+        .iter()
+        .any(|card| string_field(card, "kind") == "architecture_debt_mass");
+    vec![
+        scene_v1(
+            "overview",
+            "overview_constellation",
+            "Overview",
+            "Which insight should I inspect first?",
+            (
+                "source locality / module neighborhood",
+                "architecture layer or atom family rank",
+                "insight priority / measured severity",
+            ),
+            "top_insight_beacon",
+            "beacon",
+            "topInsightBeacon",
+            "selected insight support",
+            &overview_refs,
+            overview_color_role(cards),
+            "sphere",
+            "thick_glowing_line",
+            true,
+        ),
+        scene_v1(
+            "site-cover",
+            "finite_poset_site",
+            "Site / Cover",
+            "What finite site and cover did ArchSig measure?",
+            (
+                "source neighborhood",
+                "poset rank",
+                "coverage density or context size",
+            ),
+            "context_patch",
+            "patch",
+            "contextPatch",
+            "context and cover membership",
+            &overview_refs,
+            "checked",
+            "translucent_patch",
+            "arrow",
+            true,
+        ),
+        scene_v1(
+            "cech-gluing",
+            "cover_gluing",
+            "Cover & Gluing",
+            "Where does local structure fail to glue globally?",
+            (
+                "context neighborhood / source locality",
+                "context rank / restriction depth",
+                "gluing mismatch intensity",
+            ),
+            "overlap_seam",
+            "ribbon",
+            "cechMismatchSeam",
+            "overlap seam and gluing mismatch",
+            &cech_refs,
+            if has_glue_mismatch {
+                "measured_nonzero"
+            } else {
+                "measured_zero"
+            },
+            "ribbon",
+            "thick_glowing_line",
+            has_glue_mismatch || has_glue_zero,
+        ),
+        scene_v1(
+            "cech-h1-mismatch",
+            "cech_h1_mismatch",
+            "H1 Mismatch",
+            "Which mismatch class remains after local explanations?",
+            (
+                "cover overlap support",
+                "cochain / coboundary role",
+                "H1 mismatch weight",
+            ),
+            "cocycle_ribbon",
+            "ribbon",
+            "cechMismatchSeam",
+            "cocycle representative support",
+            &cech_refs,
+            if has_glue_mismatch {
+                "measured_nonzero"
+            } else {
+                "measured_zero"
+            },
+            "ribbon",
+            "thick_glowing_line",
+            has_glue_mismatch || has_glue_zero,
+        ),
+        scene_v1(
+            "obstruction",
+            "forbidden_support",
+            "Obstruction",
+            "Which atom combinations form forbidden support?",
+            (
+                "atom support neighborhood",
+                "law family",
+                "obstruction intensity",
+            ),
+            "forbidden_support_cage",
+            "cage",
+            "forbiddenSupportCage",
+            "minimal forbidden support",
+            &obstruction_refs,
+            "measured_nonzero",
+            "cage",
+            "broken_line",
+            has_repair,
+        ),
+        scene_v1(
+            "repair-dual",
+            "repair_dual",
+            "Repair",
+            "Which candidate support intersects measured obstructions?",
+            ("forbidden support", "candidate set", "lower-bound pressure"),
+            "repair_candidate_cut",
+            "cut",
+            "repairCandidateCut",
+            "minimal repair hitting set",
+            &obstruction_refs,
+            "repair_candidate",
+            "cut",
+            "arrow",
+            has_repair,
+        ),
+        scene_v1(
+            "law-conflict-tor",
+            "law_conflict",
+            "Law Conflict",
+            "Which law universe conflict is loaded on which witness?",
+            (
+                "law universe A",
+                "common ambient / blocker",
+                "law universe B",
+            ),
+            "law_conflict_bridge",
+            "bridge",
+            "lawConflictBridge",
+            "common ambient or no_common_ambient blocker",
+            &law_refs,
+            if has_law_conflict {
+                "not_computed"
+            } else {
+                "not_applicable"
+            },
+            "wall",
+            "broken_line",
+            has_law_conflict,
+        ),
+        scene_v1(
+            "hodge-debt-field",
+            "hodge_debt_field",
+            "Hodge Debt Field",
+            "Where is analytic architecture debt mass concentrated?",
+            (
+                "support locality",
+                "harmonic / exact component",
+                "debt mass / flatness distance",
+            ),
+            "analytic_debt_field",
+            "field",
+            "hodgeDebtField",
+            "harmonic mass analytic reading",
+            &hodge_refs,
+            "analytic_reading",
+            "heat",
+            "contour",
+            has_debt,
+        ),
+        scene_v1(
+            "boundary-assumption",
+            "boundary_assumption",
+            "Boundary",
+            "Which regions are checked, assumed, unknown, unmeasured, not_computed, or violated?",
+            (
+                "evidence contract",
+                "assumption status",
+                "blocker intensity",
+            ),
+            "boundary_wall",
+            "wall",
+            "boundaryWall",
+            "measurement boundary state",
+            &boundary_refs,
+            "unknown",
+            "wall_fog",
+            "broken_line",
+            true,
+        ),
+        scene_v1(
+            "source-evidence",
+            "source_evidence",
+            "Source Evidence",
+            "Which source refs ground this insight?",
+            (
+                "path / directory neighborhood",
+                "symbol / file depth",
+                "evidence role",
+            ),
+            "source_node",
+            "node",
+            "sourceNode",
+            "copyable source refs",
+            &source_refs,
+            "source_evidence",
+            "node",
+            "thin_line",
+            !string_array_at(&source_refs, &["sourceRefs"]).is_empty(),
+        ),
+    ]
+}
+
+fn overview_color_role(cards: &[Value]) -> &'static str {
+    let top_kind = cards.first().map(|card| string_field(card, "kind"));
+    match top_kind.as_deref() {
+        Some("global_glue_mismatch")
+        | Some("minimal_repair_candidate")
+        | Some("policy_conflict") => "measured_nonzero",
+        Some("no_measured_glue_mismatch") | Some("confirmed_zero") => "measured_zero",
+        Some("not_computed_blocker") => "not_computed",
+        Some("architecture_debt_mass") => "analytic_reading",
+        Some("measurement_boundary") => "unknown",
+        _ => "checked",
+    }
+}
+
+fn scene_refs_for_kinds(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    cards: &[Value],
+    kinds: &[&str],
+    include_samples: bool,
+) -> Value {
+    let kind_set = kinds.iter().copied().collect::<BTreeSet<_>>();
+    let mut insight_refs = Vec::new();
+    let mut atom_refs = BTreeSet::new();
+    let mut context_refs = BTreeSet::new();
+    let mut source_refs = BTreeSet::new();
+
+    for card in cards
+        .iter()
+        .filter(|card| kind_set.contains(string_field(card, "kind").as_str()))
+    {
+        insight_refs.push(string_field(card, "id"));
+        for atom_ref in string_array_at(card, &["evidence", "atomRefs"]) {
+            atom_refs.insert(atom_ref);
+        }
+        for context_ref in string_array_at(card, &["evidence", "contextRefs"]) {
+            context_refs.insert(context_ref);
+        }
+        for source_ref in string_array_at(card, &["evidence", "sourceRefs"]) {
+            source_refs.insert(source_ref);
+        }
+    }
+
+    if include_samples {
+        atom_refs.extend(top_atom_refs(normalized));
+        context_refs.extend(top_context_refs(normalized));
+        source_refs.extend(top_source_refs(normalized));
+    }
+
+    json!({
+        "insightRefs": insight_refs,
+        "atomRefs": atom_refs.into_iter().take(24).collect::<Vec<_>>(),
+        "contextRefs": context_refs.into_iter().take(16).collect::<Vec<_>>(),
+        "coverRefs": [packet.profile.cover_ref.clone()],
+        "sourceRefs": source_refs.into_iter().take(20).collect::<Vec<_>>()
+    })
+}
+
+fn source_scene_refs(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    cards: &[Value],
+) -> Value {
+    let mut insight_refs = Vec::new();
+    let mut atom_refs = BTreeSet::new();
+    let mut context_refs = BTreeSet::new();
+    let mut source_refs = BTreeSet::new();
+    for card in cards
+        .iter()
+        .filter(|card| !string_array_at(card, &["evidence", "sourceRefs"]).is_empty())
+    {
+        insight_refs.push(string_field(card, "id"));
+        for atom_ref in string_array_at(card, &["evidence", "atomRefs"]) {
+            atom_refs.insert(atom_ref);
+        }
+        for context_ref in string_array_at(card, &["evidence", "contextRefs"]) {
+            context_refs.insert(context_ref);
+        }
+        for source_ref in string_array_at(card, &["evidence", "sourceRefs"]) {
+            source_refs.insert(source_ref);
+        }
+    }
+    if source_refs.is_empty() {
+        source_refs.extend(top_source_refs(normalized));
+    }
+    json!({
+        "insightRefs": insight_refs,
+        "atomRefs": atom_refs.into_iter().take(24).collect::<Vec<_>>(),
+        "contextRefs": context_refs.into_iter().take(16).collect::<Vec<_>>(),
+        "coverRefs": [packet.profile.cover_ref.clone()],
+        "sourceRefs": source_refs.into_iter().take(20).collect::<Vec<_>>()
+    })
+}
+
+fn scene_v1(
+    scene_id: &str,
+    kind: &str,
+    title: &str,
+    user_question: &str,
+    axis: (&str, &str, &str),
+    layer_kind: &str,
+    geometry_role: &str,
+    click_target_kind: &str,
+    text_role: &str,
+    primary_refs: &Value,
+    color_role: &str,
+    shape_role: &str,
+    line_role: &str,
+    active: bool,
+) -> Value {
+    json!({
+        "sceneId": scene_id,
+        "kind": kind,
+        "title": title,
+        "sceneStatus": if active { "active" } else { "not_active_for_packet" },
+        "userQuestion": user_question,
+        "axisMapping": { "x": axis.0, "y": axis.1, "z": axis.2 },
+        "primaryRefs": primary_refs,
+        "layers": [{
+            "layerId": format!("layer:{scene_id}:{layer_kind}"),
+            "kind": layer_kind,
+            "geometryRole": geometry_role,
+            "encodingRef": format!("encoding:{scene_id}:main"),
+            "clickTargetKind": click_target_kind,
+            "refs": primary_refs,
+            "omissionPolicy": if active { "preserve_for_top_insight" } else { "omittable_background" },
+            "animationPurpose": if active { "navigation" } else { "orientation" }
+        }],
+        "visualEncodings": [{
+            "encodingId": format!("encoding:{scene_id}:main"),
+            "colorRole": if active { color_role } else { "not_applicable" },
+            "shapeRole": shape_role,
+            "lineRole": line_role,
+            "textRole": if active { text_role.to_string() } else { format!("not active for this packet: {text_role}") }
+        }],
+        "boundaryDigestRef": "boundary-digest:main"
+    })
+}
+
+fn insight_guided_tours_v1(cards: &[Value]) -> Vec<Value> {
+    cards
+        .iter()
+        .map(|card| {
+            let tour_id = format!("tour:{}", string_field(card, "id").trim_start_matches("insight:"));
+            json!({
+                "tourId": tour_id,
+                "title": string_field(card, "title"),
+                "insightRefs": [string_field(card, "id")],
+                "steps": [
+                    {
+                        "sceneId": "site-cover",
+                        "caption": "These contexts form the selected cover.",
+                        "highlightRefs": card["viewerNavigation"]["highlightRefs"]
+                    },
+                    {
+                        "sceneId": card["viewerNavigation"]["sceneId"],
+                        "caption": "This scene highlights the measured support or blocker.",
+                        "highlightRefs": card["viewerNavigation"]["highlightRefs"]
+                    },
+                    {
+                        "sceneId": "source-evidence",
+                        "caption": "These source refs ground the insight.",
+                        "highlightRefs": card["viewerNavigation"]["highlightRefs"]
+                    },
+                    {
+                        "sceneId": "boundary-assumption",
+                        "caption": "This boundary explains what is checked, assumed, unknown, unmeasured, or not_computed.",
+                        "highlightRefs": card["viewerNavigation"]["highlightRefs"]
+                    }
+                ]
+            })
+        })
+        .collect()
+}
+
+fn insight_copy_blocks_v1(
+    normalized: &NormalizedArchMapV2,
+    cards: &[Value],
+    boundary_digest: &Value,
+) -> Value {
+    let mut source_refs = cards
+        .iter()
+        .flat_map(|card| string_array_at(card, &["evidence", "sourceRefs"]))
+        .chain(top_source_refs(normalized))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    source_refs.truncate(20);
+    json!({
+        "sourceRefs": source_refs,
+        "llmHandoff": {
+            "instruction": "Use the following ArchSig result as bounded evidence. Do not infer beyond the listed claims and boundaries.",
+            "boundary": boundary_digest["shortText"],
+            "topInsights": cards.iter().take(3).map(|card| string_field(card, "oneLine")).collect::<Vec<_>>()
+        }
+    })
+}
+
+fn insight_refs_for_row(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    row: &AgStructuralVerdictV1,
+) -> (
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+) {
+    let row_invariants = invariant_values_for_row(packet, row);
+    let mut packet_atom_refs = collect_packet_refs_from_values(
+        &row_invariants,
+        &[
+            "supportAtomRefs",
+            "mismatchSupportRefs",
+            "witnessSupportRefs",
+            "atomRefs",
+            "atomRef",
+        ],
+    );
+    packet_atom_refs.extend(atom_refs_for_row(normalized, row));
+    let atom_refs = normalize_atom_refs(normalized, packet_atom_refs);
+    let mut context_refs = context_refs_for_atoms(normalized, &atom_refs);
+    context_refs.extend(normalize_context_refs(
+        normalized,
+        collect_packet_refs_from_values(
+            &row_invariants,
+            &[
+                "contextRefs",
+                "contextRef",
+                "selectedContexts",
+                "sourceContext",
+                "targetContext",
+            ],
+        ),
+    ));
+    context_refs = sorted_truncated(context_refs, 8);
+    let mut source_refs = source_refs_for_atoms(normalized, &atom_refs);
+    source_refs.extend(
+        collect_packet_refs_from_values(&row_invariants, &["sourceRefs", "sourceRef"])
+            .into_iter()
+            .map(|source_ref| sanitize_source_ref(&source_ref)),
+    );
+    source_refs = sorted_truncated(source_refs, 10);
+    let mut target_refs = atom_refs.clone();
+    target_refs.extend(context_refs.clone());
+    if target_refs.is_empty() {
+        target_refs.push(structural_verdict_ref(row));
+    }
+    (
+        invariant_refs_for_values(&row_invariants),
+        analytic_reading_refs_for_row(packet, row),
+        assumption_refs(packet),
+        source_refs,
+        atom_refs,
+        context_refs,
+        target_refs,
+    )
+}
+
+fn atom_refs_for_row(normalized: &NormalizedArchMapV2, row: &AgStructuralVerdictV1) -> Vec<String> {
+    let evaluator_hint = evaluator_hint(&row.evaluator);
+    let refs = normalized
+        .atoms
+        .iter()
+        .filter(|atom| {
+            evaluator_hint
+                .is_some_and(|hint| atom.axis.contains(hint) || atom.predicate.contains(hint))
+                || row
+                    .verdict_data
+                    .cert_ref
+                    .as_deref()
+                    .is_some_and(|cert| cert.contains(&atom.source_atom_id))
+        })
+        .map(|atom| atom.normalized_atom_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    refs.into_iter().take(12).collect()
+}
+
+fn context_refs_for_atoms(normalized: &NormalizedArchMapV2, atom_refs: &[String]) -> Vec<String> {
+    let atoms = atom_refs
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut refs = normalized
+        .contexts
+        .iter()
+        .filter(|context| {
+            context
+                .atom_ids
+                .iter()
+                .any(|atom| atoms.contains(atom.as_str()))
+        })
+        .map(|context| context.normalized_context_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    refs.truncate(8);
+    refs
+}
+
+fn source_refs_for_atoms(normalized: &NormalizedArchMapV2, atom_refs: &[String]) -> Vec<String> {
+    let atoms = atom_refs
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut refs = normalized
+        .atoms
+        .iter()
+        .filter(|atom| atoms.contains(atom.normalized_atom_id.as_str()))
+        .flat_map(|atom| {
+            atom.source_refs
+                .iter()
+                .map(|source_ref| sanitize_source_ref(source_ref))
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    refs.truncate(10);
+    refs
+}
+
+fn structural_verdict_ref(row: &AgStructuralVerdictV1) -> String {
+    format!(
+        "structuralVerdict/{}/{}/{}",
+        stable_ref_segment(&row.evaluator),
+        stable_ref_segment(&row.law),
+        stable_ref_segment(&row.verdict_data.method_status)
+    )
+}
+
+fn stable_ref_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+fn evaluator_hint(evaluator: &str) -> Option<&'static str> {
+    if evaluator.contains("cech") {
+        Some("cech")
+    } else if evaluator.contains("square-free") || evaluator.contains("square_free") {
+        Some("square")
+    } else if evaluator.contains("tor") {
+        Some("tor")
+    } else if evaluator.contains("laplacian") {
+        Some("laplacian")
+    } else if evaluator.contains("period") {
+        Some("period")
+    } else if evaluator.contains("transfer") {
+        Some("transfer")
+    } else {
+        None
+    }
+}
+
+fn invariant_values_for_row(
+    packet: &ArchSigMeasurementPacketV1,
+    row: &AgStructuralVerdictV1,
+) -> Vec<Value> {
+    let cert_invariant = row
+        .verdict_data
+        .cert_ref
+        .as_deref()
+        .and_then(|cert_ref| cert_ref.strip_prefix("computedInvariants/"));
+    let hint = evaluator_hint(&row.evaluator);
+    packet
+        .computed_invariants
+        .iter()
+        .filter(|value| {
+            let invariant_id = value["invariantId"].as_str().unwrap_or_default();
+            cert_invariant.is_some_and(|cert| cert == invariant_id)
+                || value["evaluator"].as_str() == Some(row.evaluator.as_str())
+                || hint.is_some_and(|hint| invariant_id.contains(hint))
+        })
+        .cloned()
+        .collect()
+}
+
+fn invariant_refs_for_values(values: &[Value]) -> Vec<String> {
+    values
+        .iter()
+        .filter_map(|value| value["invariantId"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(12)
+        .collect()
+}
+
+fn analytic_reading_refs_for_row(
+    packet: &ArchSigMeasurementPacketV1,
+    row: &AgStructuralVerdictV1,
+) -> Vec<String> {
+    packet
+        .analytic_readings
+        .iter()
+        .filter(|reading| {
+            reading.evaluator == row.evaluator
+                || reading.structural_verdict_ref.as_deref() == row.verdict_data.cert_ref.as_deref()
+                || evaluator_hint(&row.evaluator)
+                    .is_some_and(|hint| reading.reading_id.contains(hint))
+        })
+        .map(|reading| reading.reading_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(12)
+        .collect()
+}
+
+fn collect_packet_refs_from_values(values: &[Value], keys: &[&str]) -> Vec<String> {
+    let key_set = keys.iter().copied().collect::<BTreeSet<_>>();
+    let mut refs = BTreeSet::new();
+    for value in values {
+        collect_packet_refs(value, &key_set, &mut refs);
+    }
+    refs.into_iter().collect()
+}
+
+fn collect_packet_refs(value: &Value, keys: &BTreeSet<&str>, refs: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(object) => {
+            for (key, nested) in object {
+                if keys.contains(key.as_str()) {
+                    collect_strings(nested, refs);
+                }
+                collect_packet_refs(nested, keys, refs);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_packet_refs(item, keys, refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_strings(value: &Value, refs: &mut BTreeSet<String>) {
+    match value {
+        Value::String(value) => {
+            refs.insert(value.clone());
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_strings(item, refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_atom_refs(normalized: &NormalizedArchMapV2, refs: Vec<String>) -> Vec<String> {
+    let by_source = normalized
+        .atoms
+        .iter()
+        .map(|atom| {
+            (
+                atom.source_atom_id.as_str(),
+                atom.normalized_atom_id.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let normalized_ids = normalized
+        .atoms
+        .iter()
+        .map(|atom| atom.normalized_atom_id.as_str())
+        .collect::<BTreeSet<_>>();
+    refs.into_iter()
+        .filter_map(|atom_ref| {
+            if normalized_ids.contains(atom_ref.as_str()) {
+                Some(atom_ref)
+            } else {
+                by_source.get(atom_ref.as_str()).cloned()
+            }
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(12)
+        .collect()
+}
+
+fn normalize_context_refs(normalized: &NormalizedArchMapV2, refs: Vec<String>) -> Vec<String> {
+    let by_source = normalized
+        .contexts
+        .iter()
+        .map(|context| {
+            (
+                context.source_context_id.as_str(),
+                context.normalized_context_id.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let normalized_ids = normalized
+        .contexts
+        .iter()
+        .map(|context| context.normalized_context_id.as_str())
+        .collect::<BTreeSet<_>>();
+    refs.into_iter()
+        .filter_map(|context_ref| {
+            if normalized_ids.contains(context_ref.as_str()) {
+                Some(context_ref)
+            } else {
+                by_source.get(context_ref.as_str()).cloned()
+            }
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(8)
+        .collect()
+}
+
+fn sorted_truncated(refs: Vec<String>, limit: usize) -> Vec<String> {
+    refs.into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(limit)
+        .collect()
+}
+
+fn sanitize_source_ref(source_ref: &str) -> String {
+    if source_ref.starts_with('/')
+        || source_ref.contains("\\")
+        || source_ref.contains("/Users/")
+        || source_ref.contains(".codex")
+        || source_ref.contains("Documents/LEAN")
+        || source_ref.contains("HelloLean")
+    {
+        "source-ref:redacted-local-path".to_string()
+    } else {
+        source_ref.to_string()
+    }
+}
+
+fn invariant_refs(packet: &ArchSigMeasurementPacketV1) -> Vec<String> {
+    packet
+        .computed_invariants
+        .iter()
+        .filter_map(|value| value["invariantId"].as_str())
+        .map(ToOwned::to_owned)
+        .take(12)
+        .collect()
+}
+
+fn analytic_reading_refs(packet: &ArchSigMeasurementPacketV1) -> Vec<String> {
+    packet
+        .analytic_readings
+        .iter()
+        .map(|reading| reading.reading_id.clone())
+        .take(12)
+        .collect()
+}
+
+fn assumption_refs(packet: &ArchSigMeasurementPacketV1) -> Vec<String> {
+    packet
+        .assumptions
+        .iter()
+        .map(|assumption| assumption.theorem_ref.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn evaluator_refs(packet: &ArchSigMeasurementPacketV1) -> Vec<String> {
+    packet
+        .structural_verdict
+        .iter()
+        .map(|row| row.evaluator.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn top_atom_refs(normalized: &NormalizedArchMapV2) -> Vec<String> {
+    normalized
+        .atoms
+        .iter()
+        .map(|atom| atom.normalized_atom_id.clone())
+        .take(8)
+        .collect()
+}
+
+fn top_context_refs(normalized: &NormalizedArchMapV2) -> Vec<String> {
+    normalized
+        .contexts
+        .iter()
+        .map(|context| context.normalized_context_id.clone())
+        .take(8)
+        .collect()
+}
+
+fn top_source_refs(normalized: &NormalizedArchMapV2) -> Vec<String> {
+    normalized
+        .atoms
+        .iter()
+        .flat_map(|atom| {
+            atom.source_refs
+                .iter()
+                .map(|source_ref| sanitize_source_ref(source_ref))
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(12)
+        .collect()
+}
+
+fn insight_sample_refs(normalized: &NormalizedArchMapV2) -> Value {
+    json!({
+        "atomRefs": top_atom_refs(normalized),
+        "contextRefs": top_context_refs(normalized),
+        "sourceRefs": top_source_refs(normalized),
+        "note": "Sample refs support orientation only; measured insight evidence is listed under evidence."
+    })
+}
+
+fn assumption_row(row: &AgAssumptionLedgerEntryV1) -> Value {
+    json!({
+        "theoremRef": row.theorem_ref,
+        "assumption": row.assumption,
+        "status": row.status,
+        "checkedBy": row.checked_by,
+        "assumedBy": row.assumed_by
+    })
+}
+
+fn insight_rank(card: &Value) -> usize {
+    match string_field(card, "kind").as_str() {
+        "validation_failure" => 800,
+        "global_glue_mismatch" => 700,
+        "not_computed_blocker" => 650,
+        "repair_lower_bound" | "minimal_repair_candidate" => 600,
+        "policy_conflict" => 500,
+        "architecture_debt_mass" => 400,
+        "no_measured_glue_mismatch" => 300,
+        "measurement_boundary" => 250,
+        _ => 100,
+    }
+}
+
+fn insight_decision_state(card: &Value) -> &'static str {
+    match string_field(card, "severity").as_str() {
+        "high" => "needs_attention",
+        "medium" => "review_boundary",
+        _ => "informational",
+    }
+}
+
+fn empty_insight_evidence() -> Value {
+    json!({
+        "structuralVerdictRefs": [],
+        "computedInvariantRefs": [],
+        "analyticReadingRefs": [],
+        "assumptionRefs": [],
+        "sourceRefs": [],
+        "atomRefs": [],
+        "contextRefs": [],
+        "coverRefs": [],
+        "evaluatorRefs": []
+    })
+}
+
+fn empty_highlight_refs() -> Value {
+    json!({
+        "atomRefs": [],
+        "contextRefs": [],
+        "sourceRefs": []
+    })
+}
+
+fn string_field(value: &Value, field: &str) -> String {
+    value[field].as_str().unwrap_or_default().to_string()
+}
+
+fn string_at(value: &Value, path: &[&str]) -> String {
+    let mut current = value;
+    for key in path {
+        current = &current[*key];
+    }
+    current
+        .as_str()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| current.to_string())
+}
+
+fn number_at(value: &Value, path: &[&str]) -> u64 {
+    let mut current = value;
+    for key in path {
+        current = &current[*key];
+    }
+    current.as_u64().unwrap_or(0)
+}
+
+fn string_array_at(value: &Value, path: &[&str]) -> Vec<String> {
+    let mut current = value;
+    for key in path {
+        current = &current[*key];
+    }
+    current
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn slug(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
 }
 
 #[derive(Debug, Clone)]
@@ -3323,30 +4984,339 @@ pub fn build_measurement_viewer_data_v1(
     normalized: &NormalizedArchMapV2,
     packet: &ArchSigMeasurementPacketV1,
     summary: &Value,
+    insight_report: &Value,
 ) -> Value {
+    let atom_count = normalized.atoms.len();
+    let preserved_atom_refs = top_insight_atom_refs(insight_report);
+    let preserved_context_refs = top_insight_context_refs(insight_report);
+    let viewer_atoms = projected_atoms(normalized, &preserved_atom_refs, 10_000);
+    let viewer_contexts = projected_contexts(normalized, &preserved_context_refs, 20_000);
+    let viewer_covers = projected_covers(normalized, 10_000);
+    let atom_nodes = viewer_atom_nodes(&viewer_atoms, insight_report);
+    let molecule_groups = viewer_molecule_groups(&viewer_contexts);
+    let atom_edges = viewer_atom_edges(&viewer_contexts);
+    let context_memberships = normalized
+        .atoms
+        .iter()
+        .map(|atom| atom.context_memberships.len())
+        .sum::<usize>();
+    let cover_overlaps = normalized
+        .covers
+        .iter()
+        .map(|cover| cover.context_ids.len().saturating_sub(1))
+        .sum::<usize>();
+    let scene_layer_objects = insight_report["viewerVisualScenes"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|scene| scene["layers"].as_array().into_iter().flatten())
+        .count();
+    let large_graph_mode = atom_count >= 10_000
+        || context_memberships > 20_000
+        || cover_overlaps > 10_000
+        || scene_layer_objects > 1_000;
     json!({
         "schemaVersion": "archsig-atom-viewer-data-v2",
         "sourceArtifactRefs": {
             "normalizedArchMap": "normalized-archmap.json",
             "measurementPacket": "archsig-measurement-packet.json",
-            "summary": "archsig-analysis-summary.json"
+            "summary": "archsig-analysis-summary.json",
+            "insightReport": "archsig-insight-report.json",
+            "insightBrief": "archsig-insight-brief.md"
         },
+        "decisionBar": {
+            "conclusion": insight_report["headline"]["conclusionCode"],
+            "validation": "see archsig-analysis-validation.json",
+            "boundaryDigest": insight_report["boundaryDigest"]["shortText"],
+            "artifactLinks": insight_report["outputArtifacts"]
+        },
+        "atomNodes": atom_nodes,
+        "moleculeGroups": molecule_groups,
+        "atomEdges": atom_edges,
+        "insightQueue": insight_report["insightCards"],
+        "actionQueue": insight_report["actionQueue"],
+        "viewerVisualScenes": insight_report["viewerVisualScenes"],
+        "guidedTours": insight_report["guidedTours"],
+        "copyBlocks": insight_report["copyBlocks"],
         "reportPane": {
             "conclusion": summary["conclusion"],
             "profileRef": packet.profile.profile_id,
             "assumptionSummary": summary["assumptionSummary"],
-            "structuralVerdictSummary": summary["structuralVerdictSummary"]
+            "structuralVerdictSummary": summary["structuralVerdictSummary"],
+            "readThisFirst": insight_report["readThisFirst"],
+            "insightQueue": insight_report["insightCards"],
+            "actionQueue": insight_report["actionQueue"],
+            "evidenceDetailShape": ["What", "Why", "Where", "Measurement", "Boundary", "Next"],
+            "boundaryDigest": insight_report["boundaryDigest"],
+            "artifactLinks": insight_report["outputArtifacts"]
         },
         "finitePosetSite": {
-            "atoms": normalized.atoms,
-            "contexts": normalized.contexts,
-            "covers": normalized.covers
+            "atoms": viewer_atoms,
+            "contexts": viewer_contexts,
+            "covers": viewer_covers
+        },
+        "largeGraphStrategy": {
+            "mode": if large_graph_mode { "cluster_aggregation" } else { "full_projection" },
+            "thresholds": {
+                "fullGeometryAtoms": 2_000,
+                "instancedAtoms": 10_000,
+                "clusterAtoms": 50_000,
+                "contextMemberships": 20_000,
+                "coverOverlaps": 10_000,
+                "sceneLayerObjects": 1_000
+            },
+            "topInsightEvidencePinning": {
+                "policy": "preserve_for_top_insight",
+                "preservedRefs": top_insight_preserved_refs(insight_report),
+                "aggregatedRefs": if large_graph_mode { vec!["background-geometry"] } else { Vec::<&str>::new() },
+                "omittedRefs": if large_graph_mode { vec!["background-labels"] } else { Vec::<&str>::new() }
+            }
+        },
+        "omittedDetailCounts": {
+            "omittedAtoms": if atom_count > 10_000 { atom_count.saturating_sub(10_000) } else { 0 },
+            "omittedEdges": 0,
+            "omittedContextMemberships": if context_memberships > 20_000 { context_memberships.saturating_sub(20_000) } else { 0 },
+            "omittedCoverOverlaps": if cover_overlaps > 10_000 { cover_overlaps.saturating_sub(10_000) } else { 0 },
+            "omittedSceneLayerObjects": if scene_layer_objects > 1_000 { scene_layer_objects.saturating_sub(1_000) } else { 0 },
+            "omittedLabels": if atom_count > 10_000 { atom_count.saturating_sub(10_000) } else { 0 },
+            "omittedSourceRefs": 0,
+            "omittedReasons": [
+                "large graph projection may aggregate background geometry",
+                "top insight support and blocking reason objects are preserved before background objects",
+                "viewer data remains a projection and does not embed raw source content"
+            ]
         },
         "nonConclusions": [
             "Viewer data is a bounded projection of ArchMap v2 and measurement packet foundation rows.",
-            "Layout and site visualization are not AG invariant values or Lean proof objects."
+            "Layout and site visualization are not AG invariant values or Lean proof objects.",
+            "Holonomy-like views are restriction path or cover path exploration, not monodromy verdicts.",
+            "Theorem-candidate readings are not displayed as structural conclusions."
         ]
     })
+}
+
+fn top_insight_preserved_refs(insight_report: &Value) -> Vec<String> {
+    let mut refs = BTreeSet::new();
+    for value in string_array_at(insight_report, &["headline", "primaryVerdictRefs"]) {
+        refs.insert(value);
+    }
+    if let Some(card) = insight_report["insightCards"]
+        .as_array()
+        .and_then(|cards| cards.first())
+    {
+        for path in [
+            ["evidence", "structuralVerdictRefs"],
+            ["evidence", "computedInvariantRefs"],
+            ["evidence", "analyticReadingRefs"],
+            ["evidence", "atomRefs"],
+            ["evidence", "contextRefs"],
+            ["evidence", "sourceRefs"],
+            ["nextAction", "targetRefs"],
+        ] {
+            for value in string_array_at(card, &path) {
+                refs.insert(value);
+            }
+        }
+    }
+    refs.into_iter().take(32).collect()
+}
+
+fn top_insight_atom_refs(insight_report: &Value) -> BTreeSet<String> {
+    let mut refs = BTreeSet::new();
+    if let Some(card) = insight_report["insightCards"]
+        .as_array()
+        .and_then(|cards| cards.first())
+    {
+        for value in string_array_at(card, &["evidence", "atomRefs"]) {
+            refs.insert(value);
+        }
+        for value in string_array_at(card, &["viewerNavigation", "highlightRefs", "atomRefs"]) {
+            refs.insert(value);
+        }
+    }
+    refs
+}
+
+fn top_insight_context_refs(insight_report: &Value) -> BTreeSet<String> {
+    let mut refs = BTreeSet::new();
+    if let Some(card) = insight_report["insightCards"]
+        .as_array()
+        .and_then(|cards| cards.first())
+    {
+        for value in string_array_at(card, &["evidence", "contextRefs"]) {
+            refs.insert(value);
+        }
+        for value in string_array_at(card, &["viewerNavigation", "highlightRefs", "contextRefs"]) {
+            refs.insert(value);
+        }
+    }
+    refs
+}
+
+fn projected_atoms(
+    normalized: &NormalizedArchMapV2,
+    preserved_refs: &BTreeSet<String>,
+    limit: usize,
+) -> Vec<NormalizedAtomV2> {
+    let mut selected = Vec::new();
+    let mut seen = BTreeSet::new();
+    for atom in normalized.atoms.iter().filter(|atom| {
+        preserved_refs.contains(atom.normalized_atom_id.as_str())
+            || preserved_refs.contains(atom.source_atom_id.as_str())
+    }) {
+        if seen.insert(atom.normalized_atom_id.clone()) {
+            selected.push(sanitize_viewer_atom(atom.clone()));
+        }
+    }
+    for atom in &normalized.atoms {
+        if selected.len() >= limit {
+            break;
+        }
+        if seen.insert(atom.normalized_atom_id.clone()) {
+            selected.push(sanitize_viewer_atom(atom.clone()));
+        }
+    }
+    selected.truncate(limit);
+    selected
+}
+
+fn projected_contexts(
+    normalized: &NormalizedArchMapV2,
+    preserved_refs: &BTreeSet<String>,
+    limit: usize,
+) -> Vec<NormalizedContextV2> {
+    let mut selected = Vec::new();
+    let mut seen = BTreeSet::new();
+    for context in normalized.contexts.iter().filter(|context| {
+        preserved_refs.contains(context.normalized_context_id.as_str())
+            || preserved_refs.contains(context.source_context_id.as_str())
+    }) {
+        if seen.insert(context.normalized_context_id.clone()) {
+            selected.push(sanitize_viewer_context(context.clone()));
+        }
+    }
+    for context in &normalized.contexts {
+        if selected.len() >= limit {
+            break;
+        }
+        if seen.insert(context.normalized_context_id.clone()) {
+            selected.push(sanitize_viewer_context(context.clone()));
+        }
+    }
+    selected.truncate(limit);
+    selected
+}
+
+fn projected_covers(normalized: &NormalizedArchMapV2, limit: usize) -> Vec<NormalizedCoverV2> {
+    normalized
+        .covers
+        .iter()
+        .take(limit)
+        .cloned()
+        .map(sanitize_viewer_cover)
+        .collect()
+}
+
+fn viewer_atom_nodes(atoms: &[NormalizedAtomV2], insight_report: &Value) -> Vec<Value> {
+    let top_atoms = top_insight_atom_refs(insight_report);
+    atoms
+        .iter()
+        .map(|atom| {
+            let source_refs = atom
+                .source_refs
+                .iter()
+                .map(|source_ref| json!({ "ref": source_ref }))
+                .collect::<Vec<_>>();
+            json!({
+                "nodeId": atom.normalized_atom_id,
+                "sourceAtomId": atom.source_atom_id,
+                "atomKind": atom.atom_kind,
+                "atomFamily": atom.atom_kind,
+                "subjectRef": atom.subject,
+                "axis": atom.axis,
+                "predicate": atom.predicate,
+                "objectRef": atom.object,
+                "observationStatus": atom.normalization_status,
+                "normalizationStatus": atom.normalization_status,
+                "moleculeMemberships": atom.context_memberships,
+                "projectionRefs": atom.context_memberships,
+                "sourceRefSamples": source_refs,
+                "sourceRefCount": atom.source_refs.len(),
+                "objectRefCount": usize::from(atom.object.is_some()),
+                "priorityScore": if top_atoms.contains(atom.normalized_atom_id.as_str()) || top_atoms.contains(atom.source_atom_id.as_str()) { 100 } else { 10 },
+                "labels": [atom.axis.clone(), atom.predicate.clone()]
+            })
+        })
+        .collect()
+}
+
+fn viewer_molecule_groups(contexts: &[NormalizedContextV2]) -> Vec<Value> {
+    contexts
+        .iter()
+        .map(|context| {
+            json!({
+                "groupId": context.normalized_context_id,
+                "sourceMoleculeId": context.source_context_id,
+                "atomObservationRefs": context.atom_ids,
+                "atomIds": context.atom_ids,
+                "generatedMoleculeCandidateStatus": context.poset_status,
+                "requiredPortStatus": "not_applicable",
+                "compositionStatus": context.poset_status
+            })
+        })
+        .collect()
+}
+
+fn viewer_atom_edges(contexts: &[NormalizedContextV2]) -> Vec<Value> {
+    let mut edges = Vec::new();
+    for context in contexts {
+        for target in &context.restricts_to {
+            edges.push(json!({
+                "edgeId": format!("edge:{}->{}", context.normalized_context_id, target),
+                "sourceNodeRef": context.normalized_context_id,
+                "targetNodeRef": target,
+                "edgeKind": "contextRestriction"
+            }));
+        }
+        for pair in context.atom_ids.windows(2) {
+            if let [source, target] = pair {
+                edges.push(json!({
+                    "edgeId": format!("edge:{}:{}->{}", context.normalized_context_id, source, target),
+                    "sourceNodeRef": source,
+                    "targetNodeRef": target,
+                    "edgeKind": "contextMembership"
+                }));
+            }
+        }
+    }
+    edges
+}
+
+fn sanitize_viewer_atom(mut atom: NormalizedAtomV2) -> NormalizedAtomV2 {
+    atom.source_refs = atom
+        .source_refs
+        .iter()
+        .map(|source_ref| sanitize_source_ref(source_ref))
+        .collect();
+    atom
+}
+
+fn sanitize_viewer_context(mut context: NormalizedContextV2) -> NormalizedContextV2 {
+    context.source_refs = context
+        .source_refs
+        .iter()
+        .map(|source_ref| sanitize_source_ref(source_ref))
+        .collect();
+    context
+}
+
+fn sanitize_viewer_cover(mut cover: NormalizedCoverV2) -> NormalizedCoverV2 {
+    cover.source_refs = cover
+        .source_refs
+        .iter()
+        .map(|source_ref| sanitize_source_ref(source_ref))
+        .collect();
+    cover
 }
 
 fn validate_profile_refs(

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -11,9 +11,9 @@ mod typed_evaluator;
 mod validation;
 
 pub use ag_measurement::{
-    build_foundation_measurement_packet_v1, build_measurement_summary_v1,
-    build_measurement_viewer_data_v1, selected_measurement_profile_v1,
-    validate_measurement_packet_v1,
+    build_foundation_measurement_packet_v1, build_insight_brief_v1, build_insight_report_v1,
+    build_measurement_summary_v1, build_measurement_viewer_data_v1,
+    selected_measurement_profile_v1, validate_measurement_packet_v1,
 };
 pub use archmap::{
     ArchMapSourceInventoryInput, compare_archmap_v2_doctrine, validate_archmap_report,

--- a/tools/archsig/src/main.rs
+++ b/tools/archsig/src/main.rs
@@ -6,14 +6,15 @@ use std::process::ExitCode;
 use archsig::{
     ARCHMAP_V1_SCHEMA, ARCHMAP_V2_SCHEMA, ArchMapDocumentV1, ArchMapDocumentV2,
     LAW_POLICY_V1_SCHEMA, LawPolicyDocumentV1, SchemaVersionCatalogV0,
-    build_architecture_distance_v1, build_foundation_measurement_packet_v1,
-    build_measurement_summary_v1, build_measurement_viewer_data_v1, build_typed_analysis_packet_v1,
-    build_typed_analysis_summary_v1, build_typed_analysis_validation_v1,
-    build_typed_atom_viewer_data_v1, build_typed_detail_index_v1,
-    build_typed_llm_interpretation_packet_v1, enrich_architecture_distance_with_part4_bundle_v1,
-    evaluate_typed_v1, normalize_archmap_v1, normalize_archmap_v2,
-    static_law_evaluator_registry_v1, static_schema_version_catalog, validate_archmap_v1_report,
-    validate_archmap_v2_report, validate_law_policy_v1_report, validate_measurement_packet_v1,
+    build_architecture_distance_v1, build_foundation_measurement_packet_v1, build_insight_brief_v1,
+    build_insight_report_v1, build_measurement_summary_v1, build_measurement_viewer_data_v1,
+    build_typed_analysis_packet_v1, build_typed_analysis_summary_v1,
+    build_typed_analysis_validation_v1, build_typed_atom_viewer_data_v1,
+    build_typed_detail_index_v1, build_typed_llm_interpretation_packet_v1,
+    enrich_architecture_distance_with_part4_bundle_v1, evaluate_typed_v1, normalize_archmap_v1,
+    normalize_archmap_v2, static_law_evaluator_registry_v1, static_schema_version_catalog,
+    validate_archmap_v1_report, validate_archmap_v2_report, validate_law_policy_v1_report,
+    validate_measurement_packet_v1,
 };
 use clap::{Parser, Subcommand};
 use serde_json::Value;
@@ -723,6 +724,8 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             let typed_evaluator_results_path = out_dir.join("typed-evaluator-results.json");
             let architecture_distance_path = out_dir.join("architecture-distance.json");
             let measurement_packet_path = out_dir.join("archsig-measurement-packet.json");
+            let insight_report_path = out_dir.join("archsig-insight-report.json");
+            let insight_brief_path = out_dir.join("archsig-insight-brief.md");
             let analysis_packet_path = out_dir.join("archsig-analysis-packet.json");
             let analysis_validation_path = out_dir.join("archsig-analysis-validation.json");
             let llm_interpretation_path = out_dir.join("llm-interpretation-packet.json");
@@ -739,8 +742,48 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
             write_json(Some(archmap_validation_path), &archmap_preflight)?;
             write_json(Some(law_policy_validation_path), &law_policy_preflight)?;
             if archmap_failed || law_policy_failed {
+                let insight_report = build_validation_failure_insight_report(
+                    &archmap_preflight,
+                    &law_policy_preflight,
+                );
+                let insight_brief = build_insight_brief_v1(&insight_report);
+                let viewer_data = build_validation_failure_viewer_data(&insight_report);
+                write_json(Some(insight_report_path), &insight_report)?;
+                std::fs::write(insight_brief_path, insight_brief)?;
+                write_json(Some(atom_viewer_data_path), &viewer_data)?;
+                write_json(
+                    Some(run_manifest_path),
+                    &serde_json::json!({
+                        "schema": "archsig-run-manifest/v1",
+                        "command": "analyze",
+                        "status": "validation_failed",
+                        "generatedArtifacts": [
+                            "archmap-validation.json",
+                            "law-policy-validation.json",
+                            "archsig-insight-report.json",
+                            "archsig-insight-brief.md",
+                            "archsig-atom-viewer-data.json",
+                            "archsig-run-manifest.json"
+                        ],
+                        "artifactLinks": {
+                            "archmapValidation": "archmap-validation.json",
+                            "lawPolicyValidation": "law-policy-validation.json",
+                            "insightReport": "archsig-insight-report.json",
+                            "insightBrief": "archsig-insight-brief.md",
+                            "viewerData": "archsig-atom-viewer-data.json"
+                        },
+                        "validationResultSummary": {
+                            "archmap": { "result": summary_result(&archmap_preflight) },
+                            "lawPolicy": { "result": summary_result(&law_policy_preflight) }
+                        },
+                        "nonConclusions": [
+                            "Validation failure insight is a pre-normalization projection and does not contain measurement packet claims.",
+                            "No measurement packet, structural verdict, or AG invariant was computed after failed preflight validation."
+                        ]
+                    }),
+                )?;
                 eprintln!(
-                    "archsig analyze wrote validation artifacts to {} and stopped before normalization",
+                    "archsig analyze wrote validation insight artifacts to {} and stopped before normalization",
                     out_dir.display()
                 );
                 return Ok(ExitCode::from(1));
@@ -762,10 +805,17 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                 let packet_failed = packet_validation.iter().any(|check| check.result == "fail");
                 write_json(Some(measurement_packet_path), &measurement_packet)?;
                 let measurement_summary = build_measurement_summary_v1(&measurement_packet);
+                let insight_report = build_insight_report_v1(
+                    &normalized_archmap,
+                    &measurement_packet,
+                    &measurement_summary,
+                );
+                let insight_brief = build_insight_brief_v1(&insight_report);
                 let measurement_viewer_data = build_measurement_viewer_data_v1(
                     &normalized_archmap,
                     &measurement_packet,
                     &measurement_summary,
+                    &insight_report,
                 );
                 write_json(
                     Some(analysis_validation_path),
@@ -787,6 +837,11 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                     &measurement_viewer_data,
                 )?;
                 write_json(
+                    Some(insight_report_path),
+                    &insight_report,
+                )?;
+                std::fs::write(insight_brief_path, insight_brief)?;
+                write_json(
                     Some(run_manifest_path),
                     &serde_json::json!({
                         "schemaVersion": "archsig-run-manifest-v2",
@@ -801,9 +856,18 @@ fn run() -> Result<ExitCode, Box<dyn Error>> {
                             "archsig-measurement-packet.json",
                             "archsig-analysis-validation.json",
                             "archsig-analysis-summary.json",
+                            "archsig-insight-report.json",
+                            "archsig-insight-brief.md",
                             "archsig-atom-viewer-data.json",
                             "archsig-run-manifest.json"
                         ],
+                        "artifactLinks": {
+                            "measurementPacket": "archsig-measurement-packet.json",
+                            "summary": "archsig-analysis-summary.json",
+                            "insightReport": "archsig-insight-report.json",
+                            "insightBrief": "archsig-insight-brief.md",
+                            "viewerData": "archsig-atom-viewer-data.json"
+                        },
                         "validationResultSummary": {
                             "archmap": { "result": summary_result(&archmap_preflight) },
                             "lawPolicy": { "result": summary_result(&law_policy_preflight) },
@@ -995,6 +1059,8 @@ fn remove_analyze_success_artifacts(out_dir: &PathBuf) -> Result<(), Box<dyn Err
         "typed-evaluator-results.json",
         "architecture-distance.json",
         "archsig-measurement-packet.json",
+        "archsig-insight-report.json",
+        "archsig-insight-brief.md",
         "archsig-analysis-packet.json",
         "archsig-analysis-detail-index.json",
         "archsig-analysis-validation.json",
@@ -1008,4 +1074,292 @@ fn remove_analyze_success_artifacts(out_dir: &PathBuf) -> Result<(), Box<dyn Err
         }
     }
     Ok(())
+}
+
+fn build_validation_failure_insight_report(
+    archmap_validation: &Value,
+    law_policy_validation: &Value,
+) -> Value {
+    let failed_refs = validation_failure_refs(archmap_validation, law_policy_validation);
+    let primary_ref = failed_refs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "validation:unknown-failure".to_string());
+    serde_json::json!({
+        "schema": "archsig-insight-report/v1",
+        "reportId": "insight:validation-failure",
+        "sourcePacketRef": null,
+        "generatedAt": "deterministic-run-artifact",
+        "outputArtifacts": {
+            "summaryRef": null,
+            "briefRef": "archsig-insight-brief.md",
+            "viewerDataRef": "archsig-atom-viewer-data.json"
+        },
+        "headline": {
+            "conclusionCode": "VALIDATION_FAILED_BEFORE_MEASUREMENT",
+            "title": "Validation failed before measurement",
+            "summary": "ArchSig stopped before normalization because an input validation check failed.",
+            "decisionState": "blocked",
+            "primaryVerdictRefs": [],
+            "boundaryDigestRef": "boundary-digest:validation"
+        },
+        "readThisFirst": {
+            "heading": "Read this first",
+            "conclusion": "VALIDATION_FAILED_BEFORE_MEASUREMENT",
+            "whatItMeans": "No measurement packet or AG invariant was computed. Fix the failing ArchMap or LawPolicy validation first.",
+            "whereToLookFirst": failed_refs,
+            "nextAction": "Inspect failed validation checks",
+            "boundary": "Pre-normalization validation failed; no structural verdict is available.",
+            "details": {
+                "validationRefs": failed_refs,
+                "sourceRefs": [],
+                "atomRefs": [],
+                "contextRefs": []
+            }
+        },
+        "insightCards": [{
+            "id": "insight:validation-failure:001",
+            "kind": "validation_failure",
+            "severity": "blocking",
+            "title": "Validation failed before measurement",
+            "oneLine": "ArchSig stopped before normalization because input validation failed.",
+            "whyItMatters": "The viewer and brief can identify the blocker, but they must not present measurement conclusions that were never computed.",
+            "evidence": {
+                "structuralVerdictRefs": [],
+                "computedInvariantRefs": [],
+                "analyticReadingRefs": [],
+                "assumptionRefs": [],
+                "sourceRefs": [],
+                "atomRefs": [],
+                "contextRefs": [],
+                "coverRefs": [],
+                "evaluatorRefs": [],
+                "validationRefs": failed_refs,
+                "evidenceResolutionStatus": "validation_failure_before_measurement"
+            },
+            "sampleRefs": {
+                "atomRefs": [],
+                "contextRefs": [],
+                "sourceRefs": [],
+                "note": "No normalized ArchMap projection exists after validation failure."
+            },
+            "nextAction": {
+                "label": "Inspect failed validation checks",
+                "kind": "validation_blocker",
+                "targetRefs": [primary_ref]
+            },
+            "viewerNavigation": {
+                "sceneId": "boundary-assumption",
+                "highlightRefs": {
+                    "atomRefs": [],
+                    "contextRefs": [],
+                    "sourceRefs": [],
+                    "validationRefs": failed_refs
+                }
+            },
+            "tourRefs": ["tour:validation-failure:001"],
+            "rankingBasis": ["validation_failure"],
+            "nonClaims": [
+                "This is not a measured AG obstruction.",
+                "No measurement packet, structural verdict, or analytic reading was computed."
+            ]
+        }],
+        "actionQueue": [{
+            "id": "action:validation:1",
+            "kind": "validation_blocker",
+            "title": "Inspect failed validation checks",
+            "reason": "Input validation failed before ArchSig could normalize and measure.",
+            "targetRefs": failed_refs,
+            "expectedUserOutcome": "Fix the input contract before reading measurement claims.",
+            "nonClaims": ["No AG measurement conclusion exists for this run."]
+        }],
+        "boundaryDigest": {
+            "id": "boundary-digest:validation",
+            "shortText": "Validation failed before normalization; measurement is not computed.",
+            "checkedCount": 0,
+            "assumedCount": 0,
+            "violatedCount": 1,
+            "unmeasuredCount": 0,
+            "unknownCount": 0,
+            "notComputedCount": 1,
+            "blockingCount": 1,
+            "blocking": failed_refs,
+            "nonClaims": ["Validation failure does not imply measured nonzero or measured zero."]
+        },
+        "viewerVisualScenes": [validation_failure_scene(&failed_refs)],
+        "guidedTours": [{
+            "tourId": "tour:validation-failure:001",
+            "title": "Validation failed before measurement",
+            "insightRefs": ["insight:validation-failure:001"],
+            "steps": [{
+                "sceneId": "boundary-assumption",
+                "caption": "This boundary explains why no measurement packet was produced.",
+                "highlightRefs": {
+                    "validationRefs": failed_refs
+                }
+            }]
+        }],
+        "copyBlocks": {
+            "sourceRefs": [],
+            "llmHandoff": {
+                "instruction": "Use this as a validation blocker only. Do not infer measurement conclusions.",
+                "boundary": "Validation failed before normalization.",
+                "topInsights": ["ArchSig stopped before measurement because validation failed."]
+            }
+        },
+        "rankingBasis": ["validation_failure"],
+        "claimValidation": {
+            "measuredClaimsRequireStructuralVerdictRefs": true,
+            "analyticReadingsDoNotPromoteLawfulOrUnlawful": true,
+            "validationFailureDoesNotCreateMeasurementClaim": true
+        },
+        "nonConclusions": [
+            "Validation failure insight is a pre-normalization projection.",
+            "No measurement packet claims are generated."
+        ]
+    })
+}
+
+fn build_validation_failure_viewer_data(insight_report: &Value) -> Value {
+    serde_json::json!({
+        "schemaVersion": "archsig-atom-viewer-data-v2",
+        "sourceArtifactRefs": {
+            "archmapValidation": "archmap-validation.json",
+            "lawPolicyValidation": "law-policy-validation.json",
+            "insightReport": "archsig-insight-report.json",
+            "insightBrief": "archsig-insight-brief.md"
+        },
+        "decisionBar": {
+            "conclusion": "VALIDATION_FAILED_BEFORE_MEASUREMENT",
+            "validation": "see archmap-validation.json and law-policy-validation.json",
+            "boundaryDigest": insight_report["boundaryDigest"]["shortText"],
+            "artifactLinks": insight_report["outputArtifacts"]
+        },
+        "insightQueue": insight_report["insightCards"],
+        "actionQueue": insight_report["actionQueue"],
+        "viewerVisualScenes": insight_report["viewerVisualScenes"],
+        "guidedTours": insight_report["guidedTours"],
+        "copyBlocks": insight_report["copyBlocks"],
+        "reportPane": {
+            "readThisFirst": insight_report["readThisFirst"],
+            "insightQueue": insight_report["insightCards"],
+            "actionQueue": insight_report["actionQueue"],
+            "evidenceDetailShape": ["What", "Why", "Measurement", "Boundary", "Next"],
+            "boundaryDigest": insight_report["boundaryDigest"],
+            "artifactLinks": insight_report["outputArtifacts"]
+        },
+        "finitePosetSite": {
+            "atoms": [],
+            "contexts": [],
+            "covers": []
+        },
+        "largeGraphStrategy": {
+            "mode": "validation_blocked",
+            "thresholds": {
+                "fullGeometryAtoms": 2_000,
+                "instancedAtoms": 10_000,
+                "clusterAtoms": 50_000
+            },
+            "topInsightEvidencePinning": {
+                "policy": "preserve_for_top_insight",
+                "preservedRefs": insight_report["readThisFirst"]["whereToLookFirst"],
+                "aggregatedRefs": [],
+                "omittedRefs": []
+            }
+        },
+        "omittedDetailCounts": {
+            "omittedAtoms": 0,
+            "omittedEdges": 0,
+            "omittedContextMemberships": 0,
+            "omittedCoverOverlaps": 0,
+            "omittedSceneLayerObjects": 0,
+            "omittedLabels": 0,
+            "omittedSourceRefs": 0,
+            "omittedReasons": ["normalization did not run after validation failure"]
+        },
+        "nonConclusions": [
+            "Validation failure viewer data is a diagnostic projection, not a measurement scene."
+        ]
+    })
+}
+
+fn validation_failure_refs(
+    archmap_validation: &Value,
+    law_policy_validation: &Value,
+) -> Vec<String> {
+    let mut refs = Vec::new();
+    refs.extend(validation_report_failure_refs(
+        "archmap-validation",
+        archmap_validation,
+    ));
+    refs.extend(validation_report_failure_refs(
+        "law-policy-validation",
+        law_policy_validation,
+    ));
+    if refs.is_empty() {
+        refs.push("validation:failed".to_string());
+    }
+    refs
+}
+
+fn validation_report_failure_refs(prefix: &str, report: &Value) -> Vec<String> {
+    report["checks"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|check| check["result"].as_str() == Some("fail"))
+        .map(|check| {
+            format!(
+                "{}:{}",
+                prefix,
+                check["id"]
+                    .as_str()
+                    .or_else(|| check["checkId"].as_str())
+                    .unwrap_or("failed-check")
+            )
+        })
+        .collect()
+}
+
+fn validation_failure_scene(failed_refs: &[String]) -> Value {
+    serde_json::json!({
+        "sceneId": "boundary-assumption",
+        "kind": "validation_boundary",
+        "title": "Validation Boundary",
+        "sceneStatus": "active",
+        "userQuestion": "Why did ArchSig stop before measurement?",
+        "axisMapping": {
+            "x": "input contract",
+            "y": "validation result",
+            "z": "blocked measurement stage"
+        },
+        "primaryRefs": {
+            "insightRefs": ["insight:validation-failure:001"],
+            "validationRefs": failed_refs,
+            "atomRefs": [],
+            "contextRefs": [],
+            "coverRefs": [],
+            "sourceRefs": []
+        },
+        "layers": [{
+            "layerId": "layer:boundary-assumption:validation-wall",
+            "kind": "boundary_wall",
+            "geometryRole": "wall",
+            "encodingRef": "encoding:boundary-assumption:validation",
+            "clickTargetKind": "validationBlocker",
+            "refs": {
+                "validationRefs": failed_refs
+            },
+            "omissionPolicy": "preserve_for_top_insight",
+            "animationPurpose": "navigation"
+        }],
+        "visualEncodings": [{
+            "encodingId": "encoding:boundary-assumption:validation",
+            "colorRole": "not_computed",
+            "shapeRole": "wall_fog",
+            "lineRole": "broken_line",
+            "textRole": "validation blocker before measurement"
+        }],
+        "boundaryDigestRef": "boundary-digest:validation"
+    })
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use archsig::{ArchMapDocumentV2, compare_archmap_v2_doctrine};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 fn fixture_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal")
@@ -239,6 +239,549 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
     assert_eq!(
         summary["conclusion"],
         "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_emits_insight_report_brief_and_viewer_scene_contract() {
+    let out_dir = temp_dir("ag-measurement-insight-viewer");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2_cech_h1_visible.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    let manifest = read_json(&out_dir.join("archsig-run-manifest.json"));
+    let brief = fs::read_to_string(out_dir.join("archsig-insight-brief.md"))
+        .expect("insight brief is generated");
+
+    assert_eq!(report["schema"], "archsig-insight-report/v1");
+    assert_eq!(
+        report["headline"]["conclusionCode"],
+        "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    );
+    assert_eq!(report["insightCards"][0]["kind"], "global_glue_mismatch");
+    assert!(
+        report["insightCards"][0]["whyItMatters"]
+            .as_str()
+            .is_some_and(|text| text.contains("architecture drift")),
+        "Top insight must explain why it matters"
+    );
+    assert!(
+        report["insightCards"][0]["evidence"]["structuralVerdictRefs"]
+            .as_array()
+            .is_some_and(|refs| !refs.is_empty())
+            && report["insightCards"][0]["evidence"]["sourceRefs"]
+                .as_array()
+                .is_some_and(|refs| !refs.is_empty()),
+        "Top insight must carry verdict and where refs"
+    );
+    assert_eq!(
+        report["insightCards"][0]["evidence"]["evidenceResolutionStatus"],
+        "resolved_from_packet_support"
+    );
+    assert!(
+        report["insightCards"][0]["sampleRefs"]["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("orientation only")),
+        "sample refs must be separated from measured evidence refs"
+    );
+    assert!(
+        report["rankingBasis"]
+            .as_array()
+            .expect("ranking basis is array")
+            .iter()
+            .any(|entry| entry == "measured_nonzero structural verdict"),
+        "deterministic ranking basis must be recorded"
+    );
+    assert_eq!(
+        report["insightCards"][0]["tourRefs"][0], report["guidedTours"][0]["tourId"],
+        "Insight Card tourRefs and Tour insightRefs must be mutually linked"
+    );
+    assert!(
+        report["guidedTours"][0]["insightRefs"]
+            .as_array()
+            .expect("tour insightRefs are array")
+            .contains(&report["insightCards"][0]["id"])
+    );
+    let tour_ids = report["guidedTours"]
+        .as_array()
+        .expect("guided tours are array")
+        .iter()
+        .map(|tour| tour["tourId"].as_str().expect("tour id is present"))
+        .collect::<BTreeSet<_>>();
+    for card in report["insightCards"]
+        .as_array()
+        .expect("insight cards are array")
+    {
+        for tour_ref in card["tourRefs"].as_array().expect("tour refs are array") {
+            let tour_ref = tour_ref.as_str().expect("tour ref is string");
+            assert!(
+                tour_ids.contains(tour_ref),
+                "every insight card tourRef must resolve to a guided tour"
+            );
+            let tour = report["guidedTours"]
+                .as_array()
+                .expect("guided tours are array")
+                .iter()
+                .find(|tour| tour["tourId"] == tour_ref)
+                .expect("tour ref resolves");
+            assert!(
+                tour["insightRefs"]
+                    .as_array()
+                    .expect("tour insight refs are array")
+                    .contains(&card["id"]),
+                "guided tour must link back to its insight card"
+            );
+        }
+    }
+    for scene in report["viewerVisualScenes"]
+        .as_array()
+        .expect("viewer visual scenes are array")
+    {
+        assert!(
+            scene["userQuestion"]
+                .as_str()
+                .is_some_and(|text| !text.is_empty())
+        );
+        assert!(scene["axisMapping"]["x"].as_str().is_some());
+        assert!(
+            scene["layers"][0]["refs"].is_object()
+                && scene["layers"][0]["clickTargetKind"].as_str().is_some()
+                && scene["visualEncodings"][0]["shapeRole"].as_str().is_some()
+                && scene["visualEncodings"][0]["lineRole"].as_str().is_some()
+                && scene["visualEncodings"][0]["textRole"].as_str().is_some()
+        );
+        if scene["sceneStatus"] == "active" {
+            assert_eq!(
+                scene["layers"][0]["omissionPolicy"],
+                "preserve_for_top_insight"
+            );
+        } else {
+            assert_eq!(scene["layers"][0]["omissionPolicy"], "omittable_background");
+            assert_eq!(scene["visualEncodings"][0]["colorRole"], "not_applicable");
+        }
+    }
+    assert!(
+        report["viewerVisualScenes"]
+            .as_array()
+            .expect("scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "overview"
+                && scene["layers"][0]["kind"] == "top_insight_beacon"),
+        "overview scene must carry top insight beacons"
+    );
+    assert!(
+        report["viewerVisualScenes"]
+            .as_array()
+            .expect("scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "cech-gluing"
+                && scene["layers"][0]["kind"] == "overlap_seam"),
+        "gluing scene must expose overlap seams"
+    );
+    assert!(
+        report["viewerVisualScenes"]
+            .as_array()
+            .expect("scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "cech-h1-mismatch"
+                && scene["layers"][0]["geometryRole"] == "ribbon"),
+        "H1 scene must expose cocycle representative ribbon/seam"
+    );
+    assert_eq!(
+        viewer["decisionBar"]["conclusion"],
+        "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    );
+    assert!(
+        viewer["atomNodes"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+            && viewer["moleculeGroups"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty())
+            && viewer["atomEdges"].as_array().is_some(),
+        "AG viewer data must project finitePosetSite into renderer-compatible atomNodes, moleculeGroups, and atomEdges"
+    );
+    assert!(
+        viewer["reportPane"]["evidenceDetailShape"]
+            .as_array()
+            .expect("detail shape is array")
+            .iter()
+            .any(|section| section == "Boundary")
+            && viewer["copyBlocks"]["sourceRefs"]
+                .as_array()
+                .is_some_and(|refs| !refs.is_empty()),
+        "viewer must expose Evidence Detail shape and copyable source refs"
+    );
+    assert!(
+        viewer["actionQueue"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+            && viewer["reportPane"]["actionQueue"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty()),
+        "viewer must expose suggested next inspections at top-level and in the report pane"
+    );
+    assert!(
+        viewer["largeGraphStrategy"]["topInsightEvidencePinning"]["preservedRefs"]
+            .as_array()
+            .is_some_and(|refs| !refs.is_empty()),
+        "large graph strategy must pin concrete top-insight evidence refs"
+    );
+    assert_eq!(
+        viewer["omittedDetailCounts"]["omittedSceneLayerObjects"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(summary["readThisFirst"]["heading"], "Read this first");
+    assert_eq!(
+        manifest["artifactLinks"]["insightBrief"],
+        "archsig-insight-brief.md"
+    );
+    assert!(
+        manifest["generatedArtifacts"]
+            .as_array()
+            .expect("generated artifacts are array")
+            .iter()
+            .any(|artifact| artifact == "archsig-insight-report.json")
+    );
+    assert!(brief.starts_with("# ArchSig Insight Brief\n\n## Read this first"));
+    assert!(brief.contains("## LLM handoff"));
+}
+
+#[test]
+fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundaries() {
+    let out_dir = temp_dir("ag-measurement-insight-boundaries");
+    let root = ag_measurement_root();
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join("archmap_v2.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    let brief = fs::read_to_string(out_dir.join("archsig-insight-brief.md"))
+        .expect("insight brief is generated");
+    assert!(
+        report["insightCards"]
+            .as_array()
+            .expect("insight cards are array")
+            .iter()
+            .any(|card| card["kind"] == "no_measured_glue_mismatch"),
+        "measured_zero must be represented as a profile-relative zero insight"
+    );
+    assert!(
+        viewer["viewerVisualScenes"]
+            .as_array()
+            .expect("viewer visual scenes are array")
+            .iter()
+            .filter(|scene| {
+                scene["sceneId"] == "cech-gluing"
+                    || scene["sceneId"] == "cech-h1-mismatch"
+                    || scene["sceneId"] == "obstruction"
+            })
+            .all(|scene| scene["visualEncodings"][0]["colorRole"] != "measured_nonzero"),
+        "zero or inactive scenes must not use measured_nonzero coloring"
+    );
+    assert!(
+        viewer["viewerVisualScenes"]
+            .as_array()
+            .expect("viewer visual scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "overview"
+                && scene["visualEncodings"][0]["colorRole"] == "measured_zero"),
+        "zero top insight must render overview as measured_zero, not a nonzero beacon"
+    );
+    assert!(
+        viewer["viewerVisualScenes"]
+            .as_array()
+            .expect("viewer visual scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "cech-gluing"
+                && scene["sceneStatus"] == "active"
+                && scene["visualEncodings"][0]["colorRole"] == "measured_zero"),
+        "measured_zero Cech scene must stay active and explicitly measured_zero"
+    );
+    for forbidden in [
+        "Architecture is clean",
+        "No architecture issue exists",
+        "Codebase is lawful",
+    ] {
+        assert!(
+            !brief.contains(forbidden),
+            "false clean claim must not appear in brief: {forbidden}"
+        );
+    }
+
+    let no_ambient_out_dir = temp_dir("ag-measurement-insight-no-common-ambient");
+    let mut archmap = read_json(&root.join("archmap_v2_law_conflict_tor.json"));
+    archmap["atoms"] = Value::Array(
+        archmap["atoms"]
+            .as_array()
+            .expect("atoms is array")
+            .iter()
+            .filter(|atom| atom["predicate"] != "commonAmbient")
+            .cloned()
+            .collect(),
+    );
+    archmap["contexts"][0]["atoms"] = Value::Array(
+        archmap["contexts"][0]["atoms"]
+            .as_array()
+            .expect("context atoms is array")
+            .iter()
+            .filter(|atom| atom.as_str() != Some("atom:tor-common-ambient"))
+            .cloned()
+            .collect(),
+    );
+    let archmap_path = no_ambient_out_dir.join("archmap_v2_law_conflict_tor_no_ambient.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_tor.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        no_ambient_out_dir.to_str().expect("path is utf-8"),
+    ]);
+    let report = read_json(&no_ambient_out_dir.join("archsig-insight-report.json"));
+    let viewer = read_json(&no_ambient_out_dir.join("archsig-atom-viewer-data.json"));
+    assert!(
+        report["insightCards"]
+            .as_array()
+            .expect("insight cards are array")
+            .iter()
+            .any(|card| card["kind"] == "not_computed_blocker"
+                && card["rankingBasis"]
+                    .as_array()
+                    .expect("ranking basis is array")
+                    .iter()
+                    .any(|basis| basis == "no_common_ambient")),
+        "not_computed reason code must be promoted to a blocker insight"
+    );
+    assert!(
+        viewer["viewerVisualScenes"]
+            .as_array()
+            .expect("scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "law-conflict-tor"
+                && scene["visualEncodings"][0]["textRole"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("no_common_ambient"))),
+        "LawConflict scene must show blocking reason instead of an empty conflict view"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_insight_viewer_truncates_large_background_projection() {
+    let out_dir = temp_dir("ag-measurement-insight-large-viewer");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_cech_h1_visible.json"));
+    let template_atom = archmap["atoms"]
+        .as_array()
+        .and_then(|atoms| atoms.first())
+        .cloned()
+        .expect("fixture has an atom template");
+    let original_atoms = archmap["atoms"]
+        .as_array()
+        .cloned()
+        .expect("fixture atoms are array");
+    let mut atoms = Vec::new();
+    for index in 0..10_050 {
+        let mut atom = template_atom.clone();
+        atom["id"] = Value::String(format!("atom:background:{index}"));
+        atom["predicate"] = Value::String("backgroundSample".to_string());
+        atoms.push(atom);
+    }
+    atoms.extend(original_atoms);
+    archmap["atoms"] = Value::Array(atoms);
+    let archmap_path = out_dir.join("archmap_v2_large_background.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("large archmap serializes"),
+    )
+    .expect("large archmap can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    assert!(
+        viewer["finitePosetSite"]["atoms"]
+            .as_array()
+            .is_some_and(|atoms| atoms.len() <= 10_000),
+        "viewer payload must truncate background atom projection"
+    );
+    assert_eq!(
+        viewer["largeGraphStrategy"]["mode"], "cluster_aggregation",
+        "large graph strategy must switch when the source ArchMap crosses the atom threshold"
+    );
+    assert!(
+        viewer["omittedDetailCounts"]["omittedAtoms"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "viewer payload must report omitted background atoms"
+    );
+    assert!(
+        viewer["largeGraphStrategy"]["topInsightEvidencePinning"]["preservedRefs"]
+            .as_array()
+            .is_some_and(|refs| !refs.is_empty()),
+        "top insight evidence must remain pinned while background atoms are truncated"
+    );
+    assert!(
+        viewer["finitePosetSite"]["atoms"]
+            .as_array()
+            .expect("viewer atoms are array")
+            .iter()
+            .any(
+                |atom| atom["normalizedAtomId"] == "atom:left-bottom-cech-mismatch"
+                    || atom["sourceAtomId"] == "atom:left-bottom-cech-mismatch"
+            ),
+        "top insight support atom must remain in the truncated viewer projection even when it appears after background atoms"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_insight_artifacts_redact_local_source_refs() {
+    let out_dir = temp_dir("ag-measurement-insight-source-redaction");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_cech_h1_visible.json"));
+    let private_ref = "/Users/nakahata/private/internal.rs";
+    archmap["sources"][private_ref] = json!({
+        "kind": "rust",
+        "path": private_ref,
+        "symbol": "InternalOnly",
+        "line": 1
+    });
+    let atoms = archmap["atoms"].as_array_mut().expect("atoms are array");
+    let mismatch = atoms
+        .iter_mut()
+        .find(|atom| atom["id"] == "atom:left-bottom-cech-mismatch")
+        .expect("mismatch atom exists");
+    mismatch["refs"]
+        .as_array_mut()
+        .expect("refs are array")
+        .push(Value::String(private_ref.to_string()));
+    let archmap_path = out_dir.join("archmap_v2_private_source_ref.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let report = fs::read_to_string(out_dir.join("archsig-insight-report.json"))
+        .expect("insight report is generated");
+    let brief = fs::read_to_string(out_dir.join("archsig-insight-brief.md"))
+        .expect("insight brief is generated");
+    let viewer = fs::read_to_string(out_dir.join("archsig-atom-viewer-data.json"))
+        .expect("viewer data is generated");
+    for artifact in [&report, &brief, &viewer] {
+        assert!(
+            !artifact.contains(private_ref),
+            "insight artifacts must not leak local source refs"
+        );
+        assert!(
+            artifact.contains("source-ref:redacted-local-path"),
+            "insight artifacts must preserve a redacted source-ref marker"
+        );
+    }
+}
+
+#[test]
+fn cli_analyze_v2_validation_failure_emits_blocking_insight_projection() {
+    let out_dir = temp_dir("ag-measurement-insight-validation-failure");
+    let root = archmap_v1_root();
+
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        root.join("replacement_negative/archmap_label_only_semantic.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    assert!(!output.status.success());
+    assert!(
+        !out_dir.join("archsig-analysis-summary.json").exists(),
+        "validation failure must not emit a success summary"
+    );
+    assert!(
+        !out_dir.join("archsig-measurement-packet.json").exists(),
+        "validation failure must not emit a measurement packet"
+    );
+    let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    let manifest = read_json(&out_dir.join("archsig-run-manifest.json"));
+    let brief = fs::read_to_string(out_dir.join("archsig-insight-brief.md"))
+        .expect("validation brief is generated");
+    assert_eq!(report["insightCards"][0]["kind"], "validation_failure");
+    assert_eq!(
+        viewer["decisionBar"]["conclusion"],
+        "VALIDATION_FAILED_BEFORE_MEASUREMENT"
+    );
+    assert_eq!(viewer["largeGraphStrategy"]["mode"], "validation_blocked");
+    assert_eq!(manifest["status"], "validation_failed");
+    assert!(
+        brief.contains("Validation failed before measurement")
+            && brief.contains("Do not infer beyond the listed claims and boundaries."),
+        "validation brief must be usable without measurement claims"
     );
 }
 
@@ -5091,6 +5634,8 @@ fn cli_analyze_v1_validation_failure_removes_stale_success_artifacts() {
         "normalized-archmap.json",
         "typed-evaluator-results.json",
         "architecture-distance.json",
+        "archsig-insight-report.json",
+        "archsig-insight-brief.md",
         "archsig-analysis-packet.json",
         "archsig-analysis-detail-index.json",
         "archsig-analysis-validation.json",
@@ -5121,8 +5666,6 @@ fn cli_analyze_v1_validation_failure_removes_stale_success_artifacts() {
     );
     for stale_artifact in [
         "archsig-analysis-summary.json",
-        "archsig-atom-viewer-data.json",
-        "archsig-run-manifest.json",
         "normalized-archmap.json",
         "typed-evaluator-results.json",
         "architecture-distance.json",
@@ -5136,6 +5679,15 @@ fn cli_analyze_v1_validation_failure_removes_stale_success_artifacts() {
             "v1 validation failure must remove stale success artifact {stale_artifact}"
         );
     }
+    assert_eq!(
+        read_json(&out_dir.join("archsig-insight-report.json"))["insightCards"][0]["kind"],
+        "validation_failure",
+        "validation failure should replace stale insight report with a validation blocker projection"
+    );
+    assert_eq!(
+        read_json(&out_dir.join("archsig-run-manifest.json"))["status"],
+        "validation_failed"
+    );
 }
 
 #[test]
@@ -7531,6 +8083,44 @@ fn atom_viewer_uses_atom_shape_distance_inputs_for_molecule_layout() {
 }
 
 #[test]
+fn atom_viewer_reads_insight_report_surface_contract() {
+    let viewer_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("viewer/archsig-atom-viewer.html");
+    let viewer = fs::read_to_string(&viewer_path).expect("viewer html can be read");
+
+    for required in [
+        "Insight Queue",
+        "Suggested Next Inspections",
+        "Decision Bar",
+        "Read this first",
+        "copy source refs",
+        "Start tour",
+        "viewerVisualScenes",
+        "axisMapping",
+        "sceneForMode",
+        "modeForScene",
+        "sceneNodeColor",
+        "renderSceneLayers",
+        "sceneLayerMesh",
+        "sceneColorHex",
+        "handleReportAction",
+        "startGuidedTour",
+        "showTourStep",
+        "data-tour-id",
+        "data-tour-next",
+        "navigator.clipboard.writeText",
+        "data-scene-id",
+        "data-copy-source-refs",
+        "Boolean(data?.decisionBar)",
+        "evidenceDetailShape",
+    ] {
+        assert!(
+            viewer.contains(required),
+            "atom viewer must read the insight report surface contract: missing {required}"
+        );
+    }
+}
+
+#[test]
 #[ignore = "legacy large v0 ArchMap viewer projection is no longer current runtime surface"]
 fn cli_analyze_bounds_atom_viewer_data_for_large_repo_projection() {
     let out_dir = temp_dir("analyze-large-viewer-data");
@@ -9578,9 +10168,9 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
     );
     for section in [
         "Overview",
-        "Top Findings",
+        "Insight Queue",
         "Distance Diagnosis",
-        "Action Queue",
+        "Suggested Next Inspections",
         "Coverage And Boundaries",
         "Artifacts",
         "Validation Status",

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -877,7 +877,7 @@
           <div id="overview" class="list"></div>
         </div>
         <div class="section">
-          <h2>Top Findings</h2>
+          <h2>Insight Queue</h2>
           <div id="findings" class="list"></div>
         </div>
         <div class="section">
@@ -885,7 +885,7 @@
           <div id="distance-diagnosis" class="list"></div>
         </div>
         <div class="section">
-          <h2>Action Queue</h2>
+          <h2>Suggested Next Inspections</h2>
           <div id="actions" class="list"></div>
         </div>
       </div>
@@ -965,6 +965,7 @@
     let atomInstanceMesh = null;
     let selectedAtomKey = null;
     let activeLayoutContext = null;
+    let activeTourState = null;
 
     const colorByStatus = {
       observed: 0x4cc3a7,
@@ -1068,7 +1069,10 @@
     }
 
     function hasViewerContent(data) {
-      return Array.isArray(data?.atomNodes) && data.atomNodes.length > 0;
+      return (Array.isArray(data?.atomNodes) && data.atomNodes.length > 0)
+        || Boolean(data?.decisionBar)
+        || (Array.isArray(data?.insightQueue) && data.insightQueue.length > 0)
+        || (Array.isArray(data?.viewerVisualScenes) && data.viewerVisualScenes.length > 0);
     }
 
     function renderScene() {
@@ -1094,6 +1098,7 @@
       renderMoleculeGroups(renderedGroups, positions, activeLayoutContext);
       renderViewerDistanceBonds(positions, activeLayoutContext);
       renderedEdgeCount = renderEdges(edges, positions);
+      renderSceneLayers(sceneForMode(viewModeEl.value), positions);
       renderLegend();
       renderAxisHud();
       updateVisibility();
@@ -1224,6 +1229,83 @@
       const material = new THREE.LineBasicMaterial({ color: 0x5f6f86, transparent: true, opacity: points.length > 9000 ? 0.22 : 0.42 });
       edgeGroup.add(new THREE.LineSegments(geometry, material));
       return points.length / 6;
+    }
+
+    function renderSceneLayers(scene, positions) {
+      if (!scene || !Array.isArray(scene.layers) || scene.sceneStatus === "not_active_for_packet") return;
+      const encoding = Array.isArray(scene.visualEncodings) ? scene.visualEncodings[0] || {} : {};
+      const refs = scene.primaryRefs || {};
+      const atomRefs = Array.isArray(refs.atomRefs) ? refs.atomRefs : [];
+      const contextRefs = Array.isArray(refs.contextRefs) ? refs.contextRefs : [];
+      const points = [...atomRefs, ...contextRefs].map((ref) => positions.get(ref)).filter(Boolean);
+      const center = points.length ? centroid(points) : new THREE.Vector3(0, 0, 0);
+      scene.layers.forEach((layer, index) => {
+        const mesh = sceneLayerMesh(layer, encoding, center, index, points.length);
+        if (!mesh) return;
+        mesh.userData = { kind: "sceneLayer", scene, layer };
+        edgeGroup.add(mesh);
+      });
+      if (points.length > 1) {
+        const geometry = new THREE.BufferGeometry();
+        const vertices = [];
+        points.forEach((point) => vertices.push(center.x, center.y, center.z, point.x, point.y, point.z));
+        geometry.setAttribute("position", new THREE.Float32BufferAttribute(vertices, 3));
+        const material = new THREE.LineBasicMaterial({
+          color: sceneColorHex(encoding.colorRole),
+          transparent: true,
+          opacity: 0.68
+        });
+        const lines = new THREE.LineSegments(geometry, material);
+        lines.userData = { kind: "sceneLayerRefs", scene };
+        edgeGroup.add(lines);
+      }
+    }
+
+    function sceneLayerMesh(layer, encoding, center, index, supportCount) {
+      const role = layer.geometryRole || encoding.shapeRole || "beacon";
+      const color = sceneColorHex(encoding.colorRole);
+      const size = 4 + Math.min(supportCount, 16) * 0.35 + index;
+      let geometry;
+      if (role.includes("ribbon") || role.includes("seam")) {
+        geometry = new THREE.TorusGeometry(size * 1.7, 0.32, 8, 48);
+      } else if (role.includes("cage") || role.includes("wall")) {
+        geometry = new THREE.BoxGeometry(size * 2.4, size * 1.2, size * 0.28);
+      } else if (role.includes("cut")) {
+        geometry = new THREE.ConeGeometry(size, size * 2.4, 4);
+      } else if (role.includes("patch")) {
+        geometry = new THREE.CircleGeometry(size * 2.1, 32);
+      } else {
+        geometry = new THREE.SphereGeometry(size, 16, 10);
+      }
+      const material = new THREE.MeshStandardMaterial({
+        color,
+        transparent: true,
+        opacity: role.includes("patch") ? 0.28 : 0.46,
+        roughness: 0.44,
+        metalness: 0.02,
+        wireframe: role.includes("cage") || role.includes("wall")
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.copy(center);
+      mesh.position.y += 14 + index * 3;
+      mesh.rotation.x = role.includes("patch") ? -Math.PI / 2 : Math.PI / 7;
+      mesh.rotation.z = (hashText(layer.layerId || role) % 628) / 100;
+      return mesh;
+    }
+
+    function sceneColorHex(role) {
+      const colors = {
+        measured_nonzero: 0xf2c15f,
+        measured_zero: 0x64d6be,
+        not_computed: 0xff6b6b,
+        analytic_reading: 0x73b7ff,
+        repair_candidate: 0xb087ff,
+        source_evidence: 0x8bd46e,
+        unknown: 0x9fb3c8,
+        checked: 0x64d6be,
+        not_applicable: 0x5f6f86
+      };
+      return colors[role] || 0xf2c15f;
     }
 
     function buildLayoutContext(nodes, groups, data) {
@@ -1842,7 +1924,28 @@
     }
 
     function nodeColor(node) {
+      const sceneColor = sceneNodeColor(node);
+      if (sceneColor) return sceneColor;
       return colorByFamily[node.atomFamily] || colorByStatus[node.observationStatus] || 0xb087ff;
+    }
+
+    function sceneNodeColor(node) {
+      const scene = sceneForMode(viewModeEl.value);
+      if (!scene || scene.sceneStatus === "not_active_for_packet") return null;
+      const refs = scene.primaryRefs || {};
+      const atomRefs = new Set(Array.isArray(refs.atomRefs) ? refs.atomRefs.map(String) : []);
+      if (!atomRefs.has(String(node.nodeId))) return null;
+      const role = scene.visualEncodings?.[0]?.colorRole || "";
+      const colors = {
+        measured_nonzero: 0xf2c15f,
+        measured_zero: 0x64d6be,
+        not_computed: 0xff6b6b,
+        analytic_reading: 0x73b7ff,
+        repair_candidate: 0xb087ff,
+        unknown: 0x9fb3c8,
+        checked: 0x64d6be
+      };
+      return colors[role] || 0xf2c15f;
     }
 
     function currentAatContext() {
@@ -1995,6 +2098,15 @@
     }
 
     function axisHudText(mode) {
+      const scene = sceneForMode(mode);
+      if (scene && scene.axisMapping) {
+        return {
+          title: scene.title || scene.sceneId || "Insight scene",
+          x: scene.axisMapping.x || "scene x axis",
+          y: scene.axisMapping.y || "scene y axis",
+          z: scene.axisMapping.z || "scene z axis"
+        };
+      }
       const layouts = {
         families: {
           title: "Family spiral",
@@ -2078,6 +2190,41 @@
       return layouts[mode] || layouts.families;
     }
 
+    function sceneForMode(mode) {
+      const scenes = Array.isArray(currentData?.viewerVisualScenes) ? currentData.viewerVisualScenes : [];
+      const mapping = {
+        families: "overview",
+        aatAxes: "site-cover",
+        holonomy: "cech-gluing",
+        obstructionLoops: "cech-h1-mismatch",
+        obstructions: "obstruction",
+        projection: "repair-dual",
+        risk: "boundary-assumption",
+        sources: "source-evidence",
+        curvature: "hodge-debt-field",
+        flatness: "hodge-debt-field",
+        spectrum: "hodge-debt-field"
+      };
+      const sceneId = mapping[mode] || mode;
+      return scenes.find((scene) => scene.sceneId === sceneId || scene.kind === sceneId);
+    }
+
+    function modeForScene(sceneId) {
+      const mapping = {
+        overview: "families",
+        "site-cover": "aatAxes",
+        "cech-gluing": "holonomy",
+        "cech-h1-mismatch": "obstructionLoops",
+        obstruction: "obstructions",
+        "repair-dual": "projection",
+        "law-conflict-tor": "risk",
+        "hodge-debt-field": "curvature",
+        "boundary-assumption": "risk",
+        "source-evidence": "sources"
+      };
+      return mapping[sceneId] || "families";
+    }
+
     function hashText(text) {
       text = String(text);
       let hash = 0;
@@ -2105,6 +2252,8 @@
     searchEl.addEventListener("input", debounce(renderScene, 90));
     resetEl.addEventListener("click", resetCamera);
     reportToggleEl.addEventListener("click", toggleReport);
+    reportEl.addEventListener("click", handleReportAction);
+    detailEl.addEventListener("click", handleTourStepAction);
     renderer.domElement.addEventListener("pointerdown", selectVisual);
 
     fileEl.addEventListener("change", async (event) => {
@@ -2176,6 +2325,8 @@
       const detailRefs = Array.isArray(item.detailRefs) ? item.detailRefs : Array.isArray(item.packetRefs) ? item.packetRefs : [];
       const labels = Array.isArray(item.labels) ? item.labels : [];
       const rows = [
+        item.what && `What: ${item.what}`,
+        item.whyItMatters && `Why: ${item.whyItMatters}`,
         item.nodeId || item.groupId || item.ref || item.axisRef || item.lawRef,
         item.atomFamily && `family: ${item.atomFamily}`,
         item.observationStatus && `status: ${item.observationStatus}`,
@@ -2185,12 +2336,82 @@
         item.conclusion && `conclusion: ${item.conclusion}`,
         item.recommendedAction && `next: ${item.recommendedAction}`,
         item.recommendedNextAction && `next: ${item.recommendedNextAction}`,
+        item.nextAction?.label && `Next: ${item.nextAction.label}`,
+        item.evidence && `Measurement: ${compactJson(item.evidence)}`,
+        item.boundaryDigest && `Boundary: ${compactJson(item.boundaryDigest)}`,
+        Array.isArray(item.nonClaims) && item.nonClaims.length && `Boundary: ${item.nonClaims.join("; ")}`,
         labels.length && `labels: ${labels.join(", ")}`,
         sourceRefs.length && `source refs: ${sourceRefs.map(sourceRefLabel).join(", ")}`,
         detailRefs.length && `detail refs: ${detailRefs.join(", ")}`
       ].filter(Boolean);
       detailEl.innerHTML = `<h2>${escapeHtml(kind)}</h2>${rows.map((row) => `<p>${escapeHtml(String(row))}</p>`).join("")}`;
       detailEl.hidden = false;
+    }
+
+    async function handleReportAction(event) {
+      const button = event.target.closest("[data-tour-id], [data-scene-id], [data-copy-source-refs]");
+      if (!button) return;
+      if (button.dataset.tourId) {
+        startGuidedTour(button.dataset.tourId);
+      }
+      if (button.dataset.sceneId) {
+        viewModeEl.value = modeForScene(button.dataset.sceneId);
+        renderScene();
+        status(`Scene: ${button.dataset.sceneId}`);
+      }
+      if (button.dataset.copySourceRefs) {
+        await copyText(button.dataset.copySourceRefs);
+      }
+    }
+
+    function startGuidedTour(tourId) {
+      const tours = Array.isArray(currentData?.guidedTours) ? currentData.guidedTours : [];
+      const tour = tours.find((item) => item.tourId === tourId);
+      if (!tour || !Array.isArray(tour.steps) || !tour.steps.length) {
+        status(`Tour not found: ${tourId}`);
+        return;
+      }
+      activeTourState = { tour, stepIndex: 0 };
+      showTourStep();
+    }
+
+    function showTourStep() {
+      if (!activeTourState) return;
+      const { tour, stepIndex } = activeTourState;
+      const step = tour.steps[stepIndex];
+      viewModeEl.value = modeForScene(step.sceneId);
+      renderScene();
+      const nextButton = stepIndex + 1 < tour.steps.length
+        ? `<button type="button" data-tour-next="true">Next</button>`
+        : `<button type="button" data-tour-end="true">Done</button>`;
+      detailEl.innerHTML = `<h2>${escapeHtml(tour.title || tour.tourId)}</h2><p>${escapeHtml(step.caption || step.sceneId)}</p><p>${escapeHtml(compactJson(step.highlightRefs || {}))}</p><div class="chips">${nextButton}</div>`;
+      detailEl.hidden = false;
+      status(`Tour ${stepIndex + 1}/${tour.steps.length}: ${step.sceneId}`);
+    }
+
+    function handleTourStepAction(event) {
+      const next = event.target.closest("[data-tour-next]");
+      const end = event.target.closest("[data-tour-end]");
+      if (next && activeTourState) {
+        activeTourState.stepIndex += 1;
+        showTourStep();
+      }
+      if (end) {
+        activeTourState = null;
+        detailEl.hidden = true;
+        status("Tour complete");
+      }
+    }
+
+    async function copyText(text) {
+      try {
+        await navigator.clipboard.writeText(text);
+        status("Copied source refs");
+      } catch (_error) {
+        detailEl.innerHTML = `<h2>Copy source refs</h2><p>${escapeHtml(text)}</p>`;
+        detailEl.hidden = false;
+        status("Source refs shown in detail panel");
+      }
     }
 
     function sourceRefLabel(ref) {
@@ -2205,21 +2426,25 @@
       const overview = report.overview || {};
       const verdict = overview.summaryVerdict || summary.verdict || {};
       const validation = overview.validation || summary.validation || manifest.validationResultSummary || {};
+      const decisionBar = data.decisionBar || report.decisionBar || {};
+      const evidenceDetailShape = report.evidenceDetailShape || [];
+      const insightQueue = report.insightQueue || data.insightQueue || summary.insightCards || report.topFindings || summary.dominantFindings || data.analysisOverlays?.dominantFindings;
+      const actionQueue = report.actionQueue || data.actionQueue || summary.actionQueue || data.analysisOverlays?.actionQueue;
 
       document.getElementById("report-title").textContent =
-        overview.architectureId || overview.mapId || "ArchSig Atom Viewer";
+        decisionBar.conclusion || overview.architectureId || overview.mapId || "ArchSig Atom Viewer";
       document.getElementById("metric-atoms").textContent = count(data.atomNodes);
       document.getElementById("metric-groups").textContent = count(data.moleculeGroups);
       document.getElementById("metric-edges").textContent = count(data.atomEdges);
       document.getElementById("metric-verdict").innerHTML = verdictBadge(verdict);
       document.getElementById("metric-validation").innerHTML = validationBadge(validation);
 
-      renderOverview(overview, verdict, summary, data.nonConclusions || []);
-      renderItems("findings", report.topFindings || summary.dominantFindings || data.analysisOverlays?.dominantFindings, "finding");
+      renderOverview(overview, verdict, summary, data.nonConclusions || [], decisionBar, report.readThisFirst || summary.readThisFirst);
+      renderItems("findings", insightQueue, "insight");
       renderDistanceDiagnosis(report.distanceDiagnosis || summary.distanceDiagnosis || data.aatGeometryOverlays?.diagnosticDistanceReadings);
-      renderItems("actions", report.actionQueue || summary.actionQueue || data.analysisOverlays?.actionQueue, "action");
-      renderCoverage(report.coverageAndBoundaries || {}, verdict, summary);
-      renderArtifacts(report.artifacts || {}, data.sourceArtifactRefs || {}, manifest);
+      renderItems("actions", actionQueue, "action");
+      renderCoverage(report.coverageAndBoundaries || report.boundaryDigest || {}, verdict, summary);
+      renderArtifacts(report.artifacts || report.artifactLinks || decisionBar.artifactLinks || {}, data.sourceArtifactRefs || {}, manifest);
       renderValidationStatus(validation);
       renderOmitted(data.omittedDetailCounts || {}, data.truncationPolicy || {});
     }
@@ -2246,9 +2471,13 @@
       return `<span class="${klass}">${escapeHtml(String(value))}</span>`;
     }
 
-    function renderOverview(overview, verdict, summary, nonConclusions) {
+    function renderOverview(overview, verdict, summary, nonConclusions, decisionBar = {}, readThisFirst = {}) {
       const root = document.getElementById("overview");
       const rows = [
+        decisionBar.conclusion && ["Decision Bar", decisionBar.conclusion],
+        decisionBar.boundaryDigest && ["boundary digest", decisionBar.boundaryDigest],
+        readThisFirst.whatItMeans && ["Read this first", readThisFirst.whatItMeans],
+        readThisFirst.nextAction && ["next action", readThisFirst.nextAction],
         overview.mapId && ["archmap", overview.mapId],
         overview.analysisId && ["analysis", overview.analysisId],
         verdict.readingMode && ["reading mode", verdict.readingMode],
@@ -2348,14 +2577,24 @@
     function itemHtml(item, fallbackLabel, index) {
       if (item && typeof item === "object") {
         const title = item.title || item.kind || item.conclusion || item.id || `${fallbackLabel} ${index + 1}`;
-        const text = item.summary || item.description || item.reading || item.reason || item.recommendedAction || item.recommendedNextAction || JSON.stringify(item).slice(0, 240);
+        const text = item.oneLine || item.whyItMatters || item.summary || item.description || item.reading || item.reason || item.recommendedAction || item.recommendedNextAction || JSON.stringify(item).slice(0, 240);
+        const sceneId = item.viewerNavigation?.sceneId || item.sceneId;
+        const sourceRefs = item.evidence?.sourceRefs || item.sourceRefs || [];
         const refs = [
           item.ref,
           item.axisRef,
           item.lawRef,
+          item.nextAction?.label && `next: ${item.nextAction.label}`,
+          Array.isArray(item.tourRefs) && item.tourRefs.length ? `Start tour: ${item.tourRefs[0]}` : null,
+          item.evidence?.sourceRefs?.length ? `copy source refs: ${item.evidence.sourceRefs.slice(0, 3).join(", ")}` : null,
           Array.isArray(item.detailRefs) && item.detailRefs.length ? `detail: ${item.detailRefs.slice(0, 2).join(", ")}` : null
         ].filter(Boolean).join(" / ");
-        return `<div class="item"><strong>${escapeHtml(String(title))}</strong><p>${escapeHtml(String(text))}</p>${refs ? `<p>${escapeHtml(refs)}</p>` : ""}</div>`;
+        const tourId = Array.isArray(item.tourRefs) && item.tourRefs.length ? item.tourRefs[0] : null;
+        const actions = [
+          tourId ? `<button type="button" data-tour-id="${escapeAttr(tourId)}">Start tour</button>` : sceneId ? `<button type="button" data-scene-id="${escapeAttr(sceneId)}">Open scene</button>` : "",
+          Array.isArray(sourceRefs) && sourceRefs.length ? `<button type="button" data-copy-source-refs="${escapeAttr(sourceRefs.join("\\n"))}">copy source refs</button>` : ""
+        ].filter(Boolean).join("");
+        return `<div class="item"><strong>${escapeHtml(String(title))}</strong><p>${escapeHtml(String(text))}</p>${refs ? `<p>${escapeHtml(refs)}</p>` : ""}${actions ? `<div class="chips">${actions}</div>` : ""}</div>`;
       }
       return `<div class="item"><strong>${escapeHtml(`${fallbackLabel} ${index + 1}`)}</strong><p>${escapeHtml(String(item))}</p></div>`;
     }


### PR DESCRIPTION
## 概要

Closes #2012

ArchSig v0.4.0 の AG measurement 結果を UX 向けに読むため、`archsig-insight-report/v1`、`archsig-insight-brief.md`、viewer scene contract を `analyze` の標準 artifact に追加しました。

主な変更:

- Insight Card / Action Queue / Boundary Digest / Guided Tour / Copy Block を持つ typed insight report を生成
- `archsig-insight-brief.md` と manifest / viewer artifact links を追加
- Viewer の Decision Bar / Insight Queue / Evidence Detail / scene axis HUD / tour / source refs copy を insight contract に接続
- validation failure、measured zero、not_computed、large graph projection、source ref redaction の境界を regression test で固定

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build`、FieldSig test、Lean scan は対象外です。Lean / FieldSig 変更はありません。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
