### PR TITLE
Quality Surface の trace curvature 証拠を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -5,3 +5,4 @@ import Formal.AG.Research.QualitySurface.ProfileCurvature
 import Formal.AG.Research.QualitySurface.TraceTransport
 import Formal.AG.Research.QualitySurface.StateSeparation
 import Formal.AG.Research.QualitySurface.TraceLocus
+import Formal.AG.Research.QualitySurface.TraceCurvature

--- a/Formal/AG/Research/QualitySurface/TraceCurvature.lean
+++ b/Formal/AG/Research/QualitySurface/TraceCurvature.lean
@@ -1,0 +1,323 @@
+import Formal.AG.Research.QualitySurface.TraceLocus
+
+/-!
+Cycle 7 evidence for `G-aat-quality-surface-01`.
+
+This file adds a finite trace-curvature detector. Two path-ordered trace
+transports can reach the same visible scalar, verdict, and support at the
+upper-right profile while disagreeing on the trace locus and exact repair
+frontier.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace TraceCurvature
+
+/-! ## Profile square and trace certificates -/
+
+/-- Four vertices of the finite trace-curvature square. -/
+inductive TraceProfile where
+  | lowerLeft
+  | lowerRight
+  | upperLeft
+  | upperRight
+  deriving DecidableEq, Fintype
+
+/-- Named certificates carried by the trace-curvature square. -/
+inductive TraceCertificateName where
+  | seed
+  | lawStage
+  | coverStage
+  | lawThenCoverResult
+  | coverThenLawResult
+  deriving DecidableEq, Fintype
+
+open TraceProfile TraceCertificateName
+open TraceLocus
+
+/-- The selected support shared by all trace-curvature certificates. -/
+def sharedSupport : Set LocusAtom :=
+  selectedSupport
+
+/-- A trace field with no missing trace on the shared support. -/
+def tracedField : LocusAtom -> Option LocusTraceToken :=
+  fullTraceField
+
+/-- A trace field whose database atom is missing on the shared support. -/
+def curvedTraceField : LocusAtom -> Option LocusTraceToken :=
+  partialTraceField
+
+/-- No repair is required while the trace locus is full. -/
+def emptyRepairFrontier : Set LocusAtom :=
+  fun _ => False
+
+/-- The database repair frontier records the trace gap in the curved path. -/
+def curvedRepairFrontier : Set LocusAtom :=
+  databaseRepairFrontier
+
+/-- Tuple carried by each named trace certificate. -/
+structure TraceSquareCertificate where
+  visibleScalarReading : Nat
+  verdict : StateSeparation.StateVerdict
+  selectedSupport : Set LocusAtom
+  traceField : LocusAtom -> Option LocusTraceToken
+  repairFrontier : Set LocusAtom
+
+/-- The seed certificate starts with full trace coverage. -/
+def seedTraceTuple : TraceSquareCertificate where
+  visibleScalarReading := 0
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := sharedSupport
+  traceField := tracedField
+  repairFrontier := emptyRepairFrontier
+
+/-- Law strengthening alone preserves trace coverage. -/
+def lawStageTraceTuple : TraceSquareCertificate where
+  visibleScalarReading := 1
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := sharedSupport
+  traceField := tracedField
+  repairFrontier := emptyRepairFrontier
+
+/-- Cover refinement alone preserves trace coverage. -/
+def coverStageTraceTuple : TraceSquareCertificate where
+  visibleScalarReading := 1
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := sharedSupport
+  traceField := tracedField
+  repairFrontier := emptyRepairFrontier
+
+/-- The law-then-cover path remains trace complete at the upper-right profile. -/
+def lawThenCoverTraceTuple : TraceSquareCertificate where
+  visibleScalarReading := 1
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := sharedSupport
+  traceField := tracedField
+  repairFrontier := emptyRepairFrontier
+
+/-- The cover-then-law path reaches the same visible surface but loses database trace. -/
+def coverThenLawTraceTuple : TraceSquareCertificate where
+  visibleScalarReading := 1
+  verdict := StateSeparation.StateVerdict.acceptable
+  selectedSupport := sharedSupport
+  traceField := curvedTraceField
+  repairFrontier := curvedRepairFrontier
+
+/-- Read the tuple carried by a named trace certificate. -/
+def traceTuple : TraceCertificateName -> TraceSquareCertificate
+  | seed => seedTraceTuple
+  | lawStage => lawStageTraceTuple
+  | coverStage => coverStageTraceTuple
+  | lawThenCoverResult => lawThenCoverTraceTuple
+  | coverThenLawResult => coverThenLawTraceTuple
+
+/-- Profile vertex where a named trace certificate lives. -/
+def profileOf : TraceCertificateName -> TraceProfile
+  | seed => lowerLeft
+  | lawStage => lowerRight
+  | coverStage => upperLeft
+  | lawThenCoverResult => upperRight
+  | coverThenLawResult => upperRight
+
+/-- Certificates typed by the profile vertex where they live. -/
+def CertificateAt (p : TraceProfile) : Type :=
+  { c : TraceCertificateName // profileOf c = p }
+
+/-- The seed trace certificate at the lower-left vertex. -/
+def seedAt : CertificateAt lowerLeft :=
+  ⟨seed, rfl⟩
+
+/-! ## Typed path transports -/
+
+/-- A typed edge transport along the trace profile square. -/
+structure EdgeTransport (source target : TraceProfile) where
+  map : CertificateAt source -> CertificateAt target
+
+/-- Bottom edge: strengthen law first. -/
+def transportLawBottom : EdgeTransport lowerLeft lowerRight where
+  map := fun _ => ⟨lawStage, rfl⟩
+
+/-- Right edge: refine cover after law strengthening. -/
+def transportCoverRight : EdgeTransport lowerRight upperRight where
+  map := fun _ => ⟨lawThenCoverResult, rfl⟩
+
+/-- Left edge: refine cover first. -/
+def transportCoverLeft : EdgeTransport lowerLeft upperLeft where
+  map := fun _ => ⟨coverStage, rfl⟩
+
+/-- Top edge: strengthen law after cover refinement. -/
+def transportLawTop : EdgeTransport upperLeft upperRight where
+  map := fun _ => ⟨coverThenLawResult, rfl⟩
+
+/-- The path that strengthens law before cover refinement. -/
+def lawThenCover (c : CertificateAt lowerLeft) : CertificateAt upperRight :=
+  transportCoverRight.map (transportLawBottom.map c)
+
+/-- The path that refines cover before law strengthening. -/
+def coverThenLaw (c : CertificateAt lowerLeft) : CertificateAt upperRight :=
+  transportLawTop.map (transportCoverLeft.map c)
+
+/-- The law-then-cover path reaches its named upper-right certificate. -/
+theorem lawThenCover_seed :
+    (lawThenCover seedAt).val = lawThenCoverResult :=
+  rfl
+
+/-- The cover-then-law path reaches its named upper-right certificate. -/
+theorem coverThenLaw_seed :
+    (coverThenLaw seedAt).val = coverThenLawResult :=
+  rfl
+
+/-! ## Visible projection and trace curvature -/
+
+/-- Visible scalar reading selected from a trace certificate. -/
+def scalarReading (c : TraceCertificateName) : Nat :=
+  (traceTuple c).visibleScalarReading
+
+/-- Selected verdict component. -/
+def verdict (c : TraceCertificateName) : StateSeparation.StateVerdict :=
+  (traceTuple c).verdict
+
+/-- Selected support carried by a trace certificate. -/
+def support (c : TraceCertificateName) : Set LocusAtom :=
+  (traceTuple c).selectedSupport
+
+/-- Trace missing locus of a named trace certificate. -/
+def traceMissingLocus (c : TraceCertificateName) : Set LocusAtom :=
+  fun atom => support c atom ∧ (traceTuple c).traceField atom = none
+
+/-- Trace repair frontier of a named trace certificate. -/
+def repairFrontier (c : TraceCertificateName) : Set LocusAtom :=
+  (traceTuple c).repairFrontier
+
+/-- The visible upper-right scalar agrees along the two paths. -/
+theorem same_scalar_after_trace_paths :
+    scalarReading (lawThenCover seedAt).val =
+      scalarReading (coverThenLaw seedAt).val :=
+  rfl
+
+/-- The visible upper-right verdict agrees along the two paths. -/
+theorem same_verdict_after_trace_paths :
+    verdict (lawThenCover seedAt).val =
+      verdict (coverThenLaw seedAt).val :=
+  rfl
+
+/-- The selected upper-right support agrees along the two paths. -/
+theorem same_support_after_trace_paths :
+    support (lawThenCover seedAt).val =
+      support (coverThenLaw seedAt).val :=
+  rfl
+
+/-- The law-then-cover path remains trace complete at upper-right. -/
+theorem lawThenCover_trace_available :
+    TraceTransport.TraceAvailableOn
+      (support (lawThenCover seedAt).val)
+      (traceTuple (lawThenCover seedAt).val).traceField :=
+  TraceLocus.fullTrace_available_on_support
+
+/-- The cover-then-law path has a missing database trace at upper-right. -/
+theorem coverThenLaw_trace_missing :
+    TraceTransport.TraceMissingOn
+      (support (coverThenLaw seedAt).val)
+      (traceTuple (coverThenLaw seedAt).val).traceField :=
+  TraceLocus.partialTrace_missing_on_support
+
+/-- The law-then-cover path has no database repair frontier at upper-right. -/
+theorem lawThenCover_no_database_repair :
+    ¬ repairFrontier (lawThenCover seedAt).val LocusAtom.database :=
+  TraceLocus.fullTrace_repair_frontier_excludes_database
+
+/-- The cover-then-law path forces the database repair frontier at upper-right. -/
+theorem coverThenLaw_forces_database_repair :
+    repairFrontier (coverThenLaw seedAt).val LocusAtom.database :=
+  TraceLocus.partialTrace_forces_database_repair
+
+/-- The cover-then-law repair frontier matches its missing trace locus. -/
+theorem coverThenLaw_repair_frontier_matches_missing_locus :
+    ∀ atom,
+      repairFrontier (coverThenLaw seedAt).val atom ↔
+        traceMissingLocus (coverThenLaw seedAt).val atom :=
+  TraceLocus.partialTrace_repair_frontier_matches_missing_locus
+
+/-- Faithfulness of visible upper-right surface to path-ordered trace locus. -/
+def TraceSquareFaithfulToTraceLocus : Prop :=
+  ∀ c₁ c₂ : CertificateAt upperRight,
+    scalarReading c₁.val = scalarReading c₂.val ->
+      verdict c₁.val = verdict c₂.val ->
+        support c₁.val = support c₂.val ->
+          ∀ atom,
+            (traceMissingLocus c₁.val atom ↔
+              traceMissingLocus c₂.val atom)
+
+/-- Faithfulness of visible upper-right surface to path-ordered repair frontier. -/
+def TraceSquareFaithfulToRepairFrontier : Prop :=
+  ∀ c₁ c₂ : CertificateAt upperRight,
+    scalarReading c₁.val = scalarReading c₂.val ->
+      verdict c₁.val = verdict c₂.val ->
+        support c₁.val = support c₂.val ->
+          ∀ atom,
+            (repairFrontier c₁.val atom ↔ repairFrontier c₂.val atom)
+
+/-- The visible upper-right surface cannot recover path-ordered trace locus. -/
+theorem trace_square_not_faithful_to_trace_locus :
+    ¬ TraceSquareFaithfulToTraceLocus := by
+  intro hfaithful
+  have hiff :=
+    hfaithful (lawThenCover seedAt) (coverThenLaw seedAt)
+      rfl rfl rfl LocusAtom.database
+  have hmissingLawThenCover :
+      traceMissingLocus (lawThenCover seedAt).val LocusAtom.database :=
+    hiff.mpr TraceLocus.partialTrace_database_missing_locus
+  exact TraceLocus.fullTrace_has_no_missing_locus
+    ⟨LocusAtom.database, hmissingLawThenCover⟩
+
+/-- The visible upper-right surface also cannot recover path-ordered repair frontier. -/
+theorem trace_square_not_faithful_to_repair_frontier :
+    ¬ TraceSquareFaithfulToRepairFrontier := by
+  intro hfaithful
+  have hiff :=
+    hfaithful (lawThenCover seedAt) (coverThenLaw seedAt)
+      rfl rfl rfl LocusAtom.database
+  have hrepairLawThenCover :
+      repairFrontier (lawThenCover seedAt).val LocusAtom.database :=
+    hiff.mpr coverThenLaw_forces_database_repair
+  exact lawThenCover_no_database_repair hrepairLawThenCover
+
+/-- Path-ordered trace curvature at a profile square. -/
+def TraceCurvatureCell : Prop :=
+  scalarReading (lawThenCover seedAt).val =
+      scalarReading (coverThenLaw seedAt).val ∧
+    verdict (lawThenCover seedAt).val =
+      verdict (coverThenLaw seedAt).val ∧
+    support (lawThenCover seedAt).val =
+      support (coverThenLaw seedAt).val ∧
+    TraceTransport.TraceAvailableOn
+      (support (lawThenCover seedAt).val)
+      (traceTuple (lawThenCover seedAt).val).traceField ∧
+    TraceTransport.TraceMissingOn
+      (support (coverThenLaw seedAt).val)
+      (traceTuple (coverThenLaw seedAt).val).traceField ∧
+    ¬ repairFrontier (lawThenCover seedAt).val LocusAtom.database ∧
+    repairFrontier (coverThenLaw seedAt).val LocusAtom.database ∧
+    (∀ atom,
+      repairFrontier (coverThenLaw seedAt).val atom ↔
+        traceMissingLocus (coverThenLaw seedAt).val atom) ∧
+    ¬ TraceSquareFaithfulToTraceLocus ∧
+    ¬ TraceSquareFaithfulToRepairFrontier
+
+/-- The finite trace square is curved in trace-locus / repair-frontier data. -/
+theorem trace_curvature_cell :
+    TraceCurvatureCell := by
+  exact ⟨same_scalar_after_trace_paths,
+    same_verdict_after_trace_paths,
+    same_support_after_trace_paths,
+    lawThenCover_trace_available,
+    coverThenLaw_trace_missing,
+    lawThenCover_no_database_repair,
+    coverThenLaw_forces_database_repair,
+    coverThenLaw_repair_frontier_matches_missing_locus,
+    trace_square_not_faithful_to_trace_locus,
+    trace_square_not_faithful_to_repair_frontier⟩
+
+end TraceCurvature
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-trace-curvature-detector.md
+++ b/research/ideas/g-aat-quality-surface-01-trace-curvature-detector.md
@@ -1,0 +1,101 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computability
+capability_category: traceability, profile-curvature, certificate-transport, repair-potential, ridge-fold
+expected_base_score: 85
+expected_evidence_multiplier: 2.0
+expected_final_score: 170
+evidence_stage: proved-in-research
+origin: G1-quality-surface-cycle-7
+tags: [quality-surface, trace-curvature, trace-locus, profile-square, repair-frontier]
+created: 2026-06-20
+cycle: 7
+lean: Formal/AG/Research/QualitySurface/TraceCurvature.lean
+---
+
+# Trace-curvature detector
+
+## 主張
+
+有限 profile square において、lower-left の trace certificate から upper-right へ向かう二つの path を構成する。
+二つの path は upper-right で同じ visible scalar reading、同じ selected verdict、同じ selected support を持つ。
+しかし、law-then-cover path は trace complete のままで、cover-then-law path は database atom に trace gap を持ち、
+その missing trace locus に対応する exact repair frontier を要求する。
+
+従って Quality Surface の traceability は、頂点の scalar / verdict / support だけではなく、
+profile change に沿う path-ordered trace locus / repair frontier の coherence を見なければならない。
+
+## 候補種別
+
+`computability`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`
+- cycle 3 の `Formal/AG/Research/QualitySurface/ProfileCurvature.lean`
+- cycle 4 の `Formal/AG/Research/QualitySurface/TraceTransport.lean`
+- cycle 6 の `Formal/AG/Research/QualitySurface/TraceLocus.lean`
+
+## 非自明性
+
+cycle 3 は profile square 上の support / repair curvature を示し、cycle 6 は同じ surface / support の下に trace locus
+と repair frontier が隠れることを示した。この候補はそれらを統合し、profile square の path ordering が trace locus と
+repair frontier の曲率として現れる finite detector を固定する。
+
+## 数学的興味
+
+Quality Surface の trace geometry は、support locus の静的 drill-down だけでなく、profile change の path coherence
+としても読む必要がある。同じ upper-right surface に到達しても、path-ordered certificate transport が trace locus を
+保つか欠くかで、repair frontier が変わる。
+
+## GOAL への前進
+
+traceability、profile-curvature、certificate transport、repair-potential、ridge-fold を同時に進める。
+SCORE threshold 1000 に向けた cycle 7 として、cycle 3 / 4 / 6 の成果を trace-curvature detector に統合する。
+
+## SCORE 見込み
+
+- `score_reason`: 同じ upper-right scalar / verdict / support の下で、path ordering によって trace completeness と
+  trace-missing exact repair frontier が分岐することを Lean で示し、visible surface が trace locus coherence と
+  repair frontier に faithful でないことを証明する。
+- `dullness_risk`: 単に二つの fields を置くだけでは弱い。typed profile square、two path composites、
+  `TraceAvailableOn` / `TraceMissingOn`、exact repair frontier、trace-locus faithfulness 否定を theorem として固定する。
+- `proof_or_evidence_plan`: `TraceProfile` square と typed `EdgeTransport` を置き、law-then-cover と cover-then-law の
+  upper-right certificate を構成する。scalar/verdict/support の一致、law path の trace availability、cover path の
+  missing trace、database repair frontier、trace locus / repair frontier nonfaithfulness、`TraceCurvatureCell` を証明する。
+
+## CS / SWE への帰結
+
+同じ final support と score に見える品質面でも、変更の順序によって trace evidence の欠落と repair frontier が変わる。
+Quality Surface viewer / report は、最終点の値だけでなく path-ordered trace coherence を見せる必要がある。
+
+## 証明・根拠の見込み
+
+Lean では `TraceSquareCertificate`、typed `EdgeTransport`、`lawThenCover`、`coverThenLaw` を定義する。
+`same_scalar_after_trace_paths`、`same_verdict_after_trace_paths`、`same_support_after_trace_paths`、
+`lawThenCover_trace_available`、`coverThenLaw_trace_missing`、`coverThenLaw_repair_frontier_matches_missing_locus`、
+`trace_square_not_faithful_to_trace_locus`、`trace_square_not_faithful_to_repair_frontier`、
+`trace_curvature_cell` を証明する。
+
+## 審判メモ
+
+- 厳密性: typed profile square、two path composites、trace availability / missing、exact repair frontier、
+  trace locus / repair frontier nonfaithfulness を Lean で固定した。
+- 研究価値: cycle 3 の path-ordered profile curvature と cycle 6 の trace locus / exact repair frontier を、
+  trace-curvature detector として統合する。
+- repo 全体価値: Research sandbox の Lean 証拠、paper seed、future viewer の path-coherence 説明として採用する。
+
+## 関連
+
+- `Finite square cell profile-curvature detector`
+- `Trace-natural certificate transport bridge`
+- `Finite trace-locus certificate grid`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 7 の G1 候補として作成。
+- 2026-06-20: `TraceCurvature.lean` を追加し、`lake env lean Formal/AG/Research/QualitySurface/TraceCurvature.lean` と
+  `lake build FormalAGResearch` の通過を確認。
+- 2026-06-20: G2-A の補強提案を受け、repair frontier 側の faithfulness 否定も追加し、
+  主要 theorem の axiom 依存がないことを確認。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 850
+- total SCORE: 1020
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -12,8 +12,9 @@
   - traceability / certificate-transport / invariance / atom-supported-quality-geometry: 120
   - traceability / quality-surface / multi-axis-signature / computability / ridge-fold: 130
   - traceability / quality-surface / certificate-transport / repair-potential / ridge-fold: 150
+  - traceability / profile-curvature / certificate-transport / repair-potential / ridge-fold: 170
 - evidence portfolio:
-  - proved-in-research: 6
+  - proved-in-research: 7
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -228,8 +229,48 @@ Lean 証拠は次を固定する。
 support 内の locus decomposition と repair frontier を保持すべきであることが Lean-backed に固定された。
 support まで表示しても、trace locus と repair frontier はなお lossful projection の下に隠れうる。
 
+## Cycle 7: Trace-curvature detector
+
+```text
+candidate: Trace-curvature detector
+candidate_type: computability
+evidence_stage: proved-in-research
+base_score: 85
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 170
+category: traceability/profile-curvature/certificate-transport/repair-potential/ridge-fold
+goal_delta: 同じ upper-right scalar、verdict、support の下でも、path ordering によって trace locus と repair frontier が分岐する trace-curvature cell を Lean-proved finite witness として固定する。
+project_value_delta: cycle 3 の profile curvature と cycle 6 の trace locus / exact repair frontier を、path-ordered trace coherence detector として統合する。
+formalization_quality: pass/high。typed profile square、two path composites、trace availability / missing、exact repair frontier、trace locus / repair frontier nonfaithfulness が Lean で明示され、主要 theorem は axiom-free / sorry-free で証明されている。
+open_questions: 任意有限 square への一般化、profile-typed certificate tuple 全体への拡張、finite codebase trace example への接続、trace curvature を broader detector class として整理すること。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/TraceCurvature.lean` は、finite trace profile square を定義する。
+lower-left の seed certificate から upper-right へ到達する二つの path として、law strengthening 後に
+cover refinement を行う `lawThenCover` と、cover refinement 後に law strengthening を行う `coverThenLaw` を置く。
+二つの path は typed `EdgeTransport` の合成として upper-right certificate space に入る。
+
+Lean 証拠は次を固定する。
+
+- `same_scalar_after_trace_paths`: 二つの path は upper-right の visible scalar reading で一致する。
+- `same_verdict_after_trace_paths`: 二つの path は selected verdict で一致する。
+- `same_support_after_trace_paths`: 二つの path は selected support で一致する。
+- `lawThenCover_trace_available`: law-then-cover path は upper-right で trace complete のままである。
+- `coverThenLaw_trace_missing`: cover-then-law path は upper-right で database trace gap を持つ。
+- `coverThenLaw_repair_frontier_matches_missing_locus`: cover-then-law path の repair frontier は missing trace locus と一致する。
+- `trace_square_not_faithful_to_trace_locus`: visible upper-right surface は path-ordered trace locus を復元できない。
+- `trace_square_not_faithful_to_repair_frontier`: 同じ surface は path-ordered repair frontier も復元できない。
+- `trace_curvature_cell`: 同じ scalar / verdict / support の下で、trace locus と exact repair frontier が path ordering により分岐する。
+
+この結果により、Quality Surface の trace geometry は、最終頂点の scalar / verdict / support だけでなく、
+profile change に沿う path-ordered trace coherence として読む必要があることが Lean-backed に固定された。
+traceability は support の静的 drill-down だけでなく、profile square 上の curvature としても現れる。
+
 ### Next Frontier
 
-次サイクルでは、`trace curvature detector` または `finite codebase trace example` を優先する。前者は
-profile-curvature と trace-missing / trace-locus state を結びつけ、後者は Research sandbox の finite trace
-locus を codebase-facing paper seed に近づける。
+G-aat-quality-surface-01 の SCORE threshold 1000 は cycle 7 で到達した。次に進める場合は、
+`finite codebase trace example`、任意有限 square への一般化、profile-typed certificate tuple 全体への拡張を
+別 GOAL / 後続 issue として扱う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 cycle 7 として、同じ upper-right scalar / selected verdict / selected support の下でも、path ordering によって trace locus と repair frontier が分岐する trace-curvature detector を Research sandbox の Lean 証拠として追加します。

この PR の merge 後、audited SCORE は `1020 / 1000` となり、tracking issue の threshold に到達します。研究 loop の phase boundary として、Issue は自動 close せず、merge 後に phase summary を残して人間判断へ返します。

## 証明した定理

- `TraceCurvature.same_scalar_after_trace_paths`
- `TraceCurvature.same_verdict_after_trace_paths`
- `TraceCurvature.same_support_after_trace_paths`
- `TraceCurvature.lawThenCover_trace_available`
- `TraceCurvature.coverThenLaw_trace_missing`
- `TraceCurvature.coverThenLaw_repair_frontier_matches_missing_locus`
- `TraceCurvature.trace_square_not_faithful_to_trace_locus`
- `TraceCurvature.trace_square_not_faithful_to_repair_frontier`
- `TraceCurvature.trace_curvature_cell`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-trace-curvature-detector.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/TraceCurvature.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` scan for major TraceCurvature theorems
- [x] private path scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

research-loop の phase boundary では tracking issue を自動 close しないため、`Closes #2348` ではなく `Refs #2348` としています。
