### PR TITLE
ArchMap v2 doctrine を固定化する

### DIFF
--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -12,18 +12,19 @@ Current source-of-truth boundaries:
 
 - ArchMap v2 is the v0.4.0 AG measurement input contract. It records
   `sources`, subject / axis-decorated `atoms`, finite-poset `contexts`,
-  selected `covers`, and `extractionDoctrineRef`. `molecules` are not a v2
-  primary field; context membership replaces them for AG measurement.
+  and selected `covers`. The extraction doctrine is fixed by ArchSig as
+  `doctrine:aat-canonical@1`; `molecules` are not a v2 primary field, and
+  context membership replaces them for AG measurement.
 - `aat-atom-vocabulary/v1` is the artifact-side projection of allowed ArchMap
   atom kind tokens with provenance back to the AAT doctrine. ArchMap v2
-  validation checks that `extractionDoctrineRef.components` resolves the
-  vocabulary and that `atoms[].kind` is a member before measurement; the check
-  does not prove source extraction soundness, semantic correctness, or whether a
-  new atom kind should be added to the doctrine.
+  validation resolves this vocabulary from the fixed AAT canonical doctrine and
+  checks that `atoms[].kind` is a member before measurement; the check does not
+  prove source extraction soundness, semantic correctness, or whether a new atom
+  kind should be added to the doctrine.
 - 観測と判定の責務境界の理論的根拠は
   [ArchMap・LawPolicy・ArchSig 責務憲章](archmap_lawpolicy_archsig_responsibility_charter.md) を見る。
-  [ArchMap 観測純化 PRD](archmap_observation_purity_prd.md) は、上記の `extractionDoctrineRef` を
-  author 入力から固定定数へ格下げし、AG 入力から判定語(`mismatch` / `obstructionGenerator` /
+  [ArchMap 観測純化 PRD](archmap_observation_purity_prd.md) は、旧 `extractionDoctrineRef` を
+  author 入力ではなく固定定数として扱い、AG 入力から判定語(`mismatch` / `obstructionGenerator` /
   計算済み certificate)を排する改修を提案している。AAT 本文の A8 Essential Uniqueness 定理そのものは
   不変であり、tool 側の単一固定 doctrine 化はその一特殊化(compute 側の cross-doctrine 比較の退化)である。
 - MeasurementProfile v1 is the first-class selected measurement regime. It

--- a/docs/tool/guideline.md
+++ b/docs/tool/guideline.md
@@ -4,7 +4,7 @@
 
 ## 境界
 
-- ArchMap v2 は supplied `archmap/v2` evidence を読む source-grounded finite poset site map である。primary input は `sources` / `atoms`(subject / axis 必須) / `contexts` / `covers` / `extractionDoctrineRef` であり、`molecules` は primary field ではない。gap、projection info、concern hints、provenance、non-conclusions を primary schema に戻さない。
+- ArchMap v2 は supplied `archmap/v2` evidence を読む source-grounded finite poset site map である。primary input は `sources` / `atoms`(subject / axis 必須) / `contexts` / `covers` であり、extraction doctrine は ArchSig 側の固定 `doctrine:aat-canonical@1` として扱う。`molecules` は primary field ではない。gap、projection info、concern hints、provenance、non-conclusions を primary schema に戻さない。
 - 現行 AAT は Atom 公理系から architecture object を構成し、それを site / sheaf /
   law algebra / obstruction ideal / lawful locus へ持ち上げる代数幾何的アーキテクチャ論である。
   ArchMap / extractor は source code から Atom evidence や AAT measurement input を提示・検査する

--- a/tools/archsig/examples/practical-rust-service/archmap/archmap.json
+++ b/tools/archsig/examples/practical-rust-service/archmap/archmap.json
@@ -1,18 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "practical-rust-commerce-fulfillment-v2",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:aat-atom-vocabulary@1",
-    "fingerprint": "sha256:aat-atom-vocabulary-v1-practical-rust-commerce",
-    "components": [
-      "V",
-      "Gamma",
-      "R",
-      "rho",
-      "E",
-      "N"
-    ]
-  },
   "sources": {
     "src:domain": {
       "kind": "rust",

--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: archmap-creater
-description: Create and validate ArchMap artifacts from repository evidence, especially AG measurement archmap/v2 finite-poset-site JSON. Use when Codex is asked to draft, generate, update, or validate an ArchMap, prepare source-grounded atoms, contexts, covers, extractionDoctrineRef, or run ArchSig analyze from code/docs/tests/traces.
+description: Create and validate ArchMap artifacts from repository evidence, especially AG measurement archmap/v2 finite-poset-site JSON. Use when Codex is asked to draft, generate, update, or validate an ArchMap, prepare source-grounded atoms, contexts, covers, or run ArchSig analyze from code/docs/tests/traces.
 ---
 
 # ArchMap Creater
@@ -13,14 +13,16 @@ ArchSig AG measurement.
 ArchMap v2 has five primary surfaces:
 
 - `schema`: exactly `archmap/v2`.
-- `extractionDoctrineRef`: declared doctrine id, fingerprint, and AAT components
-  used for A8-relative determinism.
 - `sources`: source ledger for files, symbols, docs, tests, traces, and policy
   refs that were actually read.
 - `atoms`: subject / axis-decorated primitive source-grounded Atom facts.
 - `contexts`: finite poset contexts, each with explicit atom membership and
   optional `restrictsTo` edges.
 - `covers`: finite context families selected as cover candidates.
+
+The extraction doctrine is fixed by ArchSig as `doctrine:aat-canonical@1`.
+ArchMap authors do not choose, fingerprint, or extend a doctrine in the v2
+artifact.
 
 ArchMap does not contain obstruction circuits, law violations, signature axes,
 distance results, risk findings, projection hints, concern hints, observation
@@ -68,22 +70,6 @@ artifact ids.
 
 This skill must work with only this skill bundle and a built `archsig`
 executable. Do not require the ArchSig source checkout.
-
-## Extraction Doctrine Rules
-
-Every v2 ArchMap must include:
-
-```json
-"extractionDoctrineRef": {
-  "doctrineId": "doctrine:<scope>@1",
-  "fingerprint": "sha256:<stable-fingerprint-or-user-provided-id>",
-  "components": ["V", "Gamma", "R", "rho", "E", "N"]
-}
-```
-
-Use the actual project doctrine id and fingerprint when supplied. If no
-fingerprint source is available, ask or mark validation as not final; do not
-invent comparability between different doctrines.
 
 ## Atom Rules
 

--- a/tools/archsig/skills/archmap-creater/references/examples.md
+++ b/tools/archsig/skills/archmap-creater/references/examples.md
@@ -6,11 +6,6 @@
 {
   "schema": "archmap/v2",
   "id": "example-service",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:example-service@1",
-    "fingerprint": "sha256:example-service-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src.order": { "kind": "file", "path": "src/order.rs" },
     "src.inventory": { "kind": "file", "path": "src/inventory.rs" },
@@ -85,11 +80,6 @@
 {
   "schema": "archmap/v2",
   "id": "bad-map",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:bad@1",
-    "fingerprint": "sha256:bad",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {},
   "atoms": [],
   "contexts": [],
@@ -176,11 +166,6 @@ atoms and let the AG evaluator derive mismatch / obstruction readings.
 {
   "schema": "archmap/v2",
   "id": "bad-map",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:bad@1",
-    "fingerprint": "sha256:bad",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {},
   "atoms": [],
   "molecules": []

--- a/tools/archsig/skills/archmap-creater/references/prompt-pack.md
+++ b/tools/archsig/skills/archmap-creater/references/prompt-pack.md
@@ -9,8 +9,8 @@ Create candidate evidence for an archmap/v2 JSON artifact from the selected repo
 Read only the supplied files, docs, tests, traces, and user-approved context.
 Record read evidence in sources. Write primitive architectural facts in atoms.
 Group finite observation regions in contexts and selected finite families in covers.
-Include extractionDoctrineRef only when the supplied context gives the doctrine id
-and fingerprint; otherwise return a note asking the integrator to fill it.
+Do not include extractionDoctrineRef; ArchSig supplies the fixed
+doctrine:aat-canonical@1 contract during validation and normalization.
 
 Do not create atoms mechanically from a script, AST dump, import graph, route list,
 or filename template. Use such outputs only as navigation aids. Final candidate
@@ -48,7 +48,6 @@ Sub-agents should return candidate packets, not final ArchMap JSON:
 ```json
 {
   "reviewedSources": [],
-  "candidateExtractionDoctrineRef": null,
   "candidateSources": {},
   "candidateAtoms": [],
   "candidateContexts": [],
@@ -64,8 +63,8 @@ Sub-agents should return candidate packets, not final ArchMap JSON:
 }
 ```
 
-The integrator decides what enters final `extractionDoctrineRef`, `sources`,
-`atoms`, `contexts`, and `covers`.
+The integrator decides what enters final `sources`, `atoms`, `contexts`, and
+`covers`.
 
 ## Self-Review Gate
 

--- a/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
+++ b/tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md
@@ -6,11 +6,6 @@
 {
   "schema": "archmap/v2",
   "id": "project-or-scope-id",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:project@1",
-    "fingerprint": "sha256:project-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {},
   "atoms": [],
   "contexts": [],
@@ -20,14 +15,11 @@
 
 Unknown root fields fail validation.
 
-## Extraction Doctrine
+## Fixed Doctrine
 
-`extractionDoctrineRef` is required for A8-relative determinism. Components
-must resolve the AAT atom vocabulary expected by ArchSig; the AG fixtures use
-`["V", "Gamma", "R", "rho", "E", "N"]`.
-
-The doctrine ref is a comparability boundary. Do not compare or merge ArchMaps
-with different doctrine fingerprints unless the tool explicitly accepts it.
+ArchMap v2 authors do not write `extractionDoctrineRef`. ArchSig supplies the
+fixed `doctrine:aat-canonical@1` contract and validates atom kind membership
+against its AAT vocabulary projection.
 
 ## Sources
 

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -11726,8 +11726,9 @@ mod tests {
             "sourceArchmapRef": "archmap:test",
             "sourceArchmapId": "archmap:test",
             "extractionDoctrineRef": {
-                "doctrineId": "doctrine:test",
-                "fingerprint": "sha256:test"
+                "doctrineId": "doctrine:aat-canonical@1",
+                "fingerprint": "sha256:aat-canonical-doctrine-v1",
+                "components": ["V", "Gamma", "R", "rho", "E", "N"]
             },
             "atoms": [
                 {
@@ -11805,7 +11806,7 @@ mod tests {
                 "normalizedAtomCount": 3,
                 "contextCount": 3,
                 "coverCount": 1,
-                "doctrineFingerprint": "sha256:test"
+                "doctrineFingerprint": "sha256:aat-canonical-doctrine-v1"
             },
             "nonConclusions": []
         }))

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -9,7 +9,7 @@ use crate::{
     ArchMapLeanPreservationVocabularyEntry, ArchMapSourceInventoryV0, ArchMapSourceRef,
     ArchMapValidationReportV0, ArchMapValidationReportV1, ArchMapValidationReportV2,
     ArchMapValidationSummary, ArchMapValidationSummaryV1, ArchMapValidationSummaryV2,
-    ValidationCheck, ValidationExample,
+    ValidationCheck, ValidationExample, canonical_archmap_extraction_doctrine_ref_v2,
 };
 
 pub struct ArchMapSourceInventoryInput<'a> {
@@ -22,19 +22,24 @@ pub fn compare_archmap_v2_doctrine(
     left: &ArchMapDocumentV2,
     right: &ArchMapDocumentV2,
 ) -> serde_json::Value {
-    if left.extraction_doctrine_ref.fingerprint == right.extraction_doctrine_ref.fingerprint {
+    let canonical = canonical_archmap_extraction_doctrine_ref_v2();
+    let left_is_canonical = left.extraction_doctrine_ref == canonical;
+    let right_is_canonical = right.extraction_doctrine_ref == canonical;
+    if left_is_canonical && right_is_canonical {
         serde_json::json!({
             "status": "comparable",
-            "reason": "same_doctrine",
+            "reason": "fixed_tool_doctrine",
             "leftDoctrine": left.extraction_doctrine_ref.doctrine_id,
             "rightDoctrine": right.extraction_doctrine_ref.doctrine_id
         })
     } else {
         serde_json::json!({
             "status": "not_comparable",
-            "reason": "cross_doctrine_not_comparable",
+            "reason": "invalid_fixed_doctrine",
             "leftDoctrine": left.extraction_doctrine_ref.doctrine_id,
-            "rightDoctrine": right.extraction_doctrine_ref.doctrine_id
+            "rightDoctrine": right.extraction_doctrine_ref.doctrine_id,
+            "leftCanonical": left_is_canonical,
+            "rightCanonical": right_is_canonical
         })
     }
 }
@@ -136,34 +141,32 @@ fn check_archmap_v2_schema(schema: &str) -> ValidationCheck {
 }
 
 fn check_archmap_v2_doctrine(document: &ArchMapDocumentV2) -> ValidationCheck {
+    let canonical = canonical_archmap_extraction_doctrine_ref_v2();
     let mut examples = Vec::new();
-    if document
-        .extraction_doctrine_ref
-        .doctrine_id
-        .trim()
-        .is_empty()
-    {
+    if document.extraction_doctrine_ref.doctrine_id != canonical.doctrine_id {
         examples.push(generic_validation_example(
             "extractionDoctrineRef.doctrineId",
-            "empty",
-            "doctrine id must be non-empty",
+            &document.extraction_doctrine_ref.doctrine_id,
+            "ArchMap v2 uses the fixed AAT canonical doctrine",
         ));
     }
-    if document
-        .extraction_doctrine_ref
-        .fingerprint
-        .trim()
-        .is_empty()
-    {
+    if document.extraction_doctrine_ref.fingerprint != canonical.fingerprint {
         examples.push(generic_validation_example(
             "extractionDoctrineRef.fingerprint",
-            "empty",
-            "doctrine fingerprint must be non-empty",
+            &document.extraction_doctrine_ref.fingerprint,
+            "ArchMap v2 uses the fixed AAT canonical doctrine fingerprint",
+        ));
+    }
+    if document.extraction_doctrine_ref.components != canonical.components {
+        examples.push(generic_validation_example(
+            "extractionDoctrineRef.components",
+            &document.extraction_doctrine_ref.components.join(","),
+            "ArchMap v2 uses the fixed AAT canonical doctrine components",
         ));
     }
     check_from_examples(
         "archmap-v2-extraction-doctrine-ref",
-        "ArchMap v2 declares the extraction doctrine fingerprint used for A8-relative determinism",
+        "ArchMap v2 uses the fixed AAT canonical doctrine; authors do not select doctrine",
         examples,
     )
 }
@@ -230,8 +233,8 @@ fn check_archmap_v2_atom_ids(document: &ArchMapDocumentV2) -> ValidationCheck {
 fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> ValidationCheck {
     let vocabulary = static_aat_atom_vocabulary_v1();
     let vocabulary_ref = vocabulary.vocabulary_id.as_str();
-    let declared_components = document
-        .extraction_doctrine_ref
+    let canonical_doctrine = canonical_archmap_extraction_doctrine_ref_v2();
+    let canonical_components = canonical_doctrine
         .components
         .iter()
         .map(String::as_str)
@@ -239,7 +242,7 @@ fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> Valida
     let missing_components = vocabulary
         .required_doctrine_components
         .iter()
-        .filter(|component| !declared_components.contains(component.as_str()))
+        .filter(|component| !canonical_components.contains(component.as_str()))
         .cloned()
         .collect::<Vec<_>>();
     let allowed = vocabulary
@@ -255,12 +258,12 @@ fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> Valida
     let mut examples = Vec::new();
     if !missing_components.is_empty() {
         examples.push(ValidationExample {
-            component_id: Some("extractionDoctrineRef.components".to_string()),
-            path: Some("extractionDoctrineRef.components".to_string()),
-            source: Some(document.extraction_doctrine_ref.components.join(",")),
+            component_id: Some("fixedAatCanonicalDoctrine.components".to_string()),
+            path: Some("fixedAatCanonicalDoctrine.components".to_string()),
+            source: Some(canonical_doctrine.components.join(",")),
             target: Some(vocabulary_ref.to_string()),
             evidence: Some(format!(
-                "extraction doctrine does not resolve required AAT atom vocabulary components: {}",
+                "fixed AAT canonical doctrine does not resolve required atom vocabulary components: {}",
                 missing_components.join(",")
             )),
         });
@@ -285,11 +288,11 @@ fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> Valida
                     .to_string()
             }
             (true, false) => {
-                "extraction doctrine does not resolve the declared AAT atom vocabulary"
+                "fixed AAT canonical doctrine does not resolve the declared atom vocabulary"
                     .to_string()
             }
             (false, false) => {
-                "declared AAT atom vocabulary does not contain one or more atom kind tokens and the extraction doctrine does not resolve the vocabulary"
+                "declared AAT atom vocabulary does not contain one or more atom kind tokens and the fixed AAT canonical doctrine does not resolve the vocabulary"
                     .to_string()
             }
             (true, true) => unreachable!("failed vocabulary check must have examples"),
@@ -1809,10 +1812,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(vocabulary.schema, AAT_ATOM_VOCABULARY_V1_SCHEMA);
-        assert_eq!(
-            vocabulary.doctrine_ref,
-            "aat-theory:atom-vocabulary"
-        );
+        assert_eq!(vocabulary.doctrine_ref, "aat-theory:atom-vocabulary");
         assert_eq!(actual_kinds, expected_kinds);
         assert_eq!(
             vocabulary.required_doctrine_components,
@@ -1820,8 +1820,7 @@ mod tests {
         );
         assert!(vocabulary.entries.iter().all(|entry| {
             entry.doctrine_ref == "aat-theory:atom-vocabulary"
-                && entry.provenance_ref
-                    == "aat-theory:atom-vocabulary"
+                && entry.provenance_ref == "aat-theory:atom-vocabulary"
         }));
         assert!(
             vocabulary

--- a/tools/archsig/src/schema/archmap.rs
+++ b/tools/archsig/src/schema/archmap.rs
@@ -22,6 +22,7 @@ pub struct ArchMapDocumentV1 {
 pub struct ArchMapDocumentV2 {
     pub schema: String,
     pub id: String,
+    #[serde(default = "canonical_archmap_extraction_doctrine_ref_v2")]
     pub extraction_doctrine_ref: ArchMapExtractionDoctrineRefV2,
     #[serde(default)]
     pub sources: BTreeMap<String, ArchMapSourceV1>,
@@ -40,6 +41,17 @@ pub struct ArchMapExtractionDoctrineRefV2 {
     pub fingerprint: String,
     #[serde(default)]
     pub components: Vec<String>,
+}
+
+pub fn canonical_archmap_extraction_doctrine_ref_v2() -> ArchMapExtractionDoctrineRefV2 {
+    ArchMapExtractionDoctrineRefV2 {
+        doctrine_id: "doctrine:aat-canonical@1".to_string(),
+        fingerprint: "sha256:aat-canonical-doctrine-v1".to_string(),
+        components: ["V", "Gamma", "R", "rho", "E", "N"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -68,7 +68,7 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "primary",
                 "ArchSig v0.4.0 Algebraic Geometry Measurement",
                 vec!["archsig-contract:v0.4.0-improvement"],
-                "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from extractionDoctrineRef components before checking atoms[].kind membership.",
+                "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from the fixed AAT canonical doctrine before checking atoms[].kind membership.",
                 vec![
                     "Vocabulary lint checks token membership only; it does not prove source extraction soundness or semantic correctness.",
                     "The linter does not decide whether a new atom kind should be added to the doctrine.",
@@ -81,7 +81,7 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "primary",
                 "ArchSig v0.4.0 Algebraic Geometry Measurement",
                 vec!["archsig-contract:v0.4.0-ag-measurement"],
-                "ArchMap v2 records sources, subject/axis-decorated atoms, finite context posets, covers, and extractionDoctrineRef. Molecules are not a primary v2 field.",
+                "ArchMap v2 records sources, subject/axis-decorated atoms, finite context posets, and covers. The extraction doctrine is fixed by ArchSig as doctrine:aat-canonical@1; molecules are not a primary v2 field.",
                 vec![
                     "ArchMap v2 validation does not prove source extraction soundness, U-adequacy, exactness, Lean theorem discharge, or architecture lawfulness.",
                     "Contexts and covers are observation structure; measurement choices live in MeasurementProfile.",
@@ -178,10 +178,10 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "primary",
                 "ArchSig v0.4.0 Algebraic Geometry Measurement",
                 vec!["archsig-contract:v0.4.0-ag-measurement"],
-                "Normalized ArchMap v2 is the deterministic finite-poset-site presentation produced from ArchMap v2 under a declared extraction doctrine fingerprint.",
+                "Normalized ArchMap v2 is the deterministic finite-poset-site presentation produced from ArchMap v2 under the fixed AAT canonical doctrine fingerprint.",
                 vec![
                     "Normalized ArchMap v2 does not prove source extraction soundness.",
-                    "A8 determinism is relative to the declared extraction doctrine fingerprint.",
+                    "A8 determinism is relative to the fixed tool doctrine fingerprint.",
                 ],
             ),
             artifact(

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -211,12 +211,16 @@ fn cli_accepts_archmap_v2_state_atom_kind_from_aat_vocabulary() {
 }
 
 #[test]
-fn cli_rejects_archmap_v2_atom_vocabulary_unresolved_by_doctrine_components() {
-    let out_dir = temp_dir("archmap-v2-atom-kind-vocabulary-doctrine");
+fn cli_rejects_archmap_v2_custom_extraction_doctrine() {
+    let out_dir = temp_dir("archmap-v2-custom-extraction-doctrine");
     let root = ag_measurement_root();
     let mut archmap = read_json(&root.join("archmap_v2.json"));
-    archmap["extractionDoctrineRef"]["components"] = json!(["custom"]);
-    let archmap_path = out_dir.join("archmap_v2_unresolved_atom_vocabulary.json");
+    archmap["extractionDoctrineRef"] = json!({
+        "doctrineId": "doctrine:custom@1",
+        "fingerprint": "sha256:custom",
+        "components": ["custom"]
+    });
+    let archmap_path = out_dir.join("archmap_v2_custom_extraction_doctrine.json");
     fs::write(
         &archmap_path,
         serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
@@ -241,28 +245,20 @@ fn cli_rejects_archmap_v2_atom_vocabulary_unresolved_by_doctrine_components() {
         .as_array()
         .unwrap()
         .iter()
-        .find(|check| check["id"] == "archmap-v2-atom-kind-vocabulary")
-        .expect("atom vocabulary check is present");
+        .find(|check| check["id"] == "archmap-v2-extraction-doctrine-ref")
+        .expect("fixed doctrine check is present");
     assert_eq!(check["result"], "fail");
     assert_eq!(
-        check["reason"],
-        "extraction doctrine does not resolve the declared AAT atom vocabulary"
+        check["title"],
+        "ArchMap v2 uses the fixed AAT canonical doctrine; authors do not select doctrine"
     );
     let example = &check["examples"][0];
-    assert_eq!(example["componentId"], "extractionDoctrineRef.components");
-    assert_eq!(example["path"], "extractionDoctrineRef.components");
-    assert_eq!(example["source"], "custom");
-    assert_eq!(example["target"], "aat-atom-vocabulary:ag-archmap@1");
-    assert!(example["evidence"].as_str().is_some_and(|evidence| {
-        evidence.contains(
-            "extraction doctrine does not resolve required AAT atom vocabulary components",
-        ) && evidence.contains("Gamma")
-            && evidence.contains("rho")
-    }));
-    let reason = check["reason"].as_str().expect("reason is text");
-    assert!(!reason.contains("should"));
-    assert!(!reason.contains("semantic correctness"));
-
+    assert_eq!(example["source"], "extractionDoctrineRef.doctrineId");
+    assert_eq!(example["target"], "doctrine:custom@1");
+    assert_eq!(
+        example["evidence"],
+        "ArchMap v2 uses the fixed AAT canonical doctrine"
+    );
     let analyze_out = temp_dir("archmap-v2-atom-kind-vocabulary-doctrine-analyze");
     let output = run_sig0_output(&[
         "analyze",
@@ -278,7 +274,7 @@ fn cli_rejects_archmap_v2_atom_vocabulary_unresolved_by_doctrine_components() {
     assert_eq!(
         output.status.code(),
         Some(1),
-        "analyze must fail closed before measurement when doctrine components do not resolve vocabulary\nstdout:\n{}\nstderr:\n{}",
+        "analyze must fail closed before measurement when ArchMap v2 declares a custom doctrine\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -343,7 +339,7 @@ fn cli_analyze_v2_writes_measurement_packet_foundation() {
     assert_eq!(normalized["schema"], "normalized-archmap/v2");
     assert_eq!(
         normalized["summary"]["doctrineFingerprint"],
-        "sha256:ag-fixture-doctrine"
+        "sha256:aat-canonical-doctrine-v1"
     );
 
     let packet = read_json(&out_dir.join("archsig-measurement-packet.json"));
@@ -825,7 +821,7 @@ fn cli_analyze_v2_cech_h1_visible_fixture_measures_nonzero() {
                 "atomCount": 5,
                 "contextCount": 4,
                 "coverCount": 1,
-                "doctrineFingerprint": "sha256:ag-fixture-doctrine",
+                "doctrineFingerprint": "sha256:aat-canonical-doctrine-v1",
                 "invariantId": "finite-poset-site-shape"
             },
             {
@@ -7205,19 +7201,38 @@ fn archmap_v2_normalize_is_byte_deterministic() {
 }
 
 #[test]
-fn archmap_v2_cross_doctrine_comparison_is_not_comparable() {
+fn archmap_v2_cross_doctrine_comparison_degenerates_to_comparable() {
+    let root = ag_measurement_root();
+    let left_value = read_json(&root.join("archmap_v2.json"));
+    let right_value = left_value.clone();
+    let left: ArchMapDocumentV2 = serde_json::from_value(left_value).expect("left archmap parses");
+    let right: ArchMapDocumentV2 =
+        serde_json::from_value(right_value).expect("right archmap parses");
+
+    let result = compare_archmap_v2_doctrine(&left, &right);
+    assert_eq!(result["status"], "comparable");
+    assert_eq!(result["reason"], "fixed_tool_doctrine");
+}
+
+#[test]
+fn archmap_v2_cross_doctrine_comparison_rejects_noncanonical_input() {
     let root = ag_measurement_root();
     let left_value = read_json(&root.join("archmap_v2.json"));
     let mut right_value = left_value.clone();
-    right_value["extractionDoctrineRef"]["fingerprint"] =
-        Value::String("sha256:other-doctrine".to_string());
+    right_value["extractionDoctrineRef"] = json!({
+        "doctrineId": "doctrine:custom@1",
+        "fingerprint": "sha256:other-doctrine",
+        "components": ["custom"]
+    });
     let left: ArchMapDocumentV2 = serde_json::from_value(left_value).expect("left archmap parses");
     let right: ArchMapDocumentV2 =
         serde_json::from_value(right_value).expect("right archmap parses");
 
     let result = compare_archmap_v2_doctrine(&left, &right);
     assert_eq!(result["status"], "not_comparable");
-    assert_eq!(result["reason"], "cross_doctrine_not_comparable");
+    assert_eq!(result["reason"], "invalid_fixed_doctrine");
+    assert_eq!(result["leftCanonical"], true);
+    assert_eq!(result["rightCanonical"], false);
 }
 
 #[test]
@@ -13687,7 +13702,7 @@ fn cli_schema_catalog_is_primary_archsig_surface_only() {
                     .is_some_and(|description| {
                         description.contains("artifact-side projection")
                             && description.contains("allowed ArchMap atom kind tokens")
-                            && description.contains("extractionDoctrineRef components")
+                            && description.contains("fixed AAT canonical doctrine")
                     })
                 && entry["compatibilityBoundary"]["nonConclusions"]
                     .as_array()
@@ -14827,11 +14842,6 @@ fn restriction_archmap(case: &str) -> Value {
     json!({
         "schema": "archmap/v2",
         "id": format!("ag-restriction-fixture-{case}"),
-        "extractionDoctrineRef": {
-            "doctrineId": "doctrine:ag-fixture@1",
-            "fingerprint": "sha256:ag-restriction-fixture",
-            "components": ["V", "Gamma", "R", "rho", "E", "N"]
-        },
         "sources": {
             "src:source": {"kind": "rust", "path": "src/source.rs", "symbol": "Source", "line": 1},
             "src:target": {"kind": "rust", "path": "src/target.rs", "symbol": "Target", "line": 1},
@@ -15036,11 +15046,6 @@ fn boundary_residue_archmap(case: &str) -> Value {
     json!({
         "schema": "archmap/v2",
         "id": format!("ag-boundary-residue-fixture-{case}"),
-        "extractionDoctrineRef": {
-            "doctrineId": "doctrine:ag-fixture@1",
-            "fingerprint": "sha256:ag-boundary-residue-fixture",
-            "components": ["V", "Gamma", "R", "rho", "E", "N"]
-        },
         "sources": {
             "src:core": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 core patch"},
             "src:feature": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 feature patch"},
@@ -15144,11 +15149,6 @@ fn section_archmap(case: &str) -> Value {
     json!({
         "schema": "archmap/v2",
         "id": format!("ag-section-fixture-{case}"),
-        "extractionDoctrineRef": {
-            "doctrineId": "doctrine:ag-fixture@1",
-            "fingerprint": "sha256:ag-section-fixture",
-            "components": ["V", "Gamma", "R", "rho", "E", "N"]
-        },
         "sources": {
             "src:section-carrier": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M3 section"},
             "src:forbidden-support": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M3 minimal forbidden support"},
@@ -15634,11 +15634,6 @@ fn archmap_with_contexts(atoms: Vec<Value>, contexts: Vec<Value>) -> Value {
     json!({
         "schema": "archmap/v2",
         "id": "ag-coherence-fixture",
-        "extractionDoctrineRef": {
-            "doctrineId": "doctrine:ag-fixture@1",
-            "fingerprint": "sha256:ag-coherence-fixture",
-            "components": ["V", "Gamma", "R", "rho", "E", "N"]
-        },
         "sources": {
             "src:a": {"kind": "rust", "path": "src/a.rs", "symbol": "A", "line": 1},
             "src:b": {"kind": "rust", "path": "src/b.rs", "symbol": "B", "line": 1},

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:order": {
       "kind": "rust",
@@ -32,7 +27,9 @@
       "subject": "src:order",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:order"]
+      "refs": [
+        "src:order"
+      ]
     },
     {
       "id": "atom:inventory",
@@ -40,7 +37,9 @@
       "subject": "src:inventory",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:inventory"]
+      "refs": [
+        "src:inventory"
+      ]
     },
     {
       "id": "atom:order-inventory-restriction",
@@ -49,33 +48,60 @@
       "object": "src:inventory",
       "axis": "restriction",
       "predicate": "dependsOn",
-      "refs": ["src:order", "src:inventory"]
+      "refs": [
+        "src:order",
+        "src:inventory"
+      ]
     }
   ],
   "contexts": [
     {
       "id": "ctx:order",
-      "atoms": ["atom:order", "atom:order-inventory-restriction"],
-      "restrictsTo": ["ctx:shared"],
-      "refs": ["src:order"]
+      "atoms": [
+        "atom:order",
+        "atom:order-inventory-restriction"
+      ],
+      "restrictsTo": [
+        "ctx:shared"
+      ],
+      "refs": [
+        "src:order"
+      ]
     },
     {
       "id": "ctx:inventory",
-      "atoms": ["atom:inventory", "atom:order-inventory-restriction"],
-      "restrictsTo": ["ctx:shared"],
-      "refs": ["src:inventory"]
+      "atoms": [
+        "atom:inventory",
+        "atom:order-inventory-restriction"
+      ],
+      "restrictsTo": [
+        "ctx:shared"
+      ],
+      "refs": [
+        "src:inventory"
+      ]
     },
     {
       "id": "ctx:shared",
-      "atoms": ["atom:order-inventory-restriction"],
-      "refs": ["src:cover"]
+      "atoms": [
+        "atom:order-inventory-restriction"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:order-inventory",
-      "contexts": ["ctx:order", "ctx:inventory", "ctx:shared"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:order",
+        "ctx:inventory",
+        "ctx:shared"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_cech_h1_visible.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-cech-h1-visible-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:top": {
       "kind": "rust",
@@ -64,7 +59,9 @@
       "subject": "src:top",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:top"]
+      "refs": [
+        "src:top"
+      ]
     },
     {
       "id": "atom:left",
@@ -72,7 +69,9 @@
       "subject": "src:left",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:left"]
+      "refs": [
+        "src:left"
+      ]
     },
     {
       "id": "atom:right",
@@ -80,7 +79,9 @@
       "subject": "src:right",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:right"]
+      "refs": [
+        "src:right"
+      ]
     },
     {
       "id": "atom:bottom",
@@ -88,7 +89,9 @@
       "subject": "src:bottom",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:bottom"]
+      "refs": [
+        "src:bottom"
+      ]
     },
     {
       "id": "atom:left-bottom-cech-mismatch",
@@ -97,39 +100,74 @@
       "object": "ctx:bottom",
       "axis": "cech",
       "predicate": "mismatch",
-      "refs": ["ctx:left", "ctx:bottom", "src:cover"]
+      "refs": [
+        "ctx:left",
+        "ctx:bottom",
+        "src:cover"
+      ]
     }
   ],
   "contexts": [
     {
       "id": "ctx:top",
-      "atoms": ["atom:top"],
-      "restrictsTo": ["ctx:left", "ctx:right"],
-      "refs": ["ctx:top"]
+      "atoms": [
+        "atom:top"
+      ],
+      "restrictsTo": [
+        "ctx:left",
+        "ctx:right"
+      ],
+      "refs": [
+        "ctx:top"
+      ]
     },
     {
       "id": "ctx:left",
-      "atoms": ["atom:left", "atom:left-bottom-cech-mismatch"],
-      "restrictsTo": ["ctx:bottom"],
-      "refs": ["ctx:left"]
+      "atoms": [
+        "atom:left",
+        "atom:left-bottom-cech-mismatch"
+      ],
+      "restrictsTo": [
+        "ctx:bottom"
+      ],
+      "refs": [
+        "ctx:left"
+      ]
     },
     {
       "id": "ctx:right",
-      "atoms": ["atom:right"],
-      "restrictsTo": ["ctx:bottom"],
-      "refs": ["ctx:right"]
+      "atoms": [
+        "atom:right"
+      ],
+      "restrictsTo": [
+        "ctx:bottom"
+      ],
+      "refs": [
+        "ctx:right"
+      ]
     },
     {
       "id": "ctx:bottom",
-      "atoms": ["atom:bottom"],
-      "refs": ["ctx:bottom"]
+      "atoms": [
+        "atom:bottom"
+      ],
+      "refs": [
+        "ctx:bottom"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:order-inventory",
-      "contexts": ["ctx:top", "ctx:left", "ctx:right", "ctx:bottom"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:top",
+        "ctx:left",
+        "ctx:right",
+        "ctx:bottom"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_law_conflict_tor.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_law_conflict_tor.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-law-conflict-tor-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:checkout-policy": {
       "kind": "policy",
@@ -36,7 +31,9 @@
       "object": "law:checkout,law:inventory",
       "axis": "tor",
       "predicate": "commonAmbient",
-      "refs": ["src:ambient"]
+      "refs": [
+        "src:ambient"
+      ]
     },
     {
       "id": "atom:checkout-law-generator",
@@ -45,7 +42,9 @@
       "object": "x_checkout,x_inventory",
       "axis": "tor",
       "predicate": "lawIdealGenerator",
-      "refs": ["src:checkout-policy"]
+      "refs": [
+        "src:checkout-policy"
+      ]
     },
     {
       "id": "atom:inventory-law-generator",
@@ -54,7 +53,9 @@
       "object": "x_inventory,x_payment",
       "axis": "tor",
       "predicate": "lawIdealGenerator",
-      "refs": ["src:inventory-policy"]
+      "refs": [
+        "src:inventory-policy"
+      ]
     }
   ],
   "contexts": [
@@ -65,14 +66,20 @@
         "atom:checkout-law-generator",
         "atom:inventory-law-generator"
       ],
-      "refs": ["src:cover"]
+      "refs": [
+        "src:cover"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:law-conflict-tor",
-      "contexts": ["ctx:tor-common-ambient"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:tor-common-ambient"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_period_stokes.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_period_stokes.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-period-stokes-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:period-alpha": {
       "kind": "policy",
@@ -41,7 +36,9 @@
       "object": "cycle:alpha=2",
       "axis": "period",
       "predicate": "periodIntegral",
-      "refs": ["src:period-alpha"]
+      "refs": [
+        "src:period-alpha"
+      ]
     },
     {
       "id": "atom:period-omega-beta",
@@ -50,7 +47,9 @@
       "object": "cycle:beta=-1",
       "axis": "period",
       "predicate": "periodIntegral",
-      "refs": ["src:period-beta"]
+      "refs": [
+        "src:period-beta"
+      ]
     },
     {
       "id": "atom:stokes-domega-sigma",
@@ -59,7 +58,9 @@
       "object": "chain:sigma=3",
       "axis": "period",
       "predicate": "dOmegaIntegral",
-      "refs": ["src:stokes-domega"]
+      "refs": [
+        "src:stokes-domega"
+      ]
     },
     {
       "id": "atom:stokes-boundary-sigma",
@@ -68,7 +69,9 @@
       "object": "chain:sigma=3",
       "axis": "period",
       "predicate": "boundaryPeriod",
-      "refs": ["src:stokes-boundary"]
+      "refs": [
+        "src:stokes-boundary"
+      ]
     }
   ],
   "contexts": [
@@ -80,14 +83,20 @@
         "atom:stokes-domega-sigma",
         "atom:stokes-boundary-sigma"
       ],
-      "refs": ["src:cover"]
+      "refs": [
+        "src:cover"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:period-stokes",
-      "contexts": ["ctx:period-stokes-local"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:period-stokes-local"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_sheaf_laplacian.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_sheaf_laplacian.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-sheaf-laplacian-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:left-cell": {
       "kind": "policy",
@@ -36,7 +31,9 @@
       "object": "1",
       "axis": "laplacian",
       "predicate": "cellularCochain",
-      "refs": ["src:left-cell"]
+      "refs": [
+        "src:left-cell"
+      ]
     },
     {
       "id": "atom:laplacian-right-cochain",
@@ -45,7 +42,9 @@
       "object": "0",
       "axis": "laplacian",
       "predicate": "cellularCochain",
-      "refs": ["src:right-cell"]
+      "refs": [
+        "src:right-cell"
+      ]
     },
     {
       "id": "atom:laplacian-boundary",
@@ -54,7 +53,9 @@
       "object": "cell:right",
       "axis": "laplacian",
       "predicate": "cellularBoundary",
-      "refs": ["src:boundary"]
+      "refs": [
+        "src:boundary"
+      ]
     }
   ],
   "contexts": [
@@ -65,14 +66,20 @@
         "atom:laplacian-right-cochain",
         "atom:laplacian-boundary"
       ],
-      "refs": ["src:cover"]
+      "refs": [
+        "src:cover"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:sheaf-laplacian",
-      "contexts": ["ctx:sheaf-laplacian-local"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:sheaf-laplacian-local"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_square_free_repair.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-square-free-repair-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:checkout": {
       "kind": "rust",
@@ -48,7 +43,9 @@
       "subject": "src:checkout",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:checkout"]
+      "refs": [
+        "src:checkout"
+      ]
     },
     {
       "id": "atom:inventory",
@@ -56,7 +53,9 @@
       "subject": "src:inventory",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:inventory"]
+      "refs": [
+        "src:inventory"
+      ]
     },
     {
       "id": "atom:payment",
@@ -64,7 +63,9 @@
       "subject": "src:payment",
       "axis": "static",
       "predicate": "component",
-      "refs": ["src:payment"]
+      "refs": [
+        "src:payment"
+      ]
     },
     {
       "id": "atom:ob-checkout-inventory",
@@ -73,7 +74,10 @@
       "object": "x_inventory",
       "axis": "square-free",
       "predicate": "obstructionGenerator",
-      "refs": ["src:checkout", "src:inventory"]
+      "refs": [
+        "src:checkout",
+        "src:inventory"
+      ]
     },
     {
       "id": "atom:ob-inventory-payment",
@@ -82,7 +86,10 @@
       "object": "x_payment",
       "axis": "square-free",
       "predicate": "obstructionGenerator",
-      "refs": ["src:inventory", "src:payment"]
+      "refs": [
+        "src:inventory",
+        "src:payment"
+      ]
     },
     {
       "id": "atom:nsdepth-certificate",
@@ -91,7 +98,9 @@
       "object": "nsdepth=2;depthRule=alexanderDualMaxMinimalHittingSet@1;minimalForbiddenSupports=x_checkout+x_inventory|x_inventory+x_payment;supportAtomRefs=atom:ob-checkout-inventory,atom:ob-inventory-payment",
       "axis": "square-free",
       "predicate": "nsdepthCertificate",
-      "refs": ["src:certificate"]
+      "refs": [
+        "src:certificate"
+      ]
     },
     {
       "id": "atom:nsdepth-scope-u",
@@ -100,7 +109,9 @@
       "object": "nsdepth=2;generators=x_checkout+x_inventory|x_inventory+x_payment",
       "axis": "square-free",
       "predicate": "nsdepthMonotoneScope",
-      "refs": ["src:nsdepth-monotone"]
+      "refs": [
+        "src:nsdepth-monotone"
+      ]
     },
     {
       "id": "atom:nsdepth-scope-u-prime",
@@ -109,7 +120,9 @@
       "object": "extends=law-scope:U;nsdepth=1;generators=x_checkout+x_inventory|x_inventory+x_payment|x_checkout+x_payment",
       "axis": "square-free",
       "predicate": "nsdepthMonotoneScope",
-      "refs": ["src:nsdepth-monotone"]
+      "refs": [
+        "src:nsdepth-monotone"
+      ]
     }
   ],
   "contexts": [
@@ -125,14 +138,20 @@
         "atom:nsdepth-scope-u",
         "atom:nsdepth-scope-u-prime"
       ],
-      "refs": ["src:cover"]
+      "refs": [
+        "src:cover"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:square-free-repair",
-      "contexts": ["ctx:square-free-local"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:square-free-local"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json
+++ b/tools/archsig/tests/fixtures/ag_measurement/archmap_v2_support_transfer.json
@@ -1,11 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "ag-measurement-support-transfer-fixture",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": ["V", "Gamma", "R", "rho", "E", "N"]
-  },
   "sources": {
     "src:transfer-api": {
       "kind": "policy",
@@ -46,7 +41,9 @@
       "object": "support:api,support:data",
       "axis": "transfer",
       "predicate": "repairPath",
-      "refs": ["src:repair-path"]
+      "refs": [
+        "src:repair-path"
+      ]
     },
     {
       "id": "atom:transfer-path-api",
@@ -55,7 +52,9 @@
       "object": "support:api=0.25",
       "axis": "transfer",
       "predicate": "transferPairing",
-      "refs": ["src:transfer-api"]
+      "refs": [
+        "src:transfer-api"
+      ]
     },
     {
       "id": "atom:transfer-path-data",
@@ -64,7 +63,9 @@
       "object": "support:data=0.75",
       "axis": "transfer",
       "predicate": "transferPairing",
-      "refs": ["src:transfer-data"]
+      "refs": [
+        "src:transfer-data"
+      ]
     },
     {
       "id": "atom:transfer-ground-api",
@@ -73,7 +74,9 @@
       "object": "2",
       "axis": "transfer",
       "predicate": "groundCost",
-      "refs": ["src:ground-api"]
+      "refs": [
+        "src:ground-api"
+      ]
     },
     {
       "id": "atom:transfer-ground-data",
@@ -82,7 +85,9 @@
       "object": "4",
       "axis": "transfer",
       "predicate": "groundCost",
-      "refs": ["src:ground-data"]
+      "refs": [
+        "src:ground-data"
+      ]
     }
   ],
   "contexts": [
@@ -95,14 +100,20 @@
         "atom:transfer-ground-api",
         "atom:transfer-ground-data"
       ],
-      "refs": ["src:cover"]
+      "refs": [
+        "src:cover"
+      ]
     }
   ],
   "covers": [
     {
       "id": "cover:support-transfer",
-      "contexts": ["ctx:support-transfer-local"],
-      "refs": ["src:cover"]
+      "contexts": [
+        "ctx:support-transfer-local"
+      ],
+      "refs": [
+        "src:cover"
+      ]
     }
   ]
 }

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -98,7 +98,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from extractionDoctrineRef components before checking atoms[].kind membership.",
+        "fieldMappingPolicy": "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from the fixed AAT canonical doctrine before checking atoms[].kind membership.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",
@@ -125,7 +125,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "ArchMap v2 records sources, subject/axis-decorated atoms, finite context posets, covers, and extractionDoctrineRef. Molecules are not a primary v2 field.",
+        "fieldMappingPolicy": "ArchMap v2 records sources, subject/axis-decorated atoms, finite context posets, and covers. The extraction doctrine is fixed by ArchSig as doctrine:aat-canonical@1; molecules are not a primary v2 field.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",
@@ -318,7 +318,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "Normalized ArchMap v2 is the deterministic finite-poset-site presentation produced from ArchMap v2 under a declared extraction doctrine fingerprint.",
+        "fieldMappingPolicy": "Normalized ArchMap v2 is the deterministic finite-poset-site presentation produced from ArchMap v2 under the fixed AAT canonical doctrine fingerprint.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",
@@ -329,7 +329,7 @@
         ],
         "nonConclusions": [
           "Normalized ArchMap v2 does not prove source extraction soundness.",
-          "A8 determinism is relative to the declared extraction doctrine fingerprint."
+          "A8 determinism is relative to the fixed tool doctrine fingerprint."
         ]
       }
     },

--- a/tools/archview/examples/seam-ignition/frame-00.archmap.json
+++ b/tools/archview/examples/seam-ignition/frame-00.archmap.json
@@ -1,18 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "seam-ignition-f00-calm",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": [
-      "V",
-      "Gamma",
-      "R",
-      "rho",
-      "E",
-      "N"
-    ]
-  },
   "sources": {
     "src:top": {
       "kind": "rust",

--- a/tools/archview/examples/seam-ignition/frame-01.archmap.json
+++ b/tools/archview/examples/seam-ignition/frame-01.archmap.json
@@ -1,18 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "seam-ignition-f01-ignition",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": [
-      "V",
-      "Gamma",
-      "R",
-      "rho",
-      "E",
-      "N"
-    ]
-  },
   "sources": {
     "src:top": {
       "kind": "rust",

--- a/tools/archview/examples/seam-ignition/frame-02.archmap.json
+++ b/tools/archview/examples/seam-ignition/frame-02.archmap.json
@@ -1,18 +1,6 @@
 {
   "schema": "archmap/v2",
   "id": "seam-ignition-f02-healed",
-  "extractionDoctrineRef": {
-    "doctrineId": "doctrine:ag-fixture@1",
-    "fingerprint": "sha256:ag-fixture-doctrine",
-    "components": [
-      "V",
-      "Gamma",
-      "R",
-      "rho",
-      "E",
-      "N"
-    ]
-  },
   "sources": {
     "src:top": {
       "kind": "rust",


### PR DESCRIPTION
## 概要

Closes #2335

ArchMap v2 の `extractionDoctrineRef` を author が選ぶ入力から外し、ArchSig 側の固定 `doctrine:aat-canonical@1` として扱うようにしました。

- `extractionDoctrineRef` 欠落時に canonical doctrine を補う default を追加
- custom doctrine が validation / analyze preflight で fail closed になるテストを追加
- doctrine comparison helper は canonical 同士だけを comparable とし、非 canonical 入力は `invalid_fixed_doctrine` として拒否
- AG measurement / ArchView / practical example fixtures から author 入力としての `extractionDoctrineRef` を削除
- schema catalog、tool docs、ArchMap authoring skill references を固定 doctrine contract に更新

計画変更:
- なし。R2 の AG measurement 生値化、R3 の判定語 hard-error、R4 の診断語例外条項削除は #2335 の対象外として残しています。local-review でも diagnostic-shaped fixture が残る点は指摘されましたが、これは PRD loop の次 iteration で扱う既知ギャップです。

## 証明した定理

- なし

## 編集したドキュメント

- `docs/tool/README.md`
- `docs/tool/guideline.md`
- `tools/archsig/skills/archmap-creater/SKILL.md`
- `tools/archsig/skills/archmap-creater/references/examples.md`
- `tools/archsig/skills/archmap-creater/references/prompt-pack.md`
- `tools/archsig/skills/archmap-creater/references/schema-cheatsheet.md`
- `tools/archsig/tests/fixtures/minimal/schema_version_catalog.json`

## 実施したテスト

- [x] `cargo test --manifest-path tools/archsig/Cargo.toml` pass: unit 110 passed, CLI 145 passed / 21 ignored, doc-tests 0
- [x] `cargo run --manifest-path tools/archsig/Cargo.toml -- analyze --archmap tools/archsig/tests/fixtures/ag_measurement/archmap_v2.json --law-policy tools/archsig/tests/fixtures/ag_measurement/law_policy_ag.json --out-dir .tmp/archsig-r1-analyze` pass
- [x] `git diff --check` pass
- [x] hidden / bidirectional Unicode scan: no hits
- [x] privacy / local-path scan on changed public/tooling surfaces: no hits
- [ ] `lake build` 未実施。Lean 変更なし
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml` 未実施。FieldSig 変更なし
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan 未実施。Lean 変更なし

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status: tooling implementation。Lean 定理追加なし
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
