### PR TITLE
Quality Surface の trace transport 証拠を追加

### DIFF
--- a/Formal/AG/Research/QualitySurface/TraceTransport.lean
+++ b/Formal/AG/Research/QualitySurface/TraceTransport.lean
@@ -1,0 +1,203 @@
+import Formal.AG.Research.QualitySurface.ProfileCurvature
+
+/-!
+Cycle 4 evidence for `G-aat-quality-surface-01`.
+
+The file separates support transport from trace-token transport. Trace
+naturality preserves trace availability along transported support, while a
+finite witness shows that support can be transported and still leave a
+trace-missing target atom when naturality fails.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace TraceTransport
+
+universe u v w x
+
+/-- The support obtained by transporting a source support along an atom map. -/
+def TransportedSupport {Source : Type u} {Target : Type v}
+    (atomMap : Source -> Target) (sourceSupport : Set Source) : Set Target :=
+  fun target => ∃ source, sourceSupport source ∧ atomMap source = target
+
+/-- A partial trace field is available on every atom in a selected support. -/
+def TraceAvailableOn {Atom : Type u} {TraceToken : Type v}
+    (support : Set Atom) (traceField : Atom -> Option TraceToken) : Prop :=
+  ∀ atom, support atom -> ∃ token, traceField atom = some token
+
+/-- A selected support has at least one atom whose trace token is missing. -/
+def TraceMissingOn {Atom : Type u} {TraceToken : Type v}
+    (support : Set Atom) (traceField : Atom -> Option TraceToken) : Prop :=
+  ∃ atom, support atom ∧ traceField atom = none
+
+/--
+Trace naturality for one profile change.
+
+On selected source support, reading the target trace after atom transport agrees
+with transporting the source trace token.
+-/
+def TraceNatural {Source : Type u} {Target : Type v}
+    {SourceTrace : Type w} {TargetTrace : Type x}
+    (sourceSupport : Set Source) (atomMap : Source -> Target)
+    (traceMap : SourceTrace -> TargetTrace)
+    (sourceTraceField : Source -> Option SourceTrace)
+    (targetTraceField : Target -> Option TargetTrace) : Prop :=
+  ∀ source, sourceSupport source ->
+    targetTraceField (atomMap source) =
+      Option.map traceMap (sourceTraceField source)
+
+/--
+Trace naturality preserves trace availability along transported support.
+
+This is the positive bridge theorem: if the source support is traced and the
+profile change respects trace tokens, then every transported target support atom
+is traced.
+-/
+theorem traceAvailableOn_transport_of_traceNatural
+    {Source : Type u} {Target : Type v}
+    {SourceTrace : Type w} {TargetTrace : Type x}
+    {sourceSupport : Set Source} {atomMap : Source -> Target}
+    {traceMap : SourceTrace -> TargetTrace}
+    {sourceTraceField : Source -> Option SourceTrace}
+    {targetTraceField : Target -> Option TargetTrace}
+    (hsource : TraceAvailableOn sourceSupport sourceTraceField)
+    (hnatural :
+      TraceNatural sourceSupport atomMap traceMap sourceTraceField
+        targetTraceField) :
+    TraceAvailableOn (TransportedSupport atomMap sourceSupport)
+      targetTraceField := by
+  intro target htarget
+  rcases htarget with ⟨source, hsourceSupport, hmap⟩
+  rcases hsource source hsourceSupport with ⟨token, htoken⟩
+  refine ⟨traceMap token, ?_⟩
+  rw [← hmap]
+  rw [hnatural source hsourceSupport, htoken]
+  rfl
+
+/-! ## A finite support-transport / trace-missing witness -/
+
+/-- Source atoms before the profile change. -/
+inductive SourceAtom where
+  | a
+  | b
+  deriving DecidableEq, Fintype
+
+/-- Target atoms after the profile change. -/
+inductive TargetAtom where
+  | aPrime
+  | bPrime
+  deriving DecidableEq, Fintype
+
+/-- Trace tokens available on the source certificate. -/
+inductive SourceTraceToken where
+  | refA
+  | refB
+  deriving DecidableEq
+
+/-- Trace tokens available on the target certificate. -/
+inductive TargetTraceToken where
+  | refA
+  | refB
+  deriving DecidableEq
+
+open SourceAtom TargetAtom
+
+/-- Both source atoms belong to the selected support. -/
+def sourceSupport : Set SourceAtom :=
+  fun _ => True
+
+/-- The profile change transports each source atom to its target atom. -/
+def atomTransport : SourceAtom -> TargetAtom
+  | a => aPrime
+  | b => bPrime
+
+/-- Source trace tokens are renamed along the profile change. -/
+def traceTokenTransport : SourceTraceToken -> TargetTraceToken
+  | SourceTraceToken.refA => TargetTraceToken.refA
+  | SourceTraceToken.refB => TargetTraceToken.refB
+
+/-- The source trace field is available on both selected support atoms. -/
+def sourceTraceField : SourceAtom -> Option SourceTraceToken
+  | a => some SourceTraceToken.refA
+  | b => some SourceTraceToken.refB
+
+/-- A target trace field that preserves trace tokens naturally. -/
+def targetTraceFieldNatural : TargetAtom -> Option TargetTraceToken
+  | aPrime => some TargetTraceToken.refA
+  | bPrime => some TargetTraceToken.refB
+
+/-- A target trace field where the transported `b` atom has no available token. -/
+def targetTraceFieldMissing : TargetAtom -> Option TargetTraceToken
+  | aPrime => some TargetTraceToken.refA
+  | bPrime => none
+
+/-- The transported target support. -/
+def targetSupport : Set TargetAtom :=
+  TransportedSupport atomTransport sourceSupport
+
+/-- The source support is fully traced. -/
+theorem sourceTraceAvailable :
+    TraceAvailableOn sourceSupport sourceTraceField := by
+  intro atom _hatom
+  cases atom with
+  | a => exact ⟨SourceTraceToken.refA, rfl⟩
+  | b => exact ⟨SourceTraceToken.refB, rfl⟩
+
+/-- The natural target trace field satisfies trace naturality. -/
+theorem targetTraceNatural :
+    TraceNatural sourceSupport atomTransport traceTokenTransport
+      sourceTraceField targetTraceFieldNatural := by
+  intro source _hsource
+  cases source <;> rfl
+
+/-- Natural trace transport preserves target trace availability. -/
+theorem targetTraceAvailable_of_traceNatural :
+    TraceAvailableOn targetSupport targetTraceFieldNatural :=
+  traceAvailableOn_transport_of_traceNatural sourceTraceAvailable
+    targetTraceNatural
+
+/-- The transported support contains `bPrime`. -/
+theorem bPrime_mem_targetSupport : targetSupport bPrime := by
+  exact ⟨SourceAtom.b, trivial, rfl⟩
+
+/-- The missing target trace field has no token at `bPrime`. -/
+theorem targetTraceMissing_bPrime :
+    targetTraceFieldMissing bPrime = none :=
+  rfl
+
+/-- Support transport can hold while the transported support has a missing trace. -/
+theorem supportTransported_but_traceMissing :
+    targetSupport bPrime ∧ targetTraceFieldMissing bPrime = none :=
+  And.intro bPrime_mem_targetSupport targetTraceMissing_bPrime
+
+/-- The missing target trace field is not trace-natural. -/
+theorem targetTraceMissing_not_traceNatural :
+    ¬ TraceNatural sourceSupport atomTransport traceTokenTransport
+      sourceTraceField targetTraceFieldMissing := by
+  intro hnatural
+  have hb := hnatural SourceAtom.b trivial
+  change (none : Option TargetTraceToken) =
+    some TargetTraceToken.refB at hb
+  cases hb
+
+/-- The finite missing-trace witness on transported support. -/
+theorem missingTraceOn_targetSupport :
+    TraceMissingOn targetSupport targetTraceFieldMissing :=
+  ⟨bPrime, bPrime_mem_targetSupport, targetTraceMissing_bPrime⟩
+
+/--
+The cycle-4 finite bridge witness: support transport alone does not transport
+traceability. The target support contains `bPrime`, its trace token is missing,
+and the missing trace field fails trace naturality.
+-/
+theorem support_transport_without_trace_naturality_has_missing_trace :
+    targetSupport bPrime ∧
+      targetTraceFieldMissing bPrime = none ∧
+        ¬ TraceNatural sourceSupport atomTransport traceTokenTransport
+          sourceTraceField targetTraceFieldMissing := by
+  exact And.intro bPrime_mem_targetSupport
+    (And.intro targetTraceMissing_bPrime targetTraceMissing_not_traceNatural)
+
+end TraceTransport
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-trace-natural-transport.md
+++ b/research/ideas/g-aat-quality-surface-01-trace-natural-transport.md
@@ -1,0 +1,115 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: traceability, certificate-transport, invariance, profile-curvature, atom-supported-quality-geometry
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-4
+tags: [quality-surface, traceability, certificate-transport, profile-curvature, atom-support]
+created: 2026-06-20
+cycle: 4
+lean: proved-in-research
+---
+
+# Trace-natural certificate transport bridge
+
+## 主張
+
+有限 profile change に沿って、certificate の supporting atom family を運ぶ atom transport と、
+利用可能な trace token を運ぶ trace-token map を固定する。source certificate の support 上で trace field が
+定義され、target trace field が atom transport と trace-token map の自然性 square を満たすなら、
+transport 後の target support 上でも trace token への追跡可能性は保存される。
+
+主成果は、support transport は保存されていても trace naturality が破れる有限例では、target support に
+trace-missing atom が残ることを示す点に置く。保存 theorem は補助結果であり、finite missing-trace witness が
+support transport と trace transport を分離する。したがって traceability は certificate tuple の飾りではなく、
+profile transport が保つべき certificate geometry の成分である。
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- `docs/note/aat_quality_surface.md` の source reference claim boundary と trace locus
+- cycle 1 の `Formal/AG/Research/QualitySurface/SupportHitting.lean`
+- cycle 3 の `Formal/AG/Research/QualitySurface/ProfileCurvature.lean`
+
+## 非自明性
+
+cycle 1 は atom support が repair frontier を制約することを示し、cycle 3 は support / repair の path
+discrepancy を profile curvature として固定した。しかし trace field はまだ support transport と結合していない。
+この候補は、support を運ぶことと trace token を運ぶことの可換性を naturality 条件として置き、
+traceability を certificate transport の保存対象に入れる。さらに、support transport が成立しても
+trace naturality がなければ target trace availability は落ちることを finite witness で分離する。
+
+## 数学的興味
+
+AAT 内部が持つのは supporting atom family までであり、source reference への対応は ArchMap / observation
+layer が供給する token として扱う。この候補は、source completeness を主張せずに、利用可能な trace token が
+profile transport に沿って保存される条件を数学的に固定する。trace naturality が破れる場合、support は運ばれても
+trace certificate は transport されず、trace-curvature の候補になる。
+
+## GOAL への前進
+
+traceability / certificate-transport / invariance を増やし、atom-supported quality geometry の certificate tuple
+にある trace component を、profile-indexed comparison map と接続する。cycle 3 の profile-curvature detector と、
+次の finite trace / measured-zero separation frontier を橋渡しする。
+
+## SCORE 見込み
+
+- `score_reason`: Lean で support transport は成立するが trace naturality が破れる finite missing-trace witness
+  を主証拠として固定し、あわせて trace naturality による trace availability preservation を補助定理として証明できれば、
+  traceability と transport の未接続 frontier を直接進める。
+- `dullness_risk`: trace field を certificate tuple に足すだけでは弱い。atom transport、trace-token map、
+  partial trace field、naturality square、missing-trace witness をすべて明示する。
+- `proof_or_evidence_plan`: finite source atom / target atom、source trace token / target trace token、
+  source support、atom transport、trace-token map、source trace field、target trace field を置く。
+  `TraceNatural`、`TraceAvailableOn`、`TransportedSupport`、`TraceMissingOn` を定義する。
+  同じ support transport を持つが target trace field が欠ける finite witness を主証拠として置き、
+  trace naturality failure と missing trace を証明する。補助的に、自然性から target trace availability が
+  保存される theorem を証明する。
+
+## CS / SWE への帰結
+
+品質 certificate が修正対象 atom family を返せても、その atom が利用可能な source reference へ trace できるとは限らない。
+trace-natural transport が成り立つ profile change では、support と trace token が一緒に運ばれるため、Quality Surface の
+drill-down は repair frontier と説明可能性を同時に保持できる。
+
+## 証明・根拠の見込み
+
+Lean では `TraceAvailableOn support trace`、`TransportedSupport atomMap sourceSupport`、
+`TraceNatural sourceSupport atomMap traceMap sourceTrace targetTrace` を定義する。
+source support 上の trace availability と trace naturality から target support 上の trace availability を導く。
+finite witness では atoms `{a,b}` を target atoms `{a',b'}` へ運び、source trace は両 atom で定義される一方、
+target trace が `b'` で欠ける例を置く。support transport は保存されるが、trace naturality は破れ、target support に
+trace-missing atom が残ることを証明する。
+
+## 審判メモ
+
+- 厳密性: 初回 `revise`、Lean evidence 後に `accept`。preservation theorem だけでは即時系に近いため、
+  finite missing-trace witness を主証拠にすることを要求。base score 55。
+- 研究価値: `accept`。base score 70。trace naturality と missing-trace witness により、
+  `T_p` を drill-down metadata ではなく certificate transport の保存成分として扱える。
+- repo 全体価値: `accept`。base score 70。AAT / SFT / tooling / website の将来 surface に価値があるが、
+  現状は toy finite witness であり、ArchMap source ref つき finite codebase trace example ではない。
+  SCORE 監査では base 60 / multiplier 2.0 / final 120 に reduce。
+
+## 関連
+
+- `Finite square cell profile-curvature detector`
+- `Finite trace-locus certificate example`
+- `Measured-zero / unmeasured / trace-missing trichotomy`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 4 の G1 候補生成から審判対象として作成。
+- 2026-06-20: G2 revise を受け、主成果を trace availability preservation から
+  support transport と trace transport を分離する finite missing-trace witness へ寄せ、expected base score を 70 に調整。
+- 2026-06-20: `Formal/AG/Research/QualitySurface/TraceTransport.lean` を追加。`lake build FormalAGResearch`
+  pass。G2 再審判は accept。G3 公理検査 pass: requested declarations depend on no axioms。G3 形式化品質監査 pass。
+- 2026-06-20: G4 SCORE 監査 reduce: base 60, multiplier 2.0, penalty 0, final 120。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,13 +4,14 @@
 
 ## Current SCORE
 
