### PR TITLE
PRD-4 AC8 boundary holonomy を定義する

### DIFF
--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -5,3 +5,4 @@ import Formal.AG.Cohomology.Cohomology
 import Formal.AG.Cohomology.FinitePosetComparison
 import Formal.AG.Cohomology.GluingMismatch
 import Formal.AG.Cohomology.LocalFlatnessGap
+import Formal.AG.Cohomology.BoundaryHolonomy

--- a/Formal/AG/Cohomology/BoundaryHolonomy.lean
+++ b/Formal/AG/Cohomology/BoundaryHolonomy.lean
@@ -1,0 +1,274 @@
+import Formal.AG.Cohomology.LocalFlatnessGap
+
+noncomputable section
+
+namespace AAT.AG
+namespace Cohomology
+
+universe u
+
+open CategoryTheory
+open Opposite
+
+/--
+IV.定義8.1: two-chart feature-extension cover.
+
+`extension` is the ambient feature-extension object `C'`, `core` is
+`C_core`, `feature` is `F`, and `boundary` is the overlap `B = C_core ∩ F`.
+The pullback/intersection construction is selected data at this layer.
+-/
+structure TwoChartFeatureExtensionCover {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} (S : Site.AATSite A) where
+  extension : S.category
+  core : S.category
+  feature : S.category
+  boundary : S.category
+  coreInclusion : core ⟶ extension
+  featureInclusion : feature ⟶ extension
+  boundaryToCore : boundary ⟶ core
+  boundaryToFeature : boundary ⟶ feature
+  extension_is_union : Prop
+  extension_is_union_holds : extension_is_union
+  boundary_is_intersection : Prop
+  boundary_is_intersection_holds : boundary_is_intersection
+
+namespace TwoChartFeatureExtensionCover
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A}
+
+/-- IV.定義8.1: the boundary object `B = C_core ∩ F`. -/
+def boundaryObject (E : TwoChartFeatureExtensionCover S) : S.category :=
+  E.boundary
+
+/-- IV.定義8.1: the ambient feature-extension object `C' = C_core ∪ F`. -/
+def extensionObject (E : TwoChartFeatureExtensionCover S) : S.category :=
+  E.extension
+
+end TwoChartFeatureExtensionCover
+
+/-- IV.定義8.2: boundary coefficient object `Ob_B`. -/
+abbrev BoundaryCoefficient {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (Ob : ObstructionSheaf S)
+    (E : TwoChartFeatureExtensionCover S) :=
+  Ob.carrier.toPresheaf.obj (op E.boundary)
+
+/-- IV.定義8.3: core-side coefficient object for the two-chart Čech complex. -/
+abbrev CoreCoefficient {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (Ob : ObstructionSheaf S)
+    (E : TwoChartFeatureExtensionCover S) :=
+  Ob.carrier.toPresheaf.obj (op E.core)
+
+/-- IV.定義8.3: feature-side coefficient object for the two-chart Čech complex. -/
+abbrev FeatureCoefficient {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (Ob : ObstructionSheaf S)
+    (E : TwoChartFeatureExtensionCover S) :=
+  Ob.carrier.toPresheaf.obj (op E.feature)
+
+/-- IV.定義8.2: boundary mismatch section `b_U ∈ H^0(B, Ob_B)`. -/
+structure BoundaryMismatchSection {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (Ob : ObstructionSheaf S)
+    (E : TwoChartFeatureExtensionCover S) where
+  value : BoundaryCoefficient Ob E
+  boundaryWitnessCoverage : Prop
+  boundaryWitnessCoverage_holds : boundaryWitnessCoverage
+
+namespace BoundaryMismatchSection
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A}
+variable {Ob : ObstructionSheaf S}
+variable {E : TwoChartFeatureExtensionCover S}
+
+/-- IV.定義8.2: read the underlying boundary mismatch value. -/
+def b_U (b : BoundaryMismatchSection Ob E) : BoundaryCoefficient Ob E :=
+  b.value
+
+end BoundaryMismatchSection
+
+/--
+IV.定義8.3: concrete two-chart Čech boundary complex.
+
+For the feature-extension cover, degree zero is
+`C^0 = Ob(C_core) × Ob(F)` and degree one is `C^1 = Ob(B)`.  The selected
+boundary differential is the difference of the core and feature restrictions
+to the boundary object.
+-/
+structure TwoChartCechBoundaryComplex {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    (Ob : ObstructionSheaf S) (E : TwoChartFeatureExtensionCover S) where
+  coreRestrictionToBoundary :
+    CoreCoefficient Ob E →+ BoundaryCoefficient Ob E
+  featureRestrictionToBoundary :
+    FeatureCoefficient Ob E →+ BoundaryCoefficient Ob E
+
+namespace TwoChartCechBoundaryComplex
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A}
+variable {Ob : ObstructionSheaf S}
+variable {E : TwoChartFeatureExtensionCover S}
+
+/-- IV.定義8.3: degree-zero two-chart cochains. -/
+abbrev C0 (_T : TwoChartCechBoundaryComplex Ob E) : Type u :=
+  CoreCoefficient Ob E × FeatureCoefficient Ob E
+
+/-- IV.定義8.3: degree-one two-chart cochains on the boundary. -/
+abbrev C1 (_T : TwoChartCechBoundaryComplex Ob E) : Type u :=
+  BoundaryCoefficient Ob E
+
+/-- IV.定義8.3: `d^0(s_core, s_feature) = s_feature|_B - s_core|_B`. -/
+def d0 (T : TwoChartCechBoundaryComplex Ob E) :
+    letI := Ob.addCommGroup E.core
+    letI := Ob.addCommGroup E.feature
+    letI := Ob.addCommGroup E.boundary
+    T.C0 →+ T.C1 :=
+  letI := Ob.addCommGroup E.core
+  letI := Ob.addCommGroup E.feature
+  letI := Ob.addCommGroup E.boundary
+  {
+    toFun := fun s =>
+      T.featureRestrictionToBoundary s.2 - T.coreRestrictionToBoundary s.1
+    map_zero' := by
+      simp
+    map_add' := by
+      intro s t
+      rcases s with ⟨s_core, s_feature⟩
+      rcases t with ⟨t_core, t_feature⟩
+      simp [sub_eq_add_neg, add_comm, add_left_comm, add_assoc]
+  }
+
+/-- IV.定義8.3: the two-chart differential has the selected boundary-difference form. -/
+theorem d0_apply (T : TwoChartCechBoundaryComplex Ob E) (s : T.C0) :
+    T.d0 s = T.featureRestrictionToBoundary s.2 - T.coreRestrictionToBoundary s.1 :=
+  rfl
+
+end TwoChartCechBoundaryComplex
+
+/--
+IV.定義8.3: two-chart Čech connecting homomorphism package.
+
+The `twoChartCech` field records the concrete `C^0 = Ob(C_core) × Ob(F)` and
+`C^1 = Ob(B)` boundary differential.  The map `delta` is then supplied as a
+selected Čech-level connecting map `H^0(B, Ob_B) -> C^1(C', Ob_C')`, together
+with the proof that its values are 1-cocycles.  This is the concrete two-chart
+Čech representation; it does not construct a derived Mayer-Vietoris triangle.
+-/
+structure TwoChartConnectingHomomorphism {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    (Ob : ObstructionSheaf S) (E : TwoChartFeatureExtensionCover S)
+    {𝒰 : CoverRelativeCechCover S}
+    (K : CoverRelativeCechComplex 𝒰 Ob) where
+  extensionCover_base :
+    𝒰.base = E.extension
+  twoChartCech :
+    TwoChartCechBoundaryComplex Ob E
+  boundaryRestrictionSource :
+    BoundaryCoefficient Ob E -> K.Cn 1
+  deltaCochain :
+    BoundaryCoefficient Ob E -> K.Cn 1
+  deltaCochain_zero :
+    letI := Ob.addCommGroup E.boundary
+    letI := K.cochainAddCommGroup 1
+    deltaCochain 0 = 0
+  deltaCochain_add :
+    ∀ b c : BoundaryCoefficient Ob E,
+      letI := Ob.addCommGroup E.boundary
+      letI := K.cochainAddCommGroup 1
+      deltaCochain (b + c) = deltaCochain b + deltaCochain c
+  deltaCochain_eq_boundaryRestrictionSource :
+    ∀ b : BoundaryCoefficient Ob E,
+      deltaCochain b = boundaryRestrictionSource b
+  delta_cocycle :
+    ∀ b : BoundaryCoefficient Ob E,
+      letI := K.cochainAddCommGroup 1
+      letI := K.cochainAddCommGroup 2
+      K.d 1 (deltaCochain b) = 0
+  cohomologyAddCommGroup :
+    AddCommGroup (K.CoverRelativeHn 1)
+  deltaCohomologyHom :
+    letI := Ob.addCommGroup E.boundary
+    letI := cohomologyAddCommGroup
+    BoundaryCoefficient Ob E →+ K.CoverRelativeHn 1
+  deltaCohomologyHom_eq_class :
+    ∀ b : BoundaryCoefficient Ob E,
+      letI := K.cochainAddCommGroup 1
+      letI := K.cochainAddCommGroup 2
+      letI := cohomologyAddCommGroup
+      deltaCohomologyHom b =
+        K.cohomologyClassSucc 0 ⟨deltaCochain b, delta_cocycle b⟩
+
+namespace TwoChartConnectingHomomorphism
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A}
+variable {Ob : ObstructionSheaf S}
+variable {E : TwoChartFeatureExtensionCover S}
+variable {𝒰 : CoverRelativeCechCover S}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+
+/-- IV.定義8.3: connecting homomorphism on boundary sections. -/
+def delta (D : TwoChartConnectingHomomorphism Ob E K) :
+    letI := Ob.addCommGroup E.boundary
+    letI := K.cochainAddCommGroup 1
+    BoundaryCoefficient Ob E →+ K.Cn 1 :=
+  letI := Ob.addCommGroup E.boundary
+  letI := K.cochainAddCommGroup 1
+  {
+    toFun := D.deltaCochain
+    map_zero' := D.deltaCochain_zero
+    map_add' := D.deltaCochain_add
+  }
+
+/-- IV.定義8.3: the connecting cochain is the selected boundary restriction. -/
+theorem delta_eq_boundaryRestrictionSource
+    (D : TwoChartConnectingHomomorphism Ob E K) (b : BoundaryCoefficient Ob E) :
+    D.delta b = D.boundaryRestrictionSource b :=
+  D.deltaCochain_eq_boundaryRestrictionSource b
+
+/-- IV.定義8.3: `delta(b)` is a selected Čech 1-cocycle. -/
+def deltaCocycle (D : TwoChartConnectingHomomorphism Ob E K)
+    (b : BoundaryCoefficient Ob E) :
+    K.CechCocycle 1 :=
+  letI := K.cochainAddCommGroup 1
+  letI := K.cochainAddCommGroup 2
+  ⟨D.delta b, D.delta_cocycle b⟩
+
+/-- IV.定義8.3: `delta : H^0(B, Ob_B) -> H^1(C', Ob_C')`. -/
+def deltaClass (D : TwoChartConnectingHomomorphism Ob E K)
+    (b : BoundaryCoefficient Ob E) :
+    K.CoverRelativeHn 1 :=
+  K.cohomologyClassSucc 0 (D.deltaCocycle b)
+
+/-- IV.定義8.3: class-level connecting homomorphism `H^0(B, Ob_B) -> H^1(C', Ob_C')`. -/
+def deltaH1 (D : TwoChartConnectingHomomorphism Ob E K) :
+    letI := Ob.addCommGroup E.boundary
+    letI := D.cohomologyAddCommGroup
+    BoundaryCoefficient Ob E →+ K.CoverRelativeHn 1 :=
+  letI := Ob.addCommGroup E.boundary
+  letI := D.cohomologyAddCommGroup
+  D.deltaCohomologyHom
+
+/-- IV.定義8.3: the class-level homomorphism agrees with the selected cocycle class. -/
+theorem deltaH1_eq_deltaClass
+    (D : TwoChartConnectingHomomorphism Ob E K) (b : BoundaryCoefficient Ob E) :
+    D.deltaH1 b = D.deltaClass b := by
+  exact D.deltaCohomologyHom_eq_class b
+
+/-- IV.定義8.3: boundary holonomy `Hol_U = delta(b_U)`. -/
+def boundaryHolonomy (D : TwoChartConnectingHomomorphism Ob E K)
+    (b : BoundaryMismatchSection Ob E) :
+    K.CoverRelativeHn 1 :=
+  D.deltaH1 b.b_U
+
+/-- IV.定義8.3: boundary holonomy agrees with the selected connecting class. -/
+theorem boundaryHolonomy_eq_delta
+    (D : TwoChartConnectingHomomorphism Ob E K)
+    (b : BoundaryMismatchSection Ob E) :
+    D.boundaryHolonomy b = D.deltaClass b.b_U :=
+  D.deltaH1_eq_deltaClass b.b_U
+
+end TwoChartConnectingHomomorphism
+
+end Cohomology
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4596,11 +4596,12 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/Cohomology.lean`,
 `Formal/AG/Cohomology/FinitePosetComparison.lean`,
 `Formal/AG/Cohomology/GluingMismatch.lean`,
-`Formal/AG/Cohomology/LocalFlatnessGap.lean`.
+`Formal/AG/Cohomology/LocalFlatnessGap.lean`,
+`Formal/AG/Cohomology/BoundaryHolonomy.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
-poset 比較 target、AC5/R3、AC6/R4、AC7/R5 に対応する entrypoint である。現時点では
+poset 比較 target、AC5/R3、AC6/R4、AC7/R5、AC8/R6 first half に対応する entrypoint である。現時点では
 `Formal/AG/Cohomology` を build 対象へ追加し、PRD-2 `Site` と PRD-3
 `LawAlgebra` への prerequisite package、obstruction coefficient sheaf carrier、
 `O_X^U`-module valued coefficient surface、`Def_U = I_U`、`ConDef_U = I_U/I_U^2`
@@ -4613,7 +4614,8 @@ finite-poset surface を明示 comparison data の下で PRD-4 comparison target
 pseudo-torsor 正規化による cocycle 自動成立補題、descent obstruction class
 `[g] in H^1(𝒰, Ob_U)`、hidden coupling class、compatible global lawful
 section から coboundary / zero class を得る step、および Local Flatness Gap
-の対偶 theorem までを Lean 上に置く。
+の対偶 theorem、2-chart feature-extension cover、boundary mismatch section、
+selected Čech-level connecting homomorphism、boundary holonomy class までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4625,6 +4627,7 @@ section から coboundary / zero class を得る step、および Local Flatness
 | `IV.R2 finite-poset comparison` | `AAT.AG.Cohomology.finitePosetCoverRelativeCover`, `FinitePosetCechComparisonData`, `FinitePosetCechComparisonData.generalComplex`, `FinitePosetCechComparisonData.comparisonTarget`, `FinitePosetCechComparisonData.cochain_to_from`, `FinitePosetCechComparisonData.differential_compatible`, `FinitePosetCechComparisonData.cohomology_target_eq`, `FinitePosetCechComparisonData.cohomology_to_from`, `FinitePosetCechComparisonData.cohomology_from_to` | `def` / `structure` / `theorem` | PRD-2 finite poset Cech complex から PRD-4 cover-relative cover を作り、明示された coefficient / additive / cochain equivalence / quotient relation data の下で PRD-4 `FinitePosetComparisonTarget` として読む。differential compatibility、finite-poset cohomology target、selected cohomology maps の round-trip laws を accessor theorem として公開する。 | `proved under explicit comparison data` |
 | `IV.定義5.1-5.3 / 原則5.2A` | `AAT.AG.Cohomology.LocalFlatnessData`, `LocalFlatnessData.factorsThroughFlat_U`, `LocalFlatnessData.pulledObstructionIdeal_eq_bot`, `RestrictedLocalLawfulSection`, `RestrictedLocalLawfulSection.factorsThroughFlat_U`, `GluingMismatchData`, `GluingMismatchData.value`, `GluingMismatchData.gluingMismatchCochain`, `GluingMismatchData.gluingMismatchCochain_apply`, `GluingMismatchData.leftRestriction_holds`, `GluingMismatchData.rightRestriction_holds`, `PseudoTorsorNormalizedMismatch`, `PseudoTorsorNormalizedMismatch.readMismatch_gluingMismatch`, `PseudoTorsorNormalizedMismatch.triple_mismatch_sum_zero`, `PseudoTorsorNormalizedMismatch.gluingMismatch_cocycle`, `descentCocycle`, `descentObstructionClass`, `descentObstructionClassOfPseudoTorsor` | `structure` / `def` / `theorem` | PRD-3 lawful section surface に基づく local flatness data、overlap 上の selected restricted lawful section、選択された比較写像による gluing mismatch cochain、abelian pseudo-torsor 正規化で mismatch cochain が `g_ij = s_j - s_i` 型の差分 carrier へ読まれ、triple-overlap sum が消えること、および既存 cover-relative `H^1(𝒰, Ob_U)` に入る descent obstruction class を定義する。Čech differential が triple sum zero を cocycle に読む方向は selected package の明示 field に相対化する。 | `defined only` / `proved accessor` |
 | `IV.定義6.1 / 6.2 / 定理7.1` | `AAT.AG.Cohomology.h1ZeroCocycle`, `h1ZeroClass`, `HiddenCouplingData`, `HiddenCouplingData.hiddenCouplingCocycle`, `HiddenCouplingData.hiddenCouplingClass`, `CompatibleGlobalLawfulSection`, `CompatibleGlobalLawfulSection.globalFactorsThroughFlat_U`, `GlobalSectionCoboundarySoundness`, `GlobalSectionCoboundarySoundness.hiddenCouplingClass_eq_zero`, `LocalFlatnessGapHypotheses`, `localFlatnessGap_no_globalLawfulSection` | `def` / `structure` / `theorem` | R4 の descent obstruction class を hidden coupling cocycle / class として読む。U-adequate cover・global lawful section・local restriction compatibility を持つ compatible global lawful section を statement-level object とし、global section から coboundary witness を得る soundness は明示 hypothesis として分離する。定理7.1 は hidden coupling class 非零なら compatible global lawful section は存在しない、という対偶 theorem として証明する。 | `proved under explicit compatibility data` |
+| `IV.定義8.1-8.3 / 9.1` | `AAT.AG.Cohomology.TwoChartFeatureExtensionCover`, `TwoChartFeatureExtensionCover.boundaryObject`, `TwoChartFeatureExtensionCover.extensionObject`, `BoundaryCoefficient`, `CoreCoefficient`, `FeatureCoefficient`, `BoundaryMismatchSection`, `BoundaryMismatchSection.b_U`, `TwoChartCechBoundaryComplex`, `TwoChartCechBoundaryComplex.C0`, `TwoChartCechBoundaryComplex.C1`, `TwoChartCechBoundaryComplex.d0`, `TwoChartCechBoundaryComplex.d0_apply`, `TwoChartConnectingHomomorphism`, `TwoChartConnectingHomomorphism.delta`, `TwoChartConnectingHomomorphism.delta_eq_boundaryRestrictionSource`, `TwoChartConnectingHomomorphism.deltaCocycle`, `TwoChartConnectingHomomorphism.deltaClass`, `TwoChartConnectingHomomorphism.deltaH1`, `TwoChartConnectingHomomorphism.deltaH1_eq_deltaClass`, `TwoChartConnectingHomomorphism.boundaryHolonomy`, `TwoChartConnectingHomomorphism.boundaryHolonomy_eq_delta` | `structure` / `abbrev` / `def` / `theorem` | 2-chart feature-extension cover `C' = C_core ∪ F` と boundary `B = C_core ∩ F` を selected cover data として記録し、`C^0 = Ob(C_core) × Ob(F)`、`C^1 = Ob(B)`、boundary differential `s_F|_B - s_core|_B`、boundary mismatch section `b_U ∈ H^0(B, Ob_B)`、selected Čech-level cochain map と selected class-level connecting homomorphism `δ : H^0(B, Ob_B) -> H^1(C', Ob_C')`、boundary holonomy `Hol_U = δ(b_U)` を既存 cover-relative Čech complex 上に置く。derived Mayer-Vietoris triangle と定理9.2 は主張しない。 | `defined only` / `proved accessor` |
 
 Non-conclusions: この entrypoint は obstruction coefficient sheaf carrier、module-valued
 coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 package、
@@ -4632,9 +4635,10 @@ coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 packag
 cover-relative cohomology notation、条件付き space-level notation、明示 comparison
 data 下の finite-poset target、R4 の local flatness / gluing mismatch / pseudo-torsor
 normalized cocycle / descent class surface、R5 の explicit compatibility data 下の
-Local Flatness Gap theorem だけを示す。任意の finite-poset regime が
+Local Flatness Gap theorem、R6 first half の 2-chart connecting homomorphism /
+boundary holonomy だけを示す。任意の finite-poset regime が
 自動的に obstruction sheaf comparison data を持つこと、descent class の非零性や
-非零 hidden coupling class の具体例、一般 descent theorem、Boundary Residue、
+非零 hidden coupling class の具体例、一般 descent theorem、Boundary Residue theorem / 定理9.2、
 Cohomological Flatness Criterion、derived category、cotangent complex、`Ext^1` はまだ形式化しない。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -796,7 +796,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/Cohomology.lean`,
 `Formal/AG/Cohomology/FinitePosetComparison.lean`,
 `Formal/AG/Cohomology/GluingMismatch.lean`,
-`Formal/AG/Cohomology/LocalFlatnessGap.lean`.
+`Formal/AG/Cohomology/LocalFlatnessGap.lean`,
+`Formal/AG/Cohomology/BoundaryHolonomy.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 は AC1/R0 と AC2/R1 から着手している。Issue
@@ -811,7 +812,9 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 [#2051](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2051)
 では gluing mismatch、pseudo-torsor normalized cocycle、descent obstruction class を追加した。Issue
 [#2054](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2054)
-では hidden coupling class と Local Flatness Gap theorem を追加した。
+では hidden coupling class と Local Flatness Gap theorem を追加した。Issue
+[#2056](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2056)
+では 2-chart connecting homomorphism と boundary holonomy を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -823,6 +826,7 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 | `IV.R2 / AC4` PRD-2 finite-poset comparison | `proved under explicit comparison data`. `Formal/AG/Cohomology/FinitePosetComparison.lean` が `finitePosetCoverRelativeCover`、`FinitePosetCechComparisonData`、`generalComplex`、`comparisonTarget`、`cochain_to_from`、`differential_compatible`、`cohomology_target_eq`、`cohomology_to_from`、`cohomology_from_to` を持つ。 | PRD-2 Type-valued coefficient surface と PRD-4 additive obstruction sheaf surface の同一視、加法構造、cochain equivalence、cohomology quotient relation、cohomology map round-trip laws は明示 data として扱う。任意の finite-poset regime がその data を自動的に持つとは主張しない。 |
 | `IV.定義5.1-5.3 / 原則5.2A` Gluing mismatch and descent class | `defined only` / `proved accessor`. `Formal/AG/Cohomology/GluingMismatch.lean` が `LocalFlatnessData`、`RestrictedLocalLawfulSection`、`GluingMismatchData`、`PseudoTorsorNormalizedMismatch`、`readMismatch_gluingMismatch`、`triple_mismatch_sum_zero`、`gluingMismatch_cocycle`、`descentObstructionClass` を持つ。 | restriction と Čech differential compatibility は selected package の明示 field に相対化する。descent class の非零性、coboundary 判定、global lawful section の不存在は R5 以降に残す。 |
 | `IV.定義6.1 / 6.2 / 定理7.1` Hidden coupling and Local Flatness Gap | `proved under explicit compatibility data`. `Formal/AG/Cohomology/LocalFlatnessGap.lean` が `HiddenCouplingData`、`hiddenCouplingCocycle`、`hiddenCouplingClass`、`CompatibleGlobalLawfulSection`、`GlobalSectionCoboundarySoundness`、`hiddenCouplingClass_eq_zero`、`LocalFlatnessGapHypotheses`、`localFlatnessGap_no_globalLawfulSection` を持つ。 | global compatible lawful section は statement-level object として分離し、global section から coboundary witness を得る soundness は明示 hypothesis として扱う。hidden coupling class の具体的非零例、一般 descent theorem、R6 Boundary Residue はまだ主張しない。 |
+| `IV.定義8.1-8.3 / 9.1` Boundary holonomy | `defined only` / `proved accessor`. `Formal/AG/Cohomology/BoundaryHolonomy.lean` が `TwoChartFeatureExtensionCover`、`BoundaryCoefficient`、`CoreCoefficient`、`FeatureCoefficient`、`BoundaryMismatchSection`、`TwoChartCechBoundaryComplex`、`d0`、`d0_apply`、`TwoChartConnectingHomomorphism`、`deltaCocycle`、`deltaClass`、`deltaH1`、`deltaH1_eq_deltaClass`、`boundaryHolonomy`、`boundaryHolonomy_eq_delta` を持つ。 | `C' = C_core ∪ F` と `B = C_core ∩ F` は selected 2-chart cover data として扱い、`C^0 = Ob(C_core) × Ob(F)`、`C^1 = Ob(B)`、`d^0 = s_F|_B - s_core|_B` を concrete Čech surface として記録する。connecting homomorphism は既存 cover-relative Čech complex 上の selected cochain map と selected class-level map であり、derived Mayer-Vietoris triangle、Boundary Residue theorem / 定理9.2 はまだ主張しない。 |
 
 第IV部 PRD-4 の証明対象ラベルは次の現在状態である。
 
@@ -836,6 +840,7 @@ PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_pr
 | `IV.定義4.1 / R3` | `defined only` / `proved accessor under explicit comparison or refinement assumptions` |
 | `IV.定義5.1-5.3 / R4` | `defined only` / `proved pseudo-torsor cocycle accessor under explicit normalization data` |
 | `IV.定理7.1` | `proved under explicit compatibility data` |
+| `IV.定義8.1-8.3 / 9.1` | `defined only` / `proved accessor` |
 | `IV.定理9.2` | `future proof obligation` |
 | `IV.定理11.1 / 系11.2` | `future proof obligation` |
 | `IV.定理12.2 / 系12.3 / 定理12.4 / 系12.5` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #2056

PRD-4 AC8/R6 first half として、2-chart feature-extension cover、boundary mismatch section、2-chart Čech boundary complex、selected class-level connecting homomorphism、boundary holonomy を `Formal/AG/Cohomology` に追加した。

定理9.2 Boundary Residue、derived Mayer-Vietoris triangle、一般 quotient group 構成は主張せず、explicit selected data として境界を残す。

## 証明した定理

- `TwoChartCechBoundaryComplex.d0_apply`
- `TwoChartConnectingHomomorphism.delta_eq_boundaryRestrictionSource`
- `TwoChartConnectingHomomorphism.deltaH1_eq_deltaClass`
- `TwoChartConnectingHomomorphism.boundaryHolonomy_eq_delta`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build Formal.AG.Cohomology.BoundaryHolonomy`
- [x] `lake env lean Formal/AG/Cohomology.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない