### PR TITLE
PRD-4 AC7 Local Flatness Gap を形式化する

### DIFF
--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -4,3 +4,4 @@ import Formal.AG.Cohomology.CechComplex
 import Formal.AG.Cohomology.Cohomology
 import Formal.AG.Cohomology.FinitePosetComparison
 import Formal.AG.Cohomology.GluingMismatch
+import Formal.AG.Cohomology.LocalFlatnessGap

--- a/Formal/AG/Cohomology/LocalFlatnessGap.lean
+++ b/Formal/AG/Cohomology/LocalFlatnessGap.lean
@@ -1,0 +1,188 @@
+import Formal.AG.Cohomology.GluingMismatch
+
+noncomputable section
+
+namespace AAT.AG
+namespace Cohomology
+
+universe u v w
+
+/-- IV.R5: the zero class in cover-relative `H^1(𝒰, Ob_U)`. -/
+def h1ZeroCocycle {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} (K : CoverRelativeCechComplex 𝒰 Ob) :
+    K.CechCocycle 1 :=
+  letI := K.cochainAddCommGroup 1
+  letI := K.cochainAddCommGroup 2
+  ⟨0, by simp [CoverRelativeCechComplex.d]⟩
+
+/-- IV.R5: zero element of the selected cover-relative `H^1`. -/
+def h1ZeroClass {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} (K : CoverRelativeCechComplex 𝒰 Ob) :
+    K.CoverRelativeHn 1 :=
+  K.cohomologyClassSucc 0 (h1ZeroCocycle K)
+
+/--
+IV.定義6.1 / 6.2: hidden coupling cocycle and class.
+
+The hidden coupling class is the R4 descent obstruction class, read with the
+selected gluing mismatch cocycle proof.  This layer does not assert that the
+class is nonzero; nonvanishing is an explicit theorem hypothesis.
+-/
+structure HiddenCouplingData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} (M : GluingMismatchData Ob D)
+    (K : CoverRelativeCechComplex 𝒰 Ob) where
+  cocycleProof :
+    letI := K.cochainAddCommGroup 2
+    K.d 1 M.gluingMismatchCochain = 0
+
+namespace HiddenCouplingData
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+variable {M : GluingMismatchData Ob D}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+
+/-- IV.定義6.1: hidden coupling cocycle `hc_U(X)` as a Čech 1-cocycle. -/
+def hiddenCouplingCocycle (H : HiddenCouplingData M K) :
+    K.CechCocycle 1 :=
+  descentCocycle M K H.cocycleProof
+
+/-- IV.定義6.2: hidden coupling class `[hc_U(X)] ∈ H^1(𝒰, Ob_U)`. -/
+def hiddenCouplingClass (H : HiddenCouplingData M K) :
+    K.CoverRelativeHn 1 :=
+  descentObstructionClass M K H.cocycleProof
+
+end HiddenCouplingData
+
+/--
+IV.定理7.1 hypothesis package: a global lawful section compatible with the
+selected local sections.
+
+This is the statement-level object whose nonexistence is concluded by
+Theorem 7.1: a selected U-adequate cover, a global lawful section factoring
+through `Flat_U(X)`, and explicit compatibility with the chosen local sections.
+It does not by itself include a coboundary witness; that soundness step is a
+separate assumption package below.
+-/
+structure CompatibleGlobalLawfulSection {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} (H : HiddenCouplingData M K) where
+  uAdequateCover : Prop
+  uAdequateCover_holds : uAdequateCover
+  globalSection :
+    LawAlgebra.LawfulLocus.LawfulSectionData.{v, w} R IOb
+  globalLawful : globalSection.Lawful
+  restrictsToLocalSections : Prop
+  restrictsToLocalSections_holds : restrictsToLocalSections
+
+namespace CompatibleGlobalLawfulSection
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+variable {M : GluingMismatchData Ob D}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+variable {H : HiddenCouplingData M K}
+
+/-- IV.定理7.1 hypothesis: the global section factors through `Flat_U`. -/
+def globalFactorsThroughFlat_U (G : CompatibleGlobalLawfulSection H) :
+    G.globalSection.FactorsThroughLawfulLocus :=
+  LawAlgebra.LawfulLocus.LawfulSectionData.factorsThroughLawfulLocus_of_lawful R
+    G.globalLawful
+
+end CompatibleGlobalLawfulSection
+
+/--
+IV.定理7.1 soundness assumption: compatible global lawful sections produce
+Čech coboundaries.
+
+This is the formal bridge for the proof sentence "if a global section exists,
+then the mismatch is a coboundary".  It is explicit because this PRD layer does
+not construct a general descent theorem for all covers.
+-/
+structure GlobalSectionCoboundarySoundness {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} (H : HiddenCouplingData M K) where
+  coboundaryWitness : K.Cn 0
+  mismatch_eq_coboundary :
+    M.gluingMismatchCochain = K.d 0 coboundaryWitness
+
+namespace GlobalSectionCoboundarySoundness
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+variable {M : GluingMismatchData Ob D}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+variable {H : HiddenCouplingData M K}
+
+/--
+IV.定理7.1 proof step: a compatible global lawful section makes the hidden
+coupling class vanish.
+-/
+theorem hiddenCouplingClass_eq_zero
+    (B : GlobalSectionCoboundarySoundness H) :
+    H.hiddenCouplingClass = h1ZeroClass K := by
+  letI := K.cochainAddCommGroup 0
+  letI := K.cochainAddCommGroup 1
+  letI := K.cochainAddCommGroup 2
+  apply Quotient.sound
+  refine ⟨B.coboundaryWitness, ?_⟩
+  change M.gluingMismatchCochain - 0 = K.d 0 B.coboundaryWitness
+  rw [sub_zero, B.mismatch_eq_coboundary]
+
+end GlobalSectionCoboundarySoundness
+
+/--
+IV.定理7.1 assumption package: global-to-coboundary soundness for the selected
+local flatness setup.
+-/
+structure LocalFlatnessGapHypotheses {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} (H : HiddenCouplingData M K) where
+  coboundarySoundness :
+    CompatibleGlobalLawfulSection.{u, v, w} H -> GlobalSectionCoboundarySoundness H
+
+/--
+IV.定理7.1: Local Flatness Gap.
+
+If the selected hidden coupling class is nonzero, then no global lawful section
+can both factor through `Flat_U(X)` and restrict to the chosen local sections.
+The statement is the contrapositive of the explicit coboundary step above and
+does not claim global descent or construct nonzero classes.
+-/
+theorem localFlatnessGap_no_globalLawfulSection
+    {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} (H : HiddenCouplingData M K)
+    (Hyp : LocalFlatnessGapHypotheses.{u, v, w} H)
+    (h_nonzero : H.hiddenCouplingClass ≠ h1ZeroClass K) :
+    ¬ Nonempty (CompatibleGlobalLawfulSection.{u, v, w} H) := by
+  intro hglobal
+  rcases hglobal with ⟨G⟩
+  exact h_nonzero (Hyp.coboundarySoundness G).hiddenCouplingClass_eq_zero
+
+end Cohomology
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4595,11 +4595,12 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/CechComplex.lean`,
 `Formal/AG/Cohomology/Cohomology.lean`,
 `Formal/AG/Cohomology/FinitePosetComparison.lean`,
-`Formal/AG/Cohomology/GluingMismatch.lean`.
+`Formal/AG/Cohomology/GluingMismatch.lean`,
+`Formal/AG/Cohomology/LocalFlatnessGap.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
-poset 比較 target、AC5/R3、AC6/R4 に対応する entrypoint である。現時点では
+poset 比較 target、AC5/R3、AC6/R4、AC7/R5 に対応する entrypoint である。現時点では
 `Formal/AG/Cohomology` を build 対象へ追加し、PRD-2 `Site` と PRD-3
 `LawAlgebra` への prerequisite package、obstruction coefficient sheaf carrier、
 `O_X^U`-module valued coefficient surface、`Def_U = I_U`、`ConDef_U = I_U/I_U^2`