-- total SCORE: 450
+- total SCORE: 570
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
   - profile-curvature / certificate-transport / computability / ridge-fold / repair-potential: 170
+  - traceability / certificate-transport / invariance / atom-supported-quality-geometry: 120
 - evidence portfolio:
-  - proved-in-research: 3
+  - proved-in-research: 4
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -110,8 +111,46 @@ Lean 証拠は次を固定する。
 transport の path coherence として固定された。scalar view が flat に見える square でも、support / repair
 frontier は曲がりうる。
 
+## Cycle 4: Trace-natural certificate transport bridge
+
+```text
+candidate: Trace-natural certificate transport bridge
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: traceability/certificate-transport/invariance/atom-supported-quality-geometry
+goal_delta: trace field を support transport の保存対象として Lean-backed に接続し、support transport と trace naturality failure を有限 witness で分離する。
+project_value_delta: AAT Research の traceability surface と将来の ArchMap / website 説明面に使える橋を追加する。ただし toy finite witness であり、finite codebase trace example でも profile-curvature 本体でもない。
+formalization_quality: pass。`TraceAvailableOn`、`TraceMissingOn`、`TransportedSupport`、`TraceNatural`、preservation theorem、finite missing-trace witness が Lean で明示されている。
+open_questions: profile-typed certificate tuple 全体への trace transport 統合、finite codebase trace example、measured-zero / unmeasured / trace-missing separation、trace curvature detector。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/TraceTransport.lean` は、support atom を target atom へ運ぶ
+`TransportedSupport` と、partial trace field の availability / missing predicate を定義する。
+`TraceNatural` は、selected source support 上で target trace field が atom transport と trace-token map に可換であることを表す。
+
+Lean 証拠は次を固定する。
+
+- `traceAvailableOn_transport_of_traceNatural`: source support 上で trace token が利用可能で、profile change が
+  trace naturality を満たすなら、transported target support 上でも trace token が利用可能である。
+- `targetTraceAvailable_of_traceNatural`: finite witness の natural target trace field は target support 上で traced である。
+- `targetTraceMissing_not_traceNatural`: transported support の `bPrime` で trace token が欠ける target trace field は
+  trace naturality を満たさない。
+- `missingTraceOn_targetSupport`: target support には trace-missing atom が存在する。
+- `support_transport_without_trace_naturality_has_missing_trace`: support transport は成立しても、trace naturality がなければ
+  transported support に missing trace が残る。
+
+この結果により、supporting atom family を運ぶことと、利用可能な trace token を運ぶことが分離された。
+AAT 内部では source extraction completeness を主張せず、利用可能な trace token の保存条件だけを certificate transport の
+一部として扱う。
+
 ### Next Frontier
 
