### PR TITLE
ArchSig viewerのcocycle ribbon omitted countを固定する

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -23,6 +23,7 @@ const MAX_LAPLACIAN_CELLS: usize = 16;
 const MAX_PERIOD_CYCLES: usize = 16;
 const MAX_TRANSFER_TARGETS: usize = 16;
 const GLUING_TRIANGLE_RENDER_LIMIT: usize = 80;
+const GLUING_COCYCLE_EDGE_RENDER_LIMIT: usize = 80;
 const GLUING_FIELD_ROW_RENDER_LIMIT: usize = 64;
 const GLUING_REGION_RENDER_LIMIT: usize = 24;
 const GLUING_CAGE_RENDER_LIMIT: usize = 80;
@@ -2445,6 +2446,20 @@ fn gluing_geometry_projection_v1(
         .map(Vec::len)
         .unwrap_or_default();
     let atom_glyph_total_count = normalized.atoms.len();
+    let cocycle_support_edge_count = nonzero_edges.len();
+    let cocycle_support_edges = nonzero_edges
+        .iter()
+        .take(GLUING_COCYCLE_EDGE_RENDER_LIMIT)
+        .map(|edge| {
+            json!({
+                "edgeId": edge.edge_id,
+                "sourceContextRef": edge.source_context,
+                "targetContextRef": edge.target_context,
+                "value": edge.value,
+                "supportAtomRefs": edge.support_atom_refs
+            })
+        })
+        .collect::<Vec<_>>();
     json!({
         "schema": "archsig-viewer-gluing-geometry/v1",
         "sourcePacketRef": "archsig-measurement-packet.json",
@@ -2461,13 +2476,7 @@ fn gluing_geometry_projection_v1(
         },
         "cocycleRibbon": {
             "supportAtomRefs": cocycle_support_atom_refs,
-            "supportEdges": nonzero_edges.iter().map(|edge| json!({
-                "edgeId": edge.edge_id,
-                "sourceContextRef": edge.source_context,
-                "targetContextRef": edge.target_context,
-                "value": edge.value,
-                "supportAtomRefs": edge.support_atom_refs
-            })).collect::<Vec<_>>(),
+            "supportEdges": cocycle_support_edges,
             "closureGapEncoding": {
                 "kind": "holonomyLikeGapMarker",
                 "visible": class_nonzero && !nonzero_edges.is_empty(),
@@ -2483,6 +2492,7 @@ fn gluing_geometry_projection_v1(
         "visualEncodingLegend": visual_encoding_legend_v1(),
         "renderLimits": {
             "nerveTriangles": GLUING_TRIANGLE_RENDER_LIMIT,
+            "cocycleSupportEdges": GLUING_COCYCLE_EDGE_RENDER_LIMIT,
             "curvatureFieldRows": GLUING_FIELD_ROW_RENDER_LIMIT,
             "curvatureRegions": GLUING_REGION_RENDER_LIMIT,
             "forbiddenCages": GLUING_CAGE_RENDER_LIMIT,
@@ -2491,7 +2501,7 @@ fn gluing_geometry_projection_v1(
         },
         "omittedGeometryCounts": {
             "nerveTriangles": triangle_count.saturating_sub(GLUING_TRIANGLE_RENDER_LIMIT),
-            "cocycleSupportEdges": 0,
+            "cocycleSupportEdges": cocycle_support_edge_count.saturating_sub(GLUING_COCYCLE_EDGE_RENDER_LIMIT),
             "curvatureFieldRows": field_row_count.saturating_sub(GLUING_FIELD_ROW_RENDER_LIMIT),
             "measuredZeroRegions": zero_region_count.saturating_sub(GLUING_REGION_RENDER_LIMIT),
             "blockedRegions": blocked_region_count.saturating_sub(GLUING_REGION_RENDER_LIMIT),
@@ -6613,6 +6623,77 @@ mod tests {
         assert_eq!(
             gluing["nerve"]["triangleSource"],
             "missing packet coverNerveProjection; viewer does not infer cover triangles"
+        );
+    }
+
+    #[test]
+    fn gluing_projection_caps_cocycle_support_edges_and_reports_omissions() {
+        let mut normalized = normalized_fixture();
+        let mut context_ids = Vec::new();
+        let mut contexts = Vec::new();
+        let mut atoms = Vec::new();
+        for index in 0..=GLUING_COCYCLE_EDGE_RENDER_LIMIT {
+            let source = format!("ctx:{index}");
+            let target = format!("ctx:{}", index + 1);
+            let atom_id = format!("atom:mismatch:{index}");
+            context_ids.push(source.clone());
+            contexts.push(NormalizedContextV2 {
+                source_context_id: source.clone(),
+                normalized_context_id: source.clone(),
+                atom_ids: vec![atom_id.clone()],
+                restricts_to: vec![target.clone()],
+                source_refs: vec![format!("fixture://{source}")],
+                poset_status: "selected".to_string(),
+            });
+            atoms.push(NormalizedAtomV2 {
+                source_atom_id: atom_id.clone(),
+                normalized_atom_id: atom_id,
+                atom_kind: "component".to_string(),
+                subject: source.clone(),
+                axis: "cech".to_string(),
+                predicate: "mismatch".to_string(),
+                object: Some(target.clone()),
+                source_refs: vec![source, target.clone()],
+                context_memberships: vec![target],
+                normalization_status: "normalized".to_string(),
+            });
+        }
+        let final_context = format!("ctx:{}", GLUING_COCYCLE_EDGE_RENDER_LIMIT + 1);
+        context_ids.push(final_context.clone());
+        contexts.push(NormalizedContextV2 {
+            source_context_id: final_context.clone(),
+            normalized_context_id: final_context.clone(),
+            atom_ids: Vec::new(),
+            restricts_to: Vec::new(),
+            source_refs: vec![format!("fixture://{final_context}")],
+            poset_status: "selected".to_string(),
+        });
+        normalized.contexts = contexts;
+        normalized.atoms = atoms;
+        normalized.covers[0].context_ids = context_ids;
+        normalized.summary.atom_count = normalized.atoms.len();
+        normalized.summary.normalized_atom_count = normalized.atoms.len();
+        normalized.summary.context_count = normalized.contexts.len();
+
+        let packet = packet_fixture();
+        let gluing = gluing_geometry_projection_v1(&normalized, &packet);
+
+        assert_eq!(
+            gluing["cocycleRibbon"]["supportEdges"]
+                .as_array()
+                .expect("support edges are array")
+                .len(),
+            GLUING_COCYCLE_EDGE_RENDER_LIMIT,
+            "cocycle ribbon support must be capped before entering the viewer projection"
+        );
+        assert_eq!(
+            gluing["renderLimits"]["cocycleSupportEdges"].as_u64(),
+            Some(GLUING_COCYCLE_EDGE_RENDER_LIMIT as u64)
+        );
+        assert_eq!(
+            gluing["omittedGeometryCounts"]["cocycleSupportEdges"].as_u64(),
+            Some(1),
+            "cocycle ribbon omissions must be reported for large H1 support"
         );
     }
 

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -791,6 +791,7 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
         gluing_geometry["omittedGeometryCounts"]
             .as_object()
             .is_some_and(|counts| counts.contains_key("measuredZeroRegions")
+                && counts.contains_key("cocycleSupportEdges")
                 && counts.contains_key("blockedRegions")
                 && counts.contains_key("atomGlyphs")),
         "gluing projection must report omitted counts for each independently capped geometry family"
@@ -3324,6 +3325,24 @@ fn cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture() {
                     .as_array()
                     .is_some_and(|items| items.len() >= min_support_edges as usize),
                 "{case_id} must render cocycle support ribbon edges"
+            );
+        }
+        if let Some(max_support_edges) = expected["maxCocycleSupportEdges"].as_u64() {
+            let support_edges = gluing["cocycleRibbon"]["supportEdges"]
+                .as_array()
+                .expect("cocycle support edges are array");
+            assert!(
+                support_edges.len() <= max_support_edges as usize,
+                "{case_id} must cap cocycle support ribbon edges"
+            );
+            assert_eq!(
+                gluing["renderLimits"]["cocycleSupportEdges"].as_u64(),
+                Some(max_support_edges),
+                "{case_id} must expose the cocycle support edge render limit"
+            );
+            assert!(
+                gluing["omittedGeometryCounts"]["cocycleSupportEdges"].is_u64(),
+                "{case_id} must expose the cocycle support edge omitted count"
             );
         }
         if let Some(closure_gap_visible) = expected["closureGapVisible"].as_bool() {
@@ -8736,6 +8755,7 @@ fn atom_viewer_reads_insight_report_surface_contract() {
         "LineDashedMaterial",
         "ConeGeometry",
         "repairMorphArrow",
+        "cocycleSupportEdges",
         "thicknessRole",
         "visualEncodingChannel",
         "thickness",

--- a/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
@@ -21,6 +21,7 @@
       "lawPolicy": "law_policy_ag.json",
       "expected": {
         "minCocycleSupportEdges": 1,
+        "maxCocycleSupportEdges": 80,
         "closureGapVisible": true,
         "requiredNonClaims": ["monodromy verdict is not generated"],
         "requiredScenes": ["cech-h1-mismatch"]
@@ -79,6 +80,7 @@
     "LineDashedMaterial",
     "ConeGeometry",
     "repairMorphArrow",
+    "cocycleSupportEdges",
     "thicknessRole",
     "visualEncodingChannel",
     "__archsigViewerDebug",

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1381,7 +1381,7 @@
         renderNerveGeometry(scene, geometry.nerve || {}, positions, encoding);
       }
       if (scene.sceneId === "cech-h1-mismatch") {
-        renderCocycleRibbon(scene, geometry.cocycleRibbon || {}, positions, encoding);
+        renderCocycleRibbon(scene, geometry.cocycleRibbon || {}, positions, encoding, geometry.renderLimits || {});
       }
       if (scene.sceneId === "hodge-debt-field") {
         renderLocusField(scene, geometry.locusField || {}, positions, geometry.renderLimits || {});
@@ -1496,8 +1496,9 @@
       addLineSegments(mismatch, sceneColorHex(encoding.colorRole || "measured_nonzero"), 0.9, "nerveMismatchEdge", { lineRole: "thick_glowing_line", thicknessRole: "thick" });
     }
 
-    function renderCocycleRibbon(scene, ribbon, positions, encoding) {
-      const supportEdges = Array.isArray(ribbon.supportEdges) ? ribbon.supportEdges : [];
+    function renderCocycleRibbon(scene, ribbon, positions, encoding, limits = {}) {
+      const supportEdgeLimit = limits.cocycleSupportEdges || 80;
+      const supportEdges = (Array.isArray(ribbon.supportEdges) ? ribbon.supportEdges : []).slice(0, supportEdgeLimit);
       const points = [];
       supportEdges.forEach((edge, index) => {
         const metrics = { xValue: index / Math.max(supportEdges.length - 1, 1), yValue: Number(edge.value || 0), zValue: Math.min((edge.supportAtomRefs || []).length, 12) };


### PR DESCRIPTION
## 概要

Closes #2115

ArchSig viewer gluing geometry の AC9 補強です。`cocycleRibbon.supportEdges` が全件投影・全件描画され、`omittedGeometryCounts.cocycleSupportEdges` が 0 固定だったため、cocycle ribbon にも degradation / omitted counts を適用します。

- `GLUING_COCYCLE_EDGE_RENDER_LIMIT` を追加し、projection 段で `supportEdges` を cap しました。
- `renderLimits.cocycleSupportEdges` と `omittedGeometryCounts.cocycleSupportEdges` を実数ベースで出力します。
- viewer の `renderCocycleRibbon` も同じ limit を尊重して slice します。
- 大規模 H1 support の unit test と golden UX / static viewer contract test を追加しました。

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（98 unit / 124 CLI passed, 21 ignored）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml gluing_projection_caps_cocycle_support_edges_and_reports_omissions`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml atom_viewer_reads_insight_report_surface_contract`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json --out-dir .tmp/archsig-viewer-cocycle-omitted-counts/cech`
- [x] analyze 出力確認: `supportEdges=1`, `renderLimits.cocycleSupportEdges=80`, `omittedGeometryCounts.cocycleSupportEdges=0`, monodromy non-claim 維持
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] private path scan（差分由来の hit なし。既存 sanitizer / redaction test literal のみ）

未実施:

- `lake build`: Lean 変更なし
- `cargo test --manifest-path tools/fieldsig/Cargo.toml`: FieldSig 変更なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status は対象外（ArchSig viewer projection のみ、定理追加なし）
- [x] docs の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

境界:

- H² coherence / monodromy verdict / automatic repair claim は導入していません。