### PR TITLE
ArchSig insight viewer PRD未達項目を補完

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -1297,6 +1297,7 @@ pub fn build_insight_report_v1(
     let viewer_visual_scenes = insight_viewer_visual_scenes_v1(normalized, packet, &insight_cards);
     let guided_tours = insight_guided_tours_v1(&insight_cards);
     let copy_blocks = insight_copy_blocks_v1(normalized, &insight_cards, &boundary_digest);
+    let omitted_detail_counts = insight_omitted_detail_counts_v1(normalized, &viewer_visual_scenes);
     let top_card = insight_cards.first().cloned().unwrap_or_else(|| {
         json!({
             "id": "insight:measurement-boundary:empty",
@@ -1350,6 +1351,7 @@ pub fn build_insight_report_v1(
         "insightCards": insight_cards,
         "actionQueue": action_queue,
         "boundaryDigest": boundary_digest,
+        "omittedDetailCounts": omitted_detail_counts,
         "viewerVisualScenes": viewer_visual_scenes,
         "guidedTours": guided_tours,
         "copyBlocks": copy_blocks,
@@ -1480,6 +1482,23 @@ pub fn build_insight_brief_v1(report: &Value) -> String {
         "- blocking: {}",
         number_at(report, &["boundaryDigest", "blockingCount"])
     ));
+    if report["omittedDetailCounts"].is_object() {
+        lines.push("- omitted detail counts:".to_string());
+        for key in [
+            "omittedAtoms",
+            "omittedEdges",
+            "omittedContextMemberships",
+            "omittedCoverOverlaps",
+            "omittedSceneLayerObjects",
+            "omittedLabels",
+            "omittedSourceRefs",
+        ] {
+            lines.push(format!(
+                "  - {key}: {}",
+                number_at(report, &["omittedDetailCounts", key])
+            ));
+        }
+    }
     lines.push(String::new());
     lines.push("## Artifact links".to_string());
     for key in ["summaryRef", "briefRef", "viewerDataRef"] {
@@ -1887,6 +1906,38 @@ fn insight_boundary_digest(packet: &ArchSigMeasurementPacketV1, summary: &Value)
     })
 }
 
+fn insight_omitted_detail_counts_v1(normalized: &NormalizedArchMapV2, scenes: &[Value]) -> Value {
+    let atom_count = normalized.atoms.len();
+    let context_memberships = normalized
+        .atoms
+        .iter()
+        .map(|atom| atom.context_memberships.len())
+        .sum::<usize>();
+    let cover_overlaps = normalized
+        .covers
+        .iter()
+        .map(|cover| cover.context_ids.len().saturating_sub(1))
+        .sum::<usize>();
+    let scene_layer_objects = scenes
+        .iter()
+        .flat_map(|scene| scene["layers"].as_array().into_iter().flatten())
+        .count();
+    json!({
+        "omittedAtoms": if atom_count > 10_000 { atom_count.saturating_sub(10_000) } else { 0 },
+        "omittedEdges": 0,
+        "omittedContextMemberships": if context_memberships > 20_000 { context_memberships.saturating_sub(20_000) } else { 0 },
+        "omittedCoverOverlaps": if cover_overlaps > 10_000 { cover_overlaps.saturating_sub(10_000) } else { 0 },
+        "omittedSceneLayerObjects": if scene_layer_objects > 1_000 { scene_layer_objects.saturating_sub(1_000) } else { 0 },
+        "omittedLabels": if atom_count > 10_000 { atom_count.saturating_sub(10_000) } else { 0 },
+        "omittedSourceRefs": 0,
+        "omittedReasons": [
+            "large graph projection may aggregate background geometry",
+            "top insight support and blocking reason objects are preserved before background objects",
+            "viewer data remains a projection and does not embed raw source content"
+        ]
+    })
+}
+
 fn insight_action_queue_v1(cards: &[Value]) -> Vec<Value> {
     cards
         .iter()
@@ -1982,12 +2033,12 @@ fn insight_viewer_visual_scenes_v1(
     let has_repair = cards
         .iter()
         .any(|card| string_field(card, "kind") == "minimal_repair_candidate");
-    let has_law_conflict = cards.iter().any(|card| {
-        matches!(
-            string_field(card, "kind").as_str(),
-            "policy_conflict" | "not_computed_blocker"
-        )
-    });
+    let has_policy_conflict = cards
+        .iter()
+        .any(|card| string_field(card, "kind") == "policy_conflict");
+    let has_not_computed_blocker = cards
+        .iter()
+        .any(|card| string_field(card, "kind") == "not_computed_blocker");
     let has_debt = cards
         .iter()
         .any(|card| string_field(card, "kind") == "architecture_debt_mass");
@@ -2100,21 +2151,27 @@ fn insight_viewer_visual_scenes_v1(
             "broken_line",
             has_repair,
         ),
-        scene_v1(
-            "repair-dual",
-            "repair_dual",
-            "Repair",
-            "Which candidate support intersects measured obstructions?",
-            ("forbidden support", "candidate set", "lower-bound pressure"),
-            "repair_candidate_cut",
-            "cut",
-            "repairCandidateCut",
-            "minimal repair hitting set",
-            &obstruction_refs,
-            "repair_candidate",
-            "cut",
-            "arrow",
-            has_repair,
+        with_scene_non_claims(
+            scene_v1(
+                "repair-dual",
+                "repair_dual",
+                "Repair",
+                "Which candidate support intersects measured obstructions?",
+                ("forbidden support", "candidate set", "lower-bound pressure"),
+                "repair_candidate_cut",
+                "cut",
+                "repairCandidateCut",
+                "minimal repair hitting set; not automatic repair",
+                &obstruction_refs,
+                "repair_candidate",
+                "cut",
+                "arrow",
+                has_repair,
+            ),
+            &[
+                "This is a combinatorial repair candidate. It is not a semantic refactor guarantee.",
+                "This does not prove repair safety.",
+            ],
         ),
         scene_v1(
             "law-conflict-tor",
@@ -2129,16 +2186,22 @@ fn insight_viewer_visual_scenes_v1(
             "law_conflict_bridge",
             "bridge",
             "lawConflictBridge",
-            "common ambient or no_common_ambient blocker",
+            if has_not_computed_blocker {
+                "no_common_ambient blocker or not_computed reason code"
+            } else {
+                "common ambient conflict witness"
+            },
             &law_refs,
-            if has_law_conflict {
+            if has_not_computed_blocker {
                 "not_computed"
+            } else if has_policy_conflict {
+                "measured_nonzero"
             } else {
                 "not_applicable"
             },
             "wall",
             "broken_line",
-            has_law_conflict,
+            has_policy_conflict || has_not_computed_blocker,
         ),
         scene_v1(
             "hodge-debt-field",
@@ -2160,26 +2223,7 @@ fn insight_viewer_visual_scenes_v1(
             "contour",
             has_debt,
         ),
-        scene_v1(
-            "boundary-assumption",
-            "boundary_assumption",
-            "Boundary",
-            "Which regions are checked, assumed, unknown, unmeasured, not_computed, or violated?",
-            (
-                "evidence contract",
-                "assumption status",
-                "blocker intensity",
-            ),
-            "boundary_wall",
-            "wall",
-            "boundaryWall",
-            "measurement boundary state",
-            &boundary_refs,
-            "unknown",
-            "wall_fog",
-            "broken_line",
-            true,
-        ),
+        boundary_scene_v1(&boundary_refs),
         scene_v1(
             "source-evidence",
             "source_evidence",
@@ -2339,6 +2383,113 @@ fn scene_v1(
             "textRole": if active { text_role.to_string() } else { format!("not active for this packet: {text_role}") }
         }],
         "boundaryDigestRef": "boundary-digest:main"
+    })
+}
+
+fn with_scene_non_claims(mut scene: Value, non_claims: &[&str]) -> Value {
+    scene["nonClaims"] = json!(non_claims);
+    scene
+}
+
+fn boundary_scene_v1(primary_refs: &Value) -> Value {
+    let states = [
+        (
+            "checked",
+            "checked_boundary_surface",
+            "surface",
+            "boundaryChecked",
+            "checked evidence boundary",
+            "checked",
+            "solid_surface",
+            "thin_line",
+        ),
+        (
+            "assumed",
+            "assumed_boundary_surface",
+            "surface",
+            "boundaryAssumed",
+            "assumed profile boundary",
+            "assumed",
+            "translucent_surface",
+            "thin_line",
+        ),
+        (
+            "unknown",
+            "unknown_boundary_region",
+            "region",
+            "boundaryUnknown",
+            "unknown unresolved region",
+            "unknown",
+            "grey_region",
+            "broken_line",
+        ),
+        (
+            "unmeasured",
+            "unmeasured_boundary_fog",
+            "fog",
+            "boundaryUnmeasured",
+            "unmeasured support",
+            "unmeasured",
+            "fog",
+            "dotted_line",
+        ),
+        (
+            "not_computed",
+            "not_computed_blocking_wall",
+            "wall",
+            "boundaryNotComputed",
+            "not_computed blocker reason",
+            "not_computed",
+            "blocking_wall",
+            "broken_line",
+        ),
+        (
+            "violated",
+            "violated_boundary",
+            "broken_boundary",
+            "boundaryViolated",
+            "violated assumption",
+            "violated",
+            "red_broken_boundary",
+            "broken_line",
+        ),
+    ];
+    json!({
+        "sceneId": "boundary-assumption",
+        "kind": "boundary_assumption",
+        "title": "Boundary",
+        "sceneStatus": "active",
+        "userQuestion": "Which regions are checked, assumed, unknown, unmeasured, not_computed, or violated?",
+        "axisMapping": {
+            "x": "evidence contract",
+            "y": "assumption status",
+            "z": "blocker intensity"
+        },
+        "primaryRefs": primary_refs,
+        "layers": states.iter().map(|(state, layer_kind, geometry_role, click_target_kind, _, _, _, _)| json!({
+            "layerId": format!("layer:boundary-assumption:{state}"),
+            "kind": layer_kind,
+            "boundaryState": state,
+            "geometryRole": geometry_role,
+            "encodingRef": format!("encoding:boundary-assumption:{state}"),
+            "clickTargetKind": click_target_kind,
+            "refs": primary_refs,
+            "omissionPolicy": "preserve_for_top_insight",
+            "animationPurpose": "navigation"
+        })).collect::<Vec<_>>(),
+        "visualEncodings": states.iter().map(|(state, _, _, _, text_role, color_role, shape_role, line_role)| json!({
+            "encodingId": format!("encoding:boundary-assumption:{state}"),
+            "boundaryState": state,
+            "colorRole": color_role,
+            "shapeRole": shape_role,
+            "lineRole": line_role,
+            "textRole": text_role
+        })).collect::<Vec<_>>(),
+        "boundaryDigestRef": "boundary-digest:main",
+        "nonClaims": [
+            "Boundary states qualify the selected measurement profile; they are not inferred source facts.",
+            "Unmeasured, unknown, not_computed, and violated states are not measured zero."
+        ]
     })
 }
 
@@ -2842,8 +2993,8 @@ fn insight_rank(card: &Value) -> usize {
         "repair_lower_bound" | "minimal_repair_candidate" => 600,
         "policy_conflict" => 500,
         "architecture_debt_mass" => 400,
-        "no_measured_glue_mismatch" => 300,
-        "measurement_boundary" => 250,
+        "measurement_boundary" => 300,
+        "no_measured_glue_mismatch" => 250,
         _ => 100,
     }
 }
@@ -5015,6 +5166,10 @@ pub fn build_measurement_viewer_data_v1(
         || context_memberships > 20_000
         || cover_overlaps > 10_000
         || scene_layer_objects > 1_000;
+    let omitted_detail_counts = insight_report["viewerVisualScenes"]
+        .as_array()
+        .map(|scenes| insight_omitted_detail_counts_v1(normalized, scenes))
+        .unwrap_or_else(|| insight_omitted_detail_counts_v1(normalized, &[]));
     json!({
         "schemaVersion": "archsig-atom-viewer-data-v2",
         "sourceArtifactRefs": {
@@ -5048,6 +5203,7 @@ pub fn build_measurement_viewer_data_v1(
             "actionQueue": insight_report["actionQueue"],
             "evidenceDetailShape": ["What", "Why", "Where", "Measurement", "Boundary", "Next"],
             "boundaryDigest": insight_report["boundaryDigest"],
+            "omittedDetailCounts": omitted_detail_counts,
             "artifactLinks": insight_report["outputArtifacts"]
         },
         "finitePosetSite": {
@@ -5072,20 +5228,7 @@ pub fn build_measurement_viewer_data_v1(
                 "omittedRefs": if large_graph_mode { vec!["background-labels"] } else { Vec::<&str>::new() }
             }
         },
-        "omittedDetailCounts": {
-            "omittedAtoms": if atom_count > 10_000 { atom_count.saturating_sub(10_000) } else { 0 },
-            "omittedEdges": 0,
-            "omittedContextMemberships": if context_memberships > 20_000 { context_memberships.saturating_sub(20_000) } else { 0 },
-            "omittedCoverOverlaps": if cover_overlaps > 10_000 { cover_overlaps.saturating_sub(10_000) } else { 0 },
-            "omittedSceneLayerObjects": if scene_layer_objects > 1_000 { scene_layer_objects.saturating_sub(1_000) } else { 0 },
-            "omittedLabels": if atom_count > 10_000 { atom_count.saturating_sub(10_000) } else { 0 },
-            "omittedSourceRefs": 0,
-            "omittedReasons": [
-                "large graph projection may aggregate background geometry",
-                "top insight support and blocking reason objects are preserved before background objects",
-                "viewer data remains a projection and does not embed raw source content"
-            ]
-        },
+        "omittedDetailCounts": insight_report["omittedDetailCounts"],
         "nonConclusions": [
             "Viewer data is a bounded projection of ArchMap v2 and measurement packet foundation rows.",
             "Layout and site visualization are not AG invariant values or Lean proof objects.",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -307,6 +307,21 @@ fn cli_analyze_v2_emits_insight_report_brief_and_viewer_scene_contract() {
             .any(|entry| entry == "measured_nonzero structural verdict"),
         "deterministic ranking basis must be recorded"
     );
+    let ranking_basis = report["rankingBasis"]
+        .as_array()
+        .expect("ranking basis is array");
+    let boundary_rank = ranking_basis
+        .iter()
+        .position(|entry| entry == "measurement boundary")
+        .expect("measurement boundary ranking basis is recorded");
+    let zero_rank = ranking_basis
+        .iter()
+        .position(|entry| entry == "measured_zero confirmation")
+        .expect("measured_zero ranking basis is recorded");
+    assert!(
+        boundary_rank < zero_rank,
+        "ranking basis must place measurement boundary before measured_zero confirmation"
+    );
     assert_eq!(
         report["insightCards"][0]["tourRefs"][0], report["guidedTours"][0]["tourId"],
         "Insight Card tourRefs and Tour insightRefs must be mutually linked"
@@ -402,6 +417,71 @@ fn cli_analyze_v2_emits_insight_report_brief_and_viewer_scene_contract() {
                 && scene["layers"][0]["geometryRole"] == "ribbon"),
         "H1 scene must expose cocycle representative ribbon/seam"
     );
+    let boundary_scene = report["viewerVisualScenes"]
+        .as_array()
+        .expect("scenes are array")
+        .iter()
+        .find(|scene| scene["sceneId"] == "boundary-assumption")
+        .expect("boundary scene is present");
+    let boundary_layers = boundary_scene["layers"]
+        .as_array()
+        .expect("boundary scene layers are array");
+    let boundary_encodings = boundary_scene["visualEncodings"]
+        .as_array()
+        .expect("boundary scene visual encodings are array");
+    assert_eq!(
+        boundary_layers.len(),
+        6,
+        "boundary scene must expose one layer per checked/assumed/unknown/unmeasured/not_computed/violated state"
+    );
+    for state in [
+        "checked",
+        "assumed",
+        "unknown",
+        "unmeasured",
+        "not_computed",
+        "violated",
+    ] {
+        assert!(
+            boundary_layers
+                .iter()
+                .any(|layer| layer["boundaryState"] == state
+                    && layer["encodingRef"] == format!("encoding:boundary-assumption:{state}")),
+            "boundary scene must include a layer for {state}"
+        );
+        assert!(
+            boundary_encodings
+                .iter()
+                .any(|encoding| encoding["boundaryState"] == state
+                    && encoding["colorRole"] == state
+                    && encoding["shapeRole"].as_str().is_some()
+                    && encoding["lineRole"].as_str().is_some()
+                    && encoding["textRole"].as_str().is_some()),
+            "boundary scene must include visual encoding for {state}"
+        );
+    }
+    let repair_scene = report["viewerVisualScenes"]
+        .as_array()
+        .expect("scenes are array")
+        .iter()
+        .find(|scene| scene["sceneId"] == "repair-dual")
+        .expect("repair scene is present");
+    assert!(
+        repair_scene["nonClaims"]
+            .as_array()
+            .expect("repair scene nonClaims are array")
+            .iter()
+            .any(|claim| claim
+                .as_str()
+                .is_some_and(|text| text.contains("not a semantic refactor guarantee"))),
+        "repair scene must carry the not-auto-repair non-claim"
+    );
+    assert!(
+        repair_scene["visualEncodings"][0]["textRole"]
+            .as_str()
+            .is_some_and(|text| text.contains("not automatic repair")),
+        "repair scene text role must keep the non-automatic repair boundary visible"
+    );
     assert_eq!(
         viewer["decisionBar"]["conclusion"],
         "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
@@ -445,6 +525,10 @@ fn cli_analyze_v2_emits_insight_report_brief_and_viewer_scene_contract() {
     assert_eq!(
         viewer["omittedDetailCounts"]["omittedSceneLayerObjects"].as_u64(),
         Some(0)
+    );
+    assert_eq!(
+        viewer["reportPane"]["omittedDetailCounts"], viewer["omittedDetailCounts"],
+        "report pane and viewer payload must agree on omitted detail counts"
     );
     assert_eq!(summary["readThisFirst"]["heading"], "Read this first");
     assert_eq!(
@@ -493,6 +577,24 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
             .any(|card| card["kind"] == "no_measured_glue_mismatch"),
         "measured_zero must be represented as a profile-relative zero insight"
     );
+    let card_kinds = report["insightCards"]
+        .as_array()
+        .expect("insight cards are array")
+        .iter()
+        .map(|card| card["kind"].as_str().unwrap_or_default())
+        .collect::<Vec<_>>();
+    let boundary_index = card_kinds
+        .iter()
+        .position(|kind| *kind == "measurement_boundary")
+        .expect("fixture must surface a measurement boundary card");
+    let zero_index = card_kinds
+        .iter()
+        .position(|kind| *kind == "no_measured_glue_mismatch")
+        .expect("fixture must surface a measured_zero card");
+    assert!(
+        boundary_index < zero_index,
+        "measurement boundary card must rank before measured_zero confirmation when both are present"
+    );
     assert!(
         viewer["viewerVisualScenes"]
             .as_array()
@@ -512,8 +614,8 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
             .expect("viewer visual scenes are array")
             .iter()
             .any(|scene| scene["sceneId"] == "overview"
-                && scene["visualEncodings"][0]["colorRole"] == "measured_zero"),
-        "zero top insight must render overview as measured_zero, not a nonzero beacon"
+                && scene["visualEncodings"][0]["colorRole"] == "unknown"),
+        "measurement boundary top insight must render overview as boundary/unknown, not a false clean or nonzero beacon"
     );
     assert!(
         viewer["viewerVisualScenes"]
@@ -600,6 +702,15 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
                     .is_some_and(|text| text.contains("no_common_ambient"))),
         "LawConflict scene must show blocking reason instead of an empty conflict view"
     );
+    assert!(
+        viewer["viewerVisualScenes"]
+            .as_array()
+            .expect("viewer visual scenes are array")
+            .iter()
+            .any(|scene| scene["sceneId"] == "law-conflict-tor"
+                && scene["visualEncodings"][0]["colorRole"] == "not_computed"),
+        "LawConflict not_computed blocker must remain visually distinct"
+    );
 }
 
 #[test]
@@ -645,6 +756,8 @@ fn cli_analyze_v2_insight_viewer_truncates_large_background_projection() {
     ]);
 
     let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    let brief = fs::read_to_string(out_dir.join("archsig-insight-brief.md"))
+        .expect("insight brief is generated");
     assert!(
         viewer["finitePosetSite"]["atoms"]
             .as_array()
@@ -661,6 +774,20 @@ fn cli_analyze_v2_insight_viewer_truncates_large_background_projection() {
             .is_some_and(|count| count > 0),
         "viewer payload must report omitted background atoms"
     );
+    for key in [
+        "omittedAtoms",
+        "omittedEdges",
+        "omittedContextMemberships",
+        "omittedCoverOverlaps",
+        "omittedSceneLayerObjects",
+        "omittedLabels",
+        "omittedSourceRefs",
+    ] {
+        assert!(
+            brief.contains(key),
+            "insight brief must include omitted detail count for {key}"
+        );
+    }
     assert!(
         viewer["largeGraphStrategy"]["topInsightEvidencePinning"]["preservedRefs"]
             .as_array()

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1233,19 +1233,22 @@
 
     function renderSceneLayers(scene, positions) {
       if (!scene || !Array.isArray(scene.layers) || scene.sceneStatus === "not_active_for_packet") return;
-      const encoding = Array.isArray(scene.visualEncodings) ? scene.visualEncodings[0] || {} : {};
+      const encodings = Array.isArray(scene.visualEncodings) ? scene.visualEncodings : [];
+      const encodingById = new Map(encodings.map((encoding) => [encoding.encodingId, encoding]));
       const refs = scene.primaryRefs || {};
       const atomRefs = Array.isArray(refs.atomRefs) ? refs.atomRefs : [];
       const contextRefs = Array.isArray(refs.contextRefs) ? refs.contextRefs : [];
       const points = [...atomRefs, ...contextRefs].map((ref) => positions.get(ref)).filter(Boolean);
       const center = points.length ? centroid(points) : new THREE.Vector3(0, 0, 0);
       scene.layers.forEach((layer, index) => {
+        const encoding = encodingById.get(layer.encodingRef) || encodings[0] || {};
         const mesh = sceneLayerMesh(layer, encoding, center, index, points.length);
         if (!mesh) return;
-        mesh.userData = { kind: "sceneLayer", scene, layer };
+        mesh.userData = { kind: "sceneLayer", scene, layer, encoding };
         edgeGroup.add(mesh);
       });
       if (points.length > 1) {
+        const encoding = encodings[0] || {};
         const geometry = new THREE.BufferGeometry();
         const vertices = [];
         points.forEach((point) => vertices.push(center.x, center.y, center.z, point.x, point.y, point.z));
@@ -1256,7 +1259,7 @@
           opacity: 0.68
         });
         const lines = new THREE.LineSegments(geometry, material);
-        lines.userData = { kind: "sceneLayerRefs", scene };
+        lines.userData = { kind: "sceneLayerRefs", scene, encoding };
         edgeGroup.add(lines);
       }
     }
@@ -1303,6 +1306,9 @@
         source_evidence: 0x8bd46e,
         unknown: 0x9fb3c8,
         checked: 0x64d6be,
+        assumed: 0x73b7ff,
+        unmeasured: 0x8a96a8,
+        violated: 0xff4d7a,
         not_applicable: 0x5f6f86
       };
       return colors[role] || 0xf2c15f;
@@ -2306,17 +2312,22 @@
       pointer.y = -(((event.clientY - rect.top) / Math.max(rect.height, 1)) * 2 - 1);
       raycaster.setFromCamera(pointer, camera);
       const hits = raycaster.intersectObjects([atomInstanceMesh].filter(Boolean), false);
-      if (!hits.length) {
-        detailEl.hidden = true;
-        selectedAtomKey = null;
-        return;
-      }
-      const hit = hits[0];
-      if (hit.object === atomInstanceMesh) {
+      if (hits.length && hits[0].object === atomInstanceMesh) {
+        const hit = hits[0];
         const node = renderedAtoms[hit.instanceId];
         selectedAtomKey = node?.nodeId || null;
         renderDetail("Atom", node);
+        return;
       }
+      const sceneHits = raycaster.intersectObjects(edgeGroup.children, true)
+        .filter((hit) => hit.object?.userData?.kind === "sceneLayer" || hit.object?.userData?.kind === "sceneLayerRefs");
+      if (sceneHits.length) {
+        const { scene, layer, encoding } = sceneHits[0].object.userData;
+        renderDetail("Scene", sceneDetailItem(scene, layer, encoding));
+        return;
+      }
+      detailEl.hidden = true;
+      selectedAtomKey = null;
     }
 
     function renderDetail(kind, item) {
@@ -2348,6 +2359,31 @@
       detailEl.hidden = false;
     }
 
+    function sceneDetailItem(scene, layer = {}, encoding = {}) {
+      const refs = layer.refs || scene.primaryRefs || {};
+      return {
+        what: scene.userQuestion,
+        conclusion: scene.sceneStatus,
+        recommendedNextAction: scene.title,
+        boundaryDigest: scene.boundaryDigestRef,
+        nonClaims: scene.nonClaims,
+        labels: [
+          scene.sceneId,
+          layer.kind,
+          layer.boundaryState && `boundary:${layer.boundaryState}`,
+          encoding.colorRole && `color:${encoding.colorRole}`,
+          encoding.shapeRole && `shape:${encoding.shapeRole}`,
+          encoding.lineRole && `line:${encoding.lineRole}`,
+          encoding.textRole && `text:${encoding.textRole}`
+        ].filter(Boolean),
+        detailRefs: [
+          ...(Array.isArray(refs.insightRefs) ? refs.insightRefs : []),
+          ...(Array.isArray(refs.atomRefs) ? refs.atomRefs.slice(0, 4) : []),
+          ...(Array.isArray(refs.contextRefs) ? refs.contextRefs.slice(0, 4) : [])
+        ]
+      };
+    }
+
     async function handleReportAction(event) {
       const button = event.target.closest("[data-tour-id], [data-scene-id], [data-copy-source-refs]");
       if (!button) return;
@@ -2357,6 +2393,8 @@
       if (button.dataset.sceneId) {
         viewModeEl.value = modeForScene(button.dataset.sceneId);
         renderScene();
+        const scene = (currentData?.viewerVisualScenes || []).find((item) => item.sceneId === button.dataset.sceneId);
+        if (scene) renderDetail("Scene", sceneDetailItem(scene, scene.layers?.[0], scene.visualEncodings?.[0]));
         status(`Scene: ${button.dataset.sceneId}`);
       }
       if (button.dataset.copySourceRefs) {


### PR DESCRIPTION
## 概要

Closes #2035
Closes #2036
Closes #2037
Closes #2038
Closes #2039

ArchSig insight viewer PRD の未達項目を補完しました。

- `archsig-insight-brief.md` に large graph projection の omitted detail counts を出力
- Boundary scene を checked / assumed / unknown / unmeasured / not_computed / violated の6状態 layer と encoding に分離
- Repair scene に自動修復ではない scene-level non-claim を追加し、viewer detail で表示
- `insight_rank` を PRD の固定順に合わせ、measurement boundary を measured_zero confirmation より上位へ修正

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（94 unit + 122 CLI passed, 21 ignored）
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（本文作成コマンドの誤解釈で実行、失敗なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
