### PR TITLE
Quality Surface の scalar collapse 証拠を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -1,2 +1,3 @@
 import Formal.AG.Research.Basic
 import Formal.AG.Research.QualitySurface.SupportHitting
+import Formal.AG.Research.QualitySurface.ScalarCollapse

--- a/Formal/AG/Research/QualitySurface/ScalarCollapse.lean
+++ b/Formal/AG/Research/QualitySurface/ScalarCollapse.lean
@@ -1,0 +1,280 @@
+import Formal.AG.Research.QualitySurface.SupportHitting
+
+/-!
+Cycle 2 evidence for `G-aat-quality-surface-01`.
+
+The file fixes a finite reading-fold witness: two certificates have the same
+scalar reading and verdict, while their selected support families and repair
+hitting requirements differ.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ScalarCollapse
+
+/-- A finite atom vocabulary for the scalar-collapse witness. -/
+inductive FoldAtom where
+  | a
+  | b
+  | c
+  deriving DecidableEq, Fintype
+
+/-- Two certificates in the same scalar fiber. -/
+inductive FoldCertificate where
+  | singleSupport
+  | splitSupport
+  deriving DecidableEq
+
+/-- A deliberately small verdict type: both certificates receive the same verdict. -/
+inductive FoldVerdict where
+  | acceptable
+  deriving DecidableEq
+
+open FoldAtom FoldCertificate FoldVerdict
+
+/-- The first certificate is supported on one atom. -/
+def supportA : Set FoldAtom :=
+  fun x => x = a
+
+/-- The second certificate has one selected support branch at `b`. -/
+def supportB : Set FoldAtom :=
+  fun x => x = b
+
+/-- The second certificate has another selected support branch at `c`. -/
+def supportC : Set FoldAtom :=
+  fun x => x = c
+
+/--
+A finite certificate tuple for the scalar-collapse witness.
+
+`selectedViolationCount` is the selected scalar projection used by the reading.
+It records a count-like scalar while leaving support and repair-frontier data in
+the full certificate tuple.
+-/
+structure FoldCertificateTuple where
+  selectedViolationCount : Nat
+  verdict : FoldVerdict
+  selectedSupportFamily : Set (Set FoldAtom)
+  repairHittingRequirement : Nat
+
+/-- The certificate whose repair frontier has one selected support branch. -/
+def singleSupportTuple : FoldCertificateTuple where
+  selectedViolationCount := 1
+  verdict := acceptable
+  selectedSupportFamily := fun M => M = supportA
+  repairHittingRequirement := 1
+
+/-- The certificate whose repair frontier has two selected support branches. -/
+def splitSupportTuple : FoldCertificateTuple where
+  selectedViolationCount := 1
+  verdict := acceptable
+  selectedSupportFamily := fun M => M = supportB ∨ M = supportC
+  repairHittingRequirement := 2
+
+/-- Map certificate names to their full finite tuple. -/
+def certificateTuple : FoldCertificate -> FoldCertificateTuple
+  | singleSupport => singleSupportTuple
+  | splitSupport => splitSupportTuple
+
+/-- The selected scalar reading: project to the selected violation count. -/
+def scalarReading (c : FoldCertificate) : Nat :=
+  (certificateTuple c).selectedViolationCount
+
+/-- The selected verdict is also unchanged by the fold. -/
+def certificateVerdict (c : FoldCertificate) : FoldVerdict :=
+  (certificateTuple c).verdict
+
+/-- Selected minimal support family for each certificate. -/
+def supportFamily (c : FoldCertificate) : Set (Set FoldAtom) :=
+  (certificateTuple c).selectedSupportFamily
+
+/-- Minimal number of support branches a repair must hit in this finite witness. -/
+def repairHittingNumber (c : FoldCertificate) : Nat :=
+  (certificateTuple c).repairHittingRequirement
+
+/-- A selected support family is populated by at least one support branch. -/
+def SupportFamilyNonempty (F : Set (Set FoldAtom)) : Prop :=
+  ∃ M : Set FoldAtom, F M
+
+/-- Selected minimal support branches form an antichain under inclusion. -/
+def SupportFamilyAntichain (F : Set (Set FoldAtom)) : Prop :=
+  ∀ {M N : Set FoldAtom},
+    F M -> F N -> (∀ x, x ∈ M -> x ∈ N) -> M = N
+
+/-- A support family with exactly one selected branch. -/
+def HasOneSupportBranch (F : Set (Set FoldAtom)) (M : Set FoldAtom) : Prop :=
+  F M ∧ ∀ N : Set FoldAtom, F N -> N = M
+
+/-- A support family with exactly two selected branches. -/
+def HasTwoSupportBranches (F : Set (Set FoldAtom)) (M N : Set FoldAtom) : Prop :=
+  F M ∧ F N ∧ M ≠ N ∧
+    ∀ K : Set FoldAtom, F K -> K = M ∨ K = N
+
+/-- The repair hitting requirement agrees with the selected support-family shape. -/
+def RepairRequirementMatchesSupportFamily : FoldCertificate -> Prop
+  | singleSupport =>
+      repairHittingNumber singleSupport = 1 ∧
+        HasOneSupportBranch (supportFamily singleSupport) supportA
+  | splitSupport =>
+      repairHittingNumber splitSupport = 2 ∧
+        HasTwoSupportBranches (supportFamily splitSupport) supportB supportC
+
+/-- The scalar reading is the selected violation-count projection. -/
+theorem scalarReading_eq_selectedViolationCount (c : FoldCertificate) :
+    scalarReading c = (certificateTuple c).selectedViolationCount :=
+  rfl
+
+/-- The two certificates have the same scalar reading. -/
+theorem same_scalarReading :
+    scalarReading singleSupport = scalarReading splitSupport :=
+  rfl
+
+/-- The two certificates have the same verdict. -/
+theorem same_verdict :
+    certificateVerdict singleSupport = certificateVerdict splitSupport :=
+  rfl
+
+/-- The support branches `a` and `b` are distinct. -/
+theorem supportB_ne_supportA : supportB ≠ supportA := by
+  intro h
+  have hbA : FoldAtom.b ∈ supportA := by
+    rw [← h]
+    rfl
+  cases hbA
+
+/-- The support branches `b` and `c` are distinct. -/
+theorem supportB_ne_supportC : supportB ≠ supportC := by
+  intro h
+  have hbC : FoldAtom.b ∈ supportC := by
+    rw [← h]
+    rfl
+  cases hbC
+
+/-- The two certificates have different selected support families. -/
+theorem supportFamily_ne :
+    supportFamily singleSupport ≠ supportFamily splitSupport := by
+  intro h
+  have hbSplit : supportFamily splitSupport supportB := Or.inl rfl
+  have hbSingle : supportFamily singleSupport supportB := by
+    rw [h]
+    exact hbSplit
+  exact supportB_ne_supportA hbSingle
+
+/-- The single-support certificate has hitting requirement one. -/
+theorem singleSupport_repairHittingNumber_eq :
+    repairHittingNumber singleSupport = 1 :=
+  rfl
+
+/-- The split-support certificate has hitting requirement two. -/
+theorem splitSupport_repairHittingNumber_eq :
+    repairHittingNumber splitSupport = 2 :=
+  rfl
+
+/-- Every selected support family in the witness is nonempty. -/
+theorem supportFamily_nonempty (c : FoldCertificate) :
+    SupportFamilyNonempty (supportFamily c) := by
+  cases c with
+  | singleSupport =>
+      exact Exists.intro supportA rfl
+  | splitSupport =>
+      exact Exists.intro supportB (Or.inl rfl)
+
+/-- The single-support certificate has exactly one selected support branch. -/
+theorem singleSupport_hasOneSupportBranch :
+    HasOneSupportBranch (supportFamily singleSupport) supportA := by
+  constructor
+  · rfl
+  · intro N hN
+    exact hN
+
+/-- The split-support certificate has exactly two selected support branches. -/
+theorem splitSupport_hasTwoSupportBranches :
+    HasTwoSupportBranches (supportFamily splitSupport) supportB supportC := by
+  constructor
+  · exact Or.inl rfl
+  · constructor
+    · exact Or.inr rfl
+    · constructor
+      · exact supportB_ne_supportC
+      · intro K hK
+        exact hK
+
+/-- The selected support branches are antichains for both certificates. -/
+theorem supportFamily_antichain (c : FoldCertificate) :
+    SupportFamilyAntichain (supportFamily c) := by
+  cases c with
+  | singleSupport =>
+      intro M N hM hN _hsub
+      rw [hM, hN]
+  | splitSupport =>
+      intro M N hM hN hsub
+      cases hM with
+      | inl hMB =>
+          cases hN with
+          | inl hNB =>
+              rw [hMB, hNB]
+          | inr hNC =>
+              have hbM : FoldAtom.b ∈ M := by
+                rw [hMB]
+                rfl
+              have hbN : FoldAtom.b ∈ N := hsub FoldAtom.b hbM
+              rw [hNC] at hbN
+              cases hbN
+      | inr hMC =>
+          cases hN with
+          | inl hNB =>
+              have hcM : FoldAtom.c ∈ M := by
+                rw [hMC]
+                rfl
+              have hcN : FoldAtom.c ∈ N := hsub FoldAtom.c hcM
+              rw [hNB] at hcN
+              cases hcN
+          | inr hNC =>
+              rw [hMC, hNC]
+
+/-- The named repair hitting requirement matches the selected support family. -/
+theorem repairRequirement_matches_supportFamily (c : FoldCertificate) :
+    RepairRequirementMatchesSupportFamily c := by
+  cases c with
+  | singleSupport =>
+      exact And.intro singleSupport_repairHittingNumber_eq singleSupport_hasOneSupportBranch
+  | splitSupport =>
+      exact And.intro splitSupport_repairHittingNumber_eq splitSupport_hasTwoSupportBranches
+
+/-- The two certificates have different repair hitting requirements. -/
+theorem repairHittingNumber_ne :
+    repairHittingNumber singleSupport ≠ repairHittingNumber splitSupport := by
+  decide
+
+/--
+The finite reading fold: scalar reading and verdict agree, but support geometry
+and repair frontier differ.
+-/
+theorem same_scalar_and_verdict_but_supportRepair_diff :
+    scalarReading singleSupport = scalarReading splitSupport ∧
+      certificateVerdict singleSupport = certificateVerdict splitSupport ∧
+        supportFamily singleSupport ≠ supportFamily splitSupport ∧
+          repairHittingNumber singleSupport ≠ repairHittingNumber splitSupport := by
+  exact And.intro same_scalarReading
+    (And.intro same_verdict (And.intro supportFamily_ne repairHittingNumber_ne))
+
+/-- Faithfulness of a scalar reading to support and repair data. -/
+def ScalarReadingFaithfulToSupportRepair
+    (r : FoldCertificate -> Nat) : Prop :=
+  ∀ c1 c2 : FoldCertificate,
+    r c1 = r c2 ->
+      certificateVerdict c1 = certificateVerdict c2 ->
+        supportFamily c1 = supportFamily c2 ∧
+          repairHittingNumber c1 = repairHittingNumber c2
+
+/-- The selected scalar reading is not faithful to support and repair data. -/
+theorem scalarReading_not_faithful_to_supportRepair :
+    ¬ ScalarReadingFaithfulToSupportRepair scalarReading := by
+  intro hfaithful
+  have hsame :=
+    hfaithful singleSupport splitSupport same_scalarReading same_verdict
+  exact supportFamily_ne hsame.1
+
+end ScalarCollapse
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-scalar-collapse-support-antichain.md
+++ b/research/ideas/g-aat-quality-surface-01-scalar-collapse-support-antichain.md
@@ -1,0 +1,92 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: ridge-fold, atom-supported-quality-geometry, repair-potential, multi-axis-signature
+expected_base_score: 80
+expected_evidence_multiplier: 2.0
+expected_final_score: 160
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-2
+tags: [quality-surface, scalar-collapse, reading-fold, atom-support, repair]
+created: 2026-06-20
+cycle: 2
+lean: proved-in-research
+---
+
+# Scalar-collapse separation by support antichains
+
+## 主張
+
+有限 certificate calculus において、certificate tuple の `selectedViolationCount` への scalar projection と
+同じ verdict を持つ二つの certificate が、
+異なる selected minimal atom support antichain と異なる repair hitting requirement を持つ例を構成できる。
+従って scalar reading は atom-supported certificate geometry の support / repair frontier を復元できない。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- `docs/note/aat_quality_surface.md` の reading fold、scalar-collapse counterexample、Atom support
+- cycle 1 の `Formal/AG/Research/QualitySurface/SupportHitting.lean`
+
+## 非自明性
+
+単なる同点例ではなく、同じ scalar fiber 内で selected minimal support antichain と repair hitting number が変わることを固定する。
+これにより、reading fold は UI 上の projection artifact ではなく、certificate geometry から scalar reading への quotient
+で失われる構造情報として現れる。
+
+## 数学的興味
+
+cycle 1 は local repair が minimal support family 全体を hit する必要を示した。cycle 2 は、その repair frontier が
+scalar reading では見えないことを有限反例として示す。Quality Surface を単一高さの曲面として読むのではなく、
+support antichain と repair requirement を保持する certificate geometry として読む理由を与える。
+
+## GOAL への前進
+
+scalar-collapse counterexample を埋め、ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature のカテゴリを増やす。
+first phase portfolio の support-local repair theorem に続く二つ目の必須 frontier になる。
+
+## SCORE 見込み
+
+- `score_reason`: Lean で finite reading fold と support / repair frontier の分離を証明できれば、scalar-collapse counterexample として強い。
+- `dullness_risk`: reading を恣意的に定数関数にするだけでは弱い。reading は certificate tuple の `selectedViolationCount` への scalar projection として明示し、同じ reading / verdict の下で support antichain と hitting number が異なることを固定する。
+- `proof_or_evidence_plan`: finite atom type と two-certificate universe を置く。一方は support antichain `{a}`、hitting number 1、もう一方は support antichain `{b}`, `{c}`、hitting number 2 を持つ。certificate tuple から `selectedViolationCount` を scalar reading として射影し、同じ scalar reading と同じ verdict を持つこと、support family と hitting number が異なること、各 support family が nonempty antichain であること、repair hitting requirement が selected support family の branch shape と対応すること、したがって scalar reading が support / repair frontier に faithful でないことを Lean Research 側で証明する。
+
+## CS / SWE への帰結
+
+同じ品質点や violation count を持つ二つの判定でも、修正が hit すべき atom family と repair frontier は変わりうる。
+そのため Quality Surface の UI は scalar reading だけでなく、背後の support antichain と repair requirement を保持する必要がある。
+
+## 証明・根拠の見込み
+
+Lean では `ToyCertificate` を二つ用意し、full certificate tuple に
+`selectedViolationCount`、`verdict`、`selectedSupportFamily`、`repairHittingRequirement`
+を持たせる。`scalarReading` は `selectedViolationCount` への projection として定義し、
+`scalarReading c₁ = scalarReading c₂` と `verdict c₁ = verdict c₂` を示す。同時に、
+`supportFamily c₁ ≠ supportFamily c₂`、`repairHittingNumber c₁ = 1`、
+`repairHittingNumber c₂ = 2`、`repairHittingNumber c₁ ≠ repairHittingNumber c₂` を証明する。
+加えて `supportFamily` が nonempty antichain であることと、`repairHittingNumber` が selected
+support family の one-branch / two-branch shape に対応することを固定する。
+最後に、それらをまとめた `scalarReading_not_faithful_to_supportRepair` という finite witness theorem を置く。
+
+## 審判メモ
+
+- 厳密性:
+- 研究価値:
+- repo 全体価値:
+
+## 関連
+
+- `Minimal-support hitting theorem for local repair`
+- `Finite profile-curvature detector on a square cell`
+- `Finite trace-locus example distinguishing zero from unmeasured`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 2 の G1 候補生成から審判対象として作成。
+- 2026-06-20: G2 三審判後に picked。A の revise を受け、scalar reading を `selectedViolationCount` への projection として固定した。
+- 2026-06-20: G3 axiom check / 形式化品質監査 pass。G4 SCORE 監査 confirm: base 80, multiplier 2.0, penalty 0, final 160。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,11 +4,12 @@
 
 ## Current SCORE
 
-- total SCORE: 120
+- total SCORE: 280
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
+  - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
 - evidence portfolio:
-  - proved-in-research: 1
+  - proved-in-research: 2
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -38,6 +39,36 @@ Lean 証拠は二段になっている。
 
 toy calculus では atom `{a,b,c}` 上に二つの selected minimal support `{a,b}` と `{c}` を固定する。repair `{a}` は `{c}` を miss するため obstruction を eliminate できず、repair `{a,c}` は両 support を hit する。この有限例が、単一の chosen support ではなく minimal support family 全体を見る必要を示す。
 
+## Cycle 2: Scalar-collapse separation by support antichains
+
+```text
+candidate: Scalar-collapse separation by support antichains
+candidate_type: orientation
+evidence_stage: proved-in-research
+base_score: 80
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 160
+category: ridge-fold/atom-supported-quality-geometry/repair-potential/multi-axis-signature
+goal_delta: scalar reading / verdict が一致しても support antichain と repair hitting requirement は復元できないことを Lean-proved finite witness として固定し、scalar-collapse frontier と support-local repair 後の第二必須 frontier を埋める。
+project_value_delta: Lean evidence、paper seed、tooling / website explanation に使える reading-fold 分離を追加する。profile transport / curvature はこの成果ではまだ進めない。
+formalization_quality: pass。`selectedViolationCount` projection、同一 scalar / verdict、異なる support family、hitting requirement 1 / 2、nonempty antichain、one / two branch shape、nonfaithfulness theorem が Lean で明示されている。
+open_questions: selected scalar projection の広い class、profile transport / curvature、finite trace field、loss-aware visualization の一般 theorem。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ScalarCollapse.lean` は、二つの finite certificate を同じ scalar fiber に置く。`scalarReading` は full certificate tuple の `selectedViolationCount` への projection であり、二つの certificate は同じ scalar reading と同じ verdict を持つ。一方で、一方の selected support family は一つの branch、もう一方は二つの branch を持ち、repair hitting requirement も 1 と 2 に分かれる。
+
+Lean 証拠は次を固定する。
+
+- `supportFamily_antichain`: 両 certificate の selected support family は nonempty antichain として振る舞う。
+- `repairRequirement_matches_supportFamily`: repair hitting requirement は selected support family の one-branch / two-branch shape に対応する。
+- `same_scalar_and_verdict_but_supportRepair_diff`: scalar reading と verdict が一致しても、support family と repair hitting requirement は異なる。
+- `scalarReading_not_faithful_to_supportRepair`: selected scalar reading は support / repair frontier に faithful ではない。
+
+この結果により、Quality Surface の scalar view は lossful projection であり、背後の certificate geometry を保持しなければ repair frontier を失うことが有限例として固定された。
+
 ### Next Frontier
 
-次サイクルでは、portfolio constraint の残りを埋めるために `scalar-collapse separation by support antichains` または `finite profile-curvature detector on a square cell` を優先する。前者は scalar reading と certificate geometry の fold を分離し、後者は certificate transport / profile curvature を直接進める。
+次サイクルでは、portfolio constraint の残りである `finite profile-curvature detector on a square cell` または `trace-natural certificate transport bridge` を優先する。前者は certificate transport / profile curvature を直接進め、後者は traceability と transport の接続を作る。


### PR DESCRIPTION
## 概要

Refs #2348

research-loop `G-aat-quality-surface-01` の cycle 2 として、scalar reading が support / repair frontier に faithful ではないことを示す Lean 証拠を追加した。

設計判断:

- `Formal/AG` 本体は編集せず、Research sandbox に証拠を閉じた。
- scalar reading は恣意的な定数関数ではなく、full certificate tuple の `selectedViolationCount` への projection として定義した。
- 同じ scalar reading / verdict を持つ二つの certificate で、selected support family と repair hitting requirement が異なることを証明した。
- selected support family は nonempty antichain として明示し、repair hitting requirement は one-branch / two-branch shape に対応させた。
- G4 SCORE 監査は base 80、multiplier 2.0、penalty 0、final SCORE 160 と判定した。

## 証明した定理

- `Formal.AG.Research.QualitySurface.ScalarCollapse.scalarReading_eq_selectedViolationCount`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.same_scalarReading`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.same_verdict`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.supportB_ne_supportA`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.supportB_ne_supportC`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.supportFamily_ne`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.singleSupport_repairHittingNumber_eq`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.splitSupport_repairHittingNumber_eq`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.supportFamily_nonempty`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.supportFamily_antichain`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.repairRequirement_matches_supportFamily`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.repairHittingNumber_ne`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.same_scalar_and_verdict_but_supportRepair_diff`
- `Formal.AG.Research.QualitySurface.ScalarCollapse.scalarReading_not_faithful_to_supportRepair`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-scalar-collapse-support-antichain.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `lake env lean .tmp/research-loop/check-scalar-collapse-axioms.lean`

## チェックリスト

- [x] 対象 Issue を本文に記載した。#2348 は research-loop tracking Issue のため、自動 close しないよう `Refs #2348` とした
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
