### PR TITLE
PRD-9 Evolution Geometry の初期Lean surfaceを追加

### DIFF
--- a/Formal/AG.lean
+++ b/Formal/AG.lean
@@ -22,3 +22,4 @@ import Formal.AG.Examples.SingularityMonodromyStackPart6
 import Formal.AG.RepresentationAnalysis
 import Formal.AG.Examples.RepresentationAnalysisPart7
 import Formal.AG.Measurement
+import Formal.AG.Evolution

--- a/Formal/AG/Evolution.lean
+++ b/Formal/AG/Evolution.lean
@@ -1,0 +1,3 @@
+import Formal.AG.Evolution.Bootstrap
+import Formal.AG.Evolution.TraceCategory
+import Formal.AG.Evolution.Profile

--- a/Formal/AG/Evolution/Bootstrap.lean
+++ b/Formal/AG/Evolution/Bootstrap.lean
@@ -1,0 +1,127 @@
+import Formal.AG.Site
+import Formal.AG.LawAlgebra
+import Formal.AG.Cohomology
+import Formal.AG.Derived
+import Formal.AG.SingularityMonodromyStack
+import Formal.AG.RepresentationAnalysis
+import Formal.AG.Measurement
+
+noncomputable section
+
+namespace AAT.AG
+namespace Evolution
+
+universe u v w x y z
+
+/-!
+PRD-9 R0 / AC1 bootstrap surface.
+
+This file opens the Part IX evolution namespace, checks that the required
+Part II--VIII entrypoints are available, and records the dependency status
+used by the PRD loop before introducing the selected trace category layer.
+-/
+
+/-- IX.R0: Part IX can use PRD-2 AAT sites. -/
+abbrev UsesAATSite {U : AtomCarrier.{u}} {A : ArchitectureObject U} :=
+  Site.AATSite A
+
+/-- IX.R0: Part IX can use PRD-3 architecture schemes. -/
+abbrev UsesArchitectureScheme {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    (S : Site.AATSite A) (k : Type v) [CommRing k] :=
+  LawAlgebra.Scheme.ArchitectureScheme.{u, v, w, x, y} S k
+
+/-- IX.R0: Part IX can use PRD-4 cover-relative Cech complexes. -/
+abbrev UsesCoverRelativeCechComplex {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (cover : Cohomology.CoverRelativeCechCover S)
+    (obstructionSheaf : Cohomology.ObstructionSheaf S) : Type u :=
+  Cohomology.CoverRelativeCechComplex cover obstructionSheaf
+
+/-- IX.R0: Part IX can use PRD-5 repair comparison profiles. -/
+abbrev UsesRepairComparisonProfile : Type (u + 1) :=
+  Derived.RepairProfile.RepairComparisonProfile.{u}
+
+/-- IX.R0: Part IX can use PRD-6 architecture strata. -/
+abbrev UsesArchitectureStratum {U : AtomCarrier.{u}} {A : ArchitectureObject U}
+    {S : Site.AATSite A} (parameter : SingularityMonodromyStack.StratumReadingParameter S)
+    (k : Type v) [CommRing k] :=
+  SingularityMonodromyStack.ArchitectureStratum.{u, v, w, x, y} parameter k
+
+/-- IX.R0: Part IX can use PRD-7 analytic reading contexts. -/
+abbrev UsesAnalyticReadingContext {U : AtomCarrier.{u}} (Obj : ArchitectureObject U)
+    {S : Site.AATSite Obj} {k : Type v} [CommRing k]
+    (p : RepresentationAnalysis.AATSchReadingParameter.{u, v, w, x, y} S k) :=
+  RepresentationAnalysis.AnalyticReadingContext.{u, v, w, x, y, z} Obj p
+
+/-- IX.R0: Part IX can use PRD-8 measurement profiles. -/
+abbrev UsesMeasurementProfile :=
+  Measurement.MeasurementProfile.{u, v}
+
+/-- IX.R0: coarse availability status for the Part IX prerequisite tower. -/
+inductive PrerequisiteStatus where
+  | available
+  | blocked
+  deriving DecidableEq
+
+/--
+IX.R0: dependency status package for PRD-9.
+
+The current repository state imports the required predecessor entrypoints. If a
+future loop finds one missing, the corresponding field records `blocked`
+without silently extending the Part IX scope.
+-/
+structure PartIXDependencyStatus where
+  site : PrerequisiteStatus
+  lawAlgebra : PrerequisiteStatus
+  cohomology : PrerequisiteStatus
+  derived : PrerequisiteStatus
+  singularityMonodromyStack : PrerequisiteStatus
+  representationAnalysis : PrerequisiteStatus
+  measurement : PrerequisiteStatus
+
+/-- IX.R0: current dependency status after importing PRD-2--8 entrypoints. -/
+def currentDependencyStatus : PartIXDependencyStatus where
+  site := .available
+  lawAlgebra := .available
+  cohomology := .available
+  derived := .available
+  singularityMonodromyStack := .available
+  representationAnalysis := .available
+  measurement := .available
+
+/-- IX.R0: the PRD-2 Site dependency is available. -/
+theorem current_site_available :
+    currentDependencyStatus.site = .available :=
+  rfl
+
+/-- IX.R0: the PRD-3 LawAlgebra dependency is available. -/
+theorem current_lawAlgebra_available :
+    currentDependencyStatus.lawAlgebra = .available :=
+  rfl
+
+/-- IX.R0: the PRD-4 Cohomology dependency is available. -/
+theorem current_cohomology_available :
+    currentDependencyStatus.cohomology = .available :=
+  rfl
+
+/-- IX.R0: the PRD-5 Derived dependency is available. -/
+theorem current_derived_available :
+    currentDependencyStatus.derived = .available :=
+  rfl
+
+/-- IX.R0: the PRD-6 SingularityMonodromyStack dependency is available. -/
+theorem current_singularityMonodromyStack_available :
+    currentDependencyStatus.singularityMonodromyStack = .available :=
+  rfl
+
+/-- IX.R0: the PRD-7 RepresentationAnalysis dependency is available. -/
+theorem current_representationAnalysis_available :
+    currentDependencyStatus.representationAnalysis = .available :=
+  rfl
+
+/-- IX.R0: the PRD-8 Measurement dependency is available. -/
+theorem current_measurement_available :
+    currentDependencyStatus.measurement = .available :=
+  rfl
+
+end Evolution
+end AAT.AG

--- a/Formal/AG/Evolution/Profile.lean
+++ b/Formal/AG/Evolution/Profile.lean
@@ -1,0 +1,106 @@
+import Formal.AG.Evolution.TraceCategory
+
+noncomputable section
+
+namespace AAT.AG
+namespace Evolution
+
+universe u v w x y z
+
+/-!
+PRD-9 R1 / AC2--AC3 evolution profile and geometry surface.
+
+An evolution profile fixes a static geometry universe, a measurement profile,
+and one selected trace category. All later temporal laws and obstruction
+readings are relative to this chosen profile.
+-/
+
+/--
+IX.§1 / R1: evolution profile for the selected Part IX trace layer.
+
+The profile carries the static geometry universe and selected trace. It does
+not assert anything about unselected events, external runtime time, or future
+paths outside the trace category.
+-/
+structure EvolutionProfile where
+  BaseGeometry : Type u
+  BaseMorphism : BaseGeometry -> BaseGeometry -> Type v
+  baseId : (X : BaseGeometry) -> BaseMorphism X X
+  baseComp :
+    {X Y Z : BaseGeometry} ->
+      BaseMorphism X Y -> BaseMorphism Y Z -> BaseMorphism X Z
+  measurementProfile : Measurement.MeasurementProfile.{w, x}
+  trace : TraceCategory.{y, z}
+  selectedOperations : Type (max u v)
+  selectedStateFamily : trace.Obj -> Type (max w x y z)
+  selectedTemporalLaws : Type (max y z)
+  selectedCoefficientProfile : Type (max w x)
+
+namespace EvolutionProfile
+
+/-- IX.§1: read the selected trace category of an evolution profile. -/
+def traceCategory (E : EvolutionProfile.{u, v, w, x, y, z}) :
+    TraceCategory.{y, z} :=
+  E.trace
+
+/-- IX.§1: read the selected measurement profile of an evolution profile. -/
+def measurement (E : EvolutionProfile.{u, v, w, x, y, z}) :
+    Measurement.MeasurementProfile.{w, x} :=
+  E.measurementProfile
+
+/--
+IX.Principle 2.2 boundary: selected trace relativity.
+
+This is a documentation-level boundary record, not a theorem about unselected
+events. It only exposes the trace category already fixed by the profile.
+-/
+structure TraceRelativity (E : EvolutionProfile.{u, v, w, x, y, z}) where
+  selectedTrace : TraceCategory.{y, z}
+  selectedTrace_eq : selectedTrace = E.trace
+
+/-- IX.Principle 2.2: read the selected trace-relativity boundary. -/
+def traceRelativityBoundary (E : EvolutionProfile.{u, v, w, x, y, z}) :
+    E.TraceRelativity :=
+  { selectedTrace := E.trace
+    selectedTrace_eq := rfl }
+
+end EvolutionProfile
+
+/--
+IX.§1 / AC3: evolution geometry over the selected trace category.
+
+This is a functor-like surface from `Tr_E` to the selected static geometry
+universe. The base geometry is supplied by the profile, so this definition
+does not claim a category of all possible AAT geometries.
+-/
+structure EvolutionGeometry (E : EvolutionProfile.{u, v, w, x, y, z}) where
+  obj : E.trace.Obj -> E.BaseGeometry
+  map : ∀ {t₀ t₁ : E.trace.Obj}, E.trace.Hom t₀ t₁ -> E.BaseMorphism (obj t₀) (obj t₁)
+  map_id : ∀ t : E.trace.Obj, map (E.trace.id t) = E.baseId (obj t)
+  map_comp :
+    ∀ {t₀ t₁ t₂ : E.trace.Obj} (f : E.trace.Hom t₀ t₁) (g : E.trace.Hom t₁ t₂),
+      map (E.trace.comp f g) = E.baseComp (map f) (map g)
+
+namespace EvolutionGeometry
+
+variable {E : EvolutionProfile.{u, v, w, x, y, z}}
+
+/-- IX.§1 / AC3: read the static geometry at a selected trace object. -/
+def geometryAt (G : EvolutionGeometry E) (t : E.trace.Obj) : E.BaseGeometry :=
+  G.obj t
+
+/-- IX.§1 / AC3: selected trace identities map to selected base identities. -/
+theorem map_identity (G : EvolutionGeometry E) (t : E.trace.Obj) :
+    G.map (E.trace.id t) = E.baseId (G.obj t) :=
+  G.map_id t
+
+/-- IX.§1 / AC3: selected trace composition maps to selected base composition. -/
+theorem map_composition (G : EvolutionGeometry E)
+    {t₀ t₁ t₂ : E.trace.Obj} (f : E.trace.Hom t₀ t₁) (g : E.trace.Hom t₁ t₂) :
+    G.map (E.trace.comp f g) = E.baseComp (G.map f) (G.map g) :=
+  G.map_comp f g
+
+end EvolutionGeometry
+
+end Evolution
+end AAT.AG

--- a/Formal/AG/Evolution/TraceCategory.lean
+++ b/Formal/AG/Evolution/TraceCategory.lean
@@ -1,0 +1,115 @@
+import Formal.AG.Evolution.Bootstrap
+
+noncomputable section
+
+namespace AAT.AG
+namespace Evolution
+
+universe u v
+
+/-!
+PRD-9 R1 / AC2 selected trace category surface.
+
+The trace category is selected data. Objects are selected time points,
+operation stages, or abstract event states; arrows are selected transitions.
+No claim is made about transitions outside the chosen profile.
+-/
+
+/--
+IX.定義2.1: selected trace category `Tr_E`.
+
+This is a small category-like interface used by Part IX. It is intentionally
+profile-relative and does not manufacture external runtime events.
+-/
+structure TraceCategory where
+  Obj : Type u
+  Hom : Obj -> Obj -> Type v
+  id : (t : Obj) -> Hom t t
+  comp : {t₀ t₁ t₂ : Obj} -> Hom t₀ t₁ -> Hom t₁ t₂ -> Hom t₀ t₂
+  id_comp :
+    ∀ {t₀ t₁ : Obj} (f : Hom t₀ t₁), comp (id t₀) f = f
+  comp_id :
+    ∀ {t₀ t₁ : Obj} (f : Hom t₀ t₁), comp f (id t₁) = f
+  assoc :
+    ∀ {t₀ t₁ t₂ t₃ : Obj} (f : Hom t₀ t₁) (g : Hom t₁ t₂)
+      (h : Hom t₂ t₃), comp (comp f g) h = comp f (comp g h)
+
+namespace TraceCategory
+
+/-- IX.定義2.1: expose the selected identity transition. -/
+def selectedIdentity (Tr : TraceCategory.{u, v}) (t : Tr.Obj) :
+    Tr.Hom t t :=
+  Tr.id t
+
+/-- IX.定義2.1: expose selected transition composition. -/
+def selectedComposition (Tr : TraceCategory.{u, v})
+    {t₀ t₁ t₂ : Tr.Obj} (f : Tr.Hom t₀ t₁) (g : Tr.Hom t₁ t₂) :
+    Tr.Hom t₀ t₂ :=
+  Tr.comp f g
+
+/-- IX.定義2.1: left identity law for selected transitions. -/
+theorem id_comp_holds (Tr : TraceCategory.{u, v})
+    {t₀ t₁ : Tr.Obj} (f : Tr.Hom t₀ t₁) :
+    Tr.comp (Tr.id t₀) f = f :=
+  Tr.id_comp f
+
+/-- IX.定義2.1: right identity law for selected transitions. -/
+theorem comp_id_holds (Tr : TraceCategory.{u, v})
+    {t₀ t₁ : Tr.Obj} (f : Tr.Hom t₀ t₁) :
+    Tr.comp f (Tr.id t₁) = f :=
+  Tr.comp_id f
+
+/-- IX.定義2.1: associativity law for selected transitions. -/
+theorem assoc_holds (Tr : TraceCategory.{u, v})
+    {t₀ t₁ t₂ t₃ : Tr.Obj} (f : Tr.Hom t₀ t₁) (g : Tr.Hom t₁ t₂)
+    (h : Tr.Hom t₂ t₃) :
+    Tr.comp (Tr.comp f g) h = Tr.comp f (Tr.comp g h) :=
+  Tr.assoc f g h
+
+/--
+IX.R1: finite trace category regime.
+
+The finite regime records a selected finite object set, finite selected hom
+sets, and closure of the certified finite subfamily under identity and
+composition. `Hom` is the profile's transition interface; `selectedArrow`
+marks the arrows admitted by this finite regime.
+-/
+structure FiniteRegime (Tr : TraceCategory.{u, v}) where
+  finiteObj : Finite Tr.Obj
+  finiteHom : ∀ t₀ t₁ : Tr.Obj, Finite (Tr.Hom t₀ t₁)
+  selectedArrow : ∀ {t₀ t₁ : Tr.Obj}, Tr.Hom t₀ t₁ -> Prop
+  idSelected : ∀ t : Tr.Obj, selectedArrow (Tr.id t)
+  compSelected :
+    ∀ {t₀ t₁ t₂ : Tr.Obj} {f : Tr.Hom t₀ t₁} {g : Tr.Hom t₁ t₂},
+      selectedArrow f -> selectedArrow g -> selectedArrow (Tr.comp f g)
+
+namespace FiniteRegime
+
+/-- IX.R1: the selected trace object type is finite. -/
+theorem object_finite {Tr : TraceCategory.{u, v}} (R : FiniteRegime Tr) :
+    Finite Tr.Obj :=
+  R.finiteObj
+
+/-- IX.R1: each selected trace hom type is finite. -/
+theorem hom_finite {Tr : TraceCategory.{u, v}} (R : FiniteRegime Tr)
+    (t₀ t₁ : Tr.Obj) : Finite (Tr.Hom t₀ t₁) :=
+  R.finiteHom t₀ t₁
+
+/-- IX.R1: identity transitions are inside the selected finite regime. -/
+theorem id_selected {Tr : TraceCategory.{u, v}} (R : FiniteRegime Tr)
+    (t : Tr.Obj) : R.selectedArrow (Tr.id t) :=
+  R.idSelected t
+
+/-- IX.R1: selected transitions are closed under selected composition. -/
+theorem comp_selected {Tr : TraceCategory.{u, v}} (R : FiniteRegime Tr)
+    {t₀ t₁ t₂ : Tr.Obj} {f : Tr.Hom t₀ t₁} {g : Tr.Hom t₁ t₂}
+    (hf : R.selectedArrow f) (hg : R.selectedArrow g) :
+    R.selectedArrow (Tr.comp f g) :=
+  R.compSelected hf hg
+
+end FiniteRegime
+
+end TraceCategory
+
+end Evolution
+end AAT.AG

--- a/docs/aat/lean_theorem_index.md
+++ b/docs/aat/lean_theorem_index.md
@@ -5025,6 +5025,22 @@ comparison morphism なしの異 ambient law conflict comparison、detecting ass
 一般 optimal transport theory、candidate-dependent readings から certified verdict への昇格、
 external data source / external procedure の忠実性は置かない。
 
+## AAT Algebraic-Geometric Part IX Evolution Geometry
+
+Tracking Issue: [#2280](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2280).
+Initial implementation Issue: [#2281](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2281).
+
+| 本文ラベル | Lean 名 | 種別 | 意味 | Status |
+| --- | --- | --- | --- | --- |
+| `IX.R0` | `Formal.AG.Evolution`, `Formal.AG.Evolution.Bootstrap`, `AAT.AG.Evolution.UsesAATSite`, `UsesArchitectureScheme`, `UsesCoverRelativeCechComplex`, `UsesRepairComparisonProfile`, `UsesArchitectureStratum`, `UsesAnalyticReadingContext`, `UsesMeasurementProfile`, `PrerequisiteStatus`, `PartIXDependencyStatus`, `currentDependencyStatus`, `current_site_available`, `current_lawAlgebra_available`, `current_cohomology_available`, `current_derived_available`, `current_singularityMonodromyStack_available`, `current_representationAnalysis_available`, `current_measurement_available` | `import` / `abbrev` / `inductive` / `structure` / `def` / `theorem` | 第IX部 Evolution Geometry module を `Formal/AG.lean` から import し、PRD-2〜8 の成果物上に立ち上げる。先行依存は concrete Lean 型参照で確認し、dependency status accessor が現時点の availability を保持する。 | `defined only` / `proved accessor` |
+| `IX.§1 / 定義2.1` | `AAT.AG.Evolution.TraceCategory`, `TraceCategory.selectedIdentity`, `TraceCategory.selectedComposition`, `TraceCategory.id_comp_holds`, `TraceCategory.comp_id_holds`, `TraceCategory.assoc_holds`, `TraceCategory.FiniteRegime`, `TraceCategory.FiniteRegime.object_finite`, `TraceCategory.FiniteRegime.hom_finite`, `TraceCategory.FiniteRegime.id_selected`, `TraceCategory.FiniteRegime.comp_selected`, `EvolutionProfile`, `EvolutionProfile.traceCategory`, `EvolutionProfile.measurement`, `EvolutionProfile.TraceRelativity`, `EvolutionProfile.traceRelativityBoundary`, `EvolutionGeometry`, `EvolutionGeometry.geometryAt`, `EvolutionGeometry.map_identity`, `EvolutionGeometry.map_composition` | `structure` / `def` / `theorem` | selected trace category、identity / composition law、finite selected trace regime、profile-relative measurement / base geometry / selected state family / temporal laws / coefficient profile、functor-like evolution geometry を定義する。finite regime は selected arrow family の identity / composition closure を保持する。 | `defined only` / `proved accessor` |
+
+Non-conclusions: この Part IX initial surface は R0/R1 entrypoint、selected trace category、finite trace regime、
+`EvolutionProfile`、functor-like `EvolutionGeometry` までを実装する。Temporal product / incidence site、
+temporal coefficient、state transition presheaf、temporal law、temporal obstruction、replay descent、
+dissipation、Lyapunov reading、force integrability statement、finite temporal examples は後続 R2 以降に残る。
+未選択 event、外部 runtime、実時間、任意 future path への zero / lawful / safe / forecast theorem は結論しない。
+
 ## Reverse-Import Theorem Packages
 
 File: `Formal/Arch/Evolution/ReverseImportTheorems.lean`.

--- a/docs/aat/proof_obligations.md
+++ b/docs/aat/proof_obligations.md
@@ -1281,6 +1281,24 @@ Initial implementation Issue: [#2211](https://github.com/iroha1203/AlgebraicArch
 | `VIII.R11 finite examples` pseudo-circle measurement, square-free hitting set, finite computability, refactor invariance, cellular Hodge, support transfer, packet / GAGA separation | `proved selected finite examples` |
 | `GeneralPersistenceStability` / `GeneralZigzagStability` / `GeneralFlatBaseChangeForLawConflict` / `GeneralPerronFrobeniusHotspot` / `GeneralOptimalTransportTheory` / `AnalyticSmallnessImpliesLawfulness` | `future proof obligation` / explicit non-goal for PRD-8 |
 
+## AAT Algebraic-Geometric Part IX Evolution Geometry Lean status
+
+Tracking Issue: [#2280](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2280).
+Initial implementation Issue: [#2281](https://github.com/iroha1203/AlgebraicArchitectureTheoryV2/issues/2281).
+
+| 対象 | 現在の扱い | 残す境界 |
+| --- | --- | --- |
+| `IX.R0` Formal/AG/Evolution entrypoint | `defined only` / `proved accessor`. `Formal/AG/Evolution.lean` が `Bootstrap.lean`、`TraceCategory.lean`、`Profile.lean` を束ね、`Formal/AG.lean` が `Formal.AG.Evolution` を import する。`UsesAATSite`、`UsesArchitectureScheme`、`UsesCoverRelativeCechComplex`、`UsesRepairComparisonProfile`、`UsesArchitectureStratum`、`UsesAnalyticReadingContext`、`UsesMeasurementProfile` が PRD-2〜8 の concrete Lean 型を参照する。`currentDependencyStatus` と accessor theorem 群は、現時点で先行依存が available であることを保持する。 | R2 以降の temporal product / coefficient / law / obstruction / replay / dissipation / Lyapunov / force / finite examples は未実装。 |
+| `IX.§1 / 定義2.1 / R1` EvolutionProfile / TraceCategory / EvolutionGeometry | `defined only` / `proved accessor`. `TraceCategory` が selected trace object、selected transition、identity、composition、identity law、associativity law を保持する。`TraceCategory.FiniteRegime` が finite object / hom と selected arrow family の identity / composition closure を保持する。`EvolutionProfile` が base geometry、measurement profile、selected trace、selected operations、selected state family、selected temporal laws、selected coefficient profile を束ねる。`EvolutionGeometry` が selected trace から base geometry への functor-like surface を持ち、`map_identity` と `map_composition` が accessor theorem として存在する。 | 未選択 event、外部 runtime、実時間、任意 future path への zero / lawful / safe / forecast は主張しない。Temporal law / obstruction への接続は後続 R2-R5 に残す。 |
+
+第IX部 PRD-9 の証明対象ラベルは次の現在状態である。
+
+| 証明対象ラベル | Lean status |
+| --- | --- |
+| `IX.R0` | `defined only` / `proved accessor` |
+| `IX.§1 / 定義2.1 / R1` EvolutionProfile / TraceCategory / EvolutionGeometry | `defined only` / `proved accessor` |
+| `IX.TemporalSite` / `TempCoeff_A` / `StateTransitionPresheaf` / `TemporalLaw` / `TemporalObstruction` / `ReplayDescentData` / `Temporal Descent Criterion` / `Finite Dissipation Stopping` / `AATLyapunovReading` / `ForceIntegrabilityObstructionCandidate` / `Part IX finite examples` | `future proof obligation` / explicit non-goal for this initial PR |
+
 ## 現在の未解決カテゴリ
 
 | カテゴリ | 扱い |


### PR DESCRIPTION
## 概要

Closes #2281

PRD-9 / Part IX Evolution Geometry の最初の Lean surface として、`Formal/AG/Evolution` を新設しました。

- R0: PRD-2〜8 の依存確認 surface を `Bootstrap.lean` に追加
- R1: selected `TraceCategory`、finite trace regime、`EvolutionProfile`、functor-like `EvolutionGeometry` を追加
- `Formal/AG.lean` の root import と、`lean_theorem_index.md` / `proof_obligations.md` の Part IX 初期台帳を同期

Tracking Issue: #2280

## 証明した定理

- `current_site_available`
- `current_lawAlgebra_available`
- `current_cohomology_available`
- `current_derived_available`
- `current_singularityMonodromyStack_available`
- `current_representationAnalysis_available`
- `current_measurement_available`
- `TraceCategory.id_comp_holds`
- `TraceCategory.comp_id_holds`
- `TraceCategory.assoc_holds`
- `TraceCategory.FiniteRegime.object_finite`
- `TraceCategory.FiniteRegime.hom_finite`
- `TraceCategory.FiniteRegime.id_selected`
- `TraceCategory.FiniteRegime.comp_selected`
- `EvolutionGeometry.map_identity`
- `EvolutionGeometry.map_composition`

## 編集したドキュメント

- `docs/aat/lean_theorem_index.md`
- `docs/aat/proof_obligations.md`

## 実施したテスト

- [x] `lake build`
  - 成功。既存 `Formal/Arch/Extension/FeatureExtensionExamples.lean` の linter warning 2件のみ。
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `lake build Formal.AG.Evolution`
- [x] `lake env lean Formal/AG.lean`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#check AAT.AG.Evolution.UsesArchitectureStratum`
- [x] `#check AAT.AG.Evolution.EvolutionProfile.traceRelativityBoundary`
- [x] `#print axioms AAT.AG.Evolution.EvolutionProfile.traceRelativityBoundary`
- [x] `$local-review`
  - AAT / Lean の4観点レビューを実施。
  - 指摘された `UsesArchitectureStratum` 台帳不一致と `TraceRelativity` API marker は修正済み。

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
