### PR TITLE
PRD-4 Cohomology 初期モジュールを追加

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -14,3 +14,4 @@ import Formal.AG.Atom.AATCore
 import Formal.AG.Examples.FiniteModel
 import Formal.AG.Site
 import Formal.AG.LawAlgebra
+import Formal.AG.Cohomology

--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -1,0 +1,1 @@
+import Formal.AG.Cohomology.Basic

--- a/Formal/AG/Cohomology/Basic.lean
+++ b/Formal/AG/Cohomology/Basic.lean
@@ -1,0 +1,48 @@
+import Formal.AG.Site
+import Formal.AG.LawAlgebra
+
+namespace AAT.AG
+namespace Cohomology
+
+universe u v
+
+/--
+IV.R0: prerequisite package for the Part IV obstruction-cohomology tower.
+
+Part IV starts only after the Part II site surface and the Part III law-algebra
+surface are available.  This package records those dependencies as data for the
+first bootstrap module; it does not define obstruction sheaves, Cech complexes,
+or cohomology groups yet.
+-/
+structure PartIVPrerequisites (k : Type v) [CommRing k] where
+  carrier : AtomCarrier.{u}
+  core : AATCorePackage carrier
+  affineChart : LawAlgebra.AffineChart.AffineAATChart k
+
+namespace PartIVPrerequisites
+
+variable {k : Type v} [CommRing k]
+
+/-- IV.R0: read the Part II prerequisite package supplied by the bootstrap data. -/
+def sitePrerequisites (P : PartIVPrerequisites.{u, v} k) :
+    Site.PartIPrerequisites.{u} where
+  carrier := P.carrier
+  core := P.core
+
+/-- IV.R0: read the Part III affine chart supplied by the bootstrap data. -/
+def selectedAffineChart (P : PartIVPrerequisites.{u, v} k) :
+    LawAlgebra.AffineChart.AffineAATChart k :=
+  P.affineChart
+
+/--
+IV.R0: the bootstrap package exposes exactly the selected architecture object
+already supplied through the Part II site prerequisite surface.
+-/
+theorem site_architectureObject_eq (P : PartIVPrerequisites.{u, v} k) :
+    P.sitePrerequisites.architectureObject = P.core.object :=
+  rfl
+
+end PartIVPrerequisites
+
+end Cohomology
+end AAT.AG


### PR DESCRIPTION
## 概要

Closes #2042

PRD-4 / AC1 の最初の周回として、`Formal/AG/Cohomology` の初期 import surface を追加しました。

- `Formal/AG/Cohomology/Basic.lean` を新設し、Part II `Site` と Part III `LawAlgebra` を前提に取る `PartIVPrerequisites` を追加
- `Formal/AG/Cohomology.lean` を新設し、Cohomology namespace の集約 import を追加
- `Formal/AG.lean` から `Formal.AG.Cohomology` を import し、root build 対象に接続

この PR では AC2 以降の obstruction sheaf、Čech complex、cohomology group、CBI 定理本体は実装していません。

## 証明した定理

- `AAT.AG.Cohomology.PartIVPrerequisites.site_architectureObject_eq`

Lean status: defined only / bootstrap implementation.

## 編集したドキュメント

- なし

## 実施したテスト

- [x] `~/.elan/bin/lake env lean Formal/AG/Cohomology/Basic.lean`
- [x] `~/.elan/bin/lake env lean Formal/AG/Cohomology.lean`
- [x] `~/.elan/bin/lake env lean Formal/AG.lean`
- [x] `~/.elan/bin/lake build`
  - 既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件が replay されたが build は成功
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## ローカルレビュー

`$local-review` の AAT / Lean 4観点 multi-agent review を実施しました。

- AAT / Lean / ArchSig boundary: 重大指摘なし
- theorem status and ledger consistency: 重大指摘なし
- Lean API and dependency quality: 重大指摘なし
- Lean verification and regression risk: 新規ファイル未追跡の運用指摘あり。stage 後に `git diff --cached --stat` と `git diff --cached --check` で解消確認済み

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない