### PR TITLE
AC-M14 analytic overlay を viewer に投影

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -31,6 +31,7 @@ const GLUING_REGION_RENDER_LIMIT: usize = 24;
 const GLUING_CAGE_RENDER_LIMIT: usize = 80;
 const GLUING_MORPH_RENDER_LIMIT: usize = 50;
 const GLUING_ATOM_GLYPH_RENDER_LIMIT: usize = 2_000;
+const ANALYTIC_OVERLAY_RENDER_LIMIT: usize = 80;
 const BOUNDARY_STATEMENT_KINDS: [&str; 6] = [
     "silence_by_design",
     "out_of_selected_vocabulary",
@@ -3985,6 +3986,7 @@ fn insight_viewer_visual_scenes_v1(
         &["architecture_debt_mass"],
         false,
     );
+    let analytic_overlay_refs = analytic_overlay_scene_refs(packet, gluing_geometry);
     let boundary_refs =
         scene_refs_for_kinds(normalized, packet, cards, &["measurement_boundary"], false);
     let source_refs = source_scene_refs(normalized, packet, cards);
@@ -4009,6 +4011,8 @@ fn insight_viewer_visual_scenes_v1(
     let has_debt = cards
         .iter()
         .any(|card| string_field(card, "kind") == "architecture_debt_mass");
+    let has_analytic_overlay =
+        !string_array_at(&analytic_overlay_refs, &["overlayRefs"]).is_empty();
     let scenes = vec![
         scene_v1(
             "overview",
@@ -4190,6 +4194,32 @@ fn insight_viewer_visual_scenes_v1(
             "contour",
             has_debt,
         ),
+        with_scene_non_claims(
+            scene_v1(
+                "analytic-overlay",
+                "analytic_overlay",
+                "Analytic Overlay",
+                "Which measured analytic readings can be inspected without promoting them to verdicts?",
+                (
+                    "analytic source family",
+                    "selected cover or support stratum",
+                    "reading magnitude / proxy height",
+                ),
+                "analytic_overlay_lane",
+                "overlay",
+                "analyticOverlay",
+                "packet analytic reading overlay; no new structural verdict",
+                &analytic_overlay_refs,
+                "analytic_reading",
+                "heat",
+                "contour",
+                has_analytic_overlay,
+            ),
+            &[
+                "Analytic overlays are packet projections only; they do not create structural verdicts.",
+                "Near-flat or low proxy values are not measured_zero lawfulness.",
+            ],
+        ),
         boundary_scene_v1(&boundary_refs),
         scene_v1(
             "source-evidence",
@@ -4241,6 +4271,16 @@ fn attach_gluing_scene_geometry(mut scene: Value, gluing_geometry: &Value) -> Va
             "locusFieldRef": "gluingGeometry.locusField",
             "projectionObjectKinds": ["curvatureHeightField", "blockedUnmeasuredRegion"]
         }),
+        "analytic-overlay" => json!({
+            "analyticOverlayBundleRef": "gluingGeometry.analyticOverlayBundle",
+            "projectionObjectKinds": [
+                "periodPairingMatrixOverlay",
+                "transferCostOverlay",
+                "spectralGapOverlay",
+                "curvatureHotspotOverlay",
+                "singularityConcentrationOverlay"
+            ]
+        }),
         _ => json!({
             "projectionObjectKinds": []
         }),
@@ -4286,6 +4326,44 @@ fn attach_gluing_scene_geometry(mut scene: Value, gluing_geometry: &Value) -> Va
     scene
 }
 
+fn analytic_overlay_scene_refs(
+    packet: &ArchSigMeasurementPacketV1,
+    gluing_geometry: &Value,
+) -> Value {
+    let overlays = gluing_geometry["analyticOverlayBundle"]["overlays"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let overlay_refs = overlays
+        .iter()
+        .filter_map(|overlay| overlay["overlayId"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let analytic_reading_refs = overlays
+        .iter()
+        .filter_map(|overlay| overlay["sourceReadingRef"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let invariant_refs = overlays
+        .iter()
+        .filter_map(|overlay| overlay["sourceInvariantRef"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    json!({
+        "overlayRefs": overlay_refs,
+        "analyticReadingRefs": analytic_reading_refs,
+        "invariantRefs": invariant_refs,
+        "coverRefs": [packet.profile.cover_ref.clone()],
+        "sourceRefs": []
+    })
+}
+
 fn visual_encoding_legend_v1() -> Value {
     json!([
         {
@@ -4296,6 +4374,7 @@ fn visual_encoding_legend_v1() -> Value {
                 "measured_zero": "teal selected-support zero",
                 "not_computed": "red blocker",
                 "unmeasured": "gray unmeasured region",
+                "analytic_reading": "blue analytic reading lane; never promoted to structural zero",
                 "repair_candidate": "violet lower-bound repair candidate"
             }
         },
@@ -4385,6 +4464,7 @@ fn gluing_geometry_projection_v1(
     let repair_morphs = repair_morph_projection(normalized, packet, &forbidden_cages);
     let locus_field = locus_field_projection(packet);
     let atom_glyphs = atom_glyph_projection(normalized);
+    let analytic_overlay_bundle = analytic_overlay_bundle_projection(packet);
     let triangle_count = cover_nerve_projection["faces"]
         .as_array()
         .map(Vec::len)
@@ -4402,6 +4482,9 @@ fn gluing_geometry_projection_v1(
         .map(Vec::len)
         .unwrap_or_default();
     let atom_glyph_total_count = normalized.atoms.len();
+    let analytic_overlay_count = analytic_overlay_bundle["rawOverlayCount"]
+        .as_u64()
+        .unwrap_or_default() as usize;
     let cocycle_support_edge_count = nonzero_edges.len();
     let cocycle_support_edges = nonzero_edges
         .iter()
@@ -4445,6 +4528,7 @@ fn gluing_geometry_projection_v1(
         "forbiddenCages": forbidden_cages,
         "repairMorphs": repair_morphs,
         "atomGlyphs": atom_glyphs,
+        "analyticOverlayBundle": analytic_overlay_bundle,
         "visualEncodingLegend": visual_encoding_legend_v1(),
         "renderLimits": {
             "nerveTriangles": GLUING_TRIANGLE_RENDER_LIMIT,
@@ -4453,7 +4537,8 @@ fn gluing_geometry_projection_v1(
             "curvatureRegions": GLUING_REGION_RENDER_LIMIT,
             "forbiddenCages": GLUING_CAGE_RENDER_LIMIT,
             "repairMorphs": GLUING_MORPH_RENDER_LIMIT,
-            "atomGlyphs": GLUING_ATOM_GLYPH_RENDER_LIMIT
+            "atomGlyphs": GLUING_ATOM_GLYPH_RENDER_LIMIT,
+            "analyticOverlays": ANALYTIC_OVERLAY_RENDER_LIMIT
         },
         "omittedGeometryCounts": {
             "nerveTriangles": triangle_count.saturating_sub(GLUING_TRIANGLE_RENDER_LIMIT),
@@ -4463,7 +4548,8 @@ fn gluing_geometry_projection_v1(
             "blockedRegions": blocked_region_count.saturating_sub(GLUING_REGION_RENDER_LIMIT),
             "forbiddenCages": forbidden_cages.len().saturating_sub(GLUING_CAGE_RENDER_LIMIT),
             "repairMorphs": repair_morphs.len().saturating_sub(GLUING_MORPH_RENDER_LIMIT),
-            "atomGlyphs": atom_glyph_total_count.saturating_sub(GLUING_ATOM_GLYPH_RENDER_LIMIT)
+            "atomGlyphs": atom_glyph_total_count.saturating_sub(GLUING_ATOM_GLYPH_RENDER_LIMIT),
+            "analyticOverlays": analytic_overlay_count.saturating_sub(ANALYTIC_OVERLAY_RENDER_LIMIT)
         },
         "nonClaims": [
             "No H2 coherence failure is visualized by this projection.",
@@ -4614,6 +4700,173 @@ fn repair_morph_projection(
             })
         })
         .collect()
+}
+
+fn analytic_overlay_bundle_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
+    let mut period_pairing = Vec::new();
+    let mut transfer_cost = Vec::new();
+    let mut spectral_gap = Vec::new();
+    let mut curvature_hotspot = Vec::new();
+
+    for reading in &packet.analytic_readings {
+        let reading_kind = string_at(&reading.value, &["readingKind"]);
+        match reading_kind.as_str() {
+            "strict-period-pairing@1" => {
+                period_pairing.push(json!({
+                    "overlayId": format!("overlay:period-pairing:{}", stable_ref_segment(&reading.reading_id)),
+                    "overlayKind": "period_pairing_matrix",
+                    "sourceReadingRef": reading.reading_id,
+                    "sourceEvaluator": reading.evaluator,
+                    "sourceReadingKind": reading_kind,
+                    "sourceRegime": reading.regime,
+                    "colorRole": "analytic_reading",
+                    "forms": reading.value["forms"].clone(),
+                    "cycleBasis": reading.value["cycleBasis"].clone(),
+                    "periodPairingMatrix": reading.value["periodPairingMatrix"].clone(),
+                    "nonClaim": reading.value["nonConclusion"].clone(),
+                    "projectionBoundary": "modelRelative period landscape; not a structural verdict"
+                }));
+            }
+            "support-localized-transfer@1" => {
+                transfer_cost.push(json!({
+                    "overlayId": format!("overlay:transfer-cost:{}", stable_ref_segment(&reading.reading_id)),
+                    "overlayKind": "wasserstein_transfer_cost",
+                    "sourceReadingRef": reading.reading_id,
+                    "sourceEvaluator": reading.evaluator,
+                    "sourceReadingKind": reading_kind,
+                    "sourceRegime": reading.regime,
+                    "colorRole": "analytic_reading",
+                    "repairPaths": reading.value["repairPaths"].clone(),
+                    "transferTargets": reading.value["transferTargets"].clone(),
+                    "transferMeasurementPairing": reading.value["transferMeasurementPairing"].clone(),
+                    "transferResidue": reading.value["transferResidue"].clone(),
+                    "wassersteinTransferCost": reading.value["wassersteinTransferCost"].clone(),
+                    "nonClaim": "Wasserstein transfer cost is a supplied finite support-localized analytic reading; it is not W1 itself and does not prove global repair safety.",
+                    "projectionBoundary": reading.value["nonConclusion"].clone()
+                }));
+            }
+            "graph-laplacian-hodge-proxy@1" => {
+                spectral_gap.push(json!({
+                    "overlayId": format!("overlay:spectral-gap:{}", stable_ref_segment(&reading.reading_id)),
+                    "overlayKind": "spectral_gap_proxy",
+                    "sourceReadingRef": reading.reading_id,
+                    "sourceEvaluator": reading.evaluator,
+                    "sourceReadingKind": reading_kind,
+                    "sourceRegime": reading.regime,
+                    "colorRole": "analytic_reading",
+                    "cells": reading.value["cells"].clone(),
+                    "spectralGap": reading.value["spectralGap"].clone(),
+                    "harmonicMass": reading.value["harmonicMass"].clone(),
+                    "distanceToFlatness": reading.value["distanceToFlatness"].clone(),
+                    "nonClaim": "spectralGap is a finite graph-Laplacian proxy eigenvalue, not L1 and not measured_zero lawfulness.",
+                    "projectionBoundary": reading.value["nonConclusion"].clone()
+                }));
+            }
+            "curvature-transfer-perron-hotspot@1" => {
+                curvature_hotspot.push(json!({
+                    "overlayId": format!("overlay:curvature-hotspot:{}", stable_ref_segment(&reading.reading_id)),
+                    "overlayKind": "curvature_spectrum_hotspot",
+                    "sourceReadingRef": reading.reading_id,
+                    "sourceEvaluator": reading.evaluator,
+                    "sourceReadingKind": reading_kind,
+                    "sourceRegime": reading.regime,
+                    "colorRole": "analytic_reading",
+                    "hotspots": reading.value["hotspots"].clone(),
+                    "nonClaim": reading.value["nonConclusion"].clone(),
+                    "projectionBoundary": "hotspot projection is gated by the landed theorem-candidate reading; it creates no structural verdict"
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    let singularity_concentration = packet
+        .computed_invariants
+        .iter()
+        .filter(|invariant| invariant["evaluator"] == "ag.law-conflict-tor@1")
+        .flat_map(|invariant| {
+            invariant["lawConflicts"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .enumerate()
+                .map(|(index, conflict)| {
+                    let shared_support = string_array_at(conflict, &["sharedSupport"]);
+                    json!({
+                        "overlayId": format!(
+                            "overlay:singularity-concentration:{}:{index}",
+                            stable_ref_segment(&string_field(invariant, "invariantId"))
+                        ),
+                        "overlayKind": "singularity_concentration",
+                        "sourceInvariantRef": invariant["invariantId"],
+                        "sourceEvaluator": invariant["evaluator"],
+                        "colorRole": "analytic_reading",
+                        "stratumRef": if shared_support.is_empty() {
+                            format!("law-conflict-stratum:{index}")
+                        } else {
+                            format!("law-conflict-stratum:{}", shared_support.join("+"))
+                        },
+                        "sharedSupport": shared_support,
+                        "multidegree": conflict["multidegree"].clone(),
+                        "commonAmbient": invariant["commonAmbient"].clone(),
+                        "concentrationCount": 1,
+                        "deformationRegime": "not_provided",
+                        "nonClaim": "singularity concentration is a selected LawConflict_1 count projection only; deformation regime is not provided and this is not object size or repair difficulty."
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    let raw_overlay_count = period_pairing.len()
+        + transfer_cost.len()
+        + spectral_gap.len()
+        + curvature_hotspot.len()
+        + singularity_concentration.len();
+
+    period_pairing.truncate(ANALYTIC_OVERLAY_RENDER_LIMIT);
+    transfer_cost.truncate(ANALYTIC_OVERLAY_RENDER_LIMIT);
+    spectral_gap.truncate(ANALYTIC_OVERLAY_RENDER_LIMIT);
+    curvature_hotspot.truncate(ANALYTIC_OVERLAY_RENDER_LIMIT);
+    let mut singularity_concentration = singularity_concentration;
+    singularity_concentration.truncate(ANALYTIC_OVERLAY_RENDER_LIMIT);
+
+    let overlays = period_pairing
+        .iter()
+        .chain(transfer_cost.iter())
+        .chain(spectral_gap.iter())
+        .chain(curvature_hotspot.iter())
+        .chain(singularity_concentration.iter())
+        .take(ANALYTIC_OVERLAY_RENDER_LIMIT)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    json!({
+        "schemaVersion": "archsig-analytic-overlay-bundle-v1",
+        "allowlist": [
+            "strict-period-pairing@1",
+            "support-localized-transfer@1",
+            "graph-laplacian-hodge-proxy@1",
+            "curvature-transfer-perron-hotspot@1",
+            "ag.law-conflict-tor@1/lawConflicts"
+        ],
+        "colorRole": "analytic_reading",
+        "rawOverlayCount": raw_overlay_count,
+        "projectionBoundary": "This bundle projects existing packet analytic readings and computed invariants into the viewer; it creates no structural verdict and never promotes analytic values to measured_zero.",
+        "periodPairingOverlays": period_pairing,
+        "transferCostOverlays": transfer_cost,
+        "spectralGapOverlays": spectral_gap,
+        "curvatureHotspotOverlays": curvature_hotspot,
+        "singularityConcentrationOverlays": singularity_concentration,
+        "overlays": overlays,
+        "nonClaims": [
+            "Period overlays are model-relative.",
+            "Transfer cost overlays are finite support-localized readings, not global repair safety.",
+            "Spectral gap overlays are proxy eigenvalues and are not structural lawfulness.",
+            "Curvature hotspot overlays are theorem-candidate projections.",
+            "Singularity concentration has deformationRegime=not_provided and is not a size or difficulty score."
+        ]
+    })
 }
 
 fn atom_refs_by_square_free_variable(
@@ -10206,6 +10459,12 @@ pub fn build_measurement_viewer_data_v1(
             "forbiddenCages": insight_report["gluingGeometry"]["forbiddenCages"],
             "repairMorphs": insight_report["gluingGeometry"]["repairMorphs"],
             "atomGlyphs": insight_report["gluingGeometry"]["atomGlyphs"],
+            "analyticOverlayBundle": insight_report["gluingGeometry"]["analyticOverlayBundle"],
+            "periodPairingOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["periodPairingOverlays"],
+            "transferCostOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["transferCostOverlays"],
+            "spectralGapOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["spectralGapOverlays"],
+            "curvatureHotspotOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["curvatureHotspotOverlays"],
+            "singularityConcentrationOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["singularityConcentrationOverlays"],
             "omittedGeometryCounts": insight_report["gluingGeometry"]["omittedGeometryCounts"],
             "nonClaims": insight_report["gluingGeometry"]["nonClaims"]
         },

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -3779,6 +3779,163 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
 }
 
 #[test]
+fn cli_analyze_v2_projects_analytic_overlay_bundle_to_viewer_lane() {
+    let period_out = run_ag_measurement_fixture(
+        "m14-period-overlay",
+        "archmap_v2_period_stokes.json",
+        "law_policy_period.json",
+    );
+    let period_packet = read_json(&period_out.join("archsig-measurement-packet.json"));
+    let period_report = read_json(&period_out.join("archsig-insight-report.json"));
+    let period_viewer = read_json(&period_out.join("archsig-atom-viewer-data.json"));
+    assert_eq!(
+        period_viewer["aatGeometryOverlays"]["analyticOverlayBundle"],
+        period_report["gluingGeometry"]["analyticOverlayBundle"],
+        "viewer data must carry the same allowlisted analytic overlay bundle as gluing geometry"
+    );
+    for expected in [
+        "strict-period-pairing@1",
+        "support-localized-transfer@1",
+        "graph-laplacian-hodge-proxy@1",
+        "curvature-transfer-perron-hotspot@1",
+        "ag.law-conflict-tor@1/lawConflicts",
+    ] {
+        assert!(
+            period_viewer["aatGeometryOverlays"]["analyticOverlayBundle"]["allowlist"]
+                .as_array()
+                .expect("allowlist is array")
+                .iter()
+                .any(|entry| entry.as_str() == Some(expected)),
+            "analytic overlay allowlist must contain {expected}"
+        );
+    }
+    assert_eq!(
+        period_packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .len(),
+        0,
+        "period overlay projection must not create structural verdict rows"
+    );
+    let period_overlay = overlay_by_kind(&period_viewer, "period_pairing_matrix");
+    assert_eq!(period_overlay["colorRole"], "analytic_reading");
+    assert_eq!(
+        period_overlay["periodPairingMatrix"],
+        serde_json::json!([[2.0, -1.0]])
+    );
+    assert_eq!(period_overlay["sourceRegime"], "analytic-measurement");
+    assert!(
+        period_overlay["nonClaim"]
+            .as_str()
+            .is_some_and(|text| text.contains("model-relative")),
+        "period overlay must carry model-relative non-claim"
+    );
+    assert_analytic_overlay_scene_active(&period_viewer);
+
+    let transfer_out = run_ag_measurement_fixture(
+        "m14-transfer-overlay",
+        "archmap_v2_support_transfer.json",
+        "law_policy_transfer.json",
+    );
+    let transfer_packet = read_json(&transfer_out.join("archsig-measurement-packet.json"));
+    let transfer_viewer = read_json(&transfer_out.join("archsig-atom-viewer-data.json"));
+    assert_eq!(
+        transfer_packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .len(),
+        0,
+        "transfer overlay projection must not create structural verdict rows"
+    );
+    let transfer_overlay = overlay_by_kind(&transfer_viewer, "wasserstein_transfer_cost");
+    assert_eq!(transfer_overlay["colorRole"], "analytic_reading");
+    assert_eq!(transfer_overlay["transferResidue"], Value::from(0.790569));
+    assert_eq!(
+        transfer_overlay["wassersteinTransferCost"],
+        Value::from(3.5)
+    );
+    assert!(
+        transfer_overlay["nonClaim"]
+            .as_str()
+            .is_some_and(|text| text.contains("not W1 itself")),
+        "transfer overlay must not claim W1/global repair safety"
+    );
+
+    let laplacian_out = run_ag_measurement_fixture(
+        "m14-laplacian-overlay",
+        "archmap_v2_sheaf_laplacian.json",
+        "law_policy_laplacian.json",
+    );
+    let laplacian_packet = read_json(&laplacian_out.join("archsig-measurement-packet.json"));
+    let laplacian_viewer = read_json(&laplacian_out.join("archsig-atom-viewer-data.json"));
+    assert_eq!(
+        laplacian_packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .len(),
+        1,
+        "spectral overlays must not add to the sheaf-laplacian structural verdict row"
+    );
+    let spectral_overlay = overlay_by_kind(&laplacian_viewer, "spectral_gap_proxy");
+    assert_eq!(spectral_overlay["colorRole"], "analytic_reading");
+    assert_eq!(spectral_overlay["spectralGap"], Value::from(2.0));
+    assert!(
+        spectral_overlay["nonClaim"]
+            .as_str()
+            .is_some_and(|text| text.contains("not measured_zero lawfulness")),
+        "spectral gap overlay must not be promoted to measured_zero"
+    );
+    let hotspot_overlay = overlay_by_kind(&laplacian_viewer, "curvature_spectrum_hotspot");
+    assert_eq!(hotspot_overlay["colorRole"], "analytic_reading");
+    assert_eq!(hotspot_overlay["sourceRegime"], "theorem-candidate");
+    assert!(
+        hotspot_overlay["hotspots"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()),
+        "hotspot overlay must be gated by an existing landed hotspot reading"
+    );
+
+    let tor_out = run_ag_measurement_fixture(
+        "m14-singularity-overlay",
+        "archmap_v2_law_conflict_tor.json",
+        "law_policy_tor.json",
+    );
+    let tor_packet = read_json(&tor_out.join("archsig-measurement-packet.json"));
+    let tor_viewer = read_json(&tor_out.join("archsig-atom-viewer-data.json"));
+    assert_eq!(
+        tor_packet["structuralVerdict"]
+            .as_array()
+            .expect("structuralVerdict is array")
+            .len(),
+        1,
+        "singularity concentration overlay must not add to the Tor structural verdict row"
+    );
+    let concentration_overlay = overlay_by_kind(&tor_viewer, "singularity_concentration");
+    assert_eq!(concentration_overlay["colorRole"], "analytic_reading");
+    assert_eq!(concentration_overlay["deformationRegime"], "not_provided");
+    assert_eq!(concentration_overlay["concentrationCount"], Value::from(1));
+
+    let square_free_out = run_ag_measurement_fixture(
+        "m14-empty-overlay",
+        "archmap_v2_square_free_repair.json",
+        "law_policy_square_free.json",
+    );
+    let square_free_viewer = read_json(&square_free_out.join("archsig-atom-viewer-data.json"));
+    assert!(
+        square_free_viewer["aatGeometryOverlays"]["analyticOverlayBundle"]["overlays"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "packets without M14 allowlisted readings must keep analytic overlays silent"
+    );
+    let inactive_scene = viewer_scene_by_id(&square_free_viewer, "analytic-overlay");
+    assert_eq!(inactive_scene["sceneStatus"], "not_active_for_packet");
+    assert_eq!(
+        inactive_scene["visualEncodings"][0]["colorRole"], "not_applicable",
+        "empty analytic overlay packet must not be rendered as a red error or structural color"
+    );
+}
+
+#[test]
 fn cli_analyze_v2_square_free_without_certificate_returns_unknown() {
     let out_dir = temp_dir("ag-measurement-square-free-no-cert");
     let root = ag_measurement_root();
@@ -9497,7 +9654,11 @@ fn practical_rust_service_example_runs_current_analyze() {
     assert_eq!(viewer["atomEdges"].as_array().map(Vec::len), Some(78));
     assert_eq!(
         viewer["viewerVisualScenes"].as_array().map(Vec::len),
-        Some(10)
+        Some(11)
+    );
+    assert_eq!(
+        viewer_scene_by_id(&viewer, "analytic-overlay")["sceneStatus"],
+        "not_active_for_packet"
     );
     assert_eq!(viewer["guidedTours"].as_array().map(Vec::len), Some(2));
     assert_eq!(
@@ -13627,6 +13788,49 @@ fn run_sig0_output(args: &[&str]) -> std::process::Output {
 fn read_json(path: &Path) -> Value {
     serde_json::from_slice(&fs::read(path).expect("json fixture can be read"))
         .expect("json fixture parses")
+}
+
+fn run_ag_measurement_fixture(case_id: &str, archmap: &str, law_policy: &str) -> PathBuf {
+    let root = ag_measurement_root();
+    let out_dir = temp_dir(case_id);
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        root.join(archmap).to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join(law_policy).to_str().expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+    out_dir
+}
+
+fn overlay_by_kind<'a>(viewer: &'a Value, overlay_kind: &str) -> &'a Value {
+    viewer["aatGeometryOverlays"]["analyticOverlayBundle"]["overlays"]
+        .as_array()
+        .expect("analytic overlay bundle overlays is array")
+        .iter()
+        .find(|overlay| overlay["overlayKind"] == overlay_kind)
+        .unwrap_or_else(|| panic!("missing analytic overlay kind {overlay_kind}"))
+}
+
+fn viewer_scene_by_id<'a>(viewer: &'a Value, scene_id: &str) -> &'a Value {
+    viewer["viewerVisualScenes"]
+        .as_array()
+        .expect("viewerVisualScenes is array")
+        .iter()
+        .find(|scene| scene["sceneId"] == scene_id)
+        .unwrap_or_else(|| panic!("missing viewer scene {scene_id}"))
+}
+
+fn assert_analytic_overlay_scene_active(viewer: &Value) {
+    let scene = viewer_scene_by_id(viewer, "analytic-overlay");
+    assert_eq!(scene["sceneStatus"], "active");
+    assert_eq!(scene["visualEncodings"][0]["colorRole"], "analytic_reading");
+    assert_eq!(
+        scene["gluingGeometryRefs"]["analyticOverlayBundleRef"],
+        "gluingGeometry.analyticOverlayBundle"
+    );
 }
 
 fn invariant_by_id<'a>(packet: &'a Value, invariant_id: &str) -> &'a Value {

--- a/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archsig_viewer_gluing_geometry_golden_ux.json
@@ -72,6 +72,7 @@
     "renderNerveGeometry",
     "renderCocycleRibbon",
     "renderLocusField",
+    "renderAnalyticOverlays",
     "renderForbiddenCages",
     "renderRepairMorphs",
     "renderAtomGlyphOverlays",
@@ -85,6 +86,7 @@
     "visualEncodingChannel",
     "__archsigViewerDebug",
     "value=\"obstructions\"",
+    "value=\"analyticOverlay\"",
     "sceneAxisPosition",
     "legendValueText",
     "gluingGeometry."

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -834,6 +834,7 @@
             <option value="obstructionLoops">AG Obstruction loops</option>
             <option value="obstructions">AG Forbidden support cages</option>
             <option value="spectrum">AG Spectrum landscape</option>
+            <option value="analyticOverlay">AG Analytic overlay</option>
             <option value="flatness">AG Flatness surface</option>
             <option value="aatAxes">AG Site / Cover</option>
             <option value="molecules">Molecule map</option>
@@ -1422,6 +1423,9 @@
       if (scene.sceneId === "hodge-debt-field") {
         renderLocusField(scene, geometry.locusField || {}, positions, geometry.renderLimits || {});
       }
+      if (scene.sceneId === "analytic-overlay") {
+        renderAnalyticOverlays(scene, geometry.analyticOverlayBundle || {}, positions, encoding, geometry.renderLimits || {});
+      }
       if (scene.sceneId === "obstruction") {
         renderForbiddenCages(scene, geometry.forbiddenCages || [], positions, encoding, geometry.renderLimits || {});
       }
@@ -1691,6 +1695,80 @@
         mesh.userData = { kind: "blockedUnmeasuredRegion", item: region };
         edgeGroup.add(mesh);
       });
+    }
+
+    function renderAnalyticOverlays(scene, bundle, positions, encoding, limits = {}) {
+      const overlays = (Array.isArray(bundle.overlays) ? bundle.overlays : []).slice(0, limits.analyticOverlays || 80);
+      const color = sceneColorHex("analytic_reading");
+      const vertices = [];
+      let previousPoint = null;
+      overlays.forEach((overlay, index) => {
+        const value = overlayMagnitude(overlay);
+        const center = sceneAxisPosition(scene, overlay.overlayId || `analytic-overlay:${index}`, index, Math.max(overlays.length, 1), groupPosition(index, Math.max(overlays.length, 1), 58), {
+          xValue: index / Math.max(overlays.length - 1, 1),
+          yValue: Math.min(value, 12),
+          zValue: Math.min(value, 12)
+        });
+        const size = 3.6 + Math.min(value, 10) * 1.4;
+        const geometry = overlayGeometry(overlay.overlayKind, size);
+        const mesh = new THREE.Mesh(
+          geometry,
+          new THREE.MeshStandardMaterial({
+            color,
+            emissive: 0x0b2f46,
+            transparent: true,
+            opacity: 0.58,
+            roughness: 0.42,
+            metalness: 0.03,
+            wireframe: overlay.overlayKind === "singularity_concentration"
+          })
+        );
+        mesh.position.copy(center);
+        mesh.position.y += 6 + Math.min(value, 12) * 1.8;
+        mesh.rotation.x = Math.PI / 8;
+        mesh.rotation.y = index * 0.42;
+        mesh.userData = { kind: overlay.overlayKind || "analyticOverlay", item: overlay, colorRole: "analytic_reading" };
+        edgeGroup.add(mesh);
+        if (previousPoint) {
+          vertices.push(previousPoint.x, previousPoint.y, previousPoint.z, mesh.position.x, mesh.position.y, mesh.position.z);
+        }
+        previousPoint = mesh.position.clone();
+        const label = createTextSprite(overlayLabel(overlay), "#e8f3ff", "rgba(14,35,58,0.72)");
+        label.position.copy(mesh.position).add(new THREE.Vector3(0, size + 5, 0));
+        label.userData = { kind: "analyticOverlayLabel", item: overlay };
+        edgeGroup.add(label);
+      });
+      addLineSegments(vertices, color, 0.38, "analyticOverlayLane", { lineRole: "contour", colorRole: "analytic_reading" });
+    }
+
+    function overlayGeometry(kind, size) {
+      if (kind === "period_pairing_matrix") return new THREE.BoxGeometry(size * 1.8, size * 0.24, size);
+      if (kind === "wasserstein_transfer_cost") return new THREE.ConeGeometry(size * 0.8, size * 1.8, 6);
+      if (kind === "spectral_gap_proxy") return new THREE.CylinderGeometry(size * 0.65, size * 0.65, size * 1.4, 20);
+      if (kind === "curvature_spectrum_hotspot") return new THREE.TorusKnotGeometry(size * 0.52, 0.28, 48, 8);
+      if (kind === "singularity_concentration") return new THREE.OctahedronGeometry(size * 0.9);
+      return new THREE.SphereGeometry(size, 16, 10);
+    }
+
+    function overlayMagnitude(overlay) {
+      const candidates = [
+        overlay.wassersteinTransferCost,
+        overlay.transferResidue,
+        overlay.spectralGap,
+        overlay.concentrationCount
+      ].map(Number).filter(Number.isFinite);
+      if (Array.isArray(overlay.periodPairingMatrix)) {
+        overlay.periodPairingMatrix.flat().map(Number).filter(Number.isFinite).forEach((value) => candidates.push(Math.abs(value)));
+      }
+      if (Array.isArray(overlay.hotspots)) {
+        overlay.hotspots.map((item) => Number(item.hotspotWeight)).filter(Number.isFinite).forEach((value) => candidates.push(value));
+      }
+      return candidates.length ? Math.max(...candidates.map(Math.abs)) : 1;
+    }
+
+    function overlayLabel(overlay) {
+      const label = String(overlay.overlayKind || "analytic").replace(/_/g, " ");
+      return label.length > 26 ? `${label.slice(0, 25)}...` : label;
     }
 
     function renderForbiddenCages(scene, cages, positions, encoding, limits) {
@@ -2851,7 +2929,8 @@
         sources: "source-evidence",
         curvature: "hodge-debt-field",
         flatness: "hodge-debt-field",
-        spectrum: "hodge-debt-field"
+        spectrum: "hodge-debt-field",
+        analyticOverlay: "analytic-overlay"
       };
       const sceneId = mapping[mode] || mode;
       return scenes.find((scene) => scene.sceneId === sceneId || scene.kind === sceneId);
@@ -2867,6 +2946,7 @@
         "repair-dual": "projection",
         "law-conflict-tor": "risk",
         "hodge-debt-field": "curvature",
+        "analytic-overlay": "analyticOverlay",
         "boundary-assumption": "risk",
         "source-evidence": "sources"
       };


### PR DESCRIPTION
## 概要

Closes #2261

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M14 対応です。

- packet 内の既存 analytic readings / computed invariants だけを allowlist して `analyticOverlayBundle` として viewer projection
- period pairing / transfer cost / spectral gap / curvature hotspot / singularity concentration の 5 種 overlay を `colorRole=analytic_reading` 固定で投影
- `analytic-overlay` scene と静的 viewer の mode/render binding を追加
- overlay 追加で structural verdict 件数が増えないこと、空 packet では沈黙することを test で固定

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加確認:

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_projects_analytic_overlay_bundle_to_viewer_lane -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_locks_archsig_viewer_gluing_geometry_golden_ux_fixture -- --nocapture`
- [x] サブエージェント M14 レビュー指摘の viewer binding / omitted count を修正済み

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
