### PR TITLE
ArchSig R2 assumption依存を行レベル化

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -28,11 +28,12 @@ Current source-of-truth boundaries:
   packet. The packet has `profile`, `structuralVerdict`,
   `computedInvariants`, `analyticReadings`, `assumptions`,
   `boundaryStatements`, and legacy-compatible `nonConclusions`. Structural
-  verdicts are limited to `measured_zero`, `measured_nonzero`, `unmeasured`,
-  `unknown`, and `not_computed`; analytic readings, including theorem-candidate
-  readings, are separate from structural verdicts. `boundaryStatements` carries
-  typed scoped qualifiers, while `nonConclusions` remains a string
-  compatibility view.
+  verdict rows may carry `dependsOnAssumptions` refs into the packet assumption
+  ledger. Verdict values are limited to `measured_zero`, `measured_nonzero`,
+  `unmeasured`, `unknown`, and `not_computed`; analytic readings, including
+  theorem-candidate readings, are separate from structural verdicts.
+  `boundaryStatements` carries typed scoped qualifiers, while `nonConclusions`
+  remains a string compatibility view.
 - v0.4.0 non-compatibility is scoped to the AG measurement path: `archmap/v2`
   plus `measurement-profile/v1` produces `archsig-measurement-packet/v1` and
   does not accept or emit the v1 typed evaluator artifact chain as that path's

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -104,13 +104,17 @@ fn boundary_statements_for_measurement_packet(
         }
     }
 
-    let not_computed_scope_refs = not_computed_scope_refs(packet)
-        .into_iter()
-        .collect::<Vec<_>>();
     for (index, assumption) in packet.assumptions.iter().enumerate() {
         if assumption.status == "violated" {
             let mut scope_refs = vec![assumption.theorem_ref.clone()];
-            scope_refs.extend(not_computed_scope_refs.clone());
+            let mut dependent_scope_refs =
+                dependent_not_computed_scope_refs(packet, &assumption.theorem_ref);
+            if dependent_scope_refs.is_empty() {
+                dependent_scope_refs = not_computed_scope_refs(packet)
+                    .into_iter()
+                    .collect::<Vec<_>>();
+            }
+            scope_refs.extend(dependent_scope_refs);
             statements.push(BoundaryStatementV1 {
                 id: format!("boundary:violated-assumption:{index}"),
                 kind: "violated_assumption".to_string(),
@@ -125,6 +129,56 @@ fn boundary_statements_for_measurement_packet(
     }
 
     statements
+}
+
+fn assumption_theorem_refs(assumptions: &[AgAssumptionLedgerEntryV1]) -> Vec<String> {
+    assumptions
+        .iter()
+        .map(|assumption| assumption.theorem_ref.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn is_measured_verdict(verdict: &str) -> bool {
+    matches!(verdict, "measured_zero" | "measured_nonzero")
+}
+
+fn apply_assumption_dependency_propagation(packet: &mut ArchSigMeasurementPacketV1) {
+    let violated = packet
+        .assumptions
+        .iter()
+        .filter(|assumption| assumption.status == "violated")
+        .map(|assumption| assumption.theorem_ref.as_str())
+        .collect::<BTreeSet<_>>();
+    if violated.is_empty() {
+        return;
+    }
+
+    for row in &mut packet.structural_verdict {
+        if !is_measured_verdict(&row.verdict) {
+            continue;
+        }
+        let violated_dependencies = row
+            .depends_on_assumptions
+            .iter()
+            .filter(|theorem_ref| violated.contains(theorem_ref.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if violated_dependencies.is_empty() {
+            continue;
+        }
+
+        row.verdict = "not_computed".to_string();
+        row.verdict_data.zero = false;
+        row.verdict_data.non_zero = false;
+        row.verdict_data.method_status = "depends_on_violated_assumption".to_string();
+        row.verdict_data.cert_ref = None;
+        row.reason = Some(format!(
+            "depends_on violated {}",
+            violated_dependencies.join(",")
+        ));
+    }
 }
 
 pub fn build_foundation_measurement_packet_v1(
@@ -189,6 +243,7 @@ pub fn build_foundation_measurement_packet_v1(
         if evaluator == "ag.cech-obstruction@1" {
             validate_cech_profile_v1(&profile)?;
             let measurement = evaluate_cech_obstruction_v1(normalized, &profile);
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
             computed_invariants.extend(measurement.computed_invariants);
             assumptions.extend(measurement.assumptions);
             structural_verdict.push(AgStructuralVerdictV1 {
@@ -205,11 +260,13 @@ pub fn build_foundation_measurement_packet_v1(
                     method_status: measurement.method_status,
                     cert_ref: measurement.cert_ref,
                 },
+                depends_on_assumptions,
                 reason: Some(measurement.reason),
             });
         } else if evaluator == "ag.square-free-repair@1" {
             validate_square_free_profile_v1(&profile)?;
             let measurement = evaluate_square_free_repair_v1(normalized, &profile)?;
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
             computed_invariants.extend(measurement.computed_invariants);
             assumptions.extend(measurement.assumptions);
             structural_verdict.push(AgStructuralVerdictV1 {
@@ -226,11 +283,13 @@ pub fn build_foundation_measurement_packet_v1(
                     method_status: measurement.method_status,
                     cert_ref: measurement.cert_ref,
                 },
+                depends_on_assumptions,
                 reason: Some(measurement.reason),
             });
         } else if evaluator == "ag.law-conflict-tor@1" {
             validate_tor_profile_v1(&profile)?;
             let measurement = evaluate_law_conflict_tor_v1(normalized, &profile)?;
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
             computed_invariants.extend(measurement.computed_invariants);
             assumptions.extend(measurement.assumptions);
             structural_verdict.push(AgStructuralVerdictV1 {
@@ -247,11 +306,13 @@ pub fn build_foundation_measurement_packet_v1(
                     method_status: measurement.method_status,
                     cert_ref: measurement.cert_ref,
                 },
+                depends_on_assumptions,
                 reason: Some(measurement.reason),
             });
         } else if evaluator == "ag.sheaf-laplacian@1" {
             validate_laplacian_profile_v1(&profile)?;
             let measurement = evaluate_sheaf_laplacian_v1(normalized, &profile)?;
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
             computed_invariants.extend(measurement.computed_invariants);
             analytic_readings.extend(measurement.analytic_readings);
             assumptions.extend(measurement.assumptions);
@@ -269,6 +330,7 @@ pub fn build_foundation_measurement_packet_v1(
                     method_status: measurement.method_status,
                     cert_ref: measurement.cert_ref,
                 },
+                depends_on_assumptions,
                 reason: Some(measurement.reason),
             });
         } else if evaluator == "ag.period-stokes@1" {
@@ -295,6 +357,7 @@ pub fn build_foundation_measurement_packet_v1(
                     method_status: "schema_foundation_only".to_string(),
                     cert_ref: None,
                 },
+                depends_on_assumptions: Vec::new(),
                 reason: Some(
                     "AG evaluator schema is registered; mathematical computation is implemented by follow-up evaluator issues".to_string(),
                 ),
@@ -321,6 +384,7 @@ pub fn build_foundation_measurement_packet_v1(
         boundary_statements: Vec::new(),
         non_conclusions,
     };
+    apply_assumption_dependency_propagation(&mut packet);
     packet.boundary_statements = boundary_statements_for_measurement_packet(&packet);
     Ok(packet)
 }
@@ -6531,10 +6595,17 @@ fn check_analytic_regime_boundary(packet: &ArchSigMeasurementPacketV1) -> Valida
 }
 
 fn check_assumption_ledger(packet: &ArchSigMeasurementPacketV1) -> ValidationCheck {
+    let assumption_refs = packet
+        .assumptions
+        .iter()
+        .map(|entry| entry.theorem_ref.as_str())
+        .collect::<BTreeSet<_>>();
     let violated = packet
         .assumptions
         .iter()
-        .any(|entry| entry.status == "violated");
+        .filter(|entry| entry.status == "violated")
+        .map(|entry| entry.theorem_ref.as_str())
+        .collect::<BTreeSet<_>>();
     let mut examples = Vec::new();
     for entry in &packet.assumptions {
         if !matches!(entry.status.as_str(), "checked" | "assumed" | "violated") {
@@ -6559,20 +6630,32 @@ fn check_assumption_ledger(packet: &ArchSigMeasurementPacketV1) -> ValidationChe
             ));
         }
     }
-    if violated {
-        for row in &packet.structural_verdict {
-            if row.verdict != "not_computed" {
+    for row in &packet.structural_verdict {
+        for theorem_ref in &row.depends_on_assumptions {
+            if !assumption_refs.contains(theorem_ref.as_str()) {
                 examples.push(generic_validation_example(
                     &row.evaluator,
-                    &row.verdict,
-                    "violated assumptions require dependent structural verdicts to be not_computed",
+                    theorem_ref,
+                    "dependsOnAssumptions entries must resolve to assumption theoremRef values",
                 ));
             }
+        }
+        if is_measured_verdict(&row.verdict)
+            && row
+                .depends_on_assumptions
+                .iter()
+                .any(|theorem_ref| violated.contains(theorem_ref.as_str()))
+        {
+            examples.push(generic_validation_example(
+                &row.evaluator,
+                &row.verdict,
+                "measured structural verdicts must not depend on violated assumptions",
+            ));
         }
     }
     check_examples(
         "measurement-packet-v1-assumption-ledger",
-        "assumption ledger records checked / assumed / violated and fail-closed verdicts",
+        "assumption ledger records checked / assumed / violated and row-level verdict dependencies",
         examples,
     )
 }
@@ -6729,6 +6812,26 @@ fn not_computed_scope_refs(packet: &ArchSigMeasurementPacketV1) -> BTreeSet<Stri
         }
     }
     refs
+}
+
+fn dependent_not_computed_scope_refs(
+    packet: &ArchSigMeasurementPacketV1,
+    theorem_ref: &str,
+) -> Vec<String> {
+    packet
+        .structural_verdict
+        .iter()
+        .filter(|row| {
+            row.verdict == "not_computed"
+                && row
+                    .depends_on_assumptions
+                    .iter()
+                    .any(|dependency| dependency == theorem_ref)
+        })
+        .map(structural_verdict_ref)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 fn check_examples(id: &str, title: &str, examples: Vec<ValidationExample>) -> ValidationCheck {
@@ -6910,14 +7013,90 @@ mod tests {
     }
 
     #[test]
-    fn violated_assumption_requires_not_computed_verdict() {
+    fn measured_verdict_depending_on_violated_assumption_fails_validation() {
         let mut packet = packet_fixture();
+        packet.structural_verdict[0].verdict = "measured_zero".to_string();
+        packet.structural_verdict[0].verdict_data.zero = true;
+        packet.structural_verdict[0].depends_on_assumptions = vec!["part8/4.2".to_string()];
         packet.assumptions[0].status = "violated".to_string();
         packet.assumptions[0].checked_by = None;
         let checks = validate_measurement_packet_v1(&packet);
         assert!(checks.iter().any(|check| {
             check.id == "measurement-packet-v1-assumption-ledger" && check.result == "fail"
         }));
+    }
+
+    #[test]
+    fn unresolved_assumption_dependency_fails_validation() {
+        let mut packet = packet_fixture();
+        packet.structural_verdict[0].depends_on_assumptions = vec!["missing/theorem".to_string()];
+        let checks = validate_measurement_packet_v1(&packet);
+        assert!(checks.iter().any(|check| {
+            check.id == "measurement-packet-v1-assumption-ledger" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn structural_verdict_dependency_field_is_serde_backward_compatible() {
+        let packet = packet_fixture();
+        assert!(
+            packet.structural_verdict[0]
+                .depends_on_assumptions
+                .is_empty()
+        );
+
+        let serialized = serde_json::to_value(&packet).expect("packet serializes");
+        assert!(
+            serialized["structuralVerdict"][0]
+                .get("dependsOnAssumptions")
+                .is_none(),
+            "empty dependsOnAssumptions stays additive and omitted from legacy-shaped rows"
+        );
+    }
+
+    #[test]
+    fn assumption_dependency_propagation_only_updates_dependent_measured_rows() {
+        let mut packet = packet_fixture();
+        packet.structural_verdict[0].verdict = "measured_zero".to_string();
+        packet.structural_verdict[0].verdict_data.zero = true;
+        packet.structural_verdict[0].depends_on_assumptions = vec!["part8/4.2".to_string()];
+        packet.structural_verdict.push(AgStructuralVerdictV1 {
+            evaluator: "ag.square-free-repair@1".to_string(),
+            law: "ag.square-free-repair".to_string(),
+            verdict: "measured_zero".to_string(),
+            verdict_data: AgVerdictDataV1 {
+                in_scope: true,
+                zero: true,
+                non_zero: false,
+                method_status: "square_free_ideal_computed".to_string(),
+                cert_ref: None,
+            },
+            depends_on_assumptions: vec!["part8/5.1".to_string()],
+            reason: Some("independent square-free row remains measured zero".to_string()),
+        });
+        packet.assumptions[0].status = "violated".to_string();
+        packet.assumptions[0].checked_by = None;
+        packet.assumptions.push(AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/5.1".to_string(),
+            assumption: "square-free witness variables selected by MeasurementProfile".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some("test".to_string()),
+            assumed_by: None,
+        });
+
+        apply_assumption_dependency_propagation(&mut packet);
+
+        assert_eq!(packet.structural_verdict[0].verdict, "not_computed");
+        assert_eq!(
+            packet.structural_verdict[0].verdict_data.method_status,
+            "depends_on_violated_assumption"
+        );
+        assert_eq!(
+            packet.structural_verdict[0].reason.as_deref(),
+            Some("depends_on violated part8/4.2")
+        );
+        assert_eq!(packet.structural_verdict[1].verdict, "measured_zero");
+        assert!(packet.structural_verdict[1].verdict_data.zero);
     }
 
     #[test]
@@ -7001,6 +7180,7 @@ mod tests {
         packet.structural_verdict[0].verdict = "not_computed".to_string();
         packet.structural_verdict[0].verdict_data.method_status =
             "empty_selected_scope".to_string();
+        packet.structural_verdict[0].depends_on_assumptions = vec!["part8/4.2".to_string()];
         packet.assumptions[0].status = "violated".to_string();
         packet.assumptions[0].checked_by = None;
         packet.boundary_statements = boundary_statements_for_measurement_packet(&packet);

--- a/tools/archsig/src/schema/measurement.rs
+++ b/tools/archsig/src/schema/measurement.rs
@@ -35,6 +35,8 @@ pub struct AgStructuralVerdictV1 {
     pub law: String,
     pub verdict: String,
     pub verdict_data: AgVerdictDataV1,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on_assumptions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -218,9 +218,10 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "primary",
                 "ArchSig v0.4.0 Algebraic Geometry Measurement",
                 vec!["docs/tool/archsig_v0_4_0_algebraic_geometry_measurement_prd.md"],
-                "ArchSig measurement packet v1 carries profile, structuralVerdict, computedInvariants, analyticReadings, assumptions, boundaryStatements, and legacy-compatible nonConclusions as the AG Definition 11.1-aligned output contract.",
+                "ArchSig measurement packet v1 carries profile, structuralVerdict with optional dependsOnAssumptions refs, computedInvariants, analyticReadings, assumptions, boundaryStatements, and legacy-compatible nonConclusions as the AG Definition 11.1-aligned output contract.",
                 vec![
                     "Structural verdicts are limited to measured_zero, measured_nonzero, unmeasured, unknown, and not_computed.",
+                    "dependsOnAssumptions records row-level refs into the packet assumption ledger; violated assumptions only normalize dependent measured rows to not_computed.",
                     "Analytic readings do not generate structural verdicts unless a certified evaluator explicitly emits one.",
                     "BoundaryStatements are typed scoped qualifiers; nonConclusions remains a string compatibility view.",
                     "Theorem-candidate readings are analytic-only.",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -426,15 +426,37 @@ fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
         serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
     )
     .expect("write archmap fixture");
+    let mut law_policy = read_json(&root.join("law_policy_ag.json"));
+    law_policy["measurementProfiles"][0]["witnessFamily"]
+        .as_array_mut()
+        .expect("witnessFamily is an array")
+        .push(json!({
+            "law": "ag.square-free-repair",
+            "variable": "x_order_inventory"
+        }));
+    law_policy["policies"]
+        .as_array_mut()
+        .expect("policies is an array")
+        .push(json!({
+            "law": "ag.square-free-repair",
+            "evaluator": "ag.square-free-repair@1",
+            "basis": ["policy-basis:layering"],
+            "scope": ["src/"],
+            "severity": "medium"
+        }));
+    let law_policy_path = out_dir.join("law_policy_ag_with_independent_square_free.json");
+    fs::write(
+        &law_policy_path,
+        serde_json::to_string_pretty(&law_policy).expect("law policy serializes"),
+    )
+    .expect("write law policy fixture");
 
     run_sig0(&[
         "analyze",
         "--archmap",
         archmap_path.to_str().expect("path is utf-8"),
         "--law-policy",
-        root.join("law_policy_ag.json")
-            .to_str()
-            .expect("path is utf-8"),
+        law_policy_path.to_str().expect("path is utf-8"),
         "--out-dir",
         out_dir.to_str().expect("path is utf-8"),
     ]);
@@ -448,6 +470,14 @@ fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
     assert_eq!(
         cech_row["verdictData"]["methodStatus"],
         "empty_selected_scope"
+    );
+    assert!(
+        cech_row["dependsOnAssumptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|theorem_ref| theorem_ref == "part8/B.8.2-empty-selected-scope"),
+        "Cech verdict must depend on its empty-scope precondition"
     );
     assert_eq!(cech_row["verdictData"].get("certRef"), None);
     let reason = cech_row["reason"].as_str().expect("reason is present");
@@ -466,6 +496,25 @@ fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
                     && entry["assumption"] == "U-adequate cover selects a non-empty Cech 1-skeleton"
             }),
         "empty selected Cech skeleton must be recorded as a violated evaluator precondition"
+    );
+    let square_free_row = packet["structuralVerdict"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["evaluator"] == "ag.square-free-repair@1")
+        .expect("independent square-free row exists");
+    assert_eq!(
+        square_free_row["verdict"], "measured_zero",
+        "independent measured_zero row must not be downgraded by unrelated violated Cech precondition"
+    );
+    assert_eq!(square_free_row["verdictData"]["zero"], true);
+    assert!(
+        !square_free_row["dependsOnAssumptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|theorem_ref| theorem_ref == "part8/B.8.2-empty-selected-scope"),
+        "independent square-free row must not depend on the Cech empty-scope precondition"
     );
     assert!(
         packet["boundaryStatements"]
@@ -502,6 +551,17 @@ fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
                         .as_str()
                         .is_some_and(|value| value.starts_with("structuralVerdict/")))),
         "violated assumption boundary must scope to the affected not_computed verdict"
+    );
+    assert!(
+        !packet["boundaryStatements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|statement| statement["kind"] == "violated_assumption")
+            .flat_map(|statement| statement["scopeRefs"].as_array().unwrap())
+            .filter_map(|scope_ref| scope_ref.as_str())
+            .any(|scope_ref| scope_ref.contains("square-free-repair")),
+        "violated Cech precondition boundary must not scope to independent square-free measured_zero"
     );
 
     let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
@@ -553,9 +613,7 @@ fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
         "--archmap",
         archmap_path.to_str().expect("path is utf-8"),
         "--law-policy",
-        root.join("law_policy_ag.json")
-            .to_str()
-            .expect("path is utf-8"),
+        law_policy_path.to_str().expect("path is utf-8"),
         "--out-dir",
         strict_out_dir.to_str().expect("path is utf-8"),
         "--strict-distance",

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -400,7 +400,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "ArchSig measurement packet v1 carries profile, structuralVerdict, computedInvariants, analyticReadings, assumptions, boundaryStatements, and legacy-compatible nonConclusions as the AG Definition 11.1-aligned output contract.",
+        "fieldMappingPolicy": "ArchSig measurement packet v1 carries profile, structuralVerdict with optional dependsOnAssumptions refs, computedInvariants, analyticReadings, assumptions, boundaryStatements, and legacy-compatible nonConclusions as the AG Definition 11.1-aligned output contract.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",
@@ -411,6 +411,7 @@
         ],
         "nonConclusions": [
           "Structural verdicts are limited to measured_zero, measured_nonzero, unmeasured, unknown, and not_computed.",
+          "dependsOnAssumptions records row-level refs into the packet assumption ledger; violated assumptions only normalize dependent measured rows to not_computed.",
           "Analytic readings do not generate structural verdicts unless a certified evaluator explicitly emits one.",
           "BoundaryStatements are typed scoped qualifiers; nonConclusions remains a string compatibility view.",
           "Theorem-candidate readings are analytic-only."


### PR DESCRIPTION
## 概要

Closes #2172

ArchSig v0.4.0 改善 R2 として、AG measurement packet の structural verdict 行に `dependsOnAssumptions` を追加し、violated assumption の波及を依存 verdict 行だけへ局所化しました。

`dependsOnAssumptions` は packet 内 `assumptions[].theoremRef` への additive / serde 後方互換 ref です。validator は未解決 ref を拒否し、`measured_zero` / `measured_nonzero` が violated assumption に依存する場合だけ fail します。builder の propagation pass は violated dependency を持つ measured 行だけを `not_computed` に正規化し、独立した `measured_zero` は保持します。

## 証明した定理

- なし

Lean status: tooling contract / empirical validation。

## 編集したドキュメント

- `docs/tool/README.md`
- `tools/archsig/tests/fixtures/minimal/schema_version_catalog.json`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（108 unit / 128 CLI pass, 21 ignored）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
