### PR TITLE
PRD-6の変形障害interfaceを追加

### DIFF
--- a/Formal/AG/SingularityMonodromyStack.lean
+++ b/Formal/AG/SingularityMonodromyStack.lean
@@ -1,3 +1,5 @@
 import Formal.AG.Cohomology
 import Formal.AG.Derived
 import Formal.AG.SingularityMonodromyStack.Stratum
+import Formal.AG.SingularityMonodromyStack.CotangentInterface
+import Formal.AG.SingularityMonodromyStack.SmoothSingular

--- a/Formal/AG/SingularityMonodromyStack/CotangentInterface.lean
+++ b/Formal/AG/SingularityMonodromyStack/CotangentInterface.lean
@@ -1,0 +1,78 @@
+import Formal.AG.SingularityMonodromyStack.Stratum
+
+noncomputable section
+
+namespace AAT.AG
+namespace SingularityMonodromyStack
+
+universe u v w x y z
+
+/--
+VI.定義3.1: selected cotangent complex data for a stratum over its reading
+parameter.
+
+This is an interface: it records the chosen cotangent complex object and
+pullback operation. It does not construct a general Illusie cotangent complex.
+-/
+structure CotangentData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    (X : ArchitectureStratum.{u, v, w, x, y} P k) where
+  Base : Type z
+  CotangentComplex : Type z
+  baseMap : X.Point -> Base
+  PullbackBase : Type z
+  pullbackComplex : PullbackBase -> CotangentComplex
+
+namespace CotangentData
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+
+/-- VI.定義3.1: expose the selected base map of the stratum. -/
+theorem baseMap_eq (L : CotangentData.{u, v, w, x, y, z} X) :
+    L.baseMap = L.baseMap :=
+  rfl
+
+end CotangentData
+
+/--
+VI.定義3.2: selected tangent-complex data.
+
+`RHom` and Ext/cohomology calculations are represented by explicit carrier
+fields and certificates. General `RHom` construction remains outside this PRD
+step.
+-/
+structure TangentData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    (X : ArchitectureStratum.{u, v, w, x, y} P k)
+    (L : CotangentData.{u, v, w, x, y, z} X) where
+  TangentComplex : Type z
+  H0 : Type z
+  H1 : Type z
+  ObstructionTarget : Type z
+  zeroObstruction : ObstructionTarget
+  rhomInterface_certificate : Prop
+  h0ComputesInfinitesimalAutomorphisms_certificate : Prop
+  h1ComputesObstructionTarget_certificate : Prop
+
+namespace TangentData
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+variable {L : CotangentData.{u, v, w, x, y, z} X}
+
+/-- VI.定義3.2: expose the selected obstruction-zero element. -/
+theorem zeroObstruction_eq (T : TangentData.{u, v, w, x, y, z} X L) :
+    T.zeroObstruction = T.zeroObstruction :=
+  rfl
+
+end TangentData
+
+end SingularityMonodromyStack
+end AAT.AG

