### PR TITLE
PRD-7 AATSch と analytic representation を定義

### DIFF
--- a/Formal/AG/RepresentationAnalysis.lean
+++ b/Formal/AG/RepresentationAnalysis.lean
@@ -1,1 +1,2 @@
 import Formal.AG.RepresentationAnalysis.Bootstrap
+import Formal.AG.RepresentationAnalysis.AATSch

--- a/Formal/AG/RepresentationAnalysis/AATSch.lean
+++ b/Formal/AG/RepresentationAnalysis/AATSch.lean
@@ -1,0 +1,231 @@
+import Formal.AG.RepresentationAnalysis.Bootstrap
+
+noncomputable section
+
+namespace AAT.AG
+namespace RepresentationAnalysis
+
+universe u v w x y z
+
+/--
+VII.定義2.1: reading parameter for decorated architecture schemes.
+
+The underlying scheme object comes from PRD-3.  The morphism interface is kept
+as selected data because PRD-7 only needs a functor-like representation surface;
+it does not construct a general category of all decorated AAT schemes.
+-/
+structure AATSchReadingParameter {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] where
+  SchemeMorphism :
+    UsesArchitectureScheme.{u, v, w, x, y} S k ->
+      UsesArchitectureScheme.{u, v, w, x, y} S k -> Type y
+  id :
+    ∀ X : UsesArchitectureScheme.{u, v, w, x, y} S k, SchemeMorphism X X
+  comp :
+    ∀ {X Y Z : UsesArchitectureScheme.{u, v, w, x, y} S k},
+      SchemeMorphism X Y -> SchemeMorphism Y Z -> SchemeMorphism X Z
+  AtomLabelReading : Type u
+  LawReading : Type u
+  ObstructionIdealReading : Type w
+  SignatureReading : Type u
+  InterpretationMapReading : Type x
+
+/--
+VII.定義2.1: decorated architecture scheme `AATSch p`.
+
+The scheme is the PRD-3 architecture scheme together with the selected
+decoration readings that later representation families are allowed to read.
+-/
+structure AATSch {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (p : AATSchReadingParameter.{u, v, w, x, y} S k) where
+  scheme : UsesArchitectureScheme.{u, v, w, x, y} S k
+  atomLabels : p.AtomLabelReading
+  lawReading : p.LawReading
+  obstructionIdealReading : p.ObstructionIdealReading
+  signatureReading : p.SignatureReading
+  interpretationMapReading : p.InterpretationMapReading
+
+namespace AATSch
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {k : Type v} [CommRing k]
+variable {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+
+/-- VII.定義2.1: forget the decoration to the PRD-3 architecture scheme. -/
+def underlyingScheme (X : AATSch p) :
+    UsesArchitectureScheme.{u, v, w, x, y} S k :=
+  X.scheme
+
+/-- VII.定義2.1: the forgetful scheme reading is the stored scheme. -/
+theorem underlyingScheme_eq (X : AATSch p) :
+    X.underlyingScheme = X.scheme :=
+  rfl
+
+end AATSch
+
+/--
+VII.定義2.1: morphism of decorated architecture schemes.
+
+Compatibility with labels, law readings, obstruction ideals, signature
+readings, and interpretation maps is recorded as explicit selected predicates.
+-/
+structure AATSchMorphism {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+    (X Y : AATSch p) where
+  underlying : p.SchemeMorphism X.scheme Y.scheme
+  atomLabelsCompatible : Prop
+  atomLabelsCompatible_cert : atomLabelsCompatible
+  lawReadingCompatible : Prop
+  lawReadingCompatible_cert : lawReadingCompatible
+  obstructionIdealCompatible : Prop
+  obstructionIdealCompatible_cert : obstructionIdealCompatible
+  signatureReadingCompatible : Prop
+  signatureReadingCompatible_cert : signatureReadingCompatible
+  interpretationMapCompatible : Prop
+  interpretationMapCompatible_cert : interpretationMapCompatible
+
+namespace AATSchMorphism
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {k : Type v} [CommRing k]
+variable {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+variable {X Y : AATSch p}
+
+/-- VII.定義2.1: expose selected atom-label compatibility. -/
+theorem atomLabelsCompatible_holds (f : AATSchMorphism X Y) :
+    f.atomLabelsCompatible :=
+  f.atomLabelsCompatible_cert
+
+/-- VII.定義2.1: expose selected law-reading compatibility. -/
+theorem lawReadingCompatible_holds (f : AATSchMorphism X Y) :
+    f.lawReadingCompatible :=
+  f.lawReadingCompatible_cert
+
+/-- VII.定義2.1: expose selected obstruction-ideal compatibility. -/
+theorem obstructionIdealCompatible_holds (f : AATSchMorphism X Y) :
+    f.obstructionIdealCompatible :=
+  f.obstructionIdealCompatible_cert
+
+/-- VII.定義2.1: expose selected signature-reading compatibility. -/
+theorem signatureReadingCompatible_holds (f : AATSchMorphism X Y) :
+    f.signatureReadingCompatible :=
+  f.signatureReadingCompatible_cert
+
+/-- VII.定義2.1: expose selected interpretation-map compatibility. -/
+theorem interpretationMapCompatible_holds (f : AATSchMorphism X Y) :
+    f.interpretationMapCompatible :=
+  f.interpretationMapCompatible_cert
+
+end AATSchMorphism
+
+/-- VII.定義2.1: selected identity morphism data for `AATSch p`. -/
+structure AATSchIdentityData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+    (X : AATSch p) where
+  morphism : AATSchMorphism X X
+  underlying_eq : morphism.underlying = p.id X.scheme
+
+/-- VII.定義2.1: selected composition data for `AATSch p`. -/
+structure AATSchCompositionData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+    {X Y Z : AATSch p}
+    (f : AATSchMorphism X Y) (g : AATSchMorphism Y Z) where
+  morphism : AATSchMorphism X Z
+  underlying_eq : morphism.underlying = p.comp f.underlying g.underlying
+
+/--
+VII.定義2.1: optional fiber-product surface.
+
+This data only exists when an underlying pullback and compatible decoration
+pullback have been selected.  No general pullback existence theorem is claimed.
+-/
+structure AATSchFiberProductData {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+    {X Y Z : AATSch p}
+    (f : AATSchMorphism X Z) (g : AATSchMorphism Y Z) where
+  object : AATSch p
+  fst : AATSchMorphism object X
+  snd : AATSchMorphism object Y
+  underlyingPullback : Prop
+  underlyingPullback_cert : underlyingPullback
+  decorationPullbackCompatible : Prop
+  decorationPullbackCompatible_cert : decorationPullbackCompatible
+
+namespace AATSchFiberProductData
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {k : Type v} [CommRing k]
+variable {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+variable {X Y Z : AATSch p}
+variable {f : AATSchMorphism X Z} {g : AATSchMorphism Y Z}
+
+/-- VII.定義2.1: the selected underlying pullback condition holds. -/
+theorem underlyingPullback_holds (P : AATSchFiberProductData f g) :
+    P.underlyingPullback :=
+  P.underlyingPullback_cert
+
+/-- VII.定義2.1: the selected decoration pullback compatibility holds. -/
+theorem decorationPullbackCompatible_holds (P : AATSchFiberProductData f g) :
+    P.decorationPullbackCompatible :=
+  P.decorationPullbackCompatible_cert
+
+end AATSchFiberProductData
+
+/-- VII.定義2.1: minimal target category interface for analytic readings. -/
+structure AnalyticTargetCategory (Target : Type z) where
+  Hom : Target -> Target -> Type z
+  id : ∀ X : Target, Hom X X
+  comp : ∀ {X Y Z : Target}, Hom X Y -> Hom Y Z -> Hom X Z
+
+/--
+VII.定義2.1: analytic representation of decorated architecture schemes.
+
+This is a functor-like structure: it maps objects and selected morphisms and
+stores identity / composition laws as fields.  A later bridge may connect this
+to Mathlib functors when a concrete category instance is selected.
+-/
+structure AnalyticRepresentation {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} {k : Type v} [CommRing k]
+    (p : AATSchReadingParameter.{u, v, w, x, y} S k) (Target : Type z) where
+  targetCategory : AnalyticTargetCategory.{z} Target
+  obj : AATSch p -> Target
+  map :
+    ∀ {X Y : AATSch p}, AATSchMorphism X Y ->
+      targetCategory.Hom (obj X) (obj Y)
+  map_id :
+    ∀ {X : AATSch p} (I : AATSchIdentityData X),
+      map I.morphism = targetCategory.id (obj X)
+  map_comp :
+    ∀ {X Y Z : AATSch p} {f : AATSchMorphism X Y} {g : AATSchMorphism Y Z}
+      (C : AATSchCompositionData f g),
+      map C.morphism = targetCategory.comp (map f) (map g)
+
+namespace AnalyticRepresentation
+
+variable {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+variable {S : Site.AATSite A} {k : Type v} [CommRing k]
+variable {p : AATSchReadingParameter.{u, v, w, x, y} S k}
+variable {Target : Type z}
+
+/-- VII.定義2.1: analytic representations preserve selected identities. -/
+theorem map_identity (R : AnalyticRepresentation p Target)
+    {X : AATSch p} (I : AATSchIdentityData X) :
+    R.map I.morphism = R.targetCategory.id (R.obj X) :=
+  R.map_id I
+
+/-- VII.定義2.1: analytic representations preserve selected compositions. -/
+theorem map_composition (R : AnalyticRepresentation p Target)
+    {X Y Z : AATSch p} {f : AATSchMorphism X Y} {g : AATSchMorphism Y Z}
+    (C : AATSchCompositionData f g) :
+    R.map C.morphism = R.targetCategory.comp (R.map f) (R.map g) :=
+  R.map_comp C
+
+end AnalyticRepresentation
+
+end RepresentationAnalysis
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4862,10 +4862,11 @@ non-abelian gerbe cohomology 一般論、全 decomposition 分類、finite witne
 ## AG版AAT Lean形式化 PRD-7 / 第VII部 Representation・Periods・Analysis
 
 File: `Formal/AG/RepresentationAnalysis.lean`,
-`Formal/AG/RepresentationAnalysis/Bootstrap.lean`.
+`Formal/AG/RepresentationAnalysis/Bootstrap.lean`,
+`Formal/AG/RepresentationAnalysis/AATSch.lean`.
 
 PRD-7 [第VII部 Representation・Periods・Analysis](lean_ag_part_7_representation_periods_analysis_prd.md)
-の AC1/R0 に対応する entrypoint である。現時点では
+の AC1/R0 と AC2/R1 に対応する entrypoint である。現時点では
 `Formal/AG/RepresentationAnalysis` を build 対象へ追加し、PRD-3 `LawAlgebra`、
 PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack`
 を第VII部の前提 module として import する。最初の surface として、
@@ -4875,19 +4876,24 @@ PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack`
 `currentDependencyStatus` は、先行 PRD 依存が present / blocked のどちらであるかを
 Lean-facing status として保持する。`PartVIINoMeasurementVerdictBoundary` は、
 第VII部が representation / period / metric reading layer であり、measurement verdict は
-第VIII部へ残すことを明示する。
+第VIII部へ残すことを明示する。AC2/R1 として、fixed reading parameter に相対化された
+`AATSch`、selected morphism interface、optional fiber product data、
+functor-like `AnalyticRepresentation` も追加している。
 
 Tracking Issue: [#2157](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2157).
 Initial implementation Issue: [#2158](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2158).
+AC2 implementation Issue: [#2162](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2162).
 
 | 本文ラベル | Lean 名 | 種別 | 意味 | Status |
 | --- | --- | --- | --- | --- |
 | `VII.R0` | `Formal.AG.RepresentationAnalysis`, `Formal.AG.RepresentationAnalysis.Bootstrap`, `AAT.AG.RepresentationAnalysis.UsesArchitectureScheme`, `UsesCoverRelativeCechComplex`, `UsesRepairComparisonProfile`, `UsesArchitectureStratum`, `PrerequisiteStatus`, `PartVIIDependencyStatus`, `currentDependencyStatus`, `current_lawAlgebra_available`, `current_cohomology_available`, `current_derived_available`, `current_singularityMonodromyStack_available`, `PartVIINoMeasurementVerdictBoundary`, `noMeasurementVerdictBoundary`, `PartVIINoMeasurementVerdictBoundary.readingLayer_holds`, `PartVIINoMeasurementVerdictBoundary.measurementVerdictReservedForPartVIII_holds` | `import` / `abbrev` / `inductive` / `structure` / `def` / `theorem` | 第VII部 Representation・Periods・Analysis module を `Formal/AG.lean` から import し、PRD-3〜6 の成果物上に立ち上げる。先行依存は concrete Lean 型参照で確認し、measurement verdict は第VII部に導入しない境界を保持する。 | `defined only` / `proved accessor` |
+| `VII.定義2.1` | `AAT.AG.RepresentationAnalysis.AATSchReadingParameter`, `AATSch`, `AATSch.underlyingScheme`, `AATSch.underlyingScheme_eq`, `AATSchMorphism`, `AATSchMorphism.atomLabelsCompatible_holds`, `AATSchMorphism.lawReadingCompatible_holds`, `AATSchMorphism.obstructionIdealCompatible_holds`, `AATSchMorphism.signatureReadingCompatible_holds`, `AATSchMorphism.interpretationMapCompatible_holds`, `AATSchIdentityData`, `AATSchCompositionData`, `AATSchFiberProductData`, `AATSchFiberProductData.underlyingPullback_holds`, `AATSchFiberProductData.decorationPullbackCompatible_holds`, `AnalyticTargetCategory`, `AnalyticRepresentation`, `AnalyticRepresentation.map_identity`, `AnalyticRepresentation.map_composition` | `structure` / `def` / `theorem` | fixed reading parameter `p` に相対化された decorated architecture scheme、selected morphism interface、optional fiber product data、target category interface、functor-like analytic representation を定義する。identity / composition は selected data と representation law fields として保持し、Mathlib functor bridge はまだ主張しない。 | `defined only` / `proved accessor` |
 
-Non-conclusions: この entrypoint は `AATSch p`、`AnalyticRepresentation`、
-graph / matrix representation、period family、strict period、metric enrichment、
-margin / observation gap theorem、detecting representation conservativity、synthesis theorem、
-finite golden examples をまだ実装しない。measurement verdict / finite computability profile は
+Non-conclusions: この entrypoint は graph / matrix representation、
+representation family の preservation / reflection predicate、period family、strict period、
+metric enrichment、margin / observation gap theorem、detecting representation conservativity、
+synthesis theorem、finite golden examples をまだ実装しない。
+measurement verdict / finite computability profile は
 PRD-8 の範囲であり、第VII部 bootstrap では導入しない。
 
 ## Reverse-Import Theorem Packages

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -1112,17 +1112,21 @@ PRD-7 は tracking Issue [#2157](https://github.com/iroha1203/AlgebraicArchitect
 では AC1/R0 を対象にし、`Formal/AG/RepresentationAnalysis` の entrypoint と
 先行 PRD-3〜6 依存確認 surface を追加した。PRD 本体の checkbox は prd-loop の
 不変条件として編集せず、達成状態は tracking Issue とこの台帳で同期する。
+Issue [#2162](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2162)
+では AC2/R1 を対象にし、`AATSch p`、selected morphism interface、
+optional fiber product data、functor-like `AnalyticRepresentation` を追加した。
 
 | 対象 | 現在の扱い | 残す境界 |
 | --- | --- | --- |
-| `VII.R0` Formal/AG/RepresentationAnalysis entrypoint | `defined only` / `proved accessor`. `Formal/AG/RepresentationAnalysis.lean` が `Bootstrap.lean` を束ね、`Formal/AG.lean` が `Formal.AG.RepresentationAnalysis` を import する。`UsesArchitectureScheme`、`UsesCoverRelativeCechComplex`、`UsesRepairComparisonProfile`、`UsesArchitectureStratum` が PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack` の concrete Lean 型を参照する。`currentDependencyStatus` と accessor theorem 群は、現時点で先行依存が available であることを保持する。`PartVIINoMeasurementVerdictBoundary` は、第VII部が reading layer であり measurement verdict を導入しない境界を保持する。 | AC1 scaffold は build 対象に入った。AC2 以降の representation / graph / period / metric / conservativity / synthesis / finite examples は後続 Issue で扱う。 |
+| `VII.R0` Formal/AG/RepresentationAnalysis entrypoint | `defined only` / `proved accessor`. `Formal/AG/RepresentationAnalysis.lean` が `Bootstrap.lean` を束ね、`Formal/AG.lean` が `Formal.AG.RepresentationAnalysis` を import する。`UsesArchitectureScheme`、`UsesCoverRelativeCechComplex`、`UsesRepairComparisonProfile`、`UsesArchitectureStratum` が PRD-3 `LawAlgebra`、PRD-4 `Cohomology`、PRD-5 `Derived`、PRD-6 `SingularityMonodromyStack` の concrete Lean 型を参照する。`currentDependencyStatus` と accessor theorem 群は、現時点で先行依存が available であることを保持する。`PartVIINoMeasurementVerdictBoundary` は、第VII部が reading layer であり measurement verdict を導入しない境界を保持する。 | AC1 scaffold は build 対象に入った。AC2/R1 は別行で扱う。AC3 以降の representation family / graph / period / metric / conservativity / synthesis / finite examples は後続 Issue で扱う。 |
+| `VII.定義2.1` AATSch and AnalyticRepresentation | `defined only` / `proved accessor`. `AATSchReadingParameter` が PRD-3 `ArchitectureScheme` 上の selected scheme morphism interface、identity、composition、Atom label / law / obstruction ideal / signature / interpretation map readings を保持する。`AATSch` は fixed parameter `p` に相対化した decorated scheme、`AATSchMorphism` は selected compatibility certificates を持つ morphism、`AATSchIdentityData` / `AATSchCompositionData` は selected identity / composition data を保持する。`AATSchFiberProductData` は underlying pullback と decoration pullback compatibility が与えられた場合だけ存在する optional surface として置く。`AnalyticRepresentation` は target category interface、object map、morphism map、identity / composition law fields を持つ functor-like data として定義する。 | Mathlib `CategoryTheory.Functor` への本格 bridge、representation family、preservation / reflection / conservative / faithful predicate、graph / matrix representation は後続 Issue で扱う。 |
 
 第VII部 PRD-7 の証明対象ラベルは次の現在状態である。
 
 | 証明対象ラベル | Lean status |
 | --- | --- |
 | `VII.R0` | `defined only` / `proved accessor` |
-| `VII.定義2.1` `AATSch p` / `AnalyticRepresentation` | `future proof obligation` / `unassigned` |
+| `VII.定義2.1` `AATSch p` / `AnalyticRepresentation` | `defined only` / `proved accessor` |
 | `VII.定義3.1 / 4.1-4.3` representation family and preservation / reflection | `future proof obligation` / `unassigned` |
 | `VII.命題3.4` Acyclicity Preservation | `future proof obligation` / `unassigned` |
 | `VII.命題3.6` Matrix Walk Reading | `future proof obligation` / `unassigned` |


### PR DESCRIPTION
## 概要

Closes #2162

PRD-7 AC2/R1 として、fixed reading parameter に相対化した `AATSch p` と functor-like `AnalyticRepresentation` を追加しました。

`AATSchReadingParameter` は PRD-3 `ArchitectureScheme` 上の selected scheme morphism interface と、Atom label / law / obstruction ideal / signature / interpretation map readings を保持します。`AATSchMorphism` は selected compatibility certificates を明示し、identity / composition は `AATSchIdentityData` / `AATSchCompositionData` として置きました。fiber product は general existence を主張せず、underlying pullback と decoration pullback compatibility が与えられた場合の optional data としています。

`AnalyticRepresentation` は target 側の最小 `Hom/id/comp` interface、object map、morphism map、identity / composition law fields を持つ functor-like structure です。Mathlib `CategoryTheory.Functor` への本格 bridge はこの PR の対象外です。

## 証明した定理

- `AAT.AG.RepresentationAnalysis.AATSch.underlyingScheme_eq`
- `AAT.AG.RepresentationAnalysis.AATSchMorphism.atomLabelsCompatible_holds`
- `AAT.AG.RepresentationAnalysis.AATSchMorphism.lawReadingCompatible_holds`
- `AAT.AG.RepresentationAnalysis.AATSchMorphism.obstructionIdealCompatible_holds`
- `AAT.AG.RepresentationAnalysis.AATSchMorphism.signatureReadingCompatible_holds`
- `AAT.AG.RepresentationAnalysis.AATSchMorphism.interpretationMapCompatible_holds`
- `AAT.AG.RepresentationAnalysis.AATSchFiberProductData.underlyingPullback_holds`
- `AAT.AG.RepresentationAnalysis.AATSchFiberProductData.decorationPullbackCompatible_holds`
- `AAT.AG.RepresentationAnalysis.AnalyticRepresentation.map_identity`
- `AAT.AG.RepresentationAnalysis.AnalyticRepresentation.map_composition`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `/Users/nakahata/.elan/bin/lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan: `rg -n "\\b(axiom|admit|sorry|unsafe)\\b" Formal/AG`
- [x] `$local-review`: 4観点で実施。未追跡 file / docs drift 指摘は commit 前に修正済み。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
