### PR TITLE
PRD-5 R0/R1 Derived入口と古典交差を追加する

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -15,3 +15,4 @@ import Formal.AG.Examples.FiniteModel
 import Formal.AG.Site
 import Formal.AG.LawAlgebra
 import Formal.AG.Cohomology
+import Formal.AG.Derived

--- a/Formal/AG/Derived.lean
+++ b/Formal/AG/Derived.lean
@@ -1,0 +1,1 @@
+import Formal.AG.Derived.LawfulLoci

--- a/Formal/AG/Derived/LawfulLoci.lean
+++ b/Formal/AG/Derived/LawfulLoci.lean
@@ -1,0 +1,77 @@
+import Formal.AG.LawAlgebra.LawfulLocus
+
+noncomputable section
+
+namespace AAT.AG
+namespace Derived
+
+universe u v
+
+namespace LawfulLoci
+
+variable (A : Type v) [CommRing A]
+
+/-- V.R0/R1: a selected law-universe reading on one affine chart. -/
+abbrev LawUniverseReading :=
+  LawAlgebra.ObstructionIdeal.SelectedLawWitnessIdealFamily.{u, v} A
+
+/-- V.R1: a pair of law universes read on the same chart algebra. -/
+structure LawUniversePair where
+  U : LawUniverseReading.{u, v} A
+  V : LawUniverseReading.{u, v} A
+
+namespace LawUniversePair
+
+/-- V.定義2.1: Part V notation `I_U` for the obstruction ideal of `U`. -/
+def I_U (P : LawUniversePair.{u, v} A) : Ideal A :=
+  P.U.localObstructionIdeal
+
+/-- V.定義2.1: Part V notation `I_V` for the obstruction ideal of `V`. -/
+def I_V (P : LawUniversePair.{u, v} A) : Ideal A :=
+  P.V.localObstructionIdeal
+
+/-- V.定義2.1: lawful locus `Flat_U(X) = V(I_U)`. -/
+def flatU (P : LawUniversePair.{u, v} A) : Set (PrimeSpectrum A) :=
+  LawAlgebra.LawfulLocus.lawfulLocus A P.I_U
+
+/-- V.定義2.1: lawful locus `Flat_V(X) = V(I_V)`. -/
+def flatV (P : LawUniversePair.{u, v} A) : Set (PrimeSpectrum A) :=
+  LawAlgebra.LawfulLocus.lawfulLocus A P.I_V
+
+/-- V.定義3.1: ideal cutting out the classical joint lawful locus. -/
+def classicalJointIdeal (P : LawUniversePair.{u, v} A) : Ideal A :=
+  P.I_U + P.I_V
+
+/-- V.定義3.1: classical joint lawful locus `Flat_U(X) ∩ Flat_V(X) = V(I_U + I_V)`. -/
+def classicalJointLawfulLocus (P : LawUniversePair.{u, v} A) :
+    Set (PrimeSpectrum A) :=
+  LawAlgebra.LawfulLocus.lawfulLocus A P.classicalJointIdeal
+
+/-- V.R1: the `U` locus reuses the PRD-3 lawful-locus surface. -/
+theorem flatU_eq_lawfulLocus (P : LawUniversePair.{u, v} A) :
+    P.flatU = LawAlgebra.LawfulLocus.localLawfulLocus A P.U :=
+  rfl
+
+/-- V.R1: the `V` locus reuses the PRD-3 lawful-locus surface. -/
+theorem flatV_eq_lawfulLocus (P : LawUniversePair.{u, v} A) :
+    P.flatV = LawAlgebra.LawfulLocus.localLawfulLocus A P.V :=
+  rfl
+
+/-- V.定義3.1: the classical joint locus is exactly `V(I_U + I_V)`. -/
+theorem classicalJointLawfulLocus_eq_zeroLocus (P : LawUniversePair.{u, v} A) :
+    P.classicalJointLawfulLocus =
+      PrimeSpectrum.zeroLocus (P.I_U + P.I_V) :=
+  rfl
+
+/-- V.定義3.1: the joint locus agrees with the intersection of the two lawful loci. -/
+theorem classicalJointLawfulLocus_eq_flatU_inter_flatV (P : LawUniversePair.{u, v} A) :
+    P.classicalJointLawfulLocus = P.flatU ∩ P.flatV := by
+  simp [classicalJointLawfulLocus, classicalJointIdeal, flatU, flatV,
+    LawAlgebra.LawfulLocus.lawfulLocus, PrimeSpectrum.zeroLocus_sup]
+
+end LawUniversePair
+
+end LawfulLoci
+
+end Derived
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4673,6 +4673,28 @@ aggregation five-term statement の証明、spectral sequence 構成、任意 ag
 non-abelian torsor triviality、スペクトル系列一般論、derived category、cotangent complex、
 `Ext^1` はまだ形式化しない。
 
+## AG版AAT Lean形式化 PRD-5 / 第V部 Derived Law Geometry と Repair
+
+File: `Formal/AG/Derived.lean`, `Formal/AG/Derived/LawfulLoci.lean`.
+
+PRD-5 [第V部 Derived Law Geometry と Repair](lean_ag_part_5_derived_law_geometry_repair_prd.md)
+の AC1/R0 と AC2/R1 に対応する entrypoint である。現時点では
+`Formal/AG/Derived` を build 対象へ追加し、PRD-3 の lawful locus / obstruction
+ideal surface を再利用して、law universe pair、`I_U` / `I_V` 記法、
+`Flat_U(X)`、`Flat_V(X)`、および classical joint lawful locus
+`V(I_U + I_V)` を Lean 上に置く。
+
+| 本文ラベル | Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- | --- |
+| `V.R0` | `Formal.AG.Derived`, `Formal.AG.Derived.LawfulLoci` | `import` | 第V部 derived-law-geometry tower の entrypoint。`Formal/AG.lean` から import され、`lake build` 対象に入る。 | `defined only` |
+| `V.定義2.1 / 定義3.1` | `AAT.AG.Derived.LawfulLoci.LawUniverseReading`, `LawUniversePair`, `LawUniversePair.I_U`, `LawUniversePair.I_V`, `LawUniversePair.flatU`, `LawUniversePair.flatV`, `LawUniversePair.classicalJointIdeal`, `LawUniversePair.classicalJointLawfulLocus`, `LawUniversePair.flatU_eq_lawfulLocus`, `LawUniversePair.flatV_eq_lawfulLocus`, `LawUniversePair.classicalJointLawfulLocus_eq_zeroLocus`, `LawUniversePair.classicalJointLawfulLocus_eq_flatU_inter_flatV` | `abbrev` / `structure` / `def` / `theorem` | 同じ chart algebra 上の二つの selected law-universe reading から、PRD-3 の `localObstructionIdeal` を `I_U` / `I_V` として読み、classical joint lawful locus を `V(I_U + I_V)` および `Flat_U(X) ∩ Flat_V(X)` として公開する。 | `defined only` / `proved accessor` |
+
+Non-conclusions: この entrypoint は derived category 一般論、Koszul complex、
+derived lawful locus、chart-level derived intersection、Tor / `LawConflict_i`、
+Taylor resolution、repair transfer、Hilbert series、well-founded repair、
+cotangent complex、`Ext^1` をまだ形式化しない。PRD-4 の `DerOb_U` は
+type-signature-only placeholder のまま維持する。
+
 ## Reverse-Import Theorem Packages
 
 File: `Formal/Arch/Evolution/ReverseImportTheorems.lean`.

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -885,6 +885,39 @@ Issue
 | `IV.定義14.1 / 定理候補14.2 / 定義14.3` | `statement only` / `defined only` / `proved accessor` |
 | `IV.定理候補10.4 / 定理候補14.2` | `future proof obligation` |
 
