### PR TITLE
ArchSig viewer貼り合わせ幾何のpacket境界を固定する

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -2290,6 +2290,13 @@ fn attach_gluing_scene_geometry(mut scene: Value, gluing_geometry: &Value) -> Va
     };
     scene["gluingGeometryRefs"] = geometry_refs;
     scene["axisMappingImplemented"] = json!(true);
+    scene["axisMetricBindings"] = json!({
+        "x": "xValue",
+        "y": "yValue",
+        "z": "zValue",
+        "fallbackBlend": 0.35,
+        "source": "renderer sceneAxisPosition reads these metric keys from each gluing geometry object"
+    });
     scene["projectionBoundary"] = json!(
         "Scene geometry is a bounded projection of archsig-measurement-packet/v1 and archsig-insight-report/v1; it does not create a new structural verdict."
     );
@@ -2385,11 +2392,9 @@ fn gluing_geometry_projection_v1(
         .iter()
         .find_map(|invariant| invariant.get("coverNerveProjection").cloned())
         .unwrap_or_else(|| {
-            cover_nerve_projection_v1(
-                normalized,
-                &selected_contexts,
-                &cech_edges,
+            empty_cover_nerve_projection_v1(
                 &packet.profile.cover_ref,
+                "missing packet coverNerveProjection; viewer does not infer cover triangles",
             )
         });
     let cover = normalized.covers.iter().find(|cover| {
@@ -2524,6 +2529,7 @@ fn forbidden_cage_projection(
     normalized: &NormalizedArchMapV2,
     packet: &ArchSigMeasurementPacketV1,
 ) -> Vec<Value> {
+    let atom_refs_by_variable = atom_refs_by_square_free_variable(normalized);
     let mut cages = Vec::new();
     for invariant in &packet.computed_invariants {
         let generators = invariant["obstructionIdeal"]["generators"]
@@ -2536,30 +2542,26 @@ fn forbidden_cage_projection(
             if support_atom_refs.is_empty() && support_variables.is_empty() {
                 continue;
             }
+            let atom_refs = if support_atom_refs.is_empty() {
+                support_variables
+                    .iter()
+                    .filter_map(|variable| atom_refs_by_variable.get(variable))
+                    .flatten()
+                    .cloned()
+                    .collect::<Vec<_>>()
+            } else {
+                support_atom_refs
+            };
             let generator_id = string_field(generator, "generatorId");
             cages.push(json!({
                 "cageId": format!("forbidden-cage:{generator_id}"),
-                "atomRefs": support_atom_refs,
+                "atomRefs": atom_refs,
                 "supportVariables": support_variables,
                 "sourceInvariantRef": invariant["invariantId"],
                 "sourceGeneratorRef": generator_id,
                 "shapeRole": "cage",
                 "lineRole": "broken_line",
-                "source": "packet obstructionIdeal.generators[].supportAtomRefs"
-            }));
-        }
-    }
-    if cages.is_empty() {
-        for atom in normalized.atoms.iter().filter(|atom| {
-            atom.predicate.contains("obstruction") || atom.predicate.contains("forbidden")
-        }) {
-            cages.push(json!({
-                "cageId": format!("forbidden-cage:{}", atom.normalized_atom_id),
-                "atomRefs": [atom.normalized_atom_id.clone()],
-                "sourceAtomRef": atom.normalized_atom_id,
-                "shapeRole": "cage",
-                "lineRole": "broken_line",
-                "source": "source-backed obstruction atom; packet has no obstructionIdeal generator support"
+                "source": "packet obstructionIdeal.generators[].supportAtomRefs/support"
             }));
         }
     }
@@ -2609,14 +2611,31 @@ fn repair_morph_projection(
         .iter()
         .enumerate()
         .map(|(index, candidate)| {
+            let candidate_variables = string_array_at(candidate, &["supportVariables"]);
+            let related_cages = related_forbidden_cages(forbidden_cages, candidate);
+            let from_cage_ref = related_cages
+                .get(index % related_cages.len().max(1))
+                .or_else(|| related_cages.first())
+                .cloned()
+                .unwrap_or_else(|| "forbidden-cage:unavailable".to_string());
+            let from_atom_refs = related_cages
+                .iter()
+                .filter_map(|cage_id| {
+                    forbidden_cages
+                        .iter()
+                        .find(|cage| cage["cageId"] == *cage_id)
+                })
+                .flat_map(|cage| string_array_at(cage, &["atomRefs"]))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
             json!({
                 "morphId": format!("repair-morph:{}", string_field(candidate, "candidateId")),
-                "fromCageRef": forbidden_cages
-                    .first()
-                    .and_then(|cage| cage["cageId"].as_str())
-                    .unwrap_or("forbidden-cage:unavailable"),
+                "fromCageRef": from_cage_ref,
+                "fromCageRefs": related_cages,
+                "fromAtomRefs": from_atom_refs,
                 "toCandidateRef": candidate["candidateId"],
-                "supportVariables": string_array_at(candidate, &["supportVariables"]),
+                "supportVariables": candidate_variables,
                 "sourceInvariantRef": candidate["sourceInvariantRef"],
                 "lowerBoundReadingRefs": lower_bound_readings
                     .iter()
@@ -2629,6 +2648,50 @@ fn repair_morph_projection(
             })
         })
         .collect()
+}
+
+fn atom_refs_by_square_free_variable(
+    normalized: &NormalizedArchMapV2,
+) -> BTreeMap<String, Vec<String>> {
+    let mut refs_by_variable = BTreeMap::<String, Vec<String>>::new();
+    for atom in &normalized.atoms {
+        for key in [
+            atom.source_atom_id.as_str(),
+            atom.normalized_atom_id.as_str(),
+            atom.subject.as_str(),
+        ] {
+            refs_by_variable
+                .entry(key.to_string())
+                .or_default()
+                .push(atom.normalized_atom_id.clone());
+        }
+    }
+    refs_by_variable
+}
+
+fn related_forbidden_cages(forbidden_cages: &[Value], candidate: &Value) -> Vec<String> {
+    let source_invariant = string_field(candidate, "sourceInvariantRef");
+    let candidate_variables = string_array_at(candidate, &["supportVariables"])
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let mut related = forbidden_cages
+        .iter()
+        .filter(|cage| {
+            cage["sourceInvariantRef"] == source_invariant
+                && string_array_at(cage, &["supportVariables"])
+                    .into_iter()
+                    .any(|variable| candidate_variables.contains(&variable))
+        })
+        .filter_map(|cage| cage["cageId"].as_str().map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
+    if related.is_empty() {
+        related = forbidden_cages
+            .iter()
+            .filter(|cage| cage["sourceInvariantRef"] == source_invariant)
+            .filter_map(|cage| cage["cageId"].as_str().map(ToOwned::to_owned))
+            .collect();
+    }
+    related
 }
 
 fn locus_field_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
@@ -5637,6 +5700,18 @@ fn cover_nerve_projection_v1(
     })
 }
 
+fn empty_cover_nerve_projection_v1(cover_ref: &str, reason: &str) -> Value {
+    json!({
+        "coverRef": cover_ref,
+        "vertices": [],
+        "edges": [],
+        "faces": [],
+        "faceSource": reason,
+        "h2CoherenceVisualized": false,
+        "projectionStatus": "not_projected_missing_packet_cover_nerve"
+    })
+}
+
 fn marker_atom_marks_edge(
     atom: &crate::NormalizedAtomV2,
     source_context: &str,
@@ -6386,6 +6461,99 @@ mod tests {
         .expect("packet fixture parses")
     }
 
+    fn normalized_fixture() -> NormalizedArchMapV2 {
+        serde_json::from_value(json!({
+            "schema": "archmap-normalized/v2",
+            "normalizerId": "test-normalizer",
+            "sourceArchmapRef": "archmap:test",
+            "sourceArchmapId": "archmap:test",
+            "extractionDoctrineRef": {
+                "doctrineId": "doctrine:test",
+                "fingerprint": "sha256:test"
+            },
+            "atoms": [
+                {
+                    "sourceAtomId": "x_checkout",
+                    "normalizedAtomId": "atom:checkout",
+                    "atomKind": "component",
+                    "subject": "x_checkout",
+                    "axis": "semantic",
+                    "predicate": "forbidden_obstruction_marker",
+                    "object": null,
+                    "sourceRefs": ["fixture://checkout"],
+                    "contextMemberships": ["ctx:a", "ctx:b", "ctx:c"],
+                    "normalizationStatus": "normalized"
+                },
+                {
+                    "sourceAtomId": "x_inventory",
+                    "normalizedAtomId": "atom:inventory",
+                    "atomKind": "component",
+                    "subject": "x_inventory",
+                    "axis": "semantic",
+                    "predicate": "service",
+                    "object": null,
+                    "sourceRefs": ["fixture://inventory"],
+                    "contextMemberships": ["ctx:a", "ctx:b", "ctx:c"],
+                    "normalizationStatus": "normalized"
+                },
+                {
+                    "sourceAtomId": "x_payment",
+                    "normalizedAtomId": "atom:payment",
+                    "atomKind": "component",
+                    "subject": "x_payment",
+                    "axis": "semantic",
+                    "predicate": "service",
+                    "object": null,
+                    "sourceRefs": ["fixture://payment"],
+                    "contextMemberships": ["ctx:b", "ctx:c"],
+                    "normalizationStatus": "normalized"
+                }
+            ],
+            "contexts": [
+                {
+                    "sourceContextId": "ctx:a",
+                    "normalizedContextId": "ctx:a",
+                    "atomIds": ["atom:checkout", "atom:inventory"],
+                    "restrictsTo": ["ctx:b"],
+                    "sourceRefs": ["fixture://a"],
+                    "posetStatus": "selected"
+                },
+                {
+                    "sourceContextId": "ctx:b",
+                    "normalizedContextId": "ctx:b",
+                    "atomIds": ["atom:checkout", "atom:inventory", "atom:payment"],
+                    "restrictsTo": ["ctx:c"],
+                    "sourceRefs": ["fixture://b"],
+                    "posetStatus": "selected"
+                },
+                {
+                    "sourceContextId": "ctx:c",
+                    "normalizedContextId": "ctx:c",
+                    "atomIds": ["atom:checkout", "atom:inventory", "atom:payment"],
+                    "restrictsTo": [],
+                    "sourceRefs": ["fixture://c"],
+                    "posetStatus": "selected"
+                }
+            ],
+            "covers": [{
+                "sourceCoverId": "cover:test",
+                "normalizedCoverId": "cover:test",
+                "contextIds": ["ctx:a", "ctx:b", "ctx:c"],
+                "sourceRefs": ["fixture://cover"],
+                "coverageStatus": "selected"
+            }],
+            "summary": {
+                "atomCount": 3,
+                "normalizedAtomCount": 3,
+                "contextCount": 3,
+                "coverCount": 1,
+                "doctrineFingerprint": "sha256:test"
+            },
+            "nonConclusions": []
+        }))
+        .expect("normalized fixture parses")
+    }
+
     #[test]
     fn invalid_structural_verdict_value_fails_validation() {
         let mut packet = packet_fixture();
@@ -6428,5 +6596,81 @@ mod tests {
             check.id == "measurement-packet-v1-theorem-candidate-analytic-only"
                 && check.result == "fail"
         }));
+    }
+
+    #[test]
+    fn gluing_projection_does_not_infer_cover_nerve_without_packet_projection() {
+        let normalized = normalized_fixture();
+        let packet = packet_fixture();
+
+        let gluing = gluing_geometry_projection_v1(&normalized, &packet);
+
+        assert_eq!(
+            gluing["nerve"]["triangles"],
+            json!([]),
+            "viewer gluing projection must not infer triangle geometry when packet has no coverNerveProjection"
+        );
+        assert_eq!(
+            gluing["nerve"]["triangleSource"],
+            "missing packet coverNerveProjection; viewer does not infer cover triangles"
+        );
+    }
+
+    #[test]
+    fn forbidden_cages_do_not_fallback_to_predicate_atoms() {
+        let normalized = normalized_fixture();
+        let packet = packet_fixture();
+
+        let cages = forbidden_cage_projection(&normalized, &packet);
+
+        assert!(
+            cages.is_empty(),
+            "predicate names alone must not create forbidden support cages without packet support"
+        );
+    }
+
+    #[test]
+    fn repair_morphs_link_related_forbidden_cages() {
+        let normalized = normalized_fixture();
+        let mut packet = packet_fixture();
+        packet.computed_invariants = vec![json!({
+            "invariantId": "square-free-repair:test",
+            "obstructionIdeal": {
+                "generators": [
+                    {
+                        "generatorId": "g0",
+                        "support": ["x_checkout", "x_inventory"]
+                    },
+                    {
+                        "generatorId": "g1",
+                        "support": ["x_inventory", "x_payment"]
+                    }
+                ]
+            },
+            "alexanderDualRepair": {
+                "minimalHittingSets": [
+                    ["x_inventory"],
+                    ["x_checkout", "x_payment"]
+                ]
+            }
+        })];
+
+        let cages = forbidden_cage_projection(&normalized, &packet);
+        let morphs = repair_morph_projection(&normalized, &packet, &cages);
+
+        assert_eq!(cages.len(), 2);
+        assert_eq!(morphs.len(), 2);
+        assert!(morphs.iter().all(|morph| {
+            morph["fromCageRefs"]
+                .as_array()
+                .is_some_and(|refs| refs.len() == 2)
+                && morph["fromAtomRefs"]
+                    .as_array()
+                    .is_some_and(|refs| !refs.is_empty())
+        }));
+        assert_eq!(
+            morphs[1]["fromCageRef"], "forbidden-cage:g1",
+            "multiple repair morphs must not all start from the first forbidden cage"
+        );
     }
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1291,9 +1291,15 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
                 items.iter().any(|item| {
                     item["animationRole"] == "continuous_morph_lower_bound"
                         && item["nonClaim"] == "not automatic repair"
+                        && item["fromCageRefs"]
+                            .as_array()
+                            .is_some_and(|refs| refs.len() >= 2)
+                        && item["fromAtomRefs"]
+                            .as_array()
+                            .is_some_and(|refs| !refs.is_empty())
                 })
             }),
-        "square-free repair fixture must project lower-bound repair candidate as continuous morph"
+        "square-free repair fixture must project lower-bound repair candidate from related forbidden supports"
     );
     assert_eq!(
         viewer["aatGeometryOverlays"]["forbiddenCages"], report["gluingGeometry"]["forbiddenCages"],
@@ -3343,6 +3349,19 @@ fn cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture() {
                 "{case_id} must render repair morph lower-bound paths"
             );
         }
+        if let Some(min_refs) = expected["minRepairFromCageRefs"].as_u64() {
+            assert!(
+                gluing["repairMorphs"]
+                    .as_array()
+                    .is_some_and(|items| items.iter().any(|item| item["fromCageRefs"]
+                        .as_array()
+                        .is_some_and(|refs| refs.len() >= min_refs as usize)
+                        && item["fromAtomRefs"]
+                            .as_array()
+                            .is_some_and(|refs| !refs.is_empty()))),
+                "{case_id} repair morphs must be grounded in related forbidden cage support"
+            );
+        }
         if let Some(min_rows) = expected["minCurvatureFieldRows"].as_u64() {
             assert!(
                 gluing["locusField"]["fieldRows"]
@@ -3417,6 +3436,21 @@ fn cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture() {
                 scene["axisMappingImplemented"].as_bool(),
                 Some(true),
                 "{case_id} scene {scene_id} must use axisMapping as geometry-driving"
+            );
+            assert_eq!(
+                scene["axisMetricBindings"]["x"].as_str(),
+                Some("xValue"),
+                "{case_id} scene {scene_id} must declare the renderer metric key for the X axis"
+            );
+            assert_eq!(
+                scene["axisMetricBindings"]["y"].as_str(),
+                Some("yValue"),
+                "{case_id} scene {scene_id} must declare the renderer metric key for the Y axis"
+            );
+            assert_eq!(
+                scene["axisMetricBindings"]["z"].as_str(),
+                Some("zValue"),
+                "{case_id} scene {scene_id} must declare the renderer metric key for the Z axis"
             );
             assert!(
                 scene["visualEncodingLegend"]

--- a/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
@@ -33,6 +33,7 @@
       "expected": {
         "minForbiddenCages": 1,
         "minRepairMorphs": 1,
+        "minRepairFromCageRefs": 2,
         "requiredNonClaims": ["not automatic repair"],
         "requiredScenes": ["obstruction", "repair-dual"]
       }

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1398,11 +1398,16 @@
 
     function sceneAxisPosition(scene, ref, index, total, fallback, metrics = {}) {
       const axes = scene?.axisMapping || {};
+      const bindings = scene?.axisMetricBindings || {};
       const totalSafe = Math.max(total || 1, 1);
       const rank = (index % totalSafe) / totalSafe;
-      const xValue = Number.isFinite(Number(metrics.xValue)) ? Number(metrics.xValue) : rank;
-      const yValue = Number.isFinite(Number(metrics.yValue)) ? Number(metrics.yValue) : 0;
-      const zValue = Number.isFinite(Number(metrics.zValue)) ? Number(metrics.zValue) : 0;
+      const xKey = bindings.x || "xValue";
+      const yKey = bindings.y || "yValue";
+      const zKey = bindings.z || "zValue";
+      const blend = Number.isFinite(Number(bindings.fallbackBlend)) ? Number(bindings.fallbackBlend) : 0.35;
+      const xValue = Number.isFinite(Number(metrics[xKey])) ? Number(metrics[xKey]) : rank;
+      const yValue = Number.isFinite(Number(metrics[yKey])) ? Number(metrics[yKey]) : 0;
+      const zValue = Number.isFinite(Number(metrics[zKey])) ? Number(metrics[zKey]) : 0;
       const xScale = 46 + (hashText(axes.x || "x") % 17);
       const yScale = 9 + (hashText(axes.y || "y") % 7);
       const zScale = 32 + (hashText(axes.z || "z") % 19);
@@ -1411,7 +1416,7 @@
       const y = -26 + yValue * yScale + rank * 18;
       const axisPoint = new THREE.Vector3(Math.cos(phase) * (radius + xValue * xScale), y, Math.sin(phase) * radius);
       if (!fallback) return axisPoint;
-      return axisPoint.lerp(fallback.clone(), 0.35);
+      return axisPoint.lerp(fallback.clone(), blend);
     }
 
     function renderNerveGeometry(scene, nerve, positions, encoding) {
@@ -1596,12 +1601,18 @@
     function renderRepairMorphs(scene, morphs, positions, encoding, limits) {
       morphs.slice(0, limits.repairMorphs || 50).forEach((morph, index) => {
         const fallback = groupPosition(index, Math.max(morphs.length, 1), 62);
+        const sourcePoints = (morph.fromAtomRefs || []).map((ref) => positions.get(ref)).filter(Boolean);
+        const sourceFallback = sourcePoints.length ? centroid(sourcePoints) : fallback.clone().add(new THREE.Vector3(-22 - index * 0.8, 18, -12));
         const target = sceneAxisPosition(scene, morph.toAtomRef || morph.toCandidateRef || morph.morphId, index, Math.max(morphs.length, 1), positions.get(morph.toAtomRef) || fallback, {
           xValue: index / Math.max(morphs.length - 1, 1),
           yValue: Math.min((morph.supportVariables || morph.supportAtomRefs || []).length, 12),
           zValue: Math.min((morph.lowerBoundReadingRefs || []).length + 1, 12)
         });
-        const start = target.clone().add(new THREE.Vector3(-22 - index * 0.8, 18, -12));
+        const start = sceneAxisPosition(scene, morph.fromCageRef || morph.morphId, index, Math.max(morphs.length, 1), sourceFallback, {
+          xValue: index / Math.max(morphs.length - 1, 1),
+          yValue: Math.min((morph.fromCageRefs || []).length, 12),
+          zValue: Math.min((morph.fromAtomRefs || []).length, 12)
+        });
         addLineSegments([start.x, start.y, start.z, target.x, target.y + 5, target.z], sceneColorHex("repair_candidate"), 0.74, "repairMorphPath");
         const marker = new THREE.Mesh(
           new THREE.SphereGeometry(2.8, 16, 10),


### PR DESCRIPTION
## 概要

Closes #2099

`docs/tool/archsig_viewer_gluing_geometry_prd.md` の final completion review で残った packet 境界・repair 対応の gap を補強します。

- packet に `coverNerveProjection` が無い場合、viewer gluing projection が cover triangle を補完しないように変更
- `forbiddenCages` を packet の `obstructionIdeal.generators[]` support 由来に限定し、predicate 名だけの fallback cage を削除
- `repairMorphs` に関連 forbidden cage refs / atom refs を持たせ、複数 support で常に最初の cage だけに接続されないように変更
- scene に `axisMetricBindings` を追加し、viewer の `sceneAxisPosition` がその binding を読むように変更
- unit / CLI / golden UX tests で上記境界を固定

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check origin/main...HEAD`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] private path / internal artifact scan（ヒットは sanitizer 実装と regression test のみ）
- [x] viewer smoke: square-free repair viewer を local preview し、Repair scene の canvas / axis HUD / omitted gluing counts / repair morph `fromCageRefs` を確認。screenshot `.tmp/archsig-viewer-gluing-boundary/repair-smoke.png` は 1280x720、nonblack 921600、bright 18855

## チェックリスト

- [x] 対象 Issue を `Closes #2099` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない