### PR TITLE
lawful locus arrangement を不変量化

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -1164,6 +1164,7 @@ fn evaluate_square_free_repair_v1(
             .collect(),
     );
     let delta_faces = stanley_reisner_faces(&witness_variables, &minimal_forbidden_supports);
+    let delta_facets = maximal_faces(&delta_faces);
     let reduced_homology = reduced_simplicial_homology_f2(&delta_faces);
     let repair_hitting_sets = minimal_hitting_sets(&witness_variables, &minimal_forbidden_supports);
     let certificate = square_free_certificate(
@@ -1265,7 +1266,13 @@ fn evaluate_square_free_repair_v1(
                 "status": "missing",
                 "effect": "structural verdict remains unknown when obstruction generators are present"
             }))
-        })],
+        }),
+        lawful_locus_arrangement_invariant(
+            profile,
+            &witness_variables,
+            &delta_facets,
+            &minimal_forbidden_supports,
+        )],
         analytic_readings: vec![AgAnalyticReadingV1 {
             reading_id: format!("theorem-candidate:repair-inspection:{}", profile.profile_id),
             evaluator: "ag.foundation@1".to_string(),
@@ -1326,6 +1333,68 @@ fn evaluate_square_free_repair_v1(
             },
         ],
     })
+}
+
+fn lawful_locus_arrangement_invariant(
+    profile: &MeasurementProfileV1,
+    witness_variables: &[String],
+    facets: &[Vec<String>],
+    minimal_forbidden_supports: &[Vec<String>],
+) -> Value {
+    let witness_set = witness_variables.iter().cloned().collect::<BTreeSet<_>>();
+    let components = facets
+        .iter()
+        .enumerate()
+        .map(|(index, facet)| {
+            let facet_set = facet.iter().cloned().collect::<BTreeSet<_>>();
+            let vanishing_coords = witness_set
+                .difference(&facet_set)
+                .cloned()
+                .collect::<Vec<_>>();
+            json!({
+                "componentId": format!("lawful-locus-component:{}", index + 1),
+                "facet": facet,
+                "vanishingCoords": vanishing_coords,
+                "dimension": facet.len()
+            })
+        })
+        .collect::<Vec<_>>();
+    let dimension = facets.iter().map(Vec::len).max().unwrap_or(0);
+
+    json!({
+        "invariantId": format!("lawful-locus-arrangement:{}", profile.profile_id),
+        "evaluator": "ag.square-free-repair@1",
+        "method": "finite-stanley-reisner-coordinate-arrangement@1",
+        "claimScope": "selected cover and selected witness-family relative finite Stanley-Reisner arrangement",
+        "selectedCoverRef": profile.cover_ref,
+        "locusSymbol": "Flat_U(X)=V(I_Delta)",
+        "witnessVariables": witness_variables,
+        "minimalForbiddenSupports": minimal_forbidden_supports,
+        "facets": facets,
+        "components": components,
+        "dimension": dimension,
+        "irreducibleComponentCount": facets.len(),
+        "nonConclusions": [
+            "This invariant does not evaluate section-specific s^* I_Ob^U=0.",
+            "The dimension is a finite coordinate-subspace arrangement dimension, not a total-correctness or runtime-safety claim.",
+            "irreducibleComponentCount is not a safety score or structural verdict."
+        ]
+    })
+}
+
+fn maximal_faces(faces: &[Vec<String>]) -> Vec<Vec<String>> {
+    let mut facets = faces
+        .iter()
+        .filter(|face| {
+            !faces.iter().any(|candidate| {
+                face.len() < candidate.len() && is_subset(face.as_slice(), candidate.as_slice())
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    facets.sort();
+    facets.dedup();
+    facets
 }
 
 fn evaluate_restriction_compatibility_v1(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -3554,6 +3554,44 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
         repair["nsdepthCertificate"]["verifiedMinimalForbiddenSupports"],
         serde_json::json!([["x_checkout", "x_inventory"], ["x_inventory", "x_payment"]])
     );
+    let arrangement = invariant_by_id(&packet, "lawful-locus-arrangement:profile:ag-square-free@1");
+    assert_eq!(
+        arrangement["method"],
+        "finite-stanley-reisner-coordinate-arrangement@1"
+    );
+    assert_eq!(
+        arrangement["facets"],
+        serde_json::json!([["x_checkout", "x_payment"], ["x_inventory"]])
+    );
+    assert_eq!(arrangement["dimension"], Value::from(2));
+    assert_eq!(arrangement["irreducibleComponentCount"], Value::from(2));
+    assert_eq!(
+        arrangement["components"],
+        serde_json::json!([
+            {
+                "componentId": "lawful-locus-component:1",
+                "facet": ["x_checkout", "x_payment"],
+                "vanishingCoords": ["x_inventory"],
+                "dimension": 2
+            },
+            {
+                "componentId": "lawful-locus-component:2",
+                "facet": ["x_inventory"],
+                "vanishingCoords": ["x_checkout", "x_payment"],
+                "dimension": 1
+            }
+        ])
+    );
+    assert!(
+        arrangement["nonConclusions"]
+            .as_array()
+            .expect("arrangement nonConclusions is array")
+            .iter()
+            .any(|entry| entry
+                .as_str()
+                .is_some_and(|text| text.contains("does not evaluate section-specific"))),
+        "lawful locus arrangement must not become a section-level verdict"
+    );
     let repair_reading = packet["analyticReadings"]
         .as_array()
         .expect("analytic readings is array")


### PR DESCRIPTION
## 概要

Closes #2255

AC-M11 として、`ag.square-free-repair@1` の既存 square-free 計測から lawful locus `Flat_U(X)=V(I_Delta)` の Stanley-Reisner arrangement 不変量を `computedInvariants` に追加した。

- `lawful-locus-arrangement:*` invariant を追加
- facets / vanishingCoords / dimension / irreducibleComponentCount を出力
- section ごとの `s^* I_Ob^U=0` 判定や total correctness claim は nonConclusions に隔離
- 新 structural verdict は生成しない

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更時）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan

`lake build` / FieldSig test / Lean scan は未実施。今回の変更は ArchSig Rust tooling の computed invariant と CLI test に限定。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

Lean status: tooling implementation; Lean 変更なし。
