### PR TITLE
NSdepth certificate の ledger 状態を computed にそろえる

### DIFF
--- a/tools/archsig/src/ag_measurement.rs
+++ b/tools/archsig/src/ag_measurement.rs
@@ -1336,18 +1336,22 @@ fn evaluate_square_free_repair_v1(
                 assumption: "NSdepth certificate payload covers the computed square-free obstruction ideal within the selected witness family".to_string(),
                 status: certificate
                     .as_ref()
-                    .filter(|certificate| certificate.status == "verified")
+                    .filter(|certificate| {
+                        matches!(certificate.status.as_str(), "verified" | "computed")
+                    })
                     .map(|_| "checked")
                     .unwrap_or("assumed")
                     .to_string(),
                 checked_by: certificate
                     .as_ref()
-                    .filter(|certificate| certificate.status == "verified")
+                    .filter(|certificate| {
+                        matches!(certificate.status.as_str(), "verified" | "computed")
+                    })
                     .map(|certificate| format!("ag.square-free-repair@1:{}", certificate.cert_ref)),
                 assumed_by: certificate
                     .as_ref()
                     .map(|certificate| {
-                        if certificate.status == "verified" {
+                        if matches!(certificate.status.as_str(), "verified" | "computed") {
                             None
                         } else {
                             Some(certificate.cert_ref.clone())

--- a/tools/archsig/src/archmap.rs
+++ b/tools/archsig/src/archmap.rs
@@ -265,7 +265,7 @@ fn diagnostic_shortcut_token(value: &str) -> Option<&'static str> {
         .find_map(|part| match part.as_str() {
             "mismatch" => Some("mismatch"),
             "obstruction" | "obstructive" => Some("obstruction"),
-            "violation" | "violate" | "violates" | "violating" => Some("violation"),
+            "violation" | "violate" | "violated" | "violates" | "violating" => Some("violation"),
             "risk" | "risky" => Some("risk"),
             "debt" => Some("debt"),
             "unsafe" => Some("unsafe"),

--- a/tools/archsig/src/schema_catalog.rs
+++ b/tools/archsig/src/schema_catalog.rs
@@ -68,7 +68,7 @@ pub fn static_schema_version_catalog() -> SchemaVersionCatalogV0 {
                 "primary",
                 "ArchSig v0.4.0 Algebraic Geometry Measurement",
                 vec!["archsig-contract:v0.4.0-improvement"],
-                "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from the fixed AAT canonical doctrine before checking atoms[].kind membership.",
+                "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation enforces the compiled-in fixed AAT canonical doctrine before checking atoms[].kind membership.",
                 vec![
                     "Vocabulary lint checks token membership only; it does not prove source extraction soundness or semantic correctness.",
                     "The linter does not decide whether a new atom kind should be added to the doctrine.",

--- a/tools/archsig/tests/cli.rs
+++ b/tools/archsig/tests/cli.rs
@@ -254,6 +254,51 @@ fn cli_rejects_archmap_v2_diagnostic_predicate_shortcut() {
 }
 
 #[test]
+fn cli_rejects_archmap_v2_violated_diagnostic_shortcut() {
+    let out_dir = temp_dir("archmap-v2-diagnostic-violated");
+    let root = ag_measurement_root();
+    let mut archmap = read_json(&root.join("archmap_v2.json"));
+    archmap["atoms"][0]["id"] = json!("atom:contract-violated");
+    for context in archmap["contexts"]
+        .as_array_mut()
+        .expect("contexts are array")
+    {
+        for atom_ref in context["atoms"]
+            .as_array_mut()
+            .expect("context atoms are array")
+        {
+            if atom_ref == "atom:order" {
+                *atom_ref = json!("atom:contract-violated");
+            }
+        }
+    }
+    let archmap_path = out_dir.join("archmap_v2_diagnostic_violated.json");
+    fs::write(
+        &archmap_path,
+        serde_json::to_string_pretty(&archmap).expect("archmap serializes"),
+    )
+    .expect("write archmap fixture");
+
+    let report = out_dir.join("archmap-validation.json");
+    run_sig0_expect_code(
+        &[
+            "archmap",
+            "--input",
+            archmap_path.to_str().expect("path is utf-8"),
+            "--out",
+            report.to_str().expect("path is utf-8"),
+        ],
+        1,
+    );
+    let json = read_json(&report);
+    assert_eq!(json["summary"]["result"], "fail");
+    let check = check_by_id(&json, "archmap-v2-no-diagnostic-shortcuts");
+    assert_eq!(check["result"], "fail");
+    assert_eq!(check["examples"][0]["source"], "atom:contract-violated");
+    assert_eq!(check["examples"][0]["target"], "id:violation");
+}
+
+#[test]
 fn cli_rejects_archmap_v2_nonzero_camel_case_shortcut() {
     let out_dir = temp_dir("archmap-v2-diagnostic-nonzero-camel");
     let root = ag_measurement_root();
@@ -3733,6 +3778,21 @@ fn cli_analyze_v2_square_free_repair_outputs_hitting_sets_and_nsdepth() {
     assert_eq!(
         repair["nsdepthCertificate"]["verifiedMinimalForbiddenSupports"],
         serde_json::json!([["x_checkout", "x_inventory"], ["x_inventory", "x_payment"]])
+    );
+    let nsdepth_assumption = packet["assumptions"]
+        .as_array()
+        .expect("assumptions are array")
+        .iter()
+        .find(|row| row["theoremRef"] == "part3/7.2B")
+        .expect("NSdepth assumption ledger row exists");
+    assert_eq!(nsdepth_assumption["status"], "checked");
+    assert_eq!(
+        nsdepth_assumption["checkedBy"],
+        "ag.square-free-repair@1:cert:nsdepth-square-free:computed"
+    );
+    assert!(
+        nsdepth_assumption["assumedBy"].is_null(),
+        "ArchSig-computed NSdepth certificate must not be downgraded to an assumption"
     );
     let arrangement = invariant_by_id(&packet, "lawful-locus-arrangement:profile:ag-square-free@1");
     assert_eq!(

--- a/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
+++ b/tools/archsig/tests/fixtures/minimal/schema_version_catalog.json
@@ -98,7 +98,7 @@
       ],
       "downstreamIssues": [],
       "compatibilityBoundary": {
-        "fieldMappingPolicy": "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation resolves it from the fixed AAT canonical doctrine before checking atoms[].kind membership.",
+        "fieldMappingPolicy": "AAT atom vocabulary v1 is an artifact-side projection of allowed ArchMap atom kind tokens with provenance refs back to the AAT doctrine. ArchMap v2 validation enforces the compiled-in fixed AAT canonical doctrine before checking atoms[].kind membership.",
         "deprecatedFields": [],
         "newRequiredAssumptions": [
           "Required fields, observation families, law refs, or analysis axes change.",


### PR DESCRIPTION
## 概要

Closes #2343

ArchMap 観測純化 PRD R2 後の追修正として、square-free repair の `computed` NSdepth certificate と assumption ledger の状態をそろえました。

- `nsdepthCertificate.status = computed` を `part3/7.2B` assumption ledger でも `checked` 扱いに変更
- `computed` certificate の ledger が `checkedBy` を持ち、`assumedBy = null` になる回帰テストを追加
- R3 診断語 hard-error の `violation` family に `violated` を追加
- schema catalog の固定 doctrine 文言を compiled-in constant に寄せ、canonical fixture を同期

## 証明した定理

- なし

## 編集したドキュメント

- なし（schema catalog fixture の文言同期のみ）

## 実施したテスト

- [ ] `lake build`（Lean 変更なしのため未実施）
- [x] `cargo test --manifest-path tools/archsig/Cargo.toml`
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なしのため未実施）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [ ] `axiom` / `admit` / `sorry` / `unsafe` scan（Lean 変更なしのため未実施）

## チェックリスト

- [x] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした（Lean 変更なし）
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない