### PR TITLE
PRD-5 R4の有限自由分解とTaylor計算surfaceを追加する

### DIFF
--- a/Formal/AG/Derived.lean
+++ b/Formal/AG/Derived.lean
@@ -1,3 +1,5 @@
 import Formal.AG.Derived.LawfulLoci
 import Formal.AG.Derived.Koszul
 import Formal.AG.Derived.Intersection
+import Formal.AG.Derived.FreeResolution
+import Formal.AG.Derived.TaylorResolution

--- a/Formal/AG/Derived/FreeResolution.lean
+++ b/Formal/AG/Derived/FreeResolution.lean
@@ -1,0 +1,130 @@
+import Formal.AG.Derived.Intersection
+
+noncomputable section
+
+namespace AAT.AG
+namespace Derived
+
+universe u v
+
+namespace FreeResolution
+
+variable (A : Type v) [CommRing A]
+
+/--
+V.R4(a): selected finite free resolution of an `A`-module.
+
+The exactness and augmentation data are explicit fields. This keeps the R4 API
+usable without claiming a global construction of all finite free resolutions.
+-/
+structure SelectedFiniteFreeResolution (M : Type v) [AddCommGroup M] [Module A M] where
+  length : Nat
+  Term : Nat -> Type v
+  [termAddCommGroup : (n : Nat) -> AddCommGroup (Term n)]
+  [termModule : (n : Nat) -> Module A (Term n)]
+  BasisIndex : Nat -> Type u
+  [basisIndexFintype : (n : Nat) -> Fintype (BasisIndex n)]
+  termLinearEquivFree : (n : Nat) -> Term n ≃ₗ[A] (BasisIndex n -> A)
+  d : (n : Nat) -> Term n.succ →ₗ[A] Term n
+  augmentation : Term 0 →ₗ[A] M
+  d_comp_d : ∀ (n : Nat) (x : Term n.succ.succ), d n (d n.succ x) = 0
+  augmentation_comp_d : ∀ x : Term 1, augmentation (d 0 x) = 0
+  supported_le_length : ∀ n, length < n -> Subsingleton (Term n)
+  exact : Prop
+  exact_holds : exact
+
+attribute [instance] SelectedFiniteFreeResolution.termAddCommGroup
+attribute [instance] SelectedFiniteFreeResolution.termModule
+attribute [instance] SelectedFiniteFreeResolution.basisIndexFintype
+
+namespace SelectedFiniteFreeResolution
+
+variable {A}
+variable {M : Type v} [AddCommGroup M] [Module A M]
+
+/-- V.R4(a): every selected term is linearly equivalent to a finite free coordinate module. -/
+def termLinearEquivFree_certificate (F : SelectedFiniteFreeResolution.{u, v} A M) (n : Nat) :
+    F.Term n ≃ₗ[A] (F.BasisIndex n -> A) :=
+  F.termLinearEquivFree n
+
+/-- V.R4(a): the selected resolution carries its exactness certificate. -/
+theorem exact_certificate (F : SelectedFiniteFreeResolution.{u, v} A M) :
+    F.exact :=
+  F.exact_holds
+
+end SelectedFiniteFreeResolution
+
+/--
+V.R4(a): selected tensor complex `F ⊗ A/I_V` attached to a finite free
+resolution. The homology carrier is explicit; R4 later bridges it to Mathlib Tor.
+-/
+structure SelectedTensorComplex
+    {M : Type v} [AddCommGroup M] [Module A M]
+    (F : SelectedFiniteFreeResolution.{u, v} A M) (I_V : Ideal A) where
+  Term : Nat -> Type v
+  [termAddCommGroup : (n : Nat) -> AddCommGroup (Term n)]
+  [termModule : (n : Nat) -> Module A (Term n)]
+  d : (n : Nat) -> Term n.succ →ₗ[A] Term n
+  d_comp_d : ∀ (n : Nat) (x : Term n.succ.succ), d n (d n.succ x) = 0
+  Homology : Nat -> Type v
+  [homologyAddCommGroup : (n : Nat) -> AddCommGroup (Homology n)]
+  [homologyModule : (n : Nat) -> Module A (Homology n)]
+  tensorOfResolution : Prop
+  tensorOfResolution_holds : tensorOfResolution
+
+attribute [instance] SelectedTensorComplex.termAddCommGroup
+attribute [instance] SelectedTensorComplex.termModule
+attribute [instance] SelectedTensorComplex.homologyAddCommGroup
+attribute [instance] SelectedTensorComplex.homologyModule
+
+namespace SelectedTensorComplex
+
+variable {A}
+variable {M : Type v} [AddCommGroup M] [Module A M]
+variable {F : SelectedFiniteFreeResolution.{u, v} A M} {I_V : Ideal A}
+
+/-- V.R4(a): homology of the selected tensor complex. -/
+abbrev homology (T : SelectedTensorComplex.{u, v} A F I_V) (i : Nat) : Type v :=
+  T.Homology i
+
+/-- V.R4(a): the selected tensor complex is recorded as `F ⊗ A/I_V`. -/
+theorem tensorOfResolution_certificate (T : SelectedTensorComplex.{u, v} A F I_V) :
+    T.tensorOfResolution :=
+  T.tensorOfResolution_holds
+
+end SelectedTensorComplex
+
+/--
+V.R4(a): package saying that a selected finite free resolution computes Mathlib
+`Tor_i(A/I_U, A/I_V)` via the homology of its tensor complex.
+-/
+structure FiniteFreeResolutionTorComputation (I_U I_V : Ideal A) where
+  quotientResolution :
+    SelectedFiniteFreeResolution.{u, v} A (A ⧸ I_U)
+  tensorComplex :
+    SelectedTensorComplex.{u, v} A quotientResolution I_V
+  torLinearEquivTensorHomology :
+    (i : Nat) -> Intersection.mathlibTor A I_U I_V i ≃ₗ[A] tensorComplex.homology i
+
+namespace FiniteFreeResolutionTorComputation
+
+variable {A}
+
+/-- V.R4(a): selected finite free resolution computes Mathlib `Tor_i`. -/
+def mathlibTorLinearEquivTensorHomology {I_U I_V : Ideal A}
+    (C : FiniteFreeResolutionTorComputation.{u, v} A I_U I_V) (i : Nat) :
+    Intersection.mathlibTor A I_U I_V i ≃ₗ[A] C.tensorComplex.homology i :=
+  C.torLinearEquivTensorHomology i
+
+/-- V.R4(a): inverse form, reading tensor-complex homology as law-conflict Tor. -/
+def tensorHomologyLinearEquivMathlibTor {I_U I_V : Ideal A}
+    (C : FiniteFreeResolutionTorComputation.{u, v} A I_U I_V) (i : Nat) :
+    C.tensorComplex.homology i ≃ₗ[A] Intersection.mathlibTor A I_U I_V i :=
+  (C.mathlibTorLinearEquivTensorHomology i).symm
+
+end FiniteFreeResolutionTorComputation
+
+end FreeResolution
+
+end Derived
+end AAT.AG

--- a/Formal/AG/Derived/TaylorResolution.lean
+++ b/Formal/AG/Derived/TaylorResolution.lean
@@ -1,0 +1,161 @@
+import Formal.AG.Derived.FreeResolution
+import Mathlib.Data.Finset.Lattice.Basic
+
+noncomputable section
+
+namespace AAT.AG
+namespace Derived
+
+universe u v
+
+namespace TaylorResolution
+
+set_option linter.unusedSectionVars false
+
+variable (A : Type v) [CommRing A]
+variable (E : Type u) [DecidableEq E]
+
+/-- V.定義5.4: square-free monomial ideal presentation by forbidden supports. -/
+structure SquareFreeMonomialIdealPresentation (I : Ideal A) where
+  Generator : Type u
+  [generatorFintype : Fintype Generator]
+  [generatorDecidableEq : DecidableEq Generator]
+  monomial : Generator -> A
+  forbiddenSupport : Generator -> Finset E
+  monomial_mem : ∀ g, monomial g ∈ I
+  spans : Ideal.span (Set.range monomial) = I
+  squareFree : Prop
+  squareFree_holds : squareFree
+
+attribute [instance] SquareFreeMonomialIdealPresentation.generatorFintype
+attribute [instance] SquareFreeMonomialIdealPresentation.generatorDecidableEq
+
+namespace SquareFreeMonomialIdealPresentation
+
+variable {A E}
+variable {I : Ideal A}
+
+/-- V.定義5.4: the selected monomial generators span the ideal. -/
+theorem generatedIdeal_eq (P : SquareFreeMonomialIdealPresentation A E I) :
+    Ideal.span (Set.range P.monomial) = I :=
+  P.spans
+
+/-- V.定義5.4: selected square-free certificate. -/
+theorem squareFree_certificate (P : SquareFreeMonomialIdealPresentation A E I) :
+    P.squareFree :=
+  P.squareFree_holds
+
+end SquareFreeMonomialIdealPresentation
+
+/-- V.R4: pair of square-free monomial ideals in a shared ambient chart algebra. -/
+structure MonomialLawConflictRegime (I_U I_V : Ideal A) where
+  left : SquareFreeMonomialIdealPresentation A E I_U
+  right : SquareFreeMonomialIdealPresentation A E I_V
+
+namespace MonomialLawConflictRegime
+
+variable {A E}
+variable {I_U I_V : Ideal A}
+
+/-- V.命題5.5: lcm multidegree of one left and one right forbidden support. -/
+def lcmSupport (R : MonomialLawConflictRegime A E I_U I_V)
+    (gU : R.left.Generator) (gV : R.right.Generator) : Finset E :=
+  R.left.forbiddenSupport gU ∪ R.right.forbiddenSupport gV
+
+/-- V.命題5.5: lcm multidegree is the union of forbidden supports. -/
+theorem lcmSupport_eq_union (R : MonomialLawConflictRegime A E I_U I_V)
+    (gU : R.left.Generator) (gV : R.right.Generator) :
+    R.lcmSupport gU gV =
+      R.left.forbiddenSupport gU ∪ R.right.forbiddenSupport gV :=
+  rfl
+
+end MonomialLawConflictRegime
+
+/--
+V.R4(b): selected Taylor complex for a square-free monomial ideal presentation.
+
+This records the Taylor surface and its resolution certificate. It does not claim
+Scarf or lcm-lattice minimality.
+-/
+structure TaylorComplex {I : Ideal A}
+    (P : SquareFreeMonomialIdealPresentation A E I) where
+  Term : Nat -> Type v
+  [termAddCommGroup : (n : Nat) -> AddCommGroup (Term n)]
+  [termModule : (n : Nat) -> Module A (Term n)]
+  d : (n : Nat) -> Term n.succ →ₗ[A] Term n
+  d_comp_d : ∀ (n : Nat) (x : Term n.succ.succ), d n (d n.succ x) = 0
+  multidegree : Finset P.Generator -> Finset E
+  multidegree_singleton :
+    ∀ g, multidegree {g} = P.forbiddenSupport g
+  multidegree_union :
+    ∀ S T, multidegree (S ∪ T) = multidegree S ∪ multidegree T
+  resolvesQuotient : Prop
+  resolvesQuotient_holds : resolvesQuotient
+
+attribute [instance] TaylorComplex.termAddCommGroup
+attribute [instance] TaylorComplex.termModule
+
+namespace TaylorComplex
+
+variable {A E}
+variable {I : Ideal A} {P : SquareFreeMonomialIdealPresentation A E I}
+
+/-- V.R4(b): selected Taylor complex resolves the quotient. -/
+theorem resolvesQuotient_certificate (T : TaylorComplex A E P) :
+    T.resolvesQuotient :=
+  T.resolvesQuotient_holds
+
+/-- V.R4(b): multidegree of a union is the lcm/union support. -/
+theorem multidegree_union_eq (T : TaylorComplex A E P)
+    (S Tset : Finset P.Generator) :
+    T.multidegree (S ∪ Tset) = T.multidegree S ∪ T.multidegree Tset :=
+  T.multidegree_union S Tset
+
+end TaylorComplex
+
+/--
+V.命題5.5: monomial conflict calculation package.
+
+The package bundles the monomial regime, selected Taylor complexes, and a finite
+free resolution computation of `LawConflict_i = Tor_i`.
+-/
+structure MonomialConflictCalculation (I_U I_V : Ideal A) where
+  regime : MonomialLawConflictRegime A E I_U I_V
+  leftTaylor : TaylorComplex A E regime.left
+  rightTaylor : TaylorComplex A E regime.right
+  computation :
+    FreeResolution.FiniteFreeResolutionTorComputation.{u, v} A I_U I_V
+  computesLawConflict : Prop
+  computesLawConflict_holds : computesLawConflict
+
+namespace MonomialConflictCalculation
+
+variable {A E}
+variable {I_U I_V : Ideal A}
+
+/-- V.命題5.5: monomial package computes law conflicts by finite free homology. -/
+theorem computesLawConflict_certificate
+    (C : MonomialConflictCalculation.{u, v} A E I_U I_V) :
+    C.computesLawConflict :=
+  C.computesLawConflict_holds
+
+/-- V.命題5.5: Mathlib `Tor_i` is read from the selected finite free tensor homology. -/
+def lawConflictLinearEquivTensorHomology
+    (C : MonomialConflictCalculation.{u, v} A E I_U I_V) (i : Nat) :
+    Intersection.mathlibTor A I_U I_V i ≃ₗ[A] C.computation.tensorComplex.homology i :=
+  C.computation.mathlibTorLinearEquivTensorHomology i
+
+/-- V.命題5.5: lcm multidegree is combined witness support. -/
+theorem lcm_multidegree_eq_union
+    (C : MonomialConflictCalculation.{u, v} A E I_U I_V)
+    (gU : C.regime.left.Generator) (gV : C.regime.right.Generator) :
+    C.regime.lcmSupport gU gV =
+      C.regime.left.forbiddenSupport gU ∪ C.regime.right.forbiddenSupport gV :=
+  C.regime.lcmSupport_eq_union gU gV
+
+end MonomialConflictCalculation
+
+end TaylorResolution
+
+end Derived
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4676,7 +4676,8 @@ non-abelian torsor triviality、スペクトル系列一般論、derived categor
 ## AG版AAT Lean形式化 PRD-5 / 第V部 Derived Law Geometry と Repair
 
 File: `Formal/AG/Derived.lean`, `Formal/AG/Derived/LawfulLoci.lean`,
-`Formal/AG/Derived/Koszul.lean`, `Formal/AG/Derived/Intersection.lean`.
+`Formal/AG/Derived/Koszul.lean`, `Formal/AG/Derived/Intersection.lean`,
+`Formal/AG/Derived/FreeResolution.lean`, `Formal/AG/Derived/TaylorResolution.lean`.
 
 PRD-5 [第V部 Derived Law Geometry と Repair](lean_ag_part_5_derived_law_geometry_repair_prd.md)
 の AC1/R0 と AC2/R1 に対応する entrypoint である。現時点では
@@ -4690,21 +4691,28 @@ R3 として、selected derived tensor complex を持つ chart-level derived int
 Mathlib `Tor` object への selected bridge に相対化した `LawConflict_i` /
 `LawConflict_0` surface、および selected global / hypercohomology notation carrier
 も追加している。
+R4 として、selected finite free resolution、selected tensor-complex Tor computation、
+Taylor complex surface、monomial law conflict regime、命題5.5 calculation package の
+carrier / accessor surface も追加している。AC5--AC7 の本証明は後続 Issue に残す。
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
-| `V.R0` | `Formal.AG.Derived`, `Formal.AG.Derived.LawfulLoci`, `Formal.AG.Derived.Koszul`, `Formal.AG.Derived.Intersection` | `import` | 第V部 derived-law-geometry tower の entrypoint。`Formal/AG.lean` から import され、`lake build` 対象に入る。 | `defined only` |
+| `V.R0` | `Formal.AG.Derived`, `Formal.AG.Derived.LawfulLoci`, `Formal.AG.Derived.Koszul`, `Formal.AG.Derived.Intersection`, `Formal.AG.Derived.FreeResolution`, `Formal.AG.Derived.TaylorResolution` | `import` | 第V部 derived-law-geometry tower の entrypoint。`Formal/AG.lean` から import され、`lake build` 対象に入る。 | `defined only` |
 | `V.定義2.1 / 定義3.1` | `AAT.AG.Derived.LawfulLoci.LawUniverseReading`, `LawUniversePair`, `LawUniversePair.I_U`, `LawUniversePair.I_V`, `LawUniversePair.flatU`, `LawUniversePair.flatV`, `LawUniversePair.classicalJointIdeal`, `LawUniversePair.classicalJointLawfulLocus`, `LawUniversePair.flatU_eq_lawfulLocus`, `LawUniversePair.flatV_eq_lawfulLocus`, `LawUniversePair.classicalJointLawfulLocus_eq_zeroLocus`, `LawUniversePair.classicalJointLawfulLocus_eq_flatU_inter_flatV` | `abbrev` / `structure` / `def` / `theorem` | 同じ chart algebra 上の二つの selected law-universe reading から、PRD-3 の `localObstructionIdeal` を `I_U` / `I_V` として読み、classical joint lawful locus を `V(I_U + I_V)` および `Flat_U(X) ∩ Flat_V(X)` として公開する。 | `defined only` / `proved accessor` |
 | `V.定義2.3 / 原則2.4` | `AAT.AG.Derived.Koszul.SelectedGeneratorFamily`, `SelectedGeneratorFamily.generatedIdeal`, `SelectedGeneratorFamily.firstTerm`, `SelectedGeneratorFamily.d1`, `SelectedGeneratorFamily.d1_mem_generatedIdeal`, `KoszulComplex`, `KoszulComplex.C0`, `KoszulComplex.C1`, `KoszulComplex.d1`, `KoszulComplex.zeroHomologyIdeal`, `KoszulComplex.zeroHomology`, `KoszulComplex.zeroHomologyIdeal_eq`, `KoszulComplex.zeroHomology_eq_classicalQuotient`, `KoszulComplex.zeroHomologyAlgEquivClassicalQuotient`, `KoszulComplex.zeroHomologyRingEquivClassicalQuotient`, `DerivedLawfulLocus`, `DerivedLawfulLocus.structureSheafComplex`, `DerivedLawfulLocus.truncation`, `DerivedLawfulLocus.truncation_eq_classicalQuotient`, `DerivedLawfulLocus.truncationAlgEquivClassicalQuotient`, `DerivedLawfulLocus.truncationRingEquivClassicalQuotient`, `DerivedLawfulLocus.truncationIdeal_eq`, `DerivedLawfulLocus.truncation_locus_eq_classical` | `structure` / `abbrev` / `def` / `theorem` | selected finite defect generators から chart-level Koszul surface を作り、zero-th truncation quotient が classical quotient `O_X/I` に戻り、その locus が classical lawful locus と一致することを accessor theorem として公開する。quotient truncation は type equality に加えて algebra/ring equivalence でも参照できる。 | `defined only` / `proved accessor` |
 | `V.定義4.1 / 5.1 / 5.2` | `AAT.AG.Derived.Intersection.classicalJointQuotient`, `AAT.AG.Derived.Intersection.mathlibTor`, `SelectedDerivedTensorComplex`, `SelectedDerivedTensorComplex.C0`, `SelectedDerivedTensorComplex.homology0`, `SelectedDerivedTensorComplex.homology0LinearEquivClassicalJoint`, `ChartDerivedIntersection`, `ChartDerivedIntersection.classicalQuotient`, `ChartDerivedIntersection.structureSheafComplex`, `ChartDerivedIntersection.homology0LinearEquivClassicalJoint`, `SelectedTorBridge`, `SelectedTorBridge.torLinearEquivMathlib`, `SelectedTorBridge.LawConflict`, `SelectedTorBridge.LawConflict₁`, `SelectedTorBridge.lawConflict_eq_tor`, `SelectedTorBridge.lawConflictLinearEquivMathlibTor`, `SelectedTorBridge.lawConflict0AlgEquivClassicalJoint`, `SelectedTorBridge.lawConflict0RingEquivClassicalJoint`, `LawConflictPackage`, `LawConflictPackage.LawConflict`, `LawConflictPackage.LawConflict₁`, `LawConflictPackage.lawConflict_eq_tor`, `LawConflictPackage.lawConflictLinearEquivMathlibTor`, `LawConflictPackage.lawConflict0AlgEquivClassicalJoint`, `LawConflictPackage.lawConflict0RingEquivClassicalJoint`, `SelectedGlobalLawConflictReading`, `SelectedGlobalLawConflictReading.H0`, `SelectedGlobalLawConflictReading.H0LawConflict₁`, `SelectedGlobalLawConflictReading.h0LinearEquivSelectedLawConflict`, `SelectedGlobalLawConflictReading.hypercohomology`, `LawfulLoci.LawUniversePair.DerivedIntersectionFor`, `LawfulLoci.LawUniversePair.derivedIntersection` | `abbrev` / `structure` / `def` / `theorem` | chart-level derived intersectionを selected Koszul presentations と selected derived tensor complex として持ち、`LawConflict_i` を Mathlib `Tor_i(O_X/I_U,O_X/I_V)` への selected linear equivalence として公開する。degree zero は `O_X/(I_U+I_V)` への algebra/ring equivalence として固定し、`H^0(X, LawConflict_i)` と hypercohomology は selected notation carrier として置く。 | `defined only` / `proved accessor` |
