### PR TITLE
Viewer Stokes audit meterを追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -43,6 +43,7 @@ const GLUING_CAGE_RENDER_LIMIT: usize = 80;
 const GLUING_MORPH_RENDER_LIMIT: usize = 50;
 const GLUING_ATOM_GLYPH_RENDER_LIMIT: usize = 2_000;
 const ANALYTIC_OVERLAY_RENDER_LIMIT: usize = 80;
+const PERIOD_STOKES_METER_RENDER_LIMIT: usize = 24;
 const BOUNDARY_STATEMENT_KINDS: [&str; 6] = [
     "silence_by_design",
     "out_of_selected_vocabulary",
@@ -3998,6 +3999,7 @@ fn insight_viewer_visual_scenes_v1(
         false,
     );
     let analytic_overlay_refs = analytic_overlay_scene_refs(packet, gluing_geometry);
+    let period_stokes_refs = period_stokes_scene_refs(packet, gluing_geometry);
     let boundary_refs =
         scene_refs_for_kinds(normalized, packet, cards, &["measurement_boundary"], false);
     let source_refs = source_scene_refs(normalized, packet, cards);
@@ -4024,6 +4026,10 @@ fn insight_viewer_visual_scenes_v1(
         .any(|card| string_field(card, "kind") == "architecture_debt_mass");
     let has_analytic_overlay =
         !string_array_at(&analytic_overlay_refs, &["overlayRefs"]).is_empty();
+    let has_period_stokes = gluing_geometry["periodStokes"]["activeMeterCount"]
+        .as_u64()
+        .unwrap_or_default()
+        > 0;
     let scenes = vec![
         scene_v1(
             "overview",
@@ -4231,6 +4237,36 @@ fn insight_viewer_visual_scenes_v1(
                 "Near-flat or low proxy values are not measured_zero lawfulness.",
             ],
         ),
+        with_scene_non_claims(
+            scene_v1(
+                "period-stokes",
+                "period_stokes_meter",
+                "Period Stokes Meter",
+                "Does the supplied finite period audit close under the selected coefficient reading?",
+                (
+                    "period cycle basis",
+                    "form / chain audit pair",
+                    "Stokes residual magnitude",
+                ),
+                "period_stokes_meter",
+                "meter",
+                "periodStokesMeter",
+                "M9 Stokes audit meter; modelRelative finite-period reading",
+                &period_stokes_refs,
+                if has_period_stokes {
+                    "analytic_reading"
+                } else {
+                    "not_applicable"
+                },
+                "ring",
+                "flow_arc",
+                has_period_stokes,
+            ),
+            &[
+                "Period Stokes meter is modelRelative to the supplied finite period model.",
+                "Period arcs and audit residuals are packet projections; the viewer creates no new structural verdict.",
+            ],
+        ),
         boundary_scene_v1(&boundary_refs),
         scene_v1(
             "source-evidence",
@@ -4290,6 +4326,14 @@ fn attach_gluing_scene_geometry(mut scene: Value, gluing_geometry: &Value) -> Va
                 "spectralGapOverlay",
                 "curvatureHotspotOverlay",
                 "singularityConcentrationOverlay"
+            ]
+        }),
+        "period-stokes" => json!({
+            "periodStokesRef": "gluingGeometry.periodStokes",
+            "projectionObjectKinds": [
+                "periodStokesCycleArc",
+                "periodStokesAuditMeter",
+                "periodStokesResidualFlux"
             ]
         }),
         _ => json!({
@@ -4370,6 +4414,41 @@ fn analytic_overlay_scene_refs(
         "overlayRefs": overlay_refs,
         "analyticReadingRefs": analytic_reading_refs,
         "invariantRefs": invariant_refs,
+        "coverRefs": [packet.profile.cover_ref.clone()],
+        "sourceRefs": []
+    })
+}
+
+fn period_stokes_scene_refs(packet: &ArchSigMeasurementPacketV1, gluing_geometry: &Value) -> Value {
+    let meters = gluing_geometry["periodStokes"]["meters"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let meter_refs = meters
+        .iter()
+        .filter_map(|meter| meter["meterId"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let invariant_refs = meters
+        .iter()
+        .filter_map(|meter| meter["sourceInvariantRef"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let structural_verdict_refs = meters
+        .iter()
+        .filter_map(|meter| meter["structuralVerdictRef"].as_str())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    json!({
+        "meterRefs": meter_refs,
+        "invariantRefs": invariant_refs,
+        "structuralVerdictRefs": structural_verdict_refs,
         "coverRefs": [packet.profile.cover_ref.clone()],
         "sourceRefs": []
     })
@@ -4476,6 +4555,7 @@ fn gluing_geometry_projection_v1(
     let locus_field = locus_field_projection(packet);
     let atom_glyphs = atom_glyph_projection(normalized);
     let analytic_overlay_bundle = analytic_overlay_bundle_projection(packet);
+    let period_stokes = period_stokes_projection(packet);
     let triangle_count = cover_nerve_projection["faces"]
         .as_array()
         .map(Vec::len)
@@ -4496,6 +4576,8 @@ fn gluing_geometry_projection_v1(
     let analytic_overlay_count = analytic_overlay_bundle["rawOverlayCount"]
         .as_u64()
         .unwrap_or_default() as usize;
+    let period_stokes_meter_count =
+        period_stokes["rawMeterCount"].as_u64().unwrap_or_default() as usize;
     let cocycle_support_edge_count = nonzero_edges.len();
     let cocycle_support_edges = nonzero_edges
         .iter()
@@ -4540,6 +4622,7 @@ fn gluing_geometry_projection_v1(
         "repairMorphs": repair_morphs,
         "atomGlyphs": atom_glyphs,
         "analyticOverlayBundle": analytic_overlay_bundle,
+        "periodStokes": period_stokes,
         "visualEncodingLegend": visual_encoding_legend_v1(),
         "renderLimits": {
             "nerveTriangles": GLUING_TRIANGLE_RENDER_LIMIT,
@@ -4549,7 +4632,8 @@ fn gluing_geometry_projection_v1(
             "forbiddenCages": GLUING_CAGE_RENDER_LIMIT,
             "repairMorphs": GLUING_MORPH_RENDER_LIMIT,
             "atomGlyphs": GLUING_ATOM_GLYPH_RENDER_LIMIT,
-            "analyticOverlays": ANALYTIC_OVERLAY_RENDER_LIMIT
+            "analyticOverlays": ANALYTIC_OVERLAY_RENDER_LIMIT,
+            "periodStokesMeters": PERIOD_STOKES_METER_RENDER_LIMIT
         },
         "omittedGeometryCounts": {
             "nerveTriangles": triangle_count.saturating_sub(GLUING_TRIANGLE_RENDER_LIMIT),
@@ -4560,7 +4644,8 @@ fn gluing_geometry_projection_v1(
             "forbiddenCages": forbidden_cages.len().saturating_sub(GLUING_CAGE_RENDER_LIMIT),
             "repairMorphs": repair_morphs.len().saturating_sub(GLUING_MORPH_RENDER_LIMIT),
             "atomGlyphs": atom_glyph_total_count.saturating_sub(GLUING_ATOM_GLYPH_RENDER_LIMIT),
-            "analyticOverlays": analytic_overlay_count.saturating_sub(ANALYTIC_OVERLAY_RENDER_LIMIT)
+            "analyticOverlays": analytic_overlay_count.saturating_sub(ANALYTIC_OVERLAY_RENDER_LIMIT),
+            "periodStokesMeters": period_stokes_meter_count.saturating_sub(PERIOD_STOKES_METER_RENDER_LIMIT)
         },
         "nonClaims": [
             "No H2 coherence failure is visualized by this projection.",
@@ -4876,6 +4961,96 @@ fn analytic_overlay_bundle_projection(packet: &ArchSigMeasurementPacketV1) -> Va
             "Spectral gap overlays are proxy eigenvalues and are not structural lawfulness.",
             "Curvature hotspot overlays are theorem-candidate projections.",
             "Singularity concentration has deformationRegime=not_provided and is not a size or difficulty score."
+        ]
+    })
+}
+
+fn period_stokes_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
+    let structural_verdict = packet
+        .structural_verdict
+        .iter()
+        .find(|row| row.evaluator == "ag.period-stokes-audit@1");
+    let structural_verdict_ref = structural_verdict.map(structural_verdict_ref);
+    let structural_verdict_value = structural_verdict
+        .map(|row| row.verdict.clone())
+        .unwrap_or_else(|| "not_computed".to_string());
+    let meters = packet
+        .computed_invariants
+        .iter()
+        .filter(|invariant| invariant["evaluator"] == "ag.period-stokes-audit@1")
+        .take(PERIOD_STOKES_METER_RENDER_LIMIT)
+        .enumerate()
+        .map(|(index, invariant)| {
+            let cycle_basis = string_array_at(invariant, &["cycleBasis"]);
+            let forms = string_array_at(invariant, &["forms"]);
+            let pairs = invariant["stokesAudit"]["pairs"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            let audit_status = invariant["stokesAudit"]["status"]
+                .as_str()
+                .unwrap_or("unknown");
+            let has_model = !cycle_basis.is_empty() && !pairs.is_empty();
+            let meter_status = if audit_status == "checked" || audit_status == "residual_nonzero" {
+                "structural_audit_projected"
+            } else if audit_status == "unknown" && !cycle_basis.is_empty() {
+                "analytic_only"
+            } else if !has_model {
+                "silent"
+            } else {
+                "analytic_only"
+            };
+            json!({
+                "meterId": format!(
+                    "period-stokes-meter:{}:{index}",
+                    stable_ref_segment(&string_field(invariant, "invariantId"))
+                ),
+                "sourceInvariantRef": invariant["invariantId"],
+                "sourceEvaluator": "ag.period-stokes-audit@1",
+                "structuralVerdictRef": structural_verdict_ref.clone(),
+                "structuralVerdict": structural_verdict_value.clone(),
+                "meterStatus": meter_status,
+                "auditStatus": audit_status,
+                "colorRole": "analytic_reading",
+                "modelRelative": true,
+                "selectedCoverRef": invariant["selectedCoverRef"],
+                "coefficient": invariant["coefficient"],
+                "forms": forms,
+                "cycleBasis": cycle_basis,
+                "periodPairingMatrix": invariant["periodPairingMatrix"],
+                "stokesAudit": invariant["stokesAudit"],
+                "pairCount": pairs.len(),
+                "maxAbsoluteResidual": invariant["stokesAudit"]["maxAbsoluteResidual"],
+                "nonzeroPairCount": invariant["stokesAudit"]["nonzeroPairCount"],
+                "nonClaim": "Stokes audit meter is modelRelative to the supplied finite period model; it visualizes packet audit residuals and creates no new structural verdict.",
+                "projectionBoundary": "periodStokes projection carries M9 packet values only; analytic period arcs are not absolute periods and not lawfulness verdicts"
+            })
+        })
+        .collect::<Vec<_>>();
+    let active_meter_count = meters
+        .iter()
+        .filter(|meter| meter["meterStatus"] == "structural_audit_projected")
+        .count();
+    let raw_meter_count = packet
+        .computed_invariants
+        .iter()
+        .filter(|invariant| invariant["evaluator"] == "ag.period-stokes-audit@1")
+        .count();
+    json!({
+        "schemaVersion": "archsig-period-stokes-meter-v1",
+        "sourceEvaluator": "ag.period-stokes-audit@1",
+        "sourceAnalyticReadingKind": "strict-period-pairing@1",
+        "colorRole": "analytic_reading",
+        "modelRelative": true,
+        "rawMeterCount": raw_meter_count,
+        "activeMeterCount": active_meter_count,
+        "meterCount": meters.len(),
+        "meters": meters,
+        "projectionBoundary": "This projection renders M9 Stokes audit values in the viewer; it does not create or modify structural verdict rows.",
+        "nonClaims": [
+            "Period arcs are modelRelative to the supplied finite period model.",
+            "The meter reads packet stokesAudit pairs; it is not an absolute period invariant.",
+            "Unknown or model-missing audits remain analytic-only or silent, never green structural closure."
         ]
     })
 }
@@ -10489,6 +10664,7 @@ pub fn build_measurement_viewer_data_v1(
             "repairMorphs": insight_report["gluingGeometry"]["repairMorphs"],
             "atomGlyphs": insight_report["gluingGeometry"]["atomGlyphs"],
             "analyticOverlayBundle": insight_report["gluingGeometry"]["analyticOverlayBundle"],
+            "periodStokes": insight_report["gluingGeometry"]["periodStokes"],
             "periodPairingOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["periodPairingOverlays"],
             "transferCostOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["transferCostOverlays"],
             "spectralGapOverlays": insight_report["gluingGeometry"]["analyticOverlayBundle"]["spectralGapOverlays"],

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -5427,6 +5427,7 @@ fn cli_analyze_v2_period_stokes_audit_outputs_structural_verdicts() {
         ]);
 
         let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
+        let viewer = read_json(&out_dir.join("archsig-atom-viewer-data.json"));
         let structural = packet["structuralVerdict"]
             .as_array()
             .expect("structural verdict is array");
@@ -5454,6 +5455,50 @@ fn cli_analyze_v2_period_stokes_audit_outputs_structural_verdicts() {
                     && reading["value"]["readingKind"] == "strict-period-pairing@1"),
             "strict-period-pairing must remain an analytic reading separate from the structural verdict"
         );
+        let period_stokes = &viewer["aatGeometryOverlays"]["periodStokes"];
+        assert_eq!(
+            period_stokes["schemaVersion"],
+            "archsig-period-stokes-meter-v1"
+        );
+        assert_eq!(period_stokes["sourceEvaluator"], "ag.period-stokes-audit@1");
+        assert_eq!(period_stokes["modelRelative"], Value::Bool(true));
+        let meters = period_stokes["meters"]
+            .as_array()
+            .expect("periodStokes meters is array");
+        assert_eq!(
+            meters.len(),
+            1,
+            "period audit fixture must project one meter"
+        );
+        let meter = &meters[0];
+        assert_eq!(meter["sourceEvaluator"], "ag.period-stokes-audit@1");
+        assert_eq!(meter["modelRelative"], Value::Bool(true));
+        assert_eq!(
+            meter["periodPairingMatrix"],
+            serde_json::json!([[2.0, -1.0]])
+        );
+        assert!(
+            meter["nonClaim"]
+                .as_str()
+                .is_some_and(|text| text.contains("creates no new structural verdict")),
+            "period meter must carry no-new-verdict non-claim"
+        );
+        if expected_verdict == "unknown" {
+            assert_eq!(meter["meterStatus"], "analytic_only");
+            assert_eq!(period_stokes["activeMeterCount"], Value::from(0));
+            assert_eq!(
+                viewer_scene_by_id(&viewer, "period-stokes")["sceneStatus"],
+                "not_active_for_packet",
+                "unknown strict coefficient audit must not render green structural closure"
+            );
+        } else {
+            assert_eq!(meter["meterStatus"], "structural_audit_projected");
+            assert_eq!(period_stokes["activeMeterCount"], Value::from(1));
+            assert_eq!(
+                viewer_scene_by_id(&viewer, "period-stokes")["sceneStatus"],
+                "active"
+            );
+        }
     }
 }
 
@@ -9787,10 +9832,14 @@ fn practical_rust_service_example_runs_current_analyze() {
     assert_eq!(viewer["atomEdges"].as_array().map(Vec::len), Some(78));
     assert_eq!(
         viewer["viewerVisualScenes"].as_array().map(Vec::len),
-        Some(11)
+        Some(12)
     );
     assert_eq!(
         viewer_scene_by_id(&viewer, "analytic-overlay")["sceneStatus"],
+        "not_active_for_packet"
+    );
+    assert_eq!(
+        viewer_scene_by_id(&viewer, "period-stokes")["sceneStatus"],
         "not_active_for_packet"
     );
     assert_eq!(viewer["guidedTours"].as_array().map(Vec::len), Some(2));
@@ -13758,7 +13807,8 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
     );
     assert!(
         html.contains("tagCohomologyLayer(patch, \"h0\", \"nerve.vertices\")")
-            && html.contains("tagCohomologyLayer(tube, \"h1\", \"cocycleRibbon.supportEdges.value\")")
+            && html
+                .contains("tagCohomologyLayer(tube, \"h1\", \"cocycleRibbon.supportEdges.value\")")
             && html.contains("tagCohomologyLayer(mesh, \"h2\", \"nerve.triangles\")")
             && html.contains("h2CoherenceVisualized: false"),
         "viewer V5 must place H0/H1/H2 geometry on degree bands without H2 verdict color"
@@ -13859,7 +13909,9 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
     );
     assert!(
         html.contains("Morph trajectories are visual projections, not verdicts.")
-            && html.contains("visual trajectory only; not semantic distance, causality, equivalence, or verdict")
+            && html.contains(
+                "visual trajectory only; not semantic distance, causality, equivalence, or verdict"
+            )
             && html.contains("geometryOverlayMorphCrossfade: true"),
         "viewer V9 must expose morph trajectory and overlay crossfade non-claims"
     );
@@ -13881,7 +13933,9 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
     assert!(
         html.contains("closureGapEncoding?.visible")
             && html.contains("twist magnitude is unmeasured")
-            && html.contains("restriction/cover path exploratory view only; no monodromy or pi1 verdict"),
+            && html.contains(
+                "restriction/cover path exploratory view only; no monodromy or pi1 verdict"
+            ),
         "viewer V10 must gate traversal on measured closureGap visibility and expose the boundary"
     );
     assert!(
@@ -13903,7 +13957,9 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
         html.contains("smoothstep(0, 1, 1 - distance)")
             && html.contains("0.25 + 0.75 * focus")
             && html.contains("degree scrub H2 remains grey silence")
-            && html.contains("degree scrub separates H0/H1/H2 viewer layers without adding H2 verdict color"),
+            && html.contains(
+                "degree scrub separates H0/H1/H2 viewer layers without adding H2 verdict color"
+            ),
         "viewer V11 must scrub by focus opacity while preserving H2 grey silence"
     );
     assert!(
@@ -13981,7 +14037,9 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("noTransversalityProof: true")
             && html.contains("discreteQuantityBundle: true")
             && html.contains("noStructuralVerdict: true")
-            && html.contains("Tor_1 residue loci: PlaneGeometry approximation, no transversality proof"),
+            && html.contains(
+                "Tor_1 residue loci: PlaneGeometry approximation, no transversality proof"
+            ),
         "viewer V15 must make PlaneGeometry approximation and non-verdict boundaries explicit"
     );
     assert!(
@@ -13990,6 +14048,22 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("explicitTransferOnly: true")
             && html.contains("repair mass transfer is rendered only when explicit packet transfer data is present"),
         "viewer V15 must gate repair mass transfer rendering on explicit packet data"
+    );
+    assert!(
+        html.contains("value=\"periodStokes\"")
+            && html.contains("renderPeriodMeter")
+            && html.contains("window.__archsigViewerPeriodStokesMeter")
+            && html.contains("periodStokesCycleArc")
+            && html.contains("periodStokesAuditMeter")
+            && html.contains("periodStokesResidualFlux"),
+        "viewer V16 must expose a Period Stokes mode and render audit meter objects"
+    );
+    assert!(
+        html.contains("modelRelative finite-period meter; not an absolute period invariant")
+            && html.contains("periodStokes viewer meter projects packet M9 values only; no new structural verdict")
+            && html.contains("noStructuralVerdictCreatedByViewer: true")
+            && html.contains("unknown audits are not green structural closure"),
+        "viewer V16 must keep period meter model-relative and avoid new structural verdict claims"
     );
     assert!(
         html.contains("type=\"file\"")

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -863,6 +863,7 @@
             <option value="obstructions">AG Forbidden support cages</option>
             <option value="spectrum">AG Spectrum landscape</option>
             <option value="analyticOverlay">AG Analytic overlay</option>
+            <option value="periodStokes">AG Period Stokes meter</option>
             <option value="flatness">AG Flatness surface</option>
             <option value="aatAxes">AG Site / Cover</option>
             <option value="molecules">Molecule map</option>
@@ -1052,6 +1053,7 @@
     let activeAssemblySnapObjects = [];
     let assemblySnapStartedAt = 0;
     let activeBreathingFiberObjects = [];
+    let activePeriodStokesObjects = [];
 
     const colorByStatus = {
       observed: 0x4cc3a7,
@@ -1347,6 +1349,7 @@
       updateFindingsTourPulse();
       updateAssemblySnapAnimation();
       updateBreathingFiberAnimation();
+      updatePeriodStokesMeterAnimation();
       renderFrame();
     }
 
@@ -1564,6 +1567,7 @@
       activeTourState = { ...(activeTourState || {}), frames: [] };
       activeAssemblySnapObjects = [];
       activeBreathingFiberObjects = [];
+      activePeriodStokesObjects = [];
       assemblySnapStartedAt = performance.now();
 
       const positions = new Map();
@@ -2157,6 +2161,9 @@
       }
       if (scene.sceneId === "analytic-overlay") {
         renderAnalyticOverlays(scene, geometry.analyticOverlayBundle || {}, positions, encoding, geometry.renderLimits || {});
+      }
+      if (scene.sceneId === "period-stokes") {
+        renderPeriodMeter(scene, geometry.periodStokes || {}, positions, encoding, geometry.renderLimits || {});
       }
       if (scene.sceneId === "obstruction") {
         renderForbiddenCages(scene, geometry.forbiddenCages || [], positions, encoding, geometry.renderLimits || {});
@@ -3318,6 +3325,213 @@
       });
       addLineSegments(vertices, color, 0.38, "analyticOverlayLane", { lineRole: "contour", colorRole: "analytic_reading" });
       window.__archsigViewerLawfulLociIntersection = lawfulLociStats;
+    }
+
+    function renderPeriodMeter(scene, periodStokes, positions, encoding, limits = {}) {
+      const meters = (Array.isArray(periodStokes.meters) ? periodStokes.meters : [])
+        .slice(0, limits.periodStokesMeters || 24);
+      const renderable = meters.filter((meter) => {
+        const pairs = Array.isArray(meter.stokesAudit?.pairs) ? meter.stokesAudit.pairs : [];
+        return Array.isArray(meter.cycleBasis) && meter.cycleBasis.length
+          && (pairs.length || meter.meterStatus === "analytic_only");
+      });
+      const stats = {
+        status: renderable.length ? "rendered" : "silent",
+        meterCount: renderable.length,
+        arcCount: 0,
+        residualFluxCount: 0,
+        checkedMeterCount: 0,
+        analyticOnlyCount: 0,
+        modelRelative: true,
+        sourceEvaluator: "ag.period-stokes-audit@1",
+        noStructuralVerdictCreatedByViewer: true,
+        projectionBoundary: "periodStokes viewer meter projects packet M9 values only; no new structural verdict"
+      };
+      renderable.forEach((meter, index) => {
+        const status = String(meter.stokesAudit?.status || meter.auditStatus || "unknown");
+        const activeStructural = meter.meterStatus === "structural_audit_projected";
+        if (activeStructural) stats.checkedMeterCount += 1;
+        if (!activeStructural) stats.analyticOnlyCount += 1;
+        const maxResidual = periodStokesResidualMagnitude(meter);
+        const center = sceneAxisPosition(scene, meter.meterId || `period-stokes:${index}`, index, Math.max(renderable.length, 1), groupPosition(index, Math.max(renderable.length, 1), 64), {
+          xValue: index / Math.max(renderable.length - 1, 1),
+          yValue: Math.min((meter.stokesAudit?.pairs || []).length, 8),
+          zValue: Math.min(maxResidual, 8)
+        });
+        center.y += 18;
+        const radius = 18 + Math.min((meter.cycleBasis || []).length, 5) * 3.2;
+        const ring = createPeriodStokesCycleArc(center, radius, meter, status, activeStructural);
+        edgeGroup.add(ring);
+        stats.arcCount += 1;
+        const pulse = createPeriodStokesMovingArc(center, radius, meter, index);
+        edgeGroup.add(pulse);
+        activePeriodStokesObjects.push(pulse);
+        const audit = createPeriodStokesAuditMeter(center, radius, meter, status, activeStructural);
+        edgeGroup.add(audit);
+        const fluxes = renderPeriodStokesResidualFluxes(center, radius, meter, status, activeStructural);
+        fluxes.forEach((flux) => edgeGroup.add(flux));
+        stats.residualFluxCount += fluxes.length;
+        const labelText = activeStructural
+          ? status === "checked"
+            ? "Stokes audit checked; max residual 0"
+            : "Stokes audit residual flux measured"
+          : "period audit analytic-only; no structural closure";
+        const label = createTextSprite(labelText, "#e8f3ff", "rgba(14,35,58,0.74)");
+        label.position.copy(center).add(new THREE.Vector3(0, radius + 11, 0));
+        label.userData = {
+          kind: "periodStokesModelRelativeLabel",
+          item: meter,
+          modelRelative: true,
+          noStructuralVerdictCreatedByViewer: true,
+          nonClaim: "modelRelative finite-period meter; not an absolute period invariant"
+        };
+        edgeGroup.add(label);
+      });
+      window.__archsigViewerPeriodStokesMeter = stats;
+    }
+
+    function createPeriodStokesCycleArc(center, radius, meter, status, activeStructural) {
+      const curve = new THREE.CatmullRomCurve3(periodStokesCirclePoints(center, radius, 64), true, "centripetal", 0.45);
+      const ring = new THREE.Mesh(
+        new THREE.TubeGeometry(curve, 128, activeStructural ? 0.58 : 0.34, 8, true),
+        new THREE.MeshStandardMaterial({
+          color: activeStructural ? 0x73b7ff : 0x9aa8b8,
+          emissive: activeStructural ? 0x12324a : 0x101820,
+          transparent: true,
+          opacity: activeStructural ? 0.76 : 0.36,
+          roughness: 0.34,
+          metalness: 0.03
+        })
+      );
+      ring.userData = {
+        kind: "periodStokesCycleArc",
+        item: meter,
+        auditStatus: status,
+        modelRelative: true,
+        analyticReadingOnly: !activeStructural,
+        noStructuralVerdictCreatedByViewer: true,
+        projectionBoundary: "period arc is modelRelative and not an absolute period invariant"
+      };
+      if (activeStructural) registerReadingBloom(ring, "period_stokes_model_relative_arc", 0.42);
+      return ring;
+    }
+
+    function createPeriodStokesMovingArc(center, radius, meter, index) {
+      const pulse = new THREE.Mesh(
+        new THREE.SphereGeometry(2.8, 18, 12),
+        new THREE.MeshStandardMaterial({
+          color: 0xe8f3ff,
+          emissive: 0x2c5571,
+          transparent: true,
+          opacity: 0.82,
+          roughness: 0.3
+        })
+      );
+      pulse.position.copy(center).add(new THREE.Vector3(radius, 0, 0));
+      pulse.userData = {
+        kind: "periodStokesAccumulationArc",
+        item: meter,
+        center: center.clone(),
+        radius,
+        phaseOffset: index * 0.73,
+        modelRelative: true,
+        drivenBy: "periodPairingMatrix",
+        noStructuralVerdictCreatedByViewer: true
+      };
+      registerReadingBloom(pulse, "period_stokes_accumulation_arc", 0.52);
+      return pulse;
+    }
+
+    function createPeriodStokesAuditMeter(center, radius, meter, status, activeStructural) {
+      const residual = periodStokesResidualMagnitude(meter);
+      const color = activeStructural && status === "checked" ? 0x64d6be
+        : activeStructural && status === "residual_nonzero" ? 0xf2c15f
+          : 0x9aa8b8;
+      const meterMesh = new THREE.Mesh(
+        new THREE.TorusGeometry(radius * 0.42, 1.1 + Math.min(residual, 4) * 0.24, 16, 80),
+        new THREE.MeshStandardMaterial({
+          color,
+          emissive: status === "checked" ? 0x0b3d35 : 0x3f2d08,
+          transparent: true,
+          opacity: activeStructural ? 0.82 : 0.32,
+          roughness: 0.28,
+          metalness: 0.04
+        })
+      );
+      meterMesh.position.copy(center);
+      meterMesh.rotation.x = Math.PI / 2;
+      meterMesh.userData = {
+        kind: "periodStokesAuditMeter",
+        item: meter,
+        auditStatus: status,
+        maxAbsoluteResidual: residual,
+        modelRelative: true,
+        structuralVerdictRef: meter.structuralVerdictRef || null,
+        noStructuralVerdictCreatedByViewer: true,
+        nonClaim: "meter reads supplied stokesAudit pairs; unknown audits are not green structural closure"
+      };
+      if (activeStructural) registerReadingBloom(meterMesh, "period_stokes_audit_meter", 0.46);
+      return meterMesh;
+    }
+
+    function renderPeriodStokesResidualFluxes(center, radius, meter, status, activeStructural) {
+      if (!activeStructural || status !== "residual_nonzero") return [];
+      const pairs = Array.isArray(meter.stokesAudit?.pairs) ? meter.stokesAudit.pairs : [];
+      return pairs.flatMap((pair, index) => {
+        const residual = Math.abs(periodStokesNumber(pair.residual));
+        if (!(residual > 0)) return [];
+        const angle = (index / Math.max(pairs.length, 1)) * Math.PI * 2;
+        const from = center.clone().add(new THREE.Vector3(Math.cos(angle) * radius * 0.58, 0, Math.sin(angle) * radius * 0.58));
+        const to = center.clone().add(new THREE.Vector3(Math.cos(angle) * (radius * 0.92 + residual * 3), 5 + residual, Math.sin(angle) * (radius * 0.92 + residual * 3)));
+        const direction = to.clone().sub(from);
+        const arrow = new THREE.ArrowHelper(direction.normalize(), from, direction.length(), 0xf2c15f, 5.4, 2.8);
+        arrow.userData = {
+          kind: "periodStokesResidualFlux",
+          item: pair,
+          residual,
+          modelRelative: true,
+          measuredNonzeroFromM9: true,
+          noStructuralVerdictCreatedByViewer: true,
+          projectionBoundary: "nonzero residual flux is driven by M9 stokesAudit.status=residual_nonzero"
+        };
+        return [arrow];
+      });
+    }
+
+    function updatePeriodStokesMeterAnimation() {
+      const t = performance.now() * 0.001;
+      activePeriodStokesObjects.forEach((object) => {
+        const center = object.userData?.center;
+        const radius = Number(object.userData?.radius || 0);
+        if (!center || !radius) return;
+        const angle = t * 0.85 + Number(object.userData.phaseOffset || 0);
+        object.position.set(
+          center.x + Math.cos(angle) * radius,
+          center.y + Math.sin(angle * 2) * 1.8,
+          center.z + Math.sin(angle) * radius
+        );
+      });
+    }
+
+    function periodStokesCirclePoints(center, radius, segments) {
+      const points = [];
+      for (let index = 0; index < segments; index += 1) {
+        const angle = (index / segments) * Math.PI * 2;
+        points.push(new THREE.Vector3(center.x + Math.cos(angle) * radius, center.y, center.z + Math.sin(angle) * radius));
+      }
+      return points;
+    }
+
+    function periodStokesResidualMagnitude(meter) {
+      const direct = periodStokesNumber(meter.maxAbsoluteResidual);
+      if (direct > 0) return direct;
+      const pairs = Array.isArray(meter.stokesAudit?.pairs) ? meter.stokesAudit.pairs : [];
+      return pairs.reduce((max, pair) => Math.max(max, Math.abs(periodStokesNumber(pair.residual))), 0);
+    }
+
+    function periodStokesNumber(value) {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : 0;
     }
 
     function overlayGeometry(kind, size) {
@@ -4666,6 +4880,15 @@
         ]);
         return;
       }
+      if (viewModeEl.value === "periodStokes") {
+        renderSimpleLegend([
+          ["64d6be", "checked Stokes audit residual"],
+          ["f2c15f", "nonzero residual flux"],
+          ["73b7ff", "modelRelative period arc"],
+          ["d8dee9", "no new structural verdict"]
+        ]);
+        return;
+      }
       if (usesFamilyLegend(viewModeEl.value)) {
         renderFamilyLegend();
         return;
@@ -4836,7 +5059,8 @@
         curvature: "hodge-debt-field",
         flatness: "hodge-debt-field",
         spectrum: "hodge-debt-field",
-        analyticOverlay: "analytic-overlay"
+        analyticOverlay: "analytic-overlay",
+        periodStokes: "period-stokes"
       };
       const sceneId = mapping[mode] || mode;
       return scenes.find((scene) => scene.sceneId === sceneId || scene.kind === sceneId);
@@ -4853,6 +5077,7 @@
         "law-conflict-tor": "risk",
         "hodge-debt-field": "curvature",
         "analytic-overlay": "analyticOverlay",
+        "period-stokes": "periodStokes",
         "boundary-assumption": "risk",
         "source-evidence": "sources"
       };


### PR DESCRIPTION
## 概要

Closes #2306

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-V16 として、M9 `ag.period-stokes-audit@1` の audit 結果を Viewer の `period-stokes` scene に投影する。

- `aatGeometryOverlays.periodStokes` / `gluingGeometry.periodStokes` を追加
- `periodStokes` view mode と `renderPeriodMeter` を追加
- modelRelative な周期周回弧、Stokes audit meter、residual flux projection を描画
- unknown / model-missing audit は green structural closure として描かず、analytic-only / silent に保持
- viewer が新 structural verdict を作らない boundary を debug state / userData / scene nonClaim に固定

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] viewer module `node --check`
- [x] period-stokes-audit preview fixture generation
- [x] Playwright headless desktop/mobile visual check（`periodStokes` mode、nonblank pixel check、`__archsigViewerPeriodStokesMeter.status === "rendered"`）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
