### PR TITLE
PRD-8 Measurement R0/R1 を追加

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -21,3 +21,4 @@ import Formal.AG.SingularityMonodromyStack
 import Formal.AG.Examples.SingularityMonodromyStackPart6
 import Formal.AG.RepresentationAnalysis
 import Formal.AG.Examples.RepresentationAnalysisPart7
+import Formal.AG.Measurement

--- a/Formal/AG/Measurement.lean
+++ b/Formal/AG/Measurement.lean
@@ -1,0 +1,3 @@
+import Formal.AG.Measurement.Bootstrap
+import Formal.AG.Measurement.Profile
+import Formal.AG.Measurement.Verdict

--- a/Formal/AG/Measurement/Bootstrap.lean
+++ b/Formal/AG/Measurement/Bootstrap.lean
@@ -1,0 +1,115 @@
+import Formal.AG.Site
+import Formal.AG.LawAlgebra
+import Formal.AG.Cohomology
+import Formal.AG.Derived
+import Formal.AG.SingularityMonodromyStack
+import Formal.AG.RepresentationAnalysis
+
+noncomputable section
+
+namespace AAT.AG
+namespace Measurement
+
+universe u v w x y z
+
+/-!
+PRD-8 R0 / AC1 bootstrap surface.
+
+This file opens the Part VIII measurement namespace, checks that the required
+Part II--VII entrypoints are available, and records the dependency status used
+by the PRD loop before introducing the measurement verdict layer.
+-/
+
+/-- VIII.R0: Part VIII can use PRD-2 finite AAT sites. -/
+abbrev UsesAATSite {U : AtomCarrier.{u}} {A : ArchitectureObject U} :=
+  Site.AATSite A
+
+/-- VIII.R0: Part VIII can use PRD-3 architecture schemes. -/
+abbrev UsesArchitectureScheme {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] :=
+  LawAlgebra.Scheme.ArchitectureScheme.{u, v, w, x, y} S k
+
+/-- VIII.R0: Part VIII can use PRD-4 cover-relative Cech complexes. -/
+abbrev UsesCoverRelativeCechComplex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (cover : Cohomology.CoverRelativeCechCover S)
+    (obstructionSheaf : Cohomology.ObstructionSheaf S) : Type u :=
+  Cohomology.CoverRelativeCechComplex cover obstructionSheaf
+
+/-- VIII.R0: Part VIII can use PRD-5 repair comparison profiles. -/
+abbrev UsesRepairComparisonProfile : Type (u + 1) :=
+  Derived.RepairProfile.RepairComparisonProfile.{u}
+
+/-- VIII.R0: Part VIII can use PRD-6 architecture strata. -/
+abbrev UsesArchitectureStratum {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (parameter : SingularityMonodromyStack.StratumReadingParameter S)
+    (k : Type v) [CommRing k] :=
+  SingularityMonodromyStack.ArchitectureStratum.{u, v, w, x, y} parameter k
+
+/-- VIII.R0: Part VIII can use PRD-7 analytic reading contexts. -/
+abbrev UsesAnalyticReadingContext {U : AtomCarrier.{u}} (Obj : ArchitectureObject U)
+    {S : Site.AATSite Obj} {k : Type v} [CommRing k]
+    (p : RepresentationAnalysis.AATSchReadingParameter.{u, v, w, x, y} S k) :=
+  RepresentationAnalysis.AnalyticReadingContext.{u, v, w, x, y, z} Obj p
+
+/-- VIII.R0: coarse availability status for the Part VIII prerequisite tower. -/
+inductive PrerequisiteStatus where
+  | available
+  | blocked
+  deriving DecidableEq
+
+/--
+VIII.R0: dependency status package for PRD-8.
+
+The current repository state imports the required predecessor entrypoints. If a
+future loop finds one missing, the corresponding field records `blocked`
+without silently extending the Part VIII scope.
+-/
+structure PartVIIIDependencyStatus where
+  site : PrerequisiteStatus
+  lawAlgebra : PrerequisiteStatus
+  cohomology : PrerequisiteStatus
+  derived : PrerequisiteStatus
+  singularityMonodromyStack : PrerequisiteStatus
+  representationAnalysis : PrerequisiteStatus
+
+/-- VIII.R0: current dependency status after importing PRD-2--7 entrypoints. -/
+def currentDependencyStatus : PartVIIIDependencyStatus where
+  site := .available
+  lawAlgebra := .available
+  cohomology := .available
+  derived := .available
+  singularityMonodromyStack := .available
+  representationAnalysis := .available
+
+/-- VIII.R0: the PRD-2 Site dependency is available. -/
+theorem current_site_available :
+    currentDependencyStatus.site = .available :=
+  rfl
+
+/-- VIII.R0: the PRD-3 LawAlgebra dependency is available. -/
+theorem current_lawAlgebra_available :
+    currentDependencyStatus.lawAlgebra = .available :=
+  rfl
+
+/-- VIII.R0: the PRD-4 Cohomology dependency is available. -/
+theorem current_cohomology_available :
+    currentDependencyStatus.cohomology = .available :=
+  rfl
+
+/-- VIII.R0: the PRD-5 Derived dependency is available. -/
+theorem current_derived_available :
+    currentDependencyStatus.derived = .available :=
+  rfl
+
+/-- VIII.R0: the PRD-6 SingularityMonodromyStack dependency is available. -/
+theorem current_singularityMonodromyStack_available :
+    currentDependencyStatus.singularityMonodromyStack = .available :=
+  rfl
+
+/-- VIII.R0: the PRD-7 RepresentationAnalysis dependency is available. -/
+theorem current_representationAnalysis_available :
+    currentDependencyStatus.representationAnalysis = .available :=
+  rfl
+
+end Measurement
+end AAT.AG

--- a/Formal/AG/Measurement/Profile.lean
+++ b/Formal/AG/Measurement/Profile.lean
@@ -1,0 +1,78 @@
+import Formal.AG.Measurement.Bootstrap
+
+noncomputable section
+
+namespace AAT.AG
+namespace Measurement
+
+universe u v
+
+/-!
+PRD-8 R1 / AC2 measurement profile surface.
+
+The profile is intentionally bounded: every predicate and certificate is
+relative to the selected profile, and no complement relation between `Zero`
+and `NonZero` is assumed.
+-/
+
+/--
+VIII.Definition 2.1: an AAT measurement profile.
+
+The fields are type-level handles for the selected site, cover, coefficient,
+effective interface, obstruction object, law universe, witness variables,
+obstruction ideal, representation family, domain, predicates, certificates,
+and selected computation method.
+-/
+structure MeasurementProfile where
+  SiteObj : Type u
+  Cover : Type u
+  Coeff : Type v
+  EffCoeff : Type (max u v)
+  ObstructionObject : Type u
+  LawUniverse : Type u
+  WitnessVariables : Type u
+  ObstructionIdeal : Type u
+  RepresentationFamily : Type u
+  Domain : Type u
+  CertRef : Domain -> Type v
+  SelectedMethod : Domain -> Type v
+  InScope : Domain -> Prop
+  OutOfScope : Domain -> Prop
+  Zero : Domain -> Prop
+  NonZero : Domain -> Prop
+  Undecided : Domain -> Prop
+  NotRunOrUnavailable : Domain -> Prop
+
+namespace MeasurementProfile
+
+/--
+VIII.R1: bounded measurement data for a selected element of the profile domain.
+
+Being measured includes scope, a selected method, and a certificate reference.
+The structural zero / nonzero interpretation is supplied separately by the
+verdict layer.
+-/
+structure Measured_M (M : MeasurementProfile.{u, v}) (alpha : M.Domain) where
+  inScope : M.InScope alpha
+  method : M.SelectedMethod alpha
+  certificate : M.CertRef alpha
+
+/-- VIII.R1: a measured element is in the profile domain scope. -/
+theorem measured_inScope {M : MeasurementProfile.{u, v}} {alpha : M.Domain}
+    (h : M.Measured_M alpha) : M.InScope alpha :=
+  h.inScope
+
+/-- VIII.R1: a measured element carries a selected method. -/
+def measured_method {M : MeasurementProfile.{u, v}} {alpha : M.Domain}
+    (h : M.Measured_M alpha) : M.SelectedMethod alpha :=
+  h.method
+
+/-- VIII.R1: a measured element carries a certificate reference. -/
+def measured_certificate {M : MeasurementProfile.{u, v}} {alpha : M.Domain}
+    (h : M.Measured_M alpha) : M.CertRef alpha :=
+  h.certificate
+
+end MeasurementProfile
+
+end Measurement
+end AAT.AG

--- a/Formal/AG/Measurement/Verdict.lean
+++ b/Formal/AG/Measurement/Verdict.lean
@@ -1,0 +1,87 @@
+import Formal.AG.Measurement.Profile
+
+noncomputable section
+
+namespace AAT.AG
+namespace Measurement
+
+universe u v
+
+/-!
+PRD-8 R1 / AC3-AC4 verdict discipline.
+
+`MeasurementVerdict` separates measured zero, measured nonzero, unmeasured,
+unknown, and not-computed states by constructors with profile-relative payloads.
+No theorem treats unmeasured as zero or unknown as nonzero.
+-/
+
+/-- VIII.Definition 3.1: profile-relative measurement verdicts. -/
+inductive MeasurementVerdict (M : MeasurementProfile.{u, v}) (alpha : M.Domain) where
+  | measured_zero :
+      M.InScope alpha -> M.Zero alpha -> M.CertRef alpha ->
+        MeasurementVerdict M alpha
+  | measured_nonzero :
+      M.InScope alpha -> M.NonZero alpha -> M.CertRef alpha ->
+        MeasurementVerdict M alpha
+  | unmeasured :
+      M.OutOfScope alpha -> MeasurementVerdict M alpha
+  | unknown :
+      M.InScope alpha -> M.Undecided alpha -> MeasurementVerdict M alpha
+  | not_computed :
+      M.NotRunOrUnavailable alpha -> MeasurementVerdict M alpha
+
+namespace MeasurementVerdict
+
+/-- VIII.Principle 3.2: an unmeasured verdict is not a measured-zero verdict. -/
+theorem unmeasured_ne_measured_zero {M : MeasurementProfile.{u, v}} {alpha : M.Domain}
+    (hout : M.OutOfScope alpha) (hin : M.InScope alpha)
+    (hz : M.Zero alpha) (cert : M.CertRef alpha) :
+    MeasurementVerdict.unmeasured (M := M) (alpha := alpha) hout ≠
+      MeasurementVerdict.measured_zero hin hz cert := by
+  intro h
+  cases h
+
+/-- VIII.Principle 3.2: an unknown verdict is not a measured-nonzero verdict. -/
+theorem unknown_ne_measured_nonzero {M : MeasurementProfile.{u, v}} {alpha : M.Domain}
+    (hin : M.InScope alpha) (hundecided : M.Undecided alpha)
+    (hnonzero : M.NonZero alpha) (cert : M.CertRef alpha) :
+    MeasurementVerdict.unknown (M := M) (alpha := alpha) hin hundecided ≠
+      MeasurementVerdict.measured_nonzero hin hnonzero cert := by
+  intro h
+  cases h
+
+/-- VIII.Principle 3.2: a not-computed verdict is not an unmeasured verdict. -/
+theorem not_computed_ne_unmeasured {M : MeasurementProfile.{u, v}} {alpha : M.Domain}
+    (hnot : M.NotRunOrUnavailable alpha) (hout : M.OutOfScope alpha) :
+    MeasurementVerdict.not_computed (M := M) (alpha := alpha) hnot ≠
+      MeasurementVerdict.unmeasured hout := by
+  intro h
+  cases h
+
+end MeasurementVerdict
+
+/--
+VIII.Definition 3.1: data attached to a selected verdict.
+
+The optional fields are deliberately payload channels, not implicit conversions
+between analytic readings and structural verdicts.
+-/
+structure VerdictData (M : MeasurementProfile.{u, v}) (alpha : M.Domain) where
+  verdict : MeasurementVerdict M alpha
+  method? : Option (M.SelectedMethod alpha)
+  cert? : Option (M.CertRef alpha)
+
+/-- VIII.Definition 3.3: structural verdicts remain separate from analytics. -/
+inductive StructuralVerdict (M : MeasurementProfile.{u, v}) (alpha : M.Domain) where
+  | fromMeasurement : MeasurementVerdict M alpha -> StructuralVerdict M alpha
+  | structuralBoundary : M.InScope alpha -> Prop -> StructuralVerdict M alpha
+
+/-- VIII.Definition 3.3: analytic readings are value readings, not verdicts. -/
+structure AnalyticReading (M : MeasurementProfile.{u, v}) (alpha : M.Domain) where
+  Value : Type v
+  value : Value
+  readingCertificate : Prop
+  readingCertificate_holds : readingCertificate
+
+end Measurement
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -4990,6 +4990,22 @@ unconditional / global conservativity theorem、R13 を越える additional gold
 measurement verdict / finite computability profile は
 PRD-8 の範囲であり、第VII部 bootstrap では導入しない。
 
+## AAT Algebraic-Geometric Part VIII Measurement Theory
+
+Tracking Issue: [#2210](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2210).
+Initial implementation Issue: [#2211](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2211).
+
+| 本文ラベル | Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- | --- |
+| `VIII.R0` | `Formal.AG.Measurement`, `Formal.AG.Measurement.Bootstrap`, `AAT.AG.Measurement.UsesAATSite`, `UsesArchitectureScheme`, `UsesCoverRelativeCechComplex`, `UsesRepairComparisonProfile`, `UsesArchitectureStratum`, `UsesAnalyticReadingContext`, `PrerequisiteStatus`, `PartVIIIDependencyStatus`, `currentDependencyStatus`, `current_site_available`, `current_lawAlgebra_available`, `current_cohomology_available`, `current_derived_available`, `current_singularityMonodromyStack_available`, `current_representationAnalysis_available` | `import` / `abbrev` / `inductive` / `structure` / `def` / `theorem` | 第VIII部 Measurement module を `Formal/AG.lean` から import し、PRD-2〜7 の成果物上に立ち上げる。先行依存は concrete Lean 型参照で確認し、dependency status accessor が現時点の availability を保持する。 | `defined only` / `proved accessor` |
+| `VIII.定義2.1` | `AAT.AG.Measurement.MeasurementProfile`, `MeasurementProfile.Measured_M`, `MeasurementProfile.measured_inScope`, `MeasurementProfile.measured_method`, `MeasurementProfile.measured_certificate` | `structure` / `def` / `theorem` | selected site、cover、coefficient、effective interface、obstruction object、law universe、witness variables、obstruction ideal、representation family、domain、certificate、method、scope、zero / nonzero / undecided / not-computed predicates を profile-relative fields として保持する。`Measured_M` は scope、selected method、certificate reference を持つ bounded measurement surface である。 | `defined only` / `proved accessor` |
+| `VIII.定義3.1 / 原則3.2 / 定義3.3` | `AAT.AG.Measurement.MeasurementVerdict`, `MeasurementVerdict.measured_zero`, `MeasurementVerdict.measured_nonzero`, `MeasurementVerdict.unmeasured`, `MeasurementVerdict.unknown`, `MeasurementVerdict.not_computed`, `MeasurementVerdict.unmeasured_ne_measured_zero`, `MeasurementVerdict.unknown_ne_measured_nonzero`, `MeasurementVerdict.not_computed_ne_unmeasured`, `VerdictData`, `StructuralVerdict`, `AnalyticReading` | `inductive` / `structure` / `theorem` | measured zero、measured nonzero、unmeasured、unknown、not-computed を依存 payload 付き constructor として分離し、constructor disjointness により `unmeasured != measured_zero`、`unknown != measured_nonzero`、`not_computed != unmeasured` を証明する。structural verdict と analytic reading は別型として定義し、analytic value から structural verdict への暗黙変換を置かない。 | `defined only` / `proved constructor disjointness` |
+
+Non-conclusions: この Part VIII 初期 surface は R0/R1 の entrypoint と verdict discipline だけを実装する。
+finite computability、Stanley-Reisner / Alexander dual repair、refactor invariance、Hodge decomposition、
+LawConflict measurement、support-localized transfer、measurement packet、AAT-GAGA comparison、finite golden
+examples は後続 Issue に残る。`Zero` と `NonZero` を論理補集合として扱う theorem は置かない。
+
 ## Reverse-Import Theorem Packages
 
 File: `Formal/Arch/Evolution/ReverseImportTheorems.lean`.

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -1239,6 +1239,34 @@ finite examples を `Formal/AG/Examples/RepresentationAnalysisPart7.lean` に追
 | `GeneralMeasureTheoryForObstructionMass` | `future proof obligation` / explicit non-goal for PRD-7 |
 | `CompleteMetricReflectionFromDistanceZero` | `future proof obligation` / explicit non-goal for PRD-7 |
 
+## AAT Algebraic-Geometric Part VIII Measurement Theory Lean status
+
+Tracking Issue: [#2210](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2210).
+Initial implementation Issue: [#2211](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2211).
+
+| 対象 | 現在の扱い | 残す境界 |
+| --- | --- | --- |
+| `VIII.R0` Formal/AG/Measurement entrypoint | `defined only` / `proved accessor`. `Formal/AG/Measurement.lean` が `Bootstrap.lean`、`Profile.lean`、`Verdict.lean` を束ね、`Formal/AG.lean` が `Formal.AG.Measurement` を import する。`UsesAATSite`、`UsesArchitectureScheme`、`UsesCoverRelativeCechComplex`、`UsesRepairComparisonProfile`、`UsesArchitectureStratum`、`UsesAnalyticReadingContext` が PRD-2〜7 の concrete Lean 型を参照する。`currentDependencyStatus` と accessor theorem 群は、現時点で先行依存が available であることを保持する。 | R2 以降の finite computability、square-free repair、Hodge、LawConflict measurement、support transfer、packet、AAT-GAGA、finite examples は後続 Issue に残る。 |
+| `VIII.定義2.1 / R1` Measurement Profile and Measured_M | `defined only` / `proved accessor`. `MeasurementProfile` が selected site、cover、coefficient、effective interface、obstruction object、law universe、witness variables、obstruction ideal、representation family、domain、certificate、method、scope、zero / nonzero / undecided / not-computed predicates を profile-relative fields として保持する。`MeasurementProfile.Measured_M` は `InScope`、selected method、certificate reference を持つ bounded predicate surface であり、`measured_inScope`、`measured_method`、`measured_certificate` が accessor として存在する。 | `Zero` と `NonZero` が補集合であることは仮定しない。R2 の finite effective interface と theorem 4.2 は未実装。 |
+| `VIII.定義3.1 / 原則3.2 / 定義3.3 / R1` Measurement Verdict discipline | `defined only` / `proved constructor disjointness`. `MeasurementVerdict` が `measured_zero`、`measured_nonzero`、`unmeasured`、`unknown`、`not_computed` を依存 payload 付き constructor として分離する。`VerdictData`、`StructuralVerdict`、`AnalyticReading` は structural verdict と analytic reading を別型として保持する。`MeasurementVerdict.unmeasured_ne_measured_zero`、`unknown_ne_measured_nonzero`、`not_computed_ne_unmeasured` が constructor disjointness を sorry なしで証明する。 | analytic value から structural verdict への暗黙変換は置かない。unmeasured を zero、unknown を nonzero として読む theorem は置かない。 |
+
+第VIII部 PRD-8 の証明対象ラベルは次の現在状態である。
+
+| 証明対象ラベル | Lean status |
+| --- | --- |
+| `VIII.R0` | `defined only` / `proved accessor` |
+| `VIII.定義2.1 / R1` Measurement Profile and `Measured_M` | `defined only` / `proved accessor` |
+| `VIII.定義3.1 / 原則3.2 / 定義3.3 / R1` Measurement Verdict discipline | `defined only` / `proved constructor disjointness` |
+| `VIII.定理4.2` Finite AAT Computability | `future proof obligation` |
+| `VIII.定理5.2` Stanley-Reisner / Alexander Dual Repair Theorem | `future proof obligation` |
+| `VIII.定理7.3` Refactor Invariance under Equivalence | `future proof obligation` |
+| `VIII.定理8.5` Finite Hodge Decomposition | `future proof obligation` |
+| `VIII.定理8.6 / 系8.7` Harmonic Debt Minimality / Essential Repair Lower Bound | `future proof obligation` |
+| `VIII.定理10.3` Support-Localized Transfer | `future proof obligation` |
+| `VIII.定理12.1` Finite Measurement Synthesis | `future proof obligation` |
+| `VIII.定理12.3` AAT-GAGA Finite Measurement Comparison | `future proof obligation` |
+| `GeneralPersistenceStability` / `GeneralZigzagStability` / `GeneralFlatBaseChangeForLawConflict` / `GeneralPerronFrobeniusHotspot` / `GeneralOptimalTransportTheory` / `AnalyticSmallnessImpliesLawfulness` | `future proof obligation` / explicit non-goal for PRD-8 |
+
 ## 現在の未解決カテゴリ
 
 | カテゴリ | 扱い |


### PR DESCRIPTION
## 概要

Closes #2211

PRD-8 Part VIII Measurement Theory の最初の Lean surface として、`Formal/AG/Measurement` を新設し、R0/R1 の entrypoint、measurement profile、verdict discipline を追加しました。

- PRD-2〜7 の predecessor entrypoint availability を `PartVIIIDependencyStatus` と accessor theorem で保持
- `MeasurementProfile` と `Measured_M` を profile-relative bounded surface として定義
- `MeasurementVerdict` の5 constructor と `VerdictData` / `StructuralVerdict` / `AnalyticReading` を追加
- `unmeasured != measured_zero`、`unknown != measured_nonzero`、`not_computed != unmeasured` を constructor disjointness として証明
- `proof_obligations.md` と `lean_theorem_index.md` に VIII.R0/R1 の status を登録

## 証明した定理

- `AAT.AG.Measurement.current_site_available`
- `AAT.AG.Measurement.current_lawAlgebra_available`
- `AAT.AG.Measurement.current_cohomology_available`
- `AAT.AG.Measurement.current_derived_available`
- `AAT.AG.Measurement.current_singularityMonodromyStack_available`
- `AAT.AG.Measurement.current_representationAnalysis_available`
- `AAT.AG.Measurement.MeasurementProfile.measured_inScope`
- `AAT.AG.Measurement.MeasurementVerdict.unmeasured_ne_measured_zero`
- `AAT.AG.Measurement.MeasurementVerdict.unknown_ne_measured_nonzero`
- `AAT.AG.Measurement.MeasurementVerdict.not_computed_ne_unmeasured`

## 編集したドキュメント

- `docs/aat/proof_obligations.md`
- `docs/aat/lean_theorem_index.md`

## 実施したテスト

- [x] `/Users/nakahata/.elan/bin/lake build Formal.AG.Measurement`
- [x] `/Users/nakahata/.elan/bin/lake build Formal.AG`
- [x] `/Users/nakahata/.elan/bin/lake build`
  - build は成功。既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ。
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
  - Lean code 対象 (`Formal/AG/Measurement`, `Formal/AG.lean`) は no match。
- [x] `$local-review`
  - AAT / Lean の4観点 multi-agent review で重大指摘なし。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
