### PR TITLE
PRD-4 AC16 aggregation と scale-stable debt を追加する

### DIFF
--- a/Formal/AG/Cohomology.lean
+++ b/Formal/AG/Cohomology.lean
@@ -12,3 +12,4 @@ import Formal.AG.Cohomology.FlatnessCriterion
 import Formal.AG.Cohomology.CoverNerve
 import Formal.AG.Cohomology.FiniteExamples
 import Formal.AG.Cohomology.PeriodStokes
+import Formal.AG.Cohomology.Aggregation

--- a/Formal/AG/Cohomology/Aggregation.lean
+++ b/Formal/AG/Cohomology/Aggregation.lean
@@ -1,0 +1,157 @@
+import Formal.AG.Cohomology.PeriodStokes
+
+noncomputable section
+
+namespace AAT.AG
+namespace Cohomology
+
+universe u
+
+/--
+IV.定義14.1: selected finite site morphism `pi : X_fine -> X_coarse`.
+
+The object map is the finite-site aggregation surface.  It is intentionally a
+selected map between the two AAT site categories and not a general geometric
+morphism construction.
+-/
+structure FiniteSiteMorphism {U : AtomCarrier.{u}}
+    {A_fine A_coarse : ArchitectureObject U}
+    (S_fine : Site.AATSite A_fine) (S_coarse : Site.AATSite A_coarse) where
+  mapObject : S_fine.category -> S_coarse.category
+  preservesSelectedCover : Prop
+  preservesSelectedCover_holds : preservesSelectedCover
+
+/--
+IV.定義14.1: selected pushforward coefficient surface `pi_* Ob`.
+
+The carrier is explicit because this PRD layer only needs the comparison
+surface and does not construct direct images for arbitrary site morphisms.
+-/
+structure PushforwardObstructionSheaf {U : AtomCarrier.{u}}
+    {A_fine A_coarse : ArchitectureObject U}
+    {S_fine : Site.AATSite A_fine} {S_coarse : Site.AATSite A_coarse}
+    (pi : FiniteSiteMorphism S_fine S_coarse)
+    (Ob : ObstructionSheaf S_fine) where
+  carrier : ObstructionSheaf S_coarse
+  readsSectionsByFinePullback : Prop
+  readsSectionsByFinePullback_holds : readsSectionsByFinePullback
+
+/--
+IV.R12: Čech-style higher direct image surface `R^q pi_* Ob` for statements.
+
+This is a statement-level carrier for theorem candidate 14.2; no derived
+functor or spectral sequence construction is claimed here.
+-/
+structure HigherDirectImageCech {U : AtomCarrier.{u}}
+    {A_fine A_coarse : ArchitectureObject U}
+    {S_fine : Site.AATSite A_fine} {S_coarse : Site.AATSite A_coarse}
+    (pi : FiniteSiteMorphism S_fine S_coarse)
+    (Ob : ObstructionSheaf S_fine) (q : Nat) where
+  carrier : Type u
+  addCommGroup : AddCommGroup carrier
+  cechComputes : Prop
+  cechComputes_holds : cechComputes
+
+attribute [instance] HigherDirectImageCech.addCommGroup
+
+/--
+IV.R12: comparison map
+`H^1(X_coarse, pi_* Ob) -> H^1(X_fine, Ob)`.
+-/
+structure AggregationComparisonMap {U : AtomCarrier.{u}}
+    {A_fine A_coarse : ArchitectureObject U}
+    {S_fine : Site.AATSite A_fine} {S_coarse : Site.AATSite A_coarse}
+    {pi : FiniteSiteMorphism S_fine S_coarse}
+    {Ob : ObstructionSheaf S_fine}
+    (POb : PushforwardObstructionSheaf pi Ob) where
+  coarseH1 : Type u
+  fineH1 : Type u
+  coarseAddCommGroup : AddCommGroup coarseH1
+  fineAddCommGroup : AddCommGroup fineH1
+  comparison : coarseH1 →+ fineH1
+  comparisonReadsPullback : Prop
+  comparisonReadsPullback_holds : comparisonReadsPullback
+
+attribute [instance] AggregationComparisonMap.coarseAddCommGroup
+attribute [instance] AggregationComparisonMap.fineAddCommGroup
+
+namespace AggregationComparisonMap
+
+variable {U : AtomCarrier.{u}}
+variable {A_fine A_coarse : ArchitectureObject U}
+variable {S_fine : Site.AATSite A_fine} {S_coarse : Site.AATSite A_coarse}
+variable {pi : FiniteSiteMorphism S_fine S_coarse}
+variable {Ob : ObstructionSheaf S_fine}
+variable {POb : PushforwardObstructionSheaf pi Ob}
+
+/-- IV.R12: membership in the image of the aggregation comparison map. -/
+def InComparisonImage (M : AggregationComparisonMap POb) (x : M.fineH1) : Prop :=
+  ∃ y : M.coarseH1, M.comparison y = x
+
+end AggregationComparisonMap
+
+/--
+IV.定理候補14.2: five-term aggregation statement shape.
+
+The theorem candidate is intentionally statement-only.  It records the exact
+five-object low-degree shape needed for aggregation without proving a spectral
+sequence.
+-/
+structure AggregationFiveTermStatement {U : AtomCarrier.{u}}
+    {A_fine A_coarse : ArchitectureObject U}
+    {S_fine : Site.AATSite A_fine} {S_coarse : Site.AATSite A_coarse}
+    {pi : FiniteSiteMorphism S_fine S_coarse}
+    {Ob : ObstructionSheaf S_fine}
+    (POb : PushforwardObstructionSheaf pi Ob) where
+  H1_coarse_piOb : Type u
+  H1_fine_Ob : Type u
+  H0_coarse_R1piOb : Type u
+  H2_coarse_piOb : Type u
+  H2_fine_Ob : Type u
+  add_H1_coarse : AddCommGroup H1_coarse_piOb
+  add_H1_fine : AddCommGroup H1_fine_Ob
+  add_H0_R1 : AddCommGroup H0_coarse_R1piOb
+  add_H2_coarse : AddCommGroup H2_coarse_piOb
+  add_H2_fine : AddCommGroup H2_fine_Ob
+  edge_H1coarse_H1fine : H1_coarse_piOb →+ H1_fine_Ob
+  edge_H1fine_H0R1 : H1_fine_Ob →+ H0_coarse_R1piOb
+  edge_H0R1_H2coarse : H0_coarse_R1piOb →+ H2_coarse_piOb
+  edge_H2coarse_H2fine : H2_coarse_piOb →+ H2_fine_Ob
+  exactness : Prop
+
+attribute [instance] AggregationFiveTermStatement.add_H1_coarse
+attribute [instance] AggregationFiveTermStatement.add_H1_fine
+attribute [instance] AggregationFiveTermStatement.add_H0_R1
+attribute [instance] AggregationFiveTermStatement.add_H2_coarse
+attribute [instance] AggregationFiveTermStatement.add_H2_fine
+
+/--
+IV.定義14.3: scale-stable debt over a selected aggregation family.
+
+A debt class is scale-stable when every selected aggregation map reads it as
+coming from the corresponding coarse comparison image.
+-/
+structure ScaleStableDebt where
+  AggregationIndex : Type u
+  FineDebt : Type u
+  fineDebtAddCommGroup : AddCommGroup FineDebt
+  CoarseDebt : AggregationIndex -> Type u
+  coarseDebtAddCommGroup : ∀ i : AggregationIndex, AddCommGroup (CoarseDebt i)
+  comparison : ∀ i : AggregationIndex, CoarseDebt i →+ FineDebt
+  debtClass : FineDebt
+  stable : ∀ i : AggregationIndex, ∃ y : CoarseDebt i, comparison i y = debtClass
+
+attribute [instance] ScaleStableDebt.fineDebtAddCommGroup
+attribute [instance] ScaleStableDebt.coarseDebtAddCommGroup
+
+namespace ScaleStableDebt
+
+/-- IV.定義14.3: read scale stability for a selected aggregation. -/
+theorem in_comparison_image (D : ScaleStableDebt.{u}) (i : D.AggregationIndex) :
+    ∃ y : D.CoarseDebt i, D.comparison i y = D.debtClass :=
+  D.stable i
+
+end ScaleStableDebt
+
+end Cohomology
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4603,7 +4603,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/FlatnessCriterion.lean`,
 `Formal/AG/Cohomology/CoverNerve.lean`,
 `Formal/AG/Cohomology/FiniteExamples.lean`,
-`Formal/AG/Cohomology/PeriodStokes.lean`.
+`Formal/AG/Cohomology/PeriodStokes.lean`,
+`Formal/AG/Cohomology/Aggregation.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
@@ -4630,7 +4631,7 @@ rank-nullity lower bound / constant coefficient nerve reading / forest vanishing
 Euler invariance、擬円周 golden example の H0/H1 分離と local-flatness-gap 型の
 global section 不存在 theorem、Boundary Residue 両方向例と forest / cycle nerve
 finite examples、period Stokes theorem と extension holonomy accounting convention
-までを Lean 上に置く。
+、aggregation / scale-stable debt statement surface までを Lean 上に置く。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
@@ -4650,6 +4651,7 @@ finite examples、period Stokes theorem と extension holonomy accounting conven
 | `IV.R10(a) / AC13` | `AAT.AG.Cohomology.FiniteExamples.PseudoCircleGolden.Chart`, `BoundaryEdge`, `edgeLeft`, `edgeRight`, `coverNerve`, `LocallyLawful`, `each_chart_lawful`, `witnessCountingObstruction`, `h0_witness_counting_sees_no_obstruction`, `BoundaryMismatchValue`, `boundaryCocycle`, `boundaryCocycle_AB_nonzero`, `CoverRelativeH1NonzeroWitness`, `CoverRelativeH1NonzeroWitness.concreteClass_nonzero`, `no_global_lawful_section_by_localFlatnessGap`, `pseudoCircle_h0_invisible_h1_obstructed` | `inductive` / `def` / `structure` / `theorem` | ArchSig v0.4.0 R14 golden fixture に対応する selected 擬円周 boundary model。各 chart は locally lawful、H0 的 witness count は zero、finite boundary cocycle は visibly nonzero。`CoverRelativeH1NonzeroWitness` が concrete `K.CechCocycle 1` と既存 `HiddenCouplingData.hiddenCouplingClass : K.CoverRelativeHn 1` を接続し、その actual cover-relative H1 class 非零から既存 `localFlatnessGap_no_globalLawfulSection` を呼んで compatible global lawful section 不在を証明する。 | `proved finite example under explicit cover-relative H1 witness` |
 | `IV.R10(b)(c) / AC14` | `AAT.AG.Cohomology.FiniteExamples.BoundaryResidueGolden.zero_boundaryResidue_glues`, `BoundaryResidueGolden.nonzero_boundaryResidue_blocks_gluing`, `BoundaryResidueGolden.boundaryResidue_two_direction_example`, `NerveGolden.forestCoverNerve`, `NerveGolden.forestCoverGluingData`, `NerveGolden.forestCover_H1_zero`, `NerveGolden.cycleCoverNerve`, `NerveGolden.cycleConstantCoefficientReading`, `NerveGolden.cycleNerve_dimH1_eq_b1` | `def` / `theorem` | Boundary Residue finite example は既存 `BoundaryResidueHypotheses` に相対化し、`delta(b)=0` から global U-flat、`delta(b)≠0` から global U-flat 不在を証明する。forest cover example は `ForestCoverGluingData` を instantiate して selected `H^1 = 0` を証明し、cycle nerve example は `ConstantCoefficientNerveReading` を instantiate して `dim H^1 = b_1` を読む。 | `proved finite examples under explicit packages` |
 | `IV.定義13.1 / 定理13.2 / 定義13.4` | `AAT.AG.Cohomology.FiniteCechChainComplex`, `FiniteCechChainComplex.boundaryOp`, `FiniteCechChainComplex.boundary_comp_zero`, `CechCochainChainPairing`, `CechCochainChainPairing.pair`, `StokesCompatiblePairing`, `StokesCompatiblePairing.cechStokes`, `ConnectingBoundaryRepresentative`, `ConnectingBoundaryRepresentative.connectingStokes`, `ExtensionHolonomyAccounting`, `ExtensionHolonomyAccounting.kappa_U_additive`, `ExtensionHolonomyAccounting.kappa_U_zero` | `structure` / `def` / `theorem` | finite Čech chain complex、boundary、cochain-chain pairing、Stokes-compatible condition を定義し、`<d omega, gamma> = <omega, boundary gamma>` を証明する。connecting homomorphism が selected coboundary representative で構成される場合の `<delta(b), gamma> = <b, boundary gamma>` も明示 compatibility data から証明する。定義13.4 は `kappa_U` の加法性を defining property とする extension holonomy accounting convention として定義し、Stokes theorem の自動系とは主張しない。 | `proved under explicit pairing/accounting data` |
+| `IV.定義14.1 / 定理候補14.2 / 定義14.3` | `AAT.AG.Cohomology.FiniteSiteMorphism`, `PushforwardObstructionSheaf`, `HigherDirectImageCech`, `AggregationComparisonMap`, `AggregationComparisonMap.InComparisonImage`, `AggregationFiveTermStatement`, `ScaleStableDebt`, `ScaleStableDebt.in_comparison_image` | `structure` / `def` / `theorem` | selected finite site morphism `pi : X_fine -> X_coarse`、pushforward `pi_* Ob`、Čech-style `R^q pi_* Ob` statement surface、`H^1(X_coarse, pi_* Ob) -> H^1(X_fine, Ob)` comparison map、定理候補14.2 の五項完全列 statement package、selected aggregation family 全体で comparison image に入る scale-stable debt を定義する。 | `statement only` / `defined only` / `proved accessor` |
 
 Non-conclusions: この entrypoint は obstruction coefficient sheaf carrier、module-valued
 coefficient surface、`Def_U` / `ConDef_U` / `DerOb_U` placeholder の R1 package、
@@ -4668,6 +4670,7 @@ finite golden example、R10(b)(c) の Boundary Residue / forest / cycle selected
 仮定なしの Cohomological Flatness Criterion、任意 cover の無条件 nerve cohomology 計算、
 ArchSig fixture JSON の検証、Boundary Residue 仮定ブロックの無条件構成、任意 cover の forest / cycle 分類、
 Stokes-compatible pairing の無条件存在、`kappa_U` accounting が Stokes theorem から自動的に従うこと、