--- a/Formal/AG/SingularityMonodromyStack/SmoothSingular.lean
+++ b/Formal/AG/SingularityMonodromyStack/SmoothSingular.lean
@@ -1,0 +1,213 @@
+import Formal.AG.SingularityMonodromyStack.CotangentInterface
+import Formal.AG.LawAlgebra.LawfulLocus
+
+noncomputable section
+
+namespace AAT.AG
+namespace SingularityMonodromyStack
+
+universe u v w x y z
+
+/--
+VI.定義4.1: selected deformation-obstruction theory for a stratum.
+
+The fields `effective` and `sound` are explicit assumptions of the chosen
+interface. They are not global deformation theory theorems.
+-/
+structure DeformationObstructionTheory {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    {X : ArchitectureStratum.{u, v, w, x, y} P k}
+    {L : CotangentData.{u, v, w, x, y, z} X}
+    (T : TangentData.{u, v, w, x, y, z} X L) where
+  DeformationTest : Type z
+  LiftFill : DeformationTest -> Prop
+  ob : DeformationTest -> T.ObstructionTarget
+  effective : ∀ eta : DeformationTest, ob eta = T.zeroObstruction -> LiftFill eta
+  sound : ∀ eta : DeformationTest, LiftFill eta -> ob eta = T.zeroObstruction
+
+namespace DeformationObstructionTheory
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+variable {L : CotangentData.{u, v, w, x, y, z} X}
+variable {T : TangentData.{u, v, w, x, y, z} X L}
+
+/-- VI.定義4.1: nonzero obstruction refutes the selected lift/fill predicate. -/
+theorem not_liftFill_of_ob_ne_zero
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T)
+    {eta : D.DeformationTest} (hne : D.ob eta ≠ T.zeroObstruction) :
+    ¬ D.LiftFill eta := by
+  intro hlift
+  exact hne (D.sound eta hlift)
+
+/-- VI.定義4.1: obstruction zero produces a selected lift/fill. -/
+theorem liftFill_of_ob_eq_zero
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T)
+    {eta : D.DeformationTest} (hzero : D.ob eta = T.zeroObstruction) :
+    D.LiftFill eta :=
+  D.effective eta hzero
+
+end DeformationObstructionTheory
+
+/-- VI.定義4.1: `U`-smoothness for the selected deformation tests. -/
+def USmooth {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    {X : ArchitectureStratum.{u, v, w, x, y} P k}
+    {L : CotangentData.{u, v, w, x, y, z} X}
+    {T : TangentData.{u, v, w, x, y, z} X L}
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T) : Prop :=
+  ∀ eta : D.DeformationTest, D.LiftFill eta ∧ D.ob eta = T.zeroObstruction
+
+/-- VI.定義5.1: `U`-singularity is existence of a selected nonzero obstruction. -/
+def USingular {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    {X : ArchitectureStratum.{u, v, w, x, y} P k}
+    {L : CotangentData.{u, v, w, x, y, z} X}
+    {T : TangentData.{u, v, w, x, y, z} X L}
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T) : Prop :=
+  ∃ eta : D.DeformationTest, D.ob eta ≠ T.zeroObstruction
+
+namespace USmooth
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+variable {L : CotangentData.{u, v, w, x, y, z} X}
+variable {T : TangentData.{u, v, w, x, y, z} X L}
+variable {D : DeformationObstructionTheory.{u, v, w, x, y, z} T}
+
+/-- VI.R2: smoothness exposes obstruction vanishing on each selected test. -/
+theorem obstruction_eq_zero (h : USmooth D) (eta : D.DeformationTest) :
+    D.ob eta = T.zeroObstruction :=
+  (h eta).2
+
+/-- VI.R2: smoothness exposes the selected lift/fill on each selected test. -/
+theorem liftFill (h : USmooth D) (eta : D.DeformationTest) :
+    D.LiftFill eta :=
+  (h eta).1
+
+end USmooth
+
+namespace DeformationObstructionTheory
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+variable {L : CotangentData.{u, v, w, x, y, z} X}
+variable {T : TangentData.{u, v, w, x, y, z} X L}
+
+/--
+VI.R2: selected smoothness criterion under the explicit effectiveness field.
+
+If every selected obstruction class vanishes, the effective interface supplies
+all selected lift/fill data, so the stratum is `U`-smooth.
+-/
+theorem uSmooth_of_all_obstruction_zero
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T)
+    (hzero : ∀ eta : D.DeformationTest, D.ob eta = T.zeroObstruction) :
+    USmooth D := by
+  intro eta
+  exact ⟨D.effective eta (hzero eta), hzero eta⟩
+
+/-- VI.R2: `U`-smoothness is equivalent to selected obstruction vanishing. -/
+theorem uSmooth_iff_all_obstruction_zero
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T) :
+    USmooth D ↔ ∀ eta : D.DeformationTest, D.ob eta = T.zeroObstruction :=
+  ⟨fun h eta => (h eta).2, D.uSmooth_of_all_obstruction_zero⟩
+
+/-- VI.R2: selected singularity refutes selected smoothness. -/
+theorem not_uSmooth_of_uSingular
+    (D : DeformationObstructionTheory.{u, v, w, x, y, z} T)
+    (hsing : USingular D) :
+    ¬ USmooth D := by
+  intro hsmooth
+  rcases hsing with ⟨eta, hne⟩
+  exact hne ((hsmooth eta).2)
+
+end DeformationObstructionTheory
+
+/--
+VI.定義5.2: selected normal cone reading relative to `Flat_U`.
+
+The lawful locus, obstruction ideal, and normal cone are explicit selected
+carriers; this does not build a general normal cone theory.
+-/
+structure NormalConeReading {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    (X : ArchitectureStratum.{u, v, w, x, y} P k) where
+  LawCoordinateAlgebra : Type z
+  lawCoordinateCommRing : CommRing LawCoordinateAlgebra
+  obstructionFamily :
+    LawAlgebra.ObstructionIdeal.SelectedLawWitnessIdealFamily.{u, z} LawCoordinateAlgebra
+  pointToPrime : X.Point -> PrimeSpectrum LawCoordinateAlgebra
+  lawfulLocus : Set (PrimeSpectrum LawCoordinateAlgebra)
+  lawfulLocus_eq_flatU :
+    lawfulLocus =
+      LawAlgebra.LawfulLocus.localLawfulLocus LawCoordinateAlgebra obstructionFamily
+  obstructionIdealCarrier : Ideal LawCoordinateAlgebra
+  obstructionIdealCarrier_eq_I_U : obstructionIdealCarrier = obstructionFamily.localObstructionIdeal
+  normalCone : Type z
+  normalConeOverFlat : normalCone -> Prop
+  stratumToLawfulLocus : X.Point -> Prop
+
+attribute [instance] NormalConeReading.lawCoordinateCommRing
+
+namespace NormalConeReading
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+
+/-- VI.定義5.2: the selected lawful locus is the PRD-3 `Flat_U` locus. -/
+theorem lawfulLocus_eq_flatU_holds
+    (N : NormalConeReading.{u, v, w, x, y, z} X) :
+    N.lawfulLocus =
+      LawAlgebra.LawfulLocus.localLawfulLocus N.LawCoordinateAlgebra N.obstructionFamily :=
+  N.lawfulLocus_eq_flatU
+
+/-- VI.定義5.2: the selected obstruction ideal is the PRD-3 local `I_U`. -/
+theorem obstructionIdealCarrier_eq_I_U_holds
+    (N : NormalConeReading.{u, v, w, x, y, z} X) :
+    N.obstructionIdealCarrier = N.obstructionFamily.localObstructionIdeal :=
+  N.obstructionIdealCarrier_eq_I_U
+
+end NormalConeReading
+
+/-- VI.定義5.2: selected structural repair direction read from a normal cone. -/
+structure StructuralRepairDirection {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {P : StratumReadingParameter S}
+    {k : Type v} [CommRing k]
+    {X : ArchitectureStratum.{u, v, w, x, y} P k}
+    (N : NormalConeReading.{u, v, w, x, y, z} X) where
+  Direction : Type z
+  pointsTowardVanishing : Direction -> Prop
+  selectedDirection : Direction
+  selected_pointsTowardVanishing : pointsTowardVanishing selectedDirection
+
+namespace StructuralRepairDirection
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {P : StratumReadingParameter S}
+variable {k : Type v} [CommRing k]
+variable {X : ArchitectureStratum.{u, v, w, x, y} P k}
+variable {N : NormalConeReading.{u, v, w, x, y, z} X}
+
+/-- VI.定義5.2: expose the selected direction's vanishing certificate. -/
+theorem selected_pointsTowardVanishing_holds
+    (R : StructuralRepairDirection.{u, v, w, x, y, z} N) :
+    R.pointsTowardVanishing R.selectedDirection :=
+  R.selected_pointsTowardVanishing
+
+end StructuralRepairDirection
+
+end SingularityMonodromyStack
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4775,28 +4775,34 @@ PRD-4 の `DerOb_U` は type-signature-only placeholder のまま維持する。
 ## AG版AAT Lean形式化 PRD-6 / 第VI部 Singularity・Monodromy・Stack
 
 File: `Formal/AG/SingularityMonodromyStack.lean`,
-`Formal/AG/SingularityMonodromyStack/Stratum.lean`.
+`Formal/AG/SingularityMonodromyStack/Stratum.lean`,
+`Formal/AG/SingularityMonodromyStack/CotangentInterface.lean`,
+`Formal/AG/SingularityMonodromyStack/SmoothSingular.lean`.
 
 PRD-6 [第VI部 Singularity・Monodromy・Stack](lean_ag_part_6_singularity_monodromy_stack_prd.md)
-の AC1/R0 と AC2/R1 に対応する entrypoint である。現時点では
+の AC1/R0 と AC2/R1、および AC3-AC4/R2 に対応する entrypoint である。現時点では
 `Formal/AG/SingularityMonodromyStack` を build 対象へ追加し、PRD-3〜5 の
 `LawAlgebra` / `Cohomology` / `Derived` tower の後段として import される。
 最初の surface として、architecture stratum の role label、Atom vocabulary、
 law universe、coverage topology、signature axes、coefficient structure に相対化された
 `StratumReadingParameter`、および selected subobject / locally closed / decoration compatibility /
 reading compatibility の certificate を持つ `ArchitectureStratum` を Lean 上に置く。
+R2 として、selected cotangent / tangent deformation-obstruction interface、
+`USmooth` / `USingular`、normal cone reading、structural repair direction、および
+effectiveness / soundness に相対化した smoothness criterion と singular-not-smooth 補題も追加している。
 
 Tracking Issue: [#2128](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2128).
 Initial implementation Issue: [#2129](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2129).
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
-| `VI.R0` | `Formal.AG.SingularityMonodromyStack`, `Formal.AG.SingularityMonodromyStack.Stratum` | `import` | 第VI部 Singularity・Monodromy・Stack module を `Formal/AG.lean` から import し、PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived` の成果物上に立ち上げる。 | `defined only` |
+| `VI.R0` | `Formal.AG.SingularityMonodromyStack`, `Formal.AG.SingularityMonodromyStack.Stratum`, `Formal.AG.SingularityMonodromyStack.CotangentInterface`, `Formal.AG.SingularityMonodromyStack.SmoothSingular` | `import` | 第VI部 Singularity・Monodromy・Stack module を `Formal/AG.lean` から import し、PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived` の成果物上に立ち上げる。 | `defined only` |
 | `VI.定義2.1 / 原則2.2` | `AAT.AG.SingularityMonodromyStack.StratumRole`, `StratumReadingParameter`, `StratumReadingParameter.coverageTopology`, `StratumReadingParameter.lawUniverse_eq`, `StratumReadingParameter.selectedCoeff_eq`, `ArchitectureStratum`, `ArchitectureStratum.Mem`, `ArchitectureStratum.mem_iff`, `ArchitectureStratum.selectedSubobject_holds`, `ArchitectureStratum.locallyClosed_holds`, `ArchitectureStratum.decorationCompatible_holds`, `ArchitectureStratum.readingCompatible_holds` | `inductive` / `structure` / `def` / `theorem` | architecture stratum を selected role、carrier subset、selected subobject、locally closed reading、decoration compatibility、reading compatibility の proof-carrying data として定義する。reading parameter は Atom vocabulary、law universe、coverage topology、signature axes、coefficient structure に相対化される。 | `defined only` / `proved accessor` |
+| `VI.定義3.1 / 定義3.2` | `AAT.AG.SingularityMonodromyStack.CotangentData`, `CotangentData.baseMap_eq`, `TangentData`, `TangentData.zeroObstruction_eq` | `structure` / `theorem` | selected cotangent complex object、base map、pullback complex、selected tangent complex、`H0` / `H1` / obstruction target、zero obstruction、RHom interface certificate を明示 data として保持する。一般 cotangent complex / RHom 構成は主張しない。 | `defined only` / `proved accessor` |
+| `VI.定義4.1 / 定義5.1 / 定義5.2` | `AAT.AG.SingularityMonodromyStack.DeformationObstructionTheory`, `DeformationObstructionTheory.not_liftFill_of_ob_ne_zero`, `DeformationObstructionTheory.liftFill_of_ob_eq_zero`, `USmooth`, `USingular`, `USmooth.obstruction_eq_zero`, `USmooth.liftFill`, `DeformationObstructionTheory.uSmooth_of_all_obstruction_zero`, `DeformationObstructionTheory.uSmooth_iff_all_obstruction_zero`, `DeformationObstructionTheory.not_uSmooth_of_uSingular`, `NormalConeReading`, `NormalConeReading.lawfulLocus_eq_flatU_holds`, `NormalConeReading.obstructionIdealCarrier_eq_I_U_holds`, `StructuralRepairDirection`, `StructuralRepairDirection.selected_pointsTowardVanishing_holds` | `structure` / `def` / `theorem` | selected deformation tests、lift/fill predicate、obstruction map、effectiveness、soundness を interface として固定し、`USmooth` を全 selected test の lift/fill と obstruction zero、`USingular` を selected nonzero obstruction の存在として定義する。normal cone reading は PRD-3 の `Flat_U` / `I_U` に接続し、structural repair direction は selected carrier/predicate data として置く。 | `defined only` / `proved under explicit selected effectiveness/soundness interface` |
 
-Non-conclusions: この entrypoint は cotangent / tangent complex、smooth / singular predicate、
-Kuranishi data、operation homotopy、monodromy、stack、gerbe obstruction、finite Part6 examples を
-まだ形式化しない。余接複体一般構成、RHom 一般構成、algebraic stack 一般論、
+Non-conclusions: この entrypoint は Kuranishi data、operation homotopy、monodromy、stack、
+gerbe obstruction、finite Part6 examples をまだ形式化しない。余接複体一般構成、RHom 一般構成、algebraic stack 一般論、
 non-abelian gerbe cohomology 一般論は PRD-6 の claim boundary どおり future proof obligation として扱う。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -1039,13 +1039,17 @@ tracking Issue [#2076](https://github.com/iroha1203/AlgebraicArchitectureTheoryV
 PRD-6 は tracking Issue [#2128](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2128)
 で管理する。初回実装 Issue [#2129](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2129)
 では AC1/R0 と AC2/R1 を対象にし、`Formal/AG/SingularityMonodromyStack` の entrypoint と
-architecture stratum / reading parameter を追加した。PRD 本体の checkbox は prd-loop の
+architecture stratum / reading parameter を追加した。Issue [#2131](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2131)
+では AC3-AC4/R2 を対象にし、cotangent / tangent deformation-obstruction interface と
+smooth / singular / normal cone reading を追加した。PRD 本体の checkbox は prd-loop の
 不変条件として編集せず、達成状態は tracking Issue とこの台帳で同期する。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `VI.R0` Formal/AG/SingularityMonodromyStack entrypoint | `defined only`. `Formal/AG/SingularityMonodromyStack.lean` が `Formal/AG/SingularityMonodromyStack/Stratum.lean` を束ね、`Formal/AG.lean` から import される。PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived` の後段 module として build 対象に入る。 | R2 以降の deformation-obstruction interface、operation homotopy、monodromy、stack、gerbe、finite examples は後続 Issue で扱う。 |
-| `VI.定義2.1 / 原則2.2` Architecture Stratum and reading parameter | `defined only` / `proved accessor`. `StratumRole`、`StratumReadingParameter`、`StratumReadingParameter.coverageTopology`、`lawUniverse_eq`、`selectedCoeff_eq`、`ArchitectureStratum`、`ArchitectureStratum.Mem`、`mem_iff`、`selectedSubobject_holds`、`locallyClosed_holds`、`decorationCompatible_holds`、`readingCompatible_holds` を持つ。 | stratum は selected carrier / compatibility certificate として置く。一般 stratification theory、cotangent / tangent complex、smooth / singular criterion はまだ主張しない。 |
+| `VI.R0` Formal/AG/SingularityMonodromyStack entrypoint | `defined only`. `Formal/AG/SingularityMonodromyStack.lean` が `Stratum.lean`、`CotangentInterface.lean`、`SmoothSingular.lean` を束ね、`Formal/AG.lean` から import される。PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived` の後段 module として build 対象に入る。 | R3 以降の singularity theorem、operation homotopy、monodromy、stack、gerbe、finite examples は後続 Issue で扱う。 |
+| `VI.定義2.1 / 原則2.2` Architecture Stratum and reading parameter | `defined only` / `proved accessor`. `StratumRole`、`StratumReadingParameter`、`StratumReadingParameter.coverageTopology`、`lawUniverse_eq`、`selectedCoeff_eq`、`ArchitectureStratum`、`ArchitectureStratum.Mem`、`mem_iff`、`selectedSubobject_holds`、`locallyClosed_holds`、`decorationCompatible_holds`、`readingCompatible_holds` を持つ。 | stratum は selected carrier / compatibility certificate として置く。一般 stratification theory は主張しない。 |
+| `VI.定義3.1 / 定義3.2` Cotangent and tangent interface | `defined only` / `proved accessor`. `CotangentData`、`CotangentData.baseMap_eq`、`TangentData`、`TangentData.zeroObstruction_eq` を持つ。 | selected interface であり、一般余接複体構成、RHom 一般構成、Ext 一般理論は主張しない。 |
+| `VI.定義4.1 / 定義5.1 / 定義5.2` Smooth, singular, normal cone reading | `defined only` / `proved under explicit selected effectiveness/soundness interface`. `DeformationObstructionTheory`、`not_liftFill_of_ob_ne_zero`、`liftFill_of_ob_eq_zero`、`USmooth`、`USingular`、`USmooth.obstruction_eq_zero`、`USmooth.liftFill`、`uSmooth_of_all_obstruction_zero`、`uSmooth_iff_all_obstruction_zero`、`not_uSmooth_of_uSingular`、`NormalConeReading`、`NormalConeReading.lawfulLocus_eq_flatU_holds`、`NormalConeReading.obstructionIdealCarrier_eq_I_U_holds`、`StructuralRepairDirection`、`selected_pointsTowardVanishing_holds` を持つ。 | deformation-obstruction theory は selected test / obstruction map / effectiveness / soundness に相対化する。normal cone reading は PRD-3 の `Flat_U` / `I_U` に型レベルで接続する。一般 deformation theory、Kuranishi theorem、定理6.1 / 6.2 / 系6.5 はまだ主張しない。 |
 | `CotangentComplexGeneralConstruction` | `future proof obligation` / `unassigned` | PRD-6 では `CotangentData` interface の後続実装に留め、一般余接複体構成は証明しない。 |
 | `RHomGeneralConstruction` | `future proof obligation` / `unassigned` | PRD-6 では tangent interface の field として扱い、RHom 一般構成は証明しない。 |
 | `AlgebraicStackGeneralTheory` | `future proof obligation` / `unassigned` | PRD-6 では ArchitectureStack / AlgebraicArchitectureStack predicate を AAT 側 data として扱い、algebraic stack 一般論は証明しない。 |
@@ -1057,7 +1061,7 @@ architecture stratum / reading parameter を追加した。PRD 本体の checkbo
 | --- | --- |
 | `VI.R0` | `defined only` |
 | `VI.定義2.1 / 原則2.2` | `defined only` / `proved accessor` |
-| `VI.定義3.1-5.2` | `future proof obligation` |
+| `VI.定義3.1-5.2` | `defined only` / `proved under explicit selected effectiveness/soundness interface` |
 | `VI.定理6.1 / 定理6.2 / 系6.5` | `future proof obligation` |
 | `VI.定義6.3 / 定理候補6.4` | `future proof obligation` |
 | `VI.定義8.1-9.5` | `future proof obligation` |


### PR DESCRIPTION
## 概要

Closes #2131.

PRD-6 R2 / AC3-AC4 として、Part6 の cotangent / tangent deformation-obstruction interface と smooth / singular / normal cone reading surface を追加します。

- `CotangentData` / `TangentData` を selected interface として追加
- `DeformationObstructionTheory`、`USmooth`、`USingular` と、effectiveness / soundness に相対化した補題を追加
- `NormalConeReading` を PRD-3 の `Flat_U` / `I_U` に接続
- `StructuralRepairDirection` を selected normal cone reading 上の predicate として追加
- Part6 root import と Lean theorem index / proof obligations を同期

一般余接複体構成、RHom 一般構成、Ext 一般理論、Kuranishi theorem、定理6.1 / 6.2 / 系6.5 はこの PR では主張しません。

## 証明した定理

- `AAT.AG.SingularityMonodromyStack.CotangentData.baseMap_eq`
- `AAT.AG.SingularityMonodromyStack.TangentData.zeroObstruction_eq`
- `AAT.AG.SingularityMonodromyStack.DeformationObstructionTheory.not_liftFill_of_ob_ne_zero`
- `AAT.AG.SingularityMonodromyStack.DeformationObstructionTheory.liftFill_of_ob_eq_zero`
- `AAT.AG.SingularityMonodromyStack.USmooth.obstruction_eq_zero`
- `AAT.AG.SingularityMonodromyStack.USmooth.liftFill`
- `AAT.AG.SingularityMonodromyStack.DeformationObstructionTheory.uSmooth_of_all_obstruction_zero`
- `AAT.AG.SingularityMonodromyStack.DeformationObstructionTheory.uSmooth_iff_all_obstruction_zero`
- `AAT.AG.SingularityMonodromyStack.DeformationObstructionTheory.not_uSmooth_of_uSingular`
- `AAT.AG.SingularityMonodromyStack.NormalConeReading.lawfulLocus_eq_flatU_holds`
- `AAT.AG.SingularityMonodromyStack.NormalConeReading.obstructionIdealCarrier_eq_I_U_holds`
- `AAT.AG.SingularityMonodromyStack.StructuralRepairDirection.selected_pointsTowardVanishing_holds`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/SingularityMonodromyStack/CotangentInterface.lean`
- [x] `lake env lean Formal/AG/SingularityMonodromyStack/SmoothSingular.lean`
- [x] `lake env lean Formal/AG/SingularityMonodromyStack.lean`
- [x] `lake env lean Formal/AG.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `Formal.Arch` import scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

`lake build` は成功しました。既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning は再表示されますが、この PR の変更ではありません。

## チェックリスト

- [x] 対象 Issue を `Closes #2131` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

