### PR TITLE
PRD-7 RepresentationAnalysis の初期足場を追加

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -19,3 +19,4 @@ import Formal.AG.Derived
 import Formal.AG.Examples.DerivedPart5
 import Formal.AG.SingularityMonodromyStack
 import Formal.AG.Examples.SingularityMonodromyStackPart6
+import Formal.AG.RepresentationAnalysis

--- a/Formal/AG/RepresentationAnalysis.lean
+++ b/Formal/AG/RepresentationAnalysis.lean
@@ -1,0 +1,1 @@
+import Formal.AG.RepresentationAnalysis.Bootstrap

--- a/Formal/AG/RepresentationAnalysis/Bootstrap.lean
+++ b/Formal/AG/RepresentationAnalysis/Bootstrap.lean
@@ -1,0 +1,121 @@
+import Formal.AG.LawAlgebra
+import Formal.AG.Cohomology
+import Formal.AG.Derived
+import Formal.AG.SingularityMonodromyStack
+
+noncomputable section
+
+namespace AAT.AG
+namespace RepresentationAnalysis
+
+universe u v w x y
+
+/-!
+PRD-7 R0 / AC1 bootstrap surface.
+
+This module is intentionally small: it only opens the Part VII namespace,
+checks that the PRD-3--6 entrypoints can be used as dependencies, and records
+that measurement verdicts remain outside Part VII.
+-/
+
+/-- VII.R0: Part VII can read PRD-3 architecture schemes. -/
+abbrev UsesArchitectureScheme {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] :=
+  LawAlgebra.Scheme.ArchitectureScheme.{u, v, w, x, y} S k
+
+/-- VII.R0: Part VII can read PRD-4 cover-relative Cech complexes. -/
+abbrev UsesCoverRelativeCechComplex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (cover : Cohomology.CoverRelativeCechCover S)
+    (obstructionSheaf : Cohomology.ObstructionSheaf S) : Type u :=
+  Cohomology.CoverRelativeCechComplex cover obstructionSheaf
+
+/-- VII.R0: Part VII can read PRD-5 repair comparison profiles. -/
+abbrev UsesRepairComparisonProfile : Type (u + 1) :=
+  Derived.RepairProfile.RepairComparisonProfile.{u}
+
+/-- VII.R0: Part VII can read PRD-6 architecture strata. -/
+abbrev UsesArchitectureStratum {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (parameter : SingularityMonodromyStack.StratumReadingParameter S)
+    (k : Type v) [CommRing k] :=
+  SingularityMonodromyStack.ArchitectureStratum.{u, v, w, x, y} parameter k
+
+/-- VII.R0: coarse availability status for the prerequisite tower. -/
+inductive PrerequisiteStatus where
+  | available
+  | blocked
+  deriving DecidableEq
+
+/--
+VII.R0: dependency status package for PRD-7.
+
+The current repository state imports the four required predecessor entrypoints.
+If a future loop finds one missing, the corresponding field is the place to
+record `blocked` in Lean-facing status rather than silently extending scope.
+-/
+structure PartVIIDependencyStatus where
+  lawAlgebra : PrerequisiteStatus
+  cohomology : PrerequisiteStatus
+  derived : PrerequisiteStatus
+  singularityMonodromyStack : PrerequisiteStatus
+
+/-- VII.R0: current dependency status after importing PRD-3--6 entrypoints. -/
+def currentDependencyStatus : PartVIIDependencyStatus where
+  lawAlgebra := .available
+  cohomology := .available
+  derived := .available
+  singularityMonodromyStack := .available
+
+/-- VII.R0: the PRD-3 LawAlgebra dependency is available. -/
+theorem current_lawAlgebra_available :
+    currentDependencyStatus.lawAlgebra = .available :=
+  rfl
+
+/-- VII.R0: the PRD-4 Cohomology dependency is available. -/
+theorem current_cohomology_available :
+    currentDependencyStatus.cohomology = .available :=
+  rfl
+
+/-- VII.R0: the PRD-5 Derived dependency is available. -/
+theorem current_derived_available :
+    currentDependencyStatus.derived = .available :=
+  rfl
+
+/-- VII.R0: the PRD-6 SingularityMonodromyStack dependency is available. -/
+theorem current_singularityMonodromyStack_available :
+    currentDependencyStatus.singularityMonodromyStack = .available :=
+  rfl
+
+/--
+VII.R0 claim boundary: Part VII prepares readings for later measurement, but it
+does not introduce a measurement verdict surface.
+-/
+structure PartVIINoMeasurementVerdictBoundary where
+  representationPeriodMetricReadingLayer : Prop
+  representationPeriodMetricReadingLayer_cert : representationPeriodMetricReadingLayer
+  measurementVerdictReservedForPartVIII : Prop
+  measurementVerdictReservedForPartVIII_cert : measurementVerdictReservedForPartVIII
+
+/-- VII.R0: the bootstrap boundary used by Part VII. -/
+def noMeasurementVerdictBoundary : PartVIINoMeasurementVerdictBoundary where
+  representationPeriodMetricReadingLayer := True
+  representationPeriodMetricReadingLayer_cert := trivial
+  measurementVerdictReservedForPartVIII := True
+  measurementVerdictReservedForPartVIII_cert := trivial
+
+namespace PartVIINoMeasurementVerdictBoundary
+
+/-- VII.R0: Part VII is a reading layer. -/
+theorem readingLayer_holds (B : PartVIINoMeasurementVerdictBoundary) :
+    B.representationPeriodMetricReadingLayer :=
+  B.representationPeriodMetricReadingLayer_cert
+
+/-- VII.R0: measurement verdicts are reserved for PRD-8. -/
+theorem measurementVerdictReservedForPartVIII_holds
+    (B : PartVIINoMeasurementVerdictBoundary) :
+    B.measurementVerdictReservedForPartVIII :=
+  B.measurementVerdictReservedForPartVIII_cert
+
+end PartVIINoMeasurementVerdictBoundary
+
+end RepresentationAnalysis
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4859,6 +4859,37 @@ measurement verdict / DistanceValue への接続、
 余接複体一般構成、RHom 一般構成、algebraic stack 一般論、stackification 一般構成、
 non-abelian gerbe cohomology 一般論、全 decomposition 分類、finite witness package を越える golden example calibration は PRD-6 の claim boundary どおり future proof obligation として扱う。
 
+## AG版AAT Lean形式化 PRD-7 / 第VII部 Representation・Periods・Analysis
+
+File: `Formal/AG/RepresentationAnalysis.lean`,
+`Formal/AG/RepresentationAnalysis/Bootstrap.lean`.
+
+PRD-7 [第VII部 Representation・Periods・Analysis](lean_ag_part_7_representation_periods_analysis_prd.md)
+の AC1/R0 に対応する entrypoint である。現時点では
+`Formal/AG/RepresentationAnalysis` を build 対象へ追加し、PRD-3 `LawAlgebra`、
+PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack`
+を第VII部の前提 module として import する。最初の surface として、
+`UsesArchitectureScheme`、`UsesCoverRelativeCechComplex`、
+`UsesRepairComparisonProfile`、`UsesArchitectureStratum` が既存 Part III-VI の
+具体 Lean 型を参照する。`PartVIIDependencyStatus` と
+`currentDependencyStatus` は、先行 PRD 依存が present / blocked のどちらであるかを
+Lean-facing status として保持する。`PartVIINoMeasurementVerdictBoundary` は、
+第VII部が representation / period / metric reading layer であり、measurement verdict は
+第VIII部へ残すことを明示する。
+
+Tracking Issue: [#2157](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2157).
+Initial implementation Issue: [#2158](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2158).
+
+| 本文ラベル | Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- | --- |
+| `VII.R0` | `Formal.AG.RepresentationAnalysis`, `Formal.AG.RepresentationAnalysis.Bootstrap`, `AAT.AG.RepresentationAnalysis.UsesArchitectureScheme`, `UsesCoverRelativeCechComplex`, `UsesRepairComparisonProfile`, `UsesArchitectureStratum`, `PrerequisiteStatus`, `PartVIIDependencyStatus`, `currentDependencyStatus`, `current_lawAlgebra_available`, `current_cohomology_available`, `current_derived_available`, `current_singularityMonodromyStack_available`, `PartVIINoMeasurementVerdictBoundary`, `noMeasurementVerdictBoundary`, `PartVIINoMeasurementVerdictBoundary.readingLayer_holds`, `PartVIINoMeasurementVerdictBoundary.measurementVerdictReservedForPartVIII_holds` | `import` / `abbrev` / `inductive` / `structure` / `def` / `theorem` | 第VII部 Representation・Periods・Analysis module を `Formal/AG.lean` から import し、PRD-3〜6 の成果物上に立ち上げる。先行依存は concrete Lean 型参照で確認し、measurement verdict は第VII部に導入しない境界を保持する。 | `defined only` / `proved accessor` |
+
+Non-conclusions: この entrypoint は `AATSch p`、`AnalyticRepresentation`、
+graph / matrix representation、period family、strict period、metric enrichment、
+margin / observation gap theorem、detecting representation conservativity、synthesis theorem、
+finite golden examples をまだ実装しない。measurement verdict / finite computability profile は
+PRD-8 の範囲であり、第VII部 bootstrap では導入しない。
+
 ## Reverse-Import Theorem Packages
 
 File: `Formal/Arch/Evolution/ReverseImportTheorems.lean`.

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -1105,6 +1105,41 @@ No Canonical Decomposition theorem を explicit selected gerbe soundness interfa
 | `VI.定義15.1 / 定義16.1 / 定理16.2` | `defined only` / `proved under explicit selected gerbe soundness interface` |
 | `VI.R12 finite examples` | `proved example theorem` |
 
+## AG版AAT Lean形式化 PRD-7 / 第VII部 Representation・Periods・Analysis
+
+PRD-7 は tracking Issue [#2157](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2157)
+で管理する。初回実装 Issue [#2158](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2158)
+では AC1/R0 を対象にし、`Formal/AG/RepresentationAnalysis` の entrypoint と
+先行 PRD-3〜6 依存確認 surface を追加した。PRD 本体の checkbox は prd-loop の
+不変条件として編集せず、達成状態は tracking Issue とこの台帳で同期する。
+
+| 対象 | 現在の扱い | 残す境界 |
+| --- | --- | --- |
+| `VII.R0` Formal/AG/RepresentationAnalysis entrypoint | `defined only` / `proved accessor`. `Formal/AG/RepresentationAnalysis.lean` が `Bootstrap.lean` を束ね、`Formal/AG.lean` が `Formal.AG.RepresentationAnalysis` を import する。`UsesArchitectureScheme`、`UsesCoverRelativeCechComplex`、`UsesRepairComparisonProfile`、`UsesArchitectureStratum` が PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack` の concrete Lean 型を参照する。`currentDependencyStatus` と accessor theorem 群は、現時点で先行依存が available であることを保持する。`PartVIINoMeasurementVerdictBoundary` は、第VII部が reading layer であり measurement verdict を導入しない境界を保持する。 | AC1 scaffold は build 対象に入った。AC2 以降の representation / graph / period / metric / conservativity / synthesis / finite examples は後続 Issue で扱う。 |
+
+第VII部 PRD-7 の証明対象ラベルは次の現在状態である。
+
+| 証明対象ラベル | Lean status |
+| --- | --- |
+| `VII.R0` | `defined only` / `proved accessor` |
+| `VII.定義2.1` `AATSch p` / `AnalyticRepresentation` | `future proof obligation` / `unassigned` |
+| `VII.定義3.1 / 4.1-4.3` representation family and preservation / reflection | `future proof obligation` / `unassigned` |
+| `VII.命題3.4` Acyclicity Preservation | `future proof obligation` / `unassigned` |
+| `VII.命題3.6` Matrix Walk Reading | `future proof obligation` / `unassigned` |
+| `VII.定義5.1-5.3 / 5.2A` broad / strict period and finite homology | `future proof obligation` / `unassigned` |
+| `VII.定理6.1 / 例6.2` Period Separation | `future proof obligation` / `unassigned` |
+| `VII.定義7.1 / 7.2` signature / curvature reading | `future proof obligation` / `unassigned` |
+| `VII.定義8.1 / 9.1 / 9.2` Metric AAT and DistanceValue | `future proof obligation` / `unassigned` |
+| `VII.定義10.1-11.2` operation distance / distance to flatness / obstruction mass | `future proof obligation` / `unassigned` |
+| `VII.定義12.1-12.8 / 定理12.5 / 定理12.7` repair cost / margin / Dehn / observation gap | `future proof obligation` / `unassigned` |
+| `VII.定義13.1 / 13.2` SingularityProfile and MonodromyIndex | `future proof obligation` / `unassigned` |
+| `VII.定義14.1 / 15.1 / 15.3 / 定理15.4` analytic context and conservativity | `future proof obligation` / `unassigned` |
+| `VII.定理16.1` Algebraic-Geometric AAT Synthesis | `future proof obligation` / `unassigned` |
+| `VII.R13 finite examples` graph/matrix, period separation, pseudo-circle period, margin, observation gap, detecting representation | `future proof obligation` / `unassigned` |
+| `GeneralSingularHomologyRealization` | `future proof obligation` / explicit non-goal for PRD-7 |
+| `GeneralMeasureTheoryForObstructionMass` | `future proof obligation` / explicit non-goal for PRD-7 |
+| `CompleteMetricReflectionFromDistanceZero` | `future proof obligation` / explicit non-goal for PRD-7 |
+
 ## 現在の未解決カテゴリ
 
 | カテゴリ | 扱い |


### PR DESCRIPTION
## 概要

Closes #2158

PRD-7 AC1/R0 として `Formal/AG/RepresentationAnalysis` の初期 entrypoint を追加しました。
PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack` の concrete Lean 型を参照する bootstrap surface を置き、先行依存が現時点で available であることを Lean-facing status として記録します。

measurement verdict は第VIII部に残し、第VII部では representation / period / metric reading layer の足場に留める boundary marker を追加しました。台帳も PRD-7 第VII部の AC1 と、AC2 以降の future proof obligation を同期しています。

## 証明した定理

- `AAT.AG.RepresentationAnalysis.current_lawAlgebra_available`
- `AAT.AG.RepresentationAnalysis.current_cohomology_available`
- `AAT.AG.RepresentationAnalysis.current_derived_available`
- `AAT.AG.RepresentationAnalysis.current_singularityMonodromyStack_available`
- `AAT.AG.RepresentationAnalysis.PartVIINoMeasurementVerdictBoundary.readingLayer_holds`
- `AAT.AG.RepresentationAnalysis.PartVIINoMeasurementVerdictBoundary.measurementVerdictReservedForPartVIII_holds`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `/Users/nakahata/.elan/bin/lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan: `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG`
- [x] `$local-review`: 4観点で実施。重大指摘なし。検証観点の staging 漏れリスクは新規 Lean files を stage して解消済み。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
