### PR TITLE
Viewer assembly snapを追加

### DIFF
--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -13928,6 +13928,27 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
         "viewer V12 must support manual pause/resume while preserving context and non-verdict boundaries"
     );
     assert!(
+        html.contains("tagAssemblySnapObject")
+            && html.contains("assemblySnapStartPosition")
+            && html.contains("easeOutBack")
+            && html.contains("window.__archsigViewerAssemblySnap"),
+        "viewer V13 must animate nerve patches as assembly snap projections"
+    );
+    assert!(
+        html.contains("assemblySnapParitySeam")
+            && html.contains("unsnappedByParityCue: true")
+            && html.contains("edge.value parity seam; not restriction-compatibility verdict")
+            && html.contains("structuralSeamVerdict: false"),
+        "viewer V13 must keep value=1 seams as parity cues rather than M2 verdicts"
+    );
+    assert!(
+        html.contains("graph cycle != H1 structural verdict")
+            && html.contains("assembly snap uses edge.value parity until M2 restriction-compatibility verdict is projected")
+            && html.contains("microGapVibration")
+            && html.contains("assembly_snap_parity_seam"),
+        "viewer V13 must preserve graph-cycle and projection boundaries while showing seam vibration"
+    );
+    assert!(
         html.contains("type=\"file\"")
             && html.contains("dragover")
             && html.contains("./archsig-atom-viewer-data.json"),

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1049,6 +1049,8 @@
     let atomLayoutMorphState = null;
     let activeCohomologyLayerGroups = {};
     let activeTourPulseGroup = null;
+    let activeAssemblySnapObjects = [];
+    let assemblySnapStartedAt = 0;
 
     const colorByStatus = {
       observed: 0x4cc3a7,
@@ -1342,6 +1344,7 @@
       updateAtomLayoutMorph();
       updateHolonomyTraversalAnimation();
       updateFindingsTourPulse();
+      updateAssemblySnapAnimation();
       renderFrame();
     }
 
@@ -1557,6 +1560,8 @@
       renderedEdgeCount = 0;
       bloomRegisteredCount = 0;
       activeTourState = { ...(activeTourState || {}), frames: [] };
+      activeAssemblySnapObjects = [];
+      assemblySnapStartedAt = performance.now();
 
       const positions = new Map();
       activeLayoutContext = buildLayoutContext(renderedAtoms, renderedGroups, currentData);
@@ -2222,11 +2227,13 @@
             side: THREE.DoubleSide
           })
         );
-        patch.position.copy(center);
-        patch.position.y = cohomologyDegreeLayer("h0").y + 1;
+        const patchTarget = pointOnCohomologyLayer(center, "h0", 1);
+        const patchStart = assemblySnapStartPosition(patchTarget, index, vertices.length);
+        patch.position.copy(patchStart);
         patch.rotation.x = -Math.PI / 2;
         patch.userData = { kind: "nerveVertexPatch", item: vertex };
         tagCohomologyLayer(patch, "h0", "nerve.vertices");
+        tagAssemblySnapObject(patch, patchStart, patchTarget, vertex.contextRef, "context_patch");
         edgeGroup.add(patch);
         const sphere = new THREE.Mesh(
           new THREE.SphereGeometry(3.2 + supportSize * 0.22, 24, 16),
@@ -2238,7 +2245,9 @@
             roughness: 0.42
           })
         );
-        sphere.position.copy(pointOnCohomologyLayer(center, "h0", 4.8 + supportSize * 0.08));
+        const sphereTarget = pointOnCohomologyLayer(center, "h0", 4.8 + supportSize * 0.08);
+        const sphereStart = assemblySnapStartPosition(sphereTarget, index, vertices.length).add(new THREE.Vector3(0, 6, 0));
+        sphere.position.copy(sphereStart);
         sphere.userData = {
           kind: "nerveContextSphere",
           item: vertex,
@@ -2246,6 +2255,7 @@
           atomRefCount: (vertex.atomRefs || []).length
         };
         tagCohomologyLayer(sphere, "h0", "nerve.vertices.atomRefs");
+        tagAssemblySnapObject(sphere, sphereStart, sphereTarget, vertex.contextRef, "context_sphere");
         edgeGroup.add(sphere);
         const label = createTextSprite(contextLabel(vertex.contextRef), "#d8dee9", "rgba(13,16,21,0.68)");
         label.position.copy(pointOnCohomologyLayer(center, "h0", 11 + supportSize * 0.08));
@@ -2254,6 +2264,7 @@
         edgeGroup.add(label);
       });
       renderNerveEdges(edges, vertexCenters, encoding);
+      renderAssemblySnapSeams(edges, vertexCenters, encoding);
       const triangleLimit = activeLayoutContext?.aat?.gluingGeometry?.renderLimits?.nerveTriangles || 80;
       triangles.slice(0, triangleLimit).forEach((triangle, index) => {
         const points = (triangle.contextRefs || [])
@@ -2313,6 +2324,151 @@
         centers.set(String(vertex.contextRef || ""), pointOnCohomologyLayer(center, "h0"));
       });
       return centers;
+    }
+
+    function assemblySnapStartPosition(target, index, total) {
+      const angle = (index / Math.max(total, 1)) * Math.PI * 2;
+      const radial = new THREE.Vector3(target.x, 0, target.z);
+      if (radial.lengthSq() < 0.001) radial.set(Math.cos(angle), 0, Math.sin(angle));
+      radial.normalize();
+      return target.clone().add(radial.multiplyScalar(120)).add(new THREE.Vector3(0, 34, 0));
+    }
+
+    function tagAssemblySnapObject(object, start, target, contextRef, role) {
+      object.userData = {
+        ...(object.userData || {}),
+        assemblySnapRole: role,
+        assemblySnapStartPosition: [Number(start.x.toFixed(3)), Number(start.y.toFixed(3)), Number(start.z.toFixed(3))],
+        assemblySnapTargetPosition: [Number(target.x.toFixed(3)), Number(target.y.toFixed(3)), Number(target.z.toFixed(3))],
+        assemblySnapProjectionOnly: true,
+        contextRef,
+        noStructuralVerdict: true,
+        projectionBoundary: "assembly snap is a viewer projection over nerve geometry; it adds no restriction-compatibility verdict"
+      };
+      activeAssemblySnapObjects.push(object);
+    }
+
+    function renderAssemblySnapSeams(edges, vertexCenters, encoding) {
+      let paritySeamCount = 0;
+      edges.forEach((edge, index) => {
+        const sourceBase = vertexCenters.get(String(edge.sourceContextRef || ""));
+        const targetBase = vertexCenters.get(String(edge.targetContextRef || ""));
+        if (!sourceBase || !targetBase) return;
+        const source = pointOnCohomologyLayer(sourceBase, "h1", 4);
+        const target = pointOnCohomologyLayer(targetBase, "h1", 4);
+        const value = Number(edge.value || 0);
+        if (value > 0) {
+          paritySeamCount += 1;
+          const midpoint = centroid([source, target]);
+          const direction = target.clone().sub(source).normalize();
+          const gap = direction.clone().multiplyScalar(5.2);
+          const vertices = [
+            source.x, source.y, source.z,
+            midpoint.x - gap.x, midpoint.y - gap.y, midpoint.z - gap.z,
+            midpoint.x + gap.x, midpoint.y + gap.y, midpoint.z + gap.z,
+            target.x, target.y, target.z
+          ];
+          const geometry = new THREE.BufferGeometry();
+          geometry.setAttribute("position", new THREE.Float32BufferAttribute(vertices, 3));
+          const seam = new THREE.LineSegments(
+            geometry,
+            new THREE.LineDashedMaterial({
+              color: sceneColorHex(encoding.colorRole || "measured_nonzero"),
+              transparent: true,
+              opacity: 0.88,
+              dashSize: 4.8,
+              gapSize: 2.2
+            })
+          );
+          if (typeof seam.computeLineDistances === "function") seam.computeLineDistances();
+          seam.userData = {
+            kind: "assemblySnapParitySeam",
+            item: edge,
+            edgeValue: value,
+            parityOnly: true,
+            unsnappedByParityCue: true,
+            m2Projected: false,
+            structuralSeamVerdict: false,
+            noStructuralVerdict: true,
+            seamJitter: true,
+            seamIndex: index,
+            nonClaim: "edge.value parity colors an overlap seam; it is not a restriction-compatibility verdict"
+          };
+          tagCohomologyLayer(seam, "h1", "nerve.edges.value.parity");
+          registerReadingBloom(seam, "assembly_snap_parity_seam", 0.48);
+          edgeGroup.add(seam);
+          if (paritySeamCount === 1) {
+            const label = createTextSprite("edge.value parity seam; not restriction-compatibility verdict", "#ffffff", "rgba(63,45,8,0.78)");
+            label.position.copy(midpoint).add(new THREE.Vector3(0, 10, 0));
+            label.userData = {
+              kind: "assemblySnapParityNonClaim",
+              edgeValueParityMarker: true,
+              noStructuralVerdict: true,
+              labelPriorityScore: 90,
+              nonClaim: "parity cue only; not a measured M2 seam verdict"
+            };
+            tagCohomologyLayer(label, "h1", "nerve.edges.value.parity");
+            edgeGroup.add(label);
+          }
+          return;
+        }
+        addLineSegments([
+          source.x, source.y + 0.2, source.z,
+          target.x, target.y + 0.2, target.z
+        ], sceneColorHex("checked"), 0.38, "assemblySnapCompatibleContact", {
+          lineRole: "snap_contact",
+          thicknessRole: "thin",
+          cohomologyDegree: "h1",
+          parityOnly: true,
+          m2Projected: false,
+          structuralSeamVerdict: false
+        });
+      });
+      window.__archsigViewerAssemblySnap = {
+        ...(window.__archsigViewerAssemblySnap || {}),
+        paritySeamCount,
+        m2Projected: false,
+        edgeValueParityMarker: true,
+        projectionBoundary: "assembly snap uses edge.value parity until M2 restriction-compatibility verdict is projected"
+      };
+    }
+
+    function easeOutBack(t) {
+      const c1 = 1.70158;
+      const c3 = c1 + 1;
+      return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+    }
+
+    function updateAssemblySnapAnimation() {
+      if (!activeAssemblySnapObjects.length) return;
+      const elapsed = performance.now() - assemblySnapStartedAt;
+      const raw = Math.min(elapsed / 1350, 1);
+      const eased = easeOutBack(raw);
+      activeAssemblySnapObjects.forEach((object) => {
+        const start = vectorFromArray(object.userData?.assemblySnapStartPosition);
+        const target = vectorFromArray(object.userData?.assemblySnapTargetPosition);
+        if (!start || !target) return;
+        object.position.copy(start.lerp(target, eased));
+        object.userData.assemblySnapProgress = Number(raw.toFixed(3));
+      });
+      edgeGroup.traverse((object) => {
+        if (!object.userData?.seamJitter) return;
+        object.position.y = Math.sin(performance.now() / 160 + Number(object.userData.seamIndex || 0)) * 0.9;
+        object.userData.microGapVibration = true;
+      });
+      window.__archsigViewerAssemblySnap = {
+        ...(window.__archsigViewerAssemblySnap || {}),
+        activePatchCount: activeAssemblySnapObjects.length,
+        progress: Number(raw.toFixed(3)),
+        patchFlyInUsesEaseOutBack: true,
+        noStructuralVerdict: true
+      };
+    }
+
+    function vectorFromArray(value) {
+      return Array.isArray(value) && value.length === 3
+        ? new THREE.Vector3(Number(value[0]), Number(value[1]), Number(value[2]))
+        : null;
     }
 
     function renderNerveEdges(edges, vertexCenters, encoding) {


### PR DESCRIPTION
## 概要

Closes #2297

AC-V13 の assembly snap として、nerve context patch / sphere を外側から `easeOutBack` で飛来させ、overlap edge へ吸着する projection animation を追加した。`edge.value > 0` は M2 verdict ではなく parity cue として扱い、micro-gap seam と non-claim label を出す。b1 graph cycle の既存 non-claim と合わせ、new structural verdict を作らない境界を保持する。

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] `node --check .tmp/v13-viewer-module.js`
- [x] Playwright preview: `archmap_v2_cech_h1_visible.json` fixture で patch fly-in / parity seam / graph-cycle non-claim を確認

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
