### PR TITLE
ArchSig skillをAG測定フォーマットに更新

### DIFF
--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -1,24 +1,57 @@
 ---
 name: archmap-creater
-description: Create and validate ArchMap v1 Atom artifacts from repository evidence. Use when Codex is asked to draft, generate, update, or validate an archmap/v1 JSON file, prepare source-grounded atoms and molecules, or run ArchSig v1 analyze from code/docs/tests/traces.
+description: Create and validate ArchMap artifacts from repository evidence, especially AG measurement archmap/v2 finite-poset-site JSON. Use when Codex is asked to draft, generate, update, or validate an ArchMap, prepare source-grounded atoms, contexts, covers, extractionDoctrineRef, or run ArchSig analyze from code/docs/tests/traces.
 ---
 
 # ArchMap Creater
 
 ## Purpose
 
-Create `archmap/v1` as source-grounded Atom input for ArchSig.
+Create `archmap/v2` as the source-grounded finite-poset-site input for
+ArchSig AG measurement.
 
-ArchMap v1 has three primary surfaces:
+ArchMap v2 has five primary surfaces:
 
-- `sources`: source ledger for files, symbols, docs, tests, traces, and policy refs that were actually read.
-- `atoms`: primitive source-grounded Atom facts from those sources.
-- `molecules`: explicit local configurations that group existing atom ids.
+- `schema`: exactly `archmap/v2`.
+- `extractionDoctrineRef`: declared doctrine id, fingerprint, and AAT components
+  used for A8-relative determinism.
+- `sources`: source ledger for files, symbols, docs, tests, traces, and policy
+  refs that were actually read.
+- `atoms`: subject / axis-decorated primitive source-grounded Atom facts.
+- `contexts`: finite poset contexts, each with explicit atom membership and
+  optional `restrictsTo` edges.
+- `covers`: finite context families selected as cover candidates.
 
 ArchMap does not contain obstruction circuits, law violations, signature axes,
 distance results, risk findings, projection hints, concern hints, observation
 gap ledgers, Lean proof objects, or global architecture truth. ArchSig computes
-bounded diagnostics later from `ArchMap + LawPolicy + evaluator registry`.
+bounded diagnostics later from `ArchMap + LawPolicy + MeasurementProfile +
+evaluator registry`.
+
+Use `archmap/v1` only when the user explicitly targets the bounded legacy
+structural-analysis path. Do not migrate v2 contexts back into v1 molecules for
+AG measurement work.
+
+## Non-Negotiable Authoring Discipline
+
+Author ArchMap by reading and interpreting source evidence, not by generating a
+static-analysis dump.
+
+- Do not create final atoms with a repository-wide script, AST walker, import
+  graph dump, filename template, or "minimal JSON" boilerplate. Scripts may help
+  list candidate files or run validation, but the accepted atoms / contexts /
+  covers must come from manual source reading and semantic integration.
+- Do not stop at a minimal component/relation inventory when the requested scope
+  exposes capabilities, states, effects, authority, contracts, runtime traces,
+  or domain semantics. A component-only ArchMap is a draft unless the source
+  scope truly contains only component existence evidence.
+- Do not use ArchMap to smuggle evaluator outcomes. Diagnostic-shaped tokens
+  such as `mismatch`, `obstruction`, `violation`, `risk`, `debt`, `unsafe`,
+  `lawful`, `nonzero`, or `failure` are forbidden as shortcuts. Use them only
+  when the extraction doctrine / fixture vocabulary explicitly requires that
+  observed relation and the source refs support it directly.
+- Before delivery, run the self-review gate in `references/prompt-pack.md`.
+  If any gate fails, revise the ArchMap instead of explaining the failure away.
 
 ## Inputs
 
@@ -36,6 +69,22 @@ artifact ids.
 This skill must work with only this skill bundle and a built `archsig`
 executable. Do not require the ArchSig source checkout.
 
+## Extraction Doctrine Rules
+
+Every v2 ArchMap must include:
+
+```json
+"extractionDoctrineRef": {
+  "doctrineId": "doctrine:<scope>@1",
+  "fingerprint": "sha256:<stable-fingerprint-or-user-provided-id>",
+  "components": ["V", "Gamma", "R", "rho", "E", "N"]
+}
+```
+
+Use the actual project doctrine id and fingerprint when supplied. If no
+fingerprint source is available, ask or mark validation as not final; do not
+invent comparability between different doctrines.
+
 ## Atom Rules
 
 Write atoms directly. In the ArchSig context these are the atoms.
@@ -45,24 +94,33 @@ Allowed atom `kind` values:
 - `component`
 - `relation`
 - `capability`
-- `dataState`
+- `state`
 - `effect`
 - `authority`
 - `contract`
 - `semantic`
 - `runtime`
 
-Each atom must have:
+Each v2 atom must have:
 
 - `id`
 - `kind`
-- the constructor-specific fields required by the v1 schema
+- `subject`
+- `axis`
 - `refs` resolving to `sources` ids
+- optional `predicate`
+- optional `object`
 - optional `label` for human display only
 
 Do not use natural-language-only atoms. `predicate`, `effect`, `authority`,
 `contract`, `meaning`, and `interaction` are controlled predicate tokens for
 ArchSig normalization, not prose paragraphs. Use `label` for prose display.
+
+Semantic atoms require use-evidence. A `semantic` atom is valid only when it
+captures how a symbol / value / boundary is used in the repository: name the
+subject, choose a predicate token from observed usage, and cite the files,
+tests, docs, or traces where that use is enacted. Do not write dictionary
+glosses, vibes, design praise, or policy conclusions as `semantic`.
 
 Do not write removed v0 fields:
 
@@ -74,10 +132,24 @@ Do not write removed v0 fields:
 - `concernHints`
 - `observationGaps`
 - `nonConclusions` as a defensive prose ledger
+- `molecules` for AG measurement v2 primary input
 
 Missing evidence is handled by ArchSig as `blocked`, `unknown`, or
 `unmeasured` when a selected evaluator needs support that is not present. Do
 not encode missing evidence as measured absence.
+
+## Context And Cover Rules
+
+Contexts and covers are source-grounded observation structure.
+
+- A `context` has `id`, non-empty `atoms`, optional `restrictsTo`, `refs`, and
+  optional `label`.
+- `restrictsTo` edges must resolve to context ids, be irreflexive, and form an
+  acyclic finite poset.
+- A `cover` has `id`, non-empty `contexts`, `refs`, and optional `label`.
+- Contexts / covers do not declare coefficients, witness variables, verdict
+  predicates, U-adequacy, exactness, Leray assumptions, or repair semantics.
+  Those belong to `MeasurementProfile` and the assumption ledger.
 
 ## Authoring Workflow
 
