### PR TITLE
AC-V3: 沈黙描画を霧とすりガラスへ分離する

### DIFF
--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -13652,7 +13652,7 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("ShadowMaterial")
             && html.contains("castShadow = true")
             && html.contains("receiveShadow = true")
-            && html.contains("scene.fog = new THREE.Fog"),
+            && html.contains("scene.fog = new THREE.FogExp2"),
         "viewer V1 PBR foundation must include three-point lighting, contact shadows, and fog"
     );
     assert!(
@@ -13688,6 +13688,30 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("selectiveBloomStatus")
             && html.contains("bloomRegisteredCount"),
         "viewer V2 must mask non-bloom objects and expose bloom diagnostics"
+    );
+    assert!(
+        html.contains("BokehPass.js")
+            && html.contains("new BokehPass(scene, camera")
+            && html.contains("updateBokehFocus()")
+            && html.contains("camera.position.distanceTo(controls.target)")
+            && html.contains("silenceDepthStatus"),
+        "viewer V3 must keep silence depth in FogExp2 and BokehPass focus"
+    );
+    assert!(
+        html.contains("createSilenceGlassMaterial")
+            && html.contains("alphaMap: silenceHatchAlphaMap")
+            && html.contains("depthWrite: false")
+            && html.contains("nerveTriangleSilenceGlass")
+            && html.contains("h2CoherenceVisualized: false")
+            && html.contains("blockedUnmeasuredRegion")
+            && html.contains("redErrorEncodingRemoved: true"),
+        "viewer V3 must render H2 and blocked silence as frosted non-verdict glass"
+    );
+    assert!(
+        html.contains("sceneColorHex(\"measured_nonzero\")")
+            && !html.contains("MeshStandardMaterial({ color: 0xff6b6b, transparent: true, opacity: 0.34, wireframe: true })")
+            && !html.contains("MeshStandardMaterial({ color: 0xff6b6b, emissive: 0x3a0808"),
+        "viewer V3 must remove red error encoding from blocked regions and closure gap marker"
     );
     assert!(
         html.contains("type=\"file\"")

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -923,6 +923,7 @@
     import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
     import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
     import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
+    import { BokehPass } from "three/addons/postprocessing/BokehPass.js";
     import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 
     const container = document.getElementById("scene");
@@ -950,7 +951,7 @@
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x0d1015);
-    scene.fog = new THREE.Fog(0x0d1015, 600, 2600);
+    scene.fog = new THREE.FogExp2(0x0d1015, 0.00078);
     const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 4000);
     const atomGroup = new THREE.Group();
     const moleculeGroup = new THREE.Group();
@@ -981,8 +982,10 @@
     const darkBloomLineMaterial = new THREE.LineBasicMaterial({ color: 0x000000 });
     const darkBloomSpriteMaterial = new THREE.SpriteMaterial({ color: 0x000000 });
     const bloomMaskedMaterials = new Map();
+    const silenceHatchAlphaMap = createSilenceHatchAlphaMap();
     let bloomComposer = null;
     let finalComposer = null;
+    let bokehPass = null;
     let bloomRegisteredCount = 0;
 
     let renderer = await createRenderer();
@@ -1119,13 +1122,46 @@
         finalComposer = new EffectComposer(targetRenderer);
         finalComposer.addPass(baseRenderPass);
         finalComposer.addPass(finalPass);
+        bokehPass = new BokehPass(scene, camera, {
+          focus: camera.position.distanceTo(controls.target),
+          aperture: 0.000055,
+          maxblur: 0.008,
+          width: 1,
+          height: 1
+        });
+        finalComposer.addPass(bokehPass);
         finalComposer.addPass(new OutputPass());
         scene.userData.selectiveBloomStatus = "enabled";
+        scene.userData.silenceDepthStatus = "fog-exp2-bokeh";
       } catch (_error) {
         bloomComposer = null;
         finalComposer = null;
+        bokehPass = null;
         scene.userData.selectiveBloomStatus = "unavailable";
+        scene.userData.silenceDepthStatus = "fallback-no-bokeh";
       }
+    }
+
+    function createSilenceHatchAlphaMap() {
+      const canvas = document.createElement("canvas");
+      canvas.width = 96;
+      canvas.height = 96;
+      const context = canvas.getContext("2d");
+      context.fillStyle = "rgba(255,255,255,0.18)";
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.strokeStyle = "rgba(255,255,255,0.42)";
+      context.lineWidth = 2;
+      for (let offset = -96; offset < 192; offset += 12) {
+        context.beginPath();
+        context.moveTo(offset, 96);
+        context.lineTo(offset + 96, 0);
+        context.stroke();
+      }
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      texture.repeat.set(3, 3);
+      return texture;
     }
 
     function createGroundShadow() {
@@ -1182,10 +1218,16 @@
         renderWithoutComposer(renderer, scene, camera);
         return;
       }
+      updateBokehFocus();
       scene.traverse(darkenNonBloomed);
       bloomComposer.render();
       scene.traverse(restoreBloomMaterials);
       finalComposer.render();
+    }
+
+    function updateBokehFocus() {
+      if (!bokehPass?.materialBokeh?.uniforms?.focus) return;
+      bokehPass.materialBokeh.uniforms.focus.value = camera.position.distanceTo(controls.target);
     }
 
     function renderWithoutComposer(targetRenderer, targetScene, targetCamera) {
@@ -1308,12 +1350,14 @@
         hasGluingGeometry: Boolean(activeLayoutContext?.aat?.gluingGeometry?.schema),
         sceneLayerObjectDelta: edgeGroup.children.length - edgeChildrenBeforeSceneLayers,
         selectiveBloomStatus: scene.userData.selectiveBloomStatus || "unknown",
+        silenceDepthStatus: scene.userData.silenceDepthStatus || "unknown",
         bloomLayer: BLOOM_LAYER,
         bloomRegisteredCount
       };
       renderLegend();
       renderAxisHud();
       updateVisibility();
+      window.__archsigViewerSceneGroups = [atomGroup, moleculeGroup, edgeGroup];
       statusText(allNodes, edges);
     }
 
@@ -1346,6 +1390,32 @@
         material.emissive.lerp(new THREE.Color(material.color || 0xffffff), 0.52);
         material.emissiveIntensity = Math.max(Number(material.emissiveIntensity || 0), intensity);
       });
+    }
+
+    function createSilenceGlassMaterial(opacity = 0.12) {
+      return new THREE.MeshPhysicalMaterial({
+        color: 0x8a94a3,
+        transparent: true,
+        opacity,
+        roughness: 0.82,
+        metalness: 0.0,
+        transmission: 0.18,
+        alphaMap: silenceHatchAlphaMap,
+        depthWrite: false,
+        side: THREE.DoubleSide
+      });
+    }
+
+    function biasObjectIntoSilenceDepth(object, amount, reason) {
+      const direction = new THREE.Vector3();
+      camera.getWorldDirection(direction);
+      object.position.addScaledVector(direction, amount);
+      object.userData = {
+        ...(object.userData || {}),
+        silenceDepthBias: amount,
+        silenceDepthReason: reason,
+        measuredFocus: false
+      };
     }
 
     function renderAtomInstances(nodes, positions) {
@@ -1711,23 +1781,24 @@
         const geometry = new THREE.BufferGeometry();
         geometry.setAttribute("position", new THREE.Float32BufferAttribute(points.flatMap((p) => [p.x, p.y, p.z]), 3));
         geometry.computeVertexNormals();
-        const mesh = new THREE.Mesh(geometry, new THREE.MeshStandardMaterial({
-          color: 0x73b7ff,
-          transparent: true,
-          opacity: 0.34,
-          side: THREE.DoubleSide,
-          roughness: 0.6
-        }));
-        mesh.userData = { kind: "nerveTriangle", item: triangle };
+        const mesh = new THREE.Mesh(geometry, createSilenceGlassMaterial(0.12));
+        mesh.userData = {
+          kind: "nerveTriangleSilenceGlass",
+          item: triangle,
+          coherenceClaim: triangle.coherenceClaim || "not_visualized",
+          h2CoherenceVisualized: false,
+          silenceBoundary: "H^2 coherence is not visualized by this viewer layer"
+        };
+        biasObjectIntoSilenceDepth(mesh, 34, "coherenceClaim:not_visualized");
         edgeGroup.add(mesh);
-        addTriangleOutline(points, "nerveTriangleOutline");
+        addTriangleOutline(points, "nerveTriangleSilenceOutline", 0x8a94a3, 0.34, "dashed_silence");
         const marker = new THREE.Mesh(
           new THREE.SphereGeometry(2.8 + Math.min((triangle.sharedAtomRefs || []).length, 6) * 0.38, 18, 12),
           new THREE.MeshStandardMaterial({
             color: 0x73b7ff,
             emissive: 0x0b2f46,
             transparent: true,
-            opacity: 0.92,
+            opacity: 0.72,
             roughness: 0.44
           })
         );
@@ -1771,12 +1842,12 @@
       addLineSegments(mismatch, sceneColorHex(encoding.colorRole || "measured_nonzero"), 0.9, "nerveMismatchEdge", { lineRole: "thick_glowing_line", thicknessRole: "thick" });
     }
 
