### PR TITLE
PRD-4 AC6 gluing mismatch を形式化する

### DIFF
--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -3,3 +3,4 @@ import Formal.AG.Cohomology.ObstructionSheaf
 import Formal.AG.Cohomology.CechComplex
 import Formal.AG.Cohomology.Cohomology
 import Formal.AG.Cohomology.FinitePosetComparison
+import Formal.AG.Cohomology.GluingMismatch

--- a/Formal/AG/Cohomology/GluingMismatch.lean
+++ b/Formal/AG/Cohomology/GluingMismatch.lean
@@ -1,0 +1,282 @@
+import Formal.AG.Cohomology.CechComplex
+
+noncomputable section
+
+namespace AAT.AG
+namespace Cohomology
+
+universe u v w
+
+open CategoryTheory
+open Opposite
+
+/--
+IV.定義5.1: local flatness data over a selected cover.
+
+Each cover chart carries a PRD-3 lawful section, and the section is required to
+satisfy the primary obstruction-ideal vanishing condition `s_i^* I_Ob^U = 0`.
+The ambient ring and ideal are explicit parameters; this layer does not build a
+scheme-level gluing theorem.
+-/
+structure LocalFlatnessData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (𝒰 : CoverRelativeCechCover S)
+    (R : Type v) [CommRing R] (IOb : Ideal R) where
+  localSection :
+    𝒰.Index -> LawAlgebra.LawfulLocus.LawfulSectionData.{v, w} R IOb
+  lawful : ∀ i : 𝒰.Index, (localSection i).Lawful
+
+namespace LocalFlatnessData
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+
+/-- IV.定義5.1: each local section factors through the lawful locus `Flat_U`. -/
+def factorsThroughFlat_U (D : LocalFlatnessData 𝒰 R IOb) (i : 𝒰.Index) :
+    (D.localSection i).FactorsThroughLawfulLocus :=
+  LawAlgebra.LawfulLocus.LawfulSectionData.factorsThroughLawfulLocus_of_lawful R
+    (D.lawful i)
+
+/-- IV.定義5.1: local lawfulness is exactly pulled obstruction-ideal vanishing. -/
+theorem pulledObstructionIdeal_eq_bot
+    (D : LocalFlatnessData 𝒰 R IOb) (i : 𝒰.Index) :
+    (D.localSection i).pulledObstructionIdeal = ⊥ :=
+  D.lawful i
+
+end LocalFlatnessData
+
+/--
+IV.定義5.2: a local lawful section restricted to a selected 1-overlap.
+
+The actual restriction morphism for lawful sections is not constructed at this
+layer.  Instead, the restricted section and its relation to the chart-local
+section are explicit selected data over the overlap simplex.
+-/
+structure RestrictedLocalLawfulSection {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {R : Type v} [CommRing R] {IOb : Ideal R}
+    (D : LocalFlatnessData 𝒰 R IOb) (σ : 𝒰.simplex 1) (i : 𝒰.Index) where
+  restrictedSection :
+    LawAlgebra.LawfulLocus.LawfulSectionData.{v, w} R IOb
+  restrictsLocalSection : Prop
+  restriction_holds : restrictsLocalSection
+  restrictedLawful : restrictedSection.Lawful
+
+namespace RestrictedLocalLawfulSection
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+
+/-- IV.定義5.2: restricted sections still factor through the lawful locus. -/
+def factorsThroughFlat_U {σ : 𝒰.simplex 1} {i : 𝒰.Index}
+    (s : RestrictedLocalLawfulSection D σ i) :
+    s.restrictedSection.FactorsThroughLawfulLocus :=
+  LawAlgebra.LawfulLocus.LawfulSectionData.factorsThroughLawfulLocus_of_lawful R
+    s.restrictedLawful
+
+end RestrictedLocalLawfulSection
+
+/--
+IV.定義5.2: parameterized gluing mismatch.
+
+The restricted sections over a 1-overlap and the map comparing them are supplied
+as data. This keeps the restriction and comparison maps selected and explicit
+instead of deriving them from an unformalized general restriction/gluing theory.
+-/
+structure GluingMismatchData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    (Ob : ObstructionSheaf S) {R : Type v} [CommRing R] {IOb : Ideal R}
+    (D : LocalFlatnessData 𝒰 R IOb) where
+  leftIndex : 𝒰.simplex 1 -> 𝒰.Index
+  rightIndex : 𝒰.simplex 1 -> 𝒰.Index
+  leftRestriction :
+    ∀ σ : 𝒰.simplex 1, RestrictedLocalLawfulSection D σ (leftIndex σ)
+  rightRestriction :
+    ∀ σ : 𝒰.simplex 1, RestrictedLocalLawfulSection D σ (rightIndex σ)
+  mismatch :
+    ∀ σ : 𝒰.simplex 1,
+      RestrictedLocalLawfulSection D σ (leftIndex σ) ->
+      RestrictedLocalLawfulSection D σ (rightIndex σ) ->
+      Ob.carrier.toPresheaf.obj (op (𝒰.overlap 1 σ))
+
+namespace GluingMismatchData
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+
+/-- IV.定義5.2: the selected mismatch value `g_ij` on a 1-overlap. -/
+def value (M : GluingMismatchData Ob D) (σ : 𝒰.simplex 1) :
+    Ob.carrier.toPresheaf.obj (op (𝒰.overlap 1 σ)) :=
+  M.mismatch σ (M.leftRestriction σ) (M.rightRestriction σ)
+
+/-- IV.定義5.2: the mismatch family as a degree-one Čech cochain. -/
+def gluingMismatchCochain (M : GluingMismatchData Ob D) :
+    CoverRelativeCechCochain 𝒰 Ob 1 :=
+  fun σ => M.value σ
+
+/-- IV.定義5.2: the cochain entry is the selected mismatch comparison map. -/
+theorem gluingMismatchCochain_apply
+    (M : GluingMismatchData Ob D) (σ : 𝒰.simplex 1) :
+    M.gluingMismatchCochain σ =
+      M.mismatch σ (M.leftRestriction σ) (M.rightRestriction σ) :=
+  rfl
+
+/-- IV.定義5.2: the left input of the mismatch is the selected overlap restriction. -/
+theorem leftRestriction_holds
+    (M : GluingMismatchData Ob D) (σ : 𝒰.simplex 1) :
+    (M.leftRestriction σ).restrictsLocalSection :=
+  (M.leftRestriction σ).restriction_holds
+
+/-- IV.定義5.2: the right input of the mismatch is the selected overlap restriction. -/
+theorem rightRestriction_holds
+    (M : GluingMismatchData Ob D) (σ : 𝒰.simplex 1) :
+    (M.rightRestriction σ).restrictsLocalSection :=
+  (M.rightRestriction σ).restriction_holds
+
+end GluingMismatchData
+
+/--
+IV.原則5.2A: pseudo-torsor normalized mismatch data.
+
+The selected difference carrier models the abelian group `G_U` in which local
+lawful sections form a pseudo-torsor. The edge mismatch is required to be the
+normalized difference `s_j - s_i`; the cycle of vertices on a 2-simplex then
+forces the triple-overlap sum to vanish. The final field states that the
+selected Čech differential reads this triple sum for the chosen mismatch
+cochain.
+-/
+structure PseudoTorsorNormalizedMismatch {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} (M : GluingMismatchData Ob D)
+    (K : CoverRelativeCechComplex 𝒰 Ob) where
+  Difference : Type u
+  differenceAddCommGroup : AddCommGroup Difference
+  readMismatch :
+    ∀ σ : 𝒰.simplex 1,
+      Ob.carrier.toPresheaf.obj (op (𝒰.overlap 1 σ)) -> Difference
+  position : 𝒰.Index -> Difference
+  edgeValue : 𝒰.simplex 1 -> Difference
+  readMismatch_value :
+    ∀ σ : 𝒰.simplex 1,
+      readMismatch σ (M.value σ) = edgeValue σ
+  edgeValue_eq_sub :
+    ∀ σ : 𝒰.simplex 1,
+      edgeValue σ = position (M.rightIndex σ) - position (M.leftIndex σ)
+  vertex : 𝒰.simplex 2 -> Fin 3 -> 𝒰.Index
+  edge01 : 𝒰.simplex 2 -> 𝒰.simplex 1
+  edge12 : 𝒰.simplex 2 -> 𝒰.simplex 1
+  edge20 : 𝒰.simplex 2 -> 𝒰.simplex 1
+  edge01_left :
+    ∀ τ : 𝒰.simplex 2, M.leftIndex (edge01 τ) = vertex τ 0
+  edge01_right :
+    ∀ τ : 𝒰.simplex 2, M.rightIndex (edge01 τ) = vertex τ 1
+  edge12_left :
+    ∀ τ : 𝒰.simplex 2, M.leftIndex (edge12 τ) = vertex τ 1
+  edge12_right :
+    ∀ τ : 𝒰.simplex 2, M.rightIndex (edge12 τ) = vertex τ 2
+  edge20_left :
+    ∀ τ : 𝒰.simplex 2, M.leftIndex (edge20 τ) = vertex τ 2
+  edge20_right :
+    ∀ τ : 𝒰.simplex 2, M.rightIndex (edge20 τ) = vertex τ 0
+  selectedDifferential_vanishes_of_triple_sum_zero :
+    letI := K.cochainAddCommGroup 2
+    (∀ τ : 𝒰.simplex 2,
+        edgeValue (edge01 τ) + edgeValue (edge12 τ) + edgeValue (edge20 τ) = 0
+    ) ->
+      K.d 1 M.gluingMismatchCochain = 0
+
+attribute [instance] PseudoTorsorNormalizedMismatch.differenceAddCommGroup
+
+namespace PseudoTorsorNormalizedMismatch
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+variable {M : GluingMismatchData Ob D}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+
+/--
+IV.原則5.2A: the selected mismatch cochain reads as the normalized
+pseudo-torsor edge value.
+-/
+theorem readMismatch_gluingMismatch
+    (N : PseudoTorsorNormalizedMismatch M K) (σ : 𝒰.simplex 1) :
+    N.readMismatch σ (M.gluingMismatchCochain σ) = N.edgeValue σ := by
+  rw [GluingMismatchData.gluingMismatchCochain_apply]
+  exact N.readMismatch_value σ
+
+/--
+IV.原則5.2A: the normalized edge differences cancel on each triple overlap.
+-/
+theorem triple_mismatch_sum_zero
+    (N : PseudoTorsorNormalizedMismatch M K) (τ : 𝒰.simplex 2) :
+    N.edgeValue (N.edge01 τ) + N.edgeValue (N.edge12 τ) +
+      N.edgeValue (N.edge20 τ) = 0 := by
+  letI := N.differenceAddCommGroup
+  rw [N.edgeValue_eq_sub (N.edge01 τ), N.edgeValue_eq_sub (N.edge12 τ),
+    N.edgeValue_eq_sub (N.edge20 τ), N.edge01_right τ, N.edge01_left τ,
+    N.edge12_right τ, N.edge12_left τ, N.edge20_right τ, N.edge20_left τ]
+  abel
+
+/--
+IV.原則5.2A: pseudo-torsor normalization automatically makes the selected
+gluing mismatch a Čech 1-cocycle.
+-/
+theorem gluingMismatch_cocycle
+    (N : PseudoTorsorNormalizedMismatch M K) :
+    letI := K.cochainAddCommGroup 2
+    K.d 1 M.gluingMismatchCochain = 0 :=
+  N.selectedDifferential_vanishes_of_triple_sum_zero
+    (fun τ => N.triple_mismatch_sum_zero τ)
+
+end PseudoTorsorNormalizedMismatch
+
+/-- IV.定義5.3: a descent cocycle is the mismatch cochain with its cocycle proof. -/
+def descentCocycle {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} (M : GluingMismatchData Ob D)
+    (K : CoverRelativeCechComplex 𝒰 Ob)
+    (h : letI := K.cochainAddCommGroup 2
+      K.d 1 M.gluingMismatchCochain = 0) :
+    K.CechCocycle 1 :=
+  ⟨M.gluingMismatchCochain, h⟩
+
+/--
+IV.定義5.3: descent obstruction class `[g] in H^1(𝒰, Ob_U)` attached to a
+selected gluing mismatch cocycle.
+-/
+def descentObstructionClass {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} (M : GluingMismatchData Ob D)
+    (K : CoverRelativeCechComplex 𝒰 Ob)
+    (h : letI := K.cochainAddCommGroup 2
+      K.d 1 M.gluingMismatchCochain = 0) :
+    K.CoverRelativeHn 1 :=
+  K.cohomologyClassSucc 0 (descentCocycle M K h)
+
+/--
+IV.定義5.3 / 原則5.2A: pseudo-torsor normalized mismatch yields the descent
+obstruction class without an extra cocycle proof.
+-/
+def descentObstructionClassOfPseudoTorsor {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob}
+    (N : PseudoTorsorNormalizedMismatch M K) :
+    K.CoverRelativeHn 1 :=
+  descentObstructionClass M K N.gluingMismatch_cocycle
+
+end Cohomology
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4594,11 +4594,12 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/ObstructionSheaf.lean`,
 `Formal/AG/Cohomology/CechComplex.lean`,
 `Formal/AG/Cohomology/Cohomology.lean`,
-`Formal/AG/Cohomology/FinitePosetComparison.lean`.
+`Formal/AG/Cohomology/FinitePosetComparison.lean`,
+`Formal/AG/Cohomology/GluingMismatch.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
-poset 比較 target、AC5/R3 に対応する entrypoint である。現時点では
+poset 比較 target、AC5/R3、AC6/R4 に対応する entrypoint である。現時点では
 `Formal/AG/Cohomology` を build 対象へ追加し、PRD-2 `Site` と PRD-3
 `LawAlgebra` への prerequisite package、obstruction coefficient sheaf carrier、
 `O_X^U`-module valued coefficient surface、`Def_U = I_U`、`ConDef_U = I_U/I_U^2`
@@ -4607,7 +4608,9 @@ carrier boundary、`DerOb_U` の type-signature-only placeholder、一般 AAT si
 cover-relative Cech complex package、`d ∘ d = 0` witness、positive degree
 `ker d / im d` quotient、条件付き `H^n(X, Ob_U)` notation package、PRD-2
 finite-poset surface を明示 comparison data の下で PRD-4 comparison target として
-読む package までを Lean 上に置く。
+読む package、local lawful section data、parameterized gluing mismatch、
+pseudo-torsor 正規化による cocycle 自動成立補題、descent obstruction class
+`[g] in H^1(𝒰, Ob_U)` までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4617,14 +4620,17 @@ finite-poset surface を明示 comparison data の下で PRD-4 comparison target
 | `IV.定義3.1-3.3` | `AAT.AG.Cohomology.CoverRelativeCechCover`, `CoverRelativeCechCochain`, `CoverRelativeCechComplex`, `CoverRelativeCechComplex.Cn`, `CoverRelativeCechComplex.d`, `CoverRelativeCechComplex.faceRestrictionTerm`, `CoverRelativeCechComplex.d_eq_alternatingFaceCombination`, `CoverRelativeCechComplex.d_comp_d_eq_zero`, `CoverRelativeCechComplex.FinitePosetComparisonTarget` | `structure` / `def` / `abbrev` / `theorem` | 一般 AAT site 上の cover-relative Cech cover、n-simplex overlap section product としての cochain、face restriction term、選択された alternating face-combination に一致する differential package、`d ∘ d = 0` witness、および PRD-2 finite-poset comparison theorem の typed target。 | `defined only` / `proved accessor` |
 | `IV.定義4.1` | `AAT.AG.Cohomology.CoverRelativeCechComplex.CechCocycle`, `CechCoboundarySetoidSucc`, `CechCohomologySucc`, `CechCohomologyZero`, `CoverRelativeHn`, `cohomologyClassSucc`, `CechToSheafComparisonHypothesis`, `RefinementSystemHypothesis`, `SpaceCohomologyNotationJustification`, `ConditionalSpaceCohomology`, `ConditionalSpaceCohomology.HnX`, `ConditionalSpaceCohomology.HnX_eq_coverRelative` | `def` / `abbrev` / `structure` / `inductive` / `theorem` | cover-relative `H^n(𝒰, Ob_U)` を一次対象として置き、positive degree は cocycle kernel を previous differential image で割る quotient として読む。`H^n(X, Ob_U)` は Cech-to-sheaf comparison または refinement system を明示する条件付き notation package に限る。 | `defined only` / `proved accessor` |
 | `IV.R2 finite-poset comparison` | `AAT.AG.Cohomology.finitePosetCoverRelativeCover`, `FinitePosetCechComparisonData`, `FinitePosetCechComparisonData.generalComplex`, `FinitePosetCechComparisonData.comparisonTarget`, `FinitePosetCechComparisonData.cochain_to_from`, `FinitePosetCechComparisonData.differential_compatible`, `FinitePosetCechComparisonData.cohomology_target_eq`, `FinitePosetCechComparisonData.cohomology_to_from`, `FinitePosetCechComparisonData.cohomology_from_to` | `def` / `structure` / `theorem` | PRD-2 finite poset Cech complex から PRD-4 cover-relative cover を作り、明示された coefficient / additive / cochain equivalence / quotient relation data の下で PRD-4 `FinitePosetComparisonTarget` として読む。differential compatibility、finite-poset cohomology target、selected cohomology maps の round-trip laws を accessor theorem として公開する。 | `proved under explicit comparison data` |
+| `IV.定義5.1-5.3 / 原則5.2A` | `AAT.AG.Cohomology.LocalFlatnessData`, `LocalFlatnessData.factorsThroughFlat_U`, `LocalFlatnessData.pulledObstructionIdeal_eq_bot`, `RestrictedLocalLawfulSection`, `RestrictedLocalLawfulSection.factorsThroughFlat_U`, `GluingMismatchData`, `GluingMismatchData.value`, `GluingMismatchData.gluingMismatchCochain`, `GluingMismatchData.gluingMismatchCochain_apply`, `GluingMismatchData.leftRestriction_holds`, `GluingMismatchData.rightRestriction_holds`, `PseudoTorsorNormalizedMismatch`, `PseudoTorsorNormalizedMismatch.readMismatch_gluingMismatch`, `PseudoTorsorNormalizedMismatch.triple_mismatch_sum_zero`, `PseudoTorsorNormalizedMismatch.gluingMismatch_cocycle`, `descentCocycle`, `descentObstructionClass`, `descentObstructionClassOfPseudoTorsor` | `structure` / `def` / `theorem` | PRD-3 lawful section surface に基づく local flatness data、overlap 上の selected restricted lawful section、選択された比較写像による gluing mismatch cochain、abelian pseudo-torsor 正規化で mismatch cochain が `g_ij = s_j - s_i` 型の差分 carrier へ読まれ、triple-overlap sum が消えること、および既存 cover-relative `H^1(𝒰, Ob_U)` に入る descent obstruction class を定義する。Čech differential が triple sum zero を cocycle に読む方向は selected package の明示 field に相対化する。 | `defined only` / `proved accessor` |
 
 Non-conclusions: この entrypoint は obstruction coefficient sheaf carrier、module-valued
 coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 package、
 一般 site の cover-relative Cech complex package、`d ∘ d = 0` witness、
 cover-relative cohomology notation、条件付き space-level notation、明示 comparison
-data 下の finite-poset target だけを示す。任意の finite-poset regime が自動的に
-obstruction sheaf comparison data を持つこと、Local Flatness Gap、Boundary Residue、
-Cohomological Flatness Criterion、derived category、cotangent complex、`Ext^1` はまだ形式化しない。
+data 下の finite-poset target、R4 の local flatness / gluing mismatch / pseudo-torsor
+normalized cocycle / descent class surface だけを示す。任意の finite-poset regime が
+自動的に obstruction sheaf comparison data を持つこと、descent class の非零性や
+coboundary 判定、Local Flatness Gap、Boundary Residue、Cohomological Flatness
+Criterion、derived category、cotangent complex、`Ext^1` はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -794,7 +794,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/ObstructionSheaf.lean`,
 `Formal/AG/Cohomology/CechComplex.lean`,
 `Formal/AG/Cohomology/Cohomology.lean`,
-`Formal/AG/Cohomology/FinitePosetComparison.lean`.
+`Formal/AG/Cohomology/FinitePosetComparison.lean`,
+`Formal/AG/Cohomology/GluingMismatch.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 は AC1/R0 と AC2/R1 から着手している。Issue
@@ -805,7 +806,9 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 [#2047](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2047)
 では一般 cover-relative Cech complex surface と条件付き cohomology notation を追加した。Issue
 [#2049](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2049)
-では PRD-2 finite-poset Cech surface との比較 target を追加する。
+では PRD-2 finite-poset Cech surface との比較 target を追加した。Issue
+[#2051](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2051)
+では gluing mismatch、pseudo-torsor normalized cocycle、descent obstruction class を追加する。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -815,6 +818,7 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 | `IV.定義3.1-3.3` General cover-relative Cech complex | `defined only` / `proved accessor`. `Formal/AG/Cohomology/CechComplex.lean` が `CoverRelativeCechCover`、`CoverRelativeCechCochain`、`CoverRelativeCechComplex`、`faceRestrictionTerm`、`d_eq_alternatingFaceCombination`、`d_comp_d_eq_zero`、`FinitePosetComparisonTarget` を持つ。 | differential は face restriction term の selected alternating face-combination に一致する package として扱う。finite poset Cech との比較は `FinitePosetComparison.lean` の明示 comparison data で読む。 |
 | `IV.定義4.1` Cover-relative and conditional cohomology notation | `defined only` / `proved accessor`. `CechCocycle`、`CechCoboundarySetoidSucc`、`CechCohomologySucc`、`CoverRelativeHn`、`CechToSheafComparisonHypothesis`、`RefinementSystemHypothesis`、`ConditionalSpaceCohomology`、`HnX_eq_coverRelative` を持つ。 | `H^n(X, Ob_U)` は比較仮定または refinement system を持つ条件付き notation に限る。無条件 sheaf cohomology は構成しない。 |
 | `IV.R2 / AC4` PRD-2 finite-poset comparison | `proved under explicit comparison data`. `Formal/AG/Cohomology/FinitePosetComparison.lean` が `finitePosetCoverRelativeCover`、`FinitePosetCechComparisonData`、`generalComplex`、`comparisonTarget`、`cochain_to_from`、`differential_compatible`、`cohomology_target_eq`、`cohomology_to_from`、`cohomology_from_to` を持つ。 | PRD-2 Type-valued coefficient surface と PRD-4 additive obstruction sheaf surface の同一視、加法構造、cochain equivalence、cohomology quotient relation、cohomology map round-trip laws は明示 data として扱う。任意の finite-poset regime がその data を自動的に持つとは主張しない。 |
+| `IV.定義5.1-5.3 / 原則5.2A` Gluing mismatch and descent class | `defined only` / `proved accessor`. `Formal/AG/Cohomology/GluingMismatch.lean` が `LocalFlatnessData`、`RestrictedLocalLawfulSection`、`GluingMismatchData`、`PseudoTorsorNormalizedMismatch`、`readMismatch_gluingMismatch`、`triple_mismatch_sum_zero`、`gluingMismatch_cocycle`、`descentObstructionClass` を持つ。 | restriction と Čech differential compatibility は selected package の明示 field に相対化する。descent class の非零性、coboundary 判定、global lawful section の不存在は R5 以降に残す。 |
 
 第IV部 PRD-4 の証明対象ラベルは次の現在状態である。
 
@@ -826,6 +830,7 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 | `IV.定義2.4 DerOb_U` | `defined only` / `type-signature-only placeholder` |
 | `IV.定義3.1-3.3 / R2` | `defined only` / `proved d_comp_d accessor`; PRD-2 finite-poset comparison target and selected cohomology round-trip laws are `proved under explicit comparison data` |
 | `IV.定義4.1 / R3` | `defined only` / `proved accessor under explicit comparison or refinement assumptions` |
+| `IV.定義5.1-5.3 / R4` | `defined only` / `proved pseudo-torsor cocycle accessor under explicit normalization data` |
 | `IV.定理7.1` | `future proof obligation` |
 | `IV.定理9.2` | `future proof obligation` |
 | `IV.定理11.1 / 系11.2` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #2051

PRD-4 AC6/R4 に対応して、gluing mismatch と descent obstruction class の Lean surface を追加しました。

- `LocalFlatnessData` で PRD-3 の lawful section / `s_i^* I_Ob^U = 0` surface を cover 上の local flatness data として読む
- `RestrictedLocalLawfulSection` と `GluingMismatchData` で overlap 上の selected restriction と parameterized mismatch cochain を定義
- `PseudoTorsorNormalizedMismatch` で mismatch cochain を `g_ij = s_j - s_i` 型の差分 carrier に読み、triple-overlap sum zero から selected Čech cocycle を得る accessor を追加
- `descentObstructionClass` / `descentObstructionClassOfPseudoTorsor` で `[g] in H^1(𝒰, Ob_U)` を既存 cover-relative cohomology surface に接続
- `lean_theorem_index.md` と `proof_obligations.md` の PRD-4 ledger を AC6/R4 まで同期

claim boundary として、restriction と Čech differential compatibility は selected package の明示 field に相対化し、descent class の非零性、coboundary 判定、global lawful section の不存在、R5/R6/R8 の定理は主張していません。

## 証明した定理

- `LocalFlatnessData.factorsThroughFlat_U`
- `LocalFlatnessData.pulledObstructionIdeal_eq_bot`
- `RestrictedLocalLawfulSection.factorsThroughFlat_U`
- `GluingMismatchData.gluingMismatchCochain_apply`
- `GluingMismatchData.leftRestriction_holds`
- `GluingMismatchData.rightRestriction_holds`
- `PseudoTorsorNormalizedMismatch.readMismatch_gluingMismatch`
- `PseudoTorsorNormalizedMismatch.triple_mismatch_sum_zero`
- `PseudoTorsorNormalizedMismatch.gluingMismatch_cocycle`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Cohomology/GluingMismatch.lean`
- [x] `lake env lean Formal/AG/Cohomology.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`（既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207` の linter warning のみ）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check origin/main..HEAD`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない