### PR TITLE
ArchMap v2 の判定語 shortcut を拒否する

### DIFF
--- a/tools/archsig/examples/practical-rust-service/archmap/archmap.json
+++ b/tools/archsig/examples/practical-rust-service/archmap/archmap.json
@@ -375,7 +375,7 @@
       "label": "ShippingPort exposes shipment planning"
     },
     {
-      "id": "atom:port-risk-component",
+      "id": "atom:port-assessment-component",
       "kind": "component",
       "subject": "app:RiskPort",
       "axis": "static",
@@ -489,7 +489,7 @@
       ]
     },
     {
-      "id": "atom:checkout-depends-on-risk-port",
+      "id": "atom:checkout-depends-on-assessment-port",
       "kind": "relation",
       "subject": "app:CheckoutService",
       "axis": "static",
@@ -549,7 +549,7 @@
       ]
     },
     {
-      "id": "atom:infra-implements-risk-port",
+      "id": "atom:infra-implements-assessment-port",
       "kind": "relation",
       "subject": "store:InMemoryCommercePlatform",
       "axis": "static",
@@ -573,7 +573,7 @@
       ]
     },
     {
-      "id": "atom:policy-engine-reads-order-risk",
+      "id": "atom:policy-engine-reads-order-assessment",
       "kind": "relation",
       "subject": "policy:PolicyEngine",
       "axis": "semantic",
@@ -939,13 +939,13 @@
         "atom:port-inventory-component",
         "atom:port-payment-component",
         "atom:port-shipping-component",
-        "atom:port-risk-component",
+        "atom:port-assessment-component",
         "atom:port-outbox-component",
         "atom:checkout-depends-on-catalog-port",
         "atom:checkout-depends-on-inventory-port",
         "atom:checkout-depends-on-payment-port",
         "atom:checkout-depends-on-shipping-port",
-        "atom:checkout-depends-on-risk-port",
+        "atom:checkout-depends-on-assessment-port",
         "atom:checkout-depends-on-outbox-port",
         "atom:capability-reserve-inventory",
         "atom:capability-authorize-payment",
@@ -973,7 +973,7 @@
         "atom:checkout-depends-on-inventory-port",
         "atom:checkout-depends-on-payment-port",
         "atom:checkout-depends-on-shipping-port",
-        "atom:checkout-depends-on-risk-port",
+        "atom:checkout-depends-on-assessment-port",
         "atom:checkout-depends-on-outbox-port",
         "atom:runtime-demo-calls-checkout",
         "atom:capability-place-order",
@@ -999,7 +999,7 @@
         "atom:infra-implements-inventory-port",
         "atom:infra-implements-payment-port",
         "atom:infra-implements-shipping-port",
-        "atom:infra-implements-risk-port",
+        "atom:infra-implements-assessment-port",
         "atom:infra-implements-outbox-port",
         "atom:infrastructure-policy-cover-overlap",
         "atom:effect-inventory-decrement",
@@ -1022,7 +1022,7 @@
       "id": "ctx:policy",
       "atoms": [
         "atom:policy-engine-component",
-        "atom:policy-engine-reads-order-risk",
+        "atom:policy-engine-reads-order-assessment",
         "atom:infrastructure-policy-cover-overlap",
         "atom:capability-evaluate-policy",
         "atom:authority-policy-rule-catalog",

--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -8987,7 +8987,7 @@ fn boundary_residue_mismatch(
     for atom in normalized
         .atoms
         .iter()
-        .filter(|atom| atom.axis == "boundary-residue" && atom.predicate == "mismatchSection")
+        .filter(|atom| atom.axis == "boundary-residue" && atom.predicate == "boundarySection")
         .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))
     {
         let selected_memberships = atom
@@ -9001,7 +9001,7 @@ fn boundary_residue_mismatch(
                 .any(|context| role_map.get(*context).map(String::as_str) != Some("boundary"))
         {
             return Err(format!(
-                "ag.boundary-residue@1 mismatchSection {} must belong only to selected boundary contexts",
+                "ag.boundary-residue@1 boundarySection {} must belong only to selected boundary contexts",
                 atom.normalized_atom_id
             ));
         }
@@ -9110,7 +9110,7 @@ fn boundary_residue_invariant_json(
                 "sourceRefs": column.source_refs
             })).collect::<Vec<_>>()
         },
