### PR TITLE
ArchSig viewerに貼り合わせ幾何を追加する

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -22,6 +22,12 @@ const MAX_TOR_WITNESS_VARIABLES: usize = 12;
 const MAX_LAPLACIAN_CELLS: usize = 16;
 const MAX_PERIOD_CYCLES: usize = 16;
 const MAX_TRANSFER_TARGETS: usize = 16;
+const GLUING_TRIANGLE_RENDER_LIMIT: usize = 80;
+const GLUING_FIELD_ROW_RENDER_LIMIT: usize = 64;
+const GLUING_REGION_RENDER_LIMIT: usize = 24;
+const GLUING_CAGE_RENDER_LIMIT: usize = 80;
+const GLUING_MORPH_RENDER_LIMIT: usize = 50;
+const GLUING_ATOM_GLYPH_RENDER_LIMIT: usize = 2_000;
 
 pub fn selected_measurement_profile_v1(
     policy: &LawPolicyDocumentV1,
@@ -1294,7 +1300,9 @@ pub fn build_insight_report_v1(
     let boundary_digest = insight_boundary_digest(packet, summary);
     let insight_cards = insight_cards_v1(normalized, packet, summary);
     let action_queue = insight_action_queue_v1(&insight_cards);
-    let viewer_visual_scenes = insight_viewer_visual_scenes_v1(normalized, packet, &insight_cards);
+    let gluing_geometry = gluing_geometry_projection_v1(normalized, packet);
+    let viewer_visual_scenes =
+        insight_viewer_visual_scenes_v1(normalized, packet, &insight_cards, &gluing_geometry);
     let guided_tours = insight_guided_tours_v1(&insight_cards);
     let copy_blocks = insight_copy_blocks_v1(normalized, &insight_cards, &boundary_digest);
     let omitted_detail_counts = insight_omitted_detail_counts_v1(normalized, &viewer_visual_scenes);
@@ -1352,6 +1360,7 @@ pub fn build_insight_report_v1(
         "actionQueue": action_queue,
         "boundaryDigest": boundary_digest,
         "omittedDetailCounts": omitted_detail_counts,
+        "gluingGeometry": gluing_geometry,
         "viewerVisualScenes": viewer_visual_scenes,
         "guidedTours": guided_tours,
         "copyBlocks": copy_blocks,
@@ -1969,6 +1978,7 @@ fn insight_viewer_visual_scenes_v1(
     normalized: &NormalizedArchMapV2,
     packet: &ArchSigMeasurementPacketV1,
     cards: &[Value],
+    gluing_geometry: &Value,
 ) -> Vec<Value> {
     let overview_refs = scene_refs_for_kinds(
         normalized,
@@ -2042,7 +2052,7 @@ fn insight_viewer_visual_scenes_v1(
     let has_debt = cards
         .iter()
         .any(|card| string_field(card, "kind") == "architecture_debt_mass");
-    vec![
+    let scenes = vec![
         scene_v1(
             "overview",
             "overview_constellation",
@@ -2244,7 +2254,463 @@ fn insight_viewer_visual_scenes_v1(
             "thin_line",
             !string_array_at(&source_refs, &["sourceRefs"]).is_empty(),
         ),
-    ]
+    ];
+    scenes
+        .into_iter()
+        .map(|scene| attach_gluing_scene_geometry(scene, gluing_geometry))
+        .collect()
+}
+
+fn attach_gluing_scene_geometry(mut scene: Value, gluing_geometry: &Value) -> Value {
+    let scene_id = string_field(&scene, "sceneId");
+    let geometry_refs = match scene_id.as_str() {
+        "site-cover" | "cech-gluing" => json!({
+            "nerveRef": "gluingGeometry.nerve",
+            "projectionObjectKinds": ["nerveVertex", "nerveEdge", "nerveTriangle"]
+        }),
+        "cech-h1-mismatch" => json!({
+            "cocycleRibbonRef": "gluingGeometry.cocycleRibbon",
+            "projectionObjectKinds": ["cocycleRibbon", "holonomyLikeGapMarker"]
+        }),
+        "obstruction" => json!({
+            "forbiddenCagesRef": "gluingGeometry.forbiddenCages",
+            "projectionObjectKinds": ["forbiddenSupportCage", "simplexEdge"]
+        }),
+        "repair-dual" => json!({
+            "repairMorphsRef": "gluingGeometry.repairMorphs",
+            "projectionObjectKinds": ["repairMorphPath", "lowerBoundMarker"]
+        }),
+        "hodge-debt-field" => json!({
+            "locusFieldRef": "gluingGeometry.locusField",
+            "projectionObjectKinds": ["curvatureHeightField", "blockedUnmeasuredRegion"]
+        }),
+        _ => json!({
+            "projectionObjectKinds": []
+        }),
+    };
+    scene["gluingGeometryRefs"] = geometry_refs;
+    scene["axisMappingImplemented"] = json!(true);
+    scene["projectionBoundary"] = json!(
+        "Scene geometry is a bounded projection of archsig-measurement-packet/v1 and archsig-insight-report/v1; it does not create a new structural verdict."
+    );
+    scene["visualEncodingLegend"] = visual_encoding_legend_v1();
+    if scene_id == "cech-h1-mismatch" {
+        let mut non_claims = string_array_at(&scene, &["nonClaims"]);
+        non_claims.push(
+            "Holonomy-like ribbon closure is an exploratory restriction-path view, not a monodromy verdict."
+                .to_string(),
+        );
+        scene["nonClaims"] = json!(non_claims);
+    }
+    if scene_id == "repair-dual" {
+        let mut non_claims = string_array_at(&scene, &["nonClaims"]);
+        non_claims.push(
+            "Repair morph animation shows lower-bound movement only; it is not an automatic repair."
+                .to_string(),
+        );
+        scene["nonClaims"] = json!(non_claims);
+    }
+    if scene_id == "hodge-debt-field"
+        && gluing_geometry["locusField"]["blockedRegions"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+    {
+        scene["visualEncodings"][0]["textRole"] = json!(
+            "curvature support field; blocked/unmeasured remains visibly separate from measured-zero"
+        );
+    }
+    scene
+}
+
+fn visual_encoding_legend_v1() -> Value {
+    json!([
+        {
+            "channel": "color",
+            "meaning": "measurement state",
+            "values": {
+                "measured_nonzero": "amber obstruction or mismatch support",
+                "measured_zero": "teal selected-support zero",
+                "not_computed": "red blocker",
+                "unmeasured": "gray unmeasured region",
+                "repair_candidate": "violet lower-bound repair candidate"
+            }
+        },
+        {
+            "channel": "shape",
+            "meaning": "geometry object kind",
+            "values": {
+                "triangle": "packet cover triple simplex face",
+                "ribbon": "Cech support path with closure gap marker",
+                "cage": "minimal forbidden support simplex",
+                "morph": "repair candidate lower-bound path",
+                "glyph": "atom fiber/carrier/valence/semantic-anchor encoding"
+            }
+        },
+        {
+            "channel": "line",
+            "meaning": "claim boundary",
+            "values": {
+                "solid": "measured or checked relation",
+                "dashed": "blocked/unmeasured boundary",
+                "thick": "top insight support"
+            }
+        },
+        {
+            "channel": "opacity",
+            "meaning": "projection confidence",
+            "values": {
+                "opaque": "source-backed selected support",
+                "translucent": "context or omitted background projection"
+            }
+        },
+        {
+            "channel": "thickness",
+            "meaning": "support priority",
+            "values": {
+                "thick": "top insight or nonzero support",
+                "thin": "orientation or background relation"
+            }
+        }
+    ])
+}
+
+fn gluing_geometry_projection_v1(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+) -> Value {
+    let selected_contexts = selected_cover_contexts(normalized, &packet.profile);
+    let cech_edges = cech_edges(normalized, &selected_contexts);
+    let cover_nerve_projection = packet
+        .computed_invariants
+        .iter()
+        .find_map(|invariant| invariant.get("coverNerveProjection").cloned())
+        .unwrap_or_else(|| {
+            cover_nerve_projection_v1(
+                normalized,
+                &selected_contexts,
+                &cech_edges,
+                &packet.profile.cover_ref,
+            )
+        });
+    let cover = normalized.covers.iter().find(|cover| {
+        cover.normalized_cover_id == packet.profile.cover_ref
+            || cover.source_cover_id == packet.profile.cover_ref
+    });
+    let cover_refs = cover
+        .map(|cover| cover.source_refs.clone())
+        .unwrap_or_default();
+    let nonzero_edges = cech_edges
+        .iter()
+        .filter(|edge| edge.value > 0 || !edge.support_atom_refs.is_empty())
+        .collect::<Vec<_>>();
+    let class_nonzero = packet
+        .computed_invariants
+        .iter()
+        .find_map(|invariant| {
+            invariant
+                .get("observedCocycle")
+                .and_then(|cocycle| cocycle.get("classNonzero"))
+                .and_then(Value::as_bool)
+        })
+        .unwrap_or(false);
+    let cocycle_support_atom_refs = nonzero_edges
+        .iter()
+        .flat_map(|edge| edge.support_atom_refs.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let forbidden_cages = forbidden_cage_projection(normalized, packet);
+    let repair_morphs = repair_morph_projection(normalized, packet, &forbidden_cages);
+    let locus_field = locus_field_projection(packet);
+    let atom_glyphs = atom_glyph_projection(normalized);
+    let triangle_count = cover_nerve_projection["faces"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
+    let field_row_count = locus_field["fieldRows"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
+    let blocked_region_count = locus_field["blockedRegions"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
+    let zero_region_count = locus_field["measuredZeroRegions"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
+    let atom_glyph_total_count = normalized.atoms.len();
+    json!({
+        "schema": "archsig-viewer-gluing-geometry/v1",
+        "sourcePacketRef": "archsig-measurement-packet.json",
+        "sourceInsightReportRef": "archsig-insight-report.json",
+        "projectionBoundary": "This geometry translates measured packet and ArchMap cover support into viewer objects. It adds no structural verdict, H2 coherence claim, or monodromy verdict.",
+        "nerve": {
+            "coverRef": packet.profile.cover_ref,
+            "sourceRefs": cover_refs,
+            "vertices": cover_nerve_projection["vertices"],
+            "edges": cover_nerve_projection["edges"],
+            "triangles": cover_nerve_projection["faces"],
+            "triangleSource": cover_nerve_projection["faceSource"],
+            "h2CoherenceVisualized": cover_nerve_projection["h2CoherenceVisualized"]
+        },
+        "cocycleRibbon": {
+            "supportAtomRefs": cocycle_support_atom_refs,
+            "supportEdges": nonzero_edges.iter().map(|edge| json!({
+                "edgeId": edge.edge_id,
+                "sourceContextRef": edge.source_context,
+                "targetContextRef": edge.target_context,
+                "value": edge.value,
+                "supportAtomRefs": edge.support_atom_refs
+            })).collect::<Vec<_>>(),
+            "closureGapEncoding": {
+                "kind": "holonomyLikeGapMarker",
+                "visible": class_nonzero && !nonzero_edges.is_empty(),
+                "lineRole": "thick_glowing_dashed_seam",
+                "source": "observedCocycle.classNonzero plus representative support from packet",
+                "nonClaim": "Exploratory restriction-path closure gap only; monodromy verdict is not generated."
+            }
+        },
+        "locusField": locus_field,
+        "forbiddenCages": forbidden_cages,
+        "repairMorphs": repair_morphs,
+        "atomGlyphs": atom_glyphs,
+        "visualEncodingLegend": visual_encoding_legend_v1(),
+        "renderLimits": {
+            "nerveTriangles": GLUING_TRIANGLE_RENDER_LIMIT,
+            "curvatureFieldRows": GLUING_FIELD_ROW_RENDER_LIMIT,
+            "curvatureRegions": GLUING_REGION_RENDER_LIMIT,
+            "forbiddenCages": GLUING_CAGE_RENDER_LIMIT,
+            "repairMorphs": GLUING_MORPH_RENDER_LIMIT,
+            "atomGlyphs": GLUING_ATOM_GLYPH_RENDER_LIMIT
+        },
+        "omittedGeometryCounts": {
+            "nerveTriangles": triangle_count.saturating_sub(GLUING_TRIANGLE_RENDER_LIMIT),
+            "cocycleSupportEdges": 0,
+            "curvatureFieldRows": field_row_count.saturating_sub(GLUING_FIELD_ROW_RENDER_LIMIT),
+            "measuredZeroRegions": zero_region_count.saturating_sub(GLUING_REGION_RENDER_LIMIT),
+            "blockedRegions": blocked_region_count.saturating_sub(GLUING_REGION_RENDER_LIMIT),
+            "forbiddenCages": forbidden_cages.len().saturating_sub(GLUING_CAGE_RENDER_LIMIT),
+            "repairMorphs": repair_morphs.len().saturating_sub(GLUING_MORPH_RENDER_LIMIT),
+            "atomGlyphs": atom_glyph_total_count.saturating_sub(GLUING_ATOM_GLYPH_RENDER_LIMIT)
+        },
+        "nonClaims": [
+            "No H2 coherence failure is visualized by this projection.",
+            "Holonomy-like ribbon display is not a monodromy verdict.",
+            "Repair morphs are lower-bound inspection aids, not automatic repairs."
+        ]
+    })
+}
+
+fn context_atom_refs(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &[String],
+) -> BTreeMap<String, Vec<String>> {
+    let selected = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    normalized
+        .contexts
+        .iter()
+        .filter(|context| selected.contains(&context.normalized_context_id))
+        .map(|context| {
+            (
+                context.normalized_context_id.clone(),
+                context.atom_ids.iter().take(24).cloned().collect(),
+            )
+        })
+        .collect()
+}
+
+fn forbidden_cage_projection(
+    normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+) -> Vec<Value> {
+    let mut cages = Vec::new();
+    for invariant in &packet.computed_invariants {
+        let generators = invariant["obstructionIdeal"]["generators"]
+            .as_array()
+            .into_iter()
+            .flatten();
+        for generator in generators {
+            let support_atom_refs = string_array_at(generator, &["supportAtomRefs"]);
+            let support_variables = string_array_at(generator, &["support"]);
+            if support_atom_refs.is_empty() && support_variables.is_empty() {
+                continue;
+            }
+            let generator_id = string_field(generator, "generatorId");
+            cages.push(json!({
+                "cageId": format!("forbidden-cage:{generator_id}"),
+                "atomRefs": support_atom_refs,
+                "supportVariables": support_variables,
+                "sourceInvariantRef": invariant["invariantId"],
+                "sourceGeneratorRef": generator_id,
+                "shapeRole": "cage",
+                "lineRole": "broken_line",
+                "source": "packet obstructionIdeal.generators[].supportAtomRefs"
+            }));
+        }
+    }
+    if cages.is_empty() {
+        for atom in normalized.atoms.iter().filter(|atom| {
+            atom.predicate.contains("obstruction") || atom.predicate.contains("forbidden")
+        }) {
+            cages.push(json!({
+                "cageId": format!("forbidden-cage:{}", atom.normalized_atom_id),
+                "atomRefs": [atom.normalized_atom_id.clone()],
+                "sourceAtomRef": atom.normalized_atom_id,
+                "shapeRole": "cage",
+                "lineRole": "broken_line",
+                "source": "source-backed obstruction atom; packet has no obstructionIdeal generator support"
+            }));
+        }
+    }
+    cages
+}
+
+fn repair_morph_projection(
+    _normalized: &NormalizedArchMapV2,
+    packet: &ArchSigMeasurementPacketV1,
+    forbidden_cages: &[Value],
+) -> Vec<Value> {
+    let lower_bound_readings = packet
+        .analytic_readings
+        .iter()
+        .filter(|reading| {
+            reading.reading_id.contains("repair")
+                || reading.evaluator.contains("support-transfer")
+                || reading.value.to_string().contains("lower-bound")
+        })
+        .collect::<Vec<_>>();
+    let repair_candidates = packet
+        .computed_invariants
+        .iter()
+        .flat_map(|invariant| {
+            invariant["alexanderDualRepair"]["minimalHittingSets"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .enumerate()
+                .map(|(index, hitting_set)| {
+                    json!({
+                        "candidateId": format!("{}:repair-candidate:{index}", string_field(invariant, "invariantId")),
+                        "sourceInvariantRef": invariant["invariantId"],
+                        "supportVariables": hitting_set
+                            .as_array()
+                            .into_iter()
+                            .flatten()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    repair_candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| {
+            json!({
+                "morphId": format!("repair-morph:{}", string_field(candidate, "candidateId")),
+                "fromCageRef": forbidden_cages
+                    .first()
+                    .and_then(|cage| cage["cageId"].as_str())
+                    .unwrap_or("forbidden-cage:unavailable"),
+                "toCandidateRef": candidate["candidateId"],
+                "supportVariables": string_array_at(candidate, &["supportVariables"]),
+                "sourceInvariantRef": candidate["sourceInvariantRef"],
+                "lowerBoundReadingRefs": lower_bound_readings
+                    .iter()
+                    .map(|reading| reading.reading_id.clone())
+                    .take(8)
+                    .collect::<Vec<_>>(),
+                "animationRole": "continuous_morph_lower_bound",
+                "samplePhase": index,
+                "nonClaim": "not automatic repair"
+            })
+        })
+        .collect()
+}
+
+fn locus_field_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
+    let field_rows = packet
+        .structural_verdict
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| row.evaluator.contains("curvature") || row.law.contains("curvature"))
+        .map(|(index, row)| {
+            json!({
+                "fieldId": format!("curvature-field:{index}:{}", row.evaluator),
+                "status": row.verdict,
+                "height": if row.verdict == "measured_nonzero" { 1 } else { 0 },
+                "colorRole": match row.verdict.as_str() {
+                    "measured_nonzero" => "measured_nonzero",
+                    "measured_zero" => "measured_zero",
+                    "not_computed" => "not_computed",
+                    "unmeasured" => "unmeasured",
+                    _ => "unknown"
+                },
+                "source": "structural verdict curvature row"
+            })
+        })
+        .collect::<Vec<_>>();
+    let blocked_regions = packet
+        .structural_verdict
+        .iter()
+        .filter(|row| {
+            matches!(
+                row.verdict.as_str(),
+                "unmeasured" | "unknown" | "not_computed"
+            )
+        })
+        .map(|row| {
+            json!({
+                "regionId": format!("blocked-region:{}", row.evaluator),
+                "status": row.verdict,
+                "shapeRole": "blocked_unmeasured_region",
+                "source": "non-terminal packet verdict"
+            })
+        })
+        .collect::<Vec<_>>();
+    let measured_zero_regions = packet
+        .structural_verdict
+        .iter()
+        .filter(|row| row.verdict == "measured_zero")
+        .map(|row| {
+            json!({
+                "regionId": format!("measured-zero-region:{}", row.evaluator),
+                "status": row.verdict,
+                "shapeRole": "smooth_measured_zero_patch",
+                "source": "selected-support zero packet verdict"
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "fieldRows": field_rows,
+        "measuredZeroRegions": measured_zero_regions,
+        "blockedRegions": blocked_regions
+    })
+}
+
+fn atom_glyph_projection(normalized: &NormalizedArchMapV2) -> Vec<Value> {
+    normalized
+        .atoms
+        .iter()
+        .take(GLUING_ATOM_GLYPH_RENDER_LIMIT)
+        .map(|atom| {
+            let semantic_anchor_missing =
+                atom.subject.is_empty() || atom.source_refs.is_empty() || atom.axis == "unknown";
+            json!({
+                "atomRef": atom.normalized_atom_id,
+                "fiber": atom.atom_kind,
+                "carrier": atom.subject,
+                "valence": atom.context_memberships.len(),
+                "semanticAnchor": if semantic_anchor_missing { "blocked_missing_anchor" } else { "source_backed" },
+                "shapeRole": if semantic_anchor_missing { "blocked_anchor_glyph" } else { "structured_atom_glyph" },
+                "sizeRole": "valence",
+                "colorRole": if semantic_anchor_missing { "not_computed" } else { "source_evidence" }
+            })
+        })
+        .collect()
 }
 
 fn overview_color_role(cards: &[Value]) -> &'static str {
@@ -3095,6 +3561,12 @@ fn evaluate_cech_obstruction_v1(
 ) -> CechMeasurementV1 {
     let selected_contexts = selected_cover_contexts(normalized, profile);
     let edges = cech_edges(normalized, &selected_contexts);
+    let cover_nerve_projection =
+        cover_nerve_projection_v1(normalized, &selected_contexts, &edges, &profile.cover_ref);
+    let cover_nerve_face_count = cover_nerve_projection["faces"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
     let component_count = graph_component_count(&selected_contexts, &edges);
     let h0_dimension = component_count;
     let h1_dimension = edges
@@ -3137,15 +3609,24 @@ fn evaluate_cech_obstruction_v1(
                 "coefficient": profile.coefficient,
                 "contextCount": selected_contexts.len(),
                 "restrictionEdgeCount": edges.len(),
+                "coverNerveProjection": cover_nerve_projection,
                 "rankD0": selected_contexts.len().saturating_sub(component_count),
                 "dimensions": {
                     "H0": h0_dimension,
                     "H1": h1_dimension
                 },
                 "selectedH2": {
-                    "dimension": 0,
-                    "status": "computed_for_selected_1_skeleton",
-                    "reason": "no selected 2-simplices are present in the finite incidence graph complex"
+                    "dimension": if cover_nerve_face_count == 0 { json!(0) } else { Value::Null },
+                    "status": if cover_nerve_face_count == 0 {
+                        "computed_for_selected_1_skeleton"
+                    } else {
+                        "not_measured_for_triple_overlap_faces"
+                    },
+                    "reason": if cover_nerve_face_count == 0 {
+                        "no selected 2-simplices are present in the finite incidence graph complex"
+                    } else {
+                        "triple-overlap faces are projected for viewer geometry only; H2 coherence remains outside this measurement"
+                    }
                 },
                 "observedCocycle": {
                     "classNonzero": h1_class_nonzero,
@@ -4990,6 +5471,125 @@ fn cech_edges(normalized: &NormalizedArchMapV2, selected_contexts: &[String]) ->
     edges
 }
 
+fn cover_nerve_projection_v1(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+    cover_ref: &str,
+) -> Value {
+    let context_atom_refs = context_atom_refs(normalized, selected_contexts);
+    let vertices = selected_contexts
+        .iter()
+        .map(|context| {
+            json!({
+                "contextRef": context,
+                "atomRefs": context_atom_refs.get(context).cloned().unwrap_or_default(),
+                "objectKind": "nerveVertex"
+            })
+        })
+        .collect::<Vec<_>>();
+    let edge_rows = edges
+        .iter()
+        .map(|edge| {
+            json!({
+                "edgeId": edge.edge_id,
+                "sourceContextRef": edge.source_context,
+                "targetContextRef": edge.target_context,
+                "value": edge.value,
+                "supportAtomRefs": edge.support_atom_refs,
+                "objectKind": "nerveEdge",
+                "source": "selected cover restriction edge"
+            })
+        })
+        .collect::<Vec<_>>();
+    let selected = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    let mut edge_by_pair = BTreeMap::new();
+    for edge in edges {
+        edge_by_pair.insert(
+            (edge.source_context.clone(), edge.target_context.clone()),
+            edge.edge_id.clone(),
+        );
+        edge_by_pair.insert(
+            (edge.target_context.clone(), edge.source_context.clone()),
+            edge.edge_id.clone(),
+        );
+    }
+    let atom_refs_by_context = normalized
+        .contexts
+        .iter()
+        .filter(|context| selected.contains(&context.normalized_context_id))
+        .map(|context| {
+            (
+                context.normalized_context_id.clone(),
+                context.atom_ids.iter().cloned().collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut faces = Vec::new();
+    for left in 0..selected_contexts.len() {
+        for middle in left + 1..selected_contexts.len() {
+            for right in middle + 1..selected_contexts.len() {
+                let contexts = [
+                    selected_contexts[left].clone(),
+                    selected_contexts[middle].clone(),
+                    selected_contexts[right].clone(),
+                ];
+                let Some(left_atoms) = atom_refs_by_context.get(&contexts[0]) else {
+                    continue;
+                };
+                let Some(middle_atoms) = atom_refs_by_context.get(&contexts[1]) else {
+                    continue;
+                };
+                let Some(right_atoms) = atom_refs_by_context.get(&contexts[2]) else {
+                    continue;
+                };
+                let shared_atom_refs = left_atoms
+                    .intersection(middle_atoms)
+                    .cloned()
+                    .collect::<BTreeSet<_>>()
+                    .intersection(right_atoms)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if shared_atom_refs.is_empty() {
+                    continue;
+                }
+                let edge_refs = [
+                    edge_by_pair
+                        .get(&(contexts[0].clone(), contexts[1].clone()))
+                        .cloned(),
+                    edge_by_pair
+                        .get(&(contexts[0].clone(), contexts[2].clone()))
+                        .cloned(),
+                    edge_by_pair
+                        .get(&(contexts[1].clone(), contexts[2].clone()))
+                        .cloned(),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+                faces.push(json!({
+                    "faceId": format!("nerve-face:{}:{}:{}", contexts[0], contexts[1], contexts[2]),
+                    "coverRef": cover_ref,
+                    "contextRefs": contexts,
+                    "edgeRefs": edge_refs,
+                    "sharedAtomRefs": shared_atom_refs,
+                    "objectKind": "nerveTriangle",
+                    "source": "selected cover triple overlap with shared atom refs",
+                    "coherenceClaim": "not_visualized"
+                }));
+            }
+        }
+    }
+    json!({
+        "coverRef": cover_ref,
+        "vertices": vertices,
+        "edges": edge_rows,
+        "faces": faces,
+        "faceSource": "selected cover triple-overlap sharedAtomRefs recorded in archsig-measurement-packet/v1; not inferred by the viewer",
+        "h2CoherenceVisualized": false
+    })
+}
+
 fn marker_atom_marks_edge(
     atom: &crate::NormalizedAtomV2,
     source_context: &str,
@@ -5193,6 +5793,19 @@ pub fn build_measurement_viewer_data_v1(
         "viewerVisualScenes": insight_report["viewerVisualScenes"],
         "guidedTours": insight_report["guidedTours"],
         "copyBlocks": insight_report["copyBlocks"],
+        "aatGeometryOverlays": {
+            "schemaVersion": "archsig-aat-geometry-overlays-v1",
+            "projectionBoundary": "bounded viewer projection of measured ArchSig AG geometry; visual richness is not a new verdict",
+            "gluingGeometry": insight_report["gluingGeometry"],
+            "nerve": insight_report["gluingGeometry"]["nerve"],
+            "cocycleRibbon": insight_report["gluingGeometry"]["cocycleRibbon"],
+            "locusField": insight_report["gluingGeometry"]["locusField"],
+            "forbiddenCages": insight_report["gluingGeometry"]["forbiddenCages"],
+            "repairMorphs": insight_report["gluingGeometry"]["repairMorphs"],
+            "atomGlyphs": insight_report["gluingGeometry"]["atomGlyphs"],
+            "omittedGeometryCounts": insight_report["gluingGeometry"]["omittedGeometryCounts"],
+            "nonClaims": insight_report["gluingGeometry"]["nonClaims"]
+        },
         "reportPane": {
             "conclusion": summary["conclusion"],
             "profileRef": packet.profile.profile_id,

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -3202,6 +3202,162 @@ fn cli_analyze_v2_sheaf_laplacian_rejects_unknown_cell() {
 }
 
 #[test]
+fn cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture() {
+    let root = ag_measurement_root();
+    let manifest = read_json(&root.join("archsig_viewer_gluing_geometry_golden_ux.json"));
+    assert_eq!(
+        manifest["schema"],
+        "archsig-viewer-gluing-geometry-golden-ux/v1"
+    );
+
+    let viewer_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("viewer/archsig-atom-viewer.html");
+    let viewer_html = fs::read_to_string(&viewer_path).expect("viewer html can be read");
+    for required in manifest["requiredViewerFunctions"]
+        .as_array()
+        .expect("requiredViewerFunctions is array")
+    {
+        let required = required
+            .as_str()
+            .expect("required viewer function is string");
+        assert!(
+            viewer_html.contains(required),
+            "gluing geometry golden UX fixture requires viewer function {required}"
+        );
+    }
+
+    for case in manifest["cases"].as_array().expect("cases is array") {
+        let case_id = case["caseId"].as_str().expect("caseId is string");
+        let out_dir = temp_dir(&format!("ag-gluing-golden-ux-{case_id}"));
+        run_sig0(&[
+            "analyze",
+            "--archmap",
+            root.join(case["archmap"].as_str().expect("archmap is string"))
+                .to_str()
+                .expect("path is utf-8"),
+            "--law-policy",
+            root.join(case["lawPolicy"].as_str().expect("lawPolicy is string"))
+                .to_str()
+                .expect("path is utf-8"),
+            "--out-dir",
+            out_dir.to_str().expect("path is utf-8"),
+        ]);
+
+        let report = read_json(&out_dir.join("archsig-insight-report.json"));
+        let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+        let gluing = &report["gluingGeometry"];
+        assert_eq!(gluing["schema"], "archsig-viewer-gluing-geometry/v1");
+        assert_eq!(
+            viewer["aatGeometryOverlays"]["gluingGeometry"], report["gluingGeometry"],
+            "{case_id} viewer data must expose the same golden gluing geometry projection"
+        );
+
+        let expected = &case["expected"];
+        if let Some(min_vertices) = expected["minNerveVertices"].as_u64() {
+            assert!(
+                gluing["nerve"]["vertices"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_vertices as usize),
+                "{case_id} must render expected cover nerve vertices"
+            );
+        }
+        if let Some(min_edges) = expected["minNerveEdges"].as_u64() {
+            assert!(
+                gluing["nerve"]["edges"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_edges as usize),
+                "{case_id} must render expected cover nerve edges"
+            );
+        }
+        if let Some(min_triangles) = expected["minNerveTriangles"].as_u64() {
+            assert!(
+                gluing["nerve"]["triangles"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_triangles as usize),
+                "{case_id} must render packet-derived cover nerve triangles"
+            );
+            assert!(
+                gluing["nerve"]["triangleSource"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("not inferred by the viewer")),
+                "{case_id} must keep triangle provenance out of viewer inference"
+            );
+        }
+        if let Some(expected_h2) = expected["h2CoherenceVisualized"].as_bool() {
+            assert_eq!(
+                gluing["nerve"]["h2CoherenceVisualized"].as_bool(),
+                Some(expected_h2),
+                "{case_id} must preserve H2 silence boundary"
+            );
+        }
+        if let Some(min_support_edges) = expected["minCocycleSupportEdges"].as_u64() {
+            assert!(
+                gluing["cocycleRibbon"]["supportEdges"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_support_edges as usize),
+                "{case_id} must render cocycle support ribbon edges"
+            );
+        }
+        if let Some(closure_gap_visible) = expected["closureGapVisible"].as_bool() {
+            assert_eq!(
+                gluing["cocycleRibbon"]["closureGapEncoding"]["visible"].as_bool(),
+                Some(closure_gap_visible),
+                "{case_id} must preserve fixed closure-gap visual encoding"
+            );
+        }
+        if let Some(min_cages) = expected["minForbiddenCages"].as_u64() {
+            assert!(
+                gluing["forbiddenCages"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_cages as usize),
+                "{case_id} must render forbidden support cages"
+            );
+        }
+        if let Some(min_morphs) = expected["minRepairMorphs"].as_u64() {
+            assert!(
+                gluing["repairMorphs"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_morphs as usize),
+                "{case_id} must render repair morph lower-bound paths"
+            );
+        }
+
+        let report_text = serde_json::to_string(&report).expect("report serializes");
+        for required in expected["requiredNonClaims"]
+            .as_array()
+            .into_iter()
+            .flatten()
+        {
+            let required = required.as_str().expect("required non-claim is string");
+            assert!(
+                report_text.contains(required),
+                "{case_id} must keep non-claim boundary text {required}"
+            );
+        }
+
+        for scene_id in expected["requiredScenes"].as_array().into_iter().flatten() {
+            let scene_id = scene_id.as_str().expect("required scene id is string");
+            let scene = viewer["viewerVisualScenes"]
+                .as_array()
+                .expect("viewerVisualScenes is array")
+                .iter()
+                .find(|scene| scene["sceneId"] == scene_id)
+                .unwrap_or_else(|| panic!("{case_id} missing scene {scene_id}"));
+            assert_eq!(
+                scene["axisMappingImplemented"].as_bool(),
+                Some(true),
+                "{case_id} scene {scene_id} must use axisMapping as geometry-driving"
+            );
+            assert!(
+                scene["visualEncodingLegend"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= 5),
+                "{case_id} scene {scene_id} must expose complete visual encoding legend"
+            );
+        }
+    }
+}
+
+#[test]
 fn cli_locks_ag_measurement_cech_h1_visible_golden_fixture() {
     let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let repo_root = crate_root

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -155,7 +155,11 @@ fn cli_analyze_v2_writes_measurement_packet_foundation() {
     assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
     let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
     assert_eq!(cech["dimensions"]["H1"], Value::from(0));
-    assert_eq!(cech["selectedH2"]["dimension"], Value::from(0));
+    assert_eq!(cech["selectedH2"]["dimension"], Value::Null);
+    assert_eq!(
+        cech["selectedH2"]["status"],
+        "not_measured_for_triple_overlap_faces"
+    );
     assert_eq!(packet["analyticReadings"][0]["regime"], "theorem-candidate");
 
     let validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
@@ -224,6 +228,12 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
         cech["observedCocycle"]["mismatchSupportRefs"][0],
         "atom:left-bottom-cech-mismatch"
     );
+    assert!(
+        cech["coverNerveProjection"]["faces"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "Cech H1 visible fixture has restriction chains but no measured triple-overlap 2-simplex"
+    );
     assert_eq!(
         cech["selectedH2"]["status"],
         "computed_for_selected_1_skeleton"
@@ -239,6 +249,108 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
     assert_eq!(
         summary["conclusion"],
         "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_cover_nerve_faces_require_packet_triple_overlap_support() {
+    let out_dir = temp_dir("ag-measurement-cech-triple-overlap");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_cech_h1_visible.json"));
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(json!({
+            "id": "atom:triple-overlap",
+            "kind": "component",
+            "subject": "src:triple-overlap",
+            "axis": "static",
+            "predicate": "tripleOverlapWitness",
+            "refs": ["src:triple-overlap"]
+        }));
+    archmap["sources"]["src:triple-overlap"] = json!({
+        "kind": "policy",
+        "path": "docs/tool/archsig_viewer_gluing_geometry_prd.md",
+        "section": "cover nerve triple-overlap fixture"
+    });
+    for context_id in ["ctx:top", "ctx:left", "ctx:bottom"] {
+        let context = archmap["contexts"]
+            .as_array_mut()
+            .expect("contexts is array")
+            .iter_mut()
+            .find(|context| context["id"] == context_id)
+            .unwrap_or_else(|| panic!("context {context_id} exists"));
+        context["atoms"]
+            .as_array_mut()
+            .expect("context atoms is array")
+            .push(Value::String("atom:triple-overlap".to_string()));
+    }
+    let archmap_path = out_dir.join("archmap_v2_cech_triple_overlap.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    let faces = cech["coverNerveProjection"]["faces"]
+        .as_array()
+        .expect("cover nerve faces are array");
+    assert!(
+        faces.iter().any(|face| {
+            let contexts = face["contextRefs"]
+                .as_array()
+                .expect("contextRefs is array")
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<BTreeSet<_>>();
+            contexts == BTreeSet::from(["ctx:bottom", "ctx:left", "ctx:top"])
+                && face["sharedAtomRefs"]
+                    .as_array()
+                    .expect("sharedAtomRefs is array")
+                    .iter()
+                    .any(|atom| atom == "atom:triple-overlap")
+                && face["coherenceClaim"] == "not_visualized"
+        }),
+        "cover nerve faces must be sourced from selected triple-overlap sharedAtomRefs"
+    );
+    assert_eq!(
+        cech["coverNerveProjection"]["faceSource"],
+        "selected cover triple-overlap sharedAtomRefs recorded in archsig-measurement-packet/v1; not inferred by the viewer"
+    );
+    assert_eq!(cech["coverNerveProjection"]["h2CoherenceVisualized"], false);
+    assert_eq!(cech["selectedH2"]["dimension"], Value::Null);
+    assert_eq!(
+        cech["selectedH2"]["status"],
+        "not_measured_for_triple_overlap_faces"
+    );
+
+    let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    assert_eq!(
+        report["gluingGeometry"]["nerve"]["triangles"], cech["coverNerveProjection"]["faces"],
+        "viewer gluing projection must consume packet-projected faces"
+    );
+    assert_eq!(
+        report["gluingGeometry"]["nerve"]["h2CoherenceVisualized"],
+        false
+    );
+    assert!(
+        report["gluingGeometry"]["nerve"]["triangleSource"]
+            .as_str()
+            .is_some_and(|text| text.contains("not inferred by the viewer"))
     );
 }
 
@@ -627,6 +739,96 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
                 && scene["visualEncodings"][0]["colorRole"] == "measured_zero"),
         "measured_zero Cech scene must stay active and explicitly measured_zero"
     );
+    let gluing_geometry = report["gluingGeometry"]
+        .as_object()
+        .expect("insight report must expose gluing geometry projection");
+    assert_eq!(
+        gluing_geometry["schema"].as_str(),
+        Some("archsig-viewer-gluing-geometry/v1"),
+        "gluing geometry projection must be typed"
+    );
+    assert!(
+        gluing_geometry["nerve"]["vertices"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+            && gluing_geometry["nerve"]["edges"]
+                .as_array()
+                .is_some_and(|items| !items.is_empty()),
+        "cover nerve must expose packet-derived vertices and restriction edges"
+    );
+    assert!(
+        gluing_geometry["nerve"]["triangleSource"]
+            .as_str()
+            .is_some_and(|text| text.contains("not inferred by the viewer")),
+        "cover nerve triangles must be sourced from packet cover projection, not viewer inference"
+    );
+    assert_eq!(
+        gluing_geometry["nerve"]["h2CoherenceVisualized"].as_bool(),
+        Some(false),
+        "gluing viewer PRD must preserve the H2 silence boundary"
+    );
+    assert!(
+        gluing_geometry["cocycleRibbon"]["closureGapEncoding"]["nonClaim"]
+            .as_str()
+            .is_some_and(|text| text.contains("monodromy verdict is not generated")),
+        "H1 cocycle ribbon must keep the monodromy non-claim explicit"
+    );
+    assert!(
+        gluing_geometry["atomGlyphs"]
+            .as_array()
+            .is_some_and(|items| items
+                .iter()
+                .any(|item| item["shapeRole"] == "structured_atom_glyph")),
+        "atom internal glyph projection must expose fiber/carrier/valence/semantic-anchor roles"
+    );
+    assert!(
+        gluing_geometry["repairMorphs"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "repair morphs must not be inferred without packet alexanderDualRepair minimal hitting sets"
+    );
+    assert!(
+        gluing_geometry["omittedGeometryCounts"]
+            .as_object()
+            .is_some_and(|counts| counts.contains_key("measuredZeroRegions")
+                && counts.contains_key("blockedRegions")
+                && counts.contains_key("atomGlyphs")),
+        "gluing projection must report omitted counts for each independently capped geometry family"
+    );
+    assert_eq!(
+        viewer["aatGeometryOverlays"]["gluingGeometry"], report["gluingGeometry"],
+        "viewer data must consume the same gluing geometry projection as the insight report"
+    );
+    for scene_id in [
+        "site-cover",
+        "cech-gluing",
+        "cech-h1-mismatch",
+        "hodge-debt-field",
+    ] {
+        let scene = viewer["viewerVisualScenes"]
+            .as_array()
+            .expect("viewer visual scenes are array")
+            .iter()
+            .find(|scene| scene["sceneId"] == scene_id)
+            .unwrap_or_else(|| panic!("scene {scene_id} exists"));
+        assert_eq!(
+            scene["axisMappingImplemented"].as_bool(),
+            Some(true),
+            "{scene_id} must mark axisMapping as geometry-driving"
+        );
+        assert!(
+            scene["visualEncodingLegend"]
+                .as_array()
+                .is_some_and(|items| items.len() >= 4),
+            "{scene_id} must carry fixed color/shape/line/opacity legend"
+        );
+        assert!(
+            scene["projectionBoundary"]
+                .as_str()
+                .is_some_and(|text| text.contains("does not create a new structural verdict")),
+            "{scene_id} must keep visual richness below verdict level"
+        );
+    }
     for forbidden in [
         "Architecture is clean",
         "No architecture issue exists",
@@ -1073,6 +1275,33 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
     assert_eq!(
         summary["conclusion"],
         "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
+    );
+    let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
+    assert!(
+        report["gluingGeometry"]["forbiddenCages"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "square-free obstruction fixture must project minimal forbidden support as cage geometry"
+    );
+    assert!(
+        report["gluingGeometry"]["repairMorphs"]
+            .as_array()
+            .is_some_and(|items| {
+                items.iter().any(|item| {
+                    item["animationRole"] == "continuous_morph_lower_bound"
+                        && item["nonClaim"] == "not automatic repair"
+                })
+            }),
+        "square-free repair fixture must project lower-bound repair candidate as continuous morph"
+    );
+    assert_eq!(
+        viewer["aatGeometryOverlays"]["forbiddenCages"], report["gluingGeometry"]["forbiddenCages"],
+        "viewer overlay must carry forbidden cage geometry"
+    );
+    assert_eq!(
+        viewer["aatGeometryOverlays"]["repairMorphs"], report["gluingGeometry"]["repairMorphs"],
+        "viewer overlay must carry repair morph geometry"
     );
 }
 
@@ -8228,8 +8457,22 @@ fn atom_viewer_reads_insight_report_surface_contract() {
         "sceneNodeColor",
         "renderSceneLayers",
         "sceneLayerMesh",
+        "renderGluingGeometry",
+        "renderNerveGeometry",
+        "renderCocycleRibbon",
+        "renderLocusField",
+        "renderForbiddenCages",
+        "renderRepairMorphs",
+        "renderAtomGlyphOverlays",
+        "updateRepairMorphAnimation",
+        "sceneAxisPosition",
+        "legendSwatchColor",
+        "legendValueText",
+        "thickness",
+        "window.__archsigViewerDebug",
         "sceneColorHex",
         "handleReportAction",
+        "const reportEl = document.getElementById(\"report\")",
         "startGuidedTour",
         "showTourStep",
         "data-tour-id",
@@ -8239,6 +8482,10 @@ fn atom_viewer_reads_insight_report_surface_contract() {
         "data-copy-source-refs",
         "Boolean(data?.decisionBar)",
         "evidenceDetailShape",
+        "holonomyLikeGapMarker",
+        "blockedUnmeasuredRegion",
+        "forbiddenSupportCage",
+        "not automatic repair",
     ] {
         assert!(
             viewer.contains(required),

--- a/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
@@ -1,0 +1,52 @@
+{
+  "schema": "archsig-viewer-gluing-geometry-golden-ux/v1",
+  "prdRef": "docs/tool/archsig_viewer_gluing_geometry_prd.md",
+  "description": "Golden UX regression manifest for ArchSig viewer gluing geometry projections.",
+  "cases": [
+    {
+      "caseId": "cover-nerve-triple-overlap",
+      "archmap": "archmap_v2.json",
+      "lawPolicy": "law_policy_ag.json",
+      "expected": {
+        "minNerveVertices": 3,
+        "minNerveEdges": 2,
+        "minNerveTriangles": 1,
+        "h2CoherenceVisualized": false,
+        "requiredScenes": ["site-cover", "cech-gluing"]
+      }
+    },
+    {
+      "caseId": "cech-h1-cocycle-ribbon",
+      "archmap": "archmap_v2_cech_h1_visible.json",
+      "lawPolicy": "law_policy_ag.json",
+      "expected": {
+        "minCocycleSupportEdges": 1,
+        "closureGapVisible": true,
+        "requiredNonClaims": ["monodromy verdict is not generated"],
+        "requiredScenes": ["cech-h1-mismatch"]
+      }
+    },
+    {
+      "caseId": "square-free-forbidden-cage-repair-morph",
+      "archmap": "archmap_v2_square_free_repair.json",
+      "lawPolicy": "law_policy_square_free.json",
+      "expected": {
+        "minForbiddenCages": 1,
+        "minRepairMorphs": 1,
+        "requiredNonClaims": ["not automatic repair"],
+        "requiredScenes": ["obstruction", "repair-dual"]
+      }
+    }
+  ],
+  "requiredViewerFunctions": [
+    "renderGluingGeometry",
+    "renderNerveGeometry",
+    "renderCocycleRibbon",
+    "renderLocusField",
+    "renderForbiddenCages",
+    "renderRepairMorphs",
+    "renderAtomGlyphOverlays",
+    "sceneAxisPosition",
+    "legendValueText"
+  ]
+}

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -920,6 +920,7 @@
     const fileEl = document.getElementById("file");
     const resetEl = document.getElementById("reset");
     const reportToggleEl = document.getElementById("report-toggle");
+    const reportEl = document.getElementById("report");
     const detailEl = document.getElementById("detail");
     const legendEl = document.getElementById("legend");
     const axisHudEl = document.getElementById("axis-hud");
@@ -1027,6 +1028,7 @@
     function animate() {
       requestAnimationFrame(animate);
       controls.update();
+      updateRepairMorphAnimation();
       renderer.render(scene, camera);
     }
 
@@ -1095,10 +1097,21 @@
       activeLayoutContext = buildLayoutContext(renderedAtoms, renderedGroups, currentData);
       renderedAtoms.forEach((node, index) => positions.set(node.nodeId, nodePosition(node, index, renderedAtoms.length, activeLayoutContext)));
       renderAtomInstances(renderedAtoms, positions);
+      renderAtomGlyphOverlays(renderedAtoms, positions, activeLayoutContext);
       renderMoleculeGroups(renderedGroups, positions, activeLayoutContext);
       renderViewerDistanceBonds(positions, activeLayoutContext);
       renderedEdgeCount = renderEdges(edges, positions);
-      renderSceneLayers(sceneForMode(viewModeEl.value), positions);
+      const activeScene = sceneForMode(viewModeEl.value);
+      const edgeChildrenBeforeSceneLayers = edgeGroup.children.length;
+      renderSceneLayers(activeScene, positions);
+      window.__archsigViewerDebug = {
+        ...(window.__archsigViewerDebug || {}),
+        activeSceneId: activeScene?.sceneId || null,
+        activeSceneStatus: activeScene?.sceneStatus || null,
+        activeSceneLayerCount: Array.isArray(activeScene?.layers) ? activeScene.layers.length : 0,
+        hasGluingGeometry: Boolean(activeLayoutContext?.aat?.gluingGeometry?.schema),
+        sceneLayerObjectDelta: edgeGroup.children.length - edgeChildrenBeforeSceneLayers
+      };
       renderLegend();
       renderAxisHud();
       updateVisibility();
@@ -1122,6 +1135,35 @@
       atomInstanceMesh.instanceMatrix.needsUpdate = true;
       if (atomInstanceMesh.instanceColor) atomInstanceMesh.instanceColor.needsUpdate = true;
       atomGroup.add(atomInstanceMesh);
+    }
+
+    function renderAtomGlyphOverlays(nodes, positions, layoutContext) {
+      const glyphs = layoutContext?.aat?.atomGlyphByRef || new Map();
+      if (!glyphs.size) return;
+      nodes.slice(0, 2000).forEach((node) => {
+        const glyph = glyphs.get(node.nodeId);
+        if (!glyph) return;
+        const p = positions.get(node.nodeId);
+        if (!p) return;
+        const valence = Math.min(Number(glyph.valence || 0), 12);
+        const blockedAnchor = String(glyph.semanticAnchor || "").includes("blocked");
+        const geometry = blockedAnchor
+          ? new THREE.OctahedronGeometry(2.6 + valence * 0.16, 0)
+          : new THREE.TorusGeometry(2.2 + valence * 0.14, 0.16, 6, 18);
+        const material = new THREE.MeshStandardMaterial({
+          color: blockedAnchor ? 0xff6b6b : 0x8bd46e,
+          transparent: true,
+          opacity: blockedAnchor ? 0.86 : 0.58,
+          roughness: 0.48,
+          metalness: 0.03,
+          wireframe: blockedAnchor
+        });
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.position.copy(p);
+        mesh.rotation.x = Math.PI / 2;
+        mesh.userData = { kind: "atomInternalGlyph", item: glyph, node };
+        atomGroup.add(mesh);
+      });
     }
 
     function renderMoleculeGroups(groups, positions, layoutContext) {
@@ -1235,6 +1277,7 @@
       if (!scene || !Array.isArray(scene.layers) || scene.sceneStatus === "not_active_for_packet") return;
       const encodings = Array.isArray(scene.visualEncodings) ? scene.visualEncodings : [];
       const encodingById = new Map(encodings.map((encoding) => [encoding.encodingId, encoding]));
+      renderGluingGeometry(scene, positions, encodings[0] || {});
       const refs = scene.primaryRefs || {};
       const atomRefs = Array.isArray(refs.atomRefs) ? refs.atomRefs : [];
       const contextRefs = Array.isArray(refs.contextRefs) ? refs.contextRefs : [];
@@ -1296,6 +1339,276 @@
       return mesh;
     }
 
+    function renderGluingGeometry(scene, positions, encoding) {
+      const geometry = activeLayoutContext?.aat?.gluingGeometry || {};
+      if (!geometry || !scene?.sceneId) return;
+      const before = edgeGroup.children.length;
+      if (scene.sceneId === "site-cover" || scene.sceneId === "cech-gluing") {
+        renderNerveGeometry(scene, geometry.nerve || {}, positions, encoding);
+      }
+      if (scene.sceneId === "cech-h1-mismatch") {
+        renderCocycleRibbon(scene, geometry.cocycleRibbon || {}, positions, encoding);
+      }
+      if (scene.sceneId === "hodge-debt-field") {
+        renderLocusField(scene, geometry.locusField || {}, positions, geometry.renderLimits || {});
+      }
+      if (scene.sceneId === "obstruction") {
+        renderForbiddenCages(scene, geometry.forbiddenCages || [], positions, encoding, geometry.renderLimits || {});
+      }
+      if (scene.sceneId === "repair-dual") {
+        renderRepairMorphs(scene, geometry.repairMorphs || [], positions, encoding, geometry.renderLimits || {});
+      }
+      const created = edgeGroup.children.slice(before);
+      window.__archsigViewerDebug = {
+        lastGluingSceneId: scene.sceneId,
+        lastGluingObjectCount: created.length,
+        lastGluingObjectKinds: created.reduce((counts, child) => {
+          const kind = child.userData?.kind || "unknown";
+          counts[kind] = (counts[kind] || 0) + 1;
+          return counts;
+        }, {}),
+        projectionBoundary: geometry.projectionBoundary || ""
+      };
+    }
+
+    function sceneAxisPosition(scene, ref, index, total, fallback, metrics = {}) {
+      const axes = scene?.axisMapping || {};
+      const totalSafe = Math.max(total || 1, 1);
+      const rank = (index % totalSafe) / totalSafe;
+      const xValue = Number.isFinite(Number(metrics.xValue)) ? Number(metrics.xValue) : rank;
+      const yValue = Number.isFinite(Number(metrics.yValue)) ? Number(metrics.yValue) : 0;
+      const zValue = Number.isFinite(Number(metrics.zValue)) ? Number(metrics.zValue) : 0;
+      const xScale = 46 + (hashText(axes.x || "x") % 17);
+      const yScale = 9 + (hashText(axes.y || "y") % 7);
+      const zScale = 32 + (hashText(axes.z || "z") % 19);
+      const phase = xValue * Math.PI * 2 + index * 0.11;
+      const radius = zScale + Math.sqrt(index + 1) * 1.8 + Math.min(Math.abs(zValue), 12) * 5;
+      const y = -26 + yValue * yScale + rank * 18;
+      const axisPoint = new THREE.Vector3(Math.cos(phase) * (radius + xValue * xScale), y, Math.sin(phase) * radius);
+      if (!fallback) return axisPoint;
+      return axisPoint.lerp(fallback.clone(), 0.35);
+    }
+
+    function renderNerveGeometry(scene, nerve, positions, encoding) {
+      const vertices = Array.isArray(nerve.vertices) ? nerve.vertices : [];
+      const edges = Array.isArray(nerve.edges) ? nerve.edges : [];
+      const triangles = Array.isArray(nerve.triangles) ? nerve.triangles : [];
+      vertices.forEach((vertex, index) => {
+        const center = sceneAxisPosition(scene, vertex.contextRef, index, Math.max(vertices.length, 1), positions.get(vertex.contextRef), {
+          xValue: index / Math.max(vertices.length - 1, 1),
+          yValue: Math.min((vertex.atomRefs || []).length, 12),
+          zValue: Math.min((vertex.atomRefs || []).length, 12)
+        });
+        if (!center) return;
+        const patch = new THREE.Mesh(
+          new THREE.CircleGeometry(5.4 + Math.min((vertex.atomRefs || []).length, 8) * 0.4, 24),
+          new THREE.MeshStandardMaterial({
+            color: 0x64d6be,
+            transparent: true,
+            opacity: 0.24,
+            roughness: 0.52,
+            side: THREE.DoubleSide
+          })
+        );
+        patch.position.copy(center);
+        patch.position.y += 4 + index * 0.2;
+        patch.rotation.x = -Math.PI / 2;
+        patch.userData = { kind: "nerveVertexPatch", item: vertex };
+        edgeGroup.add(patch);
+      });
+      renderNerveEdges(scene, edges, positions, encoding);
+      const triangleLimit = activeLayoutContext?.aat?.gluingGeometry?.renderLimits?.nerveTriangles || 80;
+      triangles.slice(0, triangleLimit).forEach((triangle, index) => {
+        const points = (triangle.contextRefs || []).map((ref, refIndex) =>
+          sceneAxisPosition(scene, ref, index * 3 + refIndex, Math.max(triangles.length * 3, 1), positions.get(ref), {
+            xValue: refIndex / 3,
+            yValue: Math.min((triangle.sharedAtomRefs || []).length, 12),
+            zValue: Math.min((triangle.edgeRefs || []).length, 3)
+          })
+        ).filter(Boolean);
+        if (points.length !== 3) return;
+        const geometry = new THREE.BufferGeometry();
+        geometry.setAttribute("position", new THREE.Float32BufferAttribute(points.flatMap((p) => [p.x, p.y + 2, p.z]), 3));
+        geometry.computeVertexNormals();
+        const mesh = new THREE.Mesh(geometry, new THREE.MeshStandardMaterial({
+          color: 0x73b7ff,
+          transparent: true,
+          opacity: 0.18,
+          side: THREE.DoubleSide,
+          roughness: 0.6
+        }));
+        mesh.userData = { kind: "nerveTriangle", item: triangle, nonClaim: "H2 coherence is not visualized" };
+        edgeGroup.add(mesh);
+      });
+    }
+
+    function renderNerveEdges(scene, edges, positions, encoding) {
+      const solid = [];
+      const mismatch = [];
+      edges.forEach((edge, index) => {
+        const metrics = { xValue: index / Math.max(edges.length - 1, 1), yValue: Number(edge.value || 0), zValue: Math.min((edge.supportAtomRefs || []).length, 12) };
+        const source = sceneAxisPosition(scene, edge.sourceContextRef, index * 2, Math.max(edges.length * 2, 1), positions.get(edge.sourceContextRef), metrics);
+        const target = sceneAxisPosition(scene, edge.targetContextRef, index * 2 + 1, Math.max(edges.length * 2, 1), positions.get(edge.targetContextRef), metrics);
+        if (!source || !target) return;
+        const bucket = Number(edge.value || 0) > 0 ? mismatch : solid;
+        bucket.push(source.x, source.y + 3, source.z, target.x, target.y + 3, target.z);
+      });
+      addLineSegments(solid, sceneColorHex("checked"), 0.52, "nerveEdge");
+      addLineSegments(mismatch, sceneColorHex(encoding.colorRole || "measured_nonzero"), 0.9, "nerveMismatchEdge");
+    }
+
+    function renderCocycleRibbon(scene, ribbon, positions, encoding) {
+      const supportEdges = Array.isArray(ribbon.supportEdges) ? ribbon.supportEdges : [];
+      const points = [];
+      supportEdges.forEach((edge, index) => {
+        const metrics = { xValue: index / Math.max(supportEdges.length - 1, 1), yValue: Number(edge.value || 0), zValue: Math.min((edge.supportAtomRefs || []).length, 12) };
+        const source = sceneAxisPosition(scene, edge.sourceContextRef, index * 2, Math.max(supportEdges.length * 2, 1), positions.get(edge.sourceContextRef), metrics);
+        const target = sceneAxisPosition(scene, edge.targetContextRef, index * 2 + 1, Math.max(supportEdges.length * 2, 1), positions.get(edge.targetContextRef), metrics);
+        if (!source || !target) return;
+        if (!points.length) points.push(source.clone().add(new THREE.Vector3(0, 8, 0)));
+        points.push(target.clone().add(new THREE.Vector3(0, 8 + Number(edge.value || 0) * 7, 0)));
+      });
+      if (points.length < 2) return;
+      const curve = new THREE.CatmullRomCurve3(points, false, "catmullrom", 0.45);
+      const tube = new THREE.Mesh(
+        new THREE.TubeGeometry(curve, 80, 0.92, 8, false),
+        new THREE.MeshStandardMaterial({
+          color: sceneColorHex(encoding.colorRole || "measured_nonzero"),
+          transparent: true,
+          opacity: 0.72,
+          roughness: 0.38,
+          metalness: 0.05
+        })
+      );
+      tube.userData = { kind: "cocycleRibbon", item: ribbon };
+      edgeGroup.add(tube);
+      if (ribbon.closureGapEncoding?.visible) {
+        const gap = new THREE.Mesh(
+          new THREE.TorusKnotGeometry(3.2, 0.34, 48, 8),
+          new THREE.MeshStandardMaterial({ color: 0xff6b6b, emissive: 0x3a0808, roughness: 0.4 })
+        );
+        gap.position.copy(points[points.length - 1]);
+        gap.userData = { kind: "holonomyLikeGapMarker", item: ribbon.closureGapEncoding };
+        edgeGroup.add(gap);
+      }
+    }
+
+    function renderLocusField(scene, field, positions, limits) {
+      const rows = Array.isArray(field.fieldRows) ? field.fieldRows : [];
+      const zeroRegions = Array.isArray(field.measuredZeroRegions) ? field.measuredZeroRegions : [];
+      const blockedRegions = Array.isArray(field.blockedRegions) ? field.blockedRegions : [];
+      rows.slice(0, limits.curvatureFieldRows || 64).forEach((row, index) => {
+        const center = sceneAxisPosition(scene, row.fieldId || `field:${index}`, index, Math.max(rows.length, 1), groupPosition(index, Math.max(rows.length, 1), 48), {
+          xValue: index / Math.max(rows.length - 1, 1),
+          yValue: Number(row.height || 0),
+          zValue: Number(row.height || 0)
+        });
+        const height = 3 + Math.min(Number(row.height || 0), 12) * 7;
+        const mesh = new THREE.Mesh(
+          new THREE.CylinderGeometry(3.6, 6.2, height, 18),
+          new THREE.MeshStandardMaterial({
+            color: sceneColorHex(row.colorRole || "analytic_reading"),
+            transparent: true,
+            opacity: 0.46,
+            roughness: 0.5
+          })
+        );
+        mesh.position.set(center.x, height / 2 - 20, center.z);
+        mesh.userData = { kind: "curvatureHeightField", item: row };
+        edgeGroup.add(mesh);
+      });
+      zeroRegions.slice(0, limits.curvatureRegions || 24).forEach((region, index) => {
+        const center = sceneAxisPosition(scene, region.regionId || `zero:${index}`, index, Math.max(zeroRegions.length, 1), groupPosition(index, Math.max(zeroRegions.length, 1), 34), { xValue: index / Math.max(zeroRegions.length - 1, 1), yValue: 0, zValue: 0 });
+        const mesh = new THREE.Mesh(
+          new THREE.CircleGeometry(7.5, 32),
+          new THREE.MeshStandardMaterial({ color: 0x64d6be, transparent: true, opacity: 0.2, side: THREE.DoubleSide })
+        );
+        mesh.position.set(center.x, -24, center.z);
+        mesh.rotation.x = -Math.PI / 2;
+        mesh.userData = { kind: "measuredZeroLocusPatch", item: region };
+        edgeGroup.add(mesh);
+      });
+      blockedRegions.slice(0, limits.curvatureRegions || 24).forEach((region, index) => {
+        const center = sceneAxisPosition(scene, region.regionId || `blocked:${index}`, index, Math.max(blockedRegions.length, 1), groupPosition(index, Math.max(blockedRegions.length, 1), 60), { xValue: index / Math.max(blockedRegions.length - 1, 1), yValue: 2, zValue: 2 });
+        const mesh = new THREE.Mesh(
+          new THREE.BoxGeometry(8, 18, 1.2),
+          new THREE.MeshStandardMaterial({ color: 0xff6b6b, transparent: true, opacity: 0.34, wireframe: true })
+        );
+        mesh.position.set(center.x, 2, center.z);
+        mesh.rotation.y = index * 0.45;
+        mesh.userData = { kind: "blockedUnmeasuredRegion", item: region };
+        edgeGroup.add(mesh);
+      });
+    }
+
+    function renderForbiddenCages(scene, cages, positions, encoding, limits) {
+      cages.slice(0, limits.forbiddenCages || 80).forEach((cage, index) => {
+        const points = (cage.atomRefs || []).map((ref) => positions.get(ref)).filter(Boolean);
+        const center = sceneAxisPosition(scene, cage.cageId || `cage:${index}`, index, Math.max(cages.length, 1), points.length ? centroid(points) : groupPosition(index, Math.max(cages.length, 1), 52), {
+          xValue: index / Math.max(cages.length - 1, 1),
+          yValue: Math.min((cage.supportVariables || cage.atomRefs || []).length, 12),
+          zValue: Math.min((cage.atomRefs || []).length, 12)
+        });
+        const size = 7 + Math.min(points.length, 8) * 1.2;
+        const mesh = new THREE.Mesh(
+          new THREE.IcosahedronGeometry(size, 1),
+          new THREE.MeshStandardMaterial({
+            color: sceneColorHex(encoding.colorRole || "measured_nonzero"),
+            transparent: true,
+            opacity: 0.36,
+            wireframe: true,
+            roughness: 0.45
+          })
+        );
+        mesh.position.copy(center);
+        mesh.position.y += 12;
+        mesh.userData = { kind: "forbiddenSupportCage", item: cage };
+        edgeGroup.add(mesh);
+        addLineSegments(points.flatMap((p) => [center.x, center.y + 12, center.z, p.x, p.y, p.z]), 0xff9468, 0.68, "forbiddenSimplexEdge");
+      });
+    }
+
+    function renderRepairMorphs(scene, morphs, positions, encoding, limits) {
+      morphs.slice(0, limits.repairMorphs || 50).forEach((morph, index) => {
+        const fallback = groupPosition(index, Math.max(morphs.length, 1), 62);
+        const target = sceneAxisPosition(scene, morph.toAtomRef || morph.toCandidateRef || morph.morphId, index, Math.max(morphs.length, 1), positions.get(morph.toAtomRef) || fallback, {
+          xValue: index / Math.max(morphs.length - 1, 1),
+          yValue: Math.min((morph.supportVariables || morph.supportAtomRefs || []).length, 12),
+          zValue: Math.min((morph.lowerBoundReadingRefs || []).length + 1, 12)
+        });
+        const start = target.clone().add(new THREE.Vector3(-22 - index * 0.8, 18, -12));
+        addLineSegments([start.x, start.y, start.z, target.x, target.y + 5, target.z], sceneColorHex("repair_candidate"), 0.74, "repairMorphPath");
+        const marker = new THREE.Mesh(
+          new THREE.SphereGeometry(2.8, 16, 10),
+          new THREE.MeshStandardMaterial({ color: 0xb087ff, emissive: 0x160a28, roughness: 0.36 })
+        );
+        marker.userData = { kind: "repairMorphMarker", item: morph, nonClaim: "not automatic repair", start, target: target.clone().add(new THREE.Vector3(0, 5, 0)), phase: index * 0.17 };
+        edgeGroup.add(marker);
+      });
+    }
+
+    function addLineSegments(vertices, color, opacity, kind) {
+      if (!vertices.length) return;
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute("position", new THREE.Float32BufferAttribute(vertices, 3));
+      const material = new THREE.LineBasicMaterial({ color, transparent: true, opacity });
+      const lines = new THREE.LineSegments(geometry, material);
+      lines.userData = { kind };
+      edgeGroup.add(lines);
+    }
+
+    function updateRepairMorphAnimation() {
+      const t = (performance.now() % 2400) / 2400;
+      const eased = 0.5 - Math.cos(t * Math.PI * 2) * 0.5;
+      edgeGroup.children.forEach((child) => {
+        if (child.userData?.kind !== "repairMorphMarker") return;
+        const { start, target, phase } = child.userData;
+        if (!start || !target) return;
+        const local = (eased + Number(phase || 0)) % 1;
+        child.position.copy(start).lerp(target, local);
+      });
+    }
+
     function sceneColorHex(role) {
       const colors = {
         measured_nonzero: 0xf2c15f,
@@ -1342,6 +1655,7 @@
     function buildAatContext(atomIndex, data) {
       const overlays = data.analysisOverlays || {};
       const geometry = data.aatGeometryOverlays || {};
+      const gluingGeometry = geometry.gluingGeometry || geometry;
       const axes = Array.isArray(overlays.signatureAxes) ? overlays.signatureAxes : [];
       const obstructions = Array.isArray(overlays.obstructionCircuits) ? overlays.obstructionCircuits : [];
       const findings = overlays.dominantFindings || {};
@@ -1456,6 +1770,8 @@
         atomToSpectrum,
         atomToViewerDistances,
         viewerDistances,
+        gluingGeometry,
+        atomGlyphByRef: new Map((Array.isArray(gluingGeometry.atomGlyphs) ? gluingGeometry.atomGlyphs : []).map((glyph) => [String(glyph.atomRef || ""), glyph])),
         axisByRef,
         axisCenters,
         obstructionCenters,
@@ -2089,10 +2405,36 @@
     }
 
     function renderLegend() {
+      const scene = sceneForMode(viewModeEl.value);
+      const sceneLegend = Array.isArray(scene?.visualEncodingLegend) ? scene.visualEncodingLegend : [];
+      if (sceneLegend.length) {
+        legendEl.innerHTML = sceneLegend.slice(0, 8).map((item) =>
+          `<span class="legend-item"><span class="swatch" style="background:#${legendSwatchColor(item.channel)}"></span>${escapeHtml(item.channel || "encoding")}: ${escapeHtml(item.meaning || "")} ${legendValueText(item.values)}</span>`
+        ).join("");
+        return;
+      }
       const items = Object.entries(colorByFamily);
       legendEl.innerHTML = items.slice(0, 12).map(([label, color]) =>
         `<span class="legend-item"><span class="swatch" style="background:#${Number(color).toString(16).padStart(6, "0")}"></span>${escapeHtml(label)}</span>`
       ).join("");
+    }
+
+    function legendSwatchColor(channel) {
+      const colors = {
+        color: "f2c15f",
+        shape: "73b7ff",
+        line: "d8dee9",
+        opacity: "8bd46e",
+        thickness: "b087ff"
+      };
+      return colors[channel] || "9fb3c8";
+    }
+
+    function legendValueText(values) {
+      if (!values || typeof values !== "object") return "";
+      return Object.entries(values).slice(0, 5).map(([key, value]) =>
+        `${key}=${value}`
+      ).join("; ");
     }
 
     function renderAxisHud() {


### PR DESCRIPTION
## 概要

Closes #2087

`docs/tool/archsig_viewer_gluing_geometry_prd.md` の PRD に対応し、ArchSig Atom Viewer に貼り合わせ幾何 projection を追加します。

- `archsig-insight-report/v1` に `gluingGeometry` を追加し、viewer data の `aatGeometryOverlays.gluingGeometry` へ同じ typed projection を渡す
- cover nerve / Cech cocycle ribbon / curvature locus field / forbidden cage / repair morph / atom internal glyph を Three.js scene に描画する
- H² coherence、monodromy verdict、自動修復の claim boundary を non-claim として維持する
- object kind 別 render limit / omitted counts と visual encoding legend を追加する

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`
  - 未実施: Lean 変更なし
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
  - 未実施: FieldSig 変更なし
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] 禁止語 / private path scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan
  - 未実施: Lean 変更なし

追加確認:
- [x] local viewer smoke: `.tmp/archsig-viewer-gluing` を http server で配信し、Chrome headless で DOM 読み込み・legend value 表示・gluing scene debug・非空 screenshot を確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
  - Lean 変更なし / tooling projection tracking
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
