### PR TITLE
ArchSig R4 atom-kind語彙lintを追加

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -13,6 +13,12 @@ Current source-of-truth boundaries:
   `sources`, subject / axis-decorated `atoms`, finite-poset `contexts`,
   selected `covers`, and `extractionDoctrineRef`. `molecules` are not a v2
   primary field; context membership replaces them for AG measurement.
+- `aat-atom-vocabulary/v1` is the artifact-side projection of allowed ArchMap
+  atom kind tokens with provenance back to the AAT doctrine. ArchMap v2
+  validation checks that `extractionDoctrineRef.components` resolves the
+  vocabulary and that `atoms[].kind` is a member before measurement; the check
+  does not prove source extraction soundness, semantic correctness, or whether a
+  new atom kind should be added to the doctrine.
 - MeasurementProfile v1 is the first-class selected measurement regime. It
   declares site / cover refs, coefficient, EffCoeff procedure, witness family,
   resolution selector, Dom / Zero / NonZero / Cert predicates, and the

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -98,7 +98,7 @@ pub fn static_aat_atom_vocabulary_v1() -> AatAtomVocabularyV1 {
             "component",
             "relation",
             "capability",
-            "dataState",
+            "state",
             "effect",
             "authority",
             "contract",
@@ -247,6 +247,11 @@ fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> Valida
         .iter()
         .map(|entry| entry.kind.as_str())
         .collect::<BTreeSet<_>>();
+    let unknown_atoms = document
+        .atoms
+        .iter()
+        .filter(|atom| !allowed.contains(atom.kind.as_str()))
+        .collect::<Vec<_>>();
     let mut examples = Vec::new();
     if !missing_components.is_empty() {
         examples.push(ValidationExample {
@@ -260,21 +265,13 @@ fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> Valida
             )),
         });
     }
-    examples.extend(
-        document
-            .atoms
-            .iter()
-            .filter(|atom| !allowed.contains(atom.kind.as_str()))
-            .map(|atom| ValidationExample {
-                component_id: Some(atom.id.clone()),
-                path: Some("atoms[].kind".to_string()),
-                source: Some(atom.kind.clone()),
-                target: Some(vocabulary_ref.to_string()),
-                evidence: Some(
-                    "declared AAT atom vocabulary does not contain this token".to_string(),
-                ),
-            }),
-    );
+    examples.extend(unknown_atoms.iter().map(|atom| ValidationExample {
+        component_id: Some(atom.id.clone()),
+        path: Some("atoms[].kind".to_string()),
+        source: Some(atom.kind.clone()),
+        target: Some(vocabulary_ref.to_string()),
+        evidence: Some("declared AAT atom vocabulary does not contain this token".to_string()),
+    }));
     let mut check = check_from_examples(
         "archmap-v2-atom-kind-vocabulary",
         "ATOMS_WITHIN_DECLARED_VOCABULARY: atom kinds are members of aat-atom-vocabulary/v1",
@@ -282,10 +279,21 @@ fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> Valida
     );
     check.metric = Some(vocabulary_ref.to_string());
     if check.result == "fail" {
-        check.reason = Some(
-            "declared AAT atom vocabulary does not contain one or more atom kind tokens or the extraction doctrine does not resolve the vocabulary"
-                .to_string(),
-        );
+        check.reason = Some(match (unknown_atoms.is_empty(), missing_components.is_empty()) {
+            (false, true) => {
+                "declared AAT atom vocabulary does not contain one or more atom kind tokens"
+                    .to_string()
+            }
+            (true, false) => {
+                "extraction doctrine does not resolve the declared AAT atom vocabulary"
+                    .to_string()
+            }
+            (false, false) => {
+                "declared AAT atom vocabulary does not contain one or more atom kind tokens and the extraction doctrine does not resolve the vocabulary"
+                    .to_string()
+            }
+            (true, true) => unreachable!("failed vocabulary check must have examples"),
+        });
     }
     check
 }
@@ -1785,7 +1793,7 @@ mod tests {
             "component",
             "relation",
             "capability",
-            "dataState",
+            "state",
             "effect",
             "authority",
             "contract",

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -2,13 +2,14 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::validation::{count_checks, duplicates, generic_validation_example, validation_check};
 use crate::{
-    ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION, ARCHMAP_V1_SCHEMA,
-    ARCHMAP_V2_SCHEMA, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ArchMapAtomV1,
-    ArchMapAtomicObservationSummary, ArchMapDocumentV0, ArchMapDocumentV1, ArchMapDocumentV2,
-    ArchMapLeanPreservationChecklistEntry, ArchMapLeanPreservationVocabularyEntry,
-    ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapValidationReportV0,
-    ArchMapValidationReportV1, ArchMapValidationReportV2, ArchMapValidationSummary,
-    ArchMapValidationSummaryV1, ArchMapValidationSummaryV2, ValidationCheck, ValidationExample,
+    AAT_ATOM_VOCABULARY_V1_SCHEMA, ARCHMAP_SCHEMA_VERSION, ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION,
+    ARCHMAP_V1_SCHEMA, ARCHMAP_V2_SCHEMA, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
+    AatAtomVocabularyEntryV1, AatAtomVocabularyV1, ArchMapAtomV1, ArchMapAtomicObservationSummary,
+    ArchMapDocumentV0, ArchMapDocumentV1, ArchMapDocumentV2, ArchMapLeanPreservationChecklistEntry,
+    ArchMapLeanPreservationVocabularyEntry, ArchMapSourceInventoryV0, ArchMapSourceRef,
+    ArchMapValidationReportV0, ArchMapValidationReportV1, ArchMapValidationReportV2,
+    ArchMapValidationSummary, ArchMapValidationSummaryV1, ArchMapValidationSummaryV2,
+    ValidationCheck, ValidationExample,
 };
 
 pub struct ArchMapSourceInventoryInput<'a> {
@@ -47,6 +48,7 @@ pub fn validate_archmap_v2_report(
         check_archmap_v2_doctrine(document),
         check_archmap_v2_sources(document),
         check_archmap_v2_atom_ids(document),
+        check_archmap_v2_atom_kind_vocabulary(document),
         check_archmap_v2_atom_shapes(document),
         check_archmap_v2_contexts(document),
         check_archmap_v2_covers(document),
@@ -78,6 +80,41 @@ pub fn validate_archmap_v2_report(
         non_conclusions: vec![
             "ArchMap v2 validation checks the finite poset site observation contract; it does not prove source extraction soundness, U-adequacy, architecture lawfulness, or Lean theorem discharge.".to_string(),
             "Contexts and covers are source-grounded observations; selected measurement coefficients, witnesses, and verdict predicates belong to MeasurementProfile.".to_string(),
+        ],
+    }
+}
+
+pub fn static_aat_atom_vocabulary_v1() -> AatAtomVocabularyV1 {
+    let doctrine_ref = "docs/aat/mathematical_theory/part_1_atoms_objects_laws.md";
+    AatAtomVocabularyV1 {
+        schema: AAT_ATOM_VOCABULARY_V1_SCHEMA.to_string(),
+        vocabulary_id: "aat-atom-vocabulary:ag-archmap@1".to_string(),
+        doctrine_ref: doctrine_ref.to_string(),
+        required_doctrine_components: ["V", "Gamma", "R", "rho", "E", "N"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        entries: [
+            "component",
+            "relation",
+            "capability",
+            "dataState",
+            "effect",
+            "authority",
+            "contract",
+            "semantic",
+            "runtime",
+        ]
+        .into_iter()
+        .map(|kind| AatAtomVocabularyEntryV1 {
+            kind: kind.to_string(),
+            doctrine_ref: doctrine_ref.to_string(),
+            provenance_ref: doctrine_ref.to_string(),
+        })
+        .collect(),
+        non_conclusions: vec![
+            "AAT atom vocabulary is an artifact-side authoring contract; it does not prove source extraction soundness or semantic correctness.".to_string(),
+            "Vocabulary lint checks token membership only and does not decide whether a new atom kind should be added to the doctrine.".to_string(),
         ],
     }
 }
@@ -188,6 +225,69 @@ fn check_archmap_v2_atom_ids(document: &ArchMapDocumentV2) -> ValidationCheck {
         "atom ids are non-empty and unique",
         examples,
     )
+}
+
+fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> ValidationCheck {
+    let vocabulary = static_aat_atom_vocabulary_v1();
+    let vocabulary_ref = vocabulary.vocabulary_id.as_str();
+    let declared_components = document
+        .extraction_doctrine_ref
+        .components
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let missing_components = vocabulary
+        .required_doctrine_components
+        .iter()
+        .filter(|component| !declared_components.contains(component.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let allowed = vocabulary
+        .entries
+        .iter()
+        .map(|entry| entry.kind.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut examples = Vec::new();
+    if !missing_components.is_empty() {
+        examples.push(ValidationExample {
+            component_id: Some("extractionDoctrineRef.components".to_string()),
+            path: Some("extractionDoctrineRef.components".to_string()),
+            source: Some(document.extraction_doctrine_ref.components.join(",")),
+            target: Some(vocabulary_ref.to_string()),
+            evidence: Some(format!(
+                "extraction doctrine does not resolve required AAT atom vocabulary components: {}",
+                missing_components.join(",")
+            )),
+        });
+    }
+    examples.extend(
+        document
+            .atoms
+            .iter()
+            .filter(|atom| !allowed.contains(atom.kind.as_str()))
+            .map(|atom| ValidationExample {
+                component_id: Some(atom.id.clone()),
+                path: Some("atoms[].kind".to_string()),
+                source: Some(atom.kind.clone()),
+                target: Some(vocabulary_ref.to_string()),
+                evidence: Some(
+                    "declared AAT atom vocabulary does not contain this token".to_string(),
+                ),
+            }),
+    );
+    let mut check = check_from_examples(
+        "archmap-v2-atom-kind-vocabulary",
+        "ATOMS_WITHIN_DECLARED_VOCABULARY: atom kinds are members of aat-atom-vocabulary/v1",
+        examples,
+    );
+    check.metric = Some(vocabulary_ref.to_string());
+    if check.result == "fail" {
+        check.reason = Some(
+            "declared AAT atom vocabulary does not contain one or more atom kind tokens or the extraction doctrine does not resolve the vocabulary"
+                .to_string(),
+        );
+    }
+    check
 }
 
 fn check_archmap_v2_atom_shapes(document: &ArchMapDocumentV2) -> ValidationCheck {
@@ -1672,4 +1772,60 @@ fn is_promoted_truth_status(status: &str) -> bool {
         status,
         "proved" | "certified" | "theorem" | "lawful" | "zeroCurvature"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_aat_atom_vocabulary_has_provenance_refs() {
+        let vocabulary = static_aat_atom_vocabulary_v1();
+        let expected_kinds = [
+            "component",
+            "relation",
+            "capability",
+            "dataState",
+            "effect",
+            "authority",
+            "contract",
+            "semantic",
+            "runtime",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+        let actual_kinds = vocabulary
+            .entries
+            .iter()
+            .map(|entry| entry.kind.as_str())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(vocabulary.schema, AAT_ATOM_VOCABULARY_V1_SCHEMA);
+        assert_eq!(
+            vocabulary.doctrine_ref,
+            "docs/aat/mathematical_theory/part_1_atoms_objects_laws.md"
+        );
+        assert_eq!(actual_kinds, expected_kinds);
+        assert_eq!(
+            vocabulary.required_doctrine_components,
+            ["V", "Gamma", "R", "rho", "E", "N"]
+        );
+        assert!(vocabulary.entries.iter().all(|entry| {
+            entry.doctrine_ref == "docs/aat/mathematical_theory/part_1_atoms_objects_laws.md"
+                && entry.provenance_ref
+                    == "docs/aat/mathematical_theory/part_1_atoms_objects_laws.md"
+        }));
+        assert!(
+            vocabulary
+                .non_conclusions
+                .iter()
+                .any(|text| text.contains("token membership only"))
+        );
+        assert!(
+            vocabulary
+                .non_conclusions
+                .iter()
+                .any(|text| text.contains("does not prove source extraction soundness"))
+        );
+    }
 }

--- a/tools/archsig/src/lib.rs
+++ b/tools/archsig/src/lib.rs
@@ -16,8 +16,8 @@ pub use ag_measurement::{
     selected_measurement_profile_v1, validate_measurement_packet_v1,
 };
 pub use archmap::{
-    ArchMapSourceInventoryInput, compare_archmap_v2_doctrine, validate_archmap_report,
-    validate_archmap_v1_report, validate_archmap_v2_report,
+    ArchMapSourceInventoryInput, compare_archmap_v2_doctrine, static_aat_atom_vocabulary_v1,
+    validate_archmap_report, validate_archmap_v1_report, validate_archmap_v2_report,
 };
 pub use archsig_analysis_packet::{
     build_archsig_analysis_packet, validate_archsig_analysis_packet_report,
@@ -29,18 +29,19 @@ pub use law_policy::{
 pub use normalizer::{normalize_archmap_v1, normalize_archmap_v2};
 pub(crate) use schema::*;
 pub use schema::{
-    ARCHITECTURE_DISTANCE_V1_SCHEMA, ARCHMAP_SCHEMA_VERSION,
+    AAT_ATOM_VOCABULARY_V1_SCHEMA, ARCHITECTURE_DISTANCE_V1_SCHEMA, ARCHMAP_SCHEMA_VERSION,
     ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION, ARCHMAP_V1_SCHEMA, ARCHMAP_V2_SCHEMA,
     ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
     ARCHSIG_ANALYSIS_PACKET_V1_SCHEMA, ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION, ARCHSIG_MEASUREMENT_PACKET_V1_SCHEMA,
-    ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION, AgAnalyticReadingV1, AgAssumptionLedgerEntryV1,
-    AgStructuralVerdictV1, AgVerdictDataV1, ArchMapAtomObservationV0, ArchMapAtomV1, ArchMapAtomV2,
-    ArchMapContextV2, ArchMapCoverV2, ArchMapDocumentV0, ArchMapDocumentV1, ArchMapDocumentV2,
-    ArchMapExtractionDoctrineRefV2, ArchMapMoleculeObservationV0, ArchMapMoleculeV1,
-    ArchMapSourceInventoryV0, ArchMapSourceRef, ArchMapSourceV1, ArchMapValidationReportV0,
-    ArchMapValidationReportV1, ArchMapValidationReportV2, ArchMapValidationSummaryV1,
-    ArchMapValidationSummaryV2, ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationReportV0,
+    ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION, AatAtomVocabularyEntryV1, AatAtomVocabularyV1,
+    AgAnalyticReadingV1, AgAssumptionLedgerEntryV1, AgStructuralVerdictV1, AgVerdictDataV1,
+    ArchMapAtomObservationV0, ArchMapAtomV1, ArchMapAtomV2, ArchMapContextV2, ArchMapCoverV2,
+    ArchMapDocumentV0, ArchMapDocumentV1, ArchMapDocumentV2, ArchMapExtractionDoctrineRefV2,
+    ArchMapMoleculeObservationV0, ArchMapMoleculeV1, ArchMapSourceInventoryV0, ArchMapSourceRef,
+    ArchMapSourceV1, ArchMapValidationReportV0, ArchMapValidationReportV1,
+    ArchMapValidationReportV2, ArchMapValidationSummaryV1, ArchMapValidationSummaryV2,
+    ArchSigAnalysisPacketV0, ArchSigAnalysisPacketValidationReportV0,
     ArchSigArtifactValidationResultV0, ArchSigAtomViewerAtomNodeV0, ArchSigAtomViewerDataV0,
     ArchSigAtomViewerEdgeV0, ArchSigAtomViewerLayoutSettingsV0, ArchSigAtomViewerMoleculeGroupV0,
     ArchSigAtomViewerOmittedDetailCountsV0, ArchSigAtomViewerSourceArtifactRefsV0,

--- a/tools/archsig/src/schema/archmap.rs
+++ b/tools/archsig/src/schema/archmap.rs
@@ -43,6 +43,25 @@ pub struct ArchMapExtractionDoctrineRefV2 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AatAtomVocabularyV1 {
+    pub schema: String,
+    pub vocabulary_id: String,
+    pub doctrine_ref: String,
+    pub required_doctrine_components: Vec<String>,
+    pub entries: Vec<AatAtomVocabularyEntryV1>,
+    pub non_conclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AatAtomVocabularyEntryV1 {
+    pub kind: String,
+    pub doctrine_ref: String,
+    pub provenance_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArchMapAtomV2 {
     pub id: String,

--- a/tools/archsig/src/schema/constants.rs
+++ b/tools/archsig/src/schema/constants.rs
@@ -1,4 +1,5 @@
 pub const ARCHMAP_SCHEMA_VERSION: &str = "archmap-observation-map-v0";
+pub const AAT_ATOM_VOCABULARY_V1_SCHEMA: &str = "aat-atom-vocabulary/v1";
 pub const ARCHMAP_V1_SCHEMA: &str = "archmap/v1";
 pub const ARCHMAP_V2_SCHEMA: &str = "archmap/v2";
 pub const ARCHMAP_SOURCE_INVENTORY_SCHEMA_VERSION: &str = "archmap-source-inventory-v0";

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -1,7 +1,8 @@
 use crate::{
-    ARCHITECTURE_DISTANCE_V1_SCHEMA, ARCHMAP_SCHEMA_VERSION, ARCHMAP_V1_SCHEMA, ARCHMAP_V2_SCHEMA,
-    ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION,
-    ARCHSIG_ANALYSIS_PACKET_V1_SCHEMA, ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
+    AAT_ATOM_VOCABULARY_V1_SCHEMA, ARCHITECTURE_DISTANCE_V1_SCHEMA, ARCHMAP_SCHEMA_VERSION,
+    ARCHMAP_V1_SCHEMA, ARCHMAP_V2_SCHEMA, ARCHMAP_VALIDATION_REPORT_SCHEMA_VERSION,
+    ARCHSIG_ANALYSIS_PACKET_SCHEMA_VERSION, ARCHSIG_ANALYSIS_PACKET_V1_SCHEMA,
+    ARCHSIG_ANALYSIS_PACKET_VALIDATION_REPORT_SCHEMA_VERSION,
     ARCHSIG_ATOM_VIEWER_DATA_SCHEMA_VERSION, ARCHSIG_MEASUREMENT_PACKET_V1_SCHEMA,
     ARCHSIG_RUN_MANIFEST_SCHEMA_VERSION, LAW_POLICY_SCHEMA_VERSION, LAW_POLICY_V1_SCHEMA,
     LAW_POLICY_VALIDATION_REPORT_SCHEMA_VERSION, MEASUREMENT_PROFILE_V1_SCHEMA,
@@ -58,6 +59,19 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 vec![
                     "ArchMap v1 validation does not run the v1 evaluator pipeline.",
                     "ArchMap v1 validation does not prove architecture lawfulness, source completeness, Lean theorem discharge, or global semantic truth.",
+                ],
+            ),
+            artifact(
+                "aat-atom-vocabulary-v1",
+                "AAT atom vocabulary v1",
+                AAT_ATOM_VOCABULARY_V1_SCHEMA,
+                "primary",
+                "ArchSig v0.4.0 Algebraic Geometry Measurement",
+                vec!["docs/tool/archsig_v0_4_0_improvement_prd.md"],
+                "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from extractionDoctrineRef components before checking atoms[].kind membership.",
+                vec![
+                    "Vocabulary lint checks token membership only; it does not prove source extraction soundness or semantic correctness.",
+                    "The linter does not decide whether a new atom kind should be added to the doctrine.",
                 ],
             ),
             artifact(
@@ -404,6 +418,7 @@ mod tests {
                 "archmap",
                 "archmap-validation-report",
                 "archmap-v1",
+                "aat-atom-vocabulary-v1",
                 "archmap-v2",
                 "law-policy",
                 "law-policy-validation-report",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -134,7 +134,7 @@ fn cli_rejects_archmap_v2_atom_kind_outside_declared_vocabulary() {
     assert_eq!(check["result"], "fail");
     assert_eq!(
         check["reason"],
-        "declared AAT atom vocabulary does not contain one or more atom kind tokens or the extraction doctrine does not resolve the vocabulary"
+        "declared AAT atom vocabulary does not contain one or more atom kind tokens"
     );
     let example = &check["examples"][0];
     assert_eq!(example["componentId"], "atom:order");
@@ -177,6 +177,40 @@ fn cli_rejects_archmap_v2_atom_kind_outside_declared_vocabulary() {
 }
 
 #[test]
+fn cli_accepts_archmap_v2_state_atom_kind_from_aat_vocabulary() {
+    let out_dir = temp_dir("archmap-v2-state-atom-kind-vocabulary");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["kind"] = json!("state");
+    let archmap_path = out_dir.join("archmap_v2_state_atom_kind.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0(&[
+        "archmap",
+        "--input",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "pass");
+    let check = json["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "archmap-v2-atom-kind-vocabulary")
+        .expect("atom vocabulary check is present");
+    assert_eq!(check["result"], "pass");
+    assert_eq!(check["metric"], "aat-atom-vocabulary:ag-archmap@1");
+}
+
+#[test]
 fn cli_rejects_archmap_v2_atom_vocabulary_unresolved_by_doctrine_components() {
     let out_dir = temp_dir("archmap-v2-atom-kind-vocabulary-doctrine");
     let root = ag_measurement_root();
@@ -212,7 +246,7 @@ fn cli_rejects_archmap_v2_atom_vocabulary_unresolved_by_doctrine_components() {
     assert_eq!(check["result"], "fail");
     assert_eq!(
         check["reason"],
-        "declared AAT atom vocabulary does not contain one or more atom kind tokens or the extraction doctrine does not resolve the vocabulary"
+        "extraction doctrine does not resolve the declared AAT atom vocabulary"
     );
     let example = &check["examples"][0];
     assert_eq!(example["componentId"], "extractionDoctrineRef.components");

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -86,6 +86,174 @@ fn cli_validates_archmap_v2_finite_poset_site_contract() {
     assert_eq!(json["summary"]["atomCount"], 3);
     assert_eq!(json["summary"]["contextCount"], 3);
     assert_eq!(json["summary"]["coverCount"], 1);
+    assert!(
+        json["checks"].as_array().unwrap().iter().any(|check| {
+            check["id"] == "archmap-v2-atom-kind-vocabulary"
+                && check["result"] == "pass"
+                && check["title"]
+                    .as_str()
+                    .is_some_and(|title| title.contains("ATOMS_WITHIN_DECLARED_VOCABULARY"))
+                && check["metric"] == "aat-atom-vocabulary:ag-archmap@1"
+        }),
+        "ArchMap v2 lint must expose the declared atom vocabulary pass conclusion"
+    );
+}
+
+#[test]
+fn cli_rejects_archmap_v2_atom_kind_outside_declared_vocabulary() {
+    let out_dir = temp_dir("archmap-v2-atom-kind-vocabulary");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["kind"] = json!("externalForecast");
+    let archmap_path = out_dir.join("archmap_v2_unknown_atom_kind.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0_expect_code(
+        &[
+            "archmap",
+            "--input",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--out",
+            report.to_str().expect("path is utf-8"),
+        ],
+        1,
+    );
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    let check = json["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "archmap-v2-atom-kind-vocabulary")
+        .expect("atom vocabulary check is present");
+    assert_eq!(check["result"], "fail");
+    assert_eq!(
+        check["reason"],
+        "declared AAT atom vocabulary does not contain one or more atom kind tokens or the extraction doctrine does not resolve the vocabulary"
+    );
+    let example = &check["examples"][0];
+    assert_eq!(example["componentId"], "atom:order");
+    assert_eq!(example["path"], "atoms[].kind");
+    assert_eq!(example["source"], "externalForecast");
+    assert_eq!(example["target"], "aat-atom-vocabulary:ag-archmap@1");
+    assert_eq!(
+        example["evidence"],
+        "declared AAT atom vocabulary does not contain this token"
+    );
+    let reason = check["reason"].as_str().expect("reason is text");
+    assert!(!reason.contains("should"));
+    assert!(!reason.contains("semantic correctness"));
+
+    let analyze_out = temp_dir("archmap-v2-atom-kind-vocabulary-analyze");
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        analyze_out.to_str().expect("path is utf-8"),
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "analyze must fail closed before measurement for vocabulary errors\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        analyze_out.join("archsig-measurement-packet.json").exists() == false,
+        "failed ArchMap v2 vocabulary preflight must not emit a measurement packet"
+    );
+    let analyze_validation = read_json(&analyze_out.join("archmap-validation.json"));
+    assert_eq!(analyze_validation["summary"]["result"], "fail");
+}
+
+#[test]
+fn cli_rejects_archmap_v2_atom_vocabulary_unresolved_by_doctrine_components() {
+    let out_dir = temp_dir("archmap-v2-atom-kind-vocabulary-doctrine");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["extractionDoctrineRef"]["components"] = json!(["custom"]);
+    let archmap_path = out_dir.join("archmap_v2_unresolved_atom_vocabulary.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0_expect_code(
+        &[
+            "archmap",
+            "--input",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--out",
+            report.to_str().expect("path is utf-8"),
+        ],
+        1,
+    );
+
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    let check = json["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "archmap-v2-atom-kind-vocabulary")
+        .expect("atom vocabulary check is present");
+    assert_eq!(check["result"], "fail");
+    assert_eq!(
+        check["reason"],
+        "declared AAT atom vocabulary does not contain one or more atom kind tokens or the extraction doctrine does not resolve the vocabulary"
+    );
+    let example = &check["examples"][0];
+    assert_eq!(example["componentId"], "extractionDoctrineRef.components");
+    assert_eq!(example["path"], "extractionDoctrineRef.components");
+    assert_eq!(example["source"], "custom");
+    assert_eq!(example["target"], "aat-atom-vocabulary:ag-archmap@1");
+    assert!(example["evidence"].as_str().is_some_and(|evidence| {
+        evidence.contains(
+            "extraction doctrine does not resolve required AAT atom vocabulary components",
+        ) && evidence.contains("Gamma")
+            && evidence.contains("rho")
+    }));
+    let reason = check["reason"].as_str().expect("reason is text");
+    assert!(!reason.contains("should"));
+    assert!(!reason.contains("semantic correctness"));
+
+    let analyze_out = temp_dir("archmap-v2-atom-kind-vocabulary-doctrine-analyze");
+    let output = run_sig0_output(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        analyze_out.to_str().expect("path is utf-8"),
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "analyze must fail closed before measurement when doctrine components do not resolve vocabulary\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        analyze_out.join("archsig-measurement-packet.json").exists() == false,
+        "failed ArchMap v2 vocabulary doctrine preflight must not emit a measurement packet"
+    );
+    let analyze_validation = read_json(&analyze_out.join("archmap-validation.json"));
+    assert_eq!(analyze_validation["summary"]["result"], "fail");
 }
 
 #[test]
@@ -10880,6 +11048,7 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
             "archmap",
             "archmap-validation-report",
             "archmap-v1",
+            "aat-atom-vocabulary-v1",
             "archmap-v2",
             "law-policy",
             "law-policy-v1",
@@ -10915,6 +11084,27 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
             "unexpected artifact role for {artifact_id}"
         );
     }
+    assert!(
+        artifacts.iter().any(|entry| {
+            entry["artifactId"] == "aat-atom-vocabulary-v1"
+                && entry["compatibilityBoundary"]["fieldMappingPolicy"]
+                    .as_str()
+                    .is_some_and(|description| {
+                        description.contains("artifact-side projection")
+                            && description.contains("allowed ArchMap atom kind tokens")
+                            && description.contains("extractionDoctrineRef components")
+                    })
+                && entry["compatibilityBoundary"]["nonConclusions"]
+                    .as_array()
+                    .is_some_and(|items| {
+                        items.iter().any(|item| {
+                            item.as_str()
+                                .is_some_and(|text| text.contains("semantic correctness"))
+                        })
+                    })
+        }),
+        "schema catalog must describe the AAT atom vocabulary artifact boundary"
+    );
     assert!(
         artifacts.iter().any(|entry| {
             entry["artifactId"] == "architecture-distance-v1"

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -87,6 +87,33 @@
       }
     },
     {
+      "artifactId": "aat-atom-vocabulary-v1",
+      "artifactName": "AAT atom vocabulary v1",
+      "schemaVersionName": "aat-atom-vocabulary/v1",
+      "artifactRole": "primary",
+      "ownerPhase": "ArchSig v0.4.0 Algebraic Geometry Measurement",
+      "status": "implemented",
+      "primaryDocs": [
+        "docs/tool/archsig_v0_4_0_improvement_prd.md"
+      ],
+      "downstreamIssues": [],
+      "compatibilityBoundary": {
+        "fieldMappingPolicy": "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from extractionDoctrineRef components before checking atoms[].kind membership.",
+        "deprecatedFields": [],
+        "newRequiredAssumptions": [
+          "Required fields, observation families, law refs, or analysis axes change.",
+          "Evidence boundaries or non-conclusions are removed or weakened."
+        ],
+        "coverageExactnessBoundary": [
+          "Coverage and exactness are artifact-local and do not imply semantic completeness."
+        ],
+        "nonConclusions": [
+          "Vocabulary lint checks token membership only; it does not prove source extraction soundness or semantic correctness.",
+          "The linter does not decide whether a new atom kind should be added to the doctrine."
+        ]
+      }
+    },
+    {
       "artifactId": "archmap-v2",
       "artifactName": "ArchMap v2 finite poset site artifact",
       "schemaVersionName": "archmap/v2",


### PR DESCRIPTION
## 概要

Closes #2160

ArchMap v2 の atom kind が `aat-atom-vocabulary/v1` に属することを、入力 validation / `archmap` lint / `analyze` preflight で fail-closed にしました。語彙 artifact は AAT 数学本文への provenance を持つ artifact-side projection として追加し、`extractionDoctrineRef.components` が vocabulary を解決しない場合も measurement へ進めないようにしています。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/README.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（100 unit / 127 CLI passed, 21 ignored）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `empirical hypothesis` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling contract / empirical validation.