+## AG版AAT Lean形式化 PRD-5 / 第V部 Derived Law Geometry と Repair
+
+File: `Formal/AG/Derived.lean`, `Formal/AG/Derived/LawfulLoci.lean`.
+
+PRD-5 [第V部 Derived Law Geometry と Repair](lean_ag_part_5_derived_law_geometry_repair_prd.md)
+は Issue [#2076](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2076)
+で tracking している。Issue
+[#2077](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2077)
+では `Formal/AG/Derived` の entrypoint と、PRD-3 の lawful locus surface を再利用した
+`I_U` / `I_V` 記法、law universe pair、classical joint lawful locus
+`V(I_U + I_V)` を追加した。
+
+| 対象 | 現在の扱い | 残す境界 |
+| --- | --- | --- |
+| `V.R0` Formal/AG/Derived entrypoint | `defined only`. `Formal/AG/Derived.lean` が `Formal/AG/Derived/LawfulLoci.lean` を束ね、`Formal/AG.lean` から import される。 | Koszul complex、derived intersection、Tor、repair profile、Hilbert series、well-founded repair はまだ定義しない。 |
+| `V.定義2.1 / 定義3.1` Lawful loci and classical joint locus | `defined only` / `proved accessor`. `LawUniverseReading`、`LawUniversePair`、`LawUniversePair.I_U`、`I_V`、`flatU`、`flatV`、`classicalJointIdeal`、`classicalJointLawfulLocus`、`flatU_eq_lawfulLocus`、`flatV_eq_lawfulLocus`、`classicalJointLawfulLocus_eq_zeroLocus`、`classicalJointLawfulLocus_eq_flatU_inter_flatV` を持つ。 | `Flat_U^der`、`LawConflict_i`、`Tor_i`、derived non-transversality は R2 以降に残す。 |
+| `IV.定義2.4 DerOb_U` の内部構成 | `future proof obligation` / `unassigned`. PRD-5 R0/R1 では触らず、PRD-5 本文が展開する chart-level Koszul / Tor 構成とは別境界として維持する。 | 余接複体 `L_{Flat/X}` と `Ext^1` の一般形式化は PRD-5 の現在 scope では実装しない。 |
+
+第V部 PRD-5 の証明対象ラベルは次の現在状態である。
+
+| 証明対象ラベル | Lean status |
+| --- | --- |
+| `V.R0` | `defined only` |
+| `V.定義2.1 / 定義3.1` | `defined only` / `proved accessor` |
+| `V.定義2.3 / 原則2.4` | `future proof obligation` |
+| `V.定義4.1 / 5.1 / 5.2` | `future proof obligation` |
+| `V.命題5.5` | `future proof obligation` |
+| `V.定理6.1 / 定理7.3` | `future proof obligation` |
+| `V.命題9.2` | `future proof obligation` |
+| `V.定理10.5 / 定理10.6` | `future proof obligation` |
+| `V.定理12.2` | `future proof obligation` |
+| `V.定理13.3 / 定理13.4` | `future proof obligation` |
+
 ## 現在の未解決カテゴリ
 
 | カテゴリ | 扱い |


### PR DESCRIPTION
## 概要

Closes #2077

PRD-5 R0/R1 の bootstrap として、`Formal/AG/Derived` entrypoint を追加し、第III部の lawful locus / obstruction ideal surface を再利用して `I_U` / `I_V`、law universe pair、classical joint lawful locus `V(I_U + I_V)` を定義しました。

local-review では `Flat_U ∩ Flat_V` への accessor が不足している指摘があり、`classicalJointLawfulLocus_eq_flatU_inter_flatV` を追加して対応しました。

## 証明した定理

- `AAT.AG.Derived.LawfulLoci.LawUniversePair.flatU_eq_lawfulLocus`
- `AAT.AG.Derived.LawfulLoci.LawUniversePair.flatV_eq_lawfulLocus`
- `AAT.AG.Derived.LawfulLoci.LawUniversePair.classicalJointLawfulLocus_eq_zeroLocus`
- `AAT.AG.Derived.LawfulLoci.LawUniversePair.classicalJointLawfulLocus_eq_flatU_inter_flatV`

## 編集したドキュメント

- `docs/aat/proof_obligations.md`
- `docs/aat/lean_theorem_index.md`

## 実施したテスト

- [x] `/Users/nakahata/.elan/bin/lake env lean Formal/AG/Derived/LawfulLoci.lean`
- [x] `/Users/nakahata/.elan/bin/lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG Formal/AG.lean`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
