### PR TITLE
ArchSig viewer貼り合わせ幾何のfinal review gapを補強する

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -2632,7 +2632,7 @@ fn repair_morph_projection(
 }
 
 fn locus_field_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
-    let field_rows = packet
+    let mut field_rows = packet
         .structural_verdict
         .iter()
         .enumerate()
@@ -2653,6 +2653,7 @@ fn locus_field_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
             })
         })
         .collect::<Vec<_>>();
+    field_rows.extend(analytic_locus_field_rows(packet));
     let blocked_regions = packet
         .structural_verdict
         .iter()
@@ -2691,6 +2692,50 @@ fn locus_field_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
     })
 }
 
+fn analytic_locus_field_rows(packet: &ArchSigMeasurementPacketV1) -> Vec<Value> {
+    let mut rows = Vec::new();
+    for reading in &packet.analytic_readings {
+        let reading_kind = string_at(&reading.value, &["readingKind"]);
+        if reading_kind != "graph-laplacian-hodge-proxy@1" {
+            continue;
+        }
+        let harmonic_mass = reading.value["harmonicMass"].as_f64().unwrap_or(0.0);
+        let distance_to_flatness = reading.value["distanceToFlatness"].as_f64().unwrap_or(0.0);
+        let mass_height = harmonic_mass.max(distance_to_flatness);
+        rows.push(json!({
+            "fieldId": format!("curvature-mass:{}", reading.reading_id),
+            "status": "analytic_reading",
+            "height": round_f64(mass_height),
+            "harmonicMass": round_f64(harmonic_mass),
+            "distanceToFlatness": round_f64(distance_to_flatness),
+            "colorRole": "analytic_reading",
+            "sourceReadingRef": reading.reading_id,
+            "source": "analytic reading harmonicMass / distanceToFlatness"
+        }));
+        for (index, transfer) in reading.value["curvatureTransferSpectrum"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let curvature = transfer["curvature"].as_f64().unwrap_or(0.0);
+            rows.push(json!({
+                "fieldId": format!("curvature-support:{}:{index}", reading.reading_id),
+                "status": "analytic_reading",
+                "height": round_f64(curvature.abs()),
+                "signedCurvature": round_f64(curvature),
+                "cellRef": string_field(transfer, "cell"),
+                "harmonicMass": round_f64(harmonic_mass),
+                "distanceToFlatness": round_f64(distance_to_flatness),
+                "colorRole": if curvature.abs() > 1.0e-9 { "analytic_reading" } else { "measured_zero" },
+                "sourceReadingRef": reading.reading_id,
+                "source": "analytic reading curvatureTransferSpectrum support / mass"
+            }));
+        }
+    }
+    rows
+}
+
 fn atom_glyph_projection(normalized: &NormalizedArchMapV2) -> Vec<Value> {
     normalized
         .atoms
@@ -2706,6 +2751,8 @@ fn atom_glyph_projection(normalized: &NormalizedArchMapV2) -> Vec<Value> {
                 "valence": atom.context_memberships.len(),
                 "semanticAnchor": if semantic_anchor_missing { "blocked_missing_anchor" } else { "source_backed" },
                 "shapeRole": if semantic_anchor_missing { "blocked_anchor_glyph" } else { "structured_atom_glyph" },
+                "fiberShapeRole": format!("fiber_shape:{}", atom.atom_kind),
+                "carrierColorRole": format!("carrier_color:{}", slug(&atom.subject)),
                 "sizeRole": "valence",
                 "colorRole": if semantic_anchor_missing { "not_computed" } else { "source_evidence" }
             })

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -3228,12 +3228,35 @@ fn cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture() {
     for case in manifest["cases"].as_array().expect("cases is array") {
         let case_id = case["caseId"].as_str().expect("caseId is string");
         let out_dir = temp_dir(&format!("ag-gluing-golden-ux-{case_id}"));
+        let archmap_path = if case["mutations"].is_array() {
+            let mut archmap =
+                read_json(&root.join(case["archmap"].as_str().expect("archmap is string")));
+            for mutation in case["mutations"].as_array().expect("mutations is array") {
+                let atom_id = mutation["atomId"].as_str().expect("atomId is string");
+                let field = mutation["field"].as_str().expect("field is string");
+                let value = mutation["value"].clone();
+                let atom = archmap["atoms"]
+                    .as_array_mut()
+                    .expect("atoms is array")
+                    .iter_mut()
+                    .find(|atom| atom["id"] == atom_id)
+                    .unwrap_or_else(|| panic!("{case_id} missing mutation atom {atom_id}"));
+                atom[field] = value;
+            }
+            let archmap_path = out_dir.join(format!("{case_id}.archmap.json"));
+            fs::write(
+                &archmap_path,
+                serde_json::to_vec_pretty(&archmap).expect("mutated archmap serializes"),
+            )
+            .expect("mutated archmap can be written");
+            archmap_path
+        } else {
+            root.join(case["archmap"].as_str().expect("archmap is string"))
+        };
         run_sig0(&[
             "analyze",
             "--archmap",
-            root.join(case["archmap"].as_str().expect("archmap is string"))
-                .to_str()
-                .expect("path is utf-8"),
+            archmap_path.to_str().expect("path is utf-8"),
             "--law-policy",
             root.join(case["lawPolicy"].as_str().expect("lawPolicy is string"))
                 .to_str()
@@ -3320,6 +3343,54 @@ fn cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture() {
                 "{case_id} must render repair morph lower-bound paths"
             );
         }
+        if let Some(min_rows) = expected["minCurvatureFieldRows"].as_u64() {
+            assert!(
+                gluing["locusField"]["fieldRows"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_rows as usize),
+                "{case_id} must render curvature support / mass field rows"
+            );
+        }
+        if let Some(min_regions) = expected["minBlockedRegions"].as_u64() {
+            assert!(
+                gluing["locusField"]["blockedRegions"]
+                    .as_array()
+                    .is_some_and(|items| items.len() >= min_regions as usize),
+                "{case_id} must keep blocked/unmeasured locus visibly separate"
+            );
+        }
+        if let Some(min_rows) = expected["minAnalyticMassRows"].as_u64() {
+            assert!(
+                gluing["locusField"]["fieldRows"]
+                    .as_array()
+                    .is_some_and(|items| items
+                        .iter()
+                        .filter(|item| item["harmonicMass"].is_number()
+                            && item["sourceReadingRef"].as_str().is_some())
+                        .count()
+                        >= min_rows as usize),
+                "{case_id} must project analytic harmonic mass into the height field"
+            );
+        }
+        if let Some(min_glyphs) = expected["minBlockedAnchorGlyphs"].as_u64() {
+            assert!(
+                gluing["atomGlyphs"].as_array().is_some_and(|items| items
+                    .iter()
+                    .filter(|item| {
+                        item["semanticAnchor"] == "blocked_missing_anchor"
+                            && item["shapeRole"] == "blocked_anchor_glyph"
+                            && item["fiberShapeRole"].as_str().is_some()
+                            && item["carrierColorRole"].as_str().is_some()
+                    })
+                    .count()
+                    >= min_glyphs as usize),
+                "{case_id} must render semantic-anchor gaps as blocker glyphs with fiber/carrier roles"
+            );
+        }
+        assert!(
+            viewer["aatGeometryOverlays"]["omittedGeometryCounts"].is_object(),
+            "{case_id} must expose geometry omitted counts to the viewer payload"
+        );
 
         let report_text = serde_json::to_string(&report).expect("report serializes");
         for required in expected["requiredNonClaims"]
@@ -8620,10 +8691,13 @@ fn atom_viewer_reads_insight_report_surface_contract() {
         "renderForbiddenCages",
         "renderRepairMorphs",
         "renderAtomGlyphOverlays",
+        "atomGlyphGeometry",
+        "atomGlyphColor",
         "updateRepairMorphAnimation",
         "sceneAxisPosition",
         "legendSwatchColor",
         "legendValueText",
+        "gluingGeometry.",
         "thickness",
         "window.__archsigViewerDebug",
         "sceneColorHex",

--- a/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
@@ -36,6 +36,33 @@
         "requiredNonClaims": ["not automatic repair"],
         "requiredScenes": ["obstruction", "repair-dual"]
       }
+    },
+    {
+      "caseId": "sheaf-laplacian-curvature-field",
+      "archmap": "archmap_v2_sheaf_laplacian.json",
+      "lawPolicy": "law_policy_laplacian.json",
+      "expected": {
+        "minCurvatureFieldRows": 3,
+        "minBlockedRegions": 1,
+        "minAnalyticMassRows": 1,
+        "requiredScenes": ["hodge-debt-field"]
+      }
+    },
+    {
+      "caseId": "semantic-anchor-blocker-glyph",
+      "archmap": "archmap_v2_cech_h1_visible.json",
+      "lawPolicy": "law_policy_ag.json",
+      "mutations": [
+        {
+          "atomId": "atom:top",
+          "field": "axis",
+          "value": "unknown"
+        }
+      ],
+      "expected": {
+        "minBlockedAnchorGlyphs": 1,
+        "requiredScenes": ["site-cover"]
+      }
     }
   ],
   "requiredViewerFunctions": [
@@ -46,7 +73,10 @@
     "renderForbiddenCages",
     "renderRepairMorphs",
     "renderAtomGlyphOverlays",
+    "atomGlyphGeometry",
+    "atomGlyphColor",
     "sceneAxisPosition",
-    "legendValueText"
+    "legendValueText",
+    "gluingGeometry."
   ]
 }

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1147,11 +1147,13 @@
         if (!p) return;
         const valence = Math.min(Number(glyph.valence || 0), 12);
         const blockedAnchor = String(glyph.semanticAnchor || "").includes("blocked");
-        const geometry = blockedAnchor
-          ? new THREE.OctahedronGeometry(2.6 + valence * 0.16, 0)
-          : new THREE.TorusGeometry(2.2 + valence * 0.14, 0.16, 6, 18);
+        const fiber = String(glyph.fiber || node.atomKind || "unknown");
+        const carrier = String(glyph.carrier || node.subject || "");
+        const baseSize = 2.2 + valence * 0.14;
+        const geometry = atomGlyphGeometry(fiber, baseSize, blockedAnchor);
+        const color = atomGlyphColor(fiber, carrier, blockedAnchor);
         const material = new THREE.MeshStandardMaterial({
-          color: blockedAnchor ? 0xff6b6b : 0x8bd46e,
+          color,
           transparent: true,
           opacity: blockedAnchor ? 0.86 : 0.58,
           roughness: 0.48,
@@ -1160,10 +1162,33 @@
         });
         const mesh = new THREE.Mesh(geometry, material);
         mesh.position.copy(p);
-        mesh.rotation.x = Math.PI / 2;
+        mesh.rotation.x = Math.PI / 2 + (hashText(fiber) % 9) * 0.07;
+        mesh.rotation.y = (hashText(carrier) % 17) * 0.11;
+        mesh.scale.setScalar(1 + Math.min(carrier.length, 24) * 0.008);
         mesh.userData = { kind: "atomInternalGlyph", item: glyph, node };
         atomGroup.add(mesh);
       });
+    }
+
+    function atomGlyphGeometry(fiber, baseSize, blockedAnchor) {
+      if (blockedAnchor) return new THREE.OctahedronGeometry(baseSize + 0.4, 0);
+      const normalized = String(fiber || "").toLowerCase();
+      if (normalized.includes("relation")) {
+        return new THREE.TorusKnotGeometry(baseSize * 0.62, 0.14, 36, 6);
+      }
+      if (normalized.includes("component")) {
+        return new THREE.TorusGeometry(baseSize, 0.16, 6, 18);
+      }
+      if (normalized.includes("operation") || normalized.includes("event")) {
+        return new THREE.TetrahedronGeometry(baseSize * 0.94, 0);
+      }
+      return new THREE.DodecahedronGeometry(baseSize * 0.72, 0);
+    }
+
+    function atomGlyphColor(fiber, carrier, blockedAnchor) {
+      if (blockedAnchor) return 0xff6b6b;
+      const hue = (hashText(`${fiber}:${carrier}`) % 360) / 360;
+      return new THREE.Color().setHSL(hue, 0.54, 0.58);
     }
 
     function renderMoleculeGroups(groups, positions, layoutContext) {
@@ -2826,7 +2851,10 @@
       renderCoverage(report.coverageAndBoundaries || report.boundaryDigest || {}, verdict, summary);
       renderArtifacts(report.artifacts || report.artifactLinks || decisionBar.artifactLinks || {}, data.sourceArtifactRefs || {}, manifest);
       renderValidationStatus(validation);
-      renderOmitted(data.omittedDetailCounts || {}, data.truncationPolicy || {});
+      const geometryCounts = data.aatGeometryOverlays?.omittedGeometryCounts
+        || data.aatGeometryOverlays?.gluingGeometry?.omittedGeometryCounts
+        || {};
+      renderOmitted(data.omittedDetailCounts || {}, data.truncationPolicy || {}, geometryCounts);
     }
 
     function count(value) {
@@ -3033,14 +3061,16 @@
       root.innerHTML = rows.length ? rows.join("") : emptyItem();
     }
 
-    function renderOmitted(counts, policy) {
+    function renderOmitted(counts, policy, geometryCounts = {}) {
       const root = document.getElementById("omitted");
       const rows = Object.entries(counts)
         .filter(([key]) => key !== "omittedReasons" && key !== "rawPacketDetail")
         .map(([key, value]) => `${key}: ${value}`);
+      const geometryRows = Object.entries(geometryCounts)
+        .map(([key, value]) => `gluingGeometry.${key}: ${value}`);
       const reasons = Array.isArray(counts.omittedReasons) ? counts.omittedReasons : [];
       const policyText = [policy.atomNodes, policy.moleculeGroups, policy.overlays].filter(Boolean);
-      const items = [...rows, counts.rawPacketDetail, ...reasons, ...policyText].filter(Boolean);
+      const items = [...geometryRows, ...rows, counts.rawPacketDetail, ...reasons, ...policyText].filter(Boolean);
       root.innerHTML = items.length
         ? items.slice(0, 12).map((item) => `<div class="item"><p>${escapeHtml(String(item))}</p></div>`).join("")
         : emptyItem();


### PR DESCRIPTION
## 概要

Closes #2093

PRD final review で残った ArchSig viewer 貼り合わせ幾何の不足を補強します。主な変更は次の通りです。

- analytic Hodge reading から curvature mass / distance-to-flatness / transfer spectrum を field projection へ反映
- atom glyph に fiber / carrier を反映し、semantic anchor blocker を異なる形状・色で見えるように変更
- omitted geometry counts を viewer の Omitted panel に表示
- golden UX fixture と manifest-driven test に curvature field、blocked region、analytic mass row、blocked anchor glyph の回帰条件を追加

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check origin/main...HEAD`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] viewer smoke: curvature scene renders `hodge-debt-field`, shows curvature field rows / blocked region / omitted gluing counts

## チェックリスト

- [x] 対象 Issue を `Closes #2093` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない