### PR TITLE
AC-M共通 structural verdict disciplineを固定

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -17,6 +17,17 @@ const VERDICTS: [&str; 5] = [
     "unknown",
     "not_computed",
 ];
+const STRUCTURAL_VERDICT_EVALUATORS: [&str; 9] = [
+    "ag.cech-obstruction@1",
+    "ag.restriction-compatibility@1",
+    "ag.section-factorization@1",
+    "ag.boundary-residue@1",
+    "ag.square-free-repair@1",
+    "ag.law-conflict-tor@1",
+    "ag.coherence-obstruction@1",
+    "ag.sheaf-laplacian@1",
+    "ag.period-stokes-audit@1",
+];
 const MAX_SQUARE_FREE_WITNESS_VARIABLES: usize = 12;
 const MAX_COHERENCE_CONTEXTS: usize = 12;
 const MAX_TOR_WITNESS_VARIABLES: usize = 12;
@@ -10788,6 +10799,7 @@ pub fn validate_measurement_packet_v1(packet: &ArchSigMeasurementPacketV1) -> Ve
     vec![
         check_packet_schema(packet),
         check_structural_verdict_values(packet),
+        check_structural_verdict_evaluators(packet),
         check_structural_verdict_data(packet),
         check_analytic_regime_boundary(packet),
         check_assumption_ledger(packet),
@@ -10834,6 +10846,26 @@ fn check_structural_verdict_values(packet: &ArchSigMeasurementPacketV1) -> Valid
     )
 }
 
+fn check_structural_verdict_evaluators(packet: &ArchSigMeasurementPacketV1) -> ValidationCheck {
+    let examples = packet
+        .structural_verdict
+        .iter()
+        .filter(|row| !STRUCTURAL_VERDICT_EVALUATORS.contains(&row.evaluator.as_str()))
+        .map(|row| {
+            generic_validation_example(
+                &row.evaluator,
+                &row.law,
+                "structural verdict evaluators must stay within the registered AG measurement surface",
+            )
+        })
+        .collect::<Vec<_>>();
+    check_examples(
+        "measurement-packet-v1-structural-verdict-evaluators",
+        "structural verdict rows are limited to registered AG measurement evaluators",
+        examples,
+    )
+}
+
 fn check_structural_verdict_data(packet: &ArchSigMeasurementPacketV1) -> ValidationCheck {
     let mut examples = Vec::new();
     for row in &packet.structural_verdict {
@@ -10849,6 +10881,20 @@ fn check_structural_verdict_data(packet: &ArchSigMeasurementPacketV1) -> Validat
                 &row.evaluator,
                 "measured_zero",
                 "measured_zero requires zero=true in VerdictData",
+            ));
+        }
+        if row.verdict == "measured_zero" && row.verdict_data.non_zero {
+            examples.push(generic_validation_example(
+                &row.evaluator,
+                "measured_zero",
+                "measured_zero requires nonZero=false in VerdictData",
+            ));
+        }
+        if row.verdict == "measured_zero" && !row.verdict_data.in_scope {
+            examples.push(generic_validation_example(
+                &row.evaluator,
+                "measured_zero",
+                "measured_zero requires inScope=true in VerdictData",
             ));
         }
         if row.verdict == "measured_nonzero" && !row.verdict_data.non_zero {
@@ -11341,8 +11387,40 @@ mod tests {
     }
 
     #[test]
+    fn unregistered_structural_verdict_evaluator_fails_validation() {
+        let mut packet = packet_fixture();
+        packet.structural_verdict[0].evaluator = "ag.synthetic-new-verdict@1".to_string();
+        let checks = validate_measurement_packet_v1(&packet);
+        assert!(checks.iter().any(|check| {
+            check.id == "measurement-packet-v1-structural-verdict-evaluators"
+                && check.result == "fail"
+        }));
+    }
+
+    #[test]
     fn zero_and_nonzero_verdict_data_fails_validation() {
         let mut packet = packet_fixture();
+        packet.structural_verdict[0].verdict_data.zero = true;
+        packet.structural_verdict[0].verdict_data.non_zero = true;
+        let checks = validate_measurement_packet_v1(&packet);
+        assert!(checks.iter().any(|check| {
+            check.id == "measurement-packet-v1-verdict-data-boundary" && check.result == "fail"
+        }));
+    }
+
+    #[test]
+    fn measured_zero_requires_unhedged_verdict_data() {
+        let mut packet = packet_fixture();
+        packet.structural_verdict[0].verdict = "measured_zero".to_string();
+        packet.structural_verdict[0].verdict_data.zero = true;
+        packet.structural_verdict[0].verdict_data.in_scope = false;
+        let checks = validate_measurement_packet_v1(&packet);
+        assert!(checks.iter().any(|check| {
+            check.id == "measurement-packet-v1-verdict-data-boundary" && check.result == "fail"
+        }));
+
+        let mut packet = packet_fixture();
+        packet.structural_verdict[0].verdict = "measured_zero".to_string();
         packet.structural_verdict[0].verdict_data.zero = true;
         packet.structural_verdict[0].verdict_data.non_zero = true;
         let checks = validate_measurement_packet_v1(&packet);

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -5458,6 +5458,88 @@ fn cli_analyze_v2_period_stokes_audit_outputs_structural_verdicts() {
 }
 
 #[test]
+fn cli_analyze_v2_common_structural_verdict_discipline_locks_prd_m_evaluators() {
+    let root_out = temp_dir("ag-measurement-common-structural-verdict-discipline");
+    let mut observed_new_structural_evaluators = BTreeSet::new();
+
+    for (case, evaluator, archmap, policy) in [
+        (
+            "restriction",
+            "ag.restriction-compatibility@1",
+            restriction_archmap("compatible"),
+            restriction_policy(),
+        ),
+        (
+            "section",
+            "ag.section-factorization@1",
+            section_archmap("lawful"),
+            section_policy(),
+        ),
+        (
+            "coherence",
+            "ag.coherence-obstruction@1",
+            coherence_triangle_archmap(true),
+            coherence_policy("F2", false),
+        ),
+        (
+            "boundary-residue",
+            "ag.boundary-residue@1",
+            boundary_residue_archmap("zero"),
+            boundary_residue_policy(),
+        ),
+    ] {
+        let packet = run_generated_ag_measurement_case(&root_out, case, archmap, policy);
+        assert_common_structural_verdict_discipline(&packet, evaluator);
+        observed_new_structural_evaluators.insert(evaluator.to_string());
+    }
+
+    let root = ag_measurement_root();
+    let mut period_archmap = read_json(&root.join("archmap_v2_period_stokes.json"));
+    period_archmap["atoms"][3]["object"] = Value::String("chain:sigma=3".to_string());
+    let mut period_policy = read_json(&root.join("law_policy_period.json"));
+    period_policy["measurementProfiles"][0]["coefficient"] = Value::String("Q".to_string());
+    period_policy["measurementProfiles"][0]["effCoeff"] =
+        Value::String("fixed-coefficient-stokes-audit@1".to_string());
+    period_policy["measurementProfiles"][0]["resolutionSelector"] =
+        Value::String("finite-poset-period-stokes-audit@1".to_string());
+    period_policy["measurementProfiles"][0]["zeroPredicate"] =
+        Value::String("stokes-residual-zero@1".to_string());
+    period_policy["measurementProfiles"][0]["nonZeroPredicate"] =
+        Value::String("stokes-residual-nonzero@1".to_string());
+    period_policy["measurementProfiles"][0]["certSelector"] =
+        Value::String("finite-certificate@1".to_string());
+    for witness in period_policy["measurementProfiles"][0]["witnessFamily"]
+        .as_array_mut()
+        .expect("witnessFamily is array")
+    {
+        witness["law"] = Value::String("ag.period-stokes-audit".to_string());
+    }
+    period_policy["policies"][0]["law"] = Value::String("ag.period-stokes-audit".to_string());
+    period_policy["policies"][0]["evaluator"] =
+        Value::String("ag.period-stokes-audit@1".to_string());
+    let period_packet = run_generated_ag_measurement_case(
+        &root_out,
+        "period-stokes-audit",
+        period_archmap,
+        period_policy,
+    );
+    assert_common_structural_verdict_discipline(&period_packet, "ag.period-stokes-audit@1");
+    observed_new_structural_evaluators.insert("ag.period-stokes-audit@1".to_string());
+
+    assert_eq!(
+        observed_new_structural_evaluators,
+        BTreeSet::from([
+            "ag.restriction-compatibility@1".to_string(),
+            "ag.section-factorization@1".to_string(),
+            "ag.coherence-obstruction@1".to_string(),
+            "ag.boundary-residue@1".to_string(),
+            "ag.period-stokes-audit@1".to_string(),
+        ]),
+        "PRD M common must limit new structural verdict evaluators to M2/M3/M5/M6/M9"
+    );
+}
+
+#[test]
 fn cli_analyze_v2_period_stokes_without_audit_is_not_computed() {
     let out_dir = temp_dir("ag-measurement-period-stokes-no-audit");
     let root = ag_measurement_root();
@@ -13927,6 +14009,103 @@ fn boundary_residue_row(packet: &Value) -> &Value {
         .iter()
         .find(|row| row["evaluator"] == "ag.boundary-residue@1")
         .expect("boundary residue row exists")
+}
+
+fn run_generated_ag_measurement_case(
+    root_out: &Path,
+    case: &str,
+    archmap: Value,
+    policy: Value,
+) -> Value {
+    let out_dir = root_out.join(case);
+    fs::create_dir_all(&out_dir).expect("case dir exists");
+    let archmap_path = out_dir.join("archmap.json");
+    let policy_path = out_dir.join("law_policy.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_vec_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("case archmap is written");
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&policy).expect("policy serializes"),
+    )
+    .expect("case policy is written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        policy_path.to_str().expect("path is utf-8"),
+        "--out-dir",
+        out_dir.to_str().expect("path is utf-8"),
+    ]);
+    read_json(&out_dir.join("archsig-measurement-packet.json"))
+}
+
+fn assert_common_structural_verdict_discipline(packet: &Value, evaluator: &str) {
+    let allowed_verdicts = BTreeSet::from([
+        "measured_zero",
+        "measured_nonzero",
+        "unmeasured",
+        "unknown",
+        "not_computed",
+    ]);
+    let structural = packet["structuralVerdict"]
+        .as_array()
+        .expect("structuralVerdict is array");
+    assert_eq!(
+        structural
+            .iter()
+            .filter(|row| row["evaluator"] == evaluator)
+            .count(),
+        1,
+        "{evaluator} must emit exactly one structural verdict row"
+    );
+
+    let violated = packet["assumptions"]
+        .as_array()
+        .expect("assumptions is array")
+        .iter()
+        .filter(|row| row["status"] == "violated")
+        .filter_map(|row| row["theoremRef"].as_str())
+        .collect::<BTreeSet<_>>();
+
+    for row in structural {
+        let verdict = row["verdict"].as_str().expect("verdict is string");
+        assert!(
+            allowed_verdicts.contains(verdict),
+            "structural verdict must stay in the five-value vocabulary"
+        );
+        if verdict == "measured_zero" {
+            assert_eq!(row["verdictData"]["inScope"], true);
+            assert_eq!(row["verdictData"]["zero"], true);
+            assert_eq!(row["verdictData"]["nonZero"], false);
+            assert!(
+                row["verdictData"]["certRef"]
+                    .as_str()
+                    .is_some_and(|cert_ref| !cert_ref.is_empty()),
+                "measured_zero must carry a certificate reference in PRD M common fixtures"
+            );
+        }
+        if matches!(verdict, "measured_zero" | "measured_nonzero") {
+            let depends_on = row["dependsOnAssumptions"]
+                .as_array()
+                .map(|dependencies| {
+                    dependencies
+                        .iter()
+                        .filter_map(|dependency| dependency.as_str())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            assert!(
+                depends_on
+                    .iter()
+                    .all(|dependency| !violated.contains(dependency)),
+                "measured structural verdicts must not depend on violated assumptions"
+            );
+        }
+    }
 }
 
 fn restriction_policy() -> Value {


### PR DESCRIPTION
## 概要

Closes #2265

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-M共通として、ArchSig AG measurement packet の structural verdict discipline を共通ゲートで固定します。

- structural verdict evaluator を current AG measurement surface に allowlist 化
- 5値 vocabulary の validator を維持しつつ、measured_zero の `inScope=true` / `zero=true` / `nonZero=false` を追加検査
- M2/M3/M5/M6/M9 の5 evaluator が各1 rowを出し、5値集合と violated dependency 非依存を守る横断 CLI test を追加
- violated assumption dependency propagation は既存規律のまま、依存 measured verdict のみ `not_computed` に正規化される test を維持

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `rg -nP "[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}]" tools/archsig/src/ag_measurement.rs tools/archsig/tests/cli.rs`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加で確認:

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml unregistered_structural_verdict_evaluator_fails_validation -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml measured_zero_requires_unhedged_verdict_data -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_analyze_v2_common_structural_verdict_discipline_locks_prd_m_evaluators -- --nocapture`
- [x] サブエージェントレビュー: 重大な問題なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない