### PR TITLE
ArchSigのH1ゼロ結論をboundaryより優先する

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -1232,10 +1232,15 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
     let cech_nonzero = packet.structural_verdict.iter().any(|verdict| {
         verdict.evaluator == "ag.cech-obstruction@1" && verdict.verdict == "measured_nonzero"
     });
+    let cech_zero = packet.structural_verdict.iter().any(|verdict| {
+        verdict.evaluator == "ag.cech-obstruction@1" && verdict.verdict == "measured_zero"
+    });
     let conclusion = if cech_nonzero {
         "MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
     } else if nonzero_count > 0 {
         "MEASURED_AG_OBSTRUCTION_UNDER_PROFILE"
+    } else if cech_zero {
+        "NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"
     } else if unmeasured_count > 0 {
         "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
     } else if packet.structural_verdict.is_empty() {
@@ -1255,6 +1260,8 @@ pub fn build_measurement_summary_v1(packet: &ArchSigMeasurementPacketV1) -> Valu
                 "Local rules are not enough to explain the selected cover; ArchSig measured a cross-context glue mismatch."
             } else if nonzero_count > 0 {
                 "ArchSig measured a selected AG obstruction under the profile."
+            } else if cech_zero {
+                "No selected H1 glue mismatch was measured under the profile."
             } else if unmeasured_count > 0 {
                 "ArchSig produced a profile-relative foundation result with unmeasured, unknown, or not_computed rows still visible."
             } else {
@@ -3579,8 +3586,8 @@ fn insight_rank(card: &Value) -> usize {
         "repair_lower_bound" | "minimal_repair_candidate" => 600,
         "policy_conflict" => 500,
         "architecture_debt_mass" => 400,
-        "measurement_boundary" => 300,
-        "no_measured_glue_mismatch" => 250,
+        "no_measured_glue_mismatch" => 300,
+        "measurement_boundary" => 200,
         _ => 100,
     }
 }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -678,9 +678,25 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
     ]);
 
     let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
     let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
     let brief = fs::read_to_string(out_dir.join("archsig-insight-brief.md"))
         .expect("insight brief is generated");
+    assert_eq!(
+        summary["conclusion"].as_str(),
+        Some("NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"),
+        "measured_zero H1 must stay conclusion-first even when boundary digest is present"
+    );
+    assert_eq!(
+        report["headline"]["conclusionCode"].as_str(),
+        Some("NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"),
+        "insight headline must keep the profile-relative zero conclusion as the product-facing verdict"
+    );
+    assert_eq!(
+        viewer["decisionBar"]["conclusion"].as_str(),
+        Some("NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE"),
+        "viewer Decision Bar must lead with the useful H1 zero conclusion, not the boundary"
+    );
     assert!(
         report["insightCards"]
             .as_array()
@@ -704,8 +720,8 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
         .position(|kind| *kind == "no_measured_glue_mismatch")
         .expect("fixture must surface a measured_zero card");
     assert!(
-        boundary_index < zero_index,
-        "measurement boundary card must rank before measured_zero confirmation when both are present"
+        zero_index < boundary_index,
+        "measured_zero confirmation must rank before measurement boundary when both are present"
     );
     assert!(
         viewer["viewerVisualScenes"]
@@ -726,8 +742,8 @@ fn cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundar
             .expect("viewer visual scenes are array")
             .iter()
             .any(|scene| scene["sceneId"] == "overview"
-                && scene["visualEncodings"][0]["colorRole"] == "unknown"),
-        "measurement boundary top insight must render overview as boundary/unknown, not a false clean or nonzero beacon"
+                && scene["visualEncodings"][0]["colorRole"] == "measured_zero"),
+        "measured_zero top insight must render overview as the selected-support zero conclusion"
     );
     assert!(
         viewer["viewerVisualScenes"]


### PR DESCRIPTION
## 概要

ArchSig の H¹ `measured_zero` surface が boundary card に負けていたため、product-facing な結論を `NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE` として summary / insight headline / viewer Decision Bar の先頭に出すよう修正します。

- H¹ zero verdict を summary conclusion の優先分岐に追加
- `no_measured_glue_mismatch` の Insight ranking を `measurement_boundary` より上へ変更
- false-clean 防止 regression を、boundary-first ではなく conclusion-first + boundary digest の形に更新

対応 Issue: なし（レビュー指摘からの直接修正）

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加確認:

- `cargo fmt --manifest-path tools/archsig/Cargo.toml`
- `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_insight_surface_preserves_false_clean_and_not_computed_boundaries`
- `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_emits_insight_report_brief_and_viewer_scene_contract`
- `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero`
- fixture 生成物で summary / insight headline / viewer Decision Bar が `NO_MEASURED_H1_OBSTRUCTION_UNDER_PROFILE` を出すことを確認

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（対象 Issue なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない