### PR TITLE
Quality Surface の state separation 証拠を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -1,3 +1,6 @@
 import Formal.AG.Research.Basic
 import Formal.AG.Research.QualitySurface.SupportHitting
 import Formal.AG.Research.QualitySurface.ScalarCollapse
+import Formal.AG.Research.QualitySurface.ProfileCurvature
+import Formal.AG.Research.QualitySurface.TraceTransport
+import Formal.AG.Research.QualitySurface.StateSeparation

--- a/Formal/AG/Research/QualitySurface/StateSeparation.lean
+++ b/Formal/AG/Research/QualitySurface/StateSeparation.lean
@@ -1,0 +1,367 @@
+import Formal.AG.Research.QualitySurface.TraceTransport
+
+/-!
+Cycle 5 evidence for `G-aat-quality-surface-01`.
+
+The file fixes a finite state-separation witness: measured zero, unmeasured,
+and trace-missing certificates can share the same visible scalar reading and
+selected verdict while differing in actual measurement, selector state, support,
+trace status, and next obligation.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace StateSeparation
+
+/-! ## Certificate state components -/
+
+/-- Visible verdict selected for the lossful display layer. -/
+inductive StateVerdict where
+  | acceptable
+  deriving DecidableEq
+
+/-- Whether the selected profile actually measured the predicate. -/
+inductive MeasurementState where
+  | measured
+  | unmeasured
+  deriving DecidableEq
+
+/-- Whether the certificate selector applies at the selected profile. -/
+inductive SelectorState where
+  | selected
+  | outside
+  deriving DecidableEq
+
+/-- Trace availability state for selected support. -/
+inductive TraceStatus where
+  | traced
+  | noSelectedSupport
+  | missingTrace
+  deriving DecidableEq
+
+/-- The next obligation exposed by the certificate state. -/
+inductive ObligationKind where
+  | none
+  | measure
+  | provideTrace
+  deriving DecidableEq
+
+/-- A finite support atom used by the trace-missing witness. -/
+inductive StateAtom where
+  | a
+  deriving DecidableEq, Fintype
+
+/-- Trace token used by the state-separation witness. -/
+inductive StateTraceToken where
+  | refA
+  deriving DecidableEq
+
+/--
+Finite certificate tuple for the state-separation witness.
+
+`visibleScalarReading` is a display convention. `actualMeasurement?` records
+whether the selected measurement actually exists.
+-/
+structure QualityCertificate where
+  visibleScalarReading : Nat
+  verdict : StateVerdict
+  measurementState : MeasurementState
+  selectorState : SelectorState
+  actualMeasurement? : Option Nat
+  selectedSupport? : Option (Set StateAtom)
+  traceField : StateAtom -> Option StateTraceToken
+  traceStatus : TraceStatus
+  obligation : ObligationKind
+
+open StateVerdict MeasurementState SelectorState TraceStatus ObligationKind
+
+/-- The selected support used by the trace-missing certificate. -/
+def supportA : Set StateAtom :=
+  fun atom => atom = StateAtom.a
+
+/-- Empty trace field for certificates with no selected support. -/
+def emptyTraceField : StateAtom -> Option StateTraceToken :=
+  fun _ => none
+
+/-- Trace field that is missing on the selected support atom. -/
+def missingTraceField : StateAtom -> Option StateTraceToken :=
+  fun _ => none
+
+/-- A measured-zero certificate has an actual zero measurement. -/
+def measuredZeroCert : QualityCertificate where
+  visibleScalarReading := 0
+  verdict := acceptable
+  measurementState := measured
+  selectorState := selected
+  actualMeasurement? := some 0
+  selectedSupport? := some (fun _ => False)
+  traceField := emptyTraceField
+  traceStatus := noSelectedSupport
+  obligation := none
+
+/-- An unmeasured certificate is outside the selected certificate selector. -/
+def unmeasuredCert : QualityCertificate where
+  visibleScalarReading := 0
+  verdict := acceptable
+  measurementState := unmeasured
+  selectorState := outside
+  actualMeasurement? := none
+  selectedSupport? := none
+  traceField := emptyTraceField
+  traceStatus := noSelectedSupport
+  obligation := measure
+
+/-- A trace-missing certificate has selected support but lacks trace coverage. -/
+def traceMissingCert : QualityCertificate where
+  visibleScalarReading := 0
+  verdict := acceptable
+  measurementState := measured
+  selectorState := selected
+  actualMeasurement? := some 0
+  selectedSupport? := some supportA
+  traceField := missingTraceField
+  traceStatus := missingTrace
+  obligation := provideTrace
+
+/-- A compact state signature protected under the certificate geometry. -/
+def protectedStateSignature (c : QualityCertificate) :
+    MeasurementState × SelectorState × Option Nat ×
+      Option (Set StateAtom) × TraceStatus × ObligationKind :=
+  (c.measurementState, c.selectorState, c.actualMeasurement?,
+    c.selectedSupport?, c.traceStatus, c.obligation)
+
+/-- The selected support, if any, has a missing trace in the actual trace field. -/
+def SelectedTraceMissing (c : QualityCertificate) : Prop :=
+  ∃ support, c.selectedSupport? = some support ∧
+    TraceTransport.TraceMissingOn support c.traceField
+
+/-! ## Structural facts for the three states -/
+
+/-- Measured-zero has a genuine actual zero measurement. -/
+theorem measuredZero_has_actual_zero :
+    measuredZeroCert.actualMeasurement? = some 0 :=
+  rfl
+
+/-- Unmeasured has no actual measurement; its visible zero is a display value. -/
+theorem unmeasured_has_no_actual_measurement :
+    unmeasuredCert.actualMeasurement? = (Option.none : Option Nat) :=
+  rfl
+
+/-- Unmeasured is outside the selected certificate selector. -/
+theorem unmeasured_selector_outside :
+    unmeasuredCert.selectorState = outside :=
+  rfl
+
+/-- Measured-zero has no follow-up obligation. -/
+theorem measuredZero_obligation_none :
+    measuredZeroCert.obligation = ObligationKind.none :=
+  rfl
+
+/-- Unmeasured requires a measurement obligation rather than a zero certificate. -/
+theorem unmeasured_obligation_measure :
+    unmeasuredCert.obligation = ObligationKind.measure :=
+  rfl
+
+/-- Trace-missing has a selected support. -/
+theorem traceMissing_has_selected_support :
+    traceMissingCert.selectedSupport? = some supportA :=
+  rfl
+
+/-- Trace-missing also has an actual measured zero value. -/
+theorem traceMissing_has_actual_zero :
+    traceMissingCert.actualMeasurement? = some 0 :=
+  rfl
+
+/-- Trace-missing has a selected support and a missing trace status. -/
+theorem traceMissing_has_selected_support_and_missing_trace :
+    traceMissingCert.selectedSupport? = some supportA ∧
+      TraceTransport.TraceMissingOn supportA traceMissingCert.traceField ∧
+      traceMissingCert.traceStatus = missingTrace := by
+  refine And.intro rfl ?_
+  refine And.intro ?_ rfl
+  exact ⟨StateAtom.a, rfl, rfl⟩
+
+/-- Trace-missing requires a trace-provision obligation. -/
+theorem traceMissing_obligation_provideTrace :
+    traceMissingCert.obligation = provideTrace :=
+  rfl
+
+/-- Measured-zero does not have a selected trace-missing support. -/
+theorem measuredZero_not_selectedTraceMissing :
+    ¬ SelectedTraceMissing measuredZeroCert := by
+  intro hmissing
+  rcases hmissing with ⟨support, hsupport, atom, hatom, _htrace⟩
+  have hset : (fun _ : StateAtom => False) = support :=
+    Option.some.inj hsupport
+  have hfalse : (fun _ : StateAtom => False) atom := by
+    rw [hset]
+    exact hatom
+  exact hfalse
+
+/-- Trace-missing has an actual missing trace on the selected support. -/
+theorem traceMissing_selectedTraceMissing :
+    SelectedTraceMissing traceMissingCert := by
+  exact ⟨supportA, rfl, StateAtom.a, rfl, rfl⟩
+
+/-- The three certificates share the same visible scalar reading. -/
+theorem same_visibleScalar_three_states :
+    measuredZeroCert.visibleScalarReading =
+        unmeasuredCert.visibleScalarReading ∧
+      measuredZeroCert.visibleScalarReading =
+        traceMissingCert.visibleScalarReading :=
+  And.intro rfl rfl
+
+/-- The three certificates share the same selected verdict. -/
+theorem same_verdict_three_states :
+    measuredZeroCert.verdict = unmeasuredCert.verdict ∧
+      measuredZeroCert.verdict = traceMissingCert.verdict :=
+  And.intro rfl rfl
+
+/-- The visible scalar / verdict layer identifies the three certificate states. -/
+theorem same_scalar_verdict_three_states :
+    measuredZeroCert.visibleScalarReading =
+        unmeasuredCert.visibleScalarReading ∧
+      measuredZeroCert.visibleScalarReading =
+        traceMissingCert.visibleScalarReading ∧
+      measuredZeroCert.verdict = unmeasuredCert.verdict ∧
+      measuredZeroCert.verdict = traceMissingCert.verdict := by
+  exact And.intro rfl (And.intro rfl (And.intro rfl rfl))
+
+/-- Measured-zero and unmeasured have different protected signatures. -/
+theorem measuredZero_state_ne_unmeasured :
+    protectedStateSignature measuredZeroCert ≠
+      protectedStateSignature unmeasuredCert := by
+  intro h
+  have hstate : MeasurementState.measured = MeasurementState.unmeasured :=
+    congrArg Prod.fst h
+  cases hstate
+
+/-- Measured-zero and trace-missing have different protected signatures. -/
+theorem measuredZero_state_ne_traceMissing :
+    protectedStateSignature measuredZeroCert ≠
+      protectedStateSignature traceMissingCert := by
+  intro h
+  have hstatus : TraceStatus.noSelectedSupport = TraceStatus.missingTrace :=
+    congrArg (fun s => s.2.2.2.2.1) h
+  cases hstatus
+
+/-- Unmeasured and trace-missing have different protected signatures. -/
+theorem unmeasured_state_ne_traceMissing :
+    protectedStateSignature unmeasuredCert ≠
+      protectedStateSignature traceMissingCert := by
+  intro h
+  have hstate : MeasurementState.unmeasured = MeasurementState.measured :=
+    congrArg Prod.fst h
+  cases hstate
+
+/-- The protected state signatures are pairwise distinct. -/
+theorem state_components_pairwise_distinct :
+    protectedStateSignature measuredZeroCert ≠
+        protectedStateSignature unmeasuredCert ∧
+      protectedStateSignature measuredZeroCert ≠
+        protectedStateSignature traceMissingCert ∧
+      protectedStateSignature unmeasuredCert ≠
+        protectedStateSignature traceMissingCert :=
+  And.intro measuredZero_state_ne_unmeasured
+    (And.intro measuredZero_state_ne_traceMissing
+      unmeasured_state_ne_traceMissing)
+
+/--
+The three zero-looking certificates are separated by actual measurement,
+selector state, trace-field evidence, and obligation.
+-/
+theorem zeroLooking_certificates_state_separated :
+    measuredZeroCert.visibleScalarReading =
+        unmeasuredCert.visibleScalarReading ∧
+      measuredZeroCert.visibleScalarReading =
+        traceMissingCert.visibleScalarReading ∧
+      measuredZeroCert.verdict = unmeasuredCert.verdict ∧
+      measuredZeroCert.verdict = traceMissingCert.verdict ∧
+      measuredZeroCert.actualMeasurement? = some 0 ∧
+      unmeasuredCert.actualMeasurement? = (Option.none : Option Nat) ∧
+      traceMissingCert.actualMeasurement? = some 0 ∧
+      unmeasuredCert.selectorState = outside ∧
+      traceMissingCert.selectedSupport? = some supportA ∧
+      SelectedTraceMissing traceMissingCert ∧
+      ¬ SelectedTraceMissing measuredZeroCert ∧
+      measuredZeroCert.obligation = ObligationKind.none ∧
+      unmeasuredCert.obligation = ObligationKind.measure ∧
+      traceMissingCert.obligation = provideTrace ∧
+      protectedStateSignature measuredZeroCert ≠
+          protectedStateSignature unmeasuredCert ∧
+        protectedStateSignature measuredZeroCert ≠
+          protectedStateSignature traceMissingCert ∧
+        protectedStateSignature unmeasuredCert ≠
+          protectedStateSignature traceMissingCert := by
+  exact And.intro rfl
+    (And.intro rfl
+    (And.intro rfl
+    (And.intro rfl
+    (And.intro measuredZero_has_actual_zero
+    (And.intro unmeasured_has_no_actual_measurement
+    (And.intro traceMissing_has_actual_zero
+    (And.intro unmeasured_selector_outside
+    (And.intro traceMissing_has_selected_support
+    (And.intro traceMissing_selectedTraceMissing
+    (And.intro measuredZero_not_selectedTraceMissing
+    (And.intro measuredZero_obligation_none
+    (And.intro unmeasured_obligation_measure
+    (And.intro traceMissing_obligation_provideTrace
+      state_components_pairwise_distinct)))))))))))))
+
+/-- Faithfulness of a scalar / verdict projection to protected state. -/
+def ScalarVerdictFaithfulToState
+    (r : QualityCertificate -> Nat)
+    (v : QualityCertificate -> StateVerdict) : Prop :=
+  ∀ c₁ c₂ : QualityCertificate,
+    r c₁ = r c₂ ->
+      v c₁ = v c₂ ->
+        protectedStateSignature c₁ = protectedStateSignature c₂
+
+/-- Faithfulness of a scalar / verdict projection to selected trace-missing state. -/
+def ScalarVerdictFaithfulToTraceMissing
+    (r : QualityCertificate -> Nat)
+    (v : QualityCertificate -> StateVerdict) : Prop :=
+  ∀ c₁ c₂ : QualityCertificate,
+    r c₁ = r c₂ ->
+      v c₁ = v c₂ ->
+        (SelectedTraceMissing c₁ ↔ SelectedTraceMissing c₂)
+
+/-- The visible scalar / verdict projection is not faithful to certificate state. -/
+theorem scalarVerdict_not_faithful_to_certificateState :
+    ¬ ScalarVerdictFaithfulToState
+      (fun c => c.visibleScalarReading) (fun c => c.verdict) := by
+  intro hfaithful
+  have hstate :=
+    hfaithful measuredZeroCert unmeasuredCert rfl rfl
+  exact measuredZero_state_ne_unmeasured hstate
+
+/--
+The same scalar / verdict projection also cannot recover whether a selected
+support has actual missing trace evidence.
+-/
+theorem scalarVerdict_not_faithful_to_traceMissingState :
+    ¬ ScalarVerdictFaithfulToState
+      (fun c => c.visibleScalarReading) (fun c => c.verdict) := by
+  intro hfaithful
+  have hstate :=
+    hfaithful measuredZeroCert traceMissingCert rfl rfl
+  exact measuredZero_state_ne_traceMissing hstate
+
+/--
+The visible scalar / verdict projection cannot recover selected trace-missing
+evidence derived from `selectedSupport?` and the actual `traceField`.
+-/
+theorem scalarVerdict_not_faithful_to_selectedTraceMissing :
+    ¬ ScalarVerdictFaithfulToTraceMissing
+      (fun c => c.visibleScalarReading) (fun c => c.verdict) := by
+  intro hfaithful
+  have hiff :=
+    hfaithful measuredZeroCert traceMissingCert rfl rfl
+  have hmissingMeasuredZero : SelectedTraceMissing measuredZeroCert :=
+    hiff.mpr traceMissing_selectedTraceMissing
+  exact measuredZero_not_selectedTraceMissing hmissingMeasuredZero
+
+end StateSeparation
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-measured-unmeasured-trace-missing.md
+++ b/research/ideas/g-aat-quality-surface-01-measured-unmeasured-trace-missing.md
@@ -1,0 +1,113 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: traceability, quality-surface, multi-axis-signature, computability, ridge-fold
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-5
+tags: [quality-surface, measured-zero, unmeasured, trace-missing, scalar-collapse]
+created: 2026-06-20
+cycle: 5
+lean: Formal/AG/Research/QualitySurface/StateSeparation.lean
+---
+
+# Measured-zero / unmeasured / trace-missing separation
+
+## 主張
+
+有限 certificate calculus において、同じ visible scalar reading `0` と同じ selected verdict を持つ三つの
+certificate 状態を構成する。
+
+1. `measured-zero`: selected predicate は測定され、actual measurement として zero certificate を持つ。
+2. `unmeasured`: selected profile / certificate selector の対象外で、actual measurement を持たない。
+3. `trace-missing`: selected support は存在し、actual measurement はあるが、partial trace field 上で利用可能な trace token が欠けている。
+
+visible scalar `0` は actual measurement ではなく lossful display convention として定義する。
+これら三状態は scalar reading と verdict では区別できないが、actual measurement、selector state、
+selected support、trace status、repair / explanation obligation によって分離される。従って scalar reading /
+verdict projection は certificate state に faithful ではない。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- `docs/note/aat_quality_surface.md` の measured zero / unmeasured 区別、trace field、reading fold
+- cycle 2 の `Formal/AG/Research/QualitySurface/ScalarCollapse.lean`
+- cycle 4 の `Formal/AG/Research/QualitySurface/TraceTransport.lean`
+
+## 非自明性
+
+単なる enum の場合分けではなく、同じ scalar fiber と同じ verdict の下で、測定済みゼロ、未測定、trace 欠落が
+異なる構造的条件と obligation を持つことを固定する。`unmeasured` は zero certificate ではなく selector outside
+として扱い、`trace-missing` は selected support と partial trace field の欠落として扱う。visible zero は
+certificate geometry の state を復元せず、Quality Surface の穴、空白、ゼロ高さ、trace 欠落を同じ数値に潰してしまう。
+
+## 数学的興味
+
+cycle 2 は scalar reading が support / repair frontier に faithful でないことを示した。cycle 4 は support
+transport と trace transport を分離した。この候補はその合流点として、zero-looking surface が実際には
+measurement-state stratification を持つことを finite witness として固定する。
+
+## GOAL への前進
+
+loss-aware visualization、traceability、multi-axis signature、ridge-fold のカテゴリを増やす。Quality Surface の
+visible scalar layer の下に、測定状態・trace 状態・obligation 状態を保持する必要を示す。
+
+## SCORE 見込み
+
+- `score_reason`: 三つの state を同じ scalar/verdict fiber 内で分離し、unmeasured が actual zero ではないこと、
+  trace-missing が selected support と partial trace field に戻ること、trace-missing 専用の faithfulness 否定
+  theorem まで Lean で固定し、loss-aware visualization と finite trace frontier を前進させる。
+- `dullness_risk`: `Option Nat` や enum の場合分けだけでは弱い。certificate tuple に visible scalar、
+  actual measurement、selector state、selected support、trace status、repair/explanation obligation を持たせ、
+  projection nonfaithfulness と state distinctness を theorem として示す。
+- `proof_or_evidence_plan`: finite `QualityCertificate` を三つ置き、tuple から `visibleScalarReading`、`verdict`、
+  `actualMeasurement?`、`selectorState`、`selectedSupport?`、`traceStatus`、`obligation` を読む。
+  三つが scalar/verdict で一致すること、`unmeasured` は `actualMeasurement? = none` であること、
+  `trace-missing` は selected support と `TraceTransport.TraceMissingOn` で定義された missing trace を持つこと、
+  protected components では互いに異なること、`ScalarVerdictFaithfulToState` と
+  `ScalarVerdictFaithfulToTraceMissing` が成り立たないことを証明する。
+
+## CS / SWE への帰結
+
+UI で同じ `0` や同じ acceptable verdict に見える場合でも、測定済みゼロ、未測定、trace 欠落では次に取る行動が異なる。
+Quality Surface は zero value だけでなく、state / trace / obligation を drill-down 可能な certificate として保持する必要がある。
+
+## 証明・根拠の見込み
+
+Lean では `MeasurementState`、`SelectorState`、`TraceStatus`、`ObligationKind` を有限型として定義する。
+`measuredZeroCert`、`unmeasuredCert`、`traceMissingCert` はすべて visible scalar reading `0` と selected verdict
+`acceptable` を持つ。一方で、`actualMeasurement?`、selector state、selected support、trace status、obligation は異なる。
+`measuredZero_has_actual_zero`、`unmeasured_has_no_actual_measurement`、
+`traceMissing_has_selected_support_and_missing_trace`、`SelectedTraceMissing`、
+`zeroLooking_certificates_state_separated`、`state_components_pairwise_distinct`、
+`scalarVerdict_not_faithful_to_certificateState`、
+`scalarVerdict_not_faithful_to_selectedTraceMissing` を証明する。
+
+## 審判メモ
+
+- 厳密性: G2 revise 後、trace-missing を `TraceTransport.TraceMissingOn` による導出条件として
+  `ScalarVerdictFaithfulToTraceMissing` の反例に直接参加させた。
+- 研究価値: cycle 2 の scalar collapse と cycle 4 の trace transport を、zero-looking surface の
+  measurement-state stratification へ接続する。
+- repo 全体価値: Research sandbox の Lean 証拠と paper seed として採用する。
+
+## 関連
+
+- `Scalar-collapse separation by support antichains`
+- `Trace-natural certificate transport bridge`
+- `finite trace-locus certificate grid`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 5 の G1 候補生成から審判対象として作成。
+- 2026-06-20: G2 revise を受け、visible scalar を actual measurement から分離し、`unmeasured` を
+  selector outside / no actual measurement、`trace-missing` を selected support + partial trace field failure として明示。
+- 2026-06-20: `SelectedTraceMissing` と `ScalarVerdictFaithfulToTraceMissing` を追加し、trace-missing が
+  scalar/verdict projection から復元できないことを Lean で証明。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,14 +4,15 @@
 
 ## Current SCORE
 
-- total SCORE: 570
+- total SCORE: 700
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
   - profile-curvature / certificate-transport / computability / ridge-fold / repair-potential: 170
   - traceability / certificate-transport / invariance / atom-supported-quality-geometry: 120
+  - traceability / quality-surface / multi-axis-signature / computability / ridge-fold: 130
 - evidence portfolio:
-  - proved-in-research: 4
+  - proved-in-research: 5
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -149,8 +150,46 @@ Lean 証拠は次を固定する。
 AAT 内部では source extraction completeness を主張せず、利用可能な trace token の保存条件だけを certificate transport の
 一部として扱う。
 
+## Cycle 5: Measured-zero / unmeasured / trace-missing separation
+
+```text
+candidate: Measured-zero / unmeasured / trace-missing separation
+candidate_type: orientation
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: traceability/quality-surface/multi-axis-signature/computability/ridge-fold
+goal_delta: 同じ visible scalar `0` と selected verdict の下で、測定済みゼロ、未測定、trace 欠落が異なる certificate state と obligation を持つことを Lean-proved finite witness として固定する。
+project_value_delta: cycle 2 の scalar collapse と cycle 4 の trace transport を接続し、loss-aware Quality Surface 表示で zero-looking state を drill-down すべき理由を paper seed として追加する。
+formalization_quality: pass。`QualityCertificate` に actual measurement、selector、support、trace field、obligation が明示され、`SelectedTraceMissing`、三状態主 theorem、trace-missing 専用 nonfaithfulness theorem が Lean で証明されている。
+open_questions: 三状態分離の一般定理化、profile-typed certificate tuple への trace status 統合、finite codebase trace example、trace curvature detector。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/StateSeparation.lean` は、同じ visible scalar reading `0` と同じ
+selected verdict を持つ三つの finite certificate を構成する。`visibleScalarReading` は display convention
+であり、actual measurement とは別フィールドとして扱われる。
+
+Lean 証拠は次を固定する。
+
+- `measuredZero_has_actual_zero`: measured-zero は actual measurement として `some 0` を持つ。
+- `unmeasured_has_no_actual_measurement`: unmeasured は actual measurement を持たず、selector outside である。
+- `traceMissing_has_selected_support_and_missing_trace`: trace-missing は selected support と
+  `TraceTransport.TraceMissingOn` による missing trace を持つ。
+- `zeroLooking_certificates_state_separated`: 三状態は scalar/verdict では一致するが、actual measurement、
+  selector state、selected trace-missing evidence、obligation、protected state signature で分離される。
+- `scalarVerdict_not_faithful_to_selectedTraceMissing`: scalar/verdict projection は selected support と
+  trace field から導かれる trace-missing state を復元できない。
+
+この結果により、Quality Surface の zero-looking surface は、測定済みゼロ、未測定、trace 欠落を
+同じ数値に潰す lossful layer であることが Lean-backed に固定された。UI / report / paper surface では、
+zero value だけでなく measurement state、selector state、trace evidence、obligation を保持する必要がある。
+
 ### Next Frontier
 
-次サイクルでは、`measured zero / unmeasured / trace-missing separation` または
-`finite trace-locus certificate example` を優先する。前者は loss-aware visualization の状態分離を進め、
-後者は trace token つき finite example を codebase-facing paper seed に近づける。
+次サイクルでは、`finite trace-locus certificate example` または `trace curvature detector` を優先する。
+前者は trace token つき finite example を codebase-facing paper seed に近づけ、後者は profile-curvature と
+trace-missing state を結びつける。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 cycle 5 として、同じ visible scalar `0` / selected verdict の下で `measured-zero`、`unmeasured`、`trace-missing` が異なる certificate state と obligation を持つことを Research sandbox の Lean 証拠として追加します。

## 証明した定理

- `StateSeparation.measuredZero_has_actual_zero`
- `StateSeparation.unmeasured_has_no_actual_measurement`
- `StateSeparation.traceMissing_has_selected_support_and_missing_trace`
- `StateSeparation.traceMissing_selectedTraceMissing`
- `StateSeparation.zeroLooking_certificates_state_separated`
- `StateSeparation.scalarVerdict_not_faithful_to_certificateState`
- `StateSeparation.scalarVerdict_not_faithful_to_traceMissingState`
- `StateSeparation.scalarVerdict_not_faithful_to_selectedTraceMissing`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-measured-unmeasured-trace-missing.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] private path scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

tracking issue 継続中の cycle PR なので、`Closes #2348` ではなく `Refs #2348` としています。
