### PR TITLE
ArchSig period-stokes audit verdict を追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -460,6 +460,30 @@ pub fn build_foundation_measurement_packet_v1(
             computed_invariants.extend(measurement.computed_invariants);
             analytic_readings.extend(measurement.analytic_readings);
             assumptions.extend(measurement.assumptions);
+        } else if evaluator == "ag.period-stokes-audit@1" {
+            validate_period_audit_profile_v1(&profile)?;
+            let measurement = evaluate_period_stokes_audit_v1(normalized, &profile)?;
+            let depends_on_assumptions = assumption_theorem_refs(&measurement.assumptions);
+            computed_invariants.extend(measurement.computed_invariants);
+            analytic_readings.extend(measurement.analytic_readings);
+            assumptions.extend(measurement.assumptions);
+            structural_verdict.push(AgStructuralVerdictV1 {
+                evaluator: evaluator.to_string(),
+                law: entry
+                    .law
+                    .clone()
+                    .unwrap_or_else(|| "ag.period-stokes-audit".to_string()),
+                verdict: measurement.verdict,
+                verdict_data: AgVerdictDataV1 {
+                    in_scope: true,
+                    zero: measurement.zero,
+                    non_zero: measurement.non_zero,
+                    method_status: measurement.method_status,
+                    cert_ref: measurement.cert_ref,
+                },
+                depends_on_assumptions,
+                reason: Some(measurement.reason),
+            });
         } else if evaluator == "ag.support-transfer@1" {
             validate_transfer_profile_v1(&profile)?;
             let measurement = evaluate_support_transfer_v1(normalized, &profile)?;
@@ -753,6 +777,19 @@ struct LaplacianEdgeV1 {
 
 #[derive(Debug, Clone)]
 struct PeriodMeasurementV1 {
+    computed_invariants: Vec<Value>,
+    analytic_readings: Vec<AgAnalyticReadingV1>,
+    assumptions: Vec<AgAssumptionLedgerEntryV1>,
+}
+
+#[derive(Debug, Clone)]
+struct PeriodAuditMeasurementV1 {
+    verdict: String,
+    zero: bool,
+    non_zero: bool,
+    method_status: String,
+    cert_ref: Option<String>,
+    reason: String,
     computed_invariants: Vec<Value>,
     analytic_readings: Vec<AgAnalyticReadingV1>,
     assumptions: Vec<AgAssumptionLedgerEntryV1>,
@@ -2156,6 +2193,177 @@ fn evaluate_period_stokes_v1(
         }],
         assumptions: period_assumptions(profile, "checked"),
     })
+}
+
+fn evaluate_period_stokes_audit_v1(
+    normalized: &NormalizedArchMapV2,
+    profile: &MeasurementProfileV1,
+) -> Result<PeriodAuditMeasurementV1, String> {
+    let selected_contexts = selected_cover_contexts(normalized, profile)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let cycle_basis = period_audit_witness_cycles(profile);
+    let pairings = period_integrals(normalized, &selected_contexts, &cycle_basis)?;
+    let d_omega = stokes_audit_values(
+        normalized,
+        &selected_contexts,
+        "dOmegaIntegral",
+        "ag.period-stokes-audit@1 d omega audit",
+    )?;
+    let boundary = stokes_audit_values(
+        normalized,
+        &selected_contexts,
+        "boundaryPeriod",
+        "ag.period-stokes-audit@1 boundary audit",
+    )?;
+
+    let audit = fixed_coefficient_stokes_audit_report(&d_omega, &boundary, &profile.coefficient);
+    let (forms, matrix, analytic_reading) =
+        period_pairing_analytic_reading(profile, &cycle_basis, &pairings, Some(audit.clone()));
+    let source_refs = pairings
+        .iter()
+        .flat_map(|pairing| pairing.source_refs.iter())
+        .chain(d_omega.iter().flat_map(|entry| entry.source_refs.iter()))
+        .chain(boundary.iter().flat_map(|entry| entry.source_refs.iter()))
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let computed_invariant = json!({
+        "invariantId": format!("period-stokes-audit:{}", profile.profile_id),
+        "evaluator": "ag.period-stokes-audit@1",
+        "method": "fixed-coefficient-stokes-audit@1",
+        "selectedCoverRef": profile.cover_ref,
+        "coefficient": profile.coefficient,
+        "forms": forms,
+        "cycleBasis": cycle_basis,
+        "periodPairingMatrix": rounded_matrix(&matrix),
+        "stokesAudit": audit,
+        "claimScope": "supplied independent dOmega/boundary accounting values under the selected fixed coefficient reading",
+        "analyticReadingRef": analytic_reading.reading_id,
+        "sourceRefs": source_refs
+    });
+
+    let status = computed_invariant["stokesAudit"]["status"]
+        .as_str()
+        .unwrap_or("unknown");
+    let (verdict, zero, non_zero, method_status, cert_ref, reason, assumption_status) =
+        match status {
+            "checked" => (
+                "measured_zero".to_string(),
+                true,
+                false,
+                "fixed_coefficient_stokes_audit_computed".to_string(),
+                Some(format!(
+                    "computedInvariants/period-stokes-audit:{}",
+                    profile.profile_id
+                )),
+                "all supplied Stokes audit residuals are zero under the selected fixed coefficient reading".to_string(),
+                "checked",
+            ),
+            "residual_nonzero" => (
+                "measured_nonzero".to_string(),
+                false,
+                true,
+                "fixed_coefficient_stokes_audit_computed".to_string(),
+                Some(format!(
+                    "computedInvariants/period-stokes-audit:{}",
+                    profile.profile_id
+                )),
+                "at least one supplied Stokes audit residual is nonzero under the selected fixed coefficient reading".to_string(),
+                "checked",
+            ),
+            "unknown" => (
+                "unknown".to_string(),
+                false,
+                false,
+                "strict_coefficient_unresolved".to_string(),
+                None,
+                computed_invariant["stokesAudit"]["reason"]
+                    .as_str()
+                    .unwrap_or("strict coefficient Stokes audit is unresolved")
+                    .to_string(),
+                "assumed",
+            ),
+            _ => (
+                "unknown".to_string(),
+                false,
+                false,
+                "period_audit_model_missing".to_string(),
+                None,
+                computed_invariant["stokesAudit"]["reason"]
+                    .as_str()
+                    .unwrap_or("period Stokes audit model is incomplete")
+                    .to_string(),
+                "violated",
+            ),
+        };
+
+    Ok(PeriodAuditMeasurementV1 {
+        verdict,
+        zero,
+        non_zero,
+        method_status,
+        cert_ref,
+        reason,
+        computed_invariants: vec![computed_invariant],
+        analytic_readings: vec![analytic_reading],
+        assumptions: period_audit_assumptions(profile, assumption_status),
+    })
+}
+
+fn period_pairing_analytic_reading(
+    profile: &MeasurementProfileV1,
+    cycle_basis: &[String],
+    pairings: &[PeriodIntegralV1],
+    stokes_audit: Option<Value>,
+) -> (Vec<String>, Vec<Vec<f64>>, AgAnalyticReadingV1) {
+    let forms = pairings
+        .iter()
+        .map(|pairing| pairing.form_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let form_index = forms
+        .iter()
+        .enumerate()
+        .map(|(index, form)| (form.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let cycle_index = cycle_basis
+        .iter()
+        .enumerate()
+        .map(|(index, cycle)| (cycle.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let mut matrix = vec![vec![0.0; cycle_basis.len()]; forms.len()];
+    for pairing in pairings {
+        if let (Some(form), Some(cycle)) = (
+            form_index.get(&pairing.form_id),
+            cycle_index.get(&pairing.cycle_id),
+        ) {
+            matrix[*form][*cycle] = pairing.value;
+        }
+    }
+    let analytic_value = json!({
+        "readingKind": "strict-period-pairing@1",
+        "selectedCoverRef": profile.cover_ref,
+        "modelRelative": true,
+        "forms": forms,
+        "cycleBasis": cycle_basis,
+        "periodPairingMatrix": rounded_matrix(&matrix),
+        "stokesAudit": stokes_audit,
+        "nonConclusion": "period pairing is a model-relative analytic reading and is not a structural lawfulness verdict"
+    });
+    (
+        form_index.keys().cloned().collect(),
+        matrix,
+        AgAnalyticReadingV1 {
+            reading_id: format!("analytic:period-stokes:{}", profile.profile_id),
+            evaluator: "ag.period-stokes@1".to_string(),
+            value: analytic_value,
+            regime: Some("analytic-measurement".to_string()),
+            structural_verdict_ref: None,
+        },
+    )
 }
 
 fn evaluate_support_transfer_v1(
@@ -5745,6 +5953,67 @@ fn validate_period_profile_v1(profile: &MeasurementProfileV1) -> Result<(), Stri
     Ok(())
 }
 
+fn validate_period_audit_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
+    let expected = [
+        (
+            "effCoeff",
+            profile.eff_coeff.as_str(),
+            "fixed-coefficient-stokes-audit@1",
+        ),
+        (
+            "resolutionSelector",
+            profile.resolution_selector.as_str(),
+            "finite-poset-period-stokes-audit@1",
+        ),
+        ("domain", profile.domain.as_str(), "finite-poset-site"),
+        (
+            "zeroPredicate",
+            profile.zero_predicate.as_str(),
+            "stokes-residual-zero@1",
+        ),
+        (
+            "nonZeroPredicate",
+            profile.non_zero_predicate.as_str(),
+            "stokes-residual-nonzero@1",
+        ),
+        (
+            "certSelector",
+            profile.cert_selector.as_str(),
+            "finite-certificate@1",
+        ),
+        (
+            "verdictDiscipline",
+            profile.verdict_discipline.as_str(),
+            "five-valued-structural-verdict@1",
+        ),
+    ];
+    for (field, actual, expected) in expected {
+        if actual != expected {
+            return Err(format!(
+                "ag.period-stokes-audit@1 requires MeasurementProfile {field}={expected}, found {actual}"
+            ));
+        }
+    }
+    if !matches!(profile.coefficient.as_str(), "F2" | "Q" | "R") {
+        return Err(format!(
+            "ag.period-stokes-audit@1 requires MeasurementProfile coefficient F2, Q, or R, found {}",
+            profile.coefficient
+        ));
+    }
+    if period_audit_witness_cycles(profile).is_empty() {
+        return Err(format!(
+            "ag.period-stokes-audit@1 requires MeasurementProfile {} witnessFamily law ag.period-stokes-audit",
+            profile.profile_id
+        ));
+    }
+    if period_audit_witness_cycles(profile).len() > MAX_PERIOD_CYCLES {
+        return Err(format!(
+            "ag.period-stokes-audit@1 supports at most {MAX_PERIOD_CYCLES} witness cycles for finite period enumeration"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_transfer_profile_v1(profile: &MeasurementProfileV1) -> Result<(), String> {
     let expected = [
         ("coefficient", profile.coefficient.as_str(), "R"),
@@ -5811,6 +6080,17 @@ fn period_witness_cycles(profile: &MeasurementProfileV1) -> Vec<String> {
         .witness_family
         .iter()
         .filter(|witness| witness.law == "ag.period-stokes")
+        .map(|witness| witness.variable.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn period_audit_witness_cycles(profile: &MeasurementProfileV1) -> Vec<String> {
+    profile
+        .witness_family
+        .iter()
+        .filter(|witness| witness.law == "ag.period-stokes-audit")
         .map(|witness| witness.variable.clone())
         .collect::<BTreeSet<_>>()
         .into_iter()
@@ -6068,12 +6348,6 @@ fn stokes_audit_report(
         let right = boundary_map[&key];
         let residual = left.value - right.value;
         max_abs_residual = max_abs_residual.max(residual.abs());
-        if residual.abs() > 1.0e-9 {
-            return Err(format!(
-                "ag.period-stokes@1 Stokes audit failed for form {} chain {}: dOmega={} boundary={} residual={}",
-                left.form_id, left.chain_id, left.value, right.value, residual
-            ));
-        }
         pairs.push(json!({
             "form": left.form_id,
             "chain": left.chain_id,
@@ -6086,10 +6360,131 @@ fn stokes_audit_report(
     }
     Ok(json!({
         "identity": "<d omega, gamma> = <omega, boundary gamma>",
-        "status": "checked",
+        "status": if max_abs_residual > 1.0e-9 {
+            "residual_nonzero"
+        } else {
+            "checked"
+        },
         "maxAbsoluteResidual": round_f64(max_abs_residual),
         "pairs": pairs
     }))
+}
+
+fn fixed_coefficient_stokes_audit_report(
+    d_omega: &[StokesAuditValueV1],
+    boundary: &[StokesAuditValueV1],
+    coefficient: &str,
+) -> Value {
+    if !matches!(coefficient, "F2" | "Q") {
+        return json!({
+            "identity": "<d omega, gamma> = <omega, boundary gamma>",
+            "status": "unknown",
+            "methodStatus": "strict_coefficient_unresolved",
+            "coefficient": coefficient,
+            "reason": "strict coefficient ring is unresolved; float/model-relative period data remains analytic-only",
+            "pairs": []
+        });
+    }
+    if d_omega.is_empty() || boundary.is_empty() {
+        return json!({
+            "identity": "<d omega, gamma> = <omega, boundary gamma>",
+            "status": "not_computed",
+            "methodStatus": "period_audit_model_missing",
+            "coefficient": coefficient,
+            "reason": "period Stokes audit requires non-empty dOmegaIntegral and boundaryPeriod values",
+            "pairs": []
+        });
+    }
+    let d_map = d_omega
+        .iter()
+        .map(|entry| ((entry.form_id.clone(), entry.chain_id.clone()), entry))
+        .collect::<BTreeMap<_, _>>();
+    let boundary_map = boundary
+        .iter()
+        .map(|entry| ((entry.form_id.clone(), entry.chain_id.clone()), entry))
+        .collect::<BTreeMap<_, _>>();
+    if d_map.keys().collect::<Vec<_>>() != boundary_map.keys().collect::<Vec<_>>() {
+        return json!({
+            "identity": "<d omega, gamma> = <omega, boundary gamma>",
+            "status": "not_computed",
+            "methodStatus": "period_audit_key_mismatch",
+            "coefficient": coefficient,
+            "reason": "period Stokes audit requires matching dOmegaIntegral and boundaryPeriod keys",
+            "pairs": []
+        });
+    }
+
+    let mut nonzero_count = 0usize;
+    let mut max_abs_residual = 0.0f64;
+    let mut pairs = Vec::new();
+    for (key, left) in d_map {
+        let right = boundary_map[&key];
+        let Some(residual) = fixed_coefficient_residual(left.value, right.value, coefficient)
+        else {
+            return json!({
+                "identity": "<d omega, gamma> = <omega, boundary gamma>",
+                "status": "unknown",
+                "methodStatus": "strict_coefficient_unresolved",
+                "coefficient": coefficient,
+                "reason": "fixed coefficient Stokes audit requires exact Q values or integer F2 representatives",
+                "pairs": []
+            });
+        };
+        if residual.abs() > 1.0e-9 {
+            nonzero_count += 1;
+        }
+        max_abs_residual = max_abs_residual.max(residual.abs());
+        pairs.push(json!({
+            "form": left.form_id,
+            "chain": left.chain_id,
+            "dOmegaIntegral": fixed_coefficient_value(left.value, coefficient),
+            "boundaryPeriod": fixed_coefficient_value(right.value, coefficient),
+            "residual": fixed_coefficient_value(residual, coefficient),
+            "dOmegaAtomRef": left.atom_ref,
+            "boundaryAtomRef": right.atom_ref
+        }));
+    }
+    json!({
+        "identity": "<d omega, gamma> = <omega, boundary gamma>",
+        "status": if nonzero_count == 0 {
+            "checked"
+        } else {
+            "residual_nonzero"
+        },
+        "methodStatus": "fixed_coefficient_stokes_audit_computed",
+        "coefficient": coefficient,
+        "maxAbsoluteResidual": fixed_coefficient_value(max_abs_residual, coefficient),
+        "nonzeroPairCount": nonzero_count,
+        "pairs": pairs
+    })
+}
+
+fn fixed_coefficient_residual(left: f64, right: f64, coefficient: &str) -> Option<f64> {
+    match coefficient {
+        "F2" => {
+            let left_int = f2_integer_representative(left)?;
+            let right_int = f2_integer_representative(right)?;
+            Some(((left_int - right_int).rem_euclid(2)) as f64)
+        }
+        "Q" => Some(round_f64(left - right)),
+        _ => None,
+    }
+}
+
+fn f2_integer_representative(value: f64) -> Option<i64> {
+    if !value.is_finite() {
+        return None;
+    }
+    let rounded = value.round();
+    ((value - rounded).abs() < 1.0e-9).then_some(rounded as i64)
+}
+
+fn fixed_coefficient_value(value: f64, coefficient: &str) -> Value {
+    if coefficient == "F2" {
+        json!(f2_integer_representative(value).unwrap_or(0).rem_euclid(2))
+    } else {
+        json!(round_f64(value))
+    }
 }
 
 fn transfer_pairings(
@@ -6441,6 +6836,36 @@ fn period_assumptions(
             status: "assumed".to_string(),
             checked_by: None,
             assumed_by: Some(format!("measurement-profile:{}", profile.profile_id)),
+        },
+    ]
+}
+
+fn period_audit_assumptions(
+    profile: &MeasurementProfileV1,
+    fixed_coefficient_status: &str,
+) -> Vec<AgAssumptionLedgerEntryV1> {
+    vec![
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part4/13.2".to_string(),
+            assumption:
+                "supplied finite Stokes accounting values share a fixed coefficient reading"
+                    .to_string(),
+            status: fixed_coefficient_status.to_string(),
+            checked_by: (fixed_coefficient_status == "checked").then(|| {
+                format!(
+                    "measurement-profile:{}.coefficient={}",
+                    profile.profile_id, profile.coefficient
+                )
+            }),
+            assumed_by: (fixed_coefficient_status != "checked")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part7/5.2A".to_string(),
+            assumption: "strict-period-pairing remains analytic and model-relative".to_string(),
+            status: "checked".to_string(),
+            checked_by: Some("strict-period-pairing@1".to_string()),
+            assumed_by: None,
         },
     ]
 }

--- a/tools/archsig/src/law_policy/registry.rs
+++ b/tools/archsig/src/law_policy/registry.rs
@@ -270,6 +270,7 @@ fn evaluator_manifests() -> Vec<LawEvaluatorManifestV1> {
         ag_manifest("ag.law-conflict-tor@1", "ag.law-conflict-tor"),
         ag_manifest("ag.sheaf-laplacian@1", "ag.sheaf-laplacian"),
         ag_manifest("ag.period-stokes@1", "ag.period-stokes"),
+        ag_period_stokes_audit_manifest(),
         ag_manifest("ag.support-transfer@1", "ag.support-transfer"),
     ]);
     manifests
@@ -338,6 +339,41 @@ fn ag_boundary_residue_manifest() -> LawEvaluatorManifestV1 {
         detail_output_refs: vec![
             "/assumptions".to_string(),
             "/computedInvariants".to_string(),
+        ],
+        negative_fixtures: Vec::new(),
+    }
+}
+
+fn ag_period_stokes_audit_manifest() -> LawEvaluatorManifestV1 {
+    LawEvaluatorManifestV1 {
+        evaluator_id: "ag.period-stokes-audit@1".to_string(),
+        law_id: "ag.period-stokes-audit".to_string(),
+        required_atom_constructors: Vec::new(),
+        required_predicates: vec![
+            "period.dOmegaIntegral".to_string(),
+            "period.boundaryPeriod".to_string(),
+        ],
+        required_molecule_condition:
+            "archmap/v2 selected cover with supplied dOmegaIntegral and boundaryPeriod audit values"
+                .to_string(),
+        scope_filtering_rule:
+            "selected finite cover and fixed coefficient MeasurementProfile".to_string(),
+        missing_blocker_rule:
+            "missing audit pairs or unresolved strict coefficient data yields unknown/not_computed, not a crash"
+                .to_string(),
+        pass_criteria:
+            "all supplied fixed-coefficient Stokes audit residuals are zero".to_string(),
+        violation_criteria:
+            "at least one supplied fixed-coefficient Stokes audit residual is nonzero".to_string(),
+        typed_result_schema: "archsig-measurement-packet/v1".to_string(),
+        distance_contribution:
+            "structural verdict is scoped to supplied independent Stokes accounting values only"
+                .to_string(),
+        summary_output_refs: vec!["/structuralVerdict".to_string()],
+        detail_output_refs: vec![
+            "/computedInvariants".to_string(),
+            "/analyticReadings".to_string(),
+            "/assumptions".to_string(),
         ],
         negative_fixtures: Vec::new(),
     }

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -4853,7 +4853,7 @@ fn cli_analyze_v2_period_stokes_outputs_pairing_and_audit_reading() {
 }
 
 #[test]
-fn cli_analyze_v2_period_stokes_audit_mismatch_fails_fast() {
+fn cli_analyze_v2_period_stokes_audit_mismatch_is_analytic_residual() {
     let out_dir = temp_dir("ag-measurement-period-stokes-audit-mismatch");
     let root = ag_measurement_root();
     let mut archmap = read_json(&root.join("archmap_v2_period_stokes.json"));
@@ -4865,7 +4865,7 @@ fn cli_analyze_v2_period_stokes_audit_mismatch_fails_fast() {
     )
     .expect("archmap fixture can be written");
 
-    let output = run_sig0_output(&[
+    run_sig0(&[
         "analyze",
         "--archmap",
         archmap_path.to_str().expect("path is utf-8"),
@@ -4876,16 +4876,127 @@ fn cli_analyze_v2_period_stokes_audit_mismatch_fails_fast() {
         "--out-dir",
         out_dir.to_str().expect("path is utf-8"),
     ]);
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("Stokes audit failed"),
-        "Stokes audit mismatch must fail as evaluator error\n{stderr}"
+
+    let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+    assert_eq!(
+        packet["structuralVerdict"]
+            .as_array()
+            .expect("structural verdict is array")
+            .len(),
+        0,
+        "legacy analytic period-stokes residual must not generate structural verdict rows"
     );
-    assert!(
-        !out_dir.join("archsig-measurement-packet.json").exists(),
-        "Stokes audit fail-fast must not leave a success packet"
+    let invariant = invariant_by_id(&packet, "period-stokes:profile:ag-period-stokes@1");
+    assert_eq!(
+        invariant["stokesAudit"]["status"], "residual_nonzero",
+        "legacy analytic period-stokes must report nonzero residual without crashing"
     );
+}
+
+#[test]
+fn cli_analyze_v2_period_stokes_audit_outputs_structural_verdicts() {
+    let root_out = temp_dir("ag-measurement-period-stokes-audit");
+    let root = ag_measurement_root();
+
+    for (case, coefficient, boundary_value, expected_verdict, expected_status) in [
+        (
+            "zero",
+            "Q",
+            "chain:sigma=3",
+            "measured_zero",
+            "fixed_coefficient_stokes_audit_computed",
+        ),
+        (
+            "nonzero",
+            "Q",
+            "chain:sigma=4",
+            "measured_nonzero",
+            "fixed_coefficient_stokes_audit_computed",
+        ),
+        (
+            "float-only",
+            "R",
+            "chain:sigma=3",
+            "unknown",
+            "strict_coefficient_unresolved",
+        ),
+    ] {
+        let out_dir = root_out.join(case);
+        fs::create_dir_all(&out_dir).expect("case dir exists");
+        let mut archmap = read_json(&root.join("archmap_v2_period_stokes.json"));
+        archmap["atoms"][3]["object"] = Value::String(boundary_value.to_string());
+        let archmap_path = out_dir.join("archmap.json");
+        fs::write(
+            &archmap_path,
+            serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+        )
+        .expect("archmap fixture can be written");
+        let mut policy = read_json(&root.join("law_policy_period.json"));
+        policy["measurementProfiles"][0]["coefficient"] = Value::String(coefficient.to_string());
+        policy["measurementProfiles"][0]["effCoeff"] =
+            Value::String("fixed-coefficient-stokes-audit@1".to_string());
+        policy["measurementProfiles"][0]["resolutionSelector"] =
+            Value::String("finite-poset-period-stokes-audit@1".to_string());
+        policy["measurementProfiles"][0]["zeroPredicate"] =
+            Value::String("stokes-residual-zero@1".to_string());
+        policy["measurementProfiles"][0]["nonZeroPredicate"] =
+            Value::String("stokes-residual-nonzero@1".to_string());
+        policy["measurementProfiles"][0]["certSelector"] =
+            Value::String("finite-certificate@1".to_string());
+        for witness in policy["measurementProfiles"][0]["witnessFamily"]
+            .as_array_mut()
+            .expect("witnessFamily is array")
+        {
+            witness["law"] = Value::String("ag.period-stokes-audit".to_string());
+        }
+        policy["policies"][0]["law"] = Value::String("ag.period-stokes-audit".to_string());
+        policy["policies"][0]["evaluator"] = Value::String("ag.period-stokes-audit@1".to_string());
+        let policy_path = out_dir.join("law_policy.json");
+        fs::write(
+            &policy_path,
+            serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+        )
+        .expect("policy fixture can be written");
+
+        run_sig0(&[
+            "analyze",
+            "--archmap",
+            archmap_path.to_str().unwrap(),
+            "--law-policy",
+            policy_path.to_str().unwrap(),
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+
+        let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+        let structural = packet["structuralVerdict"]
+            .as_array()
+            .expect("structural verdict is array");
+        assert_eq!(
+            structural.len(),
+            1,
+            "period-stokes-audit must add exactly one structural verdict row"
+        );
+        assert_eq!(structural[0]["evaluator"], "ag.period-stokes-audit@1");
+        assert_eq!(structural[0]["verdict"], expected_verdict);
+        assert_eq!(
+            structural[0]["verdictData"]["methodStatus"],
+            expected_status
+        );
+        let invariant = invariant_by_id(&packet, "period-stokes-audit:profile:ag-period-stokes@1");
+        assert_eq!(invariant["evaluator"], "ag.period-stokes-audit@1");
+        assert_eq!(invariant["stokesAudit"]["coefficient"], coefficient);
+        assert!(
+            packet["analyticReadings"]
+                .as_array()
+                .expect("analytic readings is array")
+                .iter()
+                .any(|reading| reading["evaluator"] == "ag.period-stokes@1"
+                    && reading["structuralVerdictRef"] == Value::Null
+                    && reading["value"]["readingKind"] == "strict-period-pairing@1"),
+            "strict-period-pairing must remain an analytic reading separate from the structural verdict"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #2251

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M9 に対応し、`ag.period-stokes-audit@1` structural evaluator を追加しました。

- fixed coefficient Stokes residual を `Q` / `F2` で評価し、zero は `measured_zero`、nonzero は `measured_nonzero` に正規化
- `R` / float-only では crash せず `unknown` に降格
- 既存 `ag.period-stokes@1` の residual nonzero hard Err を廃止し、analytic report の `residual_nonzero` として保持
- `strict-period-pairing@1` は `ag.period-stokes@1` analytic reading のまま、structural verdict 化しない
- registry に `ag.period-stokes-audit@1` を追加

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [x] `cargo test --manifest-path tools/fieldsig/Cargo.toml`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling implementation; Lean 変更なし。
