### PR TITLE
ArchSig v0.4.0改善: R1の空Cechスコープをnot_computed化

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -110,24 +110,15 @@ pub fn build_foundation_measurement_packet_v1(
                     .law
                     .clone()
                     .unwrap_or_else(|| "ag.cech-obstruction".to_string()),
-                verdict: if measurement.h1_class_nonzero {
-                    "measured_nonzero".to_string()
-                } else {
-                    "measured_zero".to_string()
-                },
+                verdict: measurement.verdict,
                 verdict_data: AgVerdictDataV1 {
                     in_scope: true,
-                    zero: !measurement.h1_class_nonzero,
-                    non_zero: measurement.h1_class_nonzero,
-                    method_status: "finite_f2_cech_computed".to_string(),
-                    cert_ref: Some(measurement.cert_ref),
+                    zero: measurement.zero,
+                    non_zero: measurement.non_zero,
+                    method_status: measurement.method_status,
+                    cert_ref: measurement.cert_ref,
                 },
-                reason: Some(if measurement.h1_class_nonzero {
-                    "finite F2 Cech 1-cocycle is not a coboundary on the selected cover".to_string()
-                } else {
-                    "finite F2 Cech 1-cocycle is zero or a coboundary on the selected cover"
-                        .to_string()
-                }),
+                reason: Some(measurement.reason),
             });
         } else if evaluator == "ag.square-free-repair@1" {
             validate_square_free_profile_v1(&profile)?;
@@ -3667,8 +3658,12 @@ fn slug(value: &str) -> String {
 
 #[derive(Debug, Clone)]
 struct CechMeasurementV1 {
-    h1_class_nonzero: bool,
-    cert_ref: String,
+    verdict: String,
+    zero: bool,
+    non_zero: bool,
+    method_status: String,
+    reason: String,
+    cert_ref: Option<String>,
     computed_invariants: Vec<Value>,
     assumptions: Vec<AgAssumptionLedgerEntryV1>,
 }
@@ -3700,7 +3695,9 @@ fn evaluate_cech_obstruction_v1(
         .len()
         .saturating_add(component_count)
         .saturating_sub(selected_contexts.len());
-    let h1_class_nonzero = !edge_cochain_is_coboundary(&selected_contexts, &edges);
+    let empty_selected_scope = selected_contexts.is_empty() || edges.is_empty();
+    let h1_class_nonzero =
+        !empty_selected_scope && !edge_cochain_is_coboundary(&selected_contexts, &edges);
     let representative = edges
         .iter()
         .filter(|edge| edge.value == 1)
@@ -3723,14 +3720,106 @@ fn evaluate_cech_obstruction_v1(
     let witness_support_refs = witness_violation_support_refs(normalized);
     let witness_violation_count = witness_support_refs.len();
 
+    let mut assumptions = vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/B.8.2".to_string(),
+            assumption: "F2 finite coefficient field".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some(format!(
+                "measurement-profile:{}.coefficient={}",
+                profile.profile_id, profile.coefficient
+            )),
+            assumed_by: None,
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/B.8.2".to_string(),
+            assumption: "cover-relative Cech reading".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some(format!(
+                "measurement-profile:{}.coverRef",
+                profile.profile_id
+            )),
+            assumed_by: None,
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/B.8.2".to_string(),
+            assumption: "Leray / acyclicity comparison to sheaf cohomology".to_string(),
+            status: "assumed".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+    ];
+    if empty_selected_scope {
+        assumptions.push(AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/B.8.2-empty-selected-scope".to_string(),
+            assumption: "U-adequate cover selects a non-empty Cech 1-skeleton".to_string(),
+            status: "violated".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        });
+    }
+
+    let (verdict, zero, non_zero, method_status, reason) = if empty_selected_scope {
+        (
+            "not_computed".to_string(),
+            false,
+            false,
+            "empty_selected_scope".to_string(),
+            "empty_selected_scope: selected cover has no non-empty Cech 1-skeleton for ag.cech-obstruction@1".to_string(),
+        )
+    } else if h1_class_nonzero {
+        (
+            "measured_nonzero".to_string(),
+            false,
+            true,
+            "finite_f2_cech_computed".to_string(),
+            "finite F2 Cech 1-cocycle is not a coboundary on the selected cover".to_string(),
+        )
+    } else {
+        (
+            "measured_zero".to_string(),
+            true,
+            false,
+            "finite_f2_cech_computed".to_string(),
+            "finite F2 Cech 1-cocycle is zero or a coboundary on the selected cover".to_string(),
+        )
+    };
+    let cert_ref = if empty_selected_scope {
+        None
+    } else {
+        Some(format!(
+            "computedInvariants/cech-cohomology:{}",
+            profile.profile_id
+        ))
+    };
+
     CechMeasurementV1 {
-        h1_class_nonzero,
-        cert_ref: format!("computedInvariants/cech-cohomology:{}", profile.profile_id),
+        verdict,
+        zero,
+        non_zero,
+        method_status,
+        reason,
+        cert_ref,
         computed_invariants: vec![
             json!({
                 "invariantId": format!("cech-cohomology:{}", profile.profile_id),
                 "evaluator": "ag.cech-obstruction@1",
                 "method": "finite-f2-incidence-graph-cochain@1",
+                "status": if empty_selected_scope {
+                    "not_computed"
+                } else {
+                    "computed"
+                },
+                "methodStatus": if empty_selected_scope {
+                    "empty_selected_scope"
+                } else {
+                    "finite_f2_cech_computed"
+                },
+                "reason": if empty_selected_scope {
+                    "empty_selected_scope: selected cover has no non-empty Cech 1-skeleton for ag.cech-obstruction@1"
+                } else {
+                    "selected cover has a non-empty Cech 1-skeleton for ag.cech-obstruction@1"
+                },
                 "claimScope": "selected-cover 1-skeleton Cech cochain calculation",
                 "selectedCoverRef": profile.cover_ref,
                 "coefficient": profile.coefficient,
@@ -3743,13 +3832,21 @@ fn evaluate_cech_obstruction_v1(
                     "H1": h1_dimension
                 },
                 "selectedH2": {
-                    "dimension": if cover_nerve_face_count == 0 { json!(0) } else { Value::Null },
-                    "status": if cover_nerve_face_count == 0 {
+                    "dimension": if empty_selected_scope || cover_nerve_face_count > 0 {
+                        Value::Null
+                    } else {
+                        json!(0)
+                    },
+                    "status": if empty_selected_scope {
+                        "not_computed"
+                    } else if cover_nerve_face_count == 0 {
                         "computed_for_selected_1_skeleton"
                     } else {
                         "not_measured_for_triple_overlap_faces"
                     },
-                    "reason": if cover_nerve_face_count == 0 {
+                    "reason": if empty_selected_scope {
+                        "empty_selected_scope: selected cover has no non-empty Cech 1-skeleton for ag.cech-obstruction@1"
+                    } else if cover_nerve_face_count == 0 {
                         "no selected 2-simplices are present in the finite incidence graph complex"
                     } else {
                         "triple-overlap faces are projected for viewer geometry only; H2 coherence remains outside this measurement"
@@ -3774,35 +3871,7 @@ fn evaluate_cech_obstruction_v1(
                 "nonConclusion": "Witness counting is reported as a fixture discriminator and does not determine Cech H1."
             }),
         ],
-        assumptions: vec![
-            AgAssumptionLedgerEntryV1 {
-                theorem_ref: "part8/B.8.2".to_string(),
-                assumption: "F2 finite coefficient field".to_string(),
-                status: "checked".to_string(),
-                checked_by: Some(format!(
-                    "measurement-profile:{}.coefficient={}",
-                    profile.profile_id, profile.coefficient
-                )),
-                assumed_by: None,
-            },
-            AgAssumptionLedgerEntryV1 {
-                theorem_ref: "part8/B.8.2".to_string(),
-                assumption: "cover-relative Cech reading".to_string(),
-                status: "checked".to_string(),
-                checked_by: Some(format!(
-                    "measurement-profile:{}.coverRef",
-                    profile.profile_id
-                )),
-                assumed_by: None,
-            },
-            AgAssumptionLedgerEntryV1 {
-                theorem_ref: "part8/B.8.2".to_string(),
-                assumption: "Leray / acyclicity comparison to sheaf cohomology".to_string(),
-                status: "assumed".to_string(),
-                checked_by: None,
-                assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
-            },
-        ],
+        assumptions,
     }
 }
 
@@ -6612,6 +6681,26 @@ mod tests {
         assert!(checks.iter().any(|check| {
             check.id == "measurement-packet-v1-theorem-candidate-analytic-only"
                 && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn cech_empty_selected_cover_contexts_are_not_computed() {
+        let mut normalized = normalized_fixture();
+        normalized.covers[0].context_ids.clear();
+        let profile = packet_fixture().profile;
+
+        let measurement = evaluate_cech_obstruction_v1(&normalized, &profile);
+
+        assert_eq!(measurement.verdict, "not_computed");
+        assert!(!measurement.zero);
+        assert!(!measurement.non_zero);
+        assert_eq!(measurement.method_status, "empty_selected_scope");
+        assert!(measurement.reason.contains("empty_selected_scope"));
+        assert!(measurement.assumptions.iter().any(|entry| {
+            entry.theorem_ref == "part8/B.8.2-empty-selected-scope"
+                && entry.status == "violated"
+                && entry.assumption == "U-adequate cover selects a non-empty Cech 1-skeleton"
         }));
     }
 

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -180,6 +180,136 @@ fn cli_analyze_v2_writes_measurement_packet_foundation() {
 }
 
 #[test]
+fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
+    let out_dir = temp_dir("ag-measurement-cech-empty-selected-scope");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    for context in archmap["contexts"]
+        .as_array_mut()
+        .expect("contexts are an array")
+    {
+        context["restrictsTo"] = json!([]);
+    }
+    let archmap_path = out_dir.join("archmap_v2_empty_cech_skeleton.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let cech_row = &packet["structuralVerdict"][0];
+    assert_eq!(cech_row["evaluator"], "ag.cech-obstruction@1");
+    assert_eq!(cech_row["verdict"], "not_computed");
+    assert_eq!(cech_row["verdictData"]["zero"], false);
+    assert_eq!(cech_row["verdictData"]["nonZero"], false);
+    assert_eq!(
+        cech_row["verdictData"]["methodStatus"],
+        "empty_selected_scope"
+    );
+    assert_eq!(cech_row["verdictData"].get("certRef"), None);
+    let reason = cech_row["reason"].as_str().expect("reason is present");
+    assert!(reason.contains("empty_selected_scope"));
+    assert!(!reason.contains("should"));
+    assert!(!reason.contains("author"));
+    assert!(!reason.contains("intent"));
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| {
+                entry["theoremRef"] == "part8/B.8.2-empty-selected-scope"
+                    && entry["status"] == "violated"
+                    && entry["assumption"] == "U-adequate cover selects a non-empty Cech 1-skeleton"
+            }),
+        "empty selected Cech skeleton must be recorded as a violated evaluator precondition"
+    );
+
+    let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    assert_eq!(cech["status"], "not_computed");
+    assert_eq!(cech["methodStatus"], "empty_selected_scope");
+    assert_eq!(cech["restrictionEdgeCount"], Value::from(0));
+    assert_eq!(cech["selectedH2"]["dimension"], Value::Null);
+    assert_eq!(cech["selectedH2"]["status"], "not_computed");
+    assert_eq!(
+        cech["selectedH2"]["reason"],
+        "empty_selected_scope: selected cover has no non-empty Cech 1-skeleton for ag.cech-obstruction@1"
+    );
+
+    let validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
+    assert_eq!(validation["summary"]["result"], "pass");
+
+    let summary = read_json(&out_dir.join("archsig-analysis-summary.json"));
+    assert_eq!(
+        summary["conclusion"],
+        "AG_MEASUREMENT_FOUNDATION_READY_UNDER_PROFILE"
+    );
+    assert_eq!(
+        summary["structuralVerdictSummary"]["nonTerminalCount"],
+        Value::from(1)
+    );
+    assert_eq!(
+        summary["assumptionSummary"]["violatedCount"],
+        Value::from(1)
+    );
+
+    let insight = read_json(&out_dir.join("archsig-insight-report.json"));
+    assert_eq!(
+        insight["boundaryDigest"]["blockingCount"],
+        Value::from(2),
+        "violated precondition plus not_computed Cech row are blockers"
+    );
+    assert!(
+        insight["boundaryDigest"]["blocking"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["reasonCode"] == "empty_selected_scope"),
+        "viewer/report boundary digest must expose empty scope as a blocker"
+    );
+
+    let strict_out_dir = temp_dir("ag-measurement-cech-empty-selected-scope-strict");
+    let strict_output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        strict_out_dir.to_str().expect("path is utf-8"),
+        "--strict-distance",
+    ]);
+    assert_eq!(
+        strict_output.status.code(),
+        Some(1),
+        "strict-distance must reject empty selected Cech scope\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&strict_output.stdout),
+        String::from_utf8_lossy(&strict_output.stderr)
+    );
+    let strict_stderr = String::from_utf8_lossy(&strict_output.stderr);
+    assert!(
+        strict_stderr.contains("unmeasured structural verdict rows")
+            && strict_stderr.contains("violated assumptions"),
+        "strict-distance stderr must identify non-terminal rows and violated assumptions\n{strict_stderr}"
+    );
+}
+
+#[test]
 fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
     let out_dir = temp_dir("ag-measurement-cech-h1-visible");
     let root = ag_measurement_root();


### PR DESCRIPTION
## 概要

Closes #2156

ArchSig v0.4.0 改善 PRD の R1 対応として、`ag.cech-obstruction@1` の vacuous-zero 経路を fail-closed にしました。

- selected cover が空、または selected Cech 1-skeleton が空のとき、Cech structural verdict を `measured_zero` ではなく `not_computed` にする
- reason / methodStatus を `empty_selected_scope` に固定し、CBI assumption ledger に evaluator-relative precondition violation を記録する
- empty scope 時の `certRef` と `selectedH2.dimension=0` を出さず、computed invariant も `status=not_computed` にする
- summary / insight boundary digest / `--strict-distance` で blocker として扱われることを regression test にする

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `rg -n "[\\x{200B}\\x{200C}\\x{200D}\\x{200E}\\x{200F}\\x{202A}\\x{202B}\\x{202C}\\x{202D}\\x{202E}\\x{2066}\\x{2067}\\x{2068}\\x{2069}\\x{FEFF}]" tools/archsig/src/ag_measurement.rs tools/archsig/tests/cli.rs`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Rust tooling 変更のみ、Lean source 変更なし）

ローカルレビュー:
- `$local-review` 相当の4観点レビューを実施。
- 指摘された `selectedH2.dimension=0` の残存、empty scope 時の `certRef`、`--strict-distance` 回帰不足は修正済み。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `tooling contract / empirical validation` として Issue 側で明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