@@ -88,19 +160,33 @@ not encode missing evidence as measured absence.
 2. Extract primitive atoms.
    - Split workflows, responsibilities, and policies into primitive facts.
    - Prefer small atoms with direct source refs.
-   - Use `semantic` only for a primitive source-supported meaning, not a whole workflow.
+   - Cover all observed atom kinds relevant to the scope; do not collapse
+     capability, state, effect, authority, contract, runtime, and semantic
+     evidence into coarse component / relation atoms.
+   - Use `semantic` only for a primitive source-supported meaning, not a whole
+     workflow. Extract it from use: how the term participates in commands,
+     tests, invariants, docs, status transitions, permissions, or runtime
+     traces.
 
-3. Add molecule membership.
-   - A molecule is a local configuration of existing atom ids.
-   - Do not invent molecule kind enums.
-   - Do not create reverse paths, squares, fillers, or risks in ArchMap.
+3. Add contexts and covers.
+   - Contexts are finite atom subfamilies with source refs.
+   - Use `restrictsTo` only for observed restriction direction.
+   - Covers are selected finite context families grounded in source refs.
+   - Do not create squares, fillers, obstruction classes, repairs, or risks in
+     ArchMap.
 
 4. Validate.
    - Run `archsig archmap --input <archmap.json> --out <archmap-validation.json>`.
-   - Unknown kind, unknown predicate, unresolved source refs, removed v0 fields, and legacy aliases must fail.
+   - Unknown kind, unresolved source refs, invalid context / cover refs,
+     removed v0 fields, and legacy aliases must fail.
+   - Predicate tokens are still an authoring discipline: prefer evaluator-known
+     tokens from fixtures or policy docs, but do not claim validation rejects
+     every unknown predicate unless the current tool report says so.
 
 5. Run ArchSig when LawPolicy is available.
    - Run `archsig analyze --archmap <archmap.json> --law-policy <law_policy.json> --out-dir <out>`.
+   - For AG evaluators, LawPolicy must include `measurementProfileRef` and a
+     matching `measurementProfiles[]` entry.
    - Use `--strict-distance` when blocked / unknown / unmeasured distance must fail the run.
    - Use `--emit-raw-artifacts` when packet / detail-index / LLM handoff artifacts are needed.
 
@@ -129,7 +215,7 @@ When delivering an ArchMap, include:
 1. ArchMap path
 2. source scope summary
 3. atoms grouped by kind
-4. molecule membership summary
+4. contexts and cover summary
 5. explicit notes for private / unavailable / out-of-scope evidence outside the primary JSON
 6. validation result
 7. optional analyze output directory and verdict
@@ -138,8 +224,8 @@ Use concise Japanese when working in this repository.
 
 ## References
 
-- `references/schema-cheatsheet.md`: v1 schema shape
+- `references/schema-cheatsheet.md`: v2 schema shape
 - `references/mapping-guide.md`: source cue to atom mapping
-- `references/examples.md`: v1 examples
+- `references/examples.md`: v2 examples
 - `references/repository-survey.md`: survey protocol
 - `references/prompt-pack.md`: prompt template

--- a/tools/archsig/skills/archmap-creater/agents/openai.yaml
+++ b/tools/archsig/skills/archmap-creater/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ArchMap Creater"
-  short_description: "Create and validate ArchMap artifacts"
-  default_prompt: "Use $archmap-creater to create an archmap/v1 artifact from repository evidence."
+  short_description: "Create ArchMap v2 AG input artifacts"
+  default_prompt: "Use $archmap-creater to create an archmap/v2 finite-poset-site artifact from repository evidence."

--- a/tools/archsig/skills/archmap-creater/references/examples.md
+++ b/tools/archsig/skills/archmap-creater/references/examples.md
@@ -1,13 +1,20 @@
-# ArchMap v1 Examples
+# ArchMap v2 Examples
 
 ## Minimal
 
 ```json
 {
-  "schema": "archmap/v1",
+  "schema": "archmap/v2",
   "id": "example-service",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:example-service@1",
+    "fingerprint": "sha256:example-service-doctrine",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
   "sources": {
     "src.order": { "kind": "file", "path": "src/order.rs" },
+    "src.inventory": { "kind": "file", "path": "src/inventory.rs" },
+    "src.cover": { "kind": "policy", "path": "docs/architecture.md", "section": "order-inventory cover" },
     "src.order.place_order": {
       "kind": "symbol",
       "source": "src.order",
@@ -30,6 +37,7 @@
       "id": "atom:place-order-capability",
       "kind": "capability",
       "subject": "domain.OrderService",
+      "axis": "static",
       "predicate": "placesOrder",
       "refs": ["src.order.place_order"],
       "label": "OrderService places an order"
@@ -38,18 +46,34 @@
       "id": "atom:inventory-check",
       "kind": "relation",
       "subject": "domain.OrderService",
+      "axis": "restriction",
       "predicate": "checksInventoryWith",
       "object": "domain.InventoryService",
       "refs": ["src.order.place_order"],
       "label": "OrderService checks inventory through InventoryService"
     }
   ],
-  "molecules": [
+  "contexts": [
     {
-      "id": "mol:place-order-flow",
+      "id": "ctx:order",
       "atoms": ["atom:place-order-capability", "atom:inventory-check"],
+      "restrictsTo": ["ctx:shared"],
       "refs": ["src.order.place_order"],
-      "label": "place_order local flow"
+      "label": "order context"
+    },
+    {
+      "id": "ctx:shared",
+      "atoms": ["atom:inventory-check"],
+      "refs": ["src.cover"],
+      "label": "shared order/inventory boundary"
+    }
+  ],
+  "covers": [
+    {
+      "id": "cover:order-inventory",
+      "contexts": ["ctx:order", "ctx:shared"],
+      "refs": ["src.cover"],
+      "label": "order/inventory cover"
     }
   ]
 }
@@ -59,16 +83,22 @@
 
 ```json
 {
-  "schema": "archmap/v1",
+  "schema": "archmap/v2",
   "id": "bad-map",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:bad@1",
+    "fingerprint": "sha256:bad",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
   "sources": {},
   "atoms": [],
-  "molecules": [],
+  "contexts": [],
+  "covers": [],
   "semanticObservations": []
 }
 ```
 
-Why bad: v1 does not accept removed v0 helper fields. Write a primitive
+Why bad: v2 does not accept removed v0 helper fields. Write a primitive
 `semantic` atom if a source-supported meaning is needed.
 
 ## Bad: Label-Only Atom
@@ -77,12 +107,85 @@ Why bad: v1 does not accept removed v0 helper fields. Write a primitive
 {
   "id": "atom:meaning",
   "kind": "semantic",
-  "diagram": "src.order.place_order",
+  "subject": "src.order.place_order",
+  "axis": "static",
   "refs": ["src.order.place_order"],
   "label": "This workflow is safe and follows SOLID"
 }
 ```
 
-Why bad: the machine-readable constructor-specific payload is missing, and the
-label makes a law-relative claim. Use `meaning` for a controlled semantic
-predicate token and leave lawfulness to ArchSig.
+Why bad: even if the JSON shape is structurally close, the only content is a
+law-relative prose label. Use `predicate` for a controlled semantic token and
+leave lawfulness to ArchSig.
+
+## Bad: Coarse Minimal Observation
+
+```json
+{
+  "id": "atom:order-service",
+  "kind": "component",
+  "subject": "domain.OrderService",
+  "axis": "static",
+  "predicate": "component",
+  "refs": ["src.order"]
+}
+```
+
+Why bad when used alone: if `src.order` also shows commands, state mutations,
+authority checks, contracts, or domain meanings, this atom is only one primitive
+observation. A final ArchMap that stops here is too coarse.
+
+## Good: Semantic From Use
+
+```json
+{
+  "id": "atom:reservation-hold-meaning",
+  "kind": "semantic",
+  "subject": "domain.ReservationStatus.Held",
+  "axis": "static",
+  "predicate": "preventsDoubleAllocation",
+  "refs": ["src.inventory.reserve", "test.inventory_prevents_double_allocation"],
+  "label": "Held reservations are treated as unavailable inventory in reserve and allocation tests"
+}
+```
+
+Why good: the meaning is not a dictionary gloss. It is grounded in how the
+status is used by code and tests.
+
+## Bad: Diagnostic Shortcut Atom
+
+```json
+{
+  "id": "atom:payment_inventory_mismatch",
+  "kind": "relation",
+  "subject": "ctx:payment",
+  "object": "ctx:inventory",
+  "axis": "cech",
+  "predicate": "mismatch",
+  "refs": ["src.payment", "src.inventory"]
+}
+```
+
+Why bad unless doctrine-approved: it names a diagnostic conclusion instead of a
+neutral observed relation. Prefer source-grounded relation / contract / state
+atoms and let the AG evaluator derive mismatch / obstruction readings.
+
+## Bad: Molecules In v2
+
+```json
+{
+  "schema": "archmap/v2",
+  "id": "bad-map",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:bad@1",
+    "fingerprint": "sha256:bad",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
+  "sources": {},
+  "atoms": [],
+  "molecules": []
+}
+```
+
+Why bad: AG measurement v2 primary input uses `contexts` and `covers`; v1
+`molecules` are not a primary v2 field.

--- a/tools/archsig/skills/archmap-creater/references/mapping-guide.md
+++ b/tools/archsig/skills/archmap-creater/references/mapping-guide.md
@@ -1,6 +1,7 @@
-# ArchMap v1 Mapping Guide
+# ArchMap v2 Mapping Guide
 
-ArchMap v1 records source-grounded atoms and explicit molecule membership.
+ArchMap v2 records source-grounded atoms, finite poset contexts, covers, and an
+extraction doctrine ref.
 ArchSig computes normalized predicates, evaluator results, distance diagnosis,
 and bounded conclusions later.
 
@@ -8,34 +9,88 @@ and bounded conclusions later.
 
 | Source cue | Atom kind | Payload |
 | --- | --- | --- |
-| file, module, class, service, package exists | `component` | `subject` |
-| call/import/dependency/ownership edge | `relation` | `subject`, `predicate`, `object` |
-| command, query, handler, port, adapter surface | `capability` | `subject`, `predicate` |
-| persisted state, table, field, cache, lifecycle state | `dataState` | `diagram`, `state` |
-| write, publish, enqueue, provider call, file mutation | `effect` | `diagram`, `effect` |
-| role gate, permission check, owner scope, visibility rule | `authority` | `subject`, `authority` |
-| precondition, postcondition, DTO shape, invariant, retry rule | `contract` | `diagram`, `contract` |
-| domain meaning, identity meaning, unit/status meaning | `semantic` | `diagram`, `meaning` |
-| supplied trace/log/runtime edge | `runtime` | `edge`, `interaction` |
+| file, module, class, service, package exists | `component` | `subject`, `axis: "static"` |
+| call/import/dependency/ownership edge | `relation` | `subject`, `object`, `predicate`, axis such as `restriction` |
+| command, query, handler, port, adapter surface | `capability` | `subject`, `predicate`, axis such as `static` |
+| persisted state, table, field, cache, lifecycle state | `state` | `subject`, `predicate`, axis such as `support` |
+| write, publish, enqueue, provider call, file mutation | `effect` | `subject`, `predicate`, optional `object` |
+| role gate, permission check, owner scope, visibility rule | `authority` | `subject`, `predicate` |
+| precondition, postcondition, DTO shape, invariant, retry rule | `contract` | `subject`, `predicate`, optional `object` |
+| domain meaning, identity meaning, unit/status meaning | `semantic` | `subject`, `predicate` |
+| supplied trace/log/runtime edge | `runtime` | `subject`, `predicate`, optional `object` |
 
 ## Boundary Rules
 
 - Static indexes and search results are navigation aids, not atoms.
 - Framework conventions become atoms only when the expanded source or generated artifact was inspected.
 - Workflows are discovered by reading source, then split into primitive atoms.
-- Responsibilities are molecules over atoms, not primitive atoms.
+- Responsibilities are contexts over atoms, not primitive atoms.
 - Policy/lawfulness is not written into ArchMap.
 - Missing evidence is not written as measured absence.
+- Generated import graphs, AST dumps, route lists, and symbol indexes are survey
+  aids only. They cannot be promoted wholesale into final atoms.
+- "Minimal" does not mean "coarse". If a source shows a command, state change,
+  authority check, contract, or domain meaning, preserve that primitive fact
+  instead of replacing it with a generic component or dependency atom.
 
-## Molecule Rules
+## Semantic Rules
 
-Create a molecule when the source shows a local configuration:
+Semantic atoms are late-Wittgensteinian use observations: record what a term,
+status, boundary, or value does in the repository's practice.
+
+Use a `semantic` atom when the evidence shows one of these:
+
+- a term's role in commands, tests, docs, or review rules
+- a status/value meaning through transitions, guards, or invariants
+- a domain identity that changes how code paths treat an object
+- a boundary vocabulary that controls allowed operations
+
+Do not use `semantic` for:
+
+- dictionary definitions detached from use
+- broad workflow summaries
+- "this is good/bad/lawful/unsafe" judgements
+- labels that merely restate file names or class names
+
+Every semantic atom should answer: "Which observed use makes this meaning true?"
+If that cannot be answered with refs, omit the semantic atom.
+
+## Diagnostic Token Rules
+
+Avoid diagnostic-shaped ids and predicates in authored atoms:
+
+- `*_mismatch`
+- `*_obstruction`
+- `*_violation`
+- `*_risk`
+- `*_debt`
+- `*_unsafe`
+- `*_lawful`
+- `*_nonzero`
+- `*_failure`
+
+Exception: use such a token only when the current extraction doctrine or an AG
+fixture vocabulary explicitly models it as an observed source relation, and the
+refs directly support that observation. Otherwise let ArchSig evaluators derive
+diagnostic readings from neutral atoms, contexts, covers, and LawPolicy.
+
+## Context Rules
+
+Create a context when the source shows a local finite observation region:
 
 - service method local flow
 - route / handler / service / repository interaction
 - provider mediation sequence
 - transaction boundary sequence
 - authority + state + effect local operation
+- shared boundary, adapter seam, policy surface, or selected cover patch
 
-The molecule contains atom ids only. It does not assert a square, filler,
-obstruction, homotopy, distance, risk, or repair.
+The context contains atom ids and source refs. `restrictsTo` records observed
+restriction direction between contexts. It does not assert a square, filler,
+obstruction, homotopy, distance, U-adequacy, risk, or repair.
+
+## Cover Rules
+
+Create a cover when a finite family of contexts is the source-grounded
+measurement surface for an AG profile. Covers name context ids only; they do
+not choose coefficients, witness variables, or verdict predicates.

--- a/tools/archsig/skills/archmap-creater/references/prompt-pack.md
+++ b/tools/archsig/skills/archmap-creater/references/prompt-pack.md
@@ -1,24 +1,44 @@
-# ArchMap v1 Prompt Pack
+# ArchMap v2 Prompt Pack
 
-Use this prompt when asking an LLM or sub-agent to author candidate ArchMap v1
+Use this prompt when asking an LLM or sub-agent to author candidate ArchMap v2
 evidence.
 
 ```text
-Create an archmap/v1 JSON artifact from the selected repository evidence.
+Create candidate evidence for an archmap/v2 JSON artifact from the selected repository evidence.
 
 Read only the supplied files, docs, tests, traces, and user-approved context.
 Record read evidence in sources. Write primitive architectural facts in atoms.
-Group local configurations in molecules.
+Group finite observation regions in contexts and selected finite families in covers.
+Include extractionDoctrineRef only when the supplied context gives the doctrine id
+and fingerprint; otherwise return a note asking the integrator to fill it.
+
+Do not create atoms mechanically from a script, AST dump, import graph, route list,
+or filename template. Use such outputs only as navigation aids. Final candidate
+atoms must come from reading the supplied evidence.
+
+Do not stop at coarse component/relation atoms when the evidence shows
+capabilities, states, effects, authority, contracts, runtime behavior, or domain
+semantic use. Split those into primitive atoms with direct refs.
+
+For semantic atoms, extract meaning from use. Include only meanings grounded in
+commands, tests, docs, invariants, transitions, permissions, or traces. Do not
+write dictionary glosses, vibes, or lawfulness conclusions.
 
 Do not output v0 fields: atomObservations, moleculeObservations,
 semanticObservations, projectionInfo, operationSquareEvidence, concernHints,
 observationGaps, confidence, uncertainty, or defensive nonConclusions.
+Do not output v1 molecules for archmap/v2.
 
 Do not write law violations, obstruction circuits, distance scores, risk
 claims, projection hints, proof objects, or global architecture truth.
+Do not invent diagnostic-shaped atom ids or predicates such as *_mismatch,
+*_obstruction, *_violation, *_risk, *_debt, *_unsafe, *_lawful, *_nonzero, or
+*_failure unless the supplied extraction doctrine explicitly defines that token
+as an observed source relation and the supplied evidence supports it directly.
 
-Every atom refs entry must resolve to sources. Every molecule atom entry must
-resolve to atoms. Labels are display text only.
+Every atom refs entry must resolve to sources. Every context atom entry must
+resolve to atoms. Every cover context entry must resolve to contexts. Labels are
+display text only.
 ```
 
 ## Candidate Packet For Parallel Survey
@@ -28,12 +48,37 @@ Sub-agents should return candidate packets, not final ArchMap JSON:
 ```json
 {
   "reviewedSources": [],
+  "candidateExtractionDoctrineRef": null,
   "candidateSources": {},
   "candidateAtoms": [],
-  "candidateMolecules": [],
+  "candidateContexts": [],
+  "candidateCovers": [],
   "privateUnavailableOrOutOfScopeNotes": [],
-  "integrationNotes": []
+  "integrationNotes": [],
+  "selfReview": {
+    "notScriptGenerated": true,
+    "notCoarseWhenEvidenceWasRicher": true,
+    "semanticAtomsHaveUseEvidence": true,
+    "noDiagnosticShortcutAtoms": true
+  }
 }
 ```
 
-The integrator decides what enters final `sources`, `atoms`, and `molecules`.
+The integrator decides what enters final `extractionDoctrineRef`, `sources`,
+`atoms`, `contexts`, and `covers`.
+
+## Self-Review Gate
+
+Before delivering final ArchMap JSON, answer these gates from the artifact and
+source notes:
+
+- `notScriptGenerated`: final atoms were selected by source reading, not by a
+  mechanical dump.
+- `notCoarseWhenEvidenceWasRicher`: all observed capabilities, states, effects,
+  authority, contracts, runtime behavior, and semantic use relevant to scope are
+  represented or explicitly out of scope.
+- `semanticAtomsHaveUseEvidence`: every semantic atom cites observed use.
+- `noDiagnosticShortcutAtoms`: ids / predicates do not encode evaluator
+  conclusions except doctrine-approved observed relations.
+
+Any `false` gate blocks delivery.

--- a/tools/archsig/skills/archmap-creater/references/repository-survey.md
+++ b/tools/archsig/skills/archmap-creater/references/repository-survey.md
@@ -1,7 +1,11 @@
-# Repository Survey For ArchMap v1
+# Repository Survey For ArchMap v2
 
 Use parallel survey only to collect candidate evidence. The final ArchMap is a
-single integrated `archmap/v1` artifact.
+single integrated `archmap/v2` artifact.
+
+Do not delegate ArchMap creation to a script. Mechanical inventories may guide
+the survey, but final atoms require source reading and author judgement about
+primitive observed facts.
 
 ## Recommended Surfaces
 
@@ -13,6 +17,9 @@ single integrated `archmap/v1` artifact.
 - authority and access control
 - contracts, tests, docs, and domain semantics
 - runtime traces when supplied
+- source-grounded context boundaries and restriction directions
+- finite cover candidates for AG measurement
+- project extraction doctrine id / fingerprint source when available
 
 ## Sub-Agent Output
 
@@ -21,17 +28,28 @@ Each sub-agent returns:
 - reviewed source refs
 - candidate `sources` entries
 - candidate atoms with direct refs
-- candidate molecule membership when local configuration is visible
+- candidate semantic atoms only when they include use-evidence
+- candidate contexts with atom membership and restriction direction
+- candidate covers with context membership
 - notes for private, unavailable, generated, framework-expanded, or out-of-scope evidence
 
 Sub-agents must not output obstruction, signature axes, distance, risk,
-projection hints, concern hints, or observation gaps as final ArchMap fields.
+projection hints, concern hints, observation gaps, or diagnostic-shaped shortcut
+atoms as final ArchMap fields.
 
 ## Integration Rules
 
-- Deduplicate atoms by kind, subject/diagram/edge, predicate payload, and refs.
+- Deduplicate atoms by kind, subject, axis, predicate/object payload, and refs.
 - Resolve every accepted atom `refs[]` entry into `sources`.
-- Resolve every molecule atom id into `atoms`.
-- Split coarse workflow or responsibility claims into primitive atoms plus molecule membership.
+- Resolve every context atom id into `atoms`.
+- Resolve every cover context id into `contexts`.
+- Split coarse workflow or responsibility claims into primitive atoms plus context membership.
+- Reject component-only / relation-only output when reviewed sources contain
+  capabilities, states, effects, authority, contracts, runtime traces, or
+  semantic use evidence.
+- Reject semantic atoms that do not explain the observed use that makes the
+  meaning true.
+- Reject diagnostic-shaped ids / predicates unless explicitly doctrine-approved
+  and source-supported.
 - Keep unavailable inventory in notes; do not encode it as measured absence.
 - Validate with `archsig archmap`.

--- a/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
+++ b/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
@@ -1,18 +1,33 @@
-# ArchMap v1 Schema Cheatsheet
+# ArchMap v2 Schema Cheatsheet
 
 ## Root
 
 ```json
 {
-  "schema": "archmap/v1",
+  "schema": "archmap/v2",
   "id": "project-or-scope-id",
+  "extractionDoctrineRef": {
+    "doctrineId": "doctrine:project@1",
+    "fingerprint": "sha256:project-doctrine",
+    "components": ["V", "Gamma", "R", "rho", "E", "N"]
+  },
   "sources": {},
   "atoms": [],
-  "molecules": []
+  "contexts": [],
+  "covers": []
 }
 ```
 
 Unknown root fields fail validation.
+
+## Extraction Doctrine
+
+`extractionDoctrineRef` is required for A8-relative determinism. Components
+must resolve the AAT atom vocabulary expected by ArchSig; the AG fixtures use
+`["V", "Gamma", "R", "rho", "E", "N"]`.
+
+The doctrine ref is a comparability boundary. Do not compare or merge ArchMaps
+with different doctrine fingerprints unless the tool explicitly accepts it.
 
 ## Sources
 
@@ -38,33 +53,58 @@ ArchMap JSON. Keep it in authoring notes or CI reports.
 
 ## Atoms
 
-| kind | Required fields |
-| --- | --- |
-| `component` | `subject` |
-| `relation` | `edge` or `subject`, `object`, `predicate` |
-| `capability` | `subject`, `predicate` |
-| `dataState` | `diagram`, `state` |
-| `effect` | `diagram`, `effect` |
-| `authority` | `subject`, `authority` |
-| `contract` | `diagram`, `contract` |
-| `semantic` | `diagram`, `meaning` |
-| `runtime` | `edge`, `interaction` |
+Every v2 atom has `id`, `kind`, `subject`, `axis`, and `refs`. It may also have
+`predicate`, `object`, and `label`.
+
+Common AG axes:
+
+- `static`
+- `restriction`
+- `cech`
+- `square-free`
+- `tor`
+- `support`
+- `cohomology`
+- `repair`
+- `conflict`
+- `laplacian`
+- `period`
+- `transfer`
+
+This is a practical fixture-aligned list, not a closed schema enum. Prefer
+existing fixture/evaluator axis tokens when authoring AG measurement inputs.
 
 All `refs` must resolve to `sources` ids.
 
-## Molecules
+## Contexts
 
 ```json
 {
-  "id": "mol:local-flow",
+  "id": "ctx:order",
   "atoms": ["atom:a", "atom:b"],
-  "refs": ["src.app.place_order"],
-  "label": "local flow"
+  "restrictsTo": ["ctx:shared"],
+  "refs": ["src.order"],
+  "label": "order context"
 }
 ```
 
-Molecules are explicit membership only. ArchMap does not store generated
-molecule proof, operation square evidence, obstruction, distance, or risk.
+Contexts form a finite poset over atom subfamilies. `restrictsTo` entries must
+resolve to contexts and must be acyclic.
+
+## Covers
+
+```json
+{
+  "id": "cover:order-inventory",
+  "contexts": ["ctx:order", "ctx:inventory", "ctx:shared"],
+  "refs": ["src.cover"],
+  "label": "order/inventory cover"
+}
+```
+
+Covers are observed finite context families. U-adequacy, coefficients, witness
+families, verdict predicates, exactness, and repair semantics are selected in
+MeasurementProfile, not in ArchMap.
 
 ## Removed v0 Fields
 
@@ -80,3 +120,4 @@ Do not emit:
 - `confidence`
 - `uncertainty`
 - `nonConclusions`
+- `molecules` in `archmap/v2`

--- a/tools/archsig/skills/law-policy-creater/SKILL.md
+++ b/tools/archsig/skills/law-policy-creater/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: law-policy-creater
-description: Create and validate ArchSig law-policy/v1 selector artifacts from repository architecture policies and user decisions. Use when Codex is asked to draft, update, or review a LawPolicy for ArchSig v1, select evaluator packs such as solid@1, or prepare a project-specific policy before running ArchMap through ArchSig.
+description: Create and validate ArchSig law-policy/v1 selector artifacts, including AG measurement MeasurementProfile v1 selection. Use when Codex is asked to draft, update, or review a LawPolicy, select evaluator packs such as solid@1, select AG evaluators such as ag.cech-obstruction@1, attach measurementProfileRef/measurementProfiles, or prepare a project-specific policy before running ArchMap through ArchSig.
 ---
 
 # LawPolicy Creater
 
 ## Purpose
 
-Create `law-policy/v1` as an evaluator selector for ArchSig.
+Create `law-policy/v1` as an evaluator selector for ArchSig. For the current
+AG measurement path, the same `law-policy/v1` document also carries
+`measurementProfileRef` and `measurementProfiles[]` to select
+`measurement-profile/v1`.
 
 LawPolicy v1 selects policies, evaluator ids, policy packs, basis refs, scope,
-and severity. It is not a DSL. It does not contain witness rules, signature
-axes, coverage requirements, exactness assumptions, distance formulas,
-`part4DistanceProfile`, spectrum profiles, or homotopy profiles. Those
-calculation rules belong to the ArchSig evaluator registry.
+severity, and optional first-class profile refs. It is not a DSL. It does not
+contain ad hoc witness rules, signature axes, coverage requirements, exactness
+assumptions, distance formulas, `part4DistanceProfile`, spectrum profiles, or
+homotopy profiles. Calculation rules belong to the ArchSig evaluator registry.
+AG measurement coordinates belong to `MeasurementProfile`, not to custom
+LawPolicy fields.
 
 Changing LawPolicy changes which evaluator manifests ArchSig runs. It does not
 prove architecture lawfulness, Atom truth, semantic correctness, zero
@@ -25,9 +30,13 @@ Collect:
 
 - target repository root and scope
 - intended LawPolicy path, usually `.archsig/<scope>/law_policy.json`
-- ArchMap v1 path if available
+- ArchMap v2 path if available for AG measurement, or ArchMap v1 path only for
+  the bounded legacy structural path
 - repository docs, coding standards, ADRs, review policy, or direct user decisions
 - whether the user wants a pack such as `solid@1` or individual evaluator ids
+- for AG measurement: ArchMap v2 cover id, coefficient, EffCoeff procedure,
+  witness family, resolution selector, domain, zero/nonzero/cert predicates,
+  and verdict discipline
 
 If no output path is supplied, prefer `.archsig/<scope>/law_policy.json`.
 
@@ -40,6 +49,10 @@ If no output path is supplied, prefer `.archsig/<scope>/law_policy.json`.
 2. Select policies.
    - Use a registry pack when the repo/user adopts a known family, for example `solid@1`.
    - Use individual `law` + `evaluator` entries for project-specific rules.
+   - For AG measurement, use explicit AG evaluator ids such as
+     `ag.cech-obstruction@1`, `ag.square-free-repair@1`,
+     `ag.law-conflict-tor@1`, `ag.sheaf-laplacian@1`,
+     `ag.period-stokes@1`, or `ag.support-transfer@1`.
    - Do not invent evaluator ids. Unknown evaluator ids fail validation.
 
 3. Attach basis refs.
@@ -52,7 +65,9 @@ If no output path is supplied, prefer `.archsig/<scope>/law_policy.json`.
 
 5. Validate.
    - Run `archsig law-policy --input <law_policy.json> --out <law-policy-validation.json>`.
-   - Unknown pack, unknown evaluator, unresolved basis, DSL fields, and legacy v0 fields must fail.
+   - Unknown pack, unknown evaluator, unresolved basis, unresolved
+     `measurementProfileRef`, missing AG profile, DSL fields, and legacy v0
+     fields must fail.
 
 6. Run ArchSig when ArchMap is available.
    - Run `archsig analyze --archmap <archmap.json> --law-policy <law_policy.json> --out-dir <out>`.
@@ -93,6 +108,53 @@ Individual evaluator selector:
 }
 ```
 
+AG measurement selector:
+
+```json
+{
+  "schema": "law-policy/v1",
+  "id": "ag-measurement-policy",
+  "measurementProfileRef": "profile:ag-default@1",
+  "measurementProfiles": [
+    {
+      "schema": "measurement-profile/v1",
+      "profileId": "profile:ag-default@1",
+      "siteRef": "archmap:/contexts",
+      "coverRef": "cover:<archmap-cover-id>",
+      "coefficient": "F2",
+      "effCoeff": "finite-linear-algebra@1",
+      "witnessFamily": [
+        {
+          "law": "ag.cech-obstruction",
+          "variable": "witness:<evaluator-specific-ref>"
+        }
+      ],
+      "resolutionSelector": "taylor@1",
+      "domain": "finite-poset-site",
+      "zeroPredicate": "rank-zero@1",
+      "nonZeroPredicate": "rank-positive@1",
+      "certSelector": "finite-certificate@1",
+      "verdictDiscipline": "five-valued-structural-verdict@1"
+    }
+  ],
+  "policies": [
+    {
+      "law": "ag.cech-obstruction",
+      "evaluator": "ag.cech-obstruction@1",
+      "basis": ["policy-basis:layering"],
+      "scope": ["src/"],
+      "severity": "high"
+    }
+  ]
+}
+```
+
+The runtime schema name is still `law-policy/v1`; AG measurement support is
+expressed by first-class profile fields rather than by a separate LawPolicy
+schema discriminator. Replace placeholder `coverRef` and `witnessFamily`
+values with refs selected from the actual ArchMap / profile decision before
+running `analyze`.
+
 ## Do Not Generate
 
 - `selectedLaws`
@@ -109,6 +171,9 @@ Individual evaluator selector:
 - `coverageRequirements`
 - `exactnessAssumptions`
 - arbitrary custom evaluator DSL fields
+- `measurementProfile` as a single object; use `measurementProfiles[]` plus
+  `measurementProfileRef`
+- theorem-candidate flags that create structural verdicts
 
 ## Commands
 
@@ -133,16 +198,17 @@ When delivering a LawPolicy, include:
 1. LawPolicy path
 2. source evidence or user decision used for each policy
 3. selected pack/evaluator ids
-4. basis refs
-5. scope and severity
-6. validation result
-7. optional analyze output directory and verdict
+4. measurement profile id and selected cover when AG evaluators are used
+5. basis refs
+6. scope and severity
+7. validation result
+8. optional analyze output directory and verdict
 
 Use concise Japanese when working in this repository.
 
 ## References
 
-- `references/schema-guide.md`: v1 selector schema
+- `references/schema-guide.md`: v1 selector schema and AG MeasurementProfile shape
 - `references/convention-survey.md`: finding policy evidence
 - `references/question-bank.md`: questions when policy evidence is missing
-- `references/starter_law_policy.json`: v1 starter template
+- `references/starter_law_policy.json`: AG starter template

--- a/tools/archsig/skills/law-policy-creater/agents/openai.yaml
+++ b/tools/archsig/skills/law-policy-creater/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LawPolicy Creater"
-  short_description: "Create ArchSig LawPolicy v1 selector artifacts"
-  default_prompt: "Use $law-policy-creater to derive a law-policy/v1 selector artifact from repository conventions, human intent, ArchMap evidence, and user decisions; validate the result."
+  short_description: "Create LawPolicy and AG profiles"
+  default_prompt: "Use $law-policy-creater to derive a law-policy/v1 artifact with MeasurementProfile v1 for AG measurement and validate the result."

--- a/tools/archsig/skills/law-policy-creater/references/convention-survey.md
+++ b/tools/archsig/skills/law-policy-creater/references/convention-survey.md
@@ -19,6 +19,8 @@ Then inspect likely config and architecture surfaces:
 - framework config and route/dependency declarations
 - security, tenancy, permissions, auth, transaction, provider, LLM, and runtime docs
 - tests that encode required behavior, when tests are in scope
+- ArchMap v2 covers and source-grounded context boundaries when an AG
+  measurement profile is requested
 
 ## Evidence Classification
 
@@ -33,11 +35,15 @@ Then inspect likely config and architecture surfaces:
 | --- | --- |
 | "Repository adopts SOLID" | `pack: "solid@1"`, `basis: ["policy-basis:solid"]` |
 | "Domain layer must not depend on infrastructure" | `law: "domain.no-direct-infra-dependency"`, `evaluator: "domain.no-direct-infra-dependency@1"`, `basis: ["policy-basis:layering"]` |
+| "Measure selected cover for Čech obstruction" | `law: "ag.cech-obstruction"`, `evaluator: "ag.cech-obstruction@1"`, plus `measurementProfileRef` |
+| "Measure square-free repair candidates" | `law: "ag.square-free-repair"`, `evaluator: "ag.square-free-repair@1"`, plus `measurementProfileRef` |
 | repeated but undocumented pattern | question to user, not policy yet |
 
 Do not translate evidence into witness rules, signature axes, coverage
 requirements, exactness assumptions, or distance profiles. Those are evaluator
-registry responsibilities in v1.
+registry responsibilities in v1. For AG, put selected cover, coefficient,
+witness family, resolution selector, predicates, certificate selector, and
+verdict discipline in `measurementProfiles[]`.
 
 ## Survey Output
 
@@ -46,5 +52,6 @@ Before drafting JSON, summarize:
 - docs and files read
 - candidate laws with evidence refs
 - candidate policy pack / evaluator selectors
+- candidate AG measurement profile fields, if applicable
 - decisions that need user confirmation
 - blind spots and excluded evidence

--- a/tools/archsig/skills/law-policy-creater/references/question-bank.md
+++ b/tools/archsig/skills/law-policy-creater/references/question-bank.md
@@ -13,6 +13,24 @@ Ask only what is needed to select evaluator manifests.
 - Does the repository explicitly adopt SOLID? If yes, use `pack: "solid@1"`.
 - Is domain-to-infrastructure dependency forbidden? If yes, use `domain.no-direct-infra-dependency@1`.
 - Are there project-specific policies that need a registry evaluator before they can be selected?
+- Is this an AG measurement run? If yes, which AG evaluator(s) should be
+  selected: Čech obstruction, square-free repair, law-conflict Tor, sheaf
+  Laplacian, period/Stokes, support transfer, or a newer registry evaluator?
+
+## AG MeasurementProfile
+
+- Which ArchMap v2 cover id should the profile measure?
+- Should `siteRef` be `archmap:/contexts` or a narrower context ref?
+- Which coefficient should be selected, such as `F2`, `Q`, or `R`?
+- Which EffCoeff procedure should be selected, usually `finite-linear-algebra@1`?
+- Which witness variables correspond to the selected law family?
+- Which resolution selector should be used, such as `taylor@1`?
+- Which domain and predicate selectors should be used? Algebraic structural
+  fixtures commonly use `finite-poset-site`, `rank-zero@1`,
+  `rank-positive@1`, `finite-certificate@1`, and
+  `five-valued-structural-verdict@1`; analytic fixtures such as Laplacian,
+  period, and transfer use `R`, `analytic-zero@1`,
+  `analytic-positive@1`, and `analytic-reading@1`.
 
 ## Basis
 
@@ -33,5 +51,6 @@ Do not ask users to hand-author:
 - exactness assumptions
 - distance formulas
 - spectrum or homotopy profiles
+- U-adequacy / Leray / theorem-hypothesis proofs
 
 If those are needed, the evaluator registry must grow first.

--- a/tools/archsig/skills/law-policy-creater/references/schema-guide.md
+++ b/tools/archsig/skills/law-policy-creater/references/schema-guide.md
@@ -1,6 +1,8 @@
 # LawPolicy v1 Schema Guide
 
-LawPolicy v1 is a selector over ArchSig evaluator registry entries.
+LawPolicy v1 is a selector over ArchSig evaluator registry entries. The AG
+measurement path also uses LawPolicy v1 to select a first-class
+MeasurementProfile.
 
 ## Root
 
@@ -53,11 +55,66 @@ Evaluator ids:
 - `solid.interface-segregation@1`
 - `solid.dependency-inversion@1`
 - `domain.no-direct-infra-dependency@1`
+- `ag.cech-obstruction@1`
+- `ag.coherence-obstruction@1`
+- `ag.restriction-compatibility@1`
+- `ag.section-factorization@1`
+- `ag.boundary-residue@1`
+- `ag.square-free-repair@1`
+- `ag.law-conflict-tor@1`
+- `ag.sheaf-laplacian@1`
+- `ag.period-stokes@1`
+- `ag.period-stokes-audit@1`
+- `ag.support-transfer@1`
 
 Basis refs:
 
 - `policy-basis:solid`
 - `policy-basis:layering`
+
+## MeasurementProfile v1
+
+AG evaluator selectors require `measurementProfileRef` resolving to
+`measurementProfiles[].profileId`.
+
+```json
+{
+  "schema": "measurement-profile/v1",
+  "profileId": "profile:ag-default@1",
+  "siteRef": "archmap:/contexts",
+  "coverRef": "cover:<archmap-cover-id>",
+  "coefficient": "F2",
+  "effCoeff": "finite-linear-algebra@1",
+  "witnessFamily": [
+    {
+      "law": "ag.cech-obstruction",
+      "variable": "witness:<evaluator-specific-ref>"
+    }
+  ],
+  "resolutionSelector": "taylor@1",
+  "domain": "finite-poset-site",
+  "zeroPredicate": "rank-zero@1",
+  "nonZeroPredicate": "rank-positive@1",
+  "certSelector": "finite-certificate@1",
+  "verdictDiscipline": "five-valued-structural-verdict@1"
+}
+```
+
+Rules:
+
+- `siteRef` normally points to `archmap:/contexts`.
+- `coverRef` must name a cover in the ArchMap v2 input; replace
+  `cover:<archmap-cover-id>` before running `analyze`.
+- `verdictDiscipline` must be `five-valued-structural-verdict@1`.
+- `witnessFamily[]` entries carry law ids and evaluator-specific witness refs,
+  such as square-free variables, cells, cycles, or support targets.
+- Algebraic structural profiles commonly use `F2`, `rank-zero@1`,
+  `rank-positive@1`, and `finite-certificate@1`; analytic profiles may use
+  `R`, `analytic-zero@1`, `analytic-positive@1`, and
+  `analytic-reading@1`.
+- The profile selects a bounded measurement regime; it does not prove
+  U-adequacy, exactness, Leray acyclicity, theorem hypotheses, or source
+  extraction soundness.
 
 ## Removed v0 Surfaces
 
@@ -75,6 +132,10 @@ Do not emit:
 - `homotopyMeasurementProfile`
 - `coverageRequirements`
 - `exactnessAssumptions`
+- `measurementProfile` as a root object
+- custom AG evaluator fields outside `measurementProfiles[]`
 
 ArchSig evaluator registry owns witness requirements, axes, missing blocker
-rules, distance contribution, and result status computation.
+rules, distance contribution, and result status computation. MeasurementProfile
+owns selected cover, coefficient, witness family, predicates, certificate
+selector, and verdict discipline for AG measurement.

--- a/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
+++ b/tools/archsig/skills/law-policy-creater/references/starter_law_policy.json
@@ -1,19 +1,36 @@
 {
   "schema": "law-policy/v1",
-  "id": "project-law-policy",
+  "id": "project-ag-law-policy",
+  "measurementProfileRef": "profile:ag-default@1",
+  "measurementProfiles": [
+    {
+      "schema": "measurement-profile/v1",
+      "profileId": "profile:ag-default@1",
+      "siteRef": "archmap:/contexts",
+      "coverRef": "cover:<archmap-cover-id>",
+      "coefficient": "F2",
+      "effCoeff": "finite-linear-algebra@1",
+      "witnessFamily": [
+        {
+          "law": "ag.cech-obstruction",
+          "variable": "witness:<evaluator-specific-ref>"
+        }
+      ],
+      "resolutionSelector": "taylor@1",
+      "domain": "finite-poset-site",
+      "zeroPredicate": "rank-zero@1",
+      "nonZeroPredicate": "rank-positive@1",
+      "certSelector": "finite-certificate@1",
+      "verdictDiscipline": "five-valued-structural-verdict@1"
+    }
+  ],
   "policies": [
     {
-      "pack": "solid@1",
-      "basis": ["policy-basis:solid"],
-      "scope": ["src."],
-      "severity": "review"
-    },
-    {
-      "law": "domain.no-direct-infra-dependency",
-      "evaluator": "domain.no-direct-infra-dependency@1",
+      "law": "ag.cech-obstruction",
+      "evaluator": "ag.cech-obstruction@1",
       "basis": ["policy-basis:layering"],
-      "scope": ["domain."],
-      "severity": "error"
+      "scope": ["src/"],
+      "severity": "high"
     }
   ]
 }


### PR DESCRIPTION
## 概要

ArchSig 用の `archmap-creater` / `law-policy-creater` skill を、現行の AG measurement workflow に合わせて更新する。

- `archmap-creater` を `archmap/v2` finite poset site、`extractionDoctrineRef`、`contexts` / `covers` 前提へ更新
- `law-policy-creater` を `law-policy/v1` + `measurementProfileRef` / `measurementProfiles[]` 前提へ更新
- 実務で出た再発防止として、粗い最小 atom 観測、script / AST dump 由来の機械生成、雑な `semantic`、診断 shortcut atom を skill 上で禁止
- self-review gate と bad / good examples を追加
- `archmap/v2` の atom kind を実装 vocabulary に合わせて `state` と案内
- starter LawPolicy の固定 cover / witness を placeholder 化

Issue 起点ではないため `Closes #N` はなし。

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/skills/archmap-creater/SKILL.md`
- `tools/archsig/skills/archmap-creater/references/*.md`
- `tools/archsig/skills/archmap-creater/agents/openai.yaml`
- `tools/archsig/skills/law-policy-creater/SKILL.md`
- `tools/archsig/skills/law-policy-creater/references/*.md`
- `tools/archsig/skills/law-policy-creater/references/starter_law_policy.json`
- `tools/archsig/skills/law-policy-creater/agents/openai.yaml`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（全体は未実施。下記 targeted tests を実施）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml archmap_v2`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml law_policy_v1`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- law-policy --input tools/archsig/skills/law-policy-creater/references/starter_law_policy.json --out .tmp/fix-review-starter-law-policy-validation.json`
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- archmap --input .tmp/fix-review-archmap-state.json --out .tmp/fix-review-archmap-state-validation.json`
- [x] Ruby YAML frontmatter check for both skills
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Issue 起点ではないため該当なし）
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
