### PR TITLE
PRD-4 R13 最終台帳を同期する

### DIFF
--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4607,8 +4607,7 @@ File: `Formal/AG/Cohomology.lean`, `Formal/AG/Cohomology/Basic.lean`,
 `Formal/AG/Cohomology/Aggregation.lean`.
 
 PRD-4 [第IV部 Obstruction Cohomology](lean_ag_part_4_obstruction_cohomology_prd.md)
-の AC1/R0、AC2/R1、AC3/R2 の一般 complex surface、AC4/R2 の有限
-poset 比較 target、AC5/R3、AC6/R4、AC7/R5、AC8/R6 first half、AC9/R6、AC10/R7、AC11/R8、AC12/R9、AC13/R10(a) に対応する entrypoint である。現時点では
+の AC1/R0 から AC16/R12 までに対応する entrypoint である。現時点では
 `Formal/AG/Cohomology` を build 対象へ追加し、PRD-2 `Site` と PRD-3
 `LawAlgebra` への prerequisite package、obstruction coefficient sheaf carrier、
 `O_X^U`-module valued coefficient surface、`Def_U = I_U`、`ConDef_U = I_U/I_U^2`


### PR DESCRIPTION
## 概要

Closes #2074

PRD-4 R13 / AC17-AC19 の最終台帳整合です。

- `lean_theorem_index.md` の第IV部導入文を、実装済みの AC16/R12 までに合わせる
- `proof_obligations.md` は現状の第IV部 labels と `IV.定理候補10.4 / 定理候補14.2` の `future proof obligation` 登録が整合していることを確認
- `Formal/AG` 全体の forbidden token scan で `axiom` / `admit` / `sorry` / `unsafe` が 0 件であることを確認

## 証明した定理

- なし

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`

## 実施したテスト

- [x] `/Users/nakahata/.elan/bin/lake build`
- [x] `/Users/nakahata/.elan/bin/lake env lean Formal/AG/Cohomology.lean`（第三者レビュー側）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `rg -n "\b(axiom|admit|sorry|unsafe)\b" Formal/AG`
- [x] R13 台帳 grep
- [x] subagent review: 指摘なし

`lake build` は成功しました。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の `tac1 <;> tac2` 警告のみ表示されています。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
