### PR TITLE
ArchSig 沈黙の typed boundary 三層を固定

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -65,6 +65,7 @@ fn boundary_statements_for_measurement_packet(
             text: text.clone(),
         })
         .collect::<Vec<_>>();
+    statements.extend(m8_silence_boundary_statements(packet));
 
     for (index, row) in packet.structural_verdict.iter().enumerate() {
         let scope_ref = structural_verdict_ref(row);
@@ -131,6 +132,32 @@ fn boundary_statements_for_measurement_packet(
     }
 
     statements
+}
+
+fn m8_silence_boundary_statements(packet: &ArchSigMeasurementPacketV1) -> Vec<BoundaryStatementV1> {
+    vec![
+        BoundaryStatementV1 {
+            id: "boundary:m8:higher-hn-silence".to_string(),
+            kind: "silence_by_design".to_string(),
+            scope_refs: vec![packet.packet_id.clone()],
+            reason: "higher_hn_n_ge_3_part_iv_scope_boundary".to_string(),
+            text: "Higher H^n for n>=3 is silent by design in this finite AG measurement packet: it is a Part IV scope boundary, not a measured zero result or a remaining task.".to_string(),
+        },
+        BoundaryStatementV1 {
+            id: "boundary:m8:non-abelian-stack-gerbe-vocabulary".to_string(),
+            kind: "out_of_selected_vocabulary".to_string(),
+            scope_refs: vec![packet.packet_id.clone()],
+            reason: "non_abelian_stack_gerbe_outside_abelian_f2_vocabulary".to_string(),
+            text: "Non-abelian stack/gerbe H^2(X,Aut(Dec_U)) is outside the selected banded abelian F2 vocabulary; banding-violated inputs remain outside this measurement lens.".to_string(),
+        },
+        BoundaryStatementV1 {
+            id: "boundary:m8:higher-tor-unmeasured-support".to_string(),
+            kind: "unmeasured_support".to_string(),
+            scope_refs: vec![packet.packet_id.clone()],
+            reason: "higher_tor_i_ge_2_unmeasured_support".to_string(),
+            text: "Higher Tor_i for i>=2 remains unmeasured support: degree-1 Tor_1 readings do not discharge derived transversality or all higher Tor vanishing.".to_string(),
+        },
+    ]
 }
 
 fn assumption_theorem_refs(assumptions: &[AgAssumptionLedgerEntryV1]) -> Vec<String> {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -382,6 +382,89 @@ fn cli_analyze_v2_writes_measurement_packet_foundation() {
                     .any(|scope_ref| scope_ref == "candidate-regime:stability-placeholder")),
         "analytic-only theorem candidate must be represented as a not_applicable boundary"
     );
+    let boundary_kinds = packet["boundaryStatements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|statement| statement["kind"].as_str().expect("boundary kind"))
+        .collect::<BTreeSet<_>>();
+    assert!(
+        boundary_kinds.is_subset(&BTreeSet::from([
+            "silence_by_design",
+            "out_of_selected_vocabulary",
+            "unmeasured_support",
+            "violated_assumption",
+            "blocked_method",
+            "not_applicable",
+        ])),
+        "M8 must reuse existing BoundaryStatementV1 kinds"
+    );
+    for (id, kind, reason_text, scope_text) in [
+        (
+            "boundary:m8:higher-hn-silence",
+            "silence_by_design",
+            "higher_hn_n_ge_3_part_iv_scope_boundary",
+            "Higher H^n for n>=3",
+        ),
+        (
+            "boundary:m8:non-abelian-stack-gerbe-vocabulary",
+            "out_of_selected_vocabulary",
+            "non_abelian_stack_gerbe_outside_abelian_f2_vocabulary",
+            "Non-abelian stack/gerbe",
+        ),
+        (
+            "boundary:m8:higher-tor-unmeasured-support",
+            "unmeasured_support",
+            "higher_tor_i_ge_2_unmeasured_support",
+            "Higher Tor_i for i>=2",
+        ),
+    ] {
+        assert!(
+            packet["boundaryStatements"].as_array().unwrap().iter().any(
+                |statement| statement["id"] == id
+                    && statement["kind"] == kind
+                    && statement["reason"] == reason_text
+                    && statement["scopeRefs"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|scope_ref| scope_ref == packet["packetId"].as_str().unwrap())
+                    && statement["text"]
+                        .as_str()
+                        .is_some_and(|text| text.contains(scope_text))
+            ),
+            "M8 typed boundary {id} must keep its own kind and scope"
+        );
+    }
+    assert!(
+        packet["nonConclusions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .all(|text| {
+                !text.contains("Higher H^n")
+                    && !text.contains("Non-abelian stack/gerbe")
+                    && !text.contains("Higher Tor_i")
+            }),
+        "M8 silence must be a typed boundary, not a nonConclusions headline"
+    );
+    assert_eq!(
+        packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .len(),
+        1,
+        "M8 typed boundary must not generate a structural verdict"
+    );
+    assert!(
+        packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .iter()
+            .all(|row| row["verdictData"]["methodStatus"] != "depends_on_violated_assumption"),
+        "M8 typed boundary must not trigger assumption dependency propagation"
+    );
     assert_eq!(packet["structuralVerdict"][0]["verdict"], "measured_zero");
     let cech = invariant_by_id(&packet, "cech-cohomology:profile:ag-default@1");
     assert_eq!(cech["dimensions"]["H1"], Value::from(0));


### PR DESCRIPTION
## 概要

Closes #2249

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M8 に対応し、沈黙が正しい領域を `BoundaryStatementV1` の typed boundary として三層固定しました。

- higher H^n n>=3: `silence_by_design`
- non-abelian stack-gerbe: `out_of_selected_vocabulary`
- higher Tor_i i>=2: `unmeasured_support`
- 新 structural verdict と新 boundary kind は追加しない
- M8 boundary を `nonConclusions` の主役ではなく typed boundary として出力
- assumption dependency propagation を発火させず、既存 measured verdict を降格させないことを test で固定

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling implementation; Lean 変更なし。