@@ -4610,7 +4611,9 @@ cover-relative Cech complex package、`d ∘ d = 0` witness、positive degree
 finite-poset surface を明示 comparison data の下で PRD-4 comparison target として
 読む package、local lawful section data、parameterized gluing mismatch、
 pseudo-torsor 正規化による cocycle 自動成立補題、descent obstruction class
-`[g] in H^1(𝒰, Ob_U)` までを Lean 上に置く。
+`[g] in H^1(𝒰, Ob_U)`、hidden coupling class、compatible global lawful
+section から coboundary / zero class を得る step、および Local Flatness Gap
+の対偶 theorem までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4621,16 +4624,18 @@ pseudo-torsor 正規化による cocycle 自動成立補題、descent obstructio
 | `IV.定義4.1` | `AAT.AG.Cohomology.CoverRelativeCechComplex.CechCocycle`, `CechCoboundarySetoidSucc`, `CechCohomologySucc`, `CechCohomologyZero`, `CoverRelativeHn`, `cohomologyClassSucc`, `CechToSheafComparisonHypothesis`, `RefinementSystemHypothesis`, `SpaceCohomologyNotationJustification`, `ConditionalSpaceCohomology`, `ConditionalSpaceCohomology.HnX`, `ConditionalSpaceCohomology.HnX_eq_coverRelative` | `def` / `abbrev` / `structure` / `inductive` / `theorem` | cover-relative `H^n(𝒰, Ob_U)` を一次対象として置き、positive degree は cocycle kernel を previous differential image で割る quotient として読む。`H^n(X, Ob_U)` は Cech-to-sheaf comparison または refinement system を明示する条件付き notation package に限る。 | `defined only` / `proved accessor` |
 | `IV.R2 finite-poset comparison` | `AAT.AG.Cohomology.finitePosetCoverRelativeCover`, `FinitePosetCechComparisonData`, `FinitePosetCechComparisonData.generalComplex`, `FinitePosetCechComparisonData.comparisonTarget`, `FinitePosetCechComparisonData.cochain_to_from`, `FinitePosetCechComparisonData.differential_compatible`, `FinitePosetCechComparisonData.cohomology_target_eq`, `FinitePosetCechComparisonData.cohomology_to_from`, `FinitePosetCechComparisonData.cohomology_from_to` | `def` / `structure` / `theorem` | PRD-2 finite poset Cech complex から PRD-4 cover-relative cover を作り、明示された coefficient / additive / cochain equivalence / quotient relation data の下で PRD-4 `FinitePosetComparisonTarget` として読む。differential compatibility、finite-poset cohomology target、selected cohomology maps の round-trip laws を accessor theorem として公開する。 | `proved under explicit comparison data` |
 | `IV.定義5.1-5.3 / 原則5.2A` | `AAT.AG.Cohomology.LocalFlatnessData`, `LocalFlatnessData.factorsThroughFlat_U`, `LocalFlatnessData.pulledObstructionIdeal_eq_bot`, `RestrictedLocalLawfulSection`, `RestrictedLocalLawfulSection.factorsThroughFlat_U`, `GluingMismatchData`, `GluingMismatchData.value`, `GluingMismatchData.gluingMismatchCochain`, `GluingMismatchData.gluingMismatchCochain_apply`, `GluingMismatchData.leftRestriction_holds`, `GluingMismatchData.rightRestriction_holds`, `PseudoTorsorNormalizedMismatch`, `PseudoTorsorNormalizedMismatch.readMismatch_gluingMismatch`, `PseudoTorsorNormalizedMismatch.triple_mismatch_sum_zero`, `PseudoTorsorNormalizedMismatch.gluingMismatch_cocycle`, `descentCocycle`, `descentObstructionClass`, `descentObstructionClassOfPseudoTorsor` | `structure` / `def` / `theorem` | PRD-3 lawful section surface に基づく local flatness data、overlap 上の selected restricted lawful section、選択された比較写像による gluing mismatch cochain、abelian pseudo-torsor 正規化で mismatch cochain が `g_ij = s_j - s_i` 型の差分 carrier へ読まれ、triple-overlap sum が消えること、および既存 cover-relative `H^1(𝒰, Ob_U)` に入る descent obstruction class を定義する。Čech differential が triple sum zero を cocycle に読む方向は selected package の明示 field に相対化する。 | `defined only` / `proved accessor` |
