### PR TITLE
H2 coherence projectionとanalytic lane境界を修正

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -4530,6 +4530,8 @@ fn gluing_geometry_projection_v1(
                 "missing packet coverNerveProjection; viewer does not infer cover triangles",
             )
         });
+    let cover_nerve_projection =
+        project_h2_coherence_to_cover_nerve(cover_nerve_projection, packet);
     let cover = normalized.covers.iter().find(|cover| {
         cover.normalized_cover_id == packet.profile.cover_ref
             || cover.source_cover_id == packet.profile.cover_ref
@@ -4607,7 +4609,7 @@ fn gluing_geometry_projection_v1(
         "schema": "archsig-viewer-gluing-geometry/v1",
         "sourcePacketRef": "archsig-measurement-packet.json",
         "sourceInsightReportRef": "archsig-insight-report.json",
-        "projectionBoundary": "This geometry translates measured packet and ArchMap cover support into viewer objects. It adds no structural verdict, H2 coherence claim, or monodromy verdict.",
+        "projectionBoundary": "This geometry translates measured packet and ArchMap cover support into viewer objects. It adds no structural verdict or monodromy verdict; H2 coherence color appears only when projected from ag.coherence-obstruction@1 packet verdicts.",
         "nerve": {
             "coverRef": packet.profile.cover_ref,
             "sourceRefs": cover_refs,
@@ -5337,7 +5339,7 @@ fn analytic_locus_field_rows(packet: &ArchSigMeasurementPacketV1) -> Vec<Value> 
                 "cellRef": string_field(transfer, "cell"),
                 "harmonicMass": round_f64(harmonic_mass),
                 "distanceToFlatness": round_f64(distance_to_flatness),
-                "colorRole": if curvature.abs() > 1.0e-9 { "analytic_reading" } else { "measured_zero" },
+                "colorRole": "analytic_reading",
                 "sourceReadingRef": reading.reading_id,
                 "source": "analytic reading curvatureTransferSpectrum support / mass"
             }));
@@ -10578,6 +10580,103 @@ fn cover_nerve_projection_v1(
         "faceSource": "selected cover triple-overlap sharedAtomRefs recorded in archsig-measurement-packet/v1; not inferred by the viewer",
         "h2CoherenceVisualized": false
     })
+}
+
+fn project_h2_coherence_to_cover_nerve(
+    mut cover_nerve_projection: Value,
+    packet: &ArchSigMeasurementPacketV1,
+) -> Value {
+    let Some(coherence_row) = packet
+        .structural_verdict
+        .iter()
+        .find(|row| row.evaluator == "ag.coherence-obstruction@1")
+    else {
+        return cover_nerve_projection;
+    };
+    if coherence_row.verdict != "measured_zero" && coherence_row.verdict != "measured_nonzero" {
+        return cover_nerve_projection;
+    }
+    let Some(coherence_invariant) = packet
+        .computed_invariants
+        .iter()
+        .find(|invariant| invariant["evaluator"] == "ag.coherence-obstruction@1")
+    else {
+        return cover_nerve_projection;
+    };
+
+    let structural_ref = structural_verdict_ref(coherence_row);
+    let representative_contexts = coherence_invariant["representative"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(context_key)
+        .collect::<BTreeSet<_>>();
+    let measured_faces = coherence_invariant["faces"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|face| {
+            let key = context_key(face)?;
+            let cochain_value = face["cochainValue"].as_u64().unwrap_or_default();
+            Some((key, cochain_value))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut visualized = false;
+    if let Some(faces) = cover_nerve_projection["faces"].as_array_mut() {
+        for face in faces {
+            let Some(key) = context_key(face) else {
+                continue;
+            };
+            if !measured_faces.contains_key(&key) {
+                continue;
+            }
+            let claim = if coherence_row.verdict == "measured_nonzero"
+                && representative_contexts.contains(&key)
+            {
+                "measured_nonzero"
+            } else {
+                "measured_zero"
+            };
+            if let Some(object) = face.as_object_mut() {
+                object.insert(
+                    "coherenceClaim".to_string(),
+                    Value::String(claim.to_string()),
+                );
+                object.insert("h2CoherenceVisualized".to_string(), Value::Bool(true));
+                object.insert(
+                    "structuralVerdictRef".to_string(),
+                    Value::String(structural_ref.clone()),
+                );
+                object.insert(
+                    "coherenceProjectionBoundary".to_string(),
+                    Value::String(
+                        "Projected from ag.coherence-obstruction@1; viewer adds no H2 verdict"
+                            .to_string(),
+                    ),
+                );
+            }
+            visualized = true;
+        }
+    }
+    if visualized {
+        cover_nerve_projection["h2CoherenceVisualized"] = Value::Bool(true);
+    }
+    cover_nerve_projection
+}
+
+fn context_key(value: &Value) -> Option<String> {
+    let mut contexts = value["contextRefs"]
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if contexts.is_empty() {
+        return None;
+    }
+    contexts.sort();
+    Some(contexts.join("|"))
 }
 
 fn empty_cover_nerve_projection_v1(cover_ref: &str, reason: &str) -> Value {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -2214,6 +2214,27 @@ fn cli_analyze_v2_coherence_obstruction_measures_h2_nonzero_with_representative(
                 && entry["status"] == "assumed"),
         "Leray comparison must stay assumed"
     );
+    let report = read_json(&out_dir.join("archsig-insight-report.json"));
+    assert_eq!(
+        report["gluingGeometry"]["nerve"]["h2CoherenceVisualized"], true,
+        "M5 H2 coherence verdict must be projected to the viewer nerve after it lands"
+    );
+    let h2_face = report["gluingGeometry"]["nerve"]["triangles"]
+        .as_array()
+        .expect("viewer nerve triangles are array")
+        .iter()
+        .find(|face| face["coherenceClaim"] == "measured_nonzero")
+        .expect("nonzero H2 representative face is projected");
+    assert!(
+        h2_face["structuralVerdictRef"]
+            .as_str()
+            .is_some_and(|value| value.contains("ag-coherence-obstruction-1")),
+        "H2 viewer projection must point back to the packet structural verdict"
+    );
+    assert_eq!(
+        h2_face["coherenceProjectionBoundary"],
+        "Projected from ag.coherence-obstruction@1; viewer adds no H2 verdict"
+    );
 
     let zero_cochain_dir = temp_dir("ag-measurement-coherence-h2-nonzero-zero-cochain");
     let zero_cochain_archmap_path = zero_cochain_dir.join("archmap_coherence_h2_zero_cochain.json");
@@ -5214,6 +5235,38 @@ fn cli_analyze_v2_sheaf_laplacian_near_flat_is_not_measured_zero() {
     let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
     assert_eq!(packet["structuralVerdict"][0]["verdict"], "unknown");
     assert_eq!(packet["structuralVerdict"][0]["verdictData"]["zero"], false);
+
+    let zero_out_dir = temp_dir("ag-measurement-sheaf-laplacian-exact-zero-color");
+    let mut zero_archmap = read_json(&root.join("archmap_v2_sheaf_laplacian.json"));
+    zero_archmap["atoms"][0]["object"] = Value::String("0".to_string());
+    zero_archmap["atoms"][1]["object"] = Value::String("0".to_string());
+    let zero_archmap_path = zero_out_dir.join("archmap_v2_sheaf_laplacian_exact_zero.json");
+    fs::write(
+        &zero_archmap_path,
+        serde_json::to_vec_pretty(&zero_archmap).expect("archmap serializes"),
+    )
+    .expect("archmap fixture can be written");
+    run_sig0(&[
+        "analyze",
+        "--archmap",
+        zero_archmap_path.to_str().expect("path is utf-8"),
+        "--law-policy",
+        root.join("law_policy_laplacian.json")
+            .to_str()
+            .expect("path is utf-8"),
+        "--out-dir",
+        zero_out_dir.to_str().expect("path is utf-8"),
+    ]);
+    let zero_report = read_json(&zero_out_dir.join("archsig-insight-report.json"));
+    assert!(
+        zero_report["gluingGeometry"]["locusField"]["fieldRows"]
+            .as_array()
+            .expect("fieldRows is array")
+            .iter()
+            .filter(|row| row["status"] == "analytic_reading")
+            .all(|row| row["colorRole"] == "analytic_reading"),
+        "exact-zero analytic curvature rows must stay in the analytic lane, not measured_zero"
+    );
 }
 
 #[test]
@@ -13783,7 +13836,7 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html.contains("alphaMap: silenceHatchAlphaMap")
             && html.contains("depthWrite: false")
             && html.contains("nerveTriangleSilenceGlass")
-            && html.contains("h2CoherenceVisualized: false")
+            && html.contains("H^2 coherence is not visualized by this viewer layer")
             && html.contains("blockedUnmeasuredRegion")
             && html.contains("redErrorEncodingRemoved: true"),
         "viewer V3 must render H2 and blocked silence as frosted non-verdict glass"
@@ -13842,15 +13895,16 @@ fn archsig_atom_viewer_static_app_is_packaged_asset() {
             && html
                 .contains("tagCohomologyLayer(tube, \"h1\", \"cocycleRibbon.supportEdges.value\")")
             && html.contains("tagCohomologyLayer(mesh, \"h2\", \"nerve.triangles\")")
-            && html.contains("h2CoherenceVisualized: false"),
-        "viewer V5 must place H0/H1/H2 geometry on degree bands without H2 verdict color"
+            && html.contains("createH2CoherenceMaterial")
+            && html.contains("nerveTriangleH2Coherence"),
+        "viewer V5 must place H0/H1/H2 geometry on degree bands and use M5 packet verdicts only after projection"
     );
     assert!(
         html.contains("THREE.MathUtils.lerp(0.4, 2.2")
             && html.contains("edge.value is mismatch parity, not continuous cohomology magnitude")
             && html.contains("registerMeasuredBloom(tube, \"headline_h1_cocycle_seam\"")
-            && !html.contains("registerMeasuredBloom(mesh, \"h2"),
-        "viewer V5 must size H1 ribbon by parity marker and keep bloom off H2 glass"
+            && html.contains("registerMeasuredBloom(mesh, \"h2_coherence_structural_verdict\""),
+        "viewer V5 must size H1 ribbon by parity marker and bloom H2 only when an M5 structural verdict is projected"
     );
     assert!(
         html.contains("createLocusFieldMembrane")

--- a/tools/archsig/viewer/archsig-atom-viewer.html
+++ b/tools/archsig/viewer/archsig-atom-viewer.html
@@ -1681,6 +1681,23 @@
       });
     }
 
+    function createH2CoherenceMaterial(claim) {
+      const measuredNonzero = claim === "measured_nonzero";
+      return new THREE.MeshPhysicalMaterial({
+        color: sceneColorHex(measuredNonzero ? "measured_nonzero" : "measured_zero"),
+        emissive: measuredNonzero ? 0x3b2507 : 0x063230,
+        emissiveIntensity: measuredNonzero ? 0.42 : 0.16,
+        transparent: true,
+        opacity: measuredNonzero ? 0.42 : 0.26,
+        roughness: 0.58,
+        metalness: 0.0,
+        transmission: measuredNonzero ? 0.08 : 0.22,
+        alphaMap: measuredNonzero ? null : silenceHatchAlphaMap,
+        depthWrite: false,
+        side: THREE.DoubleSide
+      });
+    }
+
     function biasObjectIntoSilenceDepth(object, amount, reason) {
       const direction = new THREE.Vector3();
       camera.getWorldDirection(direction);
@@ -2294,18 +2311,36 @@
         const geometry = new THREE.BufferGeometry();
         geometry.setAttribute("position", new THREE.Float32BufferAttribute(points.flatMap((p) => [p.x, p.y, p.z]), 3));
         geometry.computeVertexNormals();
-        const mesh = new THREE.Mesh(geometry, createSilenceGlassMaterial(0.12));
+        const h2Measured = triangle.h2CoherenceVisualized === true && Boolean(triangle.structuralVerdictRef);
+        const coherenceClaim = triangle.coherenceClaim || "not_visualized";
+        const mesh = new THREE.Mesh(
+          geometry,
+          h2Measured ? createH2CoherenceMaterial(coherenceClaim) : createSilenceGlassMaterial(0.12)
+        );
         mesh.userData = {
-          kind: "nerveTriangleSilenceGlass",
+          kind: h2Measured ? "nerveTriangleH2Coherence" : "nerveTriangleSilenceGlass",
           item: triangle,
-          coherenceClaim: triangle.coherenceClaim || "not_visualized",
-          h2CoherenceVisualized: false,
-          silenceBoundary: "H^2 coherence is not visualized by this viewer layer"
+          coherenceClaim,
+          h2CoherenceVisualized: h2Measured,
+          structuralVerdictRef: triangle.structuralVerdictRef || "",
+          projectionBoundary: triangle.coherenceProjectionBoundary || "H^2 coherence is not visualized by this viewer layer",
+          silenceBoundary: h2Measured ? "" : "H^2 coherence is not visualized by this viewer layer"
         };
         tagCohomologyLayer(mesh, "h2", "nerve.triangles");
-        biasObjectIntoSilenceDepth(mesh, 34, "coherenceClaim:not_visualized");
+        if (h2Measured) {
+          mesh.position.y += coherenceClaim === "measured_nonzero" ? 2.8 : -0.8;
+          if (coherenceClaim === "measured_nonzero") registerMeasuredBloom(mesh, "h2_coherence_structural_verdict", 0.48);
+        } else {
+          biasObjectIntoSilenceDepth(mesh, 34, "coherenceClaim:not_visualized");
+        }
         edgeGroup.add(mesh);
-        addTriangleOutline(points, "nerveTriangleSilenceOutline", 0x8a94a3, 0.34, "dashed_silence");
+        addTriangleOutline(
+          points,
+          h2Measured ? "nerveTriangleH2CoherenceOutline" : "nerveTriangleSilenceOutline",
+          h2Measured ? sceneColorHex(coherenceClaim === "measured_nonzero" ? "measured_nonzero" : "measured_zero") : 0x8a94a3,
+          h2Measured ? 0.58 : 0.34,
+          h2Measured ? "h2_structural_verdict_projection" : "dashed_silence"
+        );
         const marker = new THREE.Mesh(
           new THREE.SphereGeometry(2.8 + Math.min((triangle.sharedAtomRefs || []).length, 6) * 0.38, 18, 12),
           new THREE.MeshStandardMaterial({


### PR DESCRIPTION
## 概要

Closes #2317

PRD loop #2219 の completion review で残った H2 viewer 接続と analytic lane 色境界を修正します。

- `ag.coherence-obstruction@1` の measured H2 verdict が packet にある場合だけ、gluing geometry の nerve face へ `coherenceClaim` / `structuralVerdictRef` / projection boundary を投影
- viewer は投影済み H2 face を `nerveTriangleH2Coherence` として描き、viewer 自身は H2 verdict を作らない
- analytic curvature transfer の exact zero も `analytic_reading` 色に固定し、`measured_zero` へ昇格しない

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）
- [x] `/opt/homebrew/bin/node --experimental-vm-modules -e ...` による viewer module script 構文確認
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json --out-dir .tmp/archsig-final-review-analyze`

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
