### PR TITLE
Quality Surface の profile curvature 証拠を追加

### DIFF
--- a/Formal/AG/Research/QualitySurface/ProfileCurvature.lean
+++ b/Formal/AG/Research/QualitySurface/ProfileCurvature.lean
@@ -1,0 +1,402 @@
+import Formal.AG.Research.QualitySurface.ScalarCollapse
+
+/-!
+Cycle 3 evidence for `G-aat-quality-surface-01`.
+
+The file fixes a finite profile-square witness: two path-ordered certificate
+transports agree on scalar reading and verdict while disagreeing on selected
+support antichain and repair hitting requirement. The discrepancy is recorded
+as failure of full-certificate square coherence.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ProfileCurvature
+
+/-! ## Finite profile square and certificate tuple -/
+
+/-- The four vertices of a finite two-dimensional profile square. -/
+inductive SquareProfile where
+  | lowerLeft
+  | lowerRight
+  | upperLeft
+  | upperRight
+  deriving DecidableEq, Fintype
+
+/-- A finite atom vocabulary for the profile-curvature witness. -/
+inductive CurvatureAtom where
+  | a
+  | b
+  | c
+  deriving DecidableEq, Fintype
+
+/-- The selected verdict is intentionally unchanged along both paths. -/
+inductive CurvatureVerdict where
+  | acceptable
+  deriving DecidableEq
+
+/--
+Certificates appearing along the profile square.
+
+`lawThenCoverResult` and `coverThenLawResult` live in the same upper-right
+certificate space but arise from different path-ordered comparison maps.
+-/
+inductive SquareCertificate where
+  | seed
+  | lawStage
+  | coverStage
+  | lawThenCoverResult
+  | coverThenLawResult
+  deriving DecidableEq, Fintype
+
+open CurvatureVerdict SquareCertificate
+
+/-- The first selected support branch. -/
+def supportA : Set CurvatureAtom :=
+  fun x => x = CurvatureAtom.a
+
+/-- The first branch of the split selected support family. -/
+def supportB : Set CurvatureAtom :=
+  fun x => x = CurvatureAtom.b
+
+/-- The second branch of the split selected support family. -/
+def supportC : Set CurvatureAtom :=
+  fun x => x = CurvatureAtom.c
+
+/--
+A finite certificate tuple over a profile vertex.
+
+The scalar and verdict components are the visible reading. The support family
+and repair hitting requirement are the certificate geometry carried underneath.
+-/
+structure SquareCertificateTuple where
+  selectedScalarReading : Nat
+  selectedVerdict : CurvatureVerdict
+  selectedSupportFamily : Set (Set CurvatureAtom)
+  repairHittingRequirement : Nat
+
+/-- A one-branch support family. -/
+def oneSupportFamily : Set (Set CurvatureAtom) :=
+  fun M => M = supportA
+
+/-- A two-branch support family. -/
+def splitSupportFamily : Set (Set CurvatureAtom) :=
+  fun M => M = supportB ∨ M = supportC
+
+/-- The initial certificate before either profile change. -/
+def seedTuple : SquareCertificateTuple where
+  selectedScalarReading := 0
+  selectedVerdict := acceptable
+  selectedSupportFamily := oneSupportFamily
+  repairHittingRequirement := 1
+
+/-- The bottom-edge intermediate certificate after law strengthening. -/
+def lawStageTuple : SquareCertificateTuple where
+  selectedScalarReading := 1
+  selectedVerdict := acceptable
+  selectedSupportFamily := oneSupportFamily
+  repairHittingRequirement := 1
+
+/-- The left-edge intermediate certificate after cover refinement. -/
+def coverStageTuple : SquareCertificateTuple where
+  selectedScalarReading := 1
+  selectedVerdict := acceptable
+  selectedSupportFamily := oneSupportFamily
+  repairHittingRequirement := 1
+
+/-- The upper-right certificate reached by law strengthening then cover refinement. -/
+def lawThenCoverTuple : SquareCertificateTuple where
+  selectedScalarReading := 1
+  selectedVerdict := acceptable
+  selectedSupportFamily := oneSupportFamily
+  repairHittingRequirement := 1
+
+/-- The upper-right certificate reached by cover refinement then law strengthening. -/
+def coverThenLawTuple : SquareCertificateTuple where
+  selectedScalarReading := 1
+  selectedVerdict := acceptable
+  selectedSupportFamily := splitSupportFamily
+  repairHittingRequirement := 2
+
+/-- Read the tuple carried by a named certificate. -/
+def certificateTuple : SquareCertificate -> SquareCertificateTuple
+  | seed => seedTuple
+  | lawStage => lawStageTuple
+  | coverStage => coverStageTuple
+  | lawThenCoverResult => lawThenCoverTuple
+  | coverThenLawResult => coverThenLawTuple
+
+/-- The profile vertex where a named certificate lives. -/
+def profileOf : SquareCertificate -> SquareProfile
+  | seed => SquareProfile.lowerLeft
+  | lawStage => SquareProfile.lowerRight
+  | coverStage => SquareProfile.upperLeft
+  | lawThenCoverResult => SquareProfile.upperRight
+  | coverThenLawResult => SquareProfile.upperRight
+
+/-- Certificates typed by the profile vertex where they live. -/
+def CertificateAt (p : SquareProfile) : Type :=
+  { c : SquareCertificate // profileOf c = p }
+
+/-- The selected seed certificate at the lower-left vertex. -/
+def seedAt : CertificateAt SquareProfile.lowerLeft :=
+  ⟨seed, rfl⟩
+
+/-- The visible scalar reading selected from the certificate tuple. -/
+def scalarReading (c : SquareCertificate) : Nat :=
+  (certificateTuple c).selectedScalarReading
+
+/-- The selected verdict component. -/
+def verdict (c : SquareCertificate) : CurvatureVerdict :=
+  (certificateTuple c).selectedVerdict
+
+/-- The selected minimal support family carried by a certificate. -/
+def supportFamily (c : SquareCertificate) : Set (Set CurvatureAtom) :=
+  (certificateTuple c).selectedSupportFamily
+
+/-- The repair hitting requirement carried by a certificate. -/
+def repairHittingNumber (c : SquareCertificate) : Nat :=
+  (certificateTuple c).repairHittingRequirement
+
+/-! ## Four typed edge transports and the two path composites -/
+
+/-- A comparison map along one profile-square edge. -/
+structure EdgeTransport (source target : SquareProfile) where
+  map : CertificateAt source -> CertificateAt target
+
+/-- Bottom edge: strengthen the law universe. -/
+def transportLawBottom :
+    EdgeTransport SquareProfile.lowerLeft SquareProfile.lowerRight where
+  map := fun _ => ⟨lawStage, rfl⟩
+
+/-- Right edge: refine the cover after law strengthening. -/
+def transportCoverRight :
+    EdgeTransport SquareProfile.lowerRight SquareProfile.upperRight where
+  map := fun _ => ⟨lawThenCoverResult, rfl⟩
+
+/-- Left edge: refine the cover first. -/
+def transportCoverLeft :
+    EdgeTransport SquareProfile.lowerLeft SquareProfile.upperLeft where
+  map := fun _ => ⟨coverStage, rfl⟩
+
+/-- Top edge: strengthen the law universe after cover refinement. -/
+def transportLawTop :
+    EdgeTransport SquareProfile.upperLeft SquareProfile.upperRight where
+  map := fun _ => ⟨coverThenLawResult, rfl⟩
+
+/-- The path that strengthens law first and refines cover second. -/
+def lawThenCover
+    (c : CertificateAt SquareProfile.lowerLeft) :
+    CertificateAt SquareProfile.upperRight :=
+  transportCoverRight.map (transportLawBottom.map c)
+
+/-- The path that refines cover first and strengthens law second. -/
+def coverThenLaw
+    (c : CertificateAt SquareProfile.lowerLeft) :
+    CertificateAt SquareProfile.upperRight :=
+  transportLawTop.map (transportCoverLeft.map c)
+
+/-- The bottom edge sends the seed certificate to the law stage. -/
+theorem transportLawBottom_seed :
+    (transportLawBottom.map seedAt).val = lawStage :=
+  rfl
+
+/-- The right edge sends the law stage to the first upper-right certificate. -/
+theorem transportCoverRight_lawStage :
+    (transportCoverRight.map (transportLawBottom.map seedAt)).val =
+      lawThenCoverResult :=
+  rfl
+
+/-- The left edge sends the seed certificate to the cover stage. -/
+theorem transportCoverLeft_seed :
+    (transportCoverLeft.map seedAt).val = coverStage :=
+  rfl
+
+/-- The top edge sends the cover stage to the second upper-right certificate. -/
+theorem transportLawTop_coverStage :
+    (transportLawTop.map (transportCoverLeft.map seedAt)).val =
+      coverThenLawResult :=
+  rfl
+
+/-- The law-then-cover path reaches its named upper-right certificate. -/
+theorem lawThenCover_seed :
+    (lawThenCover seedAt).val = lawThenCoverResult :=
+  rfl
+
+/-- The cover-then-law path reaches its named upper-right certificate. -/
+theorem coverThenLaw_seed :
+    (coverThenLaw seedAt).val = coverThenLawResult :=
+  rfl
+
+/-! ## Support antichains along the transported certificates -/
+
+/-- A selected support family is populated by at least one branch. -/
+def SupportFamilyNonempty (F : Set (Set CurvatureAtom)) : Prop :=
+  ∃ M : Set CurvatureAtom, F M
+
+/-- Selected support branches form an antichain under inclusion. -/
+def SupportFamilyAntichain (F : Set (Set CurvatureAtom)) : Prop :=
+  ∀ {M N : Set CurvatureAtom},
+    F M -> F N -> (∀ x, x ∈ M -> x ∈ N) -> M = N
+
+/-- The law-then-cover transported support family is nonempty. -/
+theorem lawThenCover_supportFamily_nonempty :
+    SupportFamilyNonempty (supportFamily (lawThenCover seedAt).val) :=
+  Exists.intro supportA rfl
+
+/-- The cover-then-law transported support family is nonempty. -/
+theorem coverThenLaw_supportFamily_nonempty :
+    SupportFamilyNonempty (supportFamily (coverThenLaw seedAt).val) :=
+  Exists.intro supportB (Or.inl rfl)
+
+/-- The law-then-cover transported support family is an antichain. -/
+theorem lawThenCover_supportFamily_antichain :
+    SupportFamilyAntichain (supportFamily (lawThenCover seedAt).val) := by
+  intro M N hM hN _hsub
+  rw [hM, hN]
+
+/-- The support branches `b` and `a` are distinct. -/
+theorem supportB_ne_supportA : supportB ≠ supportA := by
+  intro h
+  have hbA : CurvatureAtom.b ∈ supportA := by
+    rw [← h]
+    rfl
+  cases hbA
+
+/-- The support branches `b` and `c` are distinct. -/
+theorem supportB_ne_supportC : supportB ≠ supportC := by
+  intro h
+  have hbC : CurvatureAtom.b ∈ supportC := by
+    rw [← h]
+    rfl
+  cases hbC
+
+/-- The cover-then-law transported support family is an antichain. -/
+theorem coverThenLaw_supportFamily_antichain :
+    SupportFamilyAntichain (supportFamily (coverThenLaw seedAt).val) := by
+  intro M N hM hN hsub
+  cases hM with
+  | inl hMB =>
+      cases hN with
+      | inl hNB =>
+          rw [hMB, hNB]
+      | inr hNC =>
+          have hbM : CurvatureAtom.b ∈ M := by
+            rw [hMB]
+            rfl
+          have hbN : CurvatureAtom.b ∈ N := hsub CurvatureAtom.b hbM
+          rw [hNC] at hbN
+          cases hbN
+  | inr hMC =>
+      cases hN with
+      | inl hNB =>
+          have hcM : CurvatureAtom.c ∈ M := by
+            rw [hMC]
+            rfl
+          have hcN : CurvatureAtom.c ∈ N := hsub CurvatureAtom.c hcM
+          rw [hNB] at hcN
+          cases hcN
+      | inr hNC =>
+          rw [hMC, hNC]
+
+/-! ## Regularity and curvature for the square -/
+
+/-- Full-certificate path coherence for a transported certificate. -/
+def FullCertificateAgreement (c₁ c₂ : SquareCertificate) : Prop :=
+  scalarReading c₁ = scalarReading c₂ ∧
+    verdict c₁ = verdict c₂ ∧
+      supportFamily c₁ = supportFamily c₂ ∧
+        repairHittingNumber c₁ = repairHittingNumber c₂
+
+/-- Full-certificate path coherence for two typed upper-right certificates. -/
+def FullCertificateAgreementAt
+    (c₁ c₂ : CertificateAt SquareProfile.upperRight) : Prop :=
+  FullCertificateAgreement c₁.val c₂.val
+
+/-- A regular square keeps the full certificate geometry coherent along paths. -/
+def RegularSquareCell (c : CertificateAt SquareProfile.lowerLeft) : Prop :=
+  FullCertificateAgreementAt (lawThenCover c) (coverThenLaw c)
+
+/-- A curvature cell is a square where full-certificate path coherence fails. -/
+def CurvatureCell (c : CertificateAt SquareProfile.lowerLeft) : Prop :=
+  ¬ RegularSquareCell c
+
+/-- The two paths agree on the selected scalar reading. -/
+theorem same_scalarReading_after_paths :
+    scalarReading (lawThenCover seedAt).val =
+      scalarReading (coverThenLaw seedAt).val :=
+  rfl
+
+/-- The two paths agree on the selected verdict. -/
+theorem same_verdict_after_paths :
+    verdict (lawThenCover seedAt).val = verdict (coverThenLaw seedAt).val :=
+  rfl
+
+/-- The two paths disagree on selected support family. -/
+theorem supportFamily_path_ne :
+    supportFamily (lawThenCover seedAt).val ≠
+      supportFamily (coverThenLaw seedAt).val := by
+  intro h
+  have hbRight : supportFamily (coverThenLaw seedAt).val supportB := Or.inl rfl
+  have hbLeft : supportFamily (lawThenCover seedAt).val supportB := by
+    rw [h]
+    exact hbRight
+  exact supportB_ne_supportA hbLeft
+
+/-- The two paths disagree on repair hitting requirement. -/
+theorem repairHittingNumber_path_ne :
+    repairHittingNumber (lawThenCover seedAt).val ≠
+      repairHittingNumber (coverThenLaw seedAt).val := by
+  decide
+
+/-- Support / repair discrepancy after the two path-ordered transports. -/
+def SupportRepairPathDiscrepancy
+    (c : CertificateAt SquareProfile.lowerLeft) : Prop :=
+  supportFamily (lawThenCover c).val ≠ supportFamily (coverThenLaw c).val ∨
+    repairHittingNumber (lawThenCover c).val ≠
+      repairHittingNumber (coverThenLaw c).val
+
+/-- The seed square has both support and repair discrepancies after transport. -/
+theorem supportAndRepairPathDiscrepancy_seed :
+    supportFamily (lawThenCover seedAt).val ≠
+        supportFamily (coverThenLaw seedAt).val ∧
+      repairHittingNumber (lawThenCover seedAt).val ≠
+        repairHittingNumber (coverThenLaw seedAt).val :=
+  And.intro supportFamily_path_ne repairHittingNumber_path_ne
+
+/-- The seed square has a support / repair discrepancy after transport. -/
+theorem supportRepairPathDiscrepancy_seed :
+    SupportRepairPathDiscrepancy seedAt :=
+  Or.inl supportFamily_path_ne
+
+/-- A support / repair discrepancy violates full-certificate regularity. -/
+theorem curvatureCell_of_supportRepair_path_discrepancy
+    {c : CertificateAt SquareProfile.lowerLeft}
+    (h : SupportRepairPathDiscrepancy c) :
+    CurvatureCell c := by
+  intro hregular
+  cases h with
+  | inl hsupport =>
+      exact hsupport hregular.2.2.1
+  | inr hrepair =>
+      exact hrepair hregular.2.2.2
+
+/-- The finite profile square is a curvature cell. -/
+theorem seed_curvatureCell : CurvatureCell seedAt :=
+  curvatureCell_of_supportRepair_path_discrepancy supportRepairPathDiscrepancy_seed
+
+/--
+The finite profile-curvature witness: the scalar reading and verdict are flat
+across the two paths, while the full certificate geometry is curved.
+-/
+theorem same_scalar_verdict_but_curved_square :
+    scalarReading (lawThenCover seedAt).val =
+        scalarReading (coverThenLaw seedAt).val ∧
+      verdict (lawThenCover seedAt).val = verdict (coverThenLaw seedAt).val ∧
+        CurvatureCell seedAt := by
+  exact And.intro same_scalarReading_after_paths
+    (And.intro same_verdict_after_paths seed_curvatureCell)
+
+end ProfileCurvature
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-profile-curvature-detector.md
+++ b/research/ideas/g-aat-quality-surface-01-profile-curvature-detector.md
@@ -1,0 +1,122 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computability
+capability_category: profile-curvature, certificate-transport, computability, ridge-fold, repair-potential
+expected_base_score: 85
+expected_evidence_multiplier: 2.0
+expected_final_score: 170
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-3
+tags: [quality-surface, profile-curvature, certificate-transport, support-antichain, repair]
+created: 2026-06-20
+cycle: 3
+lean: proved-in-research
+---
+
+# Finite square cell profile-curvature detector
+
+## 主張
+
+有限二次元 profile square を固定する。横方向の profile change を `u`、縦方向を `v` とし、
+四つの edge comparison map を明示し、二つの経路合成
+
+```text
+Phi_v' o Phi_u
+Phi_u' o Phi_v
+```
+
+が同じ初期 certificate を右上 profile の certificate space へ transport するとする。
+regular square cell は、二つの path composite が full certificate geometry
+(selected scalar reading、verdict、selected minimal atom support antichain、repair hitting requirement)
+を一致させる square として定義する。二つの合成後 certificate が同じ scalar reading と verdict を持っていても、
+selected minimal atom support antichain または repair hitting requirement が異なるなら、その square は
+path coherence を満たさず、profile-curvature cell である。
+
+## 候補種別
+
+`computability`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- `docs/note/aat_quality_surface.md` の profile curvature、finite profile grid、regular cell / curvature cell
+- cycle 1 の `Formal/AG/Research/QualitySurface/SupportHitting.lean`
+- cycle 2 の `Formal/AG/Research/QualitySurface/ScalarCollapse.lean`
+
+## 非自明性
+
+各 profile 頂点の測定値を並べるだけではなく、四つの edge comparison map と二つの path composite が
+certificate geometry をどう運ぶかを比較する。scalar reading と verdict が一致しても、support antichain と
+repair hitting requirement が一致しない場合を検出するため、単なる noncommuting function の有限例ではなく、
+cycle 1 / 2 で固定した support / repair frontier を path-ordered transport の coherence failure として読む。
+
+## 数学的興味
+
+Quality Surface を surface と呼ぶための二次元性は、値の grid ではなく、square transport の整合性にある。
+この候補は、cover refinement と law strengthening の順序が同じ scalar view に落ちても、背後の
+certificate support と repair frontier を異なる位置へ送る有限例を固定する。これにより
+`profile curvature` が可視化上の比喩ではなく、certificate transport の非可換性として現れる。
+
+## GOAL への前進
+
+profile-curvature / certificate-transport / computability のカテゴリを直接増やし、既存の
+support-local repair theorem と scalar-collapse counterexample を、有限二次元 Quality Surface 上の
+curvature detector へ接続する。
+
+## SCORE 見込み
+
+- `score_reason`: finite profile square と Lean proof で、二つの profile change order が同じ scalar / verdict
+  へ落ちながら異なる support / repair frontier を作ることを固定できれば、GOAL の profile curvature
+  frontier を直接進める。
+- `dullness_risk`: 単に二つの関数値が異なるという例や、cycle 2 の endpoint certificate に square label を
+  貼っただけの例に落ちると弱い。四つの edge comparison map、二つの path composite、regular square の
+  full-certificate coherence 条件を明示し、scalar view では見えない二次元 transport の欠陥として述べる。
+- `proof_or_evidence_plan`: finite square profile、四つの edge transport、右上への二つの path transport、
+  finite certificate tuple を Lean Research 側に置く。二つの path transport 後 certificate が同じ
+  scalar reading / verdict を持つこと、support family と repair hitting requirement が異なること、
+  support family が nonempty antichain であること、regular square cell が full certificate geometry の
+  path coherence を要求すること、従ってこの square が regular cell でなく curvature cell であることを証明する。
+
+## CS / SWE への帰結
+
+law universe を先に強めてから cover を細かくした場合と、その逆の場合で、同じ品質点・同じ verdict
+に見えても、修正が hit すべき atom family が変わることを説明できる。Quality Surface の UI は
+profile grid の高さだけでなく、edge transport と square curvature を保持する必要がある。
+
+## 証明・根拠の見込み
+
+Lean では `SquareProfile` と `SquareCertificate` を有限型として置く。四辺の transport
+`transportLawBottom`、`transportCoverLeft`、`transportCoverRight`、`transportLawTop` を定義し、
+同じ初期 certificate から右上へ行く二つの path composite を `lawThenCover` と `coverThenLaw` として定義する。
+両者の scalar reading と verdict が一致する一方で、selected support family と repair hitting number が異なる
+finite witness を作る。さらに `RegularSquareCell` を path transport 後の full certificate geometry が一致すること、
+`CurvatureCell` を path coherence failure として定義し、support / repair discrepancy が regularity を破ることを示す。
+最後に `same_scalar_verdict_but_curved_square` と
+`curvatureCell_of_supportRepair_path_discrepancy` を証明する。
+
+## 審判メモ
+
+- 厳密性: 初回と再審判は `revise`。四辺の edge transport、二つの path composite、full-certificate
+  regularity、support / repair discrepancy を Lean で明示することを要求。G3 で typed `CertificateAt`
+  と `EdgeTransport` を導入し、公理検査 pass。
+- 研究価値: `accept`。base score 85。support-local repair と scalar-collapse を profile-curvature
+  detector へ圧縮し、Quality Surface の二次元性を square transport coherence として固定する。
+- repo 全体価値: `accept`。base score 85。AAT Research / Lean / paper seed の前進として自然で、
+  tooling / website へは将来 surface の設計根拠として接続可能。ただし現サイクルでは tooling claim
+  へ直結させない。
+
+## 関連
+
+- `Minimal-support hitting theorem for local repair`
+- `Scalar-collapse separation by support antichains`
+- `Trace-natural certificate transport bridge`
+- `Measured zero / unmeasured / trace-missing separation`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 3 の G1 候補生成から審判対象として作成。
+- 2026-06-20: G2 revise を受け、証拠段階を `none` に戻し、四つの edge transport、二つの path composite、
+  regular square の full-certificate coherence 条件、curvature cell の path coherence failure を主張に明示。
+- 2026-06-20: `Formal/AG/Research/QualitySurface/ProfileCurvature.lean` を追加。`lake build FormalAGResearch`
+  pass。G3 公理検査 pass: requested declarations depend on no axioms。G3 形式化品質監査 pass。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,12 +4,13 @@
 
 ## Current SCORE
 
-- total SCORE: 280
+- total SCORE: 450
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
+  - profile-curvature / certificate-transport / computability / ridge-fold / repair-potential: 170
 - evidence portfolio:
-  - proved-in-research: 2
+  - proved-in-research: 3
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -69,6 +70,48 @@ Lean 証拠は次を固定する。
 
 この結果により、Quality Surface の scalar view は lossful projection であり、背後の certificate geometry を保持しなければ repair frontier を失うことが有限例として固定された。
 
+## Cycle 3: Finite square cell profile-curvature detector
+
+```text
+candidate: Finite square cell profile-curvature detector
+candidate_type: computability
+evidence_stage: proved-in-research
+base_score: 85
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 170
+category: profile-curvature/certificate-transport/computability/ridge-fold/repair-potential
+goal_delta: scalar reading と verdict が二つの profile-change path で一致しても、support antichain と repair hitting requirement が分岐する finite square を Lean-proved witness として固定し、profile-curvature frontier を前進させる。
+project_value_delta: AAT Research / Lean / paper seed に、Quality Surface の二次元性を path-ordered certificate transport の coherence failure として説明する素材を追加する。tooling / website への接続は将来の説明 surface に留める。
+formalization_quality: pass。`CertificateAt` による profile-typed certificate space、typed `EdgeTransport`、四辺 transport、二つの upper-right path composite、full-certificate regularity、curvature-as-coherence-failure が Lean で明示されている。
+open_questions: trace-natural certificate transport、measured-zero / unmeasured / trace-missing separation、profile curvature の broader detector class、finite codebase trace example。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ProfileCurvature.lean` は、有限 profile square を定義する。
+lower-left の seed certificate から upper-right へ到達する path として、law strengthening 後に cover
+refinement を行う `lawThenCover` と、cover refinement 後に law strengthening を行う
+`coverThenLaw` を置く。四つの edge comparison map は typed `EdgeTransport` として与えられ、
+二つの path composite はどちらも `CertificateAt upperRight` に入る。
+
+Lean 証拠は次を固定する。
+
+- `same_scalarReading_after_paths`: 二つの path は selected scalar reading で一致する。
+- `same_verdict_after_paths`: 二つの path は selected verdict で一致する。
+- `supportAndRepairPathDiscrepancy_seed`: 二つの path は selected support family と repair hitting
+  requirement で分岐する。
+- `curvatureCell_of_supportRepair_path_discrepancy`: support または repair の path discrepancy は
+  full-certificate regularity を破る。
+- `same_scalar_verdict_but_curved_square`: scalar reading と verdict は flat でも、full certificate
+  geometry は curvature cell になる。
+
+この結果により、Quality Surface の二次元性は頂点値の grid ではなく、profile change に沿う certificate
+transport の path coherence として固定された。scalar view が flat に見える square でも、support / repair
+frontier は曲がりうる。
+
 ### Next Frontier
 
-次サイクルでは、portfolio constraint の残りである `finite profile-curvature detector on a square cell` または `trace-natural certificate transport bridge` を優先する。前者は certificate transport / profile curvature を直接進め、後者は traceability と transport の接続を作る。
+次サイクルでは、`trace-natural certificate transport bridge` または
+`measured zero / unmeasured / trace-missing separation` を優先する。前者は traceability と transport
+を接続し、後者は finite trace example と loss-aware visualization の基礎を作る。


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` の cycle 3 として、有限 profile square 上の profile-curvature detector を Research sandbox に追加しました。

- `Formal/AG/Research/QualitySurface/ProfileCurvature.lean` で typed `CertificateAt`、typed `EdgeTransport`、四辺 transport、二つの path composite を定義
- scalar reading と verdict が一致しても、support family と repair hitting requirement が path によって分岐する Lean-proved witness を追加
- SCORE 監査 confirm に従い、report を total `450`、cycle 3 `+170` に更新

tracking Issue #2348 は research-loop の状態正本として開いたままにするため、`Closes #2348` は付けていません。

## 証明した定理

- `Formal.AG.Research.QualitySurface.ProfileCurvature.same_scalarReading_after_paths`
- `Formal.AG.Research.QualitySurface.ProfileCurvature.same_verdict_after_paths`
- `Formal.AG.Research.QualitySurface.ProfileCurvature.supportAndRepairPathDiscrepancy_seed`
- `Formal.AG.Research.QualitySurface.ProfileCurvature.curvatureCell_of_supportRepair_path_discrepancy`
- `Formal.AG.Research.QualitySurface.ProfileCurvature.same_scalar_verdict_but_curved_square`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-profile-curvature-detector.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `lake build FormalAGResearch`
- [x] G3 公理検査（対象 theorem は axioms なし、`sorryAx` なし）
- [x] G3 Lean 形式化品質監査
- [x] G4 SCORE 監査（confirm: base 85, multiplier 2.0, final 170）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] local path / private identifier scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Research Loop tracking Issue は閉じないため `Refs #2348`）
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
