### PR TITLE
Viewer lawful loci intersectionを追加

### DIFF
--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -13969,6 +13969,29 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
         "viewer V14 must keep fiber bundle as analytic projection without structural verdict"
     );
     assert!(
+        html.contains("createLawfulLociIntersection")
+            && html.contains("window.__archsigViewerLawfulLociIntersection")
+            && html.contains("lawfulLociIntersectionPlane")
+            && html.contains("tor1ResidueMass")
+            && html.contains("ag.law-conflict-tor@1/Tor_1 residue"),
+        "viewer V15 must render law-conflict Tor overlays as lawful loci intersection planes with Tor_1 residue mass"
+    );
+    assert!(
+        html.contains("PlaneGeometry approximation; discrete Tor_1 residue bundle")
+            && html.contains("noTransversalityProof: true")
+            && html.contains("discreteQuantityBundle: true")
+            && html.contains("noStructuralVerdict: true")
+            && html.contains("Tor_1 residue loci: PlaneGeometry approximation, no transversality proof"),
+        "viewer V15 must make PlaneGeometry approximation and non-verdict boundaries explicit"
+    );
+    assert!(
+        html.contains("lawfulLociRepairTransfers")
+            && html.contains("lawfulLociRepairMassTransfer")
+            && html.contains("explicitTransferOnly: true")
+            && html.contains("repair mass transfer is rendered only when explicit packet transfer data is present"),
+        "viewer V15 must gate repair mass transfer rendering on explicit packet data"
+    );
+    assert!(
         html.contains("type=\"file\"")
             && html.contains("dragover")
             && html.contains("./archsig-atom-viewer-data.json"),

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -3255,6 +3255,19 @@
       const color = sceneColorHex("analytic_reading");
       const vertices = [];
       let previousPoint = null;
+      const lawfulLociStats = {
+        status: "silent",
+        planeCount: 0,
+        residueCount: 0,
+        repairTransferCount: 0,
+        planeGeometryApproximation: true,
+        sourceEvaluator: "ag.law-conflict-tor@1",
+        tor1ResidueDriven: false,
+        discreteQuantityBundle: true,
+        noTransversalityProof: true,
+        noStructuralVerdict: true,
+        projectionBoundary: "PlaneGeometry approximation; discrete Tor_1 residue bundle only; selected lawful loci intersection"
+      };
       overlays.forEach((overlay, index) => {
         const value = overlayMagnitude(overlay);
         const center = sceneAxisPosition(scene, overlay.overlayId || `analytic-overlay:${index}`, index, Math.max(overlays.length, 1), groupPosition(index, Math.max(overlays.length, 1), 58), {
@@ -3290,8 +3303,21 @@
         label.position.copy(mesh.position).add(new THREE.Vector3(0, size + 5, 0));
         label.userData = { kind: "analyticOverlayLabel", item: overlay };
         edgeGroup.add(label);
+        if (isLawConflictTorSingularityOverlay(overlay)) {
+          const lawfulLociObjects = createLawfulLociIntersection(scene, overlay, mesh.position.clone(), index, Math.max(overlays.length, 1));
+          lawfulLociObjects.forEach((object) => edgeGroup.add(object));
+          lawfulLociStats.status = "rendered";
+          lawfulLociStats.planeCount += lawfulLociObjects.filter((object) => object.userData?.kind === "lawfulLociIntersectionPlane").length;
+          lawfulLociStats.residueCount += lawfulLociObjects.filter((object) => object.userData?.kind === "tor1ResidueMass").length;
+          lawfulLociStats.repairTransferCount += lawfulLociObjects.filter((object) => object.userData?.kind === "lawfulLociRepairMassTransfer").length;
+          lawfulLociStats.tor1ResidueDriven = true;
+          lawfulLociStats.lastOverlayId = overlay.overlayId || "";
+          lawfulLociStats.lastSharedSupport = Array.isArray(overlay.sharedSupport) ? overlay.sharedSupport.slice() : [];
+          lawfulLociStats.lastCommonAmbient = overlay.commonAmbient?.ambientRef || "";
+        }
       });
       addLineSegments(vertices, color, 0.38, "analyticOverlayLane", { lineRole: "contour", colorRole: "analytic_reading" });
+      window.__archsigViewerLawfulLociIntersection = lawfulLociStats;
     }
 
     function overlayGeometry(kind, size) {
@@ -3301,6 +3327,150 @@
       if (kind === "curvature_spectrum_hotspot") return new THREE.TorusKnotGeometry(size * 0.52, 0.28, 48, 8);
       if (kind === "singularity_concentration") return new THREE.OctahedronGeometry(size * 0.9);
       return new THREE.SphereGeometry(size, 16, 10);
+    }
+
+    function isLawConflictTorSingularityOverlay(overlay) {
+      return overlay?.overlayKind === "singularity_concentration"
+        && overlay?.sourceEvaluator === "ag.law-conflict-tor@1";
+    }
+
+    function createLawfulLociIntersection(scene, overlay, origin, index, total) {
+      const objects = [];
+      const concentrationCount = Number.isFinite(Number(overlay.concentrationCount))
+        ? Math.max(1, Number(overlay.concentrationCount))
+        : 1;
+      const sharedSupport = Array.isArray(overlay.sharedSupport) ? overlay.sharedSupport.filter(Boolean) : [];
+      const lawPair = Array.isArray(overlay.commonAmbient?.lawPair)
+        ? overlay.commonAmbient.lawPair.filter(Boolean).slice(0, 2)
+        : [];
+      const planeSize = 20 + Math.min(concentrationCount, 6) * 2.8 + Math.min(sharedSupport.length, 4) * 1.8;
+      const colors = [0x64d6be, 0xf2c15f];
+      const base = origin.clone().add(new THREE.Vector3(0, -2, 0));
+      const lociLabels = lawPair.length >= 2 ? lawPair : ["lawful-locus:a", "lawful-locus:b"];
+      lociLabels.slice(0, 2).forEach((lawRef, planeIndex) => {
+        const plane = new THREE.Mesh(
+          new THREE.PlaneGeometry(planeSize * 1.42, planeSize),
+          new THREE.MeshStandardMaterial({
+            color: colors[planeIndex],
+            emissive: planeIndex === 0 ? 0x06362f : 0x362805,
+            transparent: true,
+            opacity: 0.26,
+            side: THREE.DoubleSide,
+            roughness: 0.58,
+            metalness: 0.02,
+            depthWrite: false
+          })
+        );
+        plane.position.copy(base).add(new THREE.Vector3(planeIndex === 0 ? -1.8 : 1.8, 0, 0));
+        plane.rotation.set(planeIndex === 0 ? 0.08 : -0.08, planeIndex === 0 ? -0.58 : 0.58, planeIndex === 0 ? 0.1 : -0.1);
+        plane.userData = {
+          kind: "lawfulLociIntersectionPlane",
+          item: overlay,
+          lawRef,
+          sourceEvaluator: "ag.law-conflict-tor@1",
+          drivenBy: "ag.law-conflict-tor@1/Tor_1 residue",
+          planeGeometryApproximation: true,
+          discreteQuantityBundle: true,
+          noTransversalityProof: true,
+          noStructuralVerdict: true,
+          projectionBoundary: "PlaneGeometry approximation; selected LawConflict_1 common ambient only"
+        };
+        objects.push(plane);
+      });
+      const axis = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.42, 0.42, planeSize * 1.1, 12),
+        new THREE.MeshStandardMaterial({
+          color: 0xe8f3ff,
+          emissive: 0x152d40,
+          transparent: true,
+          opacity: 0.72,
+          roughness: 0.34
+        })
+      );
+      axis.position.copy(base);
+      axis.rotation.z = Math.PI / 11;
+      axis.userData = {
+        kind: "lawfulLociIntersectionAxis",
+        item: overlay,
+        sourceEvaluator: "ag.law-conflict-tor@1",
+        tor1ResidueDriven: true,
+        planeGeometryApproximation: true,
+        noTransversalityProof: true,
+        projectionBoundary: "intersection axis is visual PlaneGeometry overlap, not a transversality proof"
+      };
+      objects.push(axis);
+      const residue = new THREE.Mesh(
+        new THREE.IcosahedronGeometry(4.2 + Math.min(concentrationCount, 5) * 0.9, 1),
+        new THREE.MeshStandardMaterial({
+          color: 0xffffff,
+          emissive: 0x2a5c72,
+          transparent: true,
+          opacity: 0.86,
+          roughness: 0.28,
+          metalness: 0.04
+        })
+      );
+      residue.position.copy(base).add(new THREE.Vector3(0, 0.6, 0));
+      residue.userData = {
+        kind: "tor1ResidueMass",
+        item: overlay,
+        sourceEvaluator: "ag.law-conflict-tor@1",
+        concentrationCount,
+        sharedSupport,
+        commonAmbient: overlay.commonAmbient || {},
+        tor1ResidueDriven: true,
+        discreteQuantityBundle: true,
+        noStructuralVerdict: true,
+        noTransversalityProof: true,
+        projectionBoundary: "discrete Tor_1 residue bundle; not object size, repair difficulty, or lawful-space volume"
+      };
+      registerReadingBloom(residue, "tor1_residue_mass");
+      objects.push(residue);
+      lawfulLociRepairTransfers(overlay).forEach((transfer, transferIndex) => {
+        const arrow = createLawfulLociRepairMassTransfer(base, transfer, transferIndex, planeSize);
+        if (arrow) objects.push(arrow);
+      });
+      const note = createTextSprite("Tor_1 residue loci: PlaneGeometry approximation, no transversality proof", "#e8f3ff", "rgba(14,35,58,0.74)");
+      note.position.copy(base).add(new THREE.Vector3(0, planeSize * 0.62, 0));
+      note.userData = {
+        kind: "lawfulLociIntersectionNonClaim",
+        item: overlay,
+        planeGeometryApproximation: true,
+        tor1ResidueDriven: true,
+        noTransversalityProof: true,
+        noStructuralVerdict: true
+      };
+      objects.push(note);
+      return objects;
+    }
+
+    function lawfulLociRepairTransfers(overlay) {
+      const candidates = [
+        overlay?.repairMassTransfers,
+        overlay?.repairMassTransfer,
+        overlay?.massTransfers
+      ].filter(Boolean);
+      return candidates.flatMap((candidate) => Array.isArray(candidate) ? candidate : [candidate])
+        .filter((candidate) => candidate && typeof candidate === "object");
+    }
+
+    function createLawfulLociRepairMassTransfer(base, transfer, transferIndex, planeSize) {
+      const from = base.clone().add(new THREE.Vector3(-planeSize * 0.38, -planeSize * 0.18 + transferIndex * 2, 0));
+      const to = base.clone().add(new THREE.Vector3(planeSize * 0.38, -planeSize * 0.08 + transferIndex * 2, 0));
+      const direction = to.clone().sub(from);
+      const length = direction.length();
+      if (!length) return null;
+      const arrow = new THREE.ArrowHelper(direction.normalize(), from, length, 0xf2c15f, 4.8, 2.6);
+      arrow.userData = {
+        kind: "lawfulLociRepairMassTransfer",
+        item: transfer,
+        explicitTransferOnly: true,
+        planeGeometryApproximation: true,
+        noAutomaticRepairClaim: true,
+        noStructuralVerdict: true,
+        projectionBoundary: "repair mass transfer is rendered only when explicit packet transfer data is present"
+      };
+      return arrow;
     }
 
     function overlayMagnitude(overlay) {
@@ -3320,6 +3490,7 @@
     }
 
     function overlayLabel(overlay) {
+      if (isLawConflictTorSingularityOverlay(overlay)) return "Tor_1 residue loci";
       const label = String(overlay.overlayKind || "analytic").replace(/_/g, " ");
       return label.length > 26 ? `${label.slice(0, 25)}...` : label;
     }


### PR DESCRIPTION
## 概要

Closes #2302

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-V15 として、`ag.law-conflict-tor@1` の `singularity_concentration` overlay を Viewer の lawful loci intersection projection として表示する。

- `PlaneGeometry` による 2 枚の lawful loci 近似面、intersection axis、`Tor_1` residue marker を追加
- `window.__archsigViewerLawfulLociIntersection` で plane/residue/rendering boundary を検証可能化
- repair mass transfer は明示的な packet transfer data がある場合だけ描画し、自動 repair claim を作らない
- PlaneGeometry 近似、離散 `Tor_1` residue bundle、横断性証明ではないこと、新 structural verdict ではないことを `userData` と label に固定

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] viewer module `node --check`
- [x] law-conflict-tor fixture preview
- [x] Playwright headless desktop/mobile visual check（`analyticOverlay` mode、nonblank pixel check、`__archsigViewerLawfulLociIntersection.status === "rendered"`）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
