### PR TITLE
ArchMap authoring の診断語例外を削除する

### DIFF
--- a/tools/archsig/skills/archmap-creater/SKILL.md
+++ b/tools/archsig/skills/archmap-creater/SKILL.md
@@ -49,9 +49,9 @@ static-analysis dump.
   scope truly contains only component existence evidence.
 - Do not use ArchMap to smuggle evaluator outcomes. Diagnostic-shaped tokens
   such as `mismatch`, `obstruction`, `violation`, `risk`, `debt`, `unsafe`,
-  `lawful`, `nonzero`, or `failure` are forbidden as shortcuts. Use them only
-  when the extraction doctrine / fixture vocabulary explicitly requires that
-  observed relation and the source refs support it directly.
+  `lawful`, `nonzero`, or `failure` are forbidden in authored atom ids and
+  predicates. Record neutral observed source relations and let ArchSig derive
+  diagnostic readings later.
 - Before delivery, run the self-review gate in `references/prompt-pack.md`.
   If any gate fails, revise the ArchMap instead of explaining the failure away.
 

--- a/tools/archsig/skills/archmap-creater/references/examples.md
+++ b/tools/archsig/skills/archmap-creater/references/examples.md
@@ -156,9 +156,9 @@ status is used by code and tests.
 }
 ```
 
-Why bad unless doctrine-approved: it names a diagnostic conclusion instead of a
-neutral observed relation. Prefer source-grounded relation / contract / state
-atoms and let the AG evaluator derive mismatch / obstruction readings.
+Why bad: it names a diagnostic conclusion instead of a neutral observed
+relation. Prefer source-grounded relation / contract / state atoms and let the
+AG evaluator derive mismatch / obstruction readings.
 
 ## Bad: Molecules In v2
 

--- a/tools/archsig/skills/archmap-creater/references/mapping-guide.md
+++ b/tools/archsig/skills/archmap-creater/references/mapping-guide.md
@@ -1,7 +1,7 @@
 # ArchMap v2 Mapping Guide
 
-ArchMap v2 records source-grounded atoms, finite poset contexts, covers, and an
-extraction doctrine ref.
+ArchMap v2 records source-grounded atoms, finite poset contexts, and covers
+under the fixed ArchMap v2 extraction doctrine.
 ArchSig computes normalized predicates, evaluator results, distance diagnosis,
 and bounded conclusions later.
 
@@ -57,7 +57,7 @@ If that cannot be answered with refs, omit the semantic atom.
 
 ## Diagnostic Token Rules
 
-Avoid diagnostic-shaped ids and predicates in authored atoms:
+Do not use diagnostic-shaped ids or predicates in authored atoms:
 
 - `*_mismatch`
 - `*_obstruction`
@@ -69,10 +69,9 @@ Avoid diagnostic-shaped ids and predicates in authored atoms:
 - `*_nonzero`
 - `*_failure`
 
-Exception: use such a token only when the current extraction doctrine or an AG
-fixture vocabulary explicitly models it as an observed source relation, and the
-refs directly support that observation. Otherwise let ArchSig evaluators derive
-diagnostic readings from neutral atoms, contexts, covers, and LawPolicy.
+There is no doctrine or fixture exception for authored ids and predicates.
+ArchSig validation rejects these diagnostic shortcut tokens; let evaluators
+derive diagnostic readings from neutral atoms, contexts, covers, and LawPolicy.
 
 ## Context Rules
 

--- a/tools/archsig/skills/archmap-creater/references/prompt-pack.md
+++ b/tools/archsig/skills/archmap-creater/references/prompt-pack.md
@@ -33,8 +33,8 @@ Do not write law violations, obstruction circuits, distance scores, risk
 claims, projection hints, proof objects, or global architecture truth.
 Do not invent diagnostic-shaped atom ids or predicates such as *_mismatch,
 *_obstruction, *_violation, *_risk, *_debt, *_unsafe, *_lawful, *_nonzero, or
-*_failure unless the supplied extraction doctrine explicitly defines that token
-as an observed source relation and the supplied evidence supports it directly.
+*_failure. These tokens are forbidden in authored ids and predicates; write
+neutral observed relations and let ArchSig evaluators derive diagnostic readings.
 
 Every atom refs entry must resolve to sources. Every context atom entry must
 resolve to atoms. Every cover context entry must resolve to contexts. Labels are
@@ -78,6 +78,6 @@ source notes:
   represented or explicitly out of scope.
 - `semanticAtomsHaveUseEvidence`: every semantic atom cites observed use.
 - `noDiagnosticShortcutAtoms`: ids / predicates do not encode evaluator
-  conclusions except doctrine-approved observed relations.
+  conclusions or diagnostic shortcut tokens.
 
 Any `false` gate blocks delivery.

--- a/tools/archsig/skills/archmap-creater/references/repository-survey.md
+++ b/tools/archsig/skills/archmap-creater/references/repository-survey.md
@@ -19,7 +19,6 @@ primitive observed facts.
 - runtime traces when supplied
 - source-grounded context boundaries and restriction directions
 - finite cover candidates for AG measurement
-- project extraction doctrine id / fingerprint source when available
 
 ## Sub-Agent Output
 
@@ -49,7 +48,7 @@ atoms as final ArchMap fields.
   semantic use evidence.
 - Reject semantic atoms that do not explain the observed use that makes the
   meaning true.
-- Reject diagnostic-shaped ids / predicates unless explicitly doctrine-approved
-  and source-supported.
+- Reject diagnostic-shaped ids / predicates unconditionally; source-supported
+  observations must still be written as neutral atom ids and predicates.
 - Keep unavailable inventory in notes; do not encode it as measured absence.
 - Validate with `archsig archmap`.


### PR DESCRIPTION
## 概要

Closes #2341

ArchMap 観測純化 PRD の R4 として、`tools/archsig/skills/archmap-creater` の authoring 規律から診断語 shortcut の例外条項を削除しました。

- `mismatch` / `obstruction` / `violation` / `risk` / `debt` / `unsafe` / `lawful` / `nonzero` / `failure` 系 token を authored atom id / predicate で無条件禁止として記述
- prompt-pack / mapping-guide / examples / repository survey から doctrine-approved / fixture vocabulary 例外を削除
- 固定 doctrine 後に project doctrine fingerprint を収集する survey 項目を削除

## 証明した定理

- なし

## 編集したドキュメント

- `tools/archsig/skills/archmap-creater/SKILL.md`
- `tools/archsig/skills/archmap-creater/references/prompt-pack.md`
- `tools/archsig/skills/archmap-creater/references/mapping-guide.md`
- `tools/archsig/skills/archmap-creater/references/examples.md`
- `tools/archsig/skills/archmap-creater/references/repository-survey.md`

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更時）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない