### PR TITLE
ArchSig H2 coherence 計測を追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -18,6 +18,7 @@ const VERDICTS: [&str; 5] = [
     "not_computed",
 ];
 const MAX_SQUARE_FREE_WITNESS_VARIABLES: usize = 12;
+const MAX_COHERENCE_CONTEXTS: usize = 12;
 const MAX_TOR_WITNESS_VARIABLES: usize = 12;
 const MAX_LAPLACIAN_CELLS: usize = 16;
 const MAX_PERIOD_CYCLES: usize = 16;
@@ -263,6 +264,29 @@ pub fn build_foundation_measurement_packet_v1(
                 depends_on_assumptions,
                 reason: Some(measurement.reason),
             });
+        } else if evaluator == "ag.coherence-obstruction@1" {
+            validate_coherence_profile_v1(&profile)?;
+            let measurement = evaluate_coherence_obstruction_v1(normalized, &profile);
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
+            computed_invariants.extend(measurement.computed_invariants);
+            assumptions.extend(measurement.assumptions);
+            structural_verdict.push(AgStructuralVerdictV1 {
+                evaluator: evaluator.to_string(),
+                law: entry
+                    .law
+                    .clone()
+                    .unwrap_or_else(|| "ag.coherence-obstruction".to_string()),
+                verdict: measurement.verdict,
+                verdict_data: AgVerdictDataV1 {
+                    in_scope: true,
+                    zero: measurement.zero,
+                    non_zero: measurement.non_zero,
+                    method_status: measurement.method_status,
+                    cert_ref: measurement.cert_ref,
+                },
+                depends_on_assumptions,
+                reason: Some(measurement.reason),
+            });
         } else if evaluator == "ag.square-free-repair@1" {
             validate_square_free_profile_v1(&profile)?;
             let measurement = evaluate_square_free_repair_v1(normalized, &profile)?;
@@ -399,6 +423,42 @@ struct SquareFreeMeasurementV1 {
     reason: String,
     computed_invariants: Vec<Value>,
     assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct CoherenceMeasurementV1 {
+    verdict: String,
+    zero: bool,
+    non_zero: bool,
+    method_status: String,
+    cert_ref: Option<String>,
+    reason: String,
+    computed_invariants: Vec<Value>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct CoherenceFaceV1 {
+    face_id: String,
+    context_refs: Vec<String>,
+    edge_refs: Vec<String>,
+    shared_atom_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CoherenceTetrahedronV1 {
+    tetrahedron_id: String,
+    context_refs: Vec<String>,
+    face_refs: Vec<String>,
+    shared_atom_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CoherenceWitnessV1 {
+    atom_ref: String,
+    face_ref: String,
+    context_refs: Vec<String>,
+    source_refs: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -542,6 +602,296 @@ struct TransferGroundCostV1 {
     cost: f64,
     atom_ref: String,
     source_refs: Vec<String>,
+}
+
+fn evaluate_coherence_obstruction_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> CoherenceMeasurementV1 {
+    let selected_contexts = selected_cover_contexts(normalized, profile);
+    let selected_context_set = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    let mut assumptions = coherence_assumptions(profile, "checked");
+    if selected_contexts.len() > MAX_COHERENCE_CONTEXTS {
+        assumptions.push(AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/10.1-selected-cover-budget".to_string(),
+            assumption: format!(
+                "selected cover has at most {MAX_COHERENCE_CONTEXTS} contexts for finite H2 coherence enumeration"
+            ),
+            status: "violated".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        });
+        return CoherenceMeasurementV1 {
+            verdict: "not_computed".to_string(),
+            zero: false,
+            non_zero: false,
+            method_status: "selected_cover_too_large".to_string(),
+            cert_ref: None,
+            reason: format!(
+                "selected cover has {} contexts; ag.coherence-obstruction@1 enumerates at most {MAX_COHERENCE_CONTEXTS}",
+                selected_contexts.len()
+            ),
+            computed_invariants: vec![coherence_invariant_json(
+                profile,
+                "not_computed",
+                "selected_cover_too_large",
+                &selected_contexts,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                0,
+                0,
+                0,
+                0,
+                false,
+                Vec::new(),
+            )],
+            assumptions,
+        };
+    }
+    let edges = cech_edges(normalized, &selected_contexts);
+    let faces = coherence_faces(normalized, &selected_contexts, &edges, &profile.cover_ref);
+    let tetrahedra = coherence_tetrahedra(normalized, &selected_contexts, &faces);
+    let witness_atoms = coherence_witness_atoms(normalized, &selected_context_set);
+
+    if profile.coefficient != "F2" {
+        assumptions = coherence_assumptions(profile, "violated");
+        return CoherenceMeasurementV1 {
+            verdict: "not_computed".to_string(),
+            zero: false,
+            non_zero: false,
+            method_status: "banding_violated".to_string(),
+            cert_ref: None,
+            reason: "selected coefficient is outside the banded abelian F2 coherence vocabulary"
+                .to_string(),
+            computed_invariants: vec![coherence_invariant_json(
+                profile,
+                "not_computed",
+                "banding_violated",
+                &selected_contexts,
+                &edges,
+                &faces,
+                &tetrahedra,
+                &[],
+                &[],
+                0,
+                0,
+                0,
+                0,
+                false,
+                Vec::new(),
+            )],
+            assumptions,
+        };
+    }
+
+    if faces.is_empty() {
+        assumptions.push(AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/10.1-empty-selected-2-skeleton".to_string(),
+            assumption: "selected cover supplies a non-empty triple-overlap 2-skeleton".to_string(),
+            status: "violated".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        });
+        return CoherenceMeasurementV1 {
+            verdict: "not_computed".to_string(),
+            zero: false,
+            non_zero: false,
+            method_status: "empty_selected_2_skeleton".to_string(),
+            cert_ref: None,
+            reason:
+                "selected cover has no triple-overlap 2-skeleton for ag.coherence-obstruction@1"
+                    .to_string(),
+            computed_invariants: vec![coherence_invariant_json(
+                profile,
+                "not_computed",
+                "empty_selected_2_skeleton",
+                &selected_contexts,
+                &edges,
+                &faces,
+                &tetrahedra,
+                &[],
+                &[],
+                0,
+                0,
+                0,
+                0,
+                false,
+                Vec::new(),
+            )],
+            assumptions,
+        };
+    }
+
+    if faces.iter().any(|face| face.edge_refs.len() != 3) {
+        assumptions.push(AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/10.1-incomplete-selected-2-skeleton".to_string(),
+            assumption: "selected triple-overlap faces have all three restriction boundary edges"
+                .to_string(),
+            status: "violated".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        });
+        return CoherenceMeasurementV1 {
+            verdict: "not_computed".to_string(),
+            zero: false,
+            non_zero: false,
+            method_status: "incomplete_selected_2_skeleton".to_string(),
+            cert_ref: None,
+            reason: "selected triple-overlap 2-skeleton is missing a boundary restriction edge"
+                .to_string(),
+            computed_invariants: vec![coherence_invariant_json(
+                profile,
+                "not_computed",
+                "incomplete_selected_2_skeleton",
+                &selected_contexts,
+                &edges,
+                &faces,
+                &tetrahedra,
+                &[],
+                &[],
+                0,
+                0,
+                0,
+                0,
+                false,
+                Vec::new(),
+            )],
+            assumptions,
+        };
+    }
+
+    if witness_atoms.is_empty() {
+        return CoherenceMeasurementV1 {
+            verdict: "unmeasured".to_string(),
+            zero: false,
+            non_zero: false,
+            method_status: "coherence_witness_absent".to_string(),
+            cert_ref: None,
+            reason: "no coherence witness atom is supplied; H2 coherence remains silent"
+                .to_string(),
+            computed_invariants: vec![coherence_invariant_json(
+                profile,
+                "unmeasured",
+                "coherence_witness_absent",
+                &selected_contexts,
+                &edges,
+                &faces,
+                &tetrahedra,
+                &[],
+                &[],
+                0,
+                0,
+                0,
+                0,
+                false,
+                Vec::new(),
+            )],
+            assumptions,
+        };
+    }
+
+    let witnesses = coherence_witnesses_for_faces(&witness_atoms, &faces);
+    let h = faces
+        .iter()
+        .map(|face| {
+            (witnesses
+                .iter()
+                .filter(|witness| witness.face_ref == face.face_id)
+                .count()
+                % 2) as u8
+        })
+        .collect::<Vec<_>>();
+    let d2_rows = coherence_d2_rows(&faces, &tetrahedra);
+    let d2_h = d2_rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .zip(h.iter())
+                .fold(0u8, |acc, (entry, value)| acc ^ (entry & value))
+        })
+        .collect::<Vec<_>>();
+    let cocycle_gate_passed = d2_h.iter().all(|value| *value == 0);
+    let d1_rows = coherence_d1_rows(&edges, &faces);
+    let rank_d1 = matrix_rank_f2(d1_rows.clone());
+    let rank_d2 = matrix_rank_f2(d2_rows.clone());
+    let rank_ker_d2 = faces.len().saturating_sub(rank_d2);
+    let h2_dimension = rank_ker_d2.saturating_sub(rank_d1);
+    let selected_representative = cocycle_gate_passed
+        .then(|| {
+            if vector_in_span_f2(&d1_rows, &h) {
+                h2_representative_f2(&d2_rows, &d1_rows, faces.len()).unwrap_or_default()
+            } else {
+                h.clone()
+            }
+        })
+        .unwrap_or_default();
+    let representative = coherence_representative_json(&selected_representative, &faces);
+
+    let (verdict, zero, non_zero, method_status, reason) = if !cocycle_gate_passed {
+        (
+            "not_computed".to_string(),
+            false,
+            false,
+            "not_2_cocycle".to_string(),
+            "coherence 2-cochain fails the d2 h = 0 cocycle gate; im d1 membership is not evaluated".to_string(),
+        )
+    } else if h2_dimension == 0 {
+        (
+            "measured_zero".to_string(),
+            true,
+            false,
+            "finite_f2_h2_coherence_computed".to_string(),
+            "finite F2 H2 coherence quotient is zero on the selected cover".to_string(),
+        )
+    } else {
+        (
+            "measured_nonzero".to_string(),
+            false,
+            true,
+            "finite_f2_h2_coherence_computed".to_string(),
+            "finite F2 H2 coherence quotient is nonzero on the selected cover".to_string(),
+        )
+    };
+    let cert_ref = (verdict != "not_computed").then(|| {
+        format!(
+            "computedInvariants/coherence-obstruction:{}",
+            profile.profile_id
+        )
+    });
+
+    CoherenceMeasurementV1 {
+        verdict: verdict.to_string(),
+        zero,
+        non_zero,
+        method_status: method_status.to_string(),
+        cert_ref,
+        reason,
+        computed_invariants: vec![coherence_invariant_json(
+            profile,
+            if verdict == "not_computed" {
+                "not_computed"
+            } else {
+                "computed"
+            },
+            &method_status,
+            &selected_contexts,
+            &edges,
+            &faces,
+            &tetrahedra,
+            &witnesses,
+            &h,
+            rank_d1,
+            rank_ker_d2,
+            h2_dimension,
+            d2_rows.len(),
+            cocycle_gate_passed,
+            representative,
+        )],
+        assumptions,
+    }
 }
 
 fn evaluate_square_free_repair_v1(
@@ -4089,6 +4439,54 @@ fn validate_cech_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String
     Ok(())
 }
 
+fn validate_coherence_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "finite-linear-algebra@1",
+        ),
+        (
+            "resolutionSelector",
+            profile.resolution_selector.as_str(),
+            "h2-coherence@1",
+        ),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "rank-zero@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "rank-positive@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "finite-certificate@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.coherence-obstruction@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if !profile
+        .witness_family
+        .iter()
+        .any(|witness| witness.law == "ag.coherence-obstruction")
+    {
+        return Err(format!(
+            "ag.coherence-obstruction@1 requires MeasurementProfile {} witnessFamily law ag.coherence-obstruction",
+            profile.profile_id
+        ));
+    }
+    Ok(())
+}
+
 fn validate_square_free_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
     let expected = [
         ("coefficient", profile.coefficient.as_str(), "F2"),
@@ -5047,6 +5445,47 @@ fn transfer_assumptions(
     ]
 }
 
+fn coherence_assumptions(
+    profile: &MeasurementProfileV1,
+    coefficient_status: &str,
+) -> Vec<AgAssumptionLedgerEntryV1> {
+    vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/10.1".to_string(),
+            assumption: "banded abelian F2 coefficient object for selected H2 coherence"
+                .to_string(),
+            status: coefficient_status.to_string(),
+            checked_by: (coefficient_status == "checked").then(|| {
+                format!(
+                    "measurement-profile:{}.coefficient={}",
+                    profile.profile_id, profile.coefficient
+                )
+            }),
+            assumed_by: (coefficient_status != "checked")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/10.1".to_string(),
+            assumption: "selected cover supplies a finite triple-overlap 2-skeleton".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some(format!(
+                "measurement-profile:{}.coverRef",
+                profile.profile_id
+            )),
+            assumed_by: None,
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/B.8.2".to_string(),
+            assumption:
+                "Leray / acyclicity comparison from selected Cech complex to sheaf cohomology"
+                    .to_string(),
+            status: "assumed".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+    ]
+}
+
 fn tor_common_ambient(
     normalized: &NormalizedArchMapV2,
     selected_contexts: &BTreeSet<String>,
@@ -5820,6 +6259,436 @@ fn cech_edges(normalized: &NormalizedArchMapV2, selected_contexts: &[String]) ->
     }
     edges.sort_by(|left, right| left.edge_id.cmp(&right.edge_id));
     edges
+}
+
+fn coherence_faces(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+    cover_ref: &str,
+) -> Vec<CoherenceFaceV1> {
+    let selected = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    let mut edge_by_pair = BTreeMap::new();
+    for edge in edges {
+        edge_by_pair.insert(
+            sorted_pair(&edge.source_context, &edge.target_context),
+            edge.edge_id.clone(),
+        );
+    }
+    let atom_refs_by_context = normalized
+        .contexts
+        .iter()
+        .filter(|context| selected.contains(&context.normalized_context_id))
+        .map(|context| {
+            (
+                context.normalized_context_id.clone(),
+                context.atom_ids.iter().cloned().collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut faces = Vec::new();
+    for left in 0..selected_contexts.len() {
+        for middle in left + 1..selected_contexts.len() {
+            for right in middle + 1..selected_contexts.len() {
+                let contexts = vec![
+                    selected_contexts[left].clone(),
+                    selected_contexts[middle].clone(),
+                    selected_contexts[right].clone(),
+                ];
+                let Some(left_atoms) = atom_refs_by_context.get(&contexts[0]) else {
+                    continue;
+                };
+                let Some(middle_atoms) = atom_refs_by_context.get(&contexts[1]) else {
+                    continue;
+                };
+                let Some(right_atoms) = atom_refs_by_context.get(&contexts[2]) else {
+                    continue;
+                };
+                let shared_atom_refs = left_atoms
+                    .intersection(middle_atoms)
+                    .cloned()
+                    .collect::<BTreeSet<_>>()
+                    .intersection(right_atoms)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if shared_atom_refs.is_empty() {
+                    continue;
+                }
+                let edge_refs = [
+                    edge_by_pair.get(&sorted_pair(&contexts[0], &contexts[1])),
+                    edge_by_pair.get(&sorted_pair(&contexts[0], &contexts[2])),
+                    edge_by_pair.get(&sorted_pair(&contexts[1], &contexts[2])),
+                ]
+                .into_iter()
+                .flatten()
+                .cloned()
+                .collect::<Vec<_>>();
+                faces.push(CoherenceFaceV1 {
+                    face_id: format!(
+                        "coherence-face:{}:{}:{}:{}",
+                        cover_ref, contexts[0], contexts[1], contexts[2]
+                    ),
+                    context_refs: contexts,
+                    edge_refs,
+                    shared_atom_refs,
+                });
+            }
+        }
+    }
+    faces.sort_by(|left, right| left.face_id.cmp(&right.face_id));
+    faces
+}
+
+fn coherence_tetrahedra(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &[String],
+    faces: &[CoherenceFaceV1],
+) -> Vec<CoherenceTetrahedronV1> {
+    let face_by_contexts = faces
+        .iter()
+        .map(|face| {
+            (
+                face.context_refs.iter().cloned().collect::<BTreeSet<_>>(),
+                face.face_id.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let selected = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    let atom_refs_by_context = normalized
+        .contexts
+        .iter()
+        .filter(|context| selected.contains(&context.normalized_context_id))
+        .map(|context| {
+            (
+                context.normalized_context_id.clone(),
+                context.atom_ids.iter().cloned().collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut tetrahedra = Vec::new();
+    for first in 0..selected_contexts.len() {
+        for second in first + 1..selected_contexts.len() {
+            for third in second + 1..selected_contexts.len() {
+                for fourth in third + 1..selected_contexts.len() {
+                    let contexts = vec![
+                        selected_contexts[first].clone(),
+                        selected_contexts[second].clone(),
+                        selected_contexts[third].clone(),
+                        selected_contexts[fourth].clone(),
+                    ];
+                    let Some(shared_atom_refs) =
+                        shared_atoms_for_contexts(&atom_refs_by_context, &contexts)
+                    else {
+                        continue;
+                    };
+                    if shared_atom_refs.is_empty() {
+                        continue;
+                    }
+                    let mut face_refs = Vec::new();
+                    for omitted in 0..contexts.len() {
+                        let face_contexts = contexts
+                            .iter()
+                            .enumerate()
+                            .filter(|(index, _)| *index != omitted)
+                            .map(|(_, context)| context.clone())
+                            .collect::<BTreeSet<_>>();
+                        let Some(face_ref) = face_by_contexts.get(&face_contexts) else {
+                            face_refs.clear();
+                            break;
+                        };
+                        face_refs.push(face_ref.clone());
+                    }
+                    if face_refs.len() != 4 {
+                        continue;
+                    }
+                    tetrahedra.push(CoherenceTetrahedronV1 {
+                        tetrahedron_id: format!(
+                            "coherence-tetrahedron:{}:{}:{}:{}",
+                            contexts[0], contexts[1], contexts[2], contexts[3]
+                        ),
+                        context_refs: contexts,
+                        face_refs,
+                        shared_atom_refs,
+                    });
+                }
+            }
+        }
+    }
+    tetrahedra.sort_by(|left, right| left.tetrahedron_id.cmp(&right.tetrahedron_id));
+    tetrahedra
+}
+
+fn shared_atoms_for_contexts(
+    atom_refs_by_context: &BTreeMap<String, BTreeSet<String>>,
+    contexts: &[String],
+) -> Option<Vec<String>> {
+    let mut iter = contexts.iter();
+    let first = iter.next()?;
+    let mut shared = atom_refs_by_context.get(first)?.clone();
+    for context in iter {
+        let atoms = atom_refs_by_context.get(context)?;
+        shared = shared.intersection(atoms).cloned().collect();
+    }
+    Some(shared.into_iter().collect())
+}
+
+fn coherence_witness_atoms<'a>(
+    normalized: &'a NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+) -> Vec<&'a NormalizedAtomV2> {
+    normalized
+        .atoms
+        .iter()
+        .filter(|atom| atom.axis == "coherence")
+        .filter(|atom| {
+            matches!(
+                atom.predicate.as_str(),
+                "tripleMismatch" | "coherenceMismatch" | "h2Mismatch"
+            )
+        })
+        .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
+        .collect()
+}
+
+fn coherence_witnesses_for_faces(
+    witness_atoms: &[&NormalizedAtomV2],
+    faces: &[CoherenceFaceV1],
+) -> Vec<CoherenceWitnessV1> {
+    let mut witnesses = Vec::new();
+    for atom in witness_atoms {
+        for face in faces {
+            if coherence_atom_marks_face(atom, face) {
+                witnesses.push(CoherenceWitnessV1 {
+                    atom_ref: atom.normalized_atom_id.clone(),
+                    face_ref: face.face_id.clone(),
+                    context_refs: face.context_refs.clone(),
+                    source_refs: atom.source_refs.clone(),
+                });
+            }
+        }
+    }
+    witnesses.sort_by(|left, right| {
+        left.face_ref
+            .cmp(&right.face_ref)
+            .then_with(|| left.atom_ref.cmp(&right.atom_ref))
+    });
+    witnesses
+}
+
+fn coherence_atom_marks_face(atom: &NormalizedAtomV2, face: &CoherenceFaceV1) -> bool {
+    let mut refs = atom.source_refs.iter().cloned().collect::<BTreeSet<_>>();
+    refs.extend(atom.context_memberships.iter().cloned());
+    refs.insert(atom.subject.clone());
+    if let Some(object) = atom.object.as_deref() {
+        refs.extend(parse_csv_values(object));
+    }
+    refs.contains(&face.face_id)
+        || face.context_refs.iter().all(|context| {
+            refs.contains(context)
+                || refs.contains(unprefixed(context))
+                || refs.contains(&format!("ctx:{}", unprefixed(context)))
+        })
+}
+
+fn coherence_d1_rows(edges: &[CechEdgeV1], faces: &[CoherenceFaceV1]) -> Vec<Vec<u8>> {
+    let edge_index = edges
+        .iter()
+        .enumerate()
+        .map(|(index, edge)| (edge.edge_id.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let mut rows = vec![vec![0u8; edges.len()]; faces.len()];
+    for (row, face) in faces.iter().enumerate() {
+        for edge_ref in &face.edge_refs {
+            if let Some(column) = edge_index.get(edge_ref) {
+                rows[row][*column] ^= 1;
+            }
+        }
+    }
+    rows
+}
+
+fn coherence_d2_rows(
+    faces: &[CoherenceFaceV1],
+    tetrahedra: &[CoherenceTetrahedronV1],
+) -> Vec<Vec<u8>> {
+    let face_index = faces
+        .iter()
+        .enumerate()
+        .map(|(index, face)| (face.face_id.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let mut rows = vec![vec![0u8; faces.len()]; tetrahedra.len()];
+    for (row, tetrahedron) in tetrahedra.iter().enumerate() {
+        for face_ref in &tetrahedron.face_refs {
+            if let Some(column) = face_index.get(face_ref) {
+                rows[row][*column] ^= 1;
+            }
+        }
+    }
+    rows
+}
+
+fn vector_in_span_f2(rows: &[Vec<u8>], vector: &[u8]) -> bool {
+    if rows.len() != vector.len() {
+        return false;
+    }
+    if vector.iter().all(|value| *value == 0) {
+        return true;
+    }
+    let rank = matrix_rank_f2(rows.to_vec());
+    let mut augmented = rows.to_vec();
+    for (row, value) in augmented.iter_mut().zip(vector.iter()) {
+        row.push(*value);
+    }
+    matrix_rank_f2(augmented) == rank
+}
+
+fn h2_representative_f2(
+    d2_rows: &[Vec<u8>],
+    d1_rows: &[Vec<u8>],
+    face_count: usize,
+) -> Option<Vec<u8>> {
+    nullspace_basis_f2(d2_rows, face_count)
+        .into_iter()
+        .find(|candidate| !vector_in_span_f2(d1_rows, candidate))
+}
+
+fn nullspace_basis_f2(rows: &[Vec<u8>], columns: usize) -> Vec<Vec<u8>> {
+    let mut rref = rows
+        .iter()
+        .map(|row| {
+            let mut normalized = vec![0u8; columns];
+            for (column, value) in row.iter().take(columns).enumerate() {
+                normalized[column] = value & 1;
+            }
+            normalized
+        })
+        .collect::<Vec<_>>();
+    let mut pivot_columns = Vec::new();
+    let mut pivot_row = 0usize;
+
+    for column in 0..columns {
+        let Some(row) = (pivot_row..rref.len()).find(|row| rref[*row][column] == 1) else {
+            continue;
+        };
+        rref.swap(pivot_row, row);
+        for row in 0..rref.len() {
+            if row != pivot_row && rref[row][column] == 1 {
+                for entry in column..columns {
+                    rref[row][entry] ^= rref[pivot_row][entry];
+                }
+            }
+        }
+        pivot_columns.push(column);
+        pivot_row += 1;
+        if pivot_row == rref.len() {
+            break;
+        }
+    }
+
+    let pivot_set = pivot_columns.iter().copied().collect::<BTreeSet<_>>();
+    (0..columns)
+        .filter(|column| !pivot_set.contains(column))
+        .map(|free_column| {
+            let mut vector = vec![0u8; columns];
+            vector[free_column] = 1;
+            for (row, pivot_column) in pivot_columns.iter().enumerate() {
+                if rref[row][free_column] == 1 {
+                    vector[*pivot_column] = 1;
+                }
+            }
+            vector
+        })
+        .collect()
+}
+
+fn coherence_representative_json(cochain: &[u8], faces: &[CoherenceFaceV1]) -> Vec<Value> {
+    faces
+        .iter()
+        .zip(cochain.iter())
+        .filter(|(_, value)| **value == 1)
+        .map(|(face, _)| {
+            json!({
+                "faceRef": face.face_id,
+                "contextRefs": face.context_refs,
+                "sharedAtomRefs": face.shared_atom_refs
+            })
+        })
+        .collect::<Vec<_>>()
+}
+
+fn sorted_pair(left: &str, right: &str) -> (String, String) {
+    if left <= right {
+        (left.to_string(), right.to_string())
+    } else {
+        (right.to_string(), left.to_string())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn coherence_invariant_json(
+    profile: &MeasurementProfileV1,
+    status: &str,
+    method_status: &str,
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+    faces: &[CoherenceFaceV1],
+    tetrahedra: &[CoherenceTetrahedronV1],
+    witnesses: &[CoherenceWitnessV1],
+    cochain: &[u8],
+    rank_d1: usize,
+    rank_ker_d2: usize,
+    h2_dimension: usize,
+    d2_row_count: usize,
+    cocycle_gate_passed: bool,
+    representative: Vec<Value>,
+) -> Value {
+    json!({
+        "invariantId": format!("coherence-obstruction:{}", profile.profile_id),
+        "evaluator": "ag.coherence-obstruction@1",
+        "method": "finite-f2-h2-coherence@1",
+        "status": status,
+        "methodStatus": method_status,
+        "claimScope": "selected-cover banded abelian F2 H2 coherence calculation",
+        "selectedCoverRef": profile.cover_ref,
+        "coefficient": profile.coefficient,
+        "cohomologyQuotient": "ker d^2/im d^1",
+        "contextCount": selected_contexts.len(),
+        "edgeCount": edges.len(),
+        "faceCount": faces.len(),
+        "tetrahedronCount": tetrahedra.len(),
+        "rankD1": rank_d1,
+        "rankKerD2": rank_ker_d2,
+        "h2Dimension": h2_dimension,
+        "d2RowCount": d2_row_count,
+        "cocycleGate": {
+            "condition": "d2 h = 0",
+            "passed": cocycle_gate_passed
+        },
+        "faces": faces.iter().enumerate().map(|(index, face)| json!({
+            "faceId": face.face_id,
+            "contextRefs": face.context_refs,
+            "edgeRefs": face.edge_refs,
+            "sharedAtomRefs": face.shared_atom_refs,
+            "cochainValue": cochain.get(index).copied()
+        })).collect::<Vec<_>>(),
+        "tetrahedra": tetrahedra.iter().map(|tetrahedron| json!({
+            "tetrahedronId": tetrahedron.tetrahedron_id,
+            "contextRefs": tetrahedron.context_refs,
+            "faceRefs": tetrahedron.face_refs,
+            "sharedAtomRefs": tetrahedron.shared_atom_refs
+        })).collect::<Vec<_>>(),
+        "coherenceWitnesses": witnesses.iter().map(|witness| json!({
+            "atomRef": witness.atom_ref,
+            "faceRef": witness.face_ref,
+            "contextRefs": witness.context_refs,
+            "sourceRefs": witness.source_refs
+        })).collect::<Vec<_>>(),
+        "representative": representative,
+        "nonConclusions": [
+            "This is cover-relative H2 over banded abelian F2, not a non-abelian gerbe verdict.",
+            "H1 Cech verdict rows are not changed by this evaluator."
+        ]
+    })
 }
 
 fn cover_nerve_projection_v1(

--- a/tools/archsig/src/law_policy/registry.rs
+++ b/tools/archsig/src/law_policy/registry.rs
@@ -262,6 +262,7 @@ fn evaluator_manifests() -> Vec<LawEvaluatorManifestV1> {
     ];
     manifests.extend([
         ag_manifest("ag.cech-obstruction@1", "ag.cech-obstruction"),
+        ag_coherence_manifest(),
         ag_manifest("ag.square-free-repair@1", "ag.square-free-repair"),
         ag_manifest("ag.law-conflict-tor@1", "ag.law-conflict-tor"),
         ag_manifest("ag.sheaf-laplacian@1", "ag.sheaf-laplacian"),
@@ -269,6 +270,37 @@ fn evaluator_manifests() -> Vec<LawEvaluatorManifestV1> {
         ag_manifest("ag.support-transfer@1", "ag.support-transfer"),
     ]);
     manifests
+}
+
+fn ag_coherence_manifest() -> LawEvaluatorManifestV1 {
+    LawEvaluatorManifestV1 {
+        evaluator_id: "ag.coherence-obstruction@1".to_string(),
+        law_id: "ag.coherence-obstruction".to_string(),
+        required_atom_constructors: Vec::new(),
+        required_predicates: vec!["coherence.tripleMismatch".to_string()],
+        required_molecule_condition:
+            "archmap/v2 contexts and selected cover triple-overlap 2-skeleton".to_string(),
+        scope_filtering_rule:
+            "selected finite poset site and cover from MeasurementProfile".to_string(),
+        missing_blocker_rule:
+            "missing coherence witness atoms are unmeasured; incomplete 2-skeleton is not_computed"
+                .to_string(),
+        pass_criteria:
+            "selected-cover banded abelian F2 H2 coherence cocycle is a coboundary"
+                .to_string(),
+        violation_criteria:
+            "selected-cover banded abelian F2 H2 coherence cocycle has a representative outside im d1"
+                .to_string(),
+        typed_result_schema: "archsig-measurement-packet/v1".to_string(),
+        distance_contribution: "structural H2 coherence verdict remains cover-relative and F2-banded"
+            .to_string(),
+        summary_output_refs: vec!["/structuralVerdict".to_string()],
+        detail_output_refs: vec![
+            "/assumptions".to_string(),
+            "/computedInvariants".to_string(),
+        ],
+        negative_fixtures: vec!["ag_coherence_obstruction_negative.json".to_string()],
+    }
 }
 
 fn ag_manifest(evaluator_id: &str, law_id: &str) -> LawEvaluatorManifestV1 {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -809,6 +809,436 @@ fn cli_analyze_v2_cover_nerve_faces_require_packet_triple_overlap_support() {
 }
 
 #[test]
+fn cli_analyze_v2_coherence_obstruction_measures_h2_nonzero_with_representative() {
+    let out_dir = temp_dir("ag-measurement-coherence-h2-nonzero");
+    let archmap_path = out_dir.join("archmap_coherence_h2_nonzero.json");
+    let policy_path = out_dir.join("law_policy_coherence.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&coherence_boundary_archmap(true)).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&coherence_policy("F2", true)).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        policy_path.to_str().expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    let cech = packet["structuralVerdict"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["evaluator"] == "ag.cech-obstruction@1")
+        .expect("H1 row is present");
+    assert_eq!(
+        cech["verdict"], "measured_zero",
+        "H2 evaluator must not change the coexisting H1 verdict"
+    );
+    let coherence = packet["structuralVerdict"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["evaluator"] == "ag.coherence-obstruction@1")
+        .expect("H2 coherence row is present");
+    assert_eq!(coherence["verdict"], "measured_nonzero");
+    assert_eq!(coherence["verdictData"]["nonZero"], true);
+    assert_eq!(
+        coherence["verdictData"]["methodStatus"],
+        "finite_f2_h2_coherence_computed"
+    );
+    let invariant = invariant_by_id(&packet, "coherence-obstruction:profile:ag-coherence@1");
+    assert_eq!(invariant["cohomologyQuotient"], "ker d^2/im d^1");
+    assert!(
+        !serde_json::to_string(invariant)
+            .expect("invariant serializes")
+            .contains("ker d^1/im d^0"),
+        "H2 invariant prose must not use the H1 quotient"
+    );
+    assert_eq!(invariant["cocycleGate"]["passed"], true);
+    assert_eq!(
+        invariant["representative"]
+            .as_array()
+            .expect("representative is array")
+            .len(),
+        1,
+        "tetrahedron-boundary fixture carries a concrete H2 representative"
+    );
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["assumption"]
+                == "banded abelian F2 coefficient object for selected H2 coherence"
+                && entry["status"] == "checked"),
+        "coefficient=F2 must be checked in the CBI ledger"
+    );
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["assumption"]
+                == "Leray / acyclicity comparison from selected Cech complex to sheaf cohomology"
+                && entry["status"] == "assumed"),
+        "Leray comparison must stay assumed"
+    );
+
+    let zero_cochain_dir = temp_dir("ag-measurement-coherence-h2-nonzero-zero-cochain");
+    let zero_cochain_archmap_path = zero_cochain_dir.join("archmap_coherence_h2_zero_cochain.json");
+    let zero_cochain_policy_path = zero_cochain_dir.join("law_policy_coherence.json");
+    fs::write(
+        &zero_cochain_archmap_path,
+        serde_json::to_vec_pretty(&coherence_boundary_zero_cochain_archmap())
+            .expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+    fs::write(
+        &zero_cochain_policy_path,
+        serde_json::to_vec_pretty(&coherence_policy("F2", true)).expect("policy serializes"),
+    )
+    .expect("policy fixture can be written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        zero_cochain_archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        zero_cochain_policy_path.to_str().expect("path is utf-8"),
+        "--out-dir",
+        zero_cochain_dir.to_str().expect("path is utf-8"),
+    ]);
+    let zero_cochain_packet = read_json(&zero_cochain_dir.join("archsig-measurement-packet.json"));
+    let zero_cochain_row = coherence_row(&zero_cochain_packet);
+    assert_eq!(
+        zero_cochain_row["verdict"], "measured_nonzero",
+        "H2 quotient must be nonzero even when the supplied witness cochain is zero"
+    );
+    let zero_cochain_invariant = invariant_by_id(
+        &zero_cochain_packet,
+        "coherence-obstruction:profile:ag-coherence@1",
+    );
+    assert_eq!(zero_cochain_invariant["h2Dimension"], Value::from(1));
+    assert!(
+        !zero_cochain_invariant["representative"]
+            .as_array()
+            .expect("representative is array")
+            .is_empty(),
+        "nonzero H2 quotient must surface a representative independent of the zero witness cochain"
+    );
+}
+
+#[test]
+fn cli_analyze_v2_coherence_obstruction_distinguishes_zero_silence_and_banding_boundary() {
+    let root_out = temp_dir("ag-measurement-coherence-statuses");
+
+    let zero_dir = root_out.join("zero");
+    fs::create_dir_all(&zero_dir).expect("zero dir exists");
+    let zero_archmap = zero_dir.join("archmap.json");
+    let zero_policy = zero_dir.join("law_policy.json");
+    fs::write(
+        &zero_archmap,
+        serde_json::to_vec_pretty(&coherence_triangle_archmap(true)).expect("archmap serializes"),
+    )
+    .expect("zero archmap is written");
+    fs::write(
+        &zero_policy,
+        serde_json::to_vec_pretty(&coherence_policy("F2", false)).expect("policy serializes"),
+    )
+    .expect("zero policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        zero_archmap.to_str().unwrap(),
+        "--law-policy",
+        zero_policy.to_str().unwrap(),
+        "--out-dir",
+        zero_dir.to_str().unwrap(),
+    ]);
+    let zero_packet = read_json(&zero_dir.join("archsig-measurement-packet.json"));
+    let zero_row = coherence_row(&zero_packet);
+    assert_eq!(zero_row["verdict"], "measured_zero");
+    assert_eq!(zero_row["verdictData"]["zero"], true);
+    let zero_invariant =
+        invariant_by_id(&zero_packet, "coherence-obstruction:profile:ag-coherence@1");
+    assert_eq!(zero_invariant["cocycleGate"]["passed"], true);
+
+    let unmeasured_dir = root_out.join("unmeasured");
+    fs::create_dir_all(&unmeasured_dir).expect("unmeasured dir exists");
+    let unmeasured_archmap = unmeasured_dir.join("archmap.json");
+    let unmeasured_policy = unmeasured_dir.join("law_policy.json");
+    fs::write(
+        &unmeasured_archmap,
+        serde_json::to_vec_pretty(&coherence_triangle_archmap(false)).expect("archmap serializes"),
+    )
+    .expect("unmeasured archmap is written");
+    fs::write(
+        &unmeasured_policy,
+        serde_json::to_vec_pretty(&coherence_policy("F2", false)).expect("policy serializes"),
+    )
+    .expect("unmeasured policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        unmeasured_archmap.to_str().unwrap(),
+        "--law-policy",
+        unmeasured_policy.to_str().unwrap(),
+        "--out-dir",
+        unmeasured_dir.to_str().unwrap(),
+    ]);
+    let unmeasured_packet = read_json(&unmeasured_dir.join("archsig-measurement-packet.json"));
+    let unmeasured_row = coherence_row(&unmeasured_packet);
+    assert_eq!(unmeasured_row["verdict"], "unmeasured");
+    assert_eq!(
+        unmeasured_row["verdictData"]["methodStatus"],
+        "coherence_witness_absent"
+    );
+
+    let empty_dir = root_out.join("empty");
+    fs::create_dir_all(&empty_dir).expect("empty dir exists");
+    let empty_archmap = empty_dir.join("archmap.json");
+    let empty_policy = empty_dir.join("law_policy.json");
+    fs::write(
+        &empty_archmap,
+        serde_json::to_vec_pretty(&coherence_empty_archmap()).expect("archmap serializes"),
+    )
+    .expect("empty archmap is written");
+    fs::write(
+        &empty_policy,
+        serde_json::to_vec_pretty(&coherence_policy("F2", false)).expect("policy serializes"),
+    )
+    .expect("empty policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        empty_archmap.to_str().unwrap(),
+        "--law-policy",
+        empty_policy.to_str().unwrap(),
+        "--out-dir",
+        empty_dir.to_str().unwrap(),
+    ]);
+    let empty_packet = read_json(&empty_dir.join("archsig-measurement-packet.json"));
+    let empty_row = coherence_row(&empty_packet);
+    assert_eq!(empty_row["verdict"], "not_computed");
+    assert_eq!(
+        empty_row["verdictData"]["methodStatus"],
+        "empty_selected_2_skeleton"
+    );
+
+    let banding_dir = root_out.join("banding");
+    fs::create_dir_all(&banding_dir).expect("banding dir exists");
+    let banding_archmap = banding_dir.join("archmap.json");
+    let banding_policy = banding_dir.join("law_policy.json");
+    fs::write(
+        &banding_archmap,
+        serde_json::to_vec_pretty(&coherence_triangle_archmap(true)).expect("archmap serializes"),
+    )
+    .expect("banding archmap is written");
+    fs::write(
+        &banding_policy,
+        serde_json::to_vec_pretty(&coherence_policy("Aut(Dec_U)", false))
+            .expect("policy serializes"),
+    )
+    .expect("banding policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        banding_archmap.to_str().unwrap(),
+        "--law-policy",
+        banding_policy.to_str().unwrap(),
+        "--out-dir",
+        banding_dir.to_str().unwrap(),
+    ]);
+    let banding_packet = read_json(&banding_dir.join("archsig-measurement-packet.json"));
+    let banding_row = coherence_row(&banding_packet);
+    assert_eq!(banding_row["verdict"], "not_computed");
+    assert_eq!(
+        banding_row["verdictData"]["methodStatus"],
+        "banding_violated"
+    );
+    assert!(
+        banding_packet["structuralVerdict"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|row| matches!(
+                row["verdict"].as_str().unwrap(),
+                "measured_zero" | "measured_nonzero" | "unmeasured" | "unknown" | "not_computed"
+            )),
+        "coherence evaluator must reuse the existing five verdict values"
+    );
+
+    let non_cocycle_dir = root_out.join("non-cocycle");
+    fs::create_dir_all(&non_cocycle_dir).expect("non-cocycle dir exists");
+    let non_cocycle_archmap = non_cocycle_dir.join("archmap.json");
+    let non_cocycle_policy = non_cocycle_dir.join("law_policy.json");
+    fs::write(
+        &non_cocycle_archmap,
+        serde_json::to_vec_pretty(&coherence_filled_tetrahedron_archmap())
+            .expect("archmap serializes"),
+    )
+    .expect("non-cocycle archmap is written");
+    fs::write(
+        &non_cocycle_policy,
+        serde_json::to_vec_pretty(&coherence_policy("F2", false)).expect("policy serializes"),
+    )
+    .expect("non-cocycle policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        non_cocycle_archmap.to_str().unwrap(),
+        "--law-policy",
+        non_cocycle_policy.to_str().unwrap(),
+        "--out-dir",
+        non_cocycle_dir.to_str().unwrap(),
+    ]);
+    let non_cocycle_packet = read_json(&non_cocycle_dir.join("archsig-measurement-packet.json"));
+    let non_cocycle_row = coherence_row(&non_cocycle_packet);
+    assert_eq!(non_cocycle_row["verdict"], "not_computed");
+    assert_eq!(
+        non_cocycle_row["verdictData"]["methodStatus"], "not_2_cocycle",
+        "d2 h = 0 must gate im d1 membership before a nonzero verdict can be emitted"
+    );
+    let non_cocycle_invariant = invariant_by_id(
+        &non_cocycle_packet,
+        "coherence-obstruction:profile:ag-coherence@1",
+    );
+    assert_eq!(non_cocycle_invariant["cocycleGate"]["passed"], false);
+
+    let incomplete_dir = root_out.join("incomplete");
+    fs::create_dir_all(&incomplete_dir).expect("incomplete dir exists");
+    let incomplete_archmap = incomplete_dir.join("archmap.json");
+    let incomplete_policy = incomplete_dir.join("law_policy.json");
+    fs::write(
+        &incomplete_archmap,
+        serde_json::to_vec_pretty(&coherence_incomplete_triangle_archmap())
+            .expect("archmap serializes"),
+    )
+    .expect("incomplete archmap is written");
+    fs::write(
+        &incomplete_policy,
+        serde_json::to_vec_pretty(&coherence_policy("F2", false)).expect("policy serializes"),
+    )
+    .expect("incomplete policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        incomplete_archmap.to_str().unwrap(),
+        "--law-policy",
+        incomplete_policy.to_str().unwrap(),
+        "--out-dir",
+        incomplete_dir.to_str().unwrap(),
+    ]);
+    let incomplete_packet = read_json(&incomplete_dir.join("archsig-measurement-packet.json"));
+    let incomplete_row = coherence_row(&incomplete_packet);
+    assert_eq!(incomplete_row["verdict"], "not_computed");
+    assert_eq!(
+        incomplete_row["verdictData"]["methodStatus"],
+        "incomplete_selected_2_skeleton"
+    );
+
+    let oversized_dir = root_out.join("oversized");
+    fs::create_dir_all(&oversized_dir).expect("oversized dir exists");
+    let oversized_archmap = oversized_dir.join("archmap.json");
+    let oversized_policy = oversized_dir.join("law_policy.json");
+    fs::write(
+        &oversized_archmap,
+        serde_json::to_vec_pretty(&coherence_oversized_archmap()).expect("archmap serializes"),
+    )
+    .expect("oversized archmap is written");
+    fs::write(
+        &oversized_policy,
+        serde_json::to_vec_pretty(&coherence_policy("F2", false)).expect("policy serializes"),
+    )
+    .expect("oversized policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        oversized_archmap.to_str().unwrap(),
+        "--law-policy",
+        oversized_policy.to_str().unwrap(),
+        "--out-dir",
+        oversized_dir.to_str().unwrap(),
+    ]);
+    let oversized_packet = read_json(&oversized_dir.join("archsig-measurement-packet.json"));
+    let oversized_row = coherence_row(&oversized_packet);
+    assert_eq!(oversized_row["verdict"], "not_computed");
+    assert_eq!(
+        oversized_row["verdictData"]["methodStatus"],
+        "selected_cover_too_large"
+    );
+
+    let missing_family_dir = root_out.join("missing-family");
+    fs::create_dir_all(&missing_family_dir).expect("missing-family dir exists");
+    let missing_family_archmap = missing_family_dir.join("archmap.json");
+    let missing_family_policy = missing_family_dir.join("law_policy.json");
+    let mut missing_family = coherence_policy("F2", false);
+    missing_family["measurementProfiles"][0]["witnessFamily"] = Value::Array(vec![]);
+    fs::write(
+        &missing_family_archmap,
+        serde_json::to_vec_pretty(&coherence_triangle_archmap(true)).expect("archmap serializes"),
+    )
+    .expect("missing-family archmap is written");
+    fs::write(
+        &missing_family_policy,
+        serde_json::to_vec_pretty(&missing_family).expect("policy serializes"),
+    )
+    .expect("missing-family policy is written");
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            missing_family_archmap.to_str().unwrap(),
+            "--law-policy",
+            missing_family_policy.to_str().unwrap(),
+            "--out-dir",
+            missing_family_dir.to_str().unwrap(),
+        ],
+        2,
+    );
+
+    let bad_selector_dir = root_out.join("bad-selector");
+    fs::create_dir_all(&bad_selector_dir).expect("bad-selector dir exists");
+    let bad_selector_archmap = bad_selector_dir.join("archmap.json");
+    let bad_selector_policy = bad_selector_dir.join("law_policy.json");
+    let mut bad_selector = coherence_policy("F2", false);
+    bad_selector["measurementProfiles"][0]["resolutionSelector"] =
+        Value::String("taylor@1".to_string());
+    fs::write(
+        &bad_selector_archmap,
+        serde_json::to_vec_pretty(&coherence_triangle_archmap(true)).expect("archmap serializes"),
+    )
+    .expect("bad-selector archmap is written");
+    fs::write(
+        &bad_selector_policy,
+        serde_json::to_vec_pretty(&bad_selector).expect("policy serializes"),
+    )
+    .expect("bad-selector policy is written");
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            bad_selector_archmap.to_str().unwrap(),
+            "--law-policy",
+            bad_selector_policy.to_str().unwrap(),
+            "--out-dir",
+            bad_selector_dir.to_str().unwrap(),
+        ],
+        2,
+    );
+}
+
+#[test]
 fn cli_analyze_v2_emits_insight_report_brief_and_viewer_scene_contract() {
     let out_dir = temp_dir("ag-measurement-insight-viewer");
     let root = ag_measurement_root();
@@ -11136,6 +11566,542 @@ fn invariant_by_id<'a>(packet: &'a Value, invariant_id: &str) -> &'a Value {
         .iter()
         .find(|invariant| invariant["invariantId"] == invariant_id)
         .unwrap_or_else(|| panic!("missing computed invariant {invariant_id}"))
+}
+
+fn coherence_row(packet: &Value) -> &Value {
+    packet["structuralVerdict"]
+        .as_array()
+        .expect("structuralVerdict is array")
+        .iter()
+        .find(|row| row["evaluator"] == "ag.coherence-obstruction@1")
+        .expect("coherence row exists")
+}
+
+fn coherence_policy(coefficient: &str, include_cech: bool) -> Value {
+    let mut witness_family = vec![json!({
+        "law": "ag.coherence-obstruction",
+        "variable": "h2"
+    })];
+    let mut policies = vec![json!({
+        "law": "ag.coherence-obstruction",
+        "evaluator": "ag.coherence-obstruction@1",
+        "basis": ["policy-basis:layering"],
+        "scope": ["src/"],
+        "severity": "high"
+    })];
+    if include_cech {
+        witness_family.push(json!({
+            "law": "ag.cech-obstruction",
+            "variable": "x_coherence"
+        }));
+        policies.insert(
+            0,
+            json!({
+                "law": "ag.cech-obstruction",
+                "evaluator": "ag.cech-obstruction@1",
+                "basis": ["policy-basis:layering"],
+                "scope": ["src/"],
+                "severity": "high"
+            }),
+        );
+    }
+    json!({
+        "schema": "law-policy/v1",
+        "id": "ag-coherence-policy",
+        "measurementProfileRef": "profile:ag-coherence@1",
+        "measurementProfiles": [{
+            "schema": "measurement-profile/v1",
+            "profileId": "profile:ag-coherence@1",
+            "siteRef": "archmap:/contexts",
+            "coverRef": "cover:coherence",
+            "coefficient": coefficient,
+            "effCoeff": "finite-linear-algebra@1",
+            "witnessFamily": witness_family,
+            "resolutionSelector": "h2-coherence@1",
+            "domain": "finite-poset-site",
+            "zeroPredicate": "rank-zero@1",
+            "nonZeroPredicate": "rank-positive@1",
+            "certSelector": "finite-certificate@1",
+            "verdictDiscipline": "five-valued-structural-verdict@1"
+        }],
+        "policies": policies
+    })
+}
+
+fn coherence_triangle_archmap(include_witness: bool) -> Value {
+    let mut atoms = vec![
+        atom_json(
+            "atom:a",
+            "component",
+            "src:a",
+            "static",
+            "component",
+            None,
+            vec!["src:a"],
+        ),
+        atom_json(
+            "atom:b",
+            "component",
+            "src:b",
+            "static",
+            "component",
+            None,
+            vec!["src:b"],
+        ),
+        atom_json(
+            "atom:c",
+            "component",
+            "src:c",
+            "static",
+            "component",
+            None,
+            vec!["src:c"],
+        ),
+        atom_json(
+            "atom:abc",
+            "component",
+            "src:abc",
+            "static",
+            "tripleOverlapWitness",
+            None,
+            vec!["src:abc"],
+        ),
+    ];
+    if include_witness {
+        atoms.push(atom_json(
+            "atom:h2-abc",
+            "relation",
+            "ctx:a",
+            "coherence",
+            "tripleMismatch",
+            Some("ctx:a,ctx:b,ctx:c"),
+            vec!["ctx:a", "ctx:b", "ctx:c"],
+        ));
+    }
+    let c_atoms = if include_witness {
+        vec!["atom:c", "atom:abc", "atom:h2-abc"]
+    } else {
+        vec!["atom:c", "atom:abc"]
+    };
+    archmap_with_contexts(
+        atoms,
+        vec![
+            context_json("ctx:a", vec!["atom:a", "atom:abc"], vec!["ctx:b", "ctx:c"]),
+            context_json("ctx:b", vec!["atom:b", "atom:abc"], vec!["ctx:c"]),
+            context_json("ctx:c", c_atoms, vec![]),
+        ],
+    )
+}
+
+fn coherence_boundary_archmap(include_witnesses: bool) -> Value {
+    let face_specs = [
+        ("abc", vec!["ctx:a", "ctx:b", "ctx:c"]),
+        ("abd", vec!["ctx:a", "ctx:b", "ctx:d"]),
+        ("acd", vec!["ctx:a", "ctx:c", "ctx:d"]),
+        ("bcd", vec!["ctx:b", "ctx:c", "ctx:d"]),
+    ];
+    let mut atoms = vec![
+        atom_json(
+            "atom:a",
+            "component",
+            "src:a",
+            "static",
+            "component",
+            None,
+            vec!["src:a"],
+        ),
+        atom_json(
+            "atom:b",
+            "component",
+            "src:b",
+            "static",
+            "component",
+            None,
+            vec!["src:b"],
+        ),
+        atom_json(
+            "atom:c",
+            "component",
+            "src:c",
+            "static",
+            "component",
+            None,
+            vec!["src:c"],
+        ),
+        atom_json(
+            "atom:d",
+            "component",
+            "src:d",
+            "static",
+            "component",
+            None,
+            vec!["src:d"],
+        ),
+    ];
+    for (name, contexts) in face_specs.iter() {
+        atoms.push(atom_json(
+            &format!("atom:face-{name}"),
+            "component",
+            &format!("src:face-{name}"),
+            "static",
+            "tripleOverlapWitness",
+            None,
+            vec![&format!("src:face-{name}")],
+        ));
+        if include_witnesses && *name == "abc" {
+            atoms.push(atom_json(
+                &format!("atom:h2-{name}"),
+                "relation",
+                contexts[0],
+                "coherence",
+                "tripleMismatch",
+                Some(&contexts.join(",")),
+                contexts.clone(),
+            ));
+        }
+    }
+    let contexts = if include_witnesses {
+        vec![
+            context_json(
+                "ctx:a",
+                vec![
+                    "atom:a",
+                    "atom:face-abc",
+                    "atom:face-abd",
+                    "atom:face-acd",
+                    "atom:h2-abc",
+                ],
+                vec!["ctx:b", "ctx:c", "ctx:d"],
+            ),
+            context_json(
+                "ctx:b",
+                vec![
+                    "atom:b",
+                    "atom:face-abc",
+                    "atom:face-abd",
+                    "atom:face-bcd",
+                    "atom:h2-abc",
+                ],
+                vec!["ctx:c", "ctx:d"],
+            ),
+            context_json(
+                "ctx:c",
+                vec![
+                    "atom:c",
+                    "atom:face-abc",
+                    "atom:face-acd",
+                    "atom:face-bcd",
+                    "atom:h2-abc",
+                ],
+                vec!["ctx:d"],
+            ),
+            context_json(
+                "ctx:d",
+                vec!["atom:d", "atom:face-abd", "atom:face-acd", "atom:face-bcd"],
+                vec![],
+            ),
+        ]
+    } else {
+        vec![
+            context_json(
+                "ctx:a",
+                vec!["atom:a", "atom:face-abc", "atom:face-abd", "atom:face-acd"],
+                vec!["ctx:b", "ctx:c", "ctx:d"],
+            ),
+            context_json(
+                "ctx:b",
+                vec!["atom:b", "atom:face-abc", "atom:face-abd", "atom:face-bcd"],
+                vec!["ctx:c", "ctx:d"],
+            ),
+            context_json(
+                "ctx:c",
+                vec!["atom:c", "atom:face-abc", "atom:face-acd", "atom:face-bcd"],
+                vec!["ctx:d"],
+            ),
+            context_json(
+                "ctx:d",
+                vec!["atom:d", "atom:face-abd", "atom:face-acd", "atom:face-bcd"],
+                vec![],
+            ),
+        ]
+    };
+    archmap_with_contexts(atoms, contexts)
+}
+
+fn coherence_boundary_zero_cochain_archmap() -> Value {
+    let mut archmap = coherence_boundary_archmap(true);
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .push(atom_json(
+            "atom:h2-abc-duplicate",
+            "relation",
+            "ctx:a",
+            "coherence",
+            "tripleMismatch",
+            Some("ctx:a,ctx:b,ctx:c"),
+            vec!["ctx:a", "ctx:b", "ctx:c"],
+        ));
+    for context_id in ["ctx:a", "ctx:b", "ctx:c"] {
+        let context = archmap["contexts"]
+            .as_array_mut()
+            .expect("contexts is array")
+            .iter_mut()
+            .find(|context| context["id"] == context_id)
+            .unwrap_or_else(|| panic!("context {context_id} exists"));
+        context["atoms"]
+            .as_array_mut()
+            .expect("context atoms is array")
+            .push(Value::String("atom:h2-abc-duplicate".to_string()));
+    }
+    archmap
+}
+
+fn coherence_empty_archmap() -> Value {
+    archmap_with_contexts(
+        vec![
+            atom_json(
+                "atom:a",
+                "component",
+                "src:a",
+                "static",
+                "component",
+                None,
+                vec!["src:a"],
+            ),
+            atom_json(
+                "atom:b",
+                "component",
+                "src:b",
+                "static",
+                "component",
+                None,
+                vec!["src:b"],
+            ),
+        ],
+        vec![
+            context_json("ctx:a", vec!["atom:a"], vec!["ctx:b"]),
+            context_json("ctx:b", vec!["atom:b"], vec![]),
+        ],
+    )
+}
+
+fn coherence_incomplete_triangle_archmap() -> Value {
+    archmap_with_contexts(
+        vec![
+            atom_json(
+                "atom:a",
+                "component",
+                "src:a",
+                "static",
+                "component",
+                None,
+                vec!["src:a"],
+            ),
+            atom_json(
+                "atom:b",
+                "component",
+                "src:b",
+                "static",
+                "component",
+                None,
+                vec!["src:b"],
+            ),
+            atom_json(
+                "atom:c",
+                "component",
+                "src:c",
+                "static",
+                "component",
+                None,
+                vec!["src:c"],
+            ),
+            atom_json(
+                "atom:abc",
+                "component",
+                "src:abc",
+                "static",
+                "tripleOverlapWitness",
+                None,
+                vec!["src:abc"],
+            ),
+            atom_json(
+                "atom:h2-abc",
+                "relation",
+                "ctx:a",
+                "coherence",
+                "tripleMismatch",
+                Some("ctx:a,ctx:b,ctx:c"),
+                vec!["ctx:a", "ctx:b", "ctx:c"],
+            ),
+        ],
+        vec![
+            context_json(
+                "ctx:a",
+                vec!["atom:a", "atom:abc", "atom:h2-abc"],
+                vec!["ctx:b"],
+            ),
+            context_json("ctx:b", vec!["atom:b", "atom:abc", "atom:h2-abc"], vec![]),
+            context_json("ctx:c", vec!["atom:c", "atom:abc", "atom:h2-abc"], vec![]),
+        ],
+    )
+}
+
+fn coherence_oversized_archmap() -> Value {
+    let mut atoms = Vec::new();
+    let mut contexts = Vec::new();
+    for index in 0..13 {
+        let context_id = format!("ctx:n{index}");
+        let atom_id = format!("atom:n{index}");
+        atoms.push(atom_json(
+            &atom_id,
+            "component",
+            "src:a",
+            "static",
+            "component",
+            None,
+            vec!["src:a"],
+        ));
+        contexts.push(json!({
+            "id": context_id,
+            "atoms": [atom_id],
+            "refs": ["src:a"]
+        }));
+    }
+    let mut archmap = archmap_with_contexts(atoms, contexts);
+    for index in 0..13 {
+        archmap["sources"][format!("ctx:n{index}")] = json!({
+            "kind": "policy",
+            "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md",
+            "section": "M5"
+        });
+    }
+    archmap
+}
+
+fn coherence_filled_tetrahedron_archmap() -> Value {
+    let mut archmap = coherence_boundary_archmap(false);
+    archmap["atoms"]
+        .as_array_mut()
+        .expect("atoms is array")
+        .extend([
+            atom_json(
+                "atom:abcd",
+                "component",
+                "src:abcd",
+                "static",
+                "quadrupleOverlapWitness",
+                None,
+                vec!["src:abc"],
+            ),
+            atom_json(
+                "atom:h2-abc",
+                "relation",
+                "ctx:a",
+                "coherence",
+                "tripleMismatch",
+                Some("ctx:a,ctx:b,ctx:c"),
+                vec!["ctx:a", "ctx:b", "ctx:c"],
+            ),
+        ]);
+    for context_id in ["ctx:a", "ctx:b", "ctx:c", "ctx:d"] {
+        let context = archmap["contexts"]
+            .as_array_mut()
+            .expect("contexts is array")
+            .iter_mut()
+            .find(|context| context["id"] == context_id)
+            .unwrap_or_else(|| panic!("context {context_id} exists"));
+        context["atoms"]
+            .as_array_mut()
+            .expect("context atoms is array")
+            .push(Value::String("atom:abcd".to_string()));
+    }
+    for context_id in ["ctx:a", "ctx:b", "ctx:c"] {
+        let context = archmap["contexts"]
+            .as_array_mut()
+            .expect("contexts is array")
+            .iter_mut()
+            .find(|context| context["id"] == context_id)
+            .unwrap_or_else(|| panic!("context {context_id} exists"));
+        context["atoms"]
+            .as_array_mut()
+            .expect("context atoms is array")
+            .push(Value::String("atom:h2-abc".to_string()));
+    }
+    archmap
+}
+
+fn archmap_with_contexts(atoms: Vec<Value>, contexts: Vec<Value>) -> Value {
+    let cover_contexts = contexts
+        .iter()
+        .filter_map(|context| context["id"].as_str())
+        .collect::<Vec<_>>();
+    json!({
+        "schema": "archmap/v2",
+        "id": "ag-coherence-fixture",
+        "extractionDoctrineRef": {
+            "doctrineId": "doctrine:ag-fixture@1",
+            "fingerprint": "sha256:ag-coherence-fixture",
+            "components": ["V", "Gamma", "R", "rho", "E", "N"]
+        },
+        "sources": {
+            "src:a": {"kind": "rust", "path": "src/a.rs", "symbol": "A", "line": 1},
+            "src:b": {"kind": "rust", "path": "src/b.rs", "symbol": "B", "line": 1},
+            "src:c": {"kind": "rust", "path": "src/c.rs", "symbol": "C", "line": 1},
+            "src:d": {"kind": "rust", "path": "src/d.rs", "symbol": "D", "line": 1},
+            "src:abc": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "src:face-abc": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "src:face-abd": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "src:face-acd": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "src:face-bcd": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "ctx:a": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "ctx:b": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "ctx:c": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"},
+            "ctx:d": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M5"}
+        },
+        "atoms": atoms,
+        "contexts": contexts,
+        "covers": [{
+            "id": "cover:coherence",
+            "contexts": cover_contexts.clone(),
+            "refs": cover_contexts
+        }]
+    })
+}
+
+fn atom_json(
+    id: &str,
+    kind: &str,
+    subject: &str,
+    axis: &str,
+    predicate: &str,
+    object: Option<&str>,
+    refs: Vec<&str>,
+) -> Value {
+    let mut atom = json!({
+        "id": id,
+        "kind": kind,
+        "subject": subject,
+        "axis": axis,
+        "predicate": predicate,
+        "refs": refs
+    });
+    if let Some(object) = object {
+        atom["object"] = Value::String(object.to_string());
+    }
+    atom
+}
+
+fn context_json(id: &str, atoms: Vec<&str>, restricts_to: Vec<&str>) -> Value {
+    let mut context = json!({
+        "id": id,
+        "atoms": atoms,
+        "refs": [id]
+    });
+    if !restricts_to.is_empty() {
+        context["restrictsTo"] = json!(restricts_to);
+    }
+    context
 }
 
 fn has_nested_key(value: &Value, key: &str) -> bool {


### PR DESCRIPTION
## 概要

Closes #2220

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M5 に対応し、`ag.coherence-obstruction@1` を追加します。

- `ag.coherence-obstruction@1` を registry に登録し、`MeasurementProfile` から選択可能にしました。
- 選択 cover の triple-overlap 2-skeleton 上で、banded abelian F2 の `H^2 = ker d^2 / im d^1` を計算します。
- `d2 h = 0` cocycle gate を `im d^1` membership 判定の前段に置き、非 cocycle は `not_computed` に正規化します。
- witness 不在、空 2-skeleton、不完全 2-skeleton、非 F2 banding、oversized cover、profile contract 不一致を fail-closed / silent boundary として固定しました。
- viewer projection は変更せず、H2 coherence を viewer 側で新規導出しない境界を維持しています。

local-review で出た指摘への対応:
- 不完全な selected 2-skeleton は `incomplete_selected_2_skeleton` の `not_computed` に落とすようにしました。
- `witnessFamily law ag.coherence-obstruction` と `resolutionSelector=h2-coherence@1` を必須化しました。
- selected cover context 数に上限を置き、巨大 artifact 生成を避ける `selected_cover_too_large` を追加しました。
- registry manifest の `ag.coherence-obstruction@1` 説明を実装済み evaluator として更新しました。

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml coherence_obstruction -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json --out-dir .tmp/archsig-analyze-v2`
- [x] `/Users/nakahata/.elan/bin/lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `cargo fmt --manifest-path tools/archsig/Cargo.toml`

注記:
- PRD に記載されている minimal analyze command は現行 CLI では v1 入力扱いで停止したため、現行 v2 AG measurement fixture の analyze e2e を実行しました。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `tooling implementation` として Issue 側で明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