+| `V.R4 scaffold / 定義5.4 support` | `AAT.AG.Derived.FreeResolution.SelectedFiniteFreeResolution`, `SelectedFiniteFreeResolution.termLinearEquivFree_certificate`, `SelectedFiniteFreeResolution.exact_certificate`, `SelectedTensorComplex`, `SelectedTensorComplex.homology`, `SelectedTensorComplex.tensorOfResolution_certificate`, `FiniteFreeResolutionTorComputation`, `FiniteFreeResolutionTorComputation.mathlibTorLinearEquivTensorHomology`, `FiniteFreeResolutionTorComputation.tensorHomologyLinearEquivMathlibTor`, `AAT.AG.Derived.TaylorResolution.SquareFreeMonomialIdealPresentation`, `SquareFreeMonomialIdealPresentation.generatedIdeal_eq`, `SquareFreeMonomialIdealPresentation.squareFree_certificate`, `MonomialLawConflictRegime`, `MonomialLawConflictRegime.lcmSupport`, `MonomialLawConflictRegime.lcmSupport_eq_union`, `TaylorComplex`, `TaylorComplex.resolvesQuotient_certificate`, `TaylorComplex.multidegree_union_eq`, `MonomialConflictCalculation`, `MonomialConflictCalculation.computesLawConflict_certificate`, `MonomialConflictCalculation.lawConflictLinearEquivTensorHomology`, `MonomialConflictCalculation.lcm_multidegree_eq_union` | `structure` / `abbrev` / `def` / `theorem` | monomial law conflict regime を square-free monomial ideal pair として読み、selected finite free resolution / tensor complex と Mathlib `Tor_i` の homology calculation certificate、Taylor complex の selected resolution certificate、lcm multidegree が forbidden support union である accessor、命題5.5 calculation package の carrier を公開する。これは selected certificate surface であり、命題5.5 の本証明ではない。 | `defined only` / `proved accessor surface` |
 
 Non-conclusions: この entrypoint は derived category 一般論、
-Taylor resolution、repair transfer、Hilbert series、well-founded repair、cotangent complex、
+repair transfer、Hilbert series、well-founded repair、cotangent complex、
 `Ext^1` をまだ形式化しない。Koszul surface は selected finite generators に
 相対化され、generator choice independence や higher Koszul homology は主張しない。
 LawConflict は selected complex / bridge / global notation data に相対化され、Tor の計算や
-finite free resolution から bridge を構成する補題、Cech-to-sheaf comparison、
-global cohomology 計算はまだ主張しない。
+finite free resolution から bridge を構成する補題は selected package の明示 certificate
+から読む surface に限る。任意の有限自由分解が Tor を計算する一般補題、Taylor
+complex が `R/I` の自由分解である構成証明、命題5.5 の theorem package 昇格、
+Scarf complex、lcm-lattice resolution、minimality、concrete Tor nonzero examples、
+transversality theorem、Cech-to-sheaf comparison、global cohomology 計算はまだ主張しない。
 PRD-4 の `DerOb_U` は type-signature-only placeholder のまま維持する。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -888,7 +888,8 @@ Issue
 ## AG版AAT Lean形式化 PRD-5 / 第V部 Derived Law Geometry と Repair
 
 File: `Formal/AG/Derived.lean`, `Formal/AG/Derived/LawfulLoci.lean`,
