### PR TITLE
Quality Surface の trace locus 証拠を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -4,3 +4,4 @@ import Formal.AG.Research.QualitySurface.ScalarCollapse
 import Formal.AG.Research.QualitySurface.ProfileCurvature
 import Formal.AG.Research.QualitySurface.TraceTransport
 import Formal.AG.Research.QualitySurface.StateSeparation
+import Formal.AG.Research.QualitySurface.TraceLocus

--- a/Formal/AG/Research/QualitySurface/TraceLocus.lean
+++ b/Formal/AG/Research/QualitySurface/TraceLocus.lean
@@ -1,0 +1,314 @@
+import Formal.AG.Research.QualitySurface.StateSeparation
+
+/-!
+Cycle 6 evidence for `G-aat-quality-surface-01`.
+
+This file refines the trace-missing state into a finite trace-locus certificate:
+two certificates can share the same visible scalar, verdict, and selected
+support while differing in the locus of missing trace tokens and the repair
+frontier forced by that locus.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace TraceLocus
+
+/-! ## Finite trace-locus certificates -/
+
+/-- Support atoms in the finite trace-locus example. -/
+inductive LocusAtom where
+  | api
+  | database
+  | queue
+  deriving DecidableEq, Fintype
+
+/-- Trace tokens available for support atoms. -/
+inductive LocusTraceToken where
+  | refApi
+  | refDatabase
+  | refQueue
+  deriving DecidableEq
+
+open LocusAtom LocusTraceToken
+
+/-- Every atom belongs to the selected support in this finite witness. -/
+def selectedSupport : Set LocusAtom :=
+  fun _ => True
+
+/-- Trace field with full trace coverage on the selected support. -/
+def fullTraceField : LocusAtom -> Option LocusTraceToken
+  | api => some refApi
+  | database => some refDatabase
+  | queue => some refQueue
+
+/-- Trace field with one missing token on the selected support. -/
+def partialTraceField : LocusAtom -> Option LocusTraceToken
+  | api => some refApi
+  | database => none
+  | queue => some refQueue
+
+/-- Repair frontier that covers exactly the database trace gap. -/
+def databaseRepairFrontier : Set LocusAtom :=
+  fun atom => atom = database
+
+/--
+Finite certificate carrying the visible surface and the trace locus beneath it.
+
+The selected support is part of the visible certificate context, while the trace
+field and repair frontier are the protected drill-down data.
+-/
+structure TraceLocusCertificate where
+  visibleScalarReading : Nat
+  verdict : StateSeparation.StateVerdict
+  selectedSupport : Set LocusAtom
+  traceField : LocusAtom -> Option LocusTraceToken
+  repairFrontier : Set LocusAtom
+  obligation : StateSeparation.ObligationKind
+
+/-- Certificate whose selected support is fully traced. -/
+def fullTraceCert : TraceLocusCertificate where
+  visibleScalarReading := 0
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := selectedSupport
+  traceField := fullTraceField
+  repairFrontier := fun _ => False
+  obligation := StateSeparation.ObligationKind.none
+
+/-- Certificate with the same visible surface but a missing database trace. -/
+def partialTraceCert : TraceLocusCertificate where
+  visibleScalarReading := 0
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := selectedSupport
+  traceField := partialTraceField
+  repairFrontier := databaseRepairFrontier
+  obligation := StateSeparation.ObligationKind.provideTrace
+
+/-- Atoms in the selected support where a trace token is available. -/
+def TraceAvailableLocus (c : TraceLocusCertificate) : Set LocusAtom :=
+  fun atom => c.selectedSupport atom ∧ ∃ token, c.traceField atom = some token
+
+/-- Atoms in the selected support where the trace token is missing. -/
+def TraceMissingLocus (c : TraceLocusCertificate) : Set LocusAtom :=
+  fun atom => c.selectedSupport atom ∧ c.traceField atom = none
+
+/-- A repair frontier covers all missing trace atoms. -/
+def RepairCoversMissingTrace (c : TraceLocusCertificate) : Prop :=
+  ∀ atom, TraceMissingLocus c atom -> c.repairFrontier atom
+
+/-! ## Locus decomposition -/
+
+/-- Every selected support atom lies either in the available trace locus or the missing trace locus. -/
+theorem trace_locus_partition (c : TraceLocusCertificate) :
+    ∀ atom, c.selectedSupport atom ->
+      TraceAvailableLocus c atom ∨ TraceMissingLocus c atom := by
+  intro atom hsupport
+  cases htrace : c.traceField atom with
+  | none =>
+      exact Or.inr ⟨hsupport, htrace⟩
+  | some token =>
+      exact Or.inl ⟨hsupport, token, htrace⟩
+
+/-- Available and missing trace loci are disjoint. -/
+theorem trace_available_missing_disjoint (c : TraceLocusCertificate) :
+    ∀ atom, ¬ (TraceAvailableLocus c atom ∧ TraceMissingLocus c atom) := by
+  intro atom hloci
+  rcases hloci with ⟨havailable, hmissing⟩
+  rcases havailable with ⟨_hsupportAvailable, token, hsome⟩
+  rcases hmissing with ⟨_hsupportMissing, hnone⟩
+  rw [hsome] at hnone
+  cases hnone
+
+/-- The full certificate has trace coverage on the selected support. -/
+theorem fullTrace_available_on_support :
+    TraceTransport.TraceAvailableOn fullTraceCert.selectedSupport
+      fullTraceCert.traceField := by
+  intro atom _hsupport
+  cases atom with
+  | api => exact ⟨refApi, rfl⟩
+  | database => exact ⟨refDatabase, rfl⟩
+  | queue => exact ⟨refQueue, rfl⟩
+
+/-- The partial certificate has a missing database trace on the selected support. -/
+theorem partialTrace_missing_on_support :
+    TraceTransport.TraceMissingOn partialTraceCert.selectedSupport
+      partialTraceCert.traceField :=
+  ⟨database, trivial, rfl⟩
+
+/-- `TraceMissingOn` is exactly nonempty missing trace locus for these certificates. -/
+theorem traceMissingOn_iff_missingLocus_nonempty
+    (c : TraceLocusCertificate) :
+    TraceTransport.TraceMissingOn c.selectedSupport c.traceField ↔
+      ∃ atom, TraceMissingLocus c atom := by
+  rfl
+
+/-- The full certificate has no missing trace atom. -/
+theorem fullTrace_has_no_missing_locus :
+    ¬ ∃ atom, TraceMissingLocus fullTraceCert atom := by
+  intro hmissing
+  rcases hmissing with ⟨atom, _hsupport, htrace⟩
+  cases atom <;> cases htrace
+
+/-- The partial certificate's database atom lies in the missing trace locus. -/
+theorem partialTrace_database_missing_locus :
+    TraceMissingLocus partialTraceCert database :=
+  ⟨trivial, rfl⟩
+
+/-- The partial certificate's missing trace locus is exactly the database atom. -/
+theorem partialTrace_missing_locus_exact_database :
+    ∀ atom, TraceMissingLocus partialTraceCert atom ↔ atom = database := by
+  intro atom
+  constructor
+  · intro hmissing
+    rcases hmissing with ⟨_hsupport, htrace⟩
+    cases atom with
+    | api => cases htrace
+    | database => rfl
+    | queue => cases htrace
+  · intro hdatabase
+    cases hdatabase
+    exact partialTrace_database_missing_locus
+
+/-- The partial certificate's missing trace locus is covered by its repair frontier. -/
+theorem partialTrace_repair_covers_missing :
+    RepairCoversMissingTrace partialTraceCert := by
+  intro atom hmissing
+  change atom = database
+  exact (partialTrace_missing_locus_exact_database atom).mp hmissing
+
+/-- The database repair frontier is forced by the partial certificate's missing trace. -/
+theorem partialTrace_forces_database_repair :
+    partialTraceCert.repairFrontier database :=
+  partialTrace_repair_covers_missing database
+    partialTrace_database_missing_locus
+
+/-- The full certificate does not put the database atom in its repair frontier. -/
+theorem fullTrace_repair_frontier_excludes_database :
+    ¬ fullTraceCert.repairFrontier database := by
+  intro hrepair
+  exact hrepair
+
+/-- The partial certificate's repair frontier matches its missing trace locus. -/
+theorem partialTrace_repair_frontier_matches_missing_locus :
+    ∀ atom,
+      partialTraceCert.repairFrontier atom ↔
+        TraceMissingLocus partialTraceCert atom := by
+  intro atom
+  constructor
+  · intro hrepair
+    change atom = database at hrepair
+    cases hrepair
+    exact partialTrace_database_missing_locus
+  · intro hmissing
+    change atom = database
+    exact (partialTrace_missing_locus_exact_database atom).mp hmissing
+
+/-- The two certificates have different repair frontier behavior at the database atom. -/
+theorem repair_frontier_differs_on_database :
+    ¬ (fullTraceCert.repairFrontier database ↔
+      partialTraceCert.repairFrontier database) := by
+  intro hiff
+  exact fullTrace_repair_frontier_excludes_database
+    (hiff.mpr partialTrace_forces_database_repair)
+
+/-- The two certificates share the same visible scalar, verdict, and selected support. -/
+theorem same_visible_surface_and_support :
+    fullTraceCert.visibleScalarReading =
+        partialTraceCert.visibleScalarReading ∧
+      fullTraceCert.verdict = partialTraceCert.verdict ∧
+      fullTraceCert.selectedSupport = partialTraceCert.selectedSupport :=
+  And.intro rfl (And.intro rfl rfl)
+
+/-- Faithfulness of the visible surface and support to the missing trace locus. -/
+def SurfaceSupportFaithfulToMissingLocus
+    (r : TraceLocusCertificate -> Nat)
+    (v : TraceLocusCertificate -> StateSeparation.StateVerdict)
+    (s : TraceLocusCertificate -> Set LocusAtom) : Prop :=
+  ∀ c₁ c₂ : TraceLocusCertificate,
+    r c₁ = r c₂ ->
+      v c₁ = v c₂ ->
+        s c₁ = s c₂ ->
+          ∀ atom,
+            (TraceMissingLocus c₁ atom ↔ TraceMissingLocus c₂ atom)
+
+/-- Faithfulness of the visible surface and support to the repair frontier. -/
+def SurfaceSupportFaithfulToRepairFrontier
+    (r : TraceLocusCertificate -> Nat)
+    (v : TraceLocusCertificate -> StateSeparation.StateVerdict)
+    (s : TraceLocusCertificate -> Set LocusAtom) : Prop :=
+  ∀ c₁ c₂ : TraceLocusCertificate,
+    r c₁ = r c₂ ->
+      v c₁ = v c₂ ->
+        s c₁ = s c₂ ->
+          ∀ atom,
+            (c₁.repairFrontier atom ↔ c₂.repairFrontier atom)
+
+/--
+The visible scalar, verdict, and selected support do not recover the missing
+trace locus.
+-/
+theorem surfaceSupport_not_faithful_to_missing_locus :
+    ¬ SurfaceSupportFaithfulToMissingLocus
+      (fun c => c.visibleScalarReading)
+      (fun c => c.verdict)
+      (fun c => c.selectedSupport) := by
+  intro hfaithful
+  have hiff :=
+    hfaithful fullTraceCert partialTraceCert rfl rfl rfl database
+  have hmissingFull : TraceMissingLocus fullTraceCert database :=
+    hiff.mpr partialTrace_database_missing_locus
+  exact fullTrace_has_no_missing_locus ⟨database, hmissingFull⟩
+
+/--
+The visible scalar, verdict, and selected support also do not recover the
+repair frontier forced by the missing trace locus.
+-/
+theorem surfaceSupport_not_faithful_to_repair_frontier :
+    ¬ SurfaceSupportFaithfulToRepairFrontier
+      (fun c => c.visibleScalarReading)
+      (fun c => c.verdict)
+      (fun c => c.selectedSupport) := by
+  intro hfaithful
+  have hiff :=
+    hfaithful fullTraceCert partialTraceCert rfl rfl rfl database
+  have hrepairFull : fullTraceCert.repairFrontier database :=
+    hiff.mpr partialTrace_forces_database_repair
+  exact fullTrace_repair_frontier_excludes_database hrepairFull
+
+/--
+The cycle-6 finite witness: two certificates can have the same visible surface
+and selected support while the protected trace locus and repair frontier differ.
+-/
+theorem same_surface_support_but_trace_locus_diff :
+    fullTraceCert.visibleScalarReading =
+        partialTraceCert.visibleScalarReading ∧
+      fullTraceCert.verdict = partialTraceCert.verdict ∧
+      fullTraceCert.selectedSupport = partialTraceCert.selectedSupport ∧
+      TraceTransport.TraceAvailableOn fullTraceCert.selectedSupport
+        fullTraceCert.traceField ∧
+      TraceTransport.TraceMissingOn partialTraceCert.selectedSupport
+        partialTraceCert.traceField ∧
+      RepairCoversMissingTrace partialTraceCert ∧
+      partialTraceCert.repairFrontier database ∧
+      ¬ fullTraceCert.repairFrontier database ∧
+      (∀ atom,
+        partialTraceCert.repairFrontier atom ↔
+          TraceMissingLocus partialTraceCert atom) ∧
+      ¬ SurfaceSupportFaithfulToMissingLocus
+        (fun c => c.visibleScalarReading)
+        (fun c => c.verdict)
+        (fun c => c.selectedSupport) ∧
+      ¬ SurfaceSupportFaithfulToRepairFrontier
+        (fun c => c.visibleScalarReading)
+        (fun c => c.verdict)
+        (fun c => c.selectedSupport) := by
+  exact ⟨rfl, rfl, rfl, fullTrace_available_on_support,
+    partialTrace_missing_on_support, partialTrace_repair_covers_missing,
+    partialTrace_forces_database_repair,
+    fullTrace_repair_frontier_excludes_database,
+    partialTrace_repair_frontier_matches_missing_locus,
+    surfaceSupport_not_faithful_to_missing_locus,
+    surfaceSupport_not_faithful_to_repair_frontier⟩
+
+end TraceLocus
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-trace-locus-certificate.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-trace-locus-certificate.md
@@ -1,0 +1,101 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: traceability, quality-surface, certificate-transport, repair-potential, ridge-fold
+expected_base_score: 75
+expected_evidence_multiplier: 2.0
+expected_final_score: 150
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-6
+tags: [quality-surface, trace-locus, missing-trace, repair-frontier, scalar-collapse]
+created: 2026-06-20
+cycle: 6
+lean: Formal/AG/Research/QualitySurface/TraceLocus.lean
+---
+
+# Finite trace-locus certificate grid
+
+## 主張
+
+有限 support 上で、同じ visible scalar reading、同じ selected verdict、同じ selected support を持つ二つの
+certificate を構成する。一方は selected support 全体で trace token を持ち、もう一方は selected support 内の
+database atom に trace token を欠く。
+
+この差分は scalar / verdict / support からは復元できないが、missing trace locus と repair frontier では
+区別される。従って Quality Surface の traceability surface は、単に「trace missing がある」という state label
+だけでなく、support 内のどこが traced で、どこが missing で、どの repair frontier が強制されるかを保持する必要がある。
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- cycle 4 の `Formal/AG/Research/QualitySurface/TraceTransport.lean`
+- cycle 5 の `Formal/AG/Research/QualitySurface/StateSeparation.lean`
+
+## 非自明性
+
+cycle 5 は trace-missing を zero-looking state から分離した。この候補はさらに、同じ selected support の内部を
+available trace locus と missing trace locus に分解する。trace missing を単一ラベルにせず、support atom ごとの
+partial trace field と repair frontier へ落とす点が新しい。
+
+## 数学的興味
+
+Quality Surface の traceability は、global な traced / missing verdict ではなく、support 上の locus decomposition
+として読むべきである。同じ scalar fiber と selected support fiber の中でも、missing locus が違えば repair frontier は
+変わる。これは trace-aware certificate geometry の局所性を有限例として固定する。
+
+## GOAL への前進
+
+traceability、repair-potential、ridge-fold、multi-axis signature の frontier を進める。cycle 4 の trace transport と
+cycle 5 の state separation を、support 内の missing locus / repair frontier という drill-down surface へ接続する。
+
+## SCORE 見込み
+
+- `score_reason`: 同じ visible surface と selected support の下で、full trace coverage と partial trace gap が
+  分かれることを Lean で示し、missing trace locus と exact repair frontier が scalar / verdict / support projection から
+  復元できないことを証明する。
+- `dullness_risk`: 単なる `Option` の missing 例だけでは弱い。`TraceAvailableOn` / `TraceMissingOn` との接続、
+  locus partition、repair frontier coverage、projection nonfaithfulness を theorem として固定する。
+- `proof_or_evidence_plan`: finite support atom `{api, database, queue}` を置き、full trace certificate と partial trace
+  certificate を構成する。`TraceAvailableLocus`、`TraceMissingLocus`、`RepairCoversMissingTrace` を定義し、
+  partition、full availability、partial missing、repair coverage、exact frontier、surface/support nonfaithfulness を証明する。
+
+## CS / SWE への帰結
+
+同じ score / verdict / selected support を表示していても、trace token が欠けている atom が一つあるだけで次の作業は変わる。
+Quality Surface viewer / report は support-level trace locus と repair frontier を drill-down できる形で保持する必要がある。
+
+## 証明・根拠の見込み
+
+Lean では `TraceLocusCertificate` に visible scalar、verdict、selected support、trace field、repair frontier、obligation を持たせる。
+`trace_locus_partition`、`trace_available_missing_disjoint`、`fullTrace_available_on_support`、
+`partialTrace_missing_on_support`、`partialTrace_missing_locus_exact_database`、
+`partialTrace_repair_covers_missing`、`partialTrace_repair_frontier_matches_missing_locus`、
+`surfaceSupport_not_faithful_to_missing_locus`、`surfaceSupport_not_faithful_to_repair_frontier`、
+`same_surface_support_but_trace_locus_diff` を証明する。
+
+## 審判メモ
+
+- 厳密性: G2-A revise 後、repair frontier が missing trace locus と exactly 一致する theorem と、
+  repair frontier 自体の nonfaithfulness theorem を追加した。
+- 研究価値: cycle 4 の trace transport と cycle 5 の trace-missing state separation を、support 内の
+  trace locus / repair frontier 分解へ進める。
+- repo 全体価値: Research sandbox の Lean 証拠と future viewer / paper seed として採用する。
+
+## 関連
+
+- `Trace-natural certificate transport bridge`
+- `Measured-zero / unmeasured / trace-missing separation`
+- `Trace curvature detector`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 6 の G1 候補として作成。
+- 2026-06-20: `TraceLocus.lean` を追加し、`lake env lean Formal/AG/Research/QualitySurface/TraceLocus.lean` と
+  `lake build FormalAGResearch` の通過を確認。
+- 2026-06-20: G2-A / G3 revise を受け、repair frontier exactness と repair frontier nonfaithfulness を追加し、
+  主要 theorem の axiom 依存がないことを確認。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,15 +4,16 @@
 
 ## Current SCORE
 
-- total SCORE: 700
+- total SCORE: 850
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
   - profile-curvature / certificate-transport / computability / ridge-fold / repair-potential: 170
   - traceability / certificate-transport / invariance / atom-supported-quality-geometry: 120
   - traceability / quality-surface / multi-axis-signature / computability / ridge-fold: 130
+  - traceability / quality-surface / certificate-transport / repair-potential / ridge-fold: 150
 - evidence portfolio:
-  - proved-in-research: 5
+  - proved-in-research: 6
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -188,8 +189,47 @@ Lean 証拠は次を固定する。
 同じ数値に潰す lossful layer であることが Lean-backed に固定された。UI / report / paper surface では、
 zero value だけでなく measurement state、selector state、trace evidence、obligation を保持する必要がある。
 
+## Cycle 6: Finite trace-locus certificate grid
+
+```text
+candidate: Finite trace-locus certificate grid
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 75
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 150
+category: traceability/quality-surface/certificate-transport/repair-potential/ridge-fold
+goal_delta: 同じ visible scalar、selected verdict、selected support の下でも、trace locus と repair frontier が分岐することを Lean-proved finite witness として固定する。
+project_value_delta: cycle 4 の trace transport と cycle 5 の trace-missing state separation を、support 内の trace locus / exact repair frontier という drill-down surface へ接続する。
+formalization_quality: pass/high。finite support、trace field、missing locus、repair frontier、faithfulness 述語が明示され、主要 theorem は axiom-free / sorry-free で証明されている。
+open_questions: 任意有限 support への一般化、profile-typed certificate tuple への統合、finite codebase trace example、trace curvature detector との接続。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/TraceLocus.lean` は、finite support atom `{api, database, queue}` 上で、
+同じ visible scalar reading、同じ selected verdict、同じ selected support を持つ二つの trace-locus certificate
+を構成する。一方は selected support 全体で trace token を持ち、もう一方は database atom の trace token を欠く。
+
+Lean 証拠は次を固定する。
+
+- `trace_locus_partition`: selected support は available trace locus と missing trace locus に分解される。
+- `trace_available_missing_disjoint`: available locus と missing locus は交わらない。
+- `fullTrace_available_on_support`: full certificate は selected support 上で trace token を持つ。
+- `partialTrace_missing_on_support`: partial certificate は selected support 上で missing trace を持つ。
+- `partialTrace_missing_locus_exact_database`: partial certificate の missing locus は database atom ちょうどである。
+- `partialTrace_repair_frontier_matches_missing_locus`: partial certificate の repair frontier は missing locus と一致する。
+- `surfaceSupport_not_faithful_to_missing_locus`: scalar / verdict / selected support projection は missing locus を復元できない。
+- `surfaceSupport_not_faithful_to_repair_frontier`: 同じ projection は repair frontier も復元できない。
+- `same_surface_support_but_trace_locus_diff`: 同じ visible surface / support の下で trace locus と repair frontier が分岐する。
+
+この結果により、Quality Surface の traceability surface は global な traced / missing label ではなく、
+support 内の locus decomposition と repair frontier を保持すべきであることが Lean-backed に固定された。
+support まで表示しても、trace locus と repair frontier はなお lossful projection の下に隠れうる。
+
 ### Next Frontier
 
-次サイクルでは、`finite trace-locus certificate example` または `trace curvature detector` を優先する。
-前者は trace token つき finite example を codebase-facing paper seed に近づけ、後者は profile-curvature と
-trace-missing state を結びつける。
+次サイクルでは、`trace curvature detector` または `finite codebase trace example` を優先する。前者は
+profile-curvature と trace-missing / trace-locus state を結びつけ、後者は Research sandbox の finite trace
+locus を codebase-facing paper seed に近づける。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 cycle 6 として、同じ visible scalar / selected verdict / selected support の下でも、trace locus と repair frontier が分岐することを Research sandbox の Lean 証拠として追加します。

## 証明した定理

- `TraceLocus.trace_locus_partition`
- `TraceLocus.trace_available_missing_disjoint`
- `TraceLocus.fullTrace_available_on_support`
- `TraceLocus.partialTrace_missing_on_support`
- `TraceLocus.partialTrace_missing_locus_exact_database`
- `TraceLocus.partialTrace_repair_covers_missing`
- `TraceLocus.partialTrace_repair_frontier_matches_missing_locus`
- `TraceLocus.surfaceSupport_not_faithful_to_missing_locus`
- `TraceLocus.surfaceSupport_not_faithful_to_repair_frontier`
- `TraceLocus.same_surface_support_but_trace_locus_diff`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-finite-trace-locus-certificate.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/TraceLocus.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` scan for major TraceLocus theorems
- [x] private path scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

tracking issue 継続中の cycle PR なので、`Closes #2348` ではなく `Refs #2348` としています。
