### PR TITLE
PRD-4 AC15 Period Stokes を追加する

### DIFF
--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -11,3 +11,4 @@ import Formal.AG.Cohomology.HigherOverlap
 import Formal.AG.Cohomology.FlatnessCriterion
 import Formal.AG.Cohomology.CoverNerve
 import Formal.AG.Cohomology.FiniteExamples
+import Formal.AG.Cohomology.PeriodStokes

--- a/Formal/AG/Cohomology/PeriodStokes.lean
+++ b/Formal/AG/Cohomology/PeriodStokes.lean
@@ -1,0 +1,182 @@
+import Formal.AG.Cohomology.FiniteExamples
+
+noncomputable section
+
+namespace AAT.AG
+namespace Cohomology
+
+universe u
+
+/--
+IV.R11 / 定義13.1: finite Čech chain complex selected for period pairing.
+
+The boundary map is supplied together with `boundary ∘ boundary = 0`.  This is
+the chain-side companion to the selected cover-relative Čech cochain complex;
+it does not construct singular chains or a general homology theory.
+-/
+structure FiniteCechChainComplex where
+  Chain : Nat -> Type u
+  chainAddCommGroup : ∀ n : Nat, AddCommGroup (Chain n)
+  boundary : ∀ n : Nat, Chain (n + 1) →+ Chain n
+  boundary_comp :
+    ∀ (n : Nat) (γ : Chain (n + 2)), boundary n (boundary (n + 1) γ) = 0
+
+attribute [instance] FiniteCechChainComplex.chainAddCommGroup
+
+namespace FiniteCechChainComplex
+
+/-- IV.R11 / 定義13.1: readable notation for the selected boundary. -/
+def boundaryOp (C : FiniteCechChainComplex.{u}) (n : Nat) : C.Chain (n + 1) →+ C.Chain n :=
+  C.boundary n
+
+/-- IV.R11 / 定義13.1: the selected boundary squares to zero. -/
+theorem boundary_comp_zero (C : FiniteCechChainComplex.{u})
+    (n : Nat) (γ : C.Chain (n + 2)) :
+    C.boundaryOp n (C.boundaryOp (n + 1) γ) = 0 :=
+  C.boundary_comp n γ
+
+end FiniteCechChainComplex
+
+/--
+IV.R11 / 定義13.1: cochain-chain pairing for a selected Čech model.
+
+The pairing target `Period` is explicit.  In finite models this may be a field,
+a coefficient group, or a selected accounting group.
+-/
+structure CechCochainChainPairing {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    (K : CoverRelativeCechComplex 𝒰 Ob) (C : FiniteCechChainComplex.{u}) where
+  Period : Type u
+  periodAddCommGroup : AddCommGroup Period
+  pairing : ∀ n : Nat, K.Cn n -> C.Chain n -> Period
+
+attribute [instance] CechCochainChainPairing.periodAddCommGroup
+
+namespace CechCochainChainPairing
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+variable {C : FiniteCechChainComplex.{u}}
+
+/-- IV.R11 / 定義13.1: notation for `<omega, gamma>`. -/
+def pair (P : CechCochainChainPairing K C)
+    (n : Nat) (ω : K.Cn n) (γ : C.Chain n) : P.Period :=
+  P.pairing n ω γ
+
+end CechCochainChainPairing
+
+/--
+IV.R11 / 定理13.2 hypothesis: Stokes compatibility for the selected pairing.
+
+The condition says that the selected Čech differential and selected chain
+boundary are adjoint under the pairing.
+-/
+structure StokesCompatiblePairing {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {K : CoverRelativeCechComplex 𝒰 Ob} {C : FiniteCechChainComplex.{u}}
+    (P : CechCochainChainPairing K C) where
+  stokes :
+    ∀ (n : Nat) (ω : K.Cn n) (γ : C.Chain (n + 1)),
+      P.pair (n + 1) (K.d n ω) γ =
+        P.pair n ω (C.boundaryOp n γ)
+
+namespace StokesCompatiblePairing
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+variable {C : FiniteCechChainComplex.{u}}
+variable {P : CechCochainChainPairing K C}
+
+/-- IV.定理13.2: finite Čech Stokes formula. -/
+theorem cechStokes (H : StokesCompatiblePairing P)
+    (n : Nat) (ω : K.Cn n) (γ : C.Chain (n + 1)) :
+    P.pair (n + 1) (K.d n ω) γ =
+      P.pair n ω (C.boundaryOp n γ) :=
+  H.stokes n ω γ
+
+end StokesCompatiblePairing
+
+/--
+IV.R11 / 定理13.2 connecting-boundary representative data.
+
+When the selected connecting cochain `delta(b)` is represented by a coboundary
+compatible with `b`, this package records the exact pairing identity needed for
+the period formula.  It is assumption-explicit and does not assert that every
+connecting homomorphism is constructed this way.
+-/
+structure ConnectingBoundaryRepresentative {U : AtomCarrier.{u}}
+    {A : ArchitectureObject U} {S : Site.AATSite A}
+    {𝒰 : CoverRelativeCechCover S} {Ob : ObstructionSheaf S}
+    {K : CoverRelativeCechComplex 𝒰 Ob} {C : FiniteCechChainComplex.{u}}
+    (P : CechCochainChainPairing K C) where
+  BoundarySection : Type u
+  boundarySectionAddCommGroup : AddCommGroup BoundarySection
+  boundaryPairing : BoundarySection -> C.Chain 0 -> P.Period
+  deltaRepresentative : BoundarySection -> K.Cn 1
+  boundaryPairing_compatible :
+    ∀ (b : BoundarySection) (γ : C.Chain 1),
+      P.pair 1 (deltaRepresentative b) γ =
+        boundaryPairing b (C.boundaryOp 0 γ)
+
+attribute [instance] ConnectingBoundaryRepresentative.boundarySectionAddCommGroup
+
+namespace ConnectingBoundaryRepresentative
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {𝒰 : CoverRelativeCechCover S}
+variable {Ob : ObstructionSheaf S}
+variable {K : CoverRelativeCechComplex 𝒰 Ob}
+variable {C : FiniteCechChainComplex.{u}}
+variable {P : CechCochainChainPairing K C}
+
+/-- IV.定理13.2: connecting representative period formula. -/
+theorem connectingStokes
+    (R : ConnectingBoundaryRepresentative P)
+    (b : R.BoundarySection) (γ : C.Chain 1) :
+    P.pair 1 (R.deltaRepresentative b) γ =
+      R.boundaryPairing b (C.boundaryOp 0 γ) :=
+  R.boundaryPairing_compatible b γ
+
+end ConnectingBoundaryRepresentative
+
+/--
+IV.定義13.4: extension holonomy accounting convention.
+
+This is a bookkeeping convention whose defining property is additivity of
+`kappa_U`.  It is not a corollary of Theorem 13.2 by itself: a model must select
+the accounting carrier, the extension event type, and the additive `kappa_U`
+map separately.
+-/
+structure ExtensionHolonomyAccounting where
+  ExtensionEvent : Type u
+  Accounting : Type u
+  eventAddCommGroup : AddCommGroup ExtensionEvent
+  accountingAddCommGroup : AddCommGroup Accounting
+  kappa_U : ExtensionEvent →+ Accounting
+
+attribute [instance] ExtensionHolonomyAccounting.eventAddCommGroup
+attribute [instance] ExtensionHolonomyAccounting.accountingAddCommGroup
+
+namespace ExtensionHolonomyAccounting
+
+/-- IV.定義13.4: additivity is the defining property of `kappa_U`. -/
+theorem kappa_U_additive (A : ExtensionHolonomyAccounting.{u})
+    (x y : A.ExtensionEvent) :
+    A.kappa_U (x + y) = A.kappa_U x + A.kappa_U y :=
+  map_add A.kappa_U x y
+
+/-- IV.定義13.4: zero accounting follows from the selected additive map. -/
+theorem kappa_U_zero (A : ExtensionHolonomyAccounting.{u}) :
+    A.kappa_U 0 = 0 :=
+  map_zero A.kappa_U
+
+end ExtensionHolonomyAccounting
+
+end Cohomology
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4602,7 +4602,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/HigherOverlap.lean`,
 `Formal/AG/Cohomology/FlatnessCriterion.lean`,
 `Formal/AG/Cohomology/CoverNerve.lean`,
-`Formal/AG/Cohomology/FiniteExamples.lean`.
+`Formal/AG/Cohomology/FiniteExamples.lean`,
+`Formal/AG/Cohomology/PeriodStokes.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
@@ -4628,7 +4629,8 @@ Local-to-Global Flatness corollary、cover nerve と明示的な有限次元 acc
 rank-nullity lower bound / constant coefficient nerve reading / forest vanishing /
 Euler invariance、擬円周 golden example の H0/H1 分離と local-flatness-gap 型の
 global section 不存在 theorem、Boundary Residue 両方向例と forest / cycle nerve
-finite examples までを Lean 上に置く。
+finite examples、period Stokes theorem と extension holonomy accounting convention
+までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4647,6 +4649,7 @@ finite examples までを Lean 上に置く。
 | `IV.定義12.1 / 定理12.2 / 系12.3 / 定理12.4 / 系12.5` | `AAT.AG.Cohomology.CoverNerve`, `CoverNerve.ParallelEdgeComponents`, `CoverNerve.ParallelFaceComponents`, `CoverNerve.edge_component_selected`, `CoverNerve.face_component_selected`, `FiniteDimensionalNerveCohomologyData`, `FiniteDimensionalNerveCohomologyData.topologicalDebtCapacity`, `ConstantCoefficientNerveReading`, `ConstantCoefficientNerveReading.h1_equiv`, `ConstantCoefficientNerveReading.dimSpace_eq_dimNerve`, `ConstantCoefficientNerveReading.dimH1_eq_b1`, `ForestCoverGluingData`, `ForestCoverGluingData.localGluingSufficiency`, `ForestCoverGluingData.localGluingSufficiency_subsingleton`, `EulerCochainAccounting`, `EulerCochainAccounting.eulerAccounting`, `EulerCochainAccounting.ShapeStalkPreservingRefactor`, `EulerCochainAccounting.chi_invariant_under_refactor` | `structure` / `def` / `theorem` | cover nerve を chart 頂点、pairwise-overlap component 辺、triple-overlap component 面として定義し、多重 edge / face component を許す。有限 poset regime と有限次元 `k`-linear coefficient accounting data の下で `dim C^1 <= dim H^1 + dim C^0 + dim C^2` を証明し、定数係数の `k`-linear comparison data から `H^1(U,k) ≃ₗ[k] H^1(N(U),k)` と `dim H^1(U,k) = b_1(N(U))` を読む。forest / no triple faces / surjective restrictions から tree-induction absorption data を通じて selected `H^1` の全 class が `0` になること、shape/stalk-preserving refactor が Euler characteristic を保つことを証明する。 | `proved under explicit finite-dimensional accounting data` |
 | `IV.R10(a) / AC13` | `AAT.AG.Cohomology.FiniteExamples.PseudoCircleGolden.Chart`, `BoundaryEdge`, `edgeLeft`, `edgeRight`, `coverNerve`, `LocallyLawful`, `each_chart_lawful`, `witnessCountingObstruction`, `h0_witness_counting_sees_no_obstruction`, `BoundaryMismatchValue`, `boundaryCocycle`, `boundaryCocycle_AB_nonzero`, `CoverRelativeH1NonzeroWitness`, `CoverRelativeH1NonzeroWitness.concreteClass_nonzero`, `no_global_lawful_section_by_localFlatnessGap`, `pseudoCircle_h0_invisible_h1_obstructed` | `inductive` / `def` / `structure` / `theorem` | ArchSig v0.4.0 R14 golden fixture に対応する selected 擬円周 boundary model。各 chart は locally lawful、H0 的 witness count は zero、finite boundary cocycle は visibly nonzero。`CoverRelativeH1NonzeroWitness` が concrete `K.CechCocycle 1` と既存 `HiddenCouplingData.hiddenCouplingClass : K.CoverRelativeHn 1` を接続し、その actual cover-relative H1 class 非零から既存 `localFlatnessGap_no_globalLawfulSection` を呼んで compatible global lawful section 不在を証明する。 | `proved finite example under explicit cover-relative H1 witness` |
 | `IV.R10(b)(c) / AC14` | `AAT.AG.Cohomology.FiniteExamples.BoundaryResidueGolden.zero_boundaryResidue_glues`, `BoundaryResidueGolden.nonzero_boundaryResidue_blocks_gluing`, `BoundaryResidueGolden.boundaryResidue_two_direction_example`, `NerveGolden.forestCoverNerve`, `NerveGolden.forestCoverGluingData`, `NerveGolden.forestCover_H1_zero`, `NerveGolden.cycleCoverNerve`, `NerveGolden.cycleConstantCoefficientReading`, `NerveGolden.cycleNerve_dimH1_eq_b1` | `def` / `theorem` | Boundary Residue finite example は既存 `BoundaryResidueHypotheses` に相対化し、`delta(b)=0` から global U-flat、`delta(b)≠0` から global U-flat 不在を証明する。forest cover example は `ForestCoverGluingData` を instantiate して selected `H^1 = 0` を証明し、cycle nerve example は `ConstantCoefficientNerveReading` を instantiate して `dim H^1 = b_1` を読む。 | `proved finite examples under explicit packages` |
+| `IV.定義13.1 / 定理13.2 / 定義13.4` | `AAT.AG.Cohomology.FiniteCechChainComplex`, `FiniteCechChainComplex.boundaryOp`, `FiniteCechChainComplex.boundary_comp_zero`, `CechCochainChainPairing`, `CechCochainChainPairing.pair`, `StokesCompatiblePairing`, `StokesCompatiblePairing.cechStokes`, `ConnectingBoundaryRepresentative`, `ConnectingBoundaryRepresentative.connectingStokes`, `ExtensionHolonomyAccounting`, `ExtensionHolonomyAccounting.kappa_U_additive`, `ExtensionHolonomyAccounting.kappa_U_zero` | `structure` / `def` / `theorem` | finite Čech chain complex、boundary、cochain-chain pairing、Stokes-compatible condition を定義し、`<d omega, gamma> = <omega, boundary gamma>` を証明する。connecting homomorphism が selected coboundary representative で構成される場合の `<delta(b), gamma> = <b, boundary gamma>` も明示 compatibility data から証明する。定義13.4 は `kappa_U` の加法性を defining property とする extension holonomy accounting convention として定義し、Stokes theorem の自動系とは主張しない。 | `proved under explicit pairing/accounting data` |
 
 Non-conclusions: この entrypoint は obstruction coefficient sheaf carrier、module-valued
 coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 package、
@@ -4664,6 +4667,7 @@ finite golden example、R10(b)(c) の Boundary Residue / forest / cycle selected
 非零 hidden coupling class の具体例、一般 descent theorem、仮定なしの Boundary Residue theorem、
 仮定なしの Cohomological Flatness Criterion、任意 cover の無条件 nerve cohomology 計算、
 ArchSig fixture JSON の検証、Boundary Residue 仮定ブロックの無条件構成、任意 cover の forest / cycle 分類、
+Stokes-compatible pairing の無条件存在、`kappa_U` accounting が Stokes theorem から自動的に従うこと、
 non-abelian torsor triviality、スペクトル系列一般論、derived category、cotangent complex、
 `Ext^1` はまだ形式化しない。
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -802,7 +802,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/HigherOverlap.lean`,
 `Formal/AG/Cohomology/FlatnessCriterion.lean`,
 `Formal/AG/Cohomology/CoverNerve.lean`,
-`Formal/AG/Cohomology/FiniteExamples.lean`.
+`Formal/AG/Cohomology/FiniteExamples.lean`,
+`Formal/AG/Cohomology/PeriodStokes.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 は AC1/R0 と AC2/R1 から着手している。Issue
@@ -833,6 +834,9 @@ Issue
 Issue
 [#2066](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2066)
 では擬円周 boundary model の finite golden example を追加した。
+Issue
+[#2070](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2070)
+では period pairing、Stokes theorem、extension holonomy accounting convention を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -851,6 +855,7 @@ Issue
 | `IV.定義12.1 / 定理12.2 / 系12.3 / 定理12.4 / 系12.5` Cover nerve and topological debt accounting | `proved under explicit finite-dimensional accounting data`. `Formal/AG/Cohomology/CoverNerve.lean` が `CoverNerve`、`ParallelEdgeComponents`、`ParallelFaceComponents`、`edge_component_selected`、`face_component_selected`、`FiniteDimensionalNerveCohomologyData`、`topologicalDebtCapacity`、`ConstantCoefficientNerveReading`、`h1_equiv`、`dimSpace_eq_dimNerve`、`dimH1_eq_b1`、`ForestCoverGluingData`、`localGluingSufficiency`、`localGluingSufficiency_subsingleton`、`EulerCochainAccounting`、`eulerAccounting`、`ShapeStalkPreservingRefactor`、`chi_invariant_under_refactor` を持つ。 | cover nerve は chart / pairwise-overlap component / triple-overlap component の明示 structure であり、多重 component を許す。rank-nullity lower bound、constant coefficient nerve reading、forest vanishing、Euler invariance は、有限 poset regime、有限次元 `k`-linear coefficient data、selected `k`-linear comparison、tree-induction absorption、shape/stalk-preserving refactor data に相対化する。forest vanishing は selected `H^1` の各 class が `0` になる theorem として扱う。任意 cover の無条件計算定理や一般 spectral sequence は主張しない。 |
 | `IV.R10(a) / AC13` Pseudo-circle golden example | `proved finite example under explicit cover-relative H1 witness`. `Formal/AG/Cohomology/FiniteExamples.lean` が `FiniteExamples.PseudoCircleGolden.Chart`、`BoundaryEdge`、`coverNerve`、`each_chart_lawful`、`h0_witness_counting_sees_no_obstruction`、`boundaryCocycle`、`boundaryCocycle_AB_nonzero`、`CoverRelativeH1NonzeroWitness`、`concreteClass_nonzero`、`no_global_lawful_section_by_localFlatnessGap`、`pseudoCircle_h0_invisible_h1_obstructed` を持つ。 | 擬円周例は ArchSig v0.4.0 R14 golden fixture に対応する selected finite surface として扱う。H0 的 witness count は zero、finite boundary cocycle は visibly nonzero。actual cover-relative `K.CoverRelativeHn 1` の nonzero hidden coupling class は `CoverRelativeH1NonzeroWitness` として明示し、既存 `localFlatnessGap_no_globalLawfulSection` を呼んで compatible global lawful section が存在しないことを示す。ArchSig fixture JSON の検証、定理9.2 両方向例、forest / cycle nerve 例は AC14 に残す。 |
 | `IV.R10(b)(c) / AC14` Boundary Residue and nerve finite examples | `proved finite examples under explicit packages`. `Formal/AG/Cohomology/FiniteExamples.lean` が `BoundaryResidueGolden.zero_boundaryResidue_glues`、`nonzero_boundaryResidue_blocks_gluing`、`boundaryResidue_two_direction_example`、`NerveGolden.forestCoverNerve`、`forestCoverGluingData`、`forestCover_H1_zero`、`cycleCoverNerve`、`cycleConstantCoefficientReading`、`cycleNerve_dimH1_eq_b1` を持つ。 | Boundary Residue 両方向例は既存 `BoundaryResidueHypotheses` に相対化し、`delta(b)=0` から global U-flat、`delta(b)≠0` から global U-flat 不在を読む。forest/cycle nerve 例は AC12 の `ForestCoverGluingData` と `ConstantCoefficientNerveReading` を finite selected examples として instantiate する。任意 cover の一般計算や ArchSig fixture JSON 検証は主張しない。 |
+| `IV.定義13.1 / 定理13.2 / 定義13.4` Period Stokes and holonomy accounting | `proved under explicit pairing/accounting data`. `Formal/AG/Cohomology/PeriodStokes.lean` が `FiniteCechChainComplex`、`boundaryOp`、`boundary_comp_zero`、`CechCochainChainPairing`、`pair`、`StokesCompatiblePairing`、`cechStokes`、`ConnectingBoundaryRepresentative`、`connectingStokes`、`ExtensionHolonomyAccounting`、`kappa_U_additive`、`kappa_U_zero` を持つ。 | Stokes theorem は selected chain complex、cochain-chain pairing、Stokes-compatible condition に相対化する。connecting formula は selected connecting representative と boundary pairing compatibility に相対化する。定義13.4 は `kappa_U` の加法性を defining property とする会計規約であり、定理13.2 から自動的に従う系ではない。 |
 
 第IV部 PRD-4 の証明対象ラベルは次の現在状態である。
 
@@ -871,7 +876,7 @@ Issue
 | `IV.定理12.2 / 系12.3 / 定理12.4 / 系12.5` | `proved under explicit finite-dimensional accounting data` |
 | `IV.R10(a) / AC13` | `proved finite example under explicit cover-relative H1 witness` |
 | `IV.R10(b)(c) / AC14` | `proved finite examples under explicit packages` |
-| `IV.定理13.2` | `future proof obligation` |
+| `IV.定義13.1 / 定理13.2 / 定義13.4` | `proved under explicit pairing/accounting data` |
 | `IV.定理候補10.4 / 定理候補14.2` | `future proof obligation` |
 
 ## 現在の未解決カテゴリ


### PR DESCRIPTION
## 概要

Closes #2070

PRD-4 R11 / AC15 として、period pairing、Stokes theorem、extension holonomy accounting convention を追加する。

- `Formal/AG/Cohomology/PeriodStokes.lean` を追加
- finite Čech chain complex、boundary、cochain-chain pairing を定義
- Stokes-compatible condition と theorem `cechStokes` を追加
- connecting representative で構成される場合の period formula `connectingStokes` を追加
- 定義13.4 の `ExtensionHolonomyAccounting` を `kappa_U` の加法性を defining property とする会計規約として追加
- 定義13.4 は定理13.2 から自動的に従う系ではないことを docstring に記録
- `lean_theorem_index.md` と `proof_obligations.md` を同期

## 証明した定理

- `FiniteCechChainComplex.boundary_comp_zero`
- `StokesCompatiblePairing.cechStokes`
- `ConnectingBoundaryRepresentative.connectingStokes`
- `ExtensionHolonomyAccounting.kappa_U_additive`
- `ExtensionHolonomyAccounting.kappa_U_zero`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build Formal.AG.Cohomology.PeriodStokes`
- [x] `lake env lean Formal/AG/Cohomology.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）

`lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning が再表示されたが、今回の変更とは無関係。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