+| `IV.定義6.1 / 6.2 / 定理7.1` | `AAT.AG.Cohomology.h1ZeroCocycle`, `h1ZeroClass`, `HiddenCouplingData`, `HiddenCouplingData.hiddenCouplingCocycle`, `HiddenCouplingData.hiddenCouplingClass`, `CompatibleGlobalLawfulSection`, `CompatibleGlobalLawfulSection.globalFactorsThroughFlat_U`, `GlobalSectionCoboundarySoundness`, `GlobalSectionCoboundarySoundness.hiddenCouplingClass_eq_zero`, `LocalFlatnessGapHypotheses`, `localFlatnessGap_no_globalLawfulSection` | `def` / `structure` / `theorem` | R4 の descent obstruction class を hidden coupling cocycle / class として読む。U-adequate cover・global lawful section・local restriction compatibility を持つ compatible global lawful section を statement-level object とし、global section から coboundary witness を得る soundness は明示 hypothesis として分離する。定理7.1 は hidden coupling class 非零なら compatible global lawful section は存在しない、という対偶 theorem として証明する。 | `proved under explicit compatibility data` |
 
 Non-conclusions: この entrypoint は obstruction coefficient sheaf carrier、module-valued
 coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 package、
 一般 site の cover-relative Cech complex package、`d ∘ d = 0` witness、
 cover-relative cohomology notation、条件付き space-level notation、明示 comparison
 data 下の finite-poset target、R4 の local flatness / gluing mismatch / pseudo-torsor
-normalized cocycle / descent class surface だけを示す。任意の finite-poset regime が
+normalized cocycle / descent class surface、R5 の explicit compatibility data 下の
+Local Flatness Gap theorem だけを示す。任意の finite-poset regime が
 自動的に obstruction sheaf comparison data を持つこと、descent class の非零性や
-coboundary 判定、Local Flatness Gap、Boundary Residue、Cohomological Flatness
-Criterion、derived category、cotangent complex、`Ext^1` はまだ形式化しない。
+非零 hidden coupling class の具体例、一般 descent theorem、Boundary Residue、
+Cohomological Flatness Criterion、derived category、cotangent complex、`Ext^1` はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -795,7 +795,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/CechComplex.lean`,
 `Formal/AG/Cohomology/Cohomology.lean`,
 `Formal/AG/Cohomology/FinitePosetComparison.lean`,
-`Formal/AG/Cohomology/GluingMismatch.lean`.
+`Formal/AG/Cohomology/GluingMismatch.lean`,
+`Formal/AG/Cohomology/LocalFlatnessGap.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 は AC1/R0 と AC2/R1 から着手している。Issue
@@ -808,7 +809,9 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 [#2049](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2049)
 では PRD-2 finite-poset Cech surface との比較 target を追加した。Issue
 [#2051](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2051)
-では gluing mismatch、pseudo-torsor normalized cocycle、descent obstruction class を追加する。
+では gluing mismatch、pseudo-torsor normalized cocycle、descent obstruction class を追加した。Issue
+[#2054](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2054)
+では hidden coupling class と Local Flatness Gap theorem を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -819,6 +822,7 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 | `IV.定義4.1` Cover-relative and conditional cohomology notation | `defined only` / `proved accessor`. `CechCocycle`、`CechCoboundarySetoidSucc`、`CechCohomologySucc`、`CoverRelativeHn`、`CechToSheafComparisonHypothesis`、`RefinementSystemHypothesis`、`ConditionalSpaceCohomology`、`HnX_eq_coverRelative` を持つ。 | `H^n(X, Ob_U)` は比較仮定または refinement system を持つ条件付き notation に限る。無条件 sheaf cohomology は構成しない。 |
 | `IV.R2 / AC4` PRD-2 finite-poset comparison | `proved under explicit comparison data`. `Formal/AG/Cohomology/FinitePosetComparison.lean` が `finitePosetCoverRelativeCover`、`FinitePosetCechComparisonData`、`generalComplex`、`comparisonTarget`、`cochain_to_from`、`differential_compatible`、`cohomology_target_eq`、`cohomology_to_from`、`cohomology_from_to` を持つ。 | PRD-2 Type-valued coefficient surface と PRD-4 additive obstruction sheaf surface の同一視、加法構造、cochain equivalence、cohomology quotient relation、cohomology map round-trip laws は明示 data として扱う。任意の finite-poset regime がその data を自動的に持つとは主張しない。 |
 | `IV.定義5.1-5.3 / 原則5.2A` Gluing mismatch and descent class | `defined only` / `proved accessor`. `Formal/AG/Cohomology/GluingMismatch.lean` が `LocalFlatnessData`、`RestrictedLocalLawfulSection`、`GluingMismatchData`、`PseudoTorsorNormalizedMismatch`、`readMismatch_gluingMismatch`、`triple_mismatch_sum_zero`、`gluingMismatch_cocycle`、`descentObstructionClass` を持つ。 | restriction と Čech differential compatibility は selected package の明示 field に相対化する。descent class の非零性、coboundary 判定、global lawful section の不存在は R5 以降に残す。 |
+| `IV.定義6.1 / 6.2 / 定理7.1` Hidden coupling and Local Flatness Gap | `proved under explicit compatibility data`. `Formal/AG/Cohomology/LocalFlatnessGap.lean` が `HiddenCouplingData`、`hiddenCouplingCocycle`、`hiddenCouplingClass`、`CompatibleGlobalLawfulSection`、`GlobalSectionCoboundarySoundness`、`hiddenCouplingClass_eq_zero`、`LocalFlatnessGapHypotheses`、`localFlatnessGap_no_globalLawfulSection` を持つ。 | global compatible lawful section は statement-level object として分離し、global section から coboundary witness を得る soundness は明示 hypothesis として扱う。hidden coupling class の具体的非零例、一般 descent theorem、R6 Boundary Residue はまだ主張しない。 |
 
 第IV部 PRD-4 の証明対象ラベルは次の現在状態である。
 
@@ -831,7 +835,7 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 | `IV.定義3.1-3.3 / R2` | `defined only` / `proved d_comp_d accessor`; PRD-2 finite-poset comparison target and selected cohomology round-trip laws are `proved under explicit comparison data` |
 | `IV.定義4.1 / R3` | `defined only` / `proved accessor under explicit comparison or refinement assumptions` |
 | `IV.定義5.1-5.3 / R4` | `defined only` / `proved pseudo-torsor cocycle accessor under explicit normalization data` |
-| `IV.定理7.1` | `future proof obligation` |
+| `IV.定理7.1` | `proved under explicit compatibility data` |
 | `IV.定理9.2` | `future proof obligation` |
 | `IV.定理11.1 / 系11.2` | `future proof obligation` |
 | `IV.定理12.2 / 系12.3 / 定理12.4 / 系12.5` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #2054

PRD-4 AC7/R5 に対応して、hidden coupling class と Local Flatness Gap theorem の Lean surface を追加しました。

- R4 の `descentObstructionClass` を `HiddenCouplingData.hiddenCouplingClass` として読む surface を追加
- `CompatibleGlobalLawfulSection` で U-adequate cover、global lawful section、local restriction compatibility を statement-level object として定義
- `GlobalSectionCoboundarySoundness` と `LocalFlatnessGapHypotheses` で「compatible global section があれば mismatch は coboundary」を明示 hypothesis として分離
- `hiddenCouplingClass_eq_zero` で coboundary witness から hidden coupling class が zero になることを証明
- `localFlatnessGap_no_globalLawfulSection` で hidden coupling class 非零なら compatible global lawful section が存在しないことを対偶 theorem として証明
- `lean_theorem_index.md` と `proof_obligations.md` の PRD-4 ledger を AC7/R5 まで同期

claim boundary として、非零 hidden coupling class の具体例、一般 descent theorem、Boundary Residue、Cohomological Flatness Criterion は主張していません。

## 証明した定理

- `GlobalSectionCoboundarySoundness.hiddenCouplingClass_eq_zero`
- `localFlatnessGap_no_globalLawfulSection`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Cohomology/LocalFlatnessGap.lean`
- [x] `lake env lean Formal/AG/Cohomology.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`（既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207` の linter warning のみ）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない