### PR TITLE
AC-M15 common ambient coefficient ledgerを追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -8181,6 +8181,12 @@ fn tor_assumptions(
     ambient_status: &str,
     square_free_status: &str,
 ) -> Vec<AgAssumptionLedgerEntryV1> {
+    let coefficient_status = if ambient_status == "checked" {
+        "checked"
+    } else {
+        "violated"
+    };
+
     vec![
         AgAssumptionLedgerEntryV1 {
             theorem_ref: "part8/9.1".to_string(),
@@ -8189,6 +8195,18 @@ fn tor_assumptions(
             status: ambient_status.to_string(),
             checked_by: ambient.map(|ambient| ambient.atom_ref.clone()),
             assumed_by: (ambient_status != "checked")
+                .then(|| format!("measurement-profile:{}", profile.profile_id)),
+        },
+        AgAssumptionLedgerEntryV1 {
+            theorem_ref: "part8/9.1-coefficient-compatibility".to_string(),
+            assumption:
+                "common ambient coefficient compatibility under the selected single F2 coefficient model"
+                    .to_string(),
+            status: coefficient_status.to_string(),
+            checked_by: (coefficient_status == "checked").then(|| {
+                format!("measurement-profile:{}.coefficient:F2", profile.profile_id)
+            }),
+            assumed_by: (coefficient_status != "checked")
                 .then(|| format!("measurement-profile:{}", profile.profile_id)),
         },
         AgAssumptionLedgerEntryV1 {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -4327,6 +4327,14 @@ fn cli_analyze_v2_law_conflict_tor_outputs_conflict_classes() {
         packet["structuralVerdict"][0]["verdictData"]["certRef"],
         "atom:tor-common-ambient"
     );
+    assert!(
+        packet["structuralVerdict"][0]["dependsOnAssumptions"]
+            .as_array()
+            .expect("dependsOnAssumptions is array")
+            .iter()
+            .any(|theorem_ref| theorem_ref == "part8/9.1-coefficient-compatibility"),
+        "Tor verdict must depend on the common ambient coefficient compatibility ledger row"
+    );
     assert_eq!(
         packet["structuralVerdict"]
             .as_array()
@@ -4345,6 +4353,12 @@ fn cli_analyze_v2_law_conflict_tor_outputs_conflict_classes() {
     assert_eq!(
         tor["commonAmbient"]["ambientRef"],
         "ambient:checkout-inventory"
+    );
+    let tor_object = tor.as_object().expect("Tor invariant is object");
+    assert!(
+        !tor_object.contains_key("coefficientRef")
+            && !tor_object.contains_key("comparisonMorphismRef"),
+        "M15 must expose coefficient compatibility through the assumption ledger, not new Tor schema fields"
     );
     assert_eq!(
         tor["lawConflicts"],
@@ -4378,6 +4392,19 @@ fn cli_analyze_v2_law_conflict_tor_outputs_conflict_classes() {
             .as_str()
             .is_some_and(|note| note.contains("higher Tor_i") && note.contains("F2")),
         "Tor boundary note must keep higher Tor and field-coefficient boundaries visible"
+    );
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .expect("assumptions is array")
+            .iter()
+            .any(|row| row["theoremRef"] == "part8/9.1-coefficient-compatibility"
+                && row["assumption"]
+                    == "common ambient coefficient compatibility under the selected single F2 coefficient model"
+                && row["status"] == "checked"
+                && row["checkedBy"]
+                    == "measurement-profile:profile:ag-law-conflict-tor@1.coefficient:F2"),
+        "Tor assumption ledger must record checked coefficient compatibility for the selected common ambient"
     );
     let hilbert = packet["analyticReadings"]
         .as_array()
@@ -4712,9 +4739,33 @@ fn cli_analyze_v2_law_conflict_tor_without_common_ambient_is_not_computed() {
         packet["structuralVerdict"][0]["verdictData"]["methodStatus"],
         "no_common_ambient"
     );
+    assert!(
+        packet["structuralVerdict"][0]["dependsOnAssumptions"]
+            .as_array()
+            .expect("dependsOnAssumptions is array")
+            .iter()
+            .any(|theorem_ref| theorem_ref == "part8/9.1-coefficient-compatibility"),
+        "not-computed Tor verdict still records the coefficient compatibility dependency"
+    );
     let tor = invariant_by_id(&packet, "law-conflict-tor:profile:ag-law-conflict-tor@1");
     assert_eq!(tor["status"], "not_computed");
     assert_eq!(tor["reason"], "no_common_ambient");
+    assert_ne!(
+        packet["structuralVerdict"][0]["verdict"], "measured_zero",
+        "violated common ambient / coefficient compatibility must not degrade to measured_zero"
+    );
+    assert!(
+        packet["assumptions"]
+            .as_array()
+            .expect("assumptions is array")
+            .iter()
+            .any(
+                |row| row["theoremRef"] == "part8/9.1-coefficient-compatibility"
+                    && row["status"] == "violated"
+                    && row["assumedBy"] == "measurement-profile:profile:ag-law-conflict-tor@1"
+            ),
+        "missing common ambient must mark coefficient compatibility violated in the assumption ledger"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #2263

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M15 として、`ag.law-conflict-tor@1` の common ambient assumption ledger に coefficient-compatibility 行を追加します。

- `part8/9.1-coefficient-compatibility` を Tor assumption ledger に追加
- 現行の単一 F2 coefficient モデルでは common ambient がある場合 `checked`、common ambient 不在時は `violated` として透明化
- 既存の `dependsOnAssumptions` / violated dependency propagation に乗せ、measured_zero とは混同しないことをテストで固定
- `coefficientRef` / `comparisonMorphismRef` の schema field は追加しない

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `rg -nP "[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}]" tools/archsig/src/ag_measurement.rs tools/archsig/tests/cli.rs`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加で確認:

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_law_conflict_tor_outputs_conflict_classes -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_law_conflict_tor_without_common_ambient_is_not_computed -- --nocapture`
- [x] サブエージェントレビュー: 重大な問題なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない