### PR TITLE
Quality Surface の support hitting 定理を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -1,1 +1,2 @@
 import Formal.AG.Research.Basic
+import Formal.AG.Research.QualitySurface.SupportHitting

--- a/Formal/AG/Research/QualitySurface/SupportHitting.lean
+++ b/Formal/AG/Research/QualitySurface/SupportHitting.lean
@@ -1,0 +1,260 @@
+import Formal.AG.Research.Basic
+
+/-!
+Cycle 1 evidence for `G-aat-quality-surface-01`.
+
+The theorem package formalizes the support-local repair principle for a finite
+atom vocabulary: an eliminating repair must hit every selected minimal atom
+support for the obstruction certificate.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+
+universe u v
+
+/-- A repair support hits a certificate support when they share an atom. -/
+def SupportHits {Atom : Type u} (H M : Set Atom) : Prop :=
+  ∃ a, a ∈ H ∧ a ∈ M
+
+/-- A repair support misses a certificate support when no atom lies in both. -/
+def SupportDisjoint {Atom : Type u} (H M : Set Atom) : Prop :=
+  ∀ a, a ∈ H -> a ∈ M -> False
+
+/-- If no hit exists, the two supports are disjoint in the support calculus. -/
+theorem supportDisjoint_of_not_hits {Atom : Type u} {H M : Set Atom}
+    (h : ¬ SupportHits H M) : SupportDisjoint H M := by
+  intro a haH haM
+  exact h (Exists.intro a (And.intro haH haM))
+
+/--
+Finite support calculus for local repair.
+
+`MinSupportFamily c` is the selected minimal atom-support family for an
+obstruction certificate `c`. `AfterRepairFamily H c` records supports that
+remain after a repair supported on `H`. The locality axiom says that a selected
+support missed by `H` survives the local repair. `Eliminates H c` is certified
+by the absence of every after-repair support. The nonempty / antichain fields
+record that the selected supports behave as a minimal support family.
+-/
+structure LocalRepairSupportCalculus (Atom : Type u) [Fintype Atom]
+    (ObstructionClass : Type v) where
+  MinSupportFamily : ObstructionClass -> Set (Set Atom)
+  AfterRepairFamily : Set Atom -> ObstructionClass -> Set (Set Atom)
+  Eliminates : Set Atom -> ObstructionClass -> Prop
+  minSupportFamilyNonempty :
+    ∀ c : ObstructionClass, ∃ M : Set Atom, MinSupportFamily c M
+  minSupportFamilyAntichain :
+    ∀ {c : ObstructionClass} {M N : Set Atom},
+      MinSupportFamily c M ->
+        MinSupportFamily c N ->
+          (∀ a, a ∈ M -> a ∈ N) ->
+            ∀ a, a ∈ N -> a ∈ M
+  repairLocalOutside :
+    ∀ {H : Set Atom} {c : ObstructionClass} {M : Set Atom},
+      MinSupportFamily c M -> SupportDisjoint H M -> AfterRepairFamily H c M
+  eliminates_no_afterSupport :
+    ∀ {H : Set Atom} {c : ObstructionClass} {M : Set Atom},
+      Eliminates H c -> AfterRepairFamily H c M -> False
+
+/--
+A minimal support that is missed by the repair support survives, so the repair
+does not eliminate the obstruction certificate.
+-/
+theorem missed_minSupport_survives {Atom : Type u} [Fintype Atom]
+    {ObstructionClass : Type v}
+    (Q : LocalRepairSupportCalculus Atom ObstructionClass)
+    {H : Set Atom} {c : ObstructionClass} {M : Set Atom}
+    (hM : Q.MinSupportFamily c M) (hmiss : SupportDisjoint H M) :
+    ¬ Q.Eliminates H c := by
+  intro helim
+  exact Q.eliminates_no_afterSupport helim (Q.repairLocalOutside hM hmiss)
+
+/--
+Support-local repair hitting theorem.
+
+If a local repair eliminates an obstruction certificate, then its repair
+support hits every selected minimal atom support of that certificate.
+-/
+theorem hits_every_minSupport_of_eliminates {Atom : Type u} [Fintype Atom]
+    {ObstructionClass : Type v}
+    (Q : LocalRepairSupportCalculus Atom ObstructionClass)
+    {H : Set Atom} {c : ObstructionClass}
+    (helim : Q.Eliminates H c) :
+    ∀ M : Set Atom, Q.MinSupportFamily c M -> SupportHits H M := by
+  intro M hM
+  by_contra hhit
+  exact (missed_minSupport_survives Q hM (supportDisjoint_of_not_hits hhit)) helim
+
+/-! ## A finite two-support certificate calculus -/
+
+/-- A toy finite atom vocabulary with two disjoint support regions. -/
+inductive ToyAtom where
+  | a
+  | b
+  | c
+  deriving DecidableEq, Fintype
+
+/-- A single obstruction certificate in the toy calculus. -/
+inductive ToyObstruction where
+  | omega
+  deriving DecidableEq
+
+namespace Toy
+
+open ToyAtom ToyObstruction
+
+/-- The first selected minimal atom support. -/
+def supportAB : Set ToyAtom :=
+  fun x => x = a ∨ x = b
+
+/-- The second selected minimal atom support. -/
+def supportC : Set ToyAtom :=
+  fun x => x = c
+
+/-- A repair touching only atom `a`. -/
+def repairA : Set ToyAtom :=
+  fun x => x = a
+
+/-- A repair touching one atom in each selected minimal support. -/
+def repairAC : Set ToyAtom :=
+  fun x => x = a ∨ x = c
+
+/-- The toy obstruction has two selected minimal atom supports. -/
+def toyMinSupport : ToyObstruction -> Set (Set ToyAtom)
+  | omega => fun M => M = supportAB ∨ M = supportC
+
+/-- A support remains after local repair exactly when the repair misses it. -/
+def toyAfterRepair (H : Set ToyAtom) (c : ToyObstruction) : Set (Set ToyAtom) :=
+  fun M => toyMinSupport c M ∧ SupportDisjoint H M
+
+/-- The toy repair eliminates the obstruction when no selected support remains. -/
+def toyEliminates (H : Set ToyAtom) (c : ToyObstruction) : Prop :=
+  ∀ M, ¬ toyAfterRepair H c M
+
+/-- The toy finite certificate calculus used as cycle-1 evidence. -/
+def toyCalculus : LocalRepairSupportCalculus ToyAtom ToyObstruction where
+  MinSupportFamily := toyMinSupport
+  AfterRepairFamily := toyAfterRepair
+  Eliminates := toyEliminates
+  minSupportFamilyNonempty := by
+    intro c
+    cases c
+    exact Exists.intro supportAB (Or.inl rfl)
+  minSupportFamilyAntichain := by
+    intro obs M N hM hN hsub x hxN
+    cases obs
+    cases hM with
+    | inl hMab =>
+        cases hN with
+        | inl hNab =>
+            rw [hMab]
+            rw [hNab] at hxN
+            exact hxN
+        | inr hNc =>
+            have haM : ToyAtom.a ∈ M := by
+              rw [hMab]
+              exact Or.inl rfl
+            have haN : ToyAtom.a ∈ N := hsub ToyAtom.a haM
+            rw [hNc] at haN
+            cases haN
+    | inr hMc =>
+        cases hN with
+        | inl hNab =>
+            have hcM : ToyAtom.c ∈ M := by
+              rw [hMc]
+              rfl
+            have hcN : ToyAtom.c ∈ N := hsub ToyAtom.c hcM
+            rw [hNab] at hcN
+            cases hcN with
+            | inl hcA => cases hcA
+            | inr hcB => cases hcB
+        | inr hNc =>
+            rw [hMc]
+            rw [hNc] at hxN
+            exact hxN
+  repairLocalOutside := by
+    intro H c M hM hmiss
+    exact And.intro hM hmiss
+  eliminates_no_afterSupport := by
+    intro H c M helim hafter
+    exact helim M hafter
+
+/-- The two selected minimal supports are distinct. -/
+theorem toy_two_minSupports_distinct : supportAB ≠ supportC := by
+  intro h
+  have haC : ToyAtom.a ∈ supportC := by
+    rw [← h]
+    exact Or.inl rfl
+  cases haC
+
+/-- `{a,b}` is a selected minimal support of the toy obstruction. -/
+theorem supportAB_minSupport :
+    toyCalculus.MinSupportFamily omega supportAB := by
+  exact Or.inl rfl
+
+/-- `{c}` is a selected minimal support of the toy obstruction. -/
+theorem supportC_minSupport :
+    toyCalculus.MinSupportFamily omega supportC := by
+  exact Or.inr rfl
+
+/-- The toy obstruction has a nonempty selected minimal support family. -/
+theorem toy_minSupportFamily_nonempty :
+    ∃ M : Set ToyAtom, toyCalculus.MinSupportFamily omega M :=
+  toyCalculus.minSupportFamilyNonempty omega
+
+/-- The selected minimal supports form an antichain in the toy calculus. -/
+theorem toy_minSupportFamily_antichain {M N : Set ToyAtom}
+    (hM : toyCalculus.MinSupportFamily omega M)
+    (hN : toyCalculus.MinSupportFamily omega N)
+    (hsub : ∀ x, x ∈ M -> x ∈ N) :
+    ∀ x, x ∈ N -> x ∈ M :=
+  toyCalculus.minSupportFamilyAntichain hM hN hsub
+
+/-- The repair `{a}` misses the selected minimal support `{c}`. -/
+theorem repairA_misses_supportC : SupportDisjoint repairA supportC := by
+  intro x hxA hxC
+  cases hxA
+  cases hxC
+
+/-- A repair supported only at `a` does not eliminate the toy obstruction. -/
+theorem repairA_does_not_eliminate_omega :
+    ¬ toyCalculus.Eliminates repairA omega :=
+  missed_minSupport_survives toyCalculus supportC_minSupport repairA_misses_supportC
+
+/-- The repair `{a,c}` hits the selected minimal support `{a,b}`. -/
+theorem repairAC_hits_supportAB : SupportHits repairAC supportAB := by
+  exact Exists.intro ToyAtom.a (And.intro (Or.inl rfl) (Or.inl rfl))
+
+/-- The repair `{a,c}` hits the selected minimal support `{c}`. -/
+theorem repairAC_hits_supportC : SupportHits repairAC supportC := by
+  exact Exists.intro ToyAtom.c (And.intro (Or.inr rfl) rfl)
+
+/-- The repair `{a,c}` eliminates the toy obstruction. -/
+theorem repairAC_eliminates_omega :
+    toyCalculus.Eliminates repairAC omega := by
+  intro M hafter
+  rcases hafter with ⟨hmin, hdisj⟩
+  cases hmin with
+  | inl hM =>
+      have hH : ToyAtom.a ∈ repairAC := Or.inl rfl
+      have hS : ToyAtom.a ∈ M := by
+        rw [hM]
+        exact Or.inl rfl
+      exact hdisj ToyAtom.a hH hS
+  | inr hM =>
+      have hH : ToyAtom.c ∈ repairAC := Or.inr rfl
+      have hS : ToyAtom.c ∈ M := by
+        rw [hM]
+        rfl
+      exact hdisj ToyAtom.c hH hS
+
+/-- In the toy calculus, an eliminating repair hits every selected support. -/
+theorem repairAC_hits_every_minSupport :
+    ∀ M : Set ToyAtom, toyCalculus.MinSupportFamily omega M -> SupportHits repairAC M :=
+  hits_every_minSupport_of_eliminates toyCalculus repairAC_eliminates_omega
+
+end Toy
+
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-minimal-support-hitting.md
+++ b/research/ideas/g-aat-quality-surface-01-minimal-support-hitting.md
@@ -1,0 +1,96 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: obstruction, repair-potential, atom-supported-quality-geometry
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-1
+tags: [quality-surface, atom-support, repair, obstruction, hitting-set]
+created: 2026-06-20
+cycle: 1
+lean: proved-in-research
+---
+
+# Minimal-support hitting theorem for local repair
+
+## 主張
+
+有限 certificate calculus を固定し、obstruction class `[z]` ごとに nonempty antichain としての
+minimal atom support family `MinSupportFamily([z])` を持つとする。repair support `H` が
+`H` 外の atom support を変えない local repair であるなら、`[z]` を消す repair support `H` は
+`MinSupportFamily([z])` の全要素を hit しなければならない。
+
+特に、ある minimal support `M ∈ MinSupportFamily([z])` について `H ∩ M = ∅` なら、
+その local repair の後も `[z]` の obstruction は残る。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- `docs/note/aat_quality_surface.md` の 10 節 Atom support と 13 節 Atom-support repair theorem
+- `Formal/AG/Measurement/SquareFreeRepair.lean` の minimal repair hitting set surface
+- `Formal/AG/Measurement/SupportTransfer.lean` の support-localized repair path surface
+
+## 非自明性
+
+support を certificate の付属情報ではなく、repair 不可能性の下界を与える構造的不変量として使う。
+minimal support family が複数ある場合、単一 support との交差では足りず、family 全体への hitting
+condition が必要になる。この点で、obstruction、minimal representative、repair locality、hitting set
+を同じ finite certificate calculus に束ねる。
+
+## 数学的興味
+
+この候補は atom-supported quality geometry の中で、obstruction certificate の support が repair
+reachability を制約することを示す。Quality Surface 上では、repair direction が存在する領域と
+obstruction が残る領域の境界を、minimal atom support family への hitting condition として読める。
+
+## GOAL への前進
+
+atom support を主成果にしながら、repair reachability を certificate geometry 内の hitting-set
+theorem として扱えるようにする。
+
+## SCORE 見込み
+
+- `score_reason`: Lean で finite support locality と hitting-set 必要条件を証明し、複数 minimal support を持つ toy calculus を固定できれば、最初の `proved-in-research` 候補として成立する。
+- `dullness_risk`: repair relation の仮定を強くしすぎると「H 外を変えないから残る」という即時系になる。abstract theorem だけでなく、複数 minimal support の finite example を添えて、family 全体への hitting condition を証拠化する。
+- `proof_or_evidence_plan`: finite atom type、support predicate、nonempty antichain としての minimal support family、local repair relation を Research 側に抽象化し、`Eliminates` と `RepairLocalOutside` から hitting condition を Lean で証明する。さらに `{a,b}` と `{c}` の二つの distinct minimal support を持つ finite calculus で、family nonempty / antichain、`{a}` repair が obstruction を残すこと、`{a,c}` repair が hitting condition を満たすことを固定する。
+
+## CS / SWE への帰結
+
+修正案が obstruction certificate の minimal atom support family に触れていない場合、その修正は対象 obstruction を消せない。
+これにより、品質判定は単なる違反数ではなく、どの atom family を hit しなければならないかという repair
+frontier を返せる。
+
+## 証明・根拠の見込み
+
+Research 側では、obstruction class `c`、nonempty antichain としての support family
+`S : Set Atom -> Prop`、repair support `H : Set Atom`、repair 後の support family `S'` を抽象化する。
+locality は `H` と交わらない support
+が repair 後にも残るという命題で表す。`Eliminates H c` は repair 後の minimal support family が空になる
+こととして置く。このとき `H` と交わらない `M ∈ MinSupportFamily(c)` があれば locality により
+`M` が repair 後にも残るため、`Eliminates H c` と矛盾する。従って `Eliminates H c` なら全ての
+minimal support `M` が `H` と交わる。
+
+## 審判メモ
+
+- 厳密性:
+- 研究価値:
+- repo 全体価値:
+
+## 関連
+
+- scalar-collapse separation by support antichains
+- finite profile-curvature detector on a square cell
+- trace-natural certificate transport bridge
+
+## 進捗ログ
+
+- 2026-06-20: G1 候補生成から cycle 1 の審判対象として作成。
+- 2026-06-20: G2 三審判後に picked。A の revise を受け、traceability を主 category から外し、finite two-support Lean example を追加。
+- 2026-06-20: G3 axiom check / 形式化品質監査 pass。G4 SCORE 監査 confirm: base 60, multiplier 2.0, penalty 0, final 120。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -1,0 +1,43 @@
+# G-aat-quality-surface-01 report
+
+この report は、atom-supported quality geometry によってアーキテクチャ品質を certificate geometry として読むための研究成果を記録する。状態の正本は GitHub tracking Issue に置き、ここには SCORE 監査を通った成果だけを載せる。
+
+## Current SCORE
+
+- total SCORE: 120
+- category scores:
+  - obstruction / repair-potential / atom-supported-quality-geometry: 120
+- evidence portfolio:
+  - proved-in-research: 1
+
+## Cycle 1: Minimal-support hitting theorem for local repair
+
+```text
+candidate: Minimal-support hitting theorem for local repair
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: obstruction/repair-potential/atom-supported-quality-geometry
+goal_delta: minimal atom support family が local repair の必要条件を与えることを Lean-proved の定理として固定し、support-local repair theorem frontier を前進させる。
+project_value_delta: Research sandbox 内で Quality Surface の repair-potential / obstruction 軸に paper seed 素材を追加する。traceability、certificate transport、profile curvature はこの成果ではまだ進めない。
+formalization_quality: pass。nonempty antichain としての minimal support family、locality boundary、elimination semantics、finite two-support example が Lean で明示されている。
+open_questions: locality を具体 calculus から導く theorem、trace field つき support certificate、profile transport / curvature と repair support の相互作用、scalar-collapse separation。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SupportHitting.lean` は、有限 atom vocabulary 上の local repair support calculus を定義する。各 obstruction certificate は nonempty antichain としての selected minimal atom support family を持つ。local repair が repair support `H` と交わらない support を残すとき、obstruction を eliminate する repair support はすべての selected minimal support を hit する。
+
+Lean 証拠は二段になっている。
+
+- `missed_minSupport_survives`: repair support が selected minimal support を miss すると、その support が repair 後にも残るため obstruction は eliminate されない。
+- `hits_every_minSupport_of_eliminates`: repair が obstruction を eliminate するなら、repair support は selected minimal support family の全要素を hit する。
+
+toy calculus では atom `{a,b,c}` 上に二つの selected minimal support `{a,b}` と `{c}` を固定する。repair `{a}` は `{c}` を miss するため obstruction を eliminate できず、repair `{a,c}` は両 support を hit する。この有限例が、単一の chosen support ではなく minimal support family 全体を見る必要を示す。
+
+### Next Frontier
+
+次サイクルでは、portfolio constraint の残りを埋めるために `scalar-collapse separation by support antichains` または `finite profile-curvature detector on a square cell` を優先する。前者は scalar reading と certificate geometry の fold を分離し、後者は certificate transport / profile curvature を直接進める。


### PR DESCRIPTION
## 概要

Refs #2348

research-loop `G-aat-quality-surface-01` の cycle 1 として、minimal atom support family が local repair の必要条件を与える Lean 証拠を `Formal/AG/Research` に追加した。

設計判断:

- `Formal/AG` 本体は編集せず、Research sandbox に証拠を閉じた。
- `MinSupportFamily` は nonempty antichain として明示し、空 family / 任意 selected family による空虚化を避けた。
- toy calculus で `{a,b}` と `{c}` の二つの selected minimal support を固定し、`{a}` repair が obstruction を消せず、`{a,c}` repair が family 全体を hit することを証明した。
- G4 SCORE 監査は base 60、multiplier 2.0、penalty 0、final SCORE 120 と判定した。

## 証明した定理

- `Formal.AG.Research.QualitySurface.missed_minSupport_survives`
- `Formal.AG.Research.QualitySurface.hits_every_minSupport_of_eliminates`
- `Formal.AG.Research.QualitySurface.Toy.toy_two_minSupports_distinct`
- `Formal.AG.Research.QualitySurface.Toy.supportAB_minSupport`
- `Formal.AG.Research.QualitySurface.Toy.supportC_minSupport`
- `Formal.AG.Research.QualitySurface.Toy.toy_minSupportFamily_nonempty`
- `Formal.AG.Research.QualitySurface.Toy.toy_minSupportFamily_antichain`
- `Formal.AG.Research.QualitySurface.Toy.repairA_does_not_eliminate_omega`
- `Formal.AG.Research.QualitySurface.Toy.repairAC_eliminates_omega`
- `Formal.AG.Research.QualitySurface.Toy.repairAC_hits_every_minSupport`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-minimal-support-hitting.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `lake env lean .tmp/research-loop/check-support-hitting-axioms.lean`

## チェックリスト

- [x] 対象 Issue を本文に記載した。#2348 は research-loop tracking Issue のため、自動 close しないよう `Refs #2348` とした
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