-次サイクルでは、`trace-natural certificate transport bridge` または
-`measured zero / unmeasured / trace-missing separation` を優先する。前者は traceability と transport
-を接続し、後者は finite trace example と loss-aware visualization の基礎を作る。
+次サイクルでは、`measured zero / unmeasured / trace-missing separation` または
+`finite trace-locus certificate example` を優先する。前者は loss-aware visualization の状態分離を進め、
+後者は trace token つき finite example を codebase-facing paper seed に近づける。


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` の cycle 4 として、trace-natural certificate transport bridge を Research sandbox に追加しました。

- `Formal/AG/Research/QualitySurface/TraceTransport.lean` で `TransportedSupport`、`TraceAvailableOn`、`TraceMissingOn`、`TraceNatural` を定義
- trace naturality による transported support 上の trace availability preservation を証明
- support transport は成立しても trace naturality が破れる finite missing-trace witness を追加
- SCORE 監査 reduce に従い、report を total `570`、cycle 4 `+120` に更新

tracking Issue #2348 は research-loop の状態正本として開いたままにするため、`Closes #2348` は付けていません。

## 証明した定理

- `Formal.AG.Research.QualitySurface.TraceTransport.traceAvailableOn_transport_of_traceNatural`
- `Formal.AG.Research.QualitySurface.TraceTransport.targetTraceAvailable_of_traceNatural`
- `Formal.AG.Research.QualitySurface.TraceTransport.targetTraceMissing_not_traceNatural`
- `Formal.AG.Research.QualitySurface.TraceTransport.missingTraceOn_targetSupport`
- `Formal.AG.Research.QualitySurface.TraceTransport.support_transport_without_trace_naturality_has_missing_trace`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-trace-natural-transport.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake build`
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）
- [x] `lake build FormalAGResearch`
- [x] G3 公理検査（対象 theorem は axioms なし、`sorryAx` なし）
- [x] G3 Lean 形式化品質監査
- [x] G4 SCORE 監査（reduce: base 60, multiplier 2.0, final 120）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] local path / private identifier scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した（Research Loop tracking Issue は閉じないため `Refs #2348`）
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
