### PR TITLE
PRD-4 AC13 擬円周ゴールデン例を追加する

### DIFF
--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -10,3 +10,4 @@ import Formal.AG.Cohomology.BoundaryResidue
 import Formal.AG.Cohomology.HigherOverlap
 import Formal.AG.Cohomology.FlatnessCriterion
 import Formal.AG.Cohomology.CoverNerve
+import Formal.AG.Cohomology.FiniteExamples

--- a/Formal/AG/Cohomology/FiniteExamples.lean
+++ b/Formal/AG/Cohomology/FiniteExamples.lean
@@ -1,0 +1,192 @@
+import Formal.AG.Cohomology.CoverNerve
+import Formal.AG.Cohomology.LocalFlatnessGap
+import Mathlib.Data.ZMod.Basic
+
+noncomputable section
+
+namespace AAT.AG
+namespace Cohomology
+namespace FiniteExamples
+
+universe u v w
+
+namespace PseudoCircleGolden
+
+/--
+IV.R10 / AC13: three selected charts in the pseudo-circle boundary model.
+
+This is the Lean-side finite golden surface corresponding to the ArchSig v0.4.0
+R14 pseudo-circle fixture: local chart witnesses are individually lawful, the
+H0-style witness count is zero, but the cyclic boundary mismatch is represented
+by a nonzero selected H1 class.  The fixture correspondence is only a docstring
+boundary; this file does not import or validate ArchSig JSON.
+-/
+inductive Chart where
+  | A
+  | B
+  | C
+  deriving DecidableEq
+
+/-- IV.R10 / AC13: pairwise boundary overlaps around the pseudo-circle. -/
+inductive BoundaryEdge where
+  | AB
+  | BC
+  | CA
+  deriving DecidableEq
+
+/-- IV.R10 / AC13: source chart of a selected boundary overlap. -/
+def edgeLeft : BoundaryEdge -> Chart
+  | BoundaryEdge.AB => Chart.A
+  | BoundaryEdge.BC => Chart.B
+  | BoundaryEdge.CA => Chart.C
+
+/-- IV.R10 / AC13: target chart of a selected boundary overlap. -/
+def edgeRight : BoundaryEdge -> Chart
+  | BoundaryEdge.AB => Chart.B
+  | BoundaryEdge.BC => Chart.C
+  | BoundaryEdge.CA => Chart.A
+
+/-- IV.R10 / AC13: the selected pseudo-circle cover nerve has no triple face. -/
+def coverNerve : CoverNerve where
+  Chart := Chart
+  EdgeComponent := BoundaryEdge
+  FaceComponent := Empty
+  edgeLeft := edgeLeft
+  edgeRight := edgeRight
+  faceEdge0 := Empty.elim
+  faceEdge1 := Empty.elim
+  faceEdge2 := Empty.elim
+  edgeOverlapComponent := fun _ => True
+  faceTripleOverlapComponent := fun _ => False
+  edgeOverlapComponent_holds := fun _ => trivial
+  faceTripleOverlapComponent_holds := Empty.elim
+
+/-- IV.R10 / AC13: local chart lawfulness predicate for the selected example. -/
+def LocallyLawful (_chart : Chart) : Prop :=
+  True
+
+/-- IV.R10 / AC13: every chart is locally lawful. -/
+theorem each_chart_lawful (chart : Chart) : LocallyLawful chart :=
+  trivial
+
+/--
+IV.R10 / AC13: H0-style witness counting sees no obstruction.
+
+This is the "all local charts pass" reading.  It is intentionally separated
+from the H1 class below, so the example records the PRD distinction between
+local witness counting and gluing obstruction.
+-/
+def witnessCountingObstruction : Nat :=
+  0
+
+/-- IV.R10 / AC13: witness counting reports zero obstruction on the pseudo-circle. -/
+theorem h0_witness_counting_sees_no_obstruction :
+    witnessCountingObstruction = 0 :=
+  rfl
+
+/-- IV.R10 / AC13: selected finite edge-value carrier for the boundary mismatch. -/
+abbrev BoundaryMismatchValue : Type :=
+  ZMod 2
+
+/--
+IV.R10 / AC13: concrete cyclic boundary cocycle.
+
+The three edge values are the selected normalized boundary mismatches around
+the pseudo-circle.  The cover-relative H1 class is supplied by
+`CoverRelativeH1NonzeroWitness` below, so this finite edge-value surface does
+not claim to compute arbitrary cover cohomology.
+-/
+def boundaryCocycle : BoundaryEdge -> BoundaryMismatchValue
+  | BoundaryEdge.AB => 1
+  | BoundaryEdge.BC => 0
+  | BoundaryEdge.CA => 0
+
+/-- IV.R10 / AC13: the selected finite boundary cocycle is visibly nonzero. -/
+theorem boundaryCocycle_AB_nonzero :
+    boundaryCocycle BoundaryEdge.AB ≠ 0 := by
+  native_decide
+
+/--
+IV.R10 / AC13: cover-relative H1 witness for the pseudo-circle golden example.
+
+This is the bridge from the finite edge-value model to the genuine PRD-4
+cover-relative cohomology surface.  The concrete cocycle lives in
+`K.CechCocycle 1`, its class is the existing `HiddenCouplingData` class
+`[hc_U(X)] in H^1(𝒰, Ob_U)`, and nonvanishing is stated in that actual
+`K.CoverRelativeHn 1` type.
+-/
+structure CoverRelativeH1NonzeroWitness {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} (H : HiddenCouplingData M K) where
+  concreteCocycle : K.CechCocycle 1
+  concreteCocycle_eq_hidden : concreteCocycle = H.hiddenCouplingCocycle
+  concreteClass_eq_hidden :
+    K.cohomologyClassSucc 0 concreteCocycle = H.hiddenCouplingClass
+  hiddenCouplingClass_nonzero : H.hiddenCouplingClass ≠ h1ZeroClass K
+
+namespace CoverRelativeH1NonzeroWitness
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {R : Type v} [CommRing R] {IOb : Ideal R}
+variable {D : LocalFlatnessData 𝒰 R IOb}
+variable {M : GluingMismatchData Ob D}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+variable {H : HiddenCouplingData M K}
+
+/-- IV.R10 / AC13: read the concrete cocycle as a genuine cover-relative H1 class. -/
+theorem concreteClass_nonzero (W : CoverRelativeH1NonzeroWitness H) :
+    K.cohomologyClassSucc 0 W.concreteCocycle ≠ h1ZeroClass K := by
+  rw [W.concreteClass_eq_hidden]
+  exact W.hiddenCouplingClass_nonzero
+
+end CoverRelativeH1NonzeroWitness
+
+/--
+IV.R10 / AC13: finite specialization of Theorem 7.1's contrapositive.
+
+This theorem calls the existing `localFlatnessGap_no_globalLawfulSection`; it is
+not a parallel toy proof.  The conclusion is therefore stated for the real
+`CompatibleGlobalLawfulSection H` type attached to the selected
+`HiddenCouplingData`.
+-/
+theorem no_global_lawful_section_by_localFlatnessGap
+    {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} {H : HiddenCouplingData M K}
+    (W : CoverRelativeH1NonzeroWitness H)
+    (Hyp : LocalFlatnessGapHypotheses.{u, v, w} H) :
+    ¬ Nonempty (CompatibleGlobalLawfulSection.{u, v, w} H) :=
+  localFlatnessGap_no_globalLawfulSection H Hyp W.hiddenCouplingClass_nonzero
+
+/--
+IV.R10 / AC13: the pseudo-circle golden example combines the two readings.
+
+The H0-style witness count is zero, while the selected H1 class is nonzero and
+therefore no compatible global lawful section exists by Theorem 7.1.
+-/
+theorem pseudoCircle_h0_invisible_h1_obstructed
+    {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+    {Ob : ObstructionSheaf S} {R : Type v} [CommRing R] {IOb : Ideal R}
+    {D : LocalFlatnessData 𝒰 R IOb} {M : GluingMismatchData Ob D}
+    {K : CoverRelativeCechComplex 𝒰 Ob} {H : HiddenCouplingData M K}
+    (W : CoverRelativeH1NonzeroWitness H)
+    (Hyp : LocalFlatnessGapHypotheses.{u, v, w} H) :
+    witnessCountingObstruction = 0 ∧
+      H.hiddenCouplingClass ≠ h1ZeroClass K ∧
+        ¬ Nonempty (CompatibleGlobalLawfulSection.{u, v, w} H) :=
+  ⟨h0_witness_counting_sees_no_obstruction,
+    W.hiddenCouplingClass_nonzero,
+    no_global_lawful_section_by_localFlatnessGap W Hyp⟩
+
+end PseudoCircleGolden
+end FiniteExamples
+end Cohomology
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4601,11 +4601,12 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/BoundaryResidue.lean`,
 `Formal/AG/Cohomology/HigherOverlap.lean`,
 `Formal/AG/Cohomology/FlatnessCriterion.lean`,
-`Formal/AG/Cohomology/CoverNerve.lean`.
+`Formal/AG/Cohomology/CoverNerve.lean`,
+`Formal/AG/Cohomology/FiniteExamples.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
-poset 比較 target、AC5/R3、AC6/R4、AC7/R5、AC8/R6 first half、AC9/R6、AC10/R7、AC11/R8、AC12/R9 に対応する entrypoint である。現時点では
+poset 比較 target、AC5/R3、AC6/R4、AC7/R5、AC8/R6 first half、AC9/R6、AC10/R7、AC11/R8、AC12/R9、AC13/R10(a) に対応する entrypoint である。現時点では
 `Formal/AG/Cohomology` を build 対象へ追加し、PRD-2 `Site` と PRD-3
 `LawAlgebra` への prerequisite package、obstruction coefficient sheaf carrier、
 `O_X^U`-module valued coefficient surface、`Def_U = I_U`、`ConDef_U = I_U/I_U^2`
@@ -4625,7 +4626,8 @@ failure `H^2` class、低次五項完全列形の theorem-candidate statement、
 effective abelian torsor surface、Cohomological Flatness Criterion と
 Local-to-Global Flatness corollary、cover nerve と明示的な有限次元 accounting data 下の
 rank-nullity lower bound / constant coefficient nerve reading / forest vanishing /
-Euler invariance までを Lean 上に置く。
+Euler invariance、擬円周 golden example の H0/H1 分離と local-flatness-gap 型の
+global section 不存在 theorem までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4642,6 +4644,7 @@ Euler invariance までを Lean 上に置く。
 | `IV.定義10.1 / 定理候補10.4` | `AAT.AG.Cohomology.TripleOverlapCoherenceFailure`, `TripleOverlapCoherenceFailure.hCocycle`, `TripleOverlapCoherenceFailure.hClass`, `LowDegreeFiveTermData`, `LowDegreeFiveTermData.FiveTermExact`, `LowDegreeFiveTermData.FiveTermStatement`, `LowDegreeFiveTermData.fiveTermExact_of_statement` | `structure` / `def` / `theorem` | triple-overlap coherence failure を degree-two Čech cocycle `h` と class `[h] in H^2(𝒰, Ob_U)` として定義し、定理候補10.4 は既存 cover-relative Čech complex に相対化された finite-cover Čech filtration provenance 付きの低次五項完全列 statement shape として `Prop` に記録する。一般スペクトル系列機構や statement の証明は構成しない。 | `statement only` / `defined only` / `proved accessor` |
 | `IV.定理11.1 / 系11.2` | `AAT.AG.Cohomology.H1ClassVanishes`, `GluingObstructionClass`, `GluingObstructionClass.h1Class`, `GluingObstructionClass.h1Class_eq`, `EffectiveAbelianObstructionTorsor`, `CohomologicalFlatnessCriterionHypotheses`, `CohomologicalFlatnessCriterionHypotheses.cohomologicalFlatnessCriterion`, `CohomologicalFlatnessCriterionHypotheses.adjustedGlobalLawfulSection_of_h1Class_zero`, `CohomologicalFlatnessCriterionHypotheses.noAdjustedGlobalLawfulSection_of_h1Class_nonzero`, `CohomologicalFlatnessCriterionHypotheses.localToGlobalFlatness` | `def` / `structure` / `theorem` | gluing obstruction を concrete cocycle `g` の class `[g] in H^1(𝒰, Ob_U)` として読み、effective abelian torsor、local flatness、abelian coefficients、U-adequate cover、soundness / completeness、axis exactness、witness coverage、descent、effective adjustment を明示 field とする仮定ブロックの下で、torsor triviality を経由して `[g]=0` と調整後の大域 lawful section の同値を証明し、`[g]≠0` なら調整後の大域 lawful section が存在しないこと、および local-to-global flatness を証明する。abelianization が non-abelian torsor の自明性を復元するとは主張しない。 | `proved under explicit Cohomological Flatness hypotheses` |
 | `IV.定義12.1 / 定理12.2 / 系12.3 / 定理12.4 / 系12.5` | `AAT.AG.Cohomology.CoverNerve`, `CoverNerve.ParallelEdgeComponents`, `CoverNerve.ParallelFaceComponents`, `CoverNerve.edge_component_selected`, `CoverNerve.face_component_selected`, `FiniteDimensionalNerveCohomologyData`, `FiniteDimensionalNerveCohomologyData.topologicalDebtCapacity`, `ConstantCoefficientNerveReading`, `ConstantCoefficientNerveReading.h1_equiv`, `ConstantCoefficientNerveReading.dimSpace_eq_dimNerve`, `ConstantCoefficientNerveReading.dimH1_eq_b1`, `ForestCoverGluingData`, `ForestCoverGluingData.localGluingSufficiency`, `ForestCoverGluingData.localGluingSufficiency_subsingleton`, `EulerCochainAccounting`, `EulerCochainAccounting.eulerAccounting`, `EulerCochainAccounting.ShapeStalkPreservingRefactor`, `EulerCochainAccounting.chi_invariant_under_refactor` | `structure` / `def` / `theorem` | cover nerve を chart 頂点、pairwise-overlap component 辺、triple-overlap component 面として定義し、多重 edge / face component を許す。有限 poset regime と有限次元 `k`-linear coefficient accounting data の下で `dim C^1 <= dim H^1 + dim C^0 + dim C^2` を証明し、定数係数の `k`-linear comparison data から `H^1(U,k) ≃ₗ[k] H^1(N(U),k)` と `dim H^1(U,k) = b_1(N(U))` を読む。forest / no triple faces / surjective restrictions から tree-induction absorption data を通じて selected `H^1` の全 class が `0` になること、shape/stalk-preserving refactor が Euler characteristic を保つことを証明する。 | `proved under explicit finite-dimensional accounting data` |
+| `IV.R10(a) / AC13` | `AAT.AG.Cohomology.FiniteExamples.PseudoCircleGolden.Chart`, `BoundaryEdge`, `edgeLeft`, `edgeRight`, `coverNerve`, `LocallyLawful`, `each_chart_lawful`, `witnessCountingObstruction`, `h0_witness_counting_sees_no_obstruction`, `BoundaryMismatchValue`, `boundaryCocycle`, `boundaryCocycle_AB_nonzero`, `CoverRelativeH1NonzeroWitness`, `CoverRelativeH1NonzeroWitness.concreteClass_nonzero`, `no_global_lawful_section_by_localFlatnessGap`, `pseudoCircle_h0_invisible_h1_obstructed` | `inductive` / `def` / `structure` / `theorem` | ArchSig v0.4.0 R14 golden fixture に対応する selected 擬円周 boundary model。各 chart は locally lawful、H0 的 witness count は zero、finite boundary cocycle は visibly nonzero。`CoverRelativeH1NonzeroWitness` が concrete `K.CechCocycle 1` と既存 `HiddenCouplingData.hiddenCouplingClass : K.CoverRelativeHn 1` を接続し、その actual cover-relative H1 class 非零から既存 `localFlatnessGap_no_globalLawfulSection` を呼んで compatible global lawful section 不在を証明する。 | `proved finite example under explicit cover-relative H1 witness` |
 
 Non-conclusions: この entrypoint は obstruction coefficient sheaf carrier、module-valued
 coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 package、
@@ -4653,10 +4656,12 @@ Local Flatness Gap theorem、R6 first half の 2-chart connecting homomorphism /
 boundary holonomy、R6 の explicit Boundary Residue hypotheses 下の theorem、
 R7 の `H^2` class と低次五項 statement、R8 の explicit Cohomological
 Flatness hypotheses 下の criterion theorem、R9 の explicit finite-dimensional
-accounting data 下の cover nerve theorem package だけを示す。任意の finite-poset regime が
+accounting data 下の cover nerve theorem package、R10(a) の selected pseudo-circle
+finite golden example だけを示す。任意の finite-poset regime が
 自動的に obstruction sheaf comparison data を持つこと、descent class の非零性や
 非零 hidden coupling class の具体例、一般 descent theorem、仮定なしの Boundary Residue theorem、
 仮定なしの Cohomological Flatness Criterion、任意 cover の無条件 nerve cohomology 計算、
+ArchSig fixture JSON の検証、定理9.2 両方向 finite example、forest / cycle nerve finite example、
 non-abelian torsor triviality、スペクトル系列一般論、derived category、cotangent complex、
 `Ext^1` はまだ形式化しない。
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -801,7 +801,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/BoundaryResidue.lean`,
 `Formal/AG/Cohomology/HigherOverlap.lean`,
 `Formal/AG/Cohomology/FlatnessCriterion.lean`,
-`Formal/AG/Cohomology/CoverNerve.lean`.
+`Formal/AG/Cohomology/CoverNerve.lean`,
+`Formal/AG/Cohomology/FiniteExamples.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 は AC1/R0 と AC2/R1 から着手している。Issue
@@ -829,6 +830,9 @@ Issue
 [#2064](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2064)
 では cover nerve と、明示的な有限次元 accounting data 下の定理12.2 / 系12.3 /
 定理12.4 / 系12.5 を追加した。
+Issue
+[#2066](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2066)
+では擬円周 boundary model の finite golden example を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -845,6 +849,7 @@ Issue
 | `IV.定義10.1 / 定理候補10.4` H2 coherence failure and five-term statement | `statement only` / `defined only` / `proved accessor`. `Formal/AG/Cohomology/HigherOverlap.lean` が `TripleOverlapCoherenceFailure`、`hCocycle`、`hClass`、`LowDegreeFiveTermData`、`FiveTermExact`、`FiveTermStatement`、`fiveTermExact_of_statement` を持つ。 | triple-overlap coherence failure は degree-two Čech cocycle と `H^2` class として扱う。定理候補10.4 は既存 cover-relative Čech complex に相対化された finite-cover Čech filtration provenance 付きの低次五項完全列 statement に限定し、スペクトル系列一般論と証明は主張しない。 |
 | `IV.定理11.1 / 系11.2` Cohomological Flatness Criterion | `proved under explicit Cohomological Flatness hypotheses`. `Formal/AG/Cohomology/FlatnessCriterion.lean` が `H1ClassVanishes`、`GluingObstructionClass`、`EffectiveAbelianObstructionTorsor`、`CohomologicalFlatnessCriterionHypotheses`、`cohomologicalFlatnessCriterion`、`adjustedGlobalLawfulSection_of_h1Class_zero`、`noAdjustedGlobalLawfulSection_of_h1Class_nonzero`、`localToGlobalFlatness` を持つ。 | local flatness、abelian coefficients、cocycle `g`、effective torsor、U-adequate cover、soundness / completeness、axis exactness、witness coverage、descent、effective adjustment は明示 field として扱う。torsor triviality を経由して `[g]=0` と調整後の大域 lawful section の同値を読む。abelianized class から non-abelian torsor の自明性が復元できるとは主張しない。 |
 | `IV.定義12.1 / 定理12.2 / 系12.3 / 定理12.4 / 系12.5` Cover nerve and topological debt accounting | `proved under explicit finite-dimensional accounting data`. `Formal/AG/Cohomology/CoverNerve.lean` が `CoverNerve`、`ParallelEdgeComponents`、`ParallelFaceComponents`、`edge_component_selected`、`face_component_selected`、`FiniteDimensionalNerveCohomologyData`、`topologicalDebtCapacity`、`ConstantCoefficientNerveReading`、`h1_equiv`、`dimSpace_eq_dimNerve`、`dimH1_eq_b1`、`ForestCoverGluingData`、`localGluingSufficiency`、`localGluingSufficiency_subsingleton`、`EulerCochainAccounting`、`eulerAccounting`、`ShapeStalkPreservingRefactor`、`chi_invariant_under_refactor` を持つ。 | cover nerve は chart / pairwise-overlap component / triple-overlap component の明示 structure であり、多重 component を許す。rank-nullity lower bound、constant coefficient nerve reading、forest vanishing、Euler invariance は、有限 poset regime、有限次元 `k`-linear coefficient data、selected `k`-linear comparison、tree-induction absorption、shape/stalk-preserving refactor data に相対化する。forest vanishing は selected `H^1` の各 class が `0` になる theorem として扱う。任意 cover の無条件計算定理や一般 spectral sequence は主張しない。 |
+| `IV.R10(a) / AC13` Pseudo-circle golden example | `proved finite example under explicit cover-relative H1 witness`. `Formal/AG/Cohomology/FiniteExamples.lean` が `FiniteExamples.PseudoCircleGolden.Chart`、`BoundaryEdge`、`coverNerve`、`each_chart_lawful`、`h0_witness_counting_sees_no_obstruction`、`boundaryCocycle`、`boundaryCocycle_AB_nonzero`、`CoverRelativeH1NonzeroWitness`、`concreteClass_nonzero`、`no_global_lawful_section_by_localFlatnessGap`、`pseudoCircle_h0_invisible_h1_obstructed` を持つ。 | 擬円周例は ArchSig v0.4.0 R14 golden fixture に対応する selected finite surface として扱う。H0 的 witness count は zero、finite boundary cocycle は visibly nonzero。actual cover-relative `K.CoverRelativeHn 1` の nonzero hidden coupling class は `CoverRelativeH1NonzeroWitness` として明示し、既存 `localFlatnessGap_no_globalLawfulSection` を呼んで compatible global lawful section が存在しないことを示す。ArchSig fixture JSON の検証、定理9.2 両方向例、forest / cycle nerve 例は AC14 に残す。 |
 
 第IV部 PRD-4 の証明対象ラベルは次の現在状態である。
 
@@ -863,6 +868,7 @@ Issue
 | `IV.定義10.1 / 定理候補10.4` | `statement only` / `defined only` / `proved accessor` |
 | `IV.定理11.1 / 系11.2` | `proved under explicit Cohomological Flatness hypotheses` |
 | `IV.定理12.2 / 系12.3 / 定理12.4 / 系12.5` | `proved under explicit finite-dimensional accounting data` |
+| `IV.R10(a) / AC13` | `proved finite example under explicit cover-relative H1 witness` |
 | `IV.定理13.2` | `future proof obligation` |
 | `IV.定理候補10.4 / 定理候補14.2` | `future proof obligation` |
 


### PR DESCRIPTION
## 概要

Closes #2066

PRD-4 R10(a) / AC13 として、擬円周 boundary model の finite golden example を Lean に追加する。

- `Formal/AG/Cohomology/FiniteExamples.lean` を追加
- 3 chart / 3 boundary edge / no triple face の selected pseudo-circle cover nerve を定義
- 各 chart が locally lawful であることを example theorem として証明
- H0 的 witness count が zero で、局所 witness counting では障害が見えないことを証明
- finite boundary cocycle の nonzero edge value を証明
- `CoverRelativeH1NonzeroWitness` により concrete `K.CechCocycle 1` と既存 `HiddenCouplingData.hiddenCouplingClass : K.CoverRelativeHn 1` を接続
- actual cover-relative H1 class 非零から既存 `localFlatnessGap_no_globalLawfulSection` を呼び、compatible global lawful section 不在を証明
- ArchSig v0.4.0 R14 golden fixture との対応を docstring boundary として記録
- `lean_theorem_index.md` と `proof_obligations.md` を同期

## 証明した定理

- `PseudoCircleGolden.each_chart_lawful`
- `PseudoCircleGolden.h0_witness_counting_sees_no_obstruction`
- `PseudoCircleGolden.boundaryCocycle_AB_nonzero`
- `PseudoCircleGolden.CoverRelativeH1NonzeroWitness.concreteClass_nonzero`
- `PseudoCircleGolden.no_global_lawful_section_by_localFlatnessGap`
- `PseudoCircleGolden.pseudoCircle_h0_invisible_h1_obstructed`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build Formal.AG.Cohomology.FiniteExamples`
- [x] `lake env lean Formal/AG/Cohomology.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）

`lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning が再表示されたが、今回の変更とは無関係。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