-`Formal/AG/Derived/Koszul.lean`, `Formal/AG/Derived/Intersection.lean`.
+`Formal/AG/Derived/Koszul.lean`, `Formal/AG/Derived/Intersection.lean`,
+`Formal/AG/Derived/FreeResolution.lean`, `Formal/AG/Derived/TaylorResolution.lean`.
 
 PRD-5 [第V部 Derived Law Geometry と Repair](lean_ag_part_5_derived_law_geometry_repair_prd.md)
 は Issue [#2076](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2076)
@@ -907,16 +908,23 @@ Issue
 Mathlib `Tor` object への selected bridge に相対化した `LawConflict_i`、
 `LawConflict_0 = O/(I_U + I_V)` accessor、および selected global /
 hypercohomology notation carrier を追加した。
+Issue
+[#2084](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2084)
+では selected finite free resolution、selected tensor-complex Tor computation、
+Taylor complex surface、monomial law conflict regime、命題5.5 calculation package
+の carrier / accessor surface を追加した。AC5--AC7 の本証明は、Mathlib `Tor`
+計算補題および Taylor resolution の構成証明として後続 Issue に残す。
 PRD 本体の checkbox は prd-loop の不変条件として編集せず、達成状態はこの台帳と
 tracking Issue [#2076](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2076)
 で管理する。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `V.R0` Formal/AG/Derived entrypoint | `defined only`. `Formal/AG/Derived.lean` が `Formal/AG/Derived/LawfulLoci.lean`、`Formal/AG/Derived/Koszul.lean`、`Formal/AG/Derived/Intersection.lean` を束ね、`Formal/AG.lean` から import される。 | Taylor calculation、repair profile、Hilbert series、well-founded repair はまだ定義しない。 |
+| `V.R0` Formal/AG/Derived entrypoint | `defined only`. `Formal/AG/Derived.lean` が `Formal/AG/Derived/LawfulLoci.lean`、`Formal/AG/Derived/Koszul.lean`、`Formal/AG/Derived/Intersection.lean`、`Formal/AG/Derived/FreeResolution.lean`、`Formal/AG/Derived/TaylorResolution.lean` を束ね、`Formal/AG.lean` から import される。 | transversality theorem、repair profile、Hilbert series、well-founded repair はまだ定義しない。 |
 | `V.定義2.1 / 定義3.1` Lawful loci and classical joint locus | `defined only` / `proved accessor`. `LawUniverseReading`、`LawUniversePair`、`LawUniversePair.I_U`、`I_V`、`flatU`、`flatV`、`classicalJointIdeal`、`classicalJointLawfulLocus`、`flatU_eq_lawfulLocus`、`flatV_eq_lawfulLocus`、`classicalJointLawfulLocus_eq_zeroLocus`、`classicalJointLawfulLocus_eq_flatU_inter_flatV` を持つ。 | この行では classical joint locus までを扱う。derived lawful locus、`LawConflict_i`、`Tor_i`、derived non-transversality は後続行で管理する。 |
 | `V.定義2.3 / 原則2.4` Koszul complex and derived lawful locus truncation | `defined only` / `proved accessor`. `Koszul.SelectedGeneratorFamily`、`SelectedGeneratorFamily.generatedIdeal`、`firstTerm`、`d1`、`d1_mem_generatedIdeal`、`KoszulComplex`、`C0`、`C1`、`d1`、`zeroHomologyIdeal`、`zeroHomology`、`zeroHomologyIdeal_eq`、`zeroHomology_eq_classicalQuotient`、`zeroHomologyAlgEquivClassicalQuotient`、`zeroHomologyRingEquivClassicalQuotient`、`DerivedLawfulLocus`、`structureSheafComplex`、`truncation`、`truncation_eq_classicalQuotient`、`truncationAlgEquivClassicalQuotient`、`truncationRingEquivClassicalQuotient`、`truncationIdeal_eq`、`truncation_locus_eq_classical` を持つ。 | chart-level selected finite generator surface であり、derived category 一般論、higher Koszul homology、Tor、generator choice independence は R3 以降または future boundary に残す。 |
-| `V.定義4.1 / 5.1 / 5.2` Derived intersection and LawConflict bridge | `defined only` / `proved accessor`. `Intersection.classicalJointQuotient`、`mathlibTor`、`SelectedDerivedTensorComplex`、`SelectedDerivedTensorComplex.C0`、`homology0`、`homology0LinearEquivClassicalJoint`、`ChartDerivedIntersection`、`ChartDerivedIntersection.classicalQuotient`、`structureSheafComplex`、`homology0LinearEquivClassicalJoint`、`SelectedTorBridge`、`SelectedTorBridge.torLinearEquivMathlib`、`SelectedTorBridge.LawConflict`、`LawConflict₁`、`lawConflict_eq_tor`、`lawConflictLinearEquivMathlibTor`、`lawConflict0AlgEquivClassicalJoint`、`lawConflict0RingEquivClassicalJoint`、`LawConflictPackage`、`LawConflictPackage.LawConflict`、`LawConflictPackage.LawConflict₁`、`LawConflictPackage.lawConflict_eq_tor`、`LawConflictPackage.lawConflictLinearEquivMathlibTor`、`LawConflictPackage.lawConflict0AlgEquivClassicalJoint`、`LawConflictPackage.lawConflict0RingEquivClassicalJoint`、`SelectedGlobalLawConflictReading`、`SelectedGlobalLawConflictReading.H0`、`H0LawConflict₁`、`h0LinearEquivSelectedLawConflict`、`hypercohomology`、`LawfulLoci.LawUniversePair.DerivedIntersectionFor`、`LawfulLoci.LawUniversePair.derivedIntersection` を持つ。 | selected complex / bridge / global notation data に相対化しており、Tor の計算、finite free resolution、Taylor resolution、finite free resolution から bridge を構成する補題、Cech-to-sheaf comparison、global cohomology 計算は R4 以降に残す。 |
+| `V.定義4.1 / 5.1 / 5.2` Derived intersection and LawConflict bridge | `defined only` / `proved accessor`. `Intersection.classicalJointQuotient`、`mathlibTor`、`SelectedDerivedTensorComplex`、`SelectedDerivedTensorComplex.C0`、`homology0`、`homology0LinearEquivClassicalJoint`、`ChartDerivedIntersection`、`ChartDerivedIntersection.classicalQuotient`、`structureSheafComplex`、`homology0LinearEquivClassicalJoint`、`SelectedTorBridge`、`SelectedTorBridge.torLinearEquivMathlib`、`SelectedTorBridge.LawConflict`、`LawConflict₁`、`lawConflict_eq_tor`、`lawConflictLinearEquivMathlibTor`、`lawConflict0AlgEquivClassicalJoint`、`lawConflict0RingEquivClassicalJoint`、`LawConflictPackage`、`LawConflictPackage.LawConflict`、`LawConflictPackage.LawConflict₁`、`LawConflictPackage.lawConflict_eq_tor`、`LawConflictPackage.lawConflictLinearEquivMathlibTor`、`LawConflictPackage.lawConflict0AlgEquivClassicalJoint`、`LawConflictPackage.lawConflict0RingEquivClassicalJoint`、`SelectedGlobalLawConflictReading`、`SelectedGlobalLawConflictReading.H0`、`H0LawConflict₁`、`h0LinearEquivSelectedLawConflict`、`hypercohomology`、`LawfulLoci.LawUniversePair.DerivedIntersectionFor`、`LawfulLoci.LawUniversePair.derivedIntersection` を持つ。 | selected complex / bridge / global notation data に相対化しており、Cech-to-sheaf comparison、global cohomology 計算は R5 以降に残す。 |
+| `V.R4 scaffold / 定義5.4 support` Monomial conflict calculation surface | `defined only` / `proved accessor surface`. `FreeResolution.SelectedFiniteFreeResolution`、`SelectedFiniteFreeResolution.termLinearEquivFree_certificate`、`exact_certificate`、`SelectedTensorComplex`、`SelectedTensorComplex.homology`、`tensorOfResolution_certificate`、`FiniteFreeResolutionTorComputation`、`mathlibTorLinearEquivTensorHomology`、`tensorHomologyLinearEquivMathlibTor`、`TaylorResolution.SquareFreeMonomialIdealPresentation`、`generatedIdeal_eq`、`squareFree_certificate`、`MonomialLawConflictRegime`、`lcmSupport`、`lcmSupport_eq_union`、`TaylorComplex`、`TaylorComplex.resolvesQuotient_certificate`、`multidegree_union_eq`、`MonomialConflictCalculation`、`computesLawConflict_certificate`、`lawConflictLinearEquivTensorHomology`、`lcm_multidegree_eq_union` を持つ。 | selected package の明示 certificate から読む surface であり、AC5--AC7 の本証明ではない。任意の有限自由分解が Tor を計算する一般補題、Taylor complex が `R/I` の自由分解である構成証明、命題5.5 の theorem package 昇格、Scarf complex、lcm-lattice resolution、minimality、concrete Tor nonzero examples、transversality theorem はまだ主張しない。 |
 | `IV.定義2.4 DerOb_U` の内部構成 | `future proof obligation` / `unassigned`. PRD-5 R0/R1 では触らず、PRD-5 本文が展開する chart-level Koszul / Tor 構成とは別境界として維持する。 | 余接複体 `L_{Flat/X}` と `Ext^1` の一般形式化は PRD-5 の現在 scope では実装しない。 |
 
 第V部 PRD-5 の証明対象ラベルは次の現在状態である。
@@ -927,7 +935,7 @@ tracking Issue [#2076](https://github.com/iroha1203/AlgebraicArchitectureTheoryV
 | `V.定義2.1 / 定義3.1` | `defined only` / `proved accessor` |
 | `V.定義2.3 / 原則2.4` | `defined only` / `proved accessor` |
 | `V.定義4.1 / 5.1 / 5.2` | `defined only` / `proved accessor` |
-| `V.命題5.5` | `future proof obligation` |
+| `V.命題5.5` | `future proof obligation` / `selected accessor surface only` |
 | `V.定理6.1 / 定理7.3` | `future proof obligation` |
 | `V.命題9.2` | `future proof obligation` |
 | `V.定理10.5 / 定理10.6` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #2084

PRD-5 R4 の前段として、有限自由分解 / Taylor complex / monomial conflict calculation の selected carrier と accessor surface を追加した。

この PR は AC5--AC7 の本証明を閉じない。任意の有限自由分解が Tor を計算する一般補題、Taylor complex の自由分解性の構成証明、命題5.5 theorem package 昇格は #2085 に残す。

主な設計判断:

- `Formal.AG.Derived.FreeResolution` を追加し、selected finite free resolution と selected tensor-complex Tor computation carrier を置く。
- 各 resolution term は finite coordinate module への linear equivalence certificate を持つ。
- `Formal.AG.Derived.TaylorResolution` を追加し、square-free monomial ideal presentation、monomial law conflict regime、Taylor complex surface、monomial conflict calculation carrier を置く。
- lcm multidegree 読みは selected forbidden support の union accessor として固定する。
- `Formal.AG.Derived` entrypoint と docs ledger を R4 scaffold 境界に同期する。

## 証明した定理

- `AAT.AG.Derived.FreeResolution.SelectedFiniteFreeResolution.termLinearEquivFree_certificate`
- `AAT.AG.Derived.FreeResolution.SelectedFiniteFreeResolution.exact_certificate`
- `AAT.AG.Derived.FreeResolution.SelectedTensorComplex.tensorOfResolution_certificate`
- `AAT.AG.Derived.FreeResolution.FiniteFreeResolutionTorComputation.mathlibTorLinearEquivTensorHomology`
- `AAT.AG.Derived.FreeResolution.FiniteFreeResolutionTorComputation.tensorHomologyLinearEquivMathlibTor`
- `AAT.AG.Derived.TaylorResolution.SquareFreeMonomialIdealPresentation.generatedIdeal_eq`
- `AAT.AG.Derived.TaylorResolution.SquareFreeMonomialIdealPresentation.squareFree_certificate`
- `AAT.AG.Derived.TaylorResolution.MonomialLawConflictRegime.lcmSupport_eq_union`
- `AAT.AG.Derived.TaylorResolution.TaylorComplex.resolvesQuotient_certificate`
- `AAT.AG.Derived.TaylorResolution.TaylorComplex.multidegree_union_eq`
- `AAT.AG.Derived.TaylorResolution.MonomialConflictCalculation.computesLawConflict_certificate`
- `AAT.AG.Derived.TaylorResolution.MonomialConflictCalculation.lawConflictLinearEquivTensorHomology`
- `AAT.AG.Derived.TaylorResolution.MonomialConflictCalculation.lcm_multidegree_eq_union`

## 編集したドキュメント

- `docs/aat/proof_obligations.md`
- `docs/aat/lean_theorem_index.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Derived/FreeResolution.lean`
- [x] `lake env lean Formal/AG/Derived/TaylorResolution.lean`
- [x] `lake env lean Formal/AG/Derived.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` では既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` に unrelated linter warning が2件再生されたが、build は成功している。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
