### PR TITLE
ArchSig Topological Debt Capacity reading を追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -4830,6 +4830,15 @@ fn evaluate_cech_obstruction_v1(
     let has_triple_overlap_faces = cover_nerve_face_count > 0;
     let h1_class_nonzero =
         !empty_selected_scope && !edge_cochain_is_coboundary(&selected_contexts, &edges);
+    let topological_debt_capacity = topological_debt_capacity_invariant_v1(
+        profile,
+        &selected_contexts,
+        &edges,
+        &cover_nerve_projection,
+        h1_dimension,
+        h1_class_nonzero,
+        empty_selected_scope,
+    );
     let representative = edges
         .iter()
         .filter(|edge| edge.value == 1)
@@ -4879,6 +4888,16 @@ fn evaluate_cech_obstruction_v1(
             status: "assumed".to_string(),
             checked_by: None,
             assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/12.3".to_string(),
+            assumption: "constant coefficient nerve b1 comparison".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some(format!(
+                "measurement-profile:{}.coefficient={}",
+                profile.profile_id, profile.coefficient
+            )),
+            assumed_by: None,
         },
     ];
     assumptions.extend(cech_effectivity_assumptions_v1(
@@ -4995,6 +5014,7 @@ fn evaluate_cech_obstruction_v1(
                     "mismatchSupportRefs": mismatch_support_refs
                 }
             }),
+            topological_debt_capacity,
             json!({
                 "invariantId": format!("witness-counting:{}", profile.profile_id),
                 "evaluator": "witness-counting@1",
@@ -5010,6 +5030,141 @@ fn evaluate_cech_obstruction_v1(
         ],
         assumptions,
     }
+}
+
+fn topological_debt_capacity_invariant_v1(
+    profile: &MeasurementProfileV1,
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+    cover_nerve_projection: &Value,
+    one_skeleton_b1: usize,
+    h1_class_nonzero: bool,
+    empty_selected_scope: bool,
+) -> Value {
+    let dim_c0 = selected_contexts.len();
+    let dim_c1 = edges.len();
+    let dim_c2 = cover_nerve_projection["faces"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
+    let raw_capacity = dim_c1 as isize - dim_c0 as isize - dim_c2 as isize;
+    let capacity_lower_bound = raw_capacity.max(0) as usize;
+    let euler_characteristic = dim_c0 as isize - dim_c1 as isize + dim_c2 as isize;
+    let nerve_complex_b1 = nerve_complex_b1_f2(selected_contexts, edges, cover_nerve_projection);
+    json!({
+        "invariantId": format!("topological-debt-capacity:{}", profile.profile_id),
+        "evaluator": "ag.cech-obstruction@1",
+        "method": "finite-f2-rank-nullity-nerve-capacity@1",
+        "status": if empty_selected_scope {
+            "not_computed"
+        } else {
+            "computed"
+        },
+        "methodStatus": if empty_selected_scope {
+            "empty_selected_scope"
+        } else {
+            "finite_f2_nerve_capacity_computed"
+        },
+        "selectedCoverRef": profile.cover_ref,
+        "coefficient": profile.coefficient,
+        "dimensions": {
+            "dimC0": dim_c0,
+            "dimC1": dim_c1,
+            "dimC2": dim_c2
+        },
+        "capacityLowerBound": if empty_selected_scope {
+            Value::Null
+        } else {
+            json!(capacity_lower_bound)
+        },
+        "capacityFormula": "max(0, dimC1 - dimC0 - dimC2)",
+        "eulerCharacteristic": if empty_selected_scope {
+            Value::Null
+        } else {
+            json!(euler_characteristic)
+        },
+        "eulerFormula": "dimC0 - dimC1 + dimC2",
+        "b1NerveReading": {
+            "oneSkeletonB1": if empty_selected_scope {
+                Value::Null
+            } else {
+                json!(one_skeleton_b1)
+            },
+            "nerveComplexB1": if empty_selected_scope {
+                Value::Null
+            } else {
+                json!(nerve_complex_b1)
+            },
+            "oneSkeletonMethod": "graph-cycle-rank@1",
+            "nerveComplexMethod": "finite-f2-simplicial-homology-with-selected-2-faces@1",
+            "distinction": "oneSkeletonB1 counts graph cycles before selected triple-overlap faces are quotiented; nerveComplexB1 includes those faces and may be smaller.",
+            "nonClaim": "capacityLowerBound and b1NerveReading are capacity/accounting readings, not new structural verdicts and not concrete H1 class existence claims."
+        },
+        "measuredCechVerdictEcho": {
+            "evaluator": "ag.cech-obstruction@1",
+            "certRef": if empty_selected_scope {
+                Value::Null
+            } else {
+                json!(format!("computedInvariants/cech-cohomology:{}", profile.profile_id))
+            },
+            "h1ClassNonzero": h1_class_nonzero,
+            "note": "This is an echo of the separate Cech structural verdict, not a capacity-derived class claim."
+        },
+        "boundaryNote": "Part IV principle 11.3 is referenced only as the Cohomological Non-Claim boundary; this row does not import any Part VII numbering or create a viewer verdict.",
+        "structuralVerdictRef": Value::Null
+    })
+}
+
+fn nerve_complex_b1_f2(
+    selected_contexts: &[String],
+    edges: &[CechEdgeV1],
+    cover_nerve_projection: &Value,
+) -> usize {
+    let mut simplices = selected_contexts
+        .iter()
+        .map(|context| vec![context.clone()])
+        .collect::<Vec<_>>();
+    simplices.extend(
+        edges
+            .iter()
+            .map(|edge| sorted_simplex([edge.source_context.clone(), edge.target_context.clone()])),
+    );
+    if let Some(faces) = cover_nerve_projection["faces"].as_array() {
+        for face in faces {
+            let contexts = face["contextRefs"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+                .collect::<Vec<_>>();
+            if contexts.len() < 3 {
+                continue;
+            }
+            let edge_refs = face["edgeRefs"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|value| value.as_str())
+                .collect::<BTreeSet<_>>();
+            if edge_refs.len() == 3 {
+                simplices.push(sorted_simplex(contexts));
+            }
+        }
+    }
+    simplices.sort();
+    simplices.dedup();
+    reduced_simplicial_homology_f2(&simplices)
+        .into_iter()
+        .find(|row| row["degree"] == 1)
+        .and_then(|row| row["dimension"].as_u64())
+        .unwrap_or(0) as usize
+}
+
+fn sorted_simplex(items: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut simplex = items.into_iter().collect::<Vec<_>>();
+    simplex.sort();
+    simplex.dedup();
+    simplex
 }
 
 fn cech_effectivity_assumptions_v1(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -574,6 +574,13 @@ fn cli_analyze_v2_cech_empty_selected_scope_is_not_computed() {
         cech["selectedH2"]["reason"],
         "empty_selected_scope: selected cover has no non-empty Cech 1-skeleton for ag.cech-obstruction@1"
     );
+    let capacity = invariant_by_id(&packet, "topological-debt-capacity:profile:ag-default@1");
+    assert_eq!(capacity["status"], "not_computed");
+    assert_eq!(capacity["methodStatus"], "empty_selected_scope");
+    assert_eq!(capacity["capacityLowerBound"], Value::Null);
+    assert_eq!(capacity["eulerCharacteristic"], Value::Null);
+    assert_eq!(capacity["b1NerveReading"]["oneSkeletonB1"], Value::Null);
+    assert_eq!(capacity["b1NerveReading"]["nerveComplexB1"], Value::Null);
 
     let validation = read_json(&out_dir.join("archsig-analysis-validation.json"));
     assert_eq!(validation["summary"]["result"], "pass");
@@ -718,8 +725,17 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
         .join("archmap_v2_cech_h1_visible.json")
         .to_string_lossy()
         .to_string();
+    let computed_without_capacity = Value::Array(
+        packet["computedInvariants"]
+            .as_array()
+            .expect("computedInvariants is array")
+            .iter()
+            .filter(|row| row["invariantId"] != "topological-debt-capacity:profile:ag-default@1")
+            .cloned()
+            .collect(),
+    );
     assert_eq!(
-        packet["computedInvariants"],
+        computed_without_capacity,
         json!([
             {
                 "archmapRef": cech_fixture_path,
@@ -841,6 +857,45 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
             }
         ]),
         "ledger transparency must not change computed invariants for the same Cech input"
+    );
+    let capacity = invariant_by_id(&packet, "topological-debt-capacity:profile:ag-default@1");
+    assert_eq!(capacity["evaluator"], "ag.cech-obstruction@1");
+    assert_eq!(capacity["status"], "computed");
+    assert_eq!(capacity["structuralVerdictRef"], Value::Null);
+    assert_eq!(capacity["dimensions"]["dimC0"], Value::from(4));
+    assert_eq!(capacity["dimensions"]["dimC1"], Value::from(4));
+    assert_eq!(capacity["dimensions"]["dimC2"], Value::from(0));
+    assert_eq!(capacity["capacityLowerBound"], Value::from(0));
+    assert_eq!(capacity["eulerCharacteristic"], Value::from(0));
+    assert_eq!(capacity["b1NerveReading"]["oneSkeletonB1"], Value::from(1));
+    assert_eq!(capacity["b1NerveReading"]["nerveComplexB1"], Value::from(1));
+    assert_eq!(
+        capacity["measuredCechVerdictEcho"]["h1ClassNonzero"],
+        Value::Bool(true)
+    );
+    assert!(
+        capacity["b1NerveReading"]["nonClaim"]
+            .as_str()
+            .is_some_and(|text| text.contains("not concrete H1 class existence claims")),
+        "capacity reading must not claim concrete H1 class existence"
+    );
+    assert!(
+        capacity["boundaryNote"]
+            .as_str()
+            .is_some_and(|text| text.contains("Part IV principle 11.3")),
+        "cohomological non-claim boundary must be scoped to Part IV"
+    );
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| {
+                entry["theoremRef"] == "part4/12.3"
+                    && entry["assumption"] == "constant coefficient nerve b1 comparison"
+                    && entry["status"] == "checked"
+            }),
+        "b1 nerve reading must be relative to a checked constant coefficient assumption"
     );
     assert_eq!(
         packet["analyticReadings"],
@@ -1017,6 +1072,51 @@ fn cli_analyze_v2_cover_nerve_faces_require_packet_triple_overlap_support() {
             .expect("context atoms is array")
             .push(Value::String("atom:triple-overlap".to_string()));
     }
+    let incomplete_dir = out_dir.join("incomplete-boundary-face");
+    fs::create_dir_all(&incomplete_dir).expect("incomplete face dir exists");
+    let incomplete_archmap_path = incomplete_dir.join("archmap_v2_cech_triple_overlap.json");
+    fs::write(
+        &incomplete_archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("incomplete face archmap fixture can be written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        incomplete_archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        incomplete_dir.to_str().expect("path is utf-8"),
+    ]);
+    let incomplete_packet = read_json(&incomplete_dir.join("archsig-measurement-packet.json"));
+    let incomplete_capacity = invariant_by_id(
+        &incomplete_packet,
+        "topological-debt-capacity:profile:ag-default@1",
+    );
+    assert_eq!(incomplete_capacity["dimensions"]["dimC1"], Value::from(4));
+    assert_eq!(incomplete_capacity["dimensions"]["dimC2"], Value::from(1));
+    assert_eq!(
+        incomplete_capacity["b1NerveReading"]["oneSkeletonB1"],
+        Value::from(1)
+    );
+    assert_eq!(
+        incomplete_capacity["b1NerveReading"]["nerveComplexB1"],
+        Value::from(1),
+        "incomplete projected face boundary must not silently add missing selected C1 edges"
+    );
+    let top_context = archmap["contexts"]
+        .as_array_mut()
+        .expect("contexts is array")
+        .iter_mut()
+        .find(|context| context["id"] == "ctx:top")
+        .expect("ctx:top exists");
+    top_context["restrictsTo"]
+        .as_array_mut()
+        .expect("ctx:top restrictsTo is array")
+        .push(Value::String("ctx:bottom".to_string()));
     let archmap_path = out_dir.join("archmap_v2_cech_triple_overlap.json");
     fs::write(
         &archmap_path,
@@ -1037,6 +1137,16 @@ fn cli_analyze_v2_cover_nerve_faces_require_packet_triple_overlap_support() {
     ]);
 
     let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .iter()
+            .filter(|row| row["evaluator"] == "ag.cech-obstruction@1")
+            .count(),
+        1,
+        "Topological Debt Capacity must not add a structural verdict row"
+    );
     let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
     let faces = cech["coverNerveProjection"]["faces"]
         .as_array()
@@ -1062,6 +1172,33 @@ fn cli_analyze_v2_cover_nerve_faces_require_packet_triple_overlap_support() {
     assert_eq!(
         cech["coverNerveProjection"]["faceSource"],
         "selected cover triple-overlap sharedAtomRefs recorded in archsig-measurement-packet/v1; not inferred by the viewer"
+    );
+    let capacity = invariant_by_id(&packet, "topological-debt-capacity:profile:ag-default@1");
+    assert_eq!(
+        capacity["structuralVerdictRef"],
+        Value::Null,
+        "Topological Debt Capacity must remain a computedInvariant reading"
+    );
+    assert_eq!(capacity["dimensions"]["dimC0"], Value::from(4));
+    assert_eq!(capacity["dimensions"]["dimC1"], Value::from(5));
+    assert_eq!(capacity["dimensions"]["dimC2"], Value::from(1));
+    assert_eq!(capacity["capacityLowerBound"], Value::from(0));
+    assert_eq!(capacity["eulerCharacteristic"], Value::from(0));
+    assert_eq!(
+        capacity["b1NerveReading"]["oneSkeletonB1"],
+        Value::from(2),
+        "extra top-bottom edge creates an additional graph cycle before the selected 2-face is quotiented"
+    );
+    assert_eq!(
+        capacity["b1NerveReading"]["nerveComplexB1"],
+        Value::from(1),
+        "selected triple-overlap face must fill one graph cycle in the nerve complex reading"
+    );
+    assert!(
+        capacity["b1NerveReading"]["distinction"]
+            .as_str()
+            .is_some_and(|text| text.contains("oneSkeletonB1 counts graph cycles")),
+        "b1 reading must label the graph-vs-complex distinction"
     );
     assert_eq!(cech["coverNerveProjection"]["h2CoherenceVisualized"], false);
     assert_eq!(cech["selectedH2"]["dimension"], Value::Null);
@@ -3209,6 +3346,61 @@ fn cli_analyze_v2_cech_ignores_unanchored_mismatch_support() {
             .expect("mismatch support refs is array")
             .len(),
         0
+    );
+}
+
+#[test]
+fn cli_analyze_v2_topological_debt_capacity_does_not_claim_h1_class() {
+    let out_dir = temp_dir("ag-measurement-cech-positive-capacity-no-class");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2_cech_h1_visible.json"));
+    archmap["atoms"][4]["object"] = Value::String("ctx:right".to_string());
+    let top_context = archmap["contexts"]
+        .as_array_mut()
+        .expect("contexts is array")
+        .iter_mut()
+        .find(|context| context["id"] == "ctx:top")
+        .expect("ctx:top exists");
+    top_context["restrictsTo"]
+        .as_array_mut()
+        .expect("ctx:top restrictsTo is array")
+        .push(Value::String("ctx:bottom".to_string()));
+    let archmap_path = out_dir.join("archmap_v2_positive_capacity_no_class.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_ag.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
+    let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
+    assert_eq!(cech["observedCocycle"]["classNonzero"], false);
+    let capacity = invariant_by_id(&packet, "topological-debt-capacity:profile:ag-default@1");
+    assert_eq!(capacity["capacityLowerBound"], Value::from(1));
+    assert_eq!(capacity["b1NerveReading"]["oneSkeletonB1"], Value::from(2));
+    assert_eq!(capacity["b1NerveReading"]["nerveComplexB1"], Value::from(2));
+    assert_eq!(
+        capacity["measuredCechVerdictEcho"]["h1ClassNonzero"],
+        Value::Bool(false)
+    );
+    assert!(
+        capacity["b1NerveReading"]["nonClaim"]
+            .as_str()
+            .is_some_and(|text| text.contains("not concrete H1 class existence claims")),
+        "positive capacity must remain a non-claim about concrete H1 class existence"
     );
 }
 

--- a/tools/fieldsig/src/archmap.rs
+++ b/tools/fieldsig/src/archmap.rs
@@ -963,14 +963,21 @@ fn archsig_measurement_verdict_has_evidence(
     row: &serde_json::Value,
     evaluator: &str,
 ) -> bool {
-    if row
+    if let Some(cert_ref) = row
         .get("verdictData")
         .and_then(|data| data.get("certRef"))
         .and_then(|value| value.as_str())
-        .is_some_and(|value| !value.trim().is_empty())
     {
+        let cert_ref = cert_ref.trim();
+        if cert_ref.is_empty() {
+            return false;
+        }
+        if let Some(invariant_id) = cert_ref.strip_prefix("computedInvariants/") {
+            return archsig_measurement_computed_invariant_ids(packet).any(|id| id == invariant_id);
+        }
         return true;
     }
+    let certificate_prefixes = archsig_measurement_certificate_invariant_prefixes(evaluator);
     packet
         .get("computedInvariants")
         .and_then(|value| value.as_array())
@@ -985,9 +992,55 @@ fn archsig_measurement_verdict_has_evidence(
                     invariant
                         .get(*key)
                         .and_then(|value| value.as_str())
-                        .is_some_and(|value| !value.trim().is_empty())
+                        .is_some_and(|value| {
+                            let value = value.trim();
+                            if value.is_empty() {
+                                return false;
+                            }
+                            certificate_prefixes
+                                .map(|prefixes| {
+                                    prefixes.iter().any(|prefix| value.starts_with(prefix))
+                                })
+                                .unwrap_or(true)
+                        })
                 })
         })
+}
+
+fn archsig_measurement_computed_invariant_ids(
+    packet: &serde_json::Value,
+) -> impl Iterator<Item = &str> {
+    packet
+        .get("computedInvariants")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .flat_map(|invariant| {
+            ["invariantId", "readingId", "id"]
+                .into_iter()
+                .filter_map(|key| {
+                    invariant
+                        .get(key)
+                        .and_then(|value| value.as_str())
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                })
+        })
+}
+
+fn archsig_measurement_certificate_invariant_prefixes(
+    evaluator: &str,
+) -> Option<&'static [&'static str]> {
+    match evaluator {
+        "ag.cech-obstruction@1" => Some(&["cech-cohomology:"]),
+        "ag.law-conflict-tor@1" => Some(&["law-conflict-tor:"]),
+        "ag.square-free-repair@1" => Some(&["square-free-repair:"]),
+        "ag.restriction-compatibility@1" => Some(&["restriction-compatibility:"]),
+        "ag.section-factorization@1" => Some(&["section-factorization:"]),
+        "ag.boundary-residue@1" => Some(&["boundary-residue:"]),
+        "ag.coherence-obstruction@1" => Some(&["coherence-obstruction:"]),
+        _ => None,
+    }
 }
 
 fn validate_archsig_measurement_packet_assumptions(

--- a/tools/fieldsig/tests/cli.rs
+++ b/tools/fieldsig/tests/cli.rs
@@ -802,6 +802,78 @@ fn cli_projects_archsig_measurement_packet_to_sft_input_boundary() {
 }
 
 #[test]
+fn cli_rejects_archsig_measurement_capacity_reading_as_cech_cert_fallback() {
+    let out_dir = temp_dir("archsig-measurement-capacity-not-cert");
+    let packet = out_dir.join("archsig-measurement-packet.json");
+    let estimate = out_dir.join("operation-support-estimate.json");
+    let packet_json = serde_json::json!({
+        "schema": "archsig-measurement-packet/v1",
+        "packetId": "measurement:capacity-not-cert",
+        "profile": {
+            "schema": "measurement-profile/v1",
+            "profileId": "profile:capacity-not-cert",
+            "siteRef": "archmap:/contexts",
+            "coverRef": "cover:test",
+            "coefficient": "F2",
+            "effCoeff": "finite-linear-algebra@1",
+            "witnessFamily": [],
+            "resolutionSelector": "cech@1",
+            "domain": "finite-poset-site",
+            "zeroPredicate": "rank-zero@1",
+            "nonZeroPredicate": "rank-positive@1",
+            "certSelector": "finite-certificate@1",
+            "verdictDiscipline": "five-valued-structural-verdict@1"
+        },
+        "structuralVerdict": [{
+            "evaluator": "ag.cech-obstruction@1",
+            "law": "ag.cech-obstruction",
+            "verdict": "measured_nonzero",
+            "verdictData": {
+                "inScope": true,
+                "zero": false,
+                "nonZero": true,
+                "methodStatus": "finite_f2_cech_computed"
+            }
+        }],
+        "computedInvariants": [{
+            "invariantId": "topological-debt-capacity:profile:capacity-not-cert",
+            "evaluator": "ag.cech-obstruction@1",
+            "status": "computed",
+            "structuralVerdictRef": null,
+            "capacityLowerBound": 1
+        }],
+        "analyticReadings": [],
+        "assumptions": [{
+            "theoremRef": "part4/12.3",
+            "assumption": "constant coefficient nerve b1 comparison",
+            "status": "checked",
+            "checkedBy": "measurement-profile:profile:capacity-not-cert.coefficient=F2"
+        }],
+        "boundaryStatements": [],
+        "nonConclusions": []
+    });
+    fs::write(
+        &packet,
+        serde_json::to_string_pretty(&packet_json).expect("measurement packet serializes"),
+    )
+    .expect("measurement packet fixture is written");
+
+    let output = run_sig0_output(&[
+        "archsig-analysis-sft-input",
+        "--measurement-packet",
+        packet.to_str().expect("measurement packet path is utf-8"),
+        "--out",
+        estimate.to_str().expect("estimate path is utf-8"),
+    ]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("requires certRef or matching computed invariant evidence"),
+        "M7 capacity reading must not act as fallback certificate for a measured Cech verdict"
+    );
+}
+
+#[test]
 fn cli_rejects_invalid_measurement_packet_handoff_inputs() {
     let out_dir = temp_dir("archsig-measurement-sft-input-rejected");
     let schema_only = out_dir.join("schema-only-measurement-packet.json");
@@ -896,7 +968,11 @@ fn cli_rejects_invalid_measurement_packet_handoff_inputs() {
                 "certRef": "computedInvariants/square-free-repair:profile:semantic-validation"
             }
         }],
-        "computedInvariants": [],
+        "computedInvariants": [{
+            "invariantId": "square-free-repair:profile:semantic-validation",
+            "evaluator": "ag.square-free-repair@1",
+            "status": "computed"
+        }],
         "analyticReadings": [],
         "assumptions": [{
             "theoremRef": "part3/7.2B",
@@ -973,6 +1049,7 @@ fn cli_rejects_invalid_measurement_packet_handoff_inputs() {
         .as_object_mut()
         .expect("verdictData is object")
         .remove("certRef");
+    missing_evidence_json["computedInvariants"] = serde_json::json!([]);
     fs::write(
         &missing_evidence_packet,
         serde_json::to_string_pretty(&missing_evidence_json)


### PR DESCRIPTION
## 概要

Closes #2247

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M7 に対応し、`ag.cech-obstruction@1` の computedInvariants に Topological Debt Capacity reading を追加しました。

- `capacityLowerBound = max(0, dimC1 - dimC0 - dimC2)` と `eulerCharacteristic = dimC0 - dimC1 + dimC2` を出力
- `b1NerveReading` で 1-skeleton b1 と selected 2-face を含む nerve complex b1 を分離
- positive capacity を concrete H1 class 存在 claim にしない境界を JSON と test で固定
- incomplete triangle face が存在しない selected C1 edge を暗黙追加しないように b1 計算を限定
- M7 reading が FieldSig handoff で Cech structural verdict の certificate fallback にならないよう evidence linkage を補強

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling implementation; Lean 変更なし。