-        "mismatchSection": mismatch.map(|mismatch| json!({
+        "boundarySection": mismatch.map(|mismatch| json!({
             "atomRefs": mismatch.atom_refs,
             "support": mismatch.support,
             "vector": mismatch.vector,
@@ -9871,7 +9871,7 @@ fn coherence_witness_atoms<'a>(
         .filter(|atom| {
             matches!(
                 atom.predicate.as_str(),
-                "tripleMismatch" | "coherenceMismatch" | "h2Mismatch"
+                "tripleSection" | "coherenceSection" | "h2Section"
             )
         })
         .filter(|atom| atom_belongs_to_selected_context(atom, selected_contexts))

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -53,6 +53,7 @@ pub fn validate_archmap_v2_report(
         check_archmap_v2_doctrine(document),
         check_archmap_v2_sources(document),
         check_archmap_v2_atom_ids(document),
+        check_archmap_v2_no_diagnostic_shortcuts(document),
         check_archmap_v2_atom_kind_vocabulary(document),
         check_archmap_v2_atom_shapes(document),
         check_archmap_v2_contexts(document),
@@ -228,6 +229,83 @@ fn check_archmap_v2_atom_ids(document: &ArchMapDocumentV2) -> ValidationCheck {
         "atom ids are non-empty and unique",
         examples,
     )
+}
+
+fn check_archmap_v2_no_diagnostic_shortcuts(document: &ArchMapDocumentV2) -> ValidationCheck {
+    let mut examples = Vec::new();
+    for atom in &document.atoms {
+        if let Some(token) = diagnostic_shortcut_token(&atom.id) {
+            examples.push(generic_validation_example(
+                &atom.id,
+                &format!("id:{token}"),
+                "ArchMap v2 atom ids must not pre-author diagnostic conclusions",
+            ));
+        }
+        if let Some(predicate) = atom.predicate.as_deref() {
+            if let Some(token) = diagnostic_shortcut_token(predicate) {
+                examples.push(generic_validation_example(
+                    &atom.id,
+                    &format!("predicate:{token}"),
+                    "ArchMap v2 atom predicates must stay observational; diagnostic conclusions belong to ArchSig",
+                ));
+            }
+        }
+    }
+    check_from_examples(
+        "archmap-v2-no-diagnostic-shortcuts",
+        "ArchMap v2 atom id / predicate fields do not pre-author diagnostic conclusions",
+        examples,
+    )
+}
+
+fn diagnostic_shortcut_token(value: &str) -> Option<&'static str> {
+    let parts = diagnostic_shortcut_parts(value);
+    parts
+        .iter()
+        .find_map(|part| match part.as_str() {
+            "mismatch" => Some("mismatch"),
+            "obstruction" | "obstructive" => Some("obstruction"),
+            "violation" | "violate" | "violates" | "violating" => Some("violation"),
+            "risk" | "risky" => Some("risk"),
+            "debt" => Some("debt"),
+            "unsafe" => Some("unsafe"),
+            "lawful" => Some("lawful"),
+            "nonzero" => Some("nonzero"),
+            "failure" | "fail" | "failed" | "failing" => Some("failure"),
+            _ => None,
+        })
+        .or_else(|| {
+            parts
+                .windows(2)
+                .any(|window| window[0] == "non" && window[1] == "zero")
+                .then_some("nonzero")
+        })
+}
+
+fn diagnostic_shortcut_parts(value: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut previous_was_lower_or_digit = false;
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            if character.is_ascii_uppercase() && previous_was_lower_or_digit && !current.is_empty()
+            {
+                parts.push(std::mem::take(&mut current));
+            }
+            current.push(character.to_ascii_lowercase());
+            previous_was_lower_or_digit =
+                character.is_ascii_lowercase() || character.is_ascii_digit();
+        } else {
+            if !current.is_empty() {
+                parts.push(std::mem::take(&mut current));
+            }
+            previous_was_lower_or_digit = false;
+        }
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+    parts
 }
 
 fn check_archmap_v2_atom_kind_vocabulary(document: &ArchMapDocumentV2) -> ValidationCheck {

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -177,6 +177,166 @@ fn cli_rejects_archmap_v2_atom_kind_outside_declared_vocabulary() {
 }
 
 #[test]
+fn cli_rejects_archmap_v2_diagnostic_atom_id_shortcut() {
+    let out_dir = temp_dir("archmap-v2-diagnostic-id");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["id"] = json!("atom:service-violation");
+    for context in archmap["contexts"]
+        .as_array_mut()
+        .expect("contexts are array")
+    {
+        for atom_ref in context["atoms"]
+            .as_array_mut()
+            .expect("context atoms are array")
+        {
+            if atom_ref == "atom:order" {
+                *atom_ref = json!("atom:service-violation");
+            }
+        }
+    }
+    let archmap_path = out_dir.join("archmap_v2_diagnostic_id.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0_expect_code(
+        &[
+            "archmap",
+            "--input",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--out",
+            report.to_str().expect("path is utf-8"),
+        ],
+        1,
+    );
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    let check = check_by_id(&json, "archmap-v2-no-diagnostic-shortcuts");
+    assert_eq!(check["result"], "fail");
+    assert_eq!(check["examples"][0]["source"], "atom:service-violation");
+    assert_eq!(check["examples"][0]["target"], "id:violation");
+}
+
+#[test]
+fn cli_rejects_archmap_v2_diagnostic_predicate_shortcut() {
+    let out_dir = temp_dir("archmap-v2-diagnostic-predicate");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["predicate"] = json!("violatesLaw");
+    let archmap_path = out_dir.join("archmap_v2_diagnostic_predicate.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0_expect_code(
+        &[
+            "archmap",
+            "--input",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--out",
+            report.to_str().expect("path is utf-8"),
+        ],
+        1,
+    );
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    let check = check_by_id(&json, "archmap-v2-no-diagnostic-shortcuts");
+    assert_eq!(check["result"], "fail");
+    assert_eq!(check["examples"][0]["source"], "atom:order");
+    assert_eq!(check["examples"][0]["target"], "predicate:violation");
+}
+
+#[test]
+fn cli_rejects_archmap_v2_nonzero_camel_case_shortcut() {
+    let out_dir = temp_dir("archmap-v2-diagnostic-nonzero-camel");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["id"] = json!("atom:selected-nonZero-section");
+    archmap["atoms"][0]["predicate"] = json!("nonZeroSignal");
+    for context in archmap["contexts"]
+        .as_array_mut()
+        .expect("contexts are array")
+    {
+        for atom_ref in context["atoms"]
+            .as_array_mut()
+            .expect("context atoms are array")
+        {
+            if atom_ref == "atom:order" {
+                *atom_ref = json!("atom:selected-nonZero-section");
+            }
+        }
+    }
+    let archmap_path = out_dir.join("archmap_v2_diagnostic_nonzero_camel.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0_expect_code(
+        &[
+            "archmap",
+            "--input",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--out",
+            report.to_str().expect("path is utf-8"),
+        ],
+        1,
+    );
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    let check = check_by_id(&json, "archmap-v2-no-diagnostic-shortcuts");
+    assert_eq!(check["result"], "fail");
+    assert!(check["examples"].as_array().unwrap().iter().any(|example| {
+        example["source"] == "atom:selected-nonZero-section" && example["target"] == "id:nonzero"
+    }));
+    assert!(check["examples"].as_array().unwrap().iter().any(|example| {
+        example["source"] == "atom:selected-nonZero-section"
+            && example["target"] == "predicate:nonzero"
+    }));
+}
+
+#[test]
+fn cli_allows_archmap_v2_semantic_free_text_without_diagnostic_lint() {
+    let out_dir = temp_dir("archmap-v2-semantic-free-text");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["kind"] = json!("semantic");
+    archmap["atoms"][0]["predicate"] = json!("meaning");
+    archmap["atoms"][0]["object"] = json!(
+        "observer notes mention mismatch, risk, violation, obstruction, nonzero, and failure as prose"
+    );
+    archmap["atoms"][0]["label"] = json!("free text can mention unsafe and lawful");
+    let archmap_path = out_dir.join("archmap_v2_semantic_free_text.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0(&[
+        "archmap",
+        "--input",
+        archmap_path.to_str().expect("path is utf-8"),
+        "--out",
+        report.to_str().expect("path is utf-8"),
+    ]);
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "pass");
+    let check = check_by_id(&json, "archmap-v2-no-diagnostic-shortcuts");
+    assert_eq!(check["result"], "pass");
+}
+
+#[test]
 fn cli_accepts_archmap_v2_state_atom_kind_from_aat_vocabulary() {
     let out_dir = temp_dir("archmap-v2-state-atom-kind-vocabulary");
     let root = ag_measurement_root();
@@ -14252,6 +14412,15 @@ fn read_json(path: &Path) -> Value {
         .expect("json fixture parses")
 }
 
+fn check_by_id<'a>(report: &'a Value, check_id: &str) -> &'a Value {
+    report["checks"]
+        .as_array()
+        .expect("checks is array")
+        .iter()
+        .find(|check| check["id"] == check_id)
+        .unwrap_or_else(|| panic!("missing validation check {check_id}"))
+}
+
 fn run_ag_measurement_fixture(case_id: &str, archmap: &str, law_policy: &str) -> PathBuf {
     let root = ag_measurement_root();
     let out_dir = temp_dir(case_id);
@@ -14753,16 +14922,16 @@ fn boundary_residue_archmap(case: &str) -> Value {
     }
     if include_mismatch {
         atoms.push(atom_json(
-            "atom:boundary-mismatch",
+            "atom:boundary-section",
             "relation",
-            "boundary:mismatch",
+            "boundary:section",
             "boundary-residue",
-            "mismatchSection",
+            "boundarySection",
             Some(mismatch_support),
             if case == "invalid-core-mismatch" {
-                vec!["ctx:core", "src:mismatch"]
+                vec!["ctx:core", "src:boundary-section"]
             } else {
-                vec!["ctx:boundary", "src:mismatch"]
+                vec!["ctx:boundary", "src:boundary-section"]
             },
         ));
     }
@@ -14814,7 +14983,7 @@ fn boundary_residue_archmap(case: &str) -> Value {
             "src:role": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 patch role"},
             "src:d0-core": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 Mayer-Vietoris d0"},
             "src:d0-feature": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 Mayer-Vietoris d0"},
-            "src:mismatch": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 boundary mismatch"},
+            "src:boundary-section": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6 boundary section"},
             "ctx:core": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6"},
             "ctx:feature": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6"},
             "ctx:boundary": {"kind": "policy", "path": "docs/tool/archsig_measurement_faithfulness_and_ag_viewer_prd.md", "section": "M6"}
@@ -15029,7 +15198,7 @@ fn coherence_triangle_archmap(include_witness: bool) -> Value {
             "relation",
             "ctx:a",
             "coherence",
-            "tripleMismatch",
+            "tripleSection",
             Some("ctx:a,ctx:b,ctx:c"),
             vec!["ctx:a", "ctx:b", "ctx:c"],
         ));
@@ -15110,7 +15279,7 @@ fn coherence_boundary_archmap(include_witnesses: bool) -> Value {
                 "relation",
                 contexts[0],
                 "coherence",
-                "tripleMismatch",
+                "tripleSection",
                 Some(&contexts.join(",")),
                 contexts.clone(),
             ));
@@ -15194,7 +15363,7 @@ fn coherence_boundary_zero_cochain_archmap() -> Value {
             "relation",
             "ctx:a",
             "coherence",
-            "tripleMismatch",
+            "tripleSection",
             Some("ctx:a,ctx:b,ctx:c"),
             vec!["ctx:a", "ctx:b", "ctx:c"],
         ));
@@ -15286,7 +15455,7 @@ fn coherence_incomplete_triangle_archmap() -> Value {
                 "relation",
                 "ctx:a",
                 "coherence",
-                "tripleMismatch",
+                "tripleSection",
                 Some("ctx:a,ctx:b,ctx:c"),
                 vec!["ctx:a", "ctx:b", "ctx:c"],
             ),
@@ -15355,7 +15524,7 @@ fn coherence_filled_tetrahedron_archmap() -> Value {
                 "relation",
                 "ctx:a",
                 "coherence",
-                "tripleMismatch",
+                "tripleSection",
                 Some("ctx:a,ctx:b,ctx:c"),
                 vec!["ctx:a", "ctx:b", "ctx:c"],
             ),


### PR DESCRIPTION
## 概要

Closes #2339

ArchMap 観測純化 PRD の R3 として、ArchMap v2 atom の `id` / `predicate` に diagnostic shortcut を含む入力を validation hard error にしました。

- `archmap-v2-no-diagnostic-shortcuts` check を v2 validation に追加
- 対象は構造化フィールド `id` / `predicate` のみ
- semantic free text 相当の `object` / `label` は lint せず、観測者の意味読み取りを保護
- `mismatch` / `obstruction` / `violation` / `risk` / `debt` / `unsafe` / `lawful` / `nonzero` / `failure` を検出
- `nonZero` のような camelCase 表記も `nonzero` として拒否
- boundary/coherence の AG test input predicate と practical sample atom id を中立語彙へ更新

## 証明した定理

- なし

## 編集したドキュメント

- なし

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml diagnostic --test cli -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_rejects_archmap_v2_nonzero_camel_case_shortcut --test cli -- --nocapture`
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml cli_allows_archmap_v2_semantic_free_text_without_diagnostic_lint --test cli -- --nocapture`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## レビュー

- local-review サブエージェント: 初回 P2 指摘 1 件（`nonZero` camelCase の `nonzero` 検出漏れ）を修正済み
- 修正後に `cli_rejects_archmap_v2_nonzero_camel_case_shortcut` を追加し、full `cargo test --manifest-path tools/archsig/Cargo.toml` を再実行済み

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
