### PR TITLE
Viewer spectral peak visualizationを追加

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -4316,7 +4316,14 @@ fn attach_gluing_scene_geometry(mut scene: Value, gluing_geometry: &Value) -> Va
         }),
         "hodge-debt-field" => json!({
             "locusFieldRef": "gluingGeometry.locusField",
-            "projectionObjectKinds": ["curvatureHeightField", "blockedUnmeasuredRegion"]
+            "spectrumLandscapeRef": "gluingGeometry.spectrumLandscape",
+            "projectionObjectKinds": [
+                "curvatureHeightField",
+                "blockedUnmeasuredRegion",
+                "spectrumLawfulPlain",
+                "spectrumLocalDeviationPeak",
+                "spectrumProxyRidge"
+            ]
         }),
         "analytic-overlay" => json!({
             "analyticOverlayBundleRef": "gluingGeometry.analyticOverlayBundle",
@@ -4556,6 +4563,7 @@ fn gluing_geometry_projection_v1(
     let atom_glyphs = atom_glyph_projection(normalized);
     let analytic_overlay_bundle = analytic_overlay_bundle_projection(packet);
     let period_stokes = period_stokes_projection(packet);
+    let spectrum_landscape = spectrum_landscape_projection(packet);
     let triangle_count = cover_nerve_projection["faces"]
         .as_array()
         .map(Vec::len)
@@ -4578,6 +4586,9 @@ fn gluing_geometry_projection_v1(
         .unwrap_or_default() as usize;
     let period_stokes_meter_count =
         period_stokes["rawMeterCount"].as_u64().unwrap_or_default() as usize;
+    let spectrum_cell_count = spectrum_landscape["rawCellCount"]
+        .as_u64()
+        .unwrap_or_default() as usize;
     let cocycle_support_edge_count = nonzero_edges.len();
     let cocycle_support_edges = nonzero_edges
         .iter()
@@ -4623,6 +4634,7 @@ fn gluing_geometry_projection_v1(
         "atomGlyphs": atom_glyphs,
         "analyticOverlayBundle": analytic_overlay_bundle,
         "periodStokes": period_stokes,
+        "spectrumLandscape": spectrum_landscape,
         "visualEncodingLegend": visual_encoding_legend_v1(),
         "renderLimits": {
             "nerveTriangles": GLUING_TRIANGLE_RENDER_LIMIT,
@@ -4633,7 +4645,8 @@ fn gluing_geometry_projection_v1(
             "repairMorphs": GLUING_MORPH_RENDER_LIMIT,
             "atomGlyphs": GLUING_ATOM_GLYPH_RENDER_LIMIT,
             "analyticOverlays": ANALYTIC_OVERLAY_RENDER_LIMIT,
-            "periodStokesMeters": PERIOD_STOKES_METER_RENDER_LIMIT
+            "periodStokesMeters": PERIOD_STOKES_METER_RENDER_LIMIT,
+            "spectrumCells": GLUING_FIELD_ROW_RENDER_LIMIT
         },
         "omittedGeometryCounts": {
             "nerveTriangles": triangle_count.saturating_sub(GLUING_TRIANGLE_RENDER_LIMIT),
@@ -4645,7 +4658,8 @@ fn gluing_geometry_projection_v1(
             "repairMorphs": repair_morphs.len().saturating_sub(GLUING_MORPH_RENDER_LIMIT),
             "atomGlyphs": atom_glyph_total_count.saturating_sub(GLUING_ATOM_GLYPH_RENDER_LIMIT),
             "analyticOverlays": analytic_overlay_count.saturating_sub(ANALYTIC_OVERLAY_RENDER_LIMIT),
-            "periodStokesMeters": period_stokes_meter_count.saturating_sub(PERIOD_STOKES_METER_RENDER_LIMIT)
+            "periodStokesMeters": period_stokes_meter_count.saturating_sub(PERIOD_STOKES_METER_RENDER_LIMIT),
+            "spectrumCells": spectrum_cell_count.saturating_sub(GLUING_FIELD_ROW_RENDER_LIMIT)
         },
         "nonClaims": [
             "No H2 coherence failure is visualized by this projection.",
@@ -5053,6 +5067,134 @@ fn period_stokes_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
             "Unknown or model-missing audits remain analytic-only or silent, never green structural closure."
         ]
     })
+}
+
+fn spectrum_landscape_projection(packet: &ArchSigMeasurementPacketV1) -> Value {
+    let hodge_reading = packet.analytic_readings.iter().find(|reading| {
+        string_at(&reading.value, &["readingKind"]) == "graph-laplacian-hodge-proxy@1"
+    });
+    let hotspot_reading = packet.analytic_readings.iter().find(|reading| {
+        string_at(&reading.value, &["readingKind"]) == "curvature-transfer-perron-hotspot@1"
+    });
+    let Some(reading) = hodge_reading else {
+        return json!({
+            "schemaVersion": "archsig-spectrum-landscape-v1",
+            "status": "silent",
+            "measurementStatus": "not_projected",
+            "colorRole": "analytic_reading",
+            "rawCellCount": 0,
+            "cells": [],
+            "hotspots": [],
+            "projectionBoundary": "No M10 graph-laplacian-hodge-proxy reading is present; viewer remains silent and creates no structural verdict."
+        });
+    };
+    let cells = string_array_at(&reading.value, &["cells"]);
+    let cochain = reading.value["cochain"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let transfer_rows = reading.value["curvatureTransferSpectrum"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let transfer_by_cell = transfer_rows
+        .iter()
+        .filter_map(|row| {
+            Some((
+                string_field(row, "cell"),
+                row["curvature"].as_f64().unwrap_or(0.0),
+            ))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let cell_rows = cells
+        .iter()
+        .take(GLUING_FIELD_ROW_RENDER_LIMIT)
+        .enumerate()
+        .map(|(index, cell)| {
+            let cochain_value = cochain.get(index).and_then(Value::as_f64).unwrap_or(0.0);
+            let curvature = transfer_by_cell.get(cell).copied().unwrap_or(0.0);
+            json!({
+                "cellRef": cell,
+                "axisRef": format!("spectrum-axis:{cell}"),
+                "cochainValue": round_f64(cochain_value),
+                "signedCurvature": round_f64(curvature),
+                "plainRole": if cochain_value.abs() < 1.0e-9 {
+                    "lawful_plain_measured_zero"
+                } else {
+                    "local_deviation"
+                },
+                "deterministicIndex": index,
+                "colorRole": "analytic_reading",
+                "measurementStatus": "proxy",
+                "notLegacyStatusField": true
+            })
+        })
+        .collect::<Vec<_>>();
+    let hotspot_rows = hotspot_reading
+        .map(|reading| {
+            reading.value["hotspots"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .take(GLUING_FIELD_ROW_RENDER_LIMIT)
+                .enumerate()
+                .map(|(index, hotspot)| {
+                    json!({
+                        "hotspotId": format!(
+                            "spectrum-hotspot:{}:{index}",
+                            stable_ref_segment(&reading.reading_id)
+                        ),
+                        "cellRef": string_field(hotspot, "cell"),
+                        "axisRef": format!("spectrum-axis:{}", string_field(hotspot, "cell")),
+                        "hotspotWeight": hotspot["hotspotWeight"].clone(),
+                        "status": "needsReview",
+                        "measurementStatus": "proxy",
+                        "colorRole": "analytic_reading",
+                        "sourceReadingRef": reading.reading_id,
+                        "sourceRegime": reading.regime,
+                        "localDeviationSecondary": true
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let spectral_radius_value = reading
+        .value
+        .get("spectralRadius")
+        .or_else(|| reading.value.get("spectralGap"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let spectral_radius_numeric = spectrum_numeric_value(&spectral_radius_value);
+
+    json!({
+        "schemaVersion": "archsig-spectrum-landscape-v1",
+        "status": "needsReview",
+        "measurementStatus": "proxy",
+        "sourceReadingRef": reading.reading_id,
+        "sourceEvaluator": reading.evaluator,
+        "sourceReadingKind": "graph-laplacian-hodge-proxy@1",
+        "hotspotReadingRef": hotspot_reading.map(|reading| reading.reading_id.clone()),
+        "hotspotReadingKind": hotspot_reading.map(|_| "curvature-transfer-perron-hotspot@1"),
+        "selectedCoverRef": reading.value["selectedCoverRef"].clone(),
+        "colorRole": "analytic_reading",
+        "rawCellCount": cells.len(),
+        "cells": cell_rows,
+        "hotspots": hotspot_rows,
+        "spectralGap": reading.value["spectralGap"].clone(),
+        "spectralRadius": spectral_radius_value,
+        "spectralRadiusNumeric": spectral_radius_numeric.map(round_f64),
+        "axisPlacement": "axisRef-deterministic",
+        "forbiddenFieldRefs": ["legacy-v0-curvature-status"],
+        "nonClaim": "Spectrum landscape is an analytic proxy reading; lawful plain and hotspots are not structural verdicts.",
+        "projectionBoundary": "spectrumLandscape carries M10/M14 packet readings only; no legacy v0 status field is read and no structural verdict is created."
+    })
+}
+
+fn spectrum_numeric_value(value: &Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|text| text.parse::<f64>().ok()))
+        .filter(|value| value.is_finite())
 }
 
 fn atom_refs_by_square_free_variable(
@@ -10660,6 +10802,7 @@ pub fn build_measurement_viewer_data_v1(
             "nerve": insight_report["gluingGeometry"]["nerve"],
             "cocycleRibbon": insight_report["gluingGeometry"]["cocycleRibbon"],
             "locusField": insight_report["gluingGeometry"]["locusField"],
+            "spectrumLandscape": insight_report["gluingGeometry"]["spectrumLandscape"],
             "forbiddenCages": insight_report["gluingGeometry"]["forbiddenCages"],
             "repairMorphs": insight_report["gluingGeometry"]["repairMorphs"],
             "atomGlyphs": insight_report["gluingGeometry"]["atomGlyphs"],

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -3894,6 +3894,38 @@ fn cli_analyze_v2_projects_analytic_overlay_bundle_to_viewer_lane() {
             .is_some_and(|items| !items.is_empty()),
         "hotspot overlay must be gated by an existing landed hotspot reading"
     );
+    let spectrum_landscape = &laplacian_viewer["aatGeometryOverlays"]["spectrumLandscape"];
+    assert_eq!(
+        spectrum_landscape["schemaVersion"],
+        "archsig-spectrum-landscape-v1"
+    );
+    assert_eq!(spectrum_landscape["measurementStatus"], "proxy");
+    assert_eq!(spectrum_landscape["colorRole"], "analytic_reading");
+    assert_eq!(spectrum_landscape["axisPlacement"], "axisRef-deterministic");
+    assert_eq!(
+        spectrum_landscape["spectralRadiusNumeric"],
+        Value::from(2.0)
+    );
+    assert!(
+        spectrum_landscape["cells"]
+            .as_array()
+            .expect("spectrum cells is array")
+            .iter()
+            .any(|cell| cell["plainRole"] == "lawful_plain_measured_zero"
+                && cell["notLegacyStatusField"] == Value::Bool(true)),
+        "spectrum projection must draw cv=0 lawful plain cells without the legacy curvature status field"
+    );
+    assert!(
+        spectrum_landscape["hotspots"]
+            .as_array()
+            .expect("spectrum hotspots is array")
+            .iter()
+            .all(
+                |hotspot| hotspot["localDeviationSecondary"] == Value::Bool(true)
+                    && hotspot["measurementStatus"] == "proxy"
+            ),
+        "spectrum hotspots must remain secondary proxy deviations"
+    );
 
     let tor_out = run_ag_measurement_fixture(
         "m14-singularity-overlay",
@@ -14064,6 +14096,24 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("noStructuralVerdictCreatedByViewer: true")
             && html.contains("unknown audits are not green structural closure"),
         "viewer V16 must keep period meter model-relative and avoid new structural verdict claims"
+    );
+    assert!(
+        html.contains("renderSpectrumPeaks")
+            && html.contains("window.__archsigViewerSpectrumPeaks")
+            && html.contains("spectrumLawfulPlain")
+            && html.contains("spectrumLocalDeviationPeak")
+            && html.contains("spectrumProxyRidge"),
+        "viewer V17 must render lawful plain, secondary peaks, and proxy ridges"
+    );
+    assert!(
+        html.contains("lawfulPlainMeasuredZeroDrawn: isLawfulPlain")
+            && html.contains("legacyStatusFieldRead: false")
+            && html.contains("analyticReadingNotVerdict: true")
+            && html.contains(
+                "SAFE lawful plain remains central; spectrum peaks are proxy local deviations"
+            )
+            && html.contains("axisRef-deterministic"),
+        "viewer V17 must keep SAFE lawful plain central with deterministic axis placement and analytic non-verdict boundary"
     );
     assert!(
         html.contains("type=\"file\"")

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1054,6 +1054,7 @@
     let assemblySnapStartedAt = 0;
     let activeBreathingFiberObjects = [];
     let activePeriodStokesObjects = [];
+    let activeSpectrumPeakObjects = [];
 
     const colorByStatus = {
       observed: 0x4cc3a7,
@@ -1350,6 +1351,7 @@
       updateAssemblySnapAnimation();
       updateBreathingFiberAnimation();
       updatePeriodStokesMeterAnimation();
+      updateSpectrumPeakAnimation();
       renderFrame();
     }
 
@@ -1568,6 +1570,7 @@
       activeAssemblySnapObjects = [];
       activeBreathingFiberObjects = [];
       activePeriodStokesObjects = [];
+      activeSpectrumPeakObjects = [];
       assemblySnapStartedAt = performance.now();
 
       const positions = new Map();
@@ -2158,6 +2161,9 @@
       }
       if (scene.sceneId === "hodge-debt-field") {
         renderLocusField(scene, geometry.locusField || {}, positions, geometry.renderLimits || {});
+        if (viewModeEl.value === "spectrum") {
+          renderSpectrumPeaks(scene, geometry.spectrumLandscape || {}, positions, encoding, geometry.renderLimits || {});
+        }
       }
       if (scene.sceneId === "analytic-overlay") {
         renderAnalyticOverlays(scene, geometry.analyticOverlayBundle || {}, positions, encoding, geometry.renderLimits || {});
@@ -3255,6 +3261,144 @@
         };
         edgeGroup.add(note);
       }
+    }
+
+    function renderSpectrumPeaks(scene, spectrum, positions, encoding, limits = {}) {
+      const cells = (Array.isArray(spectrum.cells) ? spectrum.cells : []).slice(0, limits.spectrumCells || 64);
+      const hotspots = Array.isArray(spectrum.hotspots) ? spectrum.hotspots : [];
+      const lawfulCells = cells.filter((cell) => Math.abs(spectrumNumber(cell.cochainValue)) < 1.0e-9);
+      const baseCenter = sceneAxisPosition(scene, spectrum.sourceReadingRef || "spectrum-landscape", 0, 1, new THREE.Vector3(0, 0, 0), {
+        xValue: 0.5,
+        yValue: 0,
+        zValue: 0
+      });
+      const stats = {
+        status: cells.length ? "rendered" : "silent",
+        cellCount: cells.length,
+        lawfulPlainCount: lawfulCells.length,
+        hotspotCount: hotspots.length,
+        axisPlacement: spectrum.axisPlacement || "axisRef-deterministic",
+        legacyStatusFieldRead: false,
+        measurementStatus: spectrum.measurementStatus || "proxy",
+        noStructuralVerdictCreatedByViewer: true,
+        projectionBoundary: "spectrumLandscape viewer reads M10/M14 analytic proxy values only; no legacy v0 status field and no structural verdict"
+      };
+      if (!cells.length) {
+        window.__archsigViewerSpectrumPeaks = stats;
+        return;
+      }
+      const cellPositions = new Map();
+      cells.forEach((cell, index) => {
+        const point = spectrumAxisPosition(baseCenter, cell.axisRef || cell.cellRef, index, cells.length, cell);
+        cellPositions.set(String(cell.cellRef || ""), point);
+        const isLawfulPlain = Math.abs(spectrumNumber(cell.cochainValue)) < 1.0e-9;
+        const size = isLawfulPlain ? 13 : 7 + Math.min(Math.abs(spectrumNumber(cell.signedCurvature)), 6) * 1.6;
+        const mesh = new THREE.Mesh(
+          isLawfulPlain ? new THREE.CircleGeometry(size, 48) : new THREE.ConeGeometry(size * 0.55, size * 1.35, 7),
+          new THREE.MeshStandardMaterial({
+            color: isLawfulPlain ? 0x64d6be : 0x73b7ff,
+            emissive: isLawfulPlain ? 0x0b3d35 : 0x102c48,
+            transparent: true,
+            opacity: isLawfulPlain ? 0.42 : 0.58,
+            roughness: 0.45,
+            metalness: 0.02,
+            side: THREE.DoubleSide
+          })
+        );
+        mesh.position.copy(point);
+        mesh.rotation.x = isLawfulPlain ? -Math.PI / 2 : 0;
+        mesh.userData = {
+          kind: isLawfulPlain ? "spectrumLawfulPlain" : "spectrumProxyCell",
+          item: cell,
+          axisRef: cell.axisRef,
+          deterministicAxisPlacement: true,
+          lawfulPlainMeasuredZeroDrawn: isLawfulPlain,
+          measurementStatus: cell.measurementStatus || "proxy",
+          analyticReadingNotVerdict: true,
+          noStructuralVerdictCreatedByViewer: true,
+          legacyStatusFieldRead: false,
+          projectionBoundary: "cochain cv=0 lawful plain is drawn as measured analytic support, not silence"
+        };
+        edgeGroup.add(mesh);
+      });
+      hotspots.forEach((hotspot, index) => {
+        const point = (cellPositions.get(String(hotspot.cellRef || "")) || spectrumAxisPosition(baseCenter, hotspot.axisRef || hotspot.cellRef, index, hotspots.length, hotspot)).clone();
+        const weight = Math.max(0, spectrumNumber(hotspot.hotspotWeight));
+        point.y += 14 + Math.min(weight, 2) * 15;
+        const peak = new THREE.Mesh(
+          new THREE.ConeGeometry(4.8 + weight * 4.2, 15 + weight * 18, 9),
+          new THREE.MeshStandardMaterial({
+            color: 0xf2c15f,
+            emissive: 0x3f2d08,
+            transparent: true,
+            opacity: 0.66,
+            roughness: 0.32,
+            metalness: 0.04
+          })
+        );
+        peak.position.copy(point);
+        peak.userData = {
+          kind: "spectrumLocalDeviationPeak",
+          item: hotspot,
+          hotspotSecondary: true,
+          status: hotspot.status || "needsReview",
+          measurementStatus: hotspot.measurementStatus || "proxy",
+          analyticReadingNotVerdict: true,
+          noStructuralVerdictCreatedByViewer: true,
+          legacyStatusFieldRead: false,
+          projectionBoundary: "Perron-Frobenius hotspot is a secondary local deviation, not the scene center"
+        };
+        registerReadingBloom(peak, "spectrum_local_deviation_peak", 0.44);
+        activeSpectrumPeakObjects.push(peak);
+        edgeGroup.add(peak);
+      });
+      const ridgeVertices = [];
+      hotspots.forEach((hotspot) => {
+        const point = cellPositions.get(String(hotspot.cellRef || ""));
+        if (!point) return;
+        ridgeVertices.push(baseCenter.x, baseCenter.y + 0.8, baseCenter.z, point.x, point.y + 4, point.z);
+      });
+      addLineSegments(ridgeVertices, sceneColorHex("analytic_reading"), 0.34, "spectrumProxyRidge", {
+        modelRelativeProxy: true,
+        analyticReadingNotVerdict: true,
+        noStructuralVerdictCreatedByViewer: true
+      });
+      const note = createTextSprite("SAFE lawful plain remains central; spectrum peaks are proxy local deviations", "#e8f3ff", "rgba(14,35,58,0.74)");
+      note.position.copy(baseCenter).add(new THREE.Vector3(0, 32, 0));
+      note.userData = {
+        kind: "spectrumAnalyticBoundaryLabel",
+        analyticReadingNotVerdict: true,
+        noStructuralVerdictCreatedByViewer: true,
+        legacyStatusFieldRead: false
+      };
+      edgeGroup.add(note);
+      window.__archsigViewerSpectrumPeaks = stats;
+    }
+
+    function spectrumAxisPosition(center, axisRef, index, total, item) {
+      const hash = hashText(String(axisRef || index));
+      const ring = Math.floor(index / 8);
+      const slot = index % 8;
+      const angle = (slot / Math.max(Math.min(total, 8), 1)) * Math.PI * 2;
+      const radius = item?.plainRole === "lawful_plain_measured_zero" ? 14 + ring * 10 : 38 + ring * 12;
+      return new THREE.Vector3(
+        center.x + Math.cos(angle) * radius + ((hash % 7) - 3) * 0.18,
+        center.y + (item?.plainRole === "lawful_plain_measured_zero" ? 1.2 : 6),
+        center.z + Math.sin(angle) * radius + (((hash >> 4) % 7) - 3) * 0.18
+      );
+    }
+
+    function updateSpectrumPeakAnimation() {
+      const t = performance.now() * 0.001;
+      activeSpectrumPeakObjects.forEach((object, index) => {
+        const scale = 1 + Math.sin(t * 2.2 + index * 0.7) * 0.06;
+        object.scale.set(scale, 1 + (scale - 1) * 0.55, scale);
+      });
+    }
+
+    function spectrumNumber(value) {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : 0;
     }
 
     function renderAnalyticOverlays(scene, bundle, positions, encoding, limits = {}) {


### PR DESCRIPTION
## 概要

Closes #2309

PRD `docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md` の AC-V17 として、M10/M14 の spectrum proxy reading を Viewer の `spectrum` mode で AG-faithful に表示する。

- `aatGeometryOverlays.spectrumLandscape` / `gluingGeometry.spectrumLandscape` を追加
- `graph-laplacian-hodge-proxy@1` の `cells/cochain/spectralGap` と `curvature-transfer-perron-hotspot@1` の hotspots を投影
- `cv=0` cell を scene 中心の lawful plain として描画し、hotspot は副次的な local deviation peak として表示
- `axisRef-deterministic` 配置、`spectralRadiusNumeric` 数値化、analytic-reading-not-verdict boundary を固定
- legacy v0 status field を読まず、viewer は structural verdict を作らない

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] viewer module `node --check`
- [x] sheaf-laplacian spectrum preview
- [x] Playwright headless desktop/mobile visual check（`spectrum` mode、nonblank pixel check、`__archsigViewerSpectrumPeaks.status === "rendered"`）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
