### PR TITLE
ArchSig restriction compatibility 計測を追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -287,6 +287,29 @@ pub fn build_foundation_measurement_packet_v1(
                 depends_on_assumptions,
                 reason: Some(measurement.reason),
             });
+        } else if evaluator == "ag.restriction-compatibility@1" {
+            validate_restriction_profile_v1(&profile)?;
+            let measurement = evaluate_restriction_compatibility_v1(normalized, &profile)?;
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
+            computed_invariants.extend(measurement.computed_invariants);
+            assumptions.extend(measurement.assumptions);
+            structural_verdict.push(AgStructuralVerdictV1 {
+                evaluator: evaluator.to_string(),
+                law: entry
+                    .law
+                    .clone()
+                    .unwrap_or_else(|| "ag.restriction-compatibility".to_string()),
+                verdict: measurement.verdict,
+                verdict_data: AgVerdictDataV1 {
+                    in_scope: true,
+                    zero: measurement.zero,
+                    non_zero: measurement.non_zero,
+                    method_status: measurement.method_status,
+                    cert_ref: measurement.cert_ref,
+                },
+                depends_on_assumptions,
+                reason: Some(measurement.reason),
+            });
         } else if evaluator == "ag.square-free-repair@1" {
             validate_square_free_profile_v1(&profile)?;
             let measurement = evaluate_square_free_repair_v1(normalized, &profile)?;
@@ -466,6 +489,44 @@ struct SquareFreeGeneratorV1 {
     generator_id: String,
     support: Vec<String>,
     support_atom_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RestrictionMeasurementV1 {
+    verdict: String,
+    zero: bool,
+    non_zero: bool,
+    method_status: String,
+    cert_ref: Option<String>,
+    reason: String,
+    computed_invariants: Vec<Value>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct RestrictionGeneratorV1 {
+    generator_id: String,
+    context_ref: String,
+    support: Vec<String>,
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RestrictionEdgeCheckV1 {
+    edge_ref: String,
+    source_context: String,
+    target_context: String,
+    status: String,
+    source_generators: Vec<RestrictionGeneratorV1>,
+    target_generators: Vec<RestrictionGeneratorV1>,
+    violations: Vec<RestrictionViolationV1>,
+}
+
+#[derive(Debug, Clone)]
+struct RestrictionViolationV1 {
+    generator_id: String,
+    support: Vec<String>,
+    source_refs: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1056,6 +1117,152 @@ fn evaluate_square_free_repair_v1(
                     .unwrap_or_else(|| Some(format!("measurement-profile:{}", profile.profile_id))),
             },
         ],
+    })
+}
+
+fn evaluate_restriction_compatibility_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> Result<RestrictionMeasurementV1, String> {
+    let selected_contexts = selected_cover_contexts(normalized, profile);
+    let selected = selected_contexts.iter().cloned().collect::<BTreeSet<_>>();
+    let edges = cech_edges(normalized, &selected_contexts);
+    let witness_variables = restriction_witness_variables(profile);
+    let generators = restriction_generators(normalized, &selected, &witness_variables)?;
+    let generators_by_context = generators.iter().cloned().fold(
+        BTreeMap::<String, Vec<RestrictionGeneratorV1>>::new(),
+        |mut acc, generator| {
+            acc.entry(generator.context_ref.clone())
+                .or_default()
+                .push(generator);
+            acc
+        },
+    );
+    let missing_edges = edges.is_empty();
+    let missing_generators = !missing_edges
+        && edges.iter().any(|edge| {
+            generators_by_context
+                .get(&edge.source_context)
+                .is_none_or(Vec::is_empty)
+                || generators_by_context
+                    .get(&edge.target_context)
+                    .is_none_or(Vec::is_empty)
+        });
+    let method_status = if missing_edges {
+        "empty_selected_restriction_edges"
+    } else if missing_generators {
+        "restriction_generator_missing"
+    } else {
+        "finite_support_inclusion_computed"
+    };
+    let edge_checks = if missing_edges {
+        Vec::new()
+    } else {
+        edges
+            .iter()
+            .map(|edge| {
+                let source_generators = generators_by_context
+                    .get(&edge.source_context)
+                    .cloned()
+                    .unwrap_or_default();
+                let target_generators = generators_by_context
+                    .get(&edge.target_context)
+                    .cloned()
+                    .unwrap_or_default();
+                let violations = if source_generators.is_empty() || target_generators.is_empty() {
+                    Vec::new()
+                } else {
+                    source_generators
+                        .iter()
+                        .filter(|source| {
+                            !target_generators
+                                .iter()
+                                .any(|target| is_subset(&target.support, &source.support))
+                        })
+                        .map(|source| RestrictionViolationV1 {
+                            generator_id: source.generator_id.clone(),
+                            support: source.support.clone(),
+                            source_refs: source.source_refs.clone(),
+                        })
+                        .collect::<Vec<_>>()
+                };
+                RestrictionEdgeCheckV1 {
+                    edge_ref: edge.edge_id.clone(),
+                    source_context: edge.source_context.clone(),
+                    target_context: edge.target_context.clone(),
+                    status: if source_generators.is_empty() || target_generators.is_empty() {
+                        "not_computed"
+                    } else if violations.is_empty() {
+                        "compatible"
+                    } else {
+                        "violated"
+                    }
+                    .to_string(),
+                    source_generators,
+                    target_generators,
+                    violations,
+                }
+            })
+            .collect::<Vec<_>>()
+    };
+    let violations = edge_checks
+        .iter()
+        .flat_map(|edge| edge.violations.iter())
+        .collect::<Vec<_>>();
+    let (verdict, zero, non_zero, reason) = if missing_edges {
+        (
+            "not_computed".to_string(),
+            false,
+            false,
+            "selected cover has no restriction edges for ag.restriction-compatibility@1"
+                .to_string(),
+        )
+    } else if missing_generators {
+        (
+            "not_computed".to_string(),
+            false,
+            false,
+            "selected restriction edge is missing source or target ideal generator contract"
+                .to_string(),
+        )
+    } else if violations.is_empty() {
+        (
+            "measured_zero".to_string(),
+            true,
+            false,
+            "all selected restriction edges satisfy finite monomial support inclusion".to_string(),
+        )
+    } else {
+        (
+            "measured_nonzero".to_string(),
+            false,
+            true,
+            "some selected restriction edge does not carry source ideal generators into the target ideal; this may disappear under sheaf image redefinition and is not a defect of the theory object".to_string(),
+        )
+    };
+    let cert_ref = matches!(verdict.as_str(), "measured_zero" | "measured_nonzero").then(|| {
+        format!(
+            "computedInvariants/restriction-compatibility:{}",
+            profile.profile_id
+        )
+    });
+
+    Ok(RestrictionMeasurementV1 {
+        verdict,
+        zero,
+        non_zero,
+        method_status: method_status.to_string(),
+        cert_ref,
+        reason,
+        computed_invariants: vec![restriction_invariant_json(
+            profile,
+            method_status,
+            &selected_contexts,
+            &edges,
+            &witness_variables,
+            &edge_checks,
+        )],
+        assumptions: restriction_assumptions(profile, method_status),
     })
 }
 
@@ -4501,6 +4708,61 @@ fn validate_cech_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String
     Ok(())
 }
 
+fn validate_restriction_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        ("coefficient", profile.coefficient.as_str(), "F2"),
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "finite-support-inclusion@1",
+        ),
+        (
+            "resolutionSelector",
+            profile.resolution_selector.as_str(),
+            "support-inclusion@1",
+        ),
+        ("domain", profile.domain.as_str(), "finite-poset-site"),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "all-inclusions-hold@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "some-inclusion-fails@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "finite-certificate@1",
+        ),
+        (
+            "verdictDiscipline",
+            profile.verdict_discipline.as_str(),
+            "five-valued-structural-verdict@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.restriction-compatibility@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if !profile
+        .witness_family
+        .iter()
+        .any(|witness| witness.law == "ag.restriction-compatibility")
+    {
+        return Err(
+            "ag.restriction-compatibility@1 requires MeasurementProfile witnessFamily law ag.restriction-compatibility"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 fn validate_coherence_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
     let expected = [
         (
@@ -5755,6 +6017,184 @@ fn tor_assumptions(
         AgAssumptionLedgerEntryV1 {
             theorem_ref: "part8/9.2".to_string(),
             assumption: "flat base change stability is theorem-candidate only".to_string(),
+            status: "assumed".to_string(),
+            checked_by: None,
+            assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+    ]
+}
+
+fn restriction_witness_variables(profile: &MeasurementProfileV1) -> Vec<String> {
+    let mut variables = profile
+        .witness_family
+        .iter()
+        .filter(|witness| witness.law == "ag.restriction-compatibility")
+        .map(|witness| witness.variable.clone())
+        .collect::<Vec<_>>();
+    variables.sort();
+    variables.dedup();
+    variables
+}
+
+fn restriction_generators(
+    normalized: &NormalizedArchMapV2,
+    selected_contexts: &BTreeSet<String>,
+    witness_variables: &[String],
+) -> Result<Vec<RestrictionGeneratorV1>, String> {
+    let witness_set = witness_variables.iter().cloned().collect::<BTreeSet<_>>();
+    let mut generators = Vec::new();
+    for atom in normalized
+        .atoms
+        .iter()
+        .filter(|atom| {
+            atom.axis == "restriction-compatibility"
+                && atom.predicate == "restrictionIdealGenerator"
+        })
+        .filter(|atom| selected_contexts.contains(&atom.subject))
+    {
+        if !atom
+            .context_memberships
+            .iter()
+            .any(|context| context == &atom.subject)
+        {
+            return Err(format!(
+                "ag.restriction-compatibility@1 generator {} must belong to its subject context {}",
+                atom.normalized_atom_id, atom.subject
+            ));
+        }
+        let support = restriction_generator_support(atom);
+        if support.is_empty() {
+            return Err(format!(
+                "ag.restriction-compatibility@1 generator {} has no finite support variables",
+                atom.normalized_atom_id
+            ));
+        }
+        let unknown = support
+            .iter()
+            .filter(|variable| !witness_set.contains(*variable))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !unknown.is_empty() {
+            return Err(format!(
+                "ag.restriction-compatibility@1 generator {} contains variables outside witnessFamily: {}",
+                atom.normalized_atom_id,
+                unknown.join(",")
+            ));
+        }
+        generators.push(RestrictionGeneratorV1 {
+            generator_id: atom.normalized_atom_id.clone(),
+            context_ref: atom.subject.clone(),
+            support,
+            source_refs: atom.source_refs.clone(),
+        });
+    }
+    generators.sort_by(|left, right| left.generator_id.cmp(&right.generator_id));
+    Ok(generators)
+}
+
+fn restriction_generator_support(atom: &NormalizedAtomV2) -> Vec<String> {
+    let mut support = atom
+        .object
+        .as_deref()
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    support.sort();
+    support.dedup();
+    support
+}
+
+fn restriction_invariant_json(
+    profile: &MeasurementProfileV1,
+    method_status: &str,
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+    witness_variables: &[String],
+    edge_checks: &[RestrictionEdgeCheckV1],
+) -> Value {
+    json!({
+        "invariantId": format!("restriction-compatibility:{}", profile.profile_id),
+        "evaluator": "ag.restriction-compatibility@1",
+        "method": "finite-support-inclusion@1",
+        "status": if method_status == "finite_support_inclusion_computed" { "computed" } else { "not_computed" },
+        "methodStatus": method_status,
+        "claimScope": "selected-cover separated presheaf restriction compatibility over finite monomial supports",
+        "selectedCoverRef": profile.cover_ref,
+        "witnessVariables": witness_variables,
+        "contextCount": selected_contexts.len(),
+        "restrictionEdgeCount": edges.len(),
+        "edgeChecks": edge_checks.iter().map(|edge| json!({
+            "edgeRef": edge.edge_ref,
+            "sourceContextRef": edge.source_context,
+            "targetContextRef": edge.target_context,
+            "status": edge.status,
+            "sourceGenerators": edge.source_generators.iter().map(restriction_generator_json).collect::<Vec<_>>(),
+            "targetGenerators": edge.target_generators.iter().map(restriction_generator_json).collect::<Vec<_>>(),
+            "violations": edge.violations.iter().map(|violation| json!({
+                "generatorRef": violation.generator_id,
+                "support": violation.support,
+                "sourceRefs": violation.source_refs
+            })).collect::<Vec<_>>()
+        })).collect::<Vec<_>>(),
+        "boundaryNote": "A measured_nonzero row means the selected local-sum presentation does not flow into the target ideal; sheaf image 再定義で消えうる、理論対象の defect ではない.",
+        "nonConclusions": [
+            "This is a selected-cover separated presheaf check, not a global sheaf or semantic safety proof.",
+            "H1 Cech and H2 coherence verdict rows are not changed by this evaluator."
+        ]
+    })
+}
+
+fn restriction_generator_json(generator: &RestrictionGeneratorV1) -> Value {
+    json!({
+        "generatorId": generator.generator_id,
+        "contextRef": generator.context_ref,
+        "support": generator.support,
+        "sourceRefs": generator.source_refs
+    })
+}
+
+fn restriction_assumptions(
+    profile: &MeasurementProfileV1,
+    method_status: &str,
+) -> Vec<AgAssumptionLedgerEntryV1> {
+    vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "Lean/ObstructionIdeal.RestrictionCompatible.maps_selected".to_string(),
+            assumption: "selected finite support generator family for restriction compatibility"
+                .to_string(),
+            status: if method_status == "restriction_generator_missing" {
+                "violated"
+            } else {
+                "checked"
+            }
+            .to_string(),
+            checked_by: (method_status != "restriction_generator_missing")
+                .then(|| format!("measurement-profile:{}.witnessFamily", profile.profile_id)),
+            assumed_by: (method_status == "restriction_generator_missing")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/P0-2".to_string(),
+            assumption: "selected cover supplies finite restriction edges for support inclusion"
+                .to_string(),
+            status: if method_status == "empty_selected_restriction_edges" {
+                "violated"
+            } else {
+                "checked"
+            }
+            .to_string(),
+            checked_by: (method_status != "empty_selected_restriction_edges")
+                .then(|| format!("measurement-profile:{}.coverRef", profile.profile_id)),
+            assumed_by: (method_status == "empty_selected_restriction_edges")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/P0-2-boundary".to_string(),
+            assumption: "measured nonzero restriction incompatibility is presentation-relative"
+                .to_string(),
             status: "assumed".to_string(),
             checked_by: None,
             assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),

--- a/tools/archsig/src/law_policy/registry.rs
+++ b/tools/archsig/src/law_policy/registry.rs
@@ -263,6 +263,7 @@ fn evaluator_manifests() -> Vec<LawEvaluatorManifestV1> {
     manifests.extend([
         ag_manifest("ag.cech-obstruction@1", "ag.cech-obstruction"),
         ag_coherence_manifest(),
+        ag_restriction_manifest(),
         ag_manifest("ag.square-free-repair@1", "ag.square-free-repair"),
         ag_manifest("ag.law-conflict-tor@1", "ag.law-conflict-tor"),
         ag_manifest("ag.sheaf-laplacian@1", "ag.sheaf-laplacian"),
@@ -300,6 +301,40 @@ fn ag_coherence_manifest() -> LawEvaluatorManifestV1 {
             "/computedInvariants".to_string(),
         ],
         negative_fixtures: vec!["ag_coherence_obstruction_negative.json".to_string()],
+    }
+}
+
+fn ag_restriction_manifest() -> LawEvaluatorManifestV1 {
+    LawEvaluatorManifestV1 {
+        evaluator_id: "ag.restriction-compatibility@1".to_string(),
+        law_id: "ag.restriction-compatibility".to_string(),
+        required_atom_constructors: Vec::new(),
+        required_predicates: vec![
+            "restriction-compatibility.restrictionIdealGenerator".to_string(),
+        ],
+        required_molecule_condition:
+            "archmap/v2 contexts, selected cover restriction edges, and finite ideal generator supports"
+                .to_string(),
+        scope_filtering_rule:
+            "selected finite poset site and cover from MeasurementProfile".to_string(),
+        missing_blocker_rule:
+            "missing restriction edges or endpoint generator contracts are not_computed".to_string(),
+        pass_criteria:
+            "every selected restriction edge carries source ideal generators into the target ideal"
+                .to_string(),
+        violation_criteria:
+            "some selected restriction edge has a source generator with no target generator dividing its support"
+                .to_string(),
+        typed_result_schema: "archsig-measurement-packet/v1".to_string(),
+        distance_contribution:
+            "structural restriction compatibility verdict remains selected-cover and presentation-relative"
+                .to_string(),
+        summary_output_refs: vec!["/structuralVerdict".to_string()],
+        detail_output_refs: vec![
+            "/assumptions".to_string(),
+            "/computedInvariants".to_string(),
+        ],
+        negative_fixtures: vec!["ag_restriction_compatibility_negative.json".to_string()],
     }
 }
 

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -1112,6 +1112,198 @@ fn cli_analyze_v2_cover_nerve_faces_require_packet_triple_overlap_support() {
 }
 
 #[test]
+fn cli_analyze_v2_restriction_compatibility_measures_support_inclusion() {
+    let root_out = temp_dir("ag-measurement-restriction-compatibility");
+
+    let zero_dir = root_out.join("zero");
+    fs::create_dir_all(&zero_dir).expect("zero dir exists");
+    let zero_archmap = zero_dir.join("archmap.json");
+    let zero_policy = zero_dir.join("law_policy.json");
+    fs::write(
+        &zero_archmap,
+        serde_json::to_vec_pretty(&restriction_archmap("compatible")).expect("archmap serializes"),
+    )
+    .expect("zero archmap is written");
+    fs::write(
+        &zero_policy,
+        serde_json::to_vec_pretty(&restriction_policy()).expect("policy serializes"),
+    )
+    .expect("zero policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        zero_archmap.to_str().unwrap(),
+        "--law-policy",
+        zero_policy.to_str().unwrap(),
+        "--out-dir",
+        zero_dir.to_str().unwrap(),
+    ]);
+    let zero_packet = read_json(&zero_dir.join("archsig-measurement-packet.json"));
+    let zero_row = restriction_row(&zero_packet);
+    assert_eq!(zero_row["verdict"], "measured_zero");
+    assert_eq!(zero_row["verdictData"]["zero"], true);
+    assert_eq!(
+        zero_row["verdictData"]["methodStatus"],
+        "finite_support_inclusion_computed"
+    );
+    let zero_invariant = invariant_by_id(
+        &zero_packet,
+        "restriction-compatibility:profile:ag-restriction@1",
+    );
+    assert_eq!(zero_invariant["method"], "finite-support-inclusion@1");
+    assert_eq!(zero_invariant["edgeChecks"][0]["status"], "compatible");
+
+    let nonzero_dir = root_out.join("nonzero");
+    fs::create_dir_all(&nonzero_dir).expect("nonzero dir exists");
+    let nonzero_archmap = nonzero_dir.join("archmap.json");
+    let nonzero_policy = nonzero_dir.join("law_policy.json");
+    fs::write(
+        &nonzero_archmap,
+        serde_json::to_vec_pretty(&restriction_archmap("violated")).expect("archmap serializes"),
+    )
+    .expect("nonzero archmap is written");
+    fs::write(
+        &nonzero_policy,
+        serde_json::to_vec_pretty(&restriction_policy()).expect("policy serializes"),
+    )
+    .expect("nonzero policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        nonzero_archmap.to_str().unwrap(),
+        "--law-policy",
+        nonzero_policy.to_str().unwrap(),
+        "--out-dir",
+        nonzero_dir.to_str().unwrap(),
+    ]);
+    let nonzero_packet = read_json(&nonzero_dir.join("archsig-measurement-packet.json"));
+    let nonzero_row = restriction_row(&nonzero_packet);
+    assert_eq!(nonzero_row["verdict"], "measured_nonzero");
+    assert_eq!(nonzero_row["verdictData"]["nonZero"], true);
+    let nonzero_invariant = invariant_by_id(
+        &nonzero_packet,
+        "restriction-compatibility:profile:ag-restriction@1",
+    );
+    assert_eq!(nonzero_invariant["edgeChecks"][0]["status"], "violated");
+    assert_eq!(
+        nonzero_invariant["edgeChecks"][0]["violations"][0]["generatorRef"],
+        "atom:gen-source-x"
+    );
+    assert!(
+        nonzero_invariant["edgeChecks"][0]["violations"][0]["sourceRefs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|source_ref| source_ref == "src:source-generator"),
+        "violated edge must carry source refs"
+    );
+    assert!(
+        nonzero_invariant["boundaryNote"].as_str().is_some_and(
+            |note| note.contains("sheaf image 再定義で消えうる、理論対象の defect ではない")
+        ),
+        "presentation-relative boundary must be explicit"
+    );
+    assert!(
+        nonzero_packet["structuralVerdict"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|row| matches!(
+                row["verdict"].as_str().unwrap(),
+                "measured_zero" | "measured_nonzero" | "unmeasured" | "unknown" | "not_computed"
+            )),
+        "restriction evaluator must reuse the existing five verdict values"
+    );
+
+    let missing_dir = root_out.join("missing");
+    fs::create_dir_all(&missing_dir).expect("missing dir exists");
+    let missing_archmap = missing_dir.join("archmap.json");
+    let missing_policy = missing_dir.join("law_policy.json");
+    fs::write(
+        &missing_archmap,
+        serde_json::to_vec_pretty(&restriction_archmap("missing-target"))
+            .expect("archmap serializes"),
+    )
+    .expect("missing archmap is written");
+    fs::write(
+        &missing_policy,
+        serde_json::to_vec_pretty(&restriction_policy()).expect("policy serializes"),
+    )
+    .expect("missing policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        missing_archmap.to_str().unwrap(),
+        "--law-policy",
+        missing_policy.to_str().unwrap(),
+        "--out-dir",
+        missing_dir.to_str().unwrap(),
+    ]);
+    let missing_packet = read_json(&missing_dir.join("archsig-measurement-packet.json"));
+    let missing_row = restriction_row(&missing_packet);
+    assert_eq!(missing_row["verdict"], "not_computed");
+    assert_eq!(
+        missing_row["verdictData"]["methodStatus"],
+        "restriction_generator_missing"
+    );
+
+    let empty_dir = root_out.join("empty");
+    fs::create_dir_all(&empty_dir).expect("empty dir exists");
+    let empty_archmap = empty_dir.join("archmap.json");
+    let empty_policy = empty_dir.join("law_policy.json");
+    fs::write(
+        &empty_archmap,
+        serde_json::to_vec_pretty(&restriction_archmap("empty-edges")).expect("archmap serializes"),
+    )
+    .expect("empty archmap is written");
+    fs::write(
+        &empty_policy,
+        serde_json::to_vec_pretty(&restriction_policy()).expect("policy serializes"),
+    )
+    .expect("empty policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        empty_archmap.to_str().unwrap(),
+        "--law-policy",
+        empty_policy.to_str().unwrap(),
+        "--out-dir",
+        empty_dir.to_str().unwrap(),
+    ]);
+    let empty_packet = read_json(&empty_dir.join("archsig-measurement-packet.json"));
+    let empty_row = restriction_row(&empty_packet);
+    assert_eq!(empty_row["verdict"], "not_computed");
+    assert_eq!(
+        empty_row["verdictData"]["methodStatus"],
+        "empty_selected_restriction_edges"
+    );
+
+    let bad_profile_dir = root_out.join("bad-profile");
+    fs::create_dir_all(&bad_profile_dir).expect("bad profile dir exists");
+    let bad_policy = bad_profile_dir.join("law_policy.json");
+    let mut policy = restriction_policy();
+    policy["measurementProfiles"][0]["effCoeff"] =
+        Value::String("finite-linear-algebra@1".to_string());
+    fs::write(
+        &bad_policy,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("bad policy is written");
+    run_sig0_expect_code(
+        &[
+            "analyze",
+            "--archmap",
+            zero_archmap.to_str().unwrap(),
+            "--law-policy",
+            bad_policy.to_str().unwrap(),
+            "--out-dir",
+            bad_profile_dir.to_str().unwrap(),
+        ],
+        2,
+    );
+}
+
+#[test]
 fn cli_analyze_v2_coherence_obstruction_measures_h2_nonzero_with_representative() {
     let out_dir = temp_dir("ag-measurement-coherence-h2-nonzero");
     let archmap_path = out_dir.join("archmap_coherence_h2_nonzero.json");
@@ -11878,6 +12070,150 @@ fn coherence_row(packet: &Value) -> &Value {
         .iter()
         .find(|row| row["evaluator"] == "ag.coherence-obstruction@1")
         .expect("coherence row exists")
+}
+
+fn restriction_row(packet: &Value) -> &Value {
+    packet["structuralVerdict"]
+        .as_array()
+        .expect("structuralVerdict is array")
+        .iter()
+        .find(|row| row["evaluator"] == "ag.restriction-compatibility@1")
+        .expect("restriction compatibility row exists")
+}
+
+fn restriction_policy() -> Value {
+    json!({
+        "schema": "law-policy/v1",
+        "id": "ag-restriction-policy",
+        "measurementProfileRef": "profile:ag-restriction@1",
+        "measurementProfiles": [{
+            "schema": "measurement-profile/v1",
+            "profileId": "profile:ag-restriction@1",
+            "siteRef": "archmap:/contexts",
+            "coverRef": "cover:restriction",
+            "coefficient": "F2",
+            "effCoeff": "finite-support-inclusion@1",
+            "witnessFamily": [
+                {"law": "ag.restriction-compatibility", "variable": "x"},
+                {"law": "ag.restriction-compatibility", "variable": "y"}
+            ],
+            "resolutionSelector": "support-inclusion@1",
+            "domain": "finite-poset-site",
+            "zeroPredicate": "all-inclusions-hold@1",
+            "nonZeroPredicate": "some-inclusion-fails@1",
+            "certSelector": "finite-certificate@1",
+            "verdictDiscipline": "five-valued-structural-verdict@1"
+        }],
+        "policies": [{
+            "law": "ag.restriction-compatibility",
+            "evaluator": "ag.restriction-compatibility@1",
+            "basis": ["policy-basis:layering"],
+            "scope": ["src/"],
+            "severity": "high"
+        }]
+    })
+}
+
+fn restriction_archmap(case: &str) -> Value {
+    let source_generator = match case {
+        "compatible" => Some(("atom:gen-source-xy", "x,y", "src:source-generator")),
+        "violated" | "missing-target" => Some(("atom:gen-source-x", "x", "src:source-generator")),
+        "empty-edges" => Some(("atom:gen-source-x", "x", "src:source-generator")),
+        _ => panic!("unknown restriction fixture case: {case}"),
+    };
+    let target_generator = match case {
+        "compatible" => Some(("atom:gen-target-x", "x", "src:target-generator")),
+        "violated" => Some(("atom:gen-target-xy", "x,y", "src:target-generator")),
+        "empty-edges" => Some(("atom:gen-target-x", "x", "src:target-generator")),
+        "missing-target" => None,
+        _ => panic!("unknown restriction fixture case: {case}"),
+    };
+    let mut atoms = vec![
+        atom_json(
+            "atom:source",
+            "component",
+            "src:source",
+            "static",
+            "component",
+            None,
+            vec!["src:source"],
+        ),
+        atom_json(
+            "atom:target",
+            "component",
+            "src:target",
+            "static",
+            "component",
+            None,
+            vec!["src:target"],
+        ),
+    ];
+    if let Some((atom_id, support, source_ref)) = source_generator {
+        atoms.push(atom_json(
+            atom_id,
+            "relation",
+            "ctx:source",
+            "restriction-compatibility",
+            "restrictionIdealGenerator",
+            Some(support),
+            vec!["ctx:source", source_ref],
+        ));
+    }
+    if let Some((atom_id, support, source_ref)) = target_generator {
+        atoms.push(atom_json(
+            atom_id,
+            "relation",
+            "ctx:target",
+            "restriction-compatibility",
+            "restrictionIdealGenerator",
+            Some(support),
+            vec!["ctx:target", source_ref],
+        ));
+    }
+    let mut source_atoms = vec!["atom:source"];
+    if let Some((atom_id, _, _)) = source_generator {
+        source_atoms.push(atom_id);
+    }
+    let mut target_atoms = vec!["atom:target"];
+    if let Some((atom_id, _, _)) = target_generator {
+        target_atoms.push(atom_id);
+    }
+    json!({
+        "schema": "archmap/v2",
+        "id": format!("ag-restriction-fixture-{case}"),
+        "extractionDoctrineRef": {
+            "doctrineId": "doctrine:ag-fixture@1",
+            "fingerprint": "sha256:ag-restriction-fixture",
+            "components": ["V", "Gamma", "R", "rho", "E", "N"]
+        },
+        "sources": {
+            "src:source": {"kind": "rust", "path": "src/source.rs", "symbol": "Source", "line": 1},
+            "src:target": {"kind": "rust", "path": "src/target.rs", "symbol": "Target", "line": 1},
+            "src:source-generator": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M2 source generator"},
+            "src:target-generator": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M2 target generator"},
+            "ctx:source": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M2"},
+            "ctx:target": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M2"}
+        },
+        "atoms": atoms,
+        "contexts": [
+            {
+                "id": "ctx:source",
+                "atoms": source_atoms,
+                "restrictsTo": if case == "empty-edges" { json!([]) } else { json!(["ctx:target"]) },
+                "refs": ["ctx:source"]
+            },
+            {
+                "id": "ctx:target",
+                "atoms": target_atoms,
+                "refs": ["ctx:target"]
+            }
+        ],
+        "covers": [{
+            "id": "cover:restriction",
+            "contexts": ["ctx:source", "ctx:target"],
+            "refs": ["ctx:source", "ctx:target"]
+        }]
+    })
 }
 
 fn coherence_policy(coefficient: &str, include_cech: bool) -> Value {


### PR DESCRIPTION
## 概要

Closes #2230

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M2 に対応し、selected cover 上の separated presheaf 条件を finite support inclusion として測る `ag.restriction-compatibility@1` を追加しました。

- `ag.restriction-compatibility@1` を registry に登録
- `finite-support-inclusion@1` profile validation を追加
- `restriction-compatibility.restrictionIdealGenerator` atom から context ごとの finite generator support を読み、restriction edge ごとに `res(I_i) ⊆ I_j` を有限判定
- `measured_zero`, `measured_nonzero`, `not_computed`（empty edges / generator missing）と bad profile validation を test で固定
- `measured_nonzero` の boundaryNote に「sheaf image 再定義で消えうる、理論対象の defect ではない」を明記

local-review は数学・claim boundary、テスト・fixture、実装保守性の 3 観点で実施し、いずれも重大指摘なしでした。

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加で実施:

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml restriction_compatibility -- --nocapture`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
  - Lean status: tooling implementation（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