-    function addTriangleOutline(points, kind) {
+    function addTriangleOutline(points, kind, color = 0x73b7ff, opacity = 0.9, lineRole = "solid") {
       addLineSegments([
         points[0].x, points[0].y + 0.4, points[0].z, points[1].x, points[1].y + 0.4, points[1].z,
         points[1].x, points[1].y + 0.4, points[1].z, points[2].x, points[2].y + 0.4, points[2].z,
         points[2].x, points[2].y + 0.4, points[2].z, points[0].x, points[0].y + 0.4, points[0].z
-      ], 0x73b7ff, 0.9, kind, { lineRole: "solid", thicknessRole: "thick" });
+      ], color, opacity, kind, { lineRole, thicknessRole: "thin" });
     }
 
     function contextLabel(ref) {
@@ -1851,10 +1922,19 @@
       if (ribbon.closureGapEncoding?.visible) {
         const gap = new THREE.Mesh(
           new THREE.TorusKnotGeometry(3.2, 0.34, 48, 8),
-          new THREE.MeshStandardMaterial({ color: 0xff6b6b, emissive: 0x3a0808, roughness: 0.4 })
+          new THREE.MeshStandardMaterial({
+            color: sceneColorHex("measured_nonzero"),
+            emissive: 0x3f2d08,
+            roughness: 0.4
+          })
         );
         gap.position.copy(points[points.length - 1]);
-        gap.userData = { kind: "holonomyLikeGapMarker", item: ribbon.closureGapEncoding };
+        gap.userData = {
+          kind: "holonomyLikeGapMarker",
+          item: ribbon.closureGapEncoding,
+          measuredFocus: true,
+          redErrorEncodingRemoved: true
+        };
         registerMeasuredBloom(gap, "headline_h1_closure_gap", 0.9);
         edgeGroup.add(gap);
       }
@@ -1899,11 +1979,17 @@
         const center = sceneAxisPosition(scene, region.regionId || `blocked:${index}`, index, Math.max(blockedRegions.length, 1), groupPosition(index, Math.max(blockedRegions.length, 1), 60), { xValue: index / Math.max(blockedRegions.length - 1, 1), yValue: 2, zValue: 2 });
         const mesh = new THREE.Mesh(
           new THREE.BoxGeometry(8, 18, 1.2),
-          new THREE.MeshStandardMaterial({ color: 0xff6b6b, transparent: true, opacity: 0.34, wireframe: true })
+          createSilenceGlassMaterial(0.16)
         );
         mesh.position.set(center.x, 2, center.z);
         mesh.rotation.y = index * 0.45;
-        mesh.userData = { kind: "blockedUnmeasuredRegion", item: region };
+        mesh.userData = {
+          kind: "blockedUnmeasuredRegion",
+          item: region,
+          silenceBoundary: "unmeasured support stays in fog; not a failure glyph",
+          redErrorEncodingRemoved: true
+        };
+        biasObjectIntoSilenceDepth(mesh, 58, "locusField.status:blocked");
         edgeGroup.add(mesh);
       });
     }


### PR DESCRIPTION
## 概要

Closes #2271

AC-V3 の沈黙描画を viewer に追加しました。沈黙を赤い失敗表示にせず、`FogExp2` と `BokehPass`、すりガラス material で measured / unmeasured / H^2 silence を視覚的に分離します。

主な変更:
- `scene.fog` を `FogExp2` に移行
- `BokehPass` を postprocess chain に追加し、focus を `controls.target` に追従
- H^2 nerve triangle を `nerveTriangleSilenceGlass` として低彩度・hatch alphaMap・`depthWrite=false` のすりガラスへ変更
- blocked/unmeasured region を赤 wireframe から silence glass へ変更
- closure gap marker を赤エラー色から measured_nonzero 色へ変更し、V2 の measured bloom と整合
- static asset test に V3 rendering contract を追加

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml archsig_atom_viewer_static_app_is_packaged_asset -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] Playwright + Google Chrome preview: triangle fixture で `silenceDepthStatus=fog-exp2-bokeh`, `nerveTriangleSilenceGlass=1`, red material 0
- [x] Playwright + Google Chrome preview: sheaf-laplacian fixture で `blockedUnmeasuredRegion=1`, `redErrorEncodingRemoved=1`, red material 0

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