+aggregation five-term statement の証明、spectral sequence 構成、任意 aggregation family の scale stability、
 non-abelian torsor triviality、スペクトル系列一般論、derived category、cotangent complex、
 `Ext^1` はまだ形式化しない。
 

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -803,7 +803,8 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/FlatnessCriterion.lean`,
 `Formal/AG/Cohomology/CoverNerve.lean`,
 `Formal/AG/Cohomology/FiniteExamples.lean`,
-`Formal/AG/Cohomology/PeriodStokes.lean`.
+`Formal/AG/Cohomology/PeriodStokes.lean`,
+`Formal/AG/Cohomology/Aggregation.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
 は AC1/R0 と AC2/R1 から着手している。Issue
@@ -837,6 +838,9 @@ Issue
 Issue
 [#2070](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2070)
 では period pairing、Stokes theorem、extension holonomy accounting convention を追加した。
+Issue
+[#2072](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2072)
+では aggregation map、comparison map、定理候補14.2 statement、scale-stable debt を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
@@ -856,6 +860,7 @@ Issue
 | `IV.R10(a) / AC13` Pseudo-circle golden example | `proved finite example under explicit cover-relative H1 witness`. `Formal/AG/Cohomology/FiniteExamples.lean` が `FiniteExamples.PseudoCircleGolden.Chart`、`BoundaryEdge`、`coverNerve`、`each_chart_lawful`、`h0_witness_counting_sees_no_obstruction`、`boundaryCocycle`、`boundaryCocycle_AB_nonzero`、`CoverRelativeH1NonzeroWitness`、`concreteClass_nonzero`、`no_global_lawful_section_by_localFlatnessGap`、`pseudoCircle_h0_invisible_h1_obstructed` を持つ。 | 擬円周例は ArchSig v0.4.0 R14 golden fixture に対応する selected finite surface として扱う。H0 的 witness count は zero、finite boundary cocycle は visibly nonzero。actual cover-relative `K.CoverRelativeHn 1` の nonzero hidden coupling class は `CoverRelativeH1NonzeroWitness` として明示し、既存 `localFlatnessGap_no_globalLawfulSection` を呼んで compatible global lawful section が存在しないことを示す。ArchSig fixture JSON の検証、定理9.2 両方向例、forest / cycle nerve 例は AC14 に残す。 |
 | `IV.R10(b)(c) / AC14` Boundary Residue and nerve finite examples | `proved finite examples under explicit packages`. `Formal/AG/Cohomology/FiniteExamples.lean` が `BoundaryResidueGolden.zero_boundaryResidue_glues`、`nonzero_boundaryResidue_blocks_gluing`、`boundaryResidue_two_direction_example`、`NerveGolden.forestCoverNerve`、`forestCoverGluingData`、`forestCover_H1_zero`、`cycleCoverNerve`、`cycleConstantCoefficientReading`、`cycleNerve_dimH1_eq_b1` を持つ。 | Boundary Residue 両方向例は既存 `BoundaryResidueHypotheses` に相対化し、`delta(b)=0` から global U-flat、`delta(b)≠0` から global U-flat 不在を読む。forest/cycle nerve 例は AC12 の `ForestCoverGluingData` と `ConstantCoefficientNerveReading` を finite selected examples として instantiate する。任意 cover の一般計算や ArchSig fixture JSON 検証は主張しない。 |
 | `IV.定義13.1 / 定理13.2 / 定義13.4` Period Stokes and holonomy accounting | `proved under explicit pairing/accounting data`. `Formal/AG/Cohomology/PeriodStokes.lean` が `FiniteCechChainComplex`、`boundaryOp`、`boundary_comp_zero`、`CechCochainChainPairing`、`pair`、`StokesCompatiblePairing`、`cechStokes`、`ConnectingBoundaryRepresentative`、`connectingStokes`、`ExtensionHolonomyAccounting`、`kappa_U_additive`、`kappa_U_zero` を持つ。 | Stokes theorem は selected chain complex、cochain-chain pairing、Stokes-compatible condition に相対化する。connecting formula は selected connecting representative と boundary pairing compatibility に相対化する。定義13.4 は `kappa_U` の加法性を defining property とする会計規約であり、定理13.2 から自動的に従う系ではない。 |
+| `IV.定義14.1 / 定理候補14.2 / 定義14.3` Aggregation and scale-stable debt | `statement only` / `defined only` / `proved accessor`. `Formal/AG/Cohomology/Aggregation.lean` が `FiniteSiteMorphism`、`PushforwardObstructionSheaf`、`HigherDirectImageCech`、`AggregationComparisonMap`、`InComparisonImage`、`AggregationFiveTermStatement`、`ScaleStableDebt`、`in_comparison_image` を持つ。 | finite site morphism、pushforward、higher direct image は selected statement surface として扱う。定理候補14.2 は五項完全列形の statement-only package であり、証明や spectral sequence 構成は主張しない。scale-stable debt は selected aggregation family 全体で comparison image に入ることとして定義する。 |
 
 第IV部 PRD-4 の証明対象ラベルは次の現在状態である。
 
@@ -877,6 +882,7 @@ Issue
 | `IV.R10(a) / AC13` | `proved finite example under explicit cover-relative H1 witness` |
 | `IV.R10(b)(c) / AC14` | `proved finite examples under explicit packages` |
 | `IV.定義13.1 / 定理13.2 / 定義13.4` | `proved under explicit pairing/accounting data` |
+| `IV.定義14.1 / 定理候補14.2 / 定義14.3` | `statement only` / `defined only` / `proved accessor` |
 | `IV.定理候補10.4 / 定理候補14.2` | `future proof obligation` |
 
 ## 現在の未解決カテゴリ


### PR DESCRIPTION
## 概要

Closes #2072

PRD-4 AC16 / R12 として、有限 site の aggregation surface と scale-stable debt の Lean 形式化を追加します。

- `FiniteSiteMorphism` で fine/coarse site 間の選択された射と被覆保存条件を表す
- `PushforwardObstructionSheaf` と `HigherDirectImageCech` で `pi_* Ob` と `R^q pi_* Ob` の statement-level surface を置く
- `AggregationComparisonMap` と `AggregationFiveTermStatement` で coarse/fine `H^1` 比較写像と low-degree five-term statement の形を固定する
- `ScaleStableDebt` で aggregation family 上に残る debt class を比較写像の像として記録する
- Lean theorem index / proof obligations を AC16 の実装境界に同期する

## 証明した定理

- `AAT.AG.Cohomology.ScaleStableDebt.in_comparison_image`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build Formal.AG.Cohomology.Aggregation`
- [x] `lake env lean Formal/AG/Cohomology.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` は成功しました。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の `tac1 <;> tac2` 警告のみ表示されています。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
