### PR TITLE
AC-V1 viewer PBR rendering foundationを追加

### DIFF
--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -13636,6 +13636,31 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
         "viewer must prefer WebGPU and keep a WebGL fallback"
     );
     assert!(
+        html.contains("RoomEnvironment.js")
+            && html.contains("PMREMGenerator")
+            && html.contains("scene.environment")
+            && html.contains("ACESFilmicToneMapping")
+            && html.contains("toneMappingExposure = 1.05")
+            && html.contains("SRGBColorSpace"),
+        "viewer V1 PBR foundation must configure ACES tone mapping and RoomEnvironment IBL"
+    );
+    assert!(
+        html.contains("HemisphereLight")
+            && html.contains("keyLight")
+            && html.contains("rimLight")
+            && html.contains("PCFSoftShadowMap")
+            && html.contains("ShadowMaterial")
+            && html.contains("castShadow = true")
+            && html.contains("receiveShadow = true")
+            && html.contains("scene.fog = new THREE.Fog"),
+        "viewer V1 PBR foundation must include three-point lighting, contact shadows, and fog"
+    );
+    assert!(
+        html.contains("viewerPixelRatio()")
+            && html.contains("renderer.setPixelRatio(viewerPixelRatio())"),
+        "viewer V1 must cap and reapply pixel ratio across renderer resize paths"
+    );
+    assert!(
         html.contains("type=\"file\"")
             && html.contains("dragover")
             && html.contains("./archsig-atom-viewer-data.json"),

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -918,6 +918,7 @@
   <script type="module">
     import * as THREE from "three";
     import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+    import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 
     const container = document.getElementById("scene");
     const appEl = document.querySelector(".app");
@@ -944,17 +945,32 @@
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x0d1015);
+    scene.fog = new THREE.Fog(0x0d1015, 600, 2600);
     const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 4000);
     const atomGroup = new THREE.Group();
     const moleculeGroup = new THREE.Group();
     const edgeGroup = new THREE.Group();
     scene.add(atomGroup, moleculeGroup, edgeGroup);
-    scene.add(new THREE.AmbientLight(0xffffff, 0.76));
-    const light = new THREE.DirectionalLight(0xffffff, 1.2);
-    light.position.set(70, 120, 90);
-    scene.add(light);
+    const ambientFillLight = new THREE.HemisphereLight(0xdfe9ff, 0x171d25, 0.7);
+    const keyLight = new THREE.DirectionalLight(0xffffff, 2.15);
+    keyLight.position.set(120, 180, 95);
+    keyLight.castShadow = true;
+    keyLight.shadow.mapSize.set(2048, 2048);
+    keyLight.shadow.camera.near = 20;
+    keyLight.shadow.camera.far = 620;
+    keyLight.shadow.camera.left = -420;
+    keyLight.shadow.camera.right = 420;
+    keyLight.shadow.camera.top = 320;
+    keyLight.shadow.camera.bottom = -320;
+    keyLight.shadow.bias = -0.00018;
+    const rimLight = new THREE.DirectionalLight(0x9bc7ff, 0.9);
+    rimLight.position.set(-170, 105, -150);
+    scene.add(ambientFillLight, keyLight, rimLight);
+    const groundShadow = createGroundShadow();
+    scene.add(groundShadow);
 
     let renderer = await createRenderer();
+    configureSceneEnvironment(renderer);
     container.appendChild(renderer.domElement);
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
@@ -1006,6 +1022,7 @@
           const module = await import("three/addons/renderers/webgpu/WebGPURenderer.js");
           const webgpu = new module.default({ antialias: true });
           await webgpu.init();
+          configureRendererQuality(webgpu);
           status("WebGPU renderer");
           return webgpu;
         } catch (error) {
@@ -1013,9 +1030,54 @@
         }
       }
       const webgl = new THREE.WebGLRenderer({ antialias: true });
-      webgl.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      configureRendererQuality(webgl);
       status("WebGL renderer");
       return webgl;
+    }
+
+    function viewerPixelRatio() {
+      return Math.min(window.devicePixelRatio || 1, 2);
+    }
+
+    function configureRendererQuality(targetRenderer) {
+      if (typeof targetRenderer.setPixelRatio === "function") {
+        targetRenderer.setPixelRatio(viewerPixelRatio());
+      }
+      targetRenderer.toneMapping = THREE.ACESFilmicToneMapping;
+      targetRenderer.toneMappingExposure = 1.05;
+      targetRenderer.outputColorSpace = THREE.SRGBColorSpace;
+      if (targetRenderer.shadowMap) {
+        targetRenderer.shadowMap.enabled = true;
+        targetRenderer.shadowMap.type = THREE.PCFSoftShadowMap;
+      }
+    }
+
+    function configureSceneEnvironment(targetRenderer) {
+      try {
+        const pmrem = new THREE.PMREMGenerator(targetRenderer);
+        const room = new RoomEnvironment();
+        scene.environment = pmrem.fromScene(room, 0.04).texture;
+        scene.userData.environmentSource = "RoomEnvironment PMREM";
+        room.dispose();
+        pmrem.dispose();
+      } catch (_error) {
+        scene.userData.environmentSource = "RoomEnvironment PMREM unavailable";
+      }
+    }
+
+    function createGroundShadow() {
+      const geometry = new THREE.PlaneGeometry(2200, 2200);
+      const material = new THREE.ShadowMaterial({
+        color: 0x06080c,
+        opacity: 0.28,
+        transparent: true
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.rotation.x = -Math.PI / 2;
+      mesh.position.y = -24;
+      mesh.receiveShadow = true;
+      mesh.userData.kind = "groundShadowReceiver";
+      return mesh;
     }
 
     function status(text) {
@@ -1024,6 +1086,9 @@
 
     function resize() {
       const rect = container.getBoundingClientRect();
+      if (typeof renderer.setPixelRatio === "function") {
+        renderer.setPixelRatio(viewerPixelRatio());
+      }
       renderer.setSize(rect.width, rect.height, false);
       camera.aspect = Math.max(rect.width, 1) / Math.max(rect.height, 1);
       camera.updateProjectionMatrix();
@@ -1130,6 +1195,7 @@
       const activeScene = sceneForMode(viewModeEl.value);
       const edgeChildrenBeforeSceneLayers = edgeGroup.children.length;
       renderSceneLayers(activeScene, positions);
+      applySceneShadowFlags();
       window.__archsigViewerDebug = {
         ...(window.__archsigViewerDebug || {}),
         activeSceneId: activeScene?.sceneId || null,
@@ -1142,6 +1208,19 @@
       renderAxisHud();
       updateVisibility();
       statusText(allNodes, edges);
+    }
+
+    function applySceneShadowFlags() {
+      [atomGroup, moleculeGroup, edgeGroup].forEach((group) => {
+        group.traverse((object) => {
+          if (object.isMesh || object.isInstancedMesh) {
+            object.castShadow = true;
+            object.receiveShadow = true;
+          }
+        });
+      });
+      groundShadow.receiveShadow = true;
+      groundShadow.castShadow = false;
     }
 
     function renderAtomInstances(nodes, positions) {


### PR DESCRIPTION
## 概要

Closes #2267

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-V1 として、ArchSig viewer の no-build 単一 HTML に PBR rendering foundation を追加します。

- `RoomEnvironment` + `PMREMGenerator` による scene environment IBL を追加
- WebGL/WebGPU 両 renderer に `ACESFilmicToneMapping`、`toneMappingExposure = 1.05`、`SRGBColorSpace`、pixel ratio cap を適用
- key/fill/rim の照明構成、`PCFSoftShadowMap`、`ShadowMaterial` ground receiver、Fog を追加
- dynamic scene objects に cast/receive shadow flags を付与
- Rust data/schema や structural verdict は追加しない

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan: `rg -nP "[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}]" tools/archsig/viewer/archsig-atom-viewer.html tools/archsig/tests/cli.rs`
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

追加で確認:

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml archsig_atom_viewer_static_app_is_packaged_asset -- --nocapture`
- [x] Browser preview: static viewer HTML と generated `archsig-atom-viewer-data.json` を localhost で読み込み、canvas/status/legend 表示と console error なしを確認
- [x] サブエージェントレビュー: 重大な問題なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない