### PR TITLE
研究ループ cycle 8 reading adequacy を追加

### DIFF
--- a/Formal/AG/Research/QualitySurface/ReadingAdequacy.lean
+++ b/Formal/AG/Research/QualitySurface/ReadingAdequacy.lean
@@ -1,0 +1,300 @@
+import Formal.AG.Research.QualitySurface.TraceCurvature
+
+/-!
+Cycle 8 evidence for `G-aat-quality-surface-01`.
+
+This file organizes the earlier Quality Surface finite witnesses as a declared
+reading chain. It separates visible/support readings from protected trace-locus
+and repair-frontier data, and proves that exact trace-repair certificates become
+repair-frontier faithful once the reading includes the trace missing locus.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ReadingAdequacy
+
+universe u
+
+/-! ## Reading refinement and faithfulness -/
+
+/-- A reading is an observational equivalence relation on certificates. -/
+structure Reading (Cert : Type u) where
+  Equivalent : Cert -> Cert -> Prop
+
+/-- `fine` refines `coarse` when fine equivalence implies coarse equivalence. -/
+def ReadingRefines {Cert : Type u} (fine coarse : Reading Cert) : Prop :=
+  ∀ {c₁ c₂ : Cert}, fine.Equivalent c₁ c₂ -> coarse.Equivalent c₁ c₂
+
+/-- A reading is faithful to an invariant if equivalent certificates have the same invariant. -/
+def FaithfulToInvariant {Cert : Type u}
+    (reading : Reading Cert) (SameInvariant : Cert -> Cert -> Prop) : Prop :=
+  ∀ c₁ c₂ : Cert, reading.Equivalent c₁ c₂ -> SameInvariant c₁ c₂
+
+/-- Restricted faithfulness on a certificate subregime. -/
+def FaithfulToInvariantOn {Cert : Type u} (Domain : Cert -> Prop)
+    (reading : Reading Cert) (SameInvariant : Cert -> Cert -> Prop) : Prop :=
+  ∀ c₁ c₂ : Cert,
+    Domain c₁ -> Domain c₂ -> reading.Equivalent c₁ c₂ -> SameInvariant c₁ c₂
+
+/-- Faithfulness is preserved when the reading is refined. -/
+theorem reading_refinement_preserves_faithfulness {Cert : Type u}
+    {fine coarse : Reading Cert} {SameInvariant : Cert -> Cert -> Prop}
+    (hrefines : ReadingRefines fine coarse)
+    (hfaithful : FaithfulToInvariant coarse SameInvariant) :
+    FaithfulToInvariant fine SameInvariant := by
+  intro c₁ c₂ heq
+  exact hfaithful c₁ c₂ (hrefines heq)
+
+/-- Restricted faithfulness is also preserved when the reading is refined. -/
+theorem reading_refinement_preserves_faithfulness_on {Cert : Type u}
+    {Domain : Cert -> Prop} {fine coarse : Reading Cert}
+    {SameInvariant : Cert -> Cert -> Prop}
+    (hrefines : ReadingRefines fine coarse)
+    (hfaithful : FaithfulToInvariantOn Domain coarse SameInvariant) :
+    FaithfulToInvariantOn Domain fine SameInvariant := by
+  intro c₁ c₂ hc₁ hc₂ heq
+  exact hfaithful c₁ c₂ hc₁ hc₂ (hrefines heq)
+
+/-! ## The finite trace-locus reading chain -/
+
+abbrev TraceCert :=
+  TraceLocus.TraceLocusCertificate
+
+/-- Same visible scalar and selected verdict. -/
+def SameVisibleSurface (c₁ c₂ : TraceCert) : Prop :=
+  c₁.visibleScalarReading = c₂.visibleScalarReading ∧
+    c₁.verdict = c₂.verdict
+
+/-- Same selected support, stated pointwise to avoid extensionality axioms. -/
+def SameSelectedSupport (c₁ c₂ : TraceCert) : Prop :=
+  ∀ atom, c₁.selectedSupport atom ↔ c₂.selectedSupport atom
+
+/-- Same trace missing locus. -/
+def SameTraceMissingLocus (c₁ c₂ : TraceCert) : Prop :=
+  ∀ atom,
+    TraceLocus.TraceMissingLocus c₁ atom ↔
+      TraceLocus.TraceMissingLocus c₂ atom
+
+/-- Same repair frontier. -/
+def SameRepairFrontier (c₁ c₂ : TraceCert) : Prop :=
+  ∀ atom, c₁.repairFrontier atom ↔ c₂.repairFrontier atom
+
+/-- Reading that keeps only the visible surface. -/
+def visibleSurfaceReading : Reading TraceCert where
+  Equivalent := SameVisibleSurface
+
+/-- Reading that keeps visible surface and selected support. -/
+def supportSurfaceReading : Reading TraceCert where
+  Equivalent := fun c₁ c₂ =>
+    SameVisibleSurface c₁ c₂ ∧ SameSelectedSupport c₁ c₂
+
+/-- Reading that also keeps the trace missing locus. -/
+def traceLocusAwareReading : Reading TraceCert where
+  Equivalent := fun c₁ c₂ =>
+    supportSurfaceReading.Equivalent c₁ c₂ ∧ SameTraceMissingLocus c₁ c₂
+
+/-- Reading that also keeps the repair frontier. -/
+def repairAwareReading : Reading TraceCert where
+  Equivalent := fun c₁ c₂ =>
+    traceLocusAwareReading.Equivalent c₁ c₂ ∧ SameRepairFrontier c₁ c₂
+
+/-- The support surface reading refines the visible surface reading. -/
+theorem supportSurface_refines_visibleSurface :
+    ReadingRefines supportSurfaceReading visibleSurfaceReading := by
+  intro c₁ c₂ heq
+  exact heq.1
+
+/-- The trace-locus-aware reading refines the support surface reading. -/
+theorem traceLocusAware_refines_supportSurface :
+    ReadingRefines traceLocusAwareReading supportSurfaceReading := by
+  intro c₁ c₂ heq
+  exact heq.1
+
+/-- The repair-aware reading refines the trace-locus-aware reading. -/
+theorem repairAware_refines_traceLocusAware :
+    ReadingRefines repairAwareReading traceLocusAwareReading := by
+  intro c₁ c₂ heq
+  exact heq.1
+
+/-! ## Strictness: support surface is not trace / repair adequate -/
+
+/-- The full and partial trace certificates agree at the support surface reading. -/
+theorem full_partial_supportSurface_equivalent :
+    supportSurfaceReading.Equivalent
+      TraceLocus.fullTraceCert TraceLocus.partialTraceCert := by
+  constructor
+  · exact ⟨rfl, rfl⟩
+  · intro atom
+    constructor <;> intro _ <;> trivial
+
+/--
+Even after selected support is visible, the reading does not recover the trace
+missing locus.
+-/
+theorem surfaceSupport_not_faithful_to_traceMissingLocus :
+    ¬ FaithfulToInvariant supportSurfaceReading SameTraceMissingLocus := by
+  intro hfaithful
+  have hsame :=
+    hfaithful TraceLocus.fullTraceCert TraceLocus.partialTraceCert
+      full_partial_supportSurface_equivalent
+  have hmissingFull :
+      TraceLocus.TraceMissingLocus TraceLocus.fullTraceCert
+        TraceLocus.LocusAtom.database :=
+    (hsame TraceLocus.LocusAtom.database).mpr
+      TraceLocus.partialTrace_database_missing_locus
+  exact TraceLocus.fullTrace_has_no_missing_locus
+    ⟨TraceLocus.LocusAtom.database, hmissingFull⟩
+
+/-- The full trace certificate has exact repair frontier: no missing trace, no repair. -/
+theorem fullTrace_repairFrontierExact :
+    (∀ atom,
+      TraceLocus.fullTraceCert.repairFrontier atom ↔
+        TraceLocus.TraceMissingLocus TraceLocus.fullTraceCert atom) := by
+  intro atom
+  constructor
+  · intro hrepair
+    exact False.elim hrepair
+  · intro hmissing
+    exact TraceLocus.fullTrace_has_no_missing_locus ⟨atom, hmissing⟩
+
+/-- The partial trace certificate has exact repair frontier at the missing trace locus. -/
+theorem partialTrace_repairFrontierExact :
+    (∀ atom,
+      TraceLocus.partialTraceCert.repairFrontier atom ↔
+        TraceLocus.TraceMissingLocus TraceLocus.partialTraceCert atom) :=
+  TraceLocus.partialTrace_repair_frontier_matches_missing_locus
+
+/-- Certificates whose repair frontier is exactly their trace missing locus. -/
+def RepairFrontierExact (c : TraceCert) : Prop :=
+  ∀ atom, c.repairFrontier atom ↔ TraceLocus.TraceMissingLocus c atom
+
+/--
+Inside the exact trace-repair regime, the support surface reading is still not
+faithful to the repair frontier.
+-/
+theorem surfaceSupport_not_faithful_to_exactRepairFrontier :
+    ¬ FaithfulToInvariantOn RepairFrontierExact
+      supportSurfaceReading SameRepairFrontier := by
+  intro hfaithful
+  have hsame :=
+    hfaithful TraceLocus.fullTraceCert TraceLocus.partialTraceCert
+      fullTrace_repairFrontierExact partialTrace_repairFrontierExact
+      full_partial_supportSurface_equivalent
+  have hrepairFull :
+      TraceLocus.fullTraceCert.repairFrontier TraceLocus.LocusAtom.database :=
+    (hsame TraceLocus.LocusAtom.database).mpr
+      TraceLocus.partialTrace_forces_database_repair
+  exact TraceLocus.fullTrace_repair_frontier_excludes_database hrepairFull
+
+/-! ## Adequacy under exact trace-repair -/
+
+/--
+In the exact trace-repair regime, a trace-locus-aware reading is faithful to the
+repair frontier.
+-/
+theorem traceLocusAware_faithful_to_repairFrontier_of_exact :
+    FaithfulToInvariantOn RepairFrontierExact
+      traceLocusAwareReading SameRepairFrontier := by
+  intro c₁ c₂ hexact₁ hexact₂ heq atom
+  have hmissing := heq.2 atom
+  constructor
+  · intro hrepair₁
+    have hmissing₁ : TraceLocus.TraceMissingLocus c₁ atom :=
+      (hexact₁ atom).mp hrepair₁
+    have hmissing₂ : TraceLocus.TraceMissingLocus c₂ atom :=
+      hmissing.mp hmissing₁
+    exact (hexact₂ atom).mpr hmissing₂
+  · intro hrepair₂
+    have hmissing₂ : TraceLocus.TraceMissingLocus c₂ atom :=
+      (hexact₂ atom).mp hrepair₂
+    have hmissing₁ : TraceLocus.TraceMissingLocus c₁ atom :=
+      hmissing.mpr hmissing₂
+    exact (hexact₁ atom).mpr hmissing₁
+
+/--
+The cycle-6 witness is exactly the adequacy gap: support surface agrees, but
+trace locus and exact repair frontier do not.
+-/
+theorem same_surface_support_but_trace_locus_adequacy_gap :
+    supportSurfaceReading.Equivalent
+      TraceLocus.fullTraceCert TraceLocus.partialTraceCert ∧
+      ¬ SameTraceMissingLocus
+        TraceLocus.fullTraceCert TraceLocus.partialTraceCert ∧
+      RepairFrontierExact TraceLocus.fullTraceCert ∧
+      RepairFrontierExact TraceLocus.partialTraceCert ∧
+      ¬ SameRepairFrontier
+        TraceLocus.fullTraceCert TraceLocus.partialTraceCert := by
+  constructor
+  · exact full_partial_supportSurface_equivalent
+  constructor
+  · intro hsame
+    have hmissingFull :
+        TraceLocus.TraceMissingLocus TraceLocus.fullTraceCert
+          TraceLocus.LocusAtom.database :=
+      (hsame TraceLocus.LocusAtom.database).mpr
+        TraceLocus.partialTrace_database_missing_locus
+    exact TraceLocus.fullTrace_has_no_missing_locus
+      ⟨TraceLocus.LocusAtom.database, hmissingFull⟩
+  constructor
+  · exact fullTrace_repairFrontierExact
+  constructor
+  · exact partialTrace_repairFrontierExact
+  · intro hrepair
+    have hrepairFull :
+        TraceLocus.fullTraceCert.repairFrontier TraceLocus.LocusAtom.database :=
+      (hrepair TraceLocus.LocusAtom.database).mpr
+        TraceLocus.partialTrace_forces_database_repair
+    exact TraceLocus.fullTrace_repair_frontier_excludes_database hrepairFull
+
+/-! ## Cycle-7 path-ordered trace adequacy gap -/
+
+abbrev TraceUpperRightCert :=
+  TraceCurvature.CertificateAt TraceCurvature.TraceProfile.upperRight
+
+/-- Same visible upper-right trace surface and selected support. -/
+def SameUpperRightTraceSupportSurface
+    (c₁ c₂ : TraceUpperRightCert) : Prop :=
+  TraceCurvature.scalarReading c₁.val =
+      TraceCurvature.scalarReading c₂.val ∧
+    TraceCurvature.verdict c₁.val = TraceCurvature.verdict c₂.val ∧
+    TraceCurvature.support c₁.val = TraceCurvature.support c₂.val
+
+/-- Same path-ordered repair frontier at the upper-right trace profile. -/
+def SameUpperRightRepairFrontier
+    (c₁ c₂ : TraceUpperRightCert) : Prop :=
+  ∀ atom,
+    TraceCurvature.repairFrontier c₁.val atom ↔
+      TraceCurvature.repairFrontier c₂.val atom
+
+/--
+The cycle-7 trace-curvature cell has the same visible upper-right support
+surface along both paths, but not the same path-ordered repair frontier.
+-/
+theorem traceCurvature_surfaceSupport_not_pathOrderedRepairAdequate :
+    ¬ (∀ c₁ c₂ : TraceUpperRightCert,
+      SameUpperRightTraceSupportSurface c₁ c₂ ->
+        SameUpperRightRepairFrontier c₁ c₂) := by
+  intro hfaithful
+  have hsameSurface :
+      SameUpperRightTraceSupportSurface
+        (TraceCurvature.lawThenCover TraceCurvature.seedAt)
+        (TraceCurvature.coverThenLaw TraceCurvature.seedAt) :=
+    ⟨TraceCurvature.same_scalar_after_trace_paths,
+      TraceCurvature.same_verdict_after_trace_paths,
+      TraceCurvature.same_support_after_trace_paths⟩
+  have hrepairSame :=
+    hfaithful
+      (TraceCurvature.lawThenCover TraceCurvature.seedAt)
+      (TraceCurvature.coverThenLaw TraceCurvature.seedAt)
+      hsameSurface
+  have hrepairLawThenCover :
+      TraceCurvature.repairFrontier
+        (TraceCurvature.lawThenCover TraceCurvature.seedAt).val
+        TraceLocus.LocusAtom.database :=
+    (hrepairSame TraceLocus.LocusAtom.database).mpr
+      TraceCurvature.coverThenLaw_forces_database_repair
+  exact TraceCurvature.lawThenCover_no_database_repair hrepairLawThenCover
+
+end ReadingAdequacy
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-reading-adequacy-lattice.md
+++ b/research/ideas/g-aat-quality-surface-01-reading-adequacy-lattice.md
@@ -1,0 +1,187 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: quality-surface / traceability / ridge-fold / repair-potential
+expected_base_score: 55
+expected_evidence_multiplier: 2.0
+expected_final_score: 110
+evidence_stage: proved-in-research
+origin: cycle-8
+tags: [quality-surface, reading, adequacy, projection, trace-locus, repair-frontier]
+created: 2026-06-20
+cycle: 8
+lean: proved-in-research
+---
+
+# Finite reading adequacy chain for protected quality data
+
+## 主張
+
+Quality Surface の reading projection を、宣言された有限 reading chain と factorization preorder の上で並べる。対象にする chain は、visible scalar、scalar/verdict、scalar/verdict/support、trace-locus-aware、repair-aware / full protected signature である。
+
+この有限 chain では、reading が細かくなるほど faithfulness は保存される。一方で、scalar/verdict/support までを保持しても、trace missing locus と exact repair frontier は復元できない。exact trace-repair regime では、trace missing locus を含む reading は repair frontier を復元する。したがって、この chain 内で repair frontier を読む最初の十分 reading は trace-locus-aware reading になる。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `research/reports/G-aat-quality-surface-01.md` cycle 2, 5, 6, 7
+- `Formal/AG/Research/QualitySurface/ScalarCollapse.lean`
+- `Formal/AG/Research/QualitySurface/StateSeparation.lean`
+- `Formal/AG/Research/QualitySurface/TraceLocus.lean`
+- `Formal/AG/Research/QualitySurface/TraceCurvature.lean`
+- `docs/note/aat_quality_surface.md` の loss-aware visualization と protected certificate data の構想
+
+## 非自明性
+
+既存 cycle は、個別の reading fold や trace locus の非忠実性を finite witness として固定した。この候補はそれらを単なる一覧として再掲するのではなく、reading の refinement preorder、faithfulness の保存、strictness witness、exact trace-repair regime に相対化された repair frontier の十分 reading を同じ形式で扱う。
+
+## 数学的興味
+
+可視化で選ばれる reading を、単なる UI 表示ではなく、protected invariant を復元する projection として定式化する。これにより、Quality Surface の loss-aware 表示は「どのデータを見せるか」という設計問題から、「どの invariant への faithfulness を持つ reading か」という数学的な復元問題に変わる。
+
+## GOAL への前進
+
+reading fold、traceability、repair frontier、multi-axis quality signature の関係を、projection adequacy の一つの枠へ統合し、Quality Surface が certificate geometry を保持すべき理由を復元可能性として表現する。
+
+## SCORE 見込み
+
+- `score_reason`: scalar-collapse、state separation、trace locus、trace curvature の個別 witness を、有限 reading chain と faithfulness の階層へ圧縮する。report / paper seed で Quality Surface の loss-aware surface を説明する整理定理になる。G2 後の基礎点は 55 とする。
+- `dullness_risk`: 既存 theorem の索引化だけなら dull になる。`ReadingRefines`、faithfulness preservation、strictness witness、exact repair frontier の sufficient reading、cycle 7 の path-ordered trace case への接続を Lean statement として固定することで避ける。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/ReadingAdequacy.lean` を追加する。`Reading` とその `Equivalent` field、`ReadingRefines`、`FaithfulToInvariant`、`FaithfulToInvariantOn`、`RepairFrontierExact` を定義し、既存 `TraceLocus` / `TraceCurvature` witness を使って strictness、exact repair-frontier faithfulness、path-ordered trace case の adequacy gap を証明する。
+
+## CS / SWE への帰結
+
+Quality Surface の dashboard や website surface で、scalar、verdict、support、trace locus、repair frontier のどこまで表示すればどの protected data を復元できるかを説明できる。これは実コード全体の品質断定ではなく、選ばれた certificate geometry と宣言された reading chain の adequacy に相対化された claim である。
+
+## 証明・根拠の見込み
+
+Lean 証拠は `Formal/AG/Research/QualitySurface/ReadingAdequacy.lean` に置いた。`TraceLocus.TraceLocusCertificate` を使い、reading equivalence を次のように段階化した。
+
+- visible surface: scalar と verdict の一致。
+- support surface: scalar、verdict、selected support の一致。
+- trace-locus-aware surface: support surface に加えて trace missing locus の一致。
+- repair-aware / full protected signature: repair frontier を含む。
+
+主な theorem:
+
+- `reading_refinement_preserves_faithfulness`
+- `surfaceSupport_not_faithful_to_traceMissingLocus`
+- `surfaceSupport_not_faithful_to_exactRepairFrontier`
+- `traceLocusAware_faithful_to_repairFrontier_of_exact`
+- `same_surface_support_but_trace_locus_adequacy_gap`
+- `traceCurvature_surfaceSupport_not_pathOrderedRepairAdequate`
+
+G3 で実際に証明された主要 declaration:
+
+- `Reading`
+- `ReadingRefines`
+- `FaithfulToInvariant`
+- `FaithfulToInvariantOn`
+- `reading_refinement_preserves_faithfulness`
+- `reading_refinement_preserves_faithfulness_on`
+- `supportSurface_refines_visibleSurface`
+- `traceLocusAware_refines_supportSurface`
+- `repairAware_refines_traceLocusAware`
+- `surfaceSupport_not_faithful_to_traceMissingLocus`
+- `surfaceSupport_not_faithful_to_exactRepairFrontier`
+- `traceLocusAware_faithful_to_repairFrontier_of_exact`
+- `same_surface_support_but_trace_locus_adequacy_gap`
+- `traceCurvature_surfaceSupport_not_pathOrderedRepairAdequate`
+
+## ループ必須フィールド
+
+```text
+score_reason: scalar-collapse、state separation、trace locus、trace curvature の個別 witness を有限 reading chain と faithfulness 階層へ圧縮する。
+mathematical_interest: loss-aware visualization を protected invariant の復元可能性として定式化する。
+goal_advancement: reading fold、traceability、repair frontier、multi-axis quality signature を projection adequacy の一つの枠へ統合する。
+dullness_risk: 既存 theorem の索引化に留まると dull。refinement preorder、faithfulness preservation、strictness、exact repair frontier、path-ordered trace case 接続を Lean statement として固定する。
+proof_or_evidence_plan: ReadingAdequacy.lean で Reading、ReadingRefines、FaithfulToInvariant、FaithfulToInvariantOn、RepairFrontierExact を定義し、TraceLocus / TraceCurvature witness で strictness と exact faithfulness を証明する。
+planned_theorem_names: reading_refinement_preserves_faithfulness, surfaceSupport_not_faithful_to_traceMissingLocus, surfaceSupport_not_faithful_to_exactRepairFrontier, traceLocusAware_faithful_to_repairFrontier_of_exact, same_surface_support_but_trace_locus_adequacy_gap, traceCurvature_surfaceSupport_not_pathOrderedRepairAdequate
+visible_projection: 同じ scalar / verdict / support でも trace missing locus と repair frontier が分岐し、trace-locus-aware reading で exact repair frontier が復元される。
+protected_structure: selected support、trace missing locus、repair frontier、obligation、protected state signature。
+exactness_or_minimality_claim: exact trace-repair regime と宣言された reading chain に相対化して、trace missing locus を含む reading が repair frontier に faithful で、support surface は faithful ではない。
+nonfaithfulness_or_failure_mode: support 表示までで repair frontier が見えると読むこと。
+previous_cycle_delta: cycle 2, 5, 6, 7 の個別 nonfaithfulness を projection refinement と復元可能性へ統合する。
+```
+
+## visible_projection
+
+同じ scalar / verdict / support を表示していても、trace missing locus と repair frontier が異なる pair が存在する。trace-locus-aware reading は exact trace-repair regime で repair frontier を復元できる。
+
+## protected_structure
+
+protected invariant family は、selected support、trace missing locus、repair frontier、obligation、protected state signature である。この cycle では trace missing locus と repair frontier を主対象にする。
+
+## exactness_or_minimality_claim
+
+exact trace-repair regime では、repair frontier は trace missing locus と一致する。したがって、trace missing locus を含む reading は repair frontier に faithful であり、scalar/verdict/support だけの reading は faithful ではない。この主張は宣言された finite reading chain に相対化され、repair-frontier-direct reading や full protected signature を排除する絶対的最小性は主張しない。
+
+## nonfaithfulness_or_failure_mode
+
+scalar、verdict、selected support まで表示しても、trace missing locus と repair frontier は復元できない。support 表示を追加しただけで repair frontier が見えると読むことが failure mode である。
+
+## previous_cycle_delta
+
+cycle 2 は scalar reading の非忠実性、cycle 5 は zero-looking state separation、cycle 6 は trace locus / repair frontier の分岐、cycle 7 は path-ordered trace curvature を固定した。この候補は、それらを reading adequacy の refinement order と復元可能性へ統合する。
+
+## 審判メモ
+
+- 厳密性: initial revise、clarified accept。base 55。finite reading chain と exact trace-repair regime へ相対化されていれば claim boundary は通る。G3 では `ReadingRefines`、`FaithfulToInvariant`、strictness、`RepairFrontierExact` 下の sufficiency、cycle 7 path-ordered adequacy gap を証明する必要がある。
+- 研究価値: accept。base 85。個別 witness を reading adequacy / refinement order と復元可能性の問題へ圧縮する価値がある。
+- repo 全体価値: revised accept。base 55。Research / Lean / paper seed には有用だが、新現象ではなく threshold 到達後の整理定理として扱う。
+
+## G3 監査
+
+- build: `lake build FormalAGResearch` pass、`lake env lean Formal/AG/Research/QualitySurface/ReadingAdequacy.lean` pass。
+- axiom check: pass。主要 declaration はすべて `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は出ていない。
+- formalization quality audit: pass。候補の finite reading chain 相対の主張を適切な強さで表す。絶対 lattice、絶対最小性、source extraction completeness、実コード全体の品質判定は主張していない。
+- caveat: scalar-only 段と full protected signature / obligation-aware reading は今回の独立 declaration としては切っていない。cycle 8 の主張は support surface、trace-locus-aware reading、repair-aware reading、path-ordered trace case に限定する。
+
+## G4 後の予定 report entry
+
+G4 SCORE 監査は `confirm`。`research/reports/G-aat-quality-surface-01.md` に Cycle 8 として次を載せた。
+
+```text
+candidate: Finite reading adequacy chain for protected quality data
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 55
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 110
+category: quality-surface/traceability/ridge-fold/repair-potential
+goal_delta: cycle 2/5/6/7 の reading fold、trace locus、repair frontier、trace curvature を finite reading chain と faithfulness 階層へ統合する。
+formalization_quality: pass。`ReadingRefines`、faithfulness preservation、support surface nonfaithfulness、`RepairFrontierExact` 下の trace-locus-aware sufficiency、cycle 7 path-ordered adequacy gap が axiom-free で証明されている。
+```
+
+## G4 SCORE 監査
+
+- score_verdict: `confirm`
+- base_score: 55
+- evidence_multiplier: 2.0
+- penalty: 0
+- final_score: 110
+- category: `quality-surface / traceability / ridge-fold / repair-potential`
+- goal_delta: cycle 2/5/6/7 の scalar/verdict/support loss、trace missing locus、repair frontier、path-ordered trace gap を finite reading refinement と faithfulness hierarchy に統合する。
+- project_value_delta: Lean-backed な report / paper seed として loss-aware Quality Surface の表示設計を protected invariant の復元可能性に接続する。
+- formalization_quality: pass。主要 theorem は axiom-free / sorry-free。
+- research_kiri_contribution: threshold 後の整理定理として有用だが、新現象そのものではなく既存 witness の圧縮なので base 55 が妥当。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-scalar-collapse-support-antichain.md`
+- `research/ideas/g-aat-quality-surface-01-measured-unmeasured-trace-missing.md`
+- `research/ideas/g-aat-quality-surface-01-finite-trace-locus-certificate.md`
+- `research/ideas/g-aat-quality-surface-01-trace-curvature-detector.md`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 8 候補として作成。
+- 2026-06-20: G2-A / G2-C の revise を受け、lattice / 絶対最小性を finite reading chain / 相対的十分性へ弱め、expected base score を 65 に下げた。
+- 2026-06-20: G2 clarification 後に picked。A/C の base score に合わせて expected base score を 55、expected final score を 110 に下げた。
+- 2026-06-20: `ReadingAdequacy.lean` を追加し、G3 公理検査と Lean 形式化品質監査が pass。evidence stage を `proved-in-research` に更新。
+- 2026-06-20: G4 SCORE 監査が confirm。report Cycle 8 と total SCORE 1130 を更新。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 1020
+- total SCORE: 1130
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -13,8 +13,9 @@
   - traceability / quality-surface / multi-axis-signature / computability / ridge-fold: 130
   - traceability / quality-surface / certificate-transport / repair-potential / ridge-fold: 150
   - traceability / profile-curvature / certificate-transport / repair-potential / ridge-fold: 170
+  - quality-surface / traceability / ridge-fold / repair-potential: 110
 - evidence portfolio:
-  - proved-in-research: 7
+  - proved-in-research: 8
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -269,8 +270,52 @@ Lean 証拠は次を固定する。
 profile change に沿う path-ordered trace coherence として読む必要があることが Lean-backed に固定された。
 traceability は support の静的 drill-down だけでなく、profile square 上の curvature としても現れる。
 
+## Cycle 8: Finite reading adequacy chain for protected quality data
+
+```text
+candidate: Finite reading adequacy chain for protected quality data
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 55
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 110
+category: quality-surface/traceability/ridge-fold/repair-potential
+goal_delta: cycle 2/5/6/7 の scalar/verdict/support loss、trace missing locus、repair frontier、path-ordered trace gap を、finite reading refinement と faithfulness hierarchy に統合する。
+project_value_delta: Lean-backed な report / paper seed として loss-aware Quality Surface の表示設計を protected invariant の復元可能性に接続する。
+formalization_quality: pass。`ReadingRefines`、faithfulness preservation、support surface nonfaithfulness、`RepairFrontierExact` 下の trace-locus-aware sufficiency、cycle 7 path-ordered repair adequacy gap が axiom-free / sorry-free で証明されている。
+open_questions: scalar-only reading node、obligation-aware / full protected signature reading、任意有限 square への一般化、finite codebase trace example への接続。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ReadingAdequacy.lean` は、Quality Surface の reading を
+finite chain と refinement preorder として整理する。reading は certificate 上の observational equivalence
+として扱い、`ReadingRefines` は fine reading の同値性が coarse reading の同値性を含意することを表す。
+`FaithfulToInvariant` は、ある reading で同値な certificate が protected invariant を同じくすることを表す。
+
+Lean 証拠は次を固定する。
+
+- `reading_refinement_preserves_faithfulness`: coarse reading がある invariant に faithful なら、その refinement
+  も同じ invariant に faithful である。
+- `surfaceSupport_not_faithful_to_traceMissingLocus`: visible scalar / verdict / selected support まで一致しても、
+  trace missing locus は復元できない。
+- `surfaceSupport_not_faithful_to_exactRepairFrontier`: exact trace-repair regime に制限しても、support surface
+  reading は repair frontier に faithful ではない。
+- `traceLocusAware_faithful_to_repairFrontier_of_exact`: exact trace-repair regime では、trace missing locus を含む
+  reading が repair frontier を復元する。
+- `same_surface_support_but_trace_locus_adequacy_gap`: cycle 6 の witness を、support surface と
+  trace-locus-aware reading の adequacy gap として読む。
+- `traceCurvature_surfaceSupport_not_pathOrderedRepairAdequate`: cycle 7 の trace-curvature cell では、同じ
+  upper-right scalar / verdict / support の下でも path-ordered repair frontier が復元できない。
+
+この結果により、Quality Surface の loss-aware 表示は、単なる UI choice ではなく、どの protected invariant に
+faithful な reading を選んでいるかという復元可能性の問題として固定された。主張は宣言された finite reading chain と
+exact trace-repair regime に相対化され、絶対 lattice、絶対最小性、source extraction completeness、実コード全体の
+品質判定は主張しない。
+
 ### Next Frontier
 
-G-aat-quality-surface-01 の SCORE threshold 1000 は cycle 7 で到達した。次に進める場合は、
-`finite codebase trace example`、任意有限 square への一般化、profile-typed certificate tuple 全体への拡張を
-別 GOAL / 後続 issue として扱う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 8 後の total SCORE は 1130 である。
+次に進める場合は、`finite codebase trace example`、任意有限 square への一般化、profile-typed certificate tuple
+全体への拡張、または finite profile grid holonomy criterion を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の cycle 8 として、Quality Surface の reading を finite chain / refinement preorder として整理する Lean evidence を追加します。cycle 2/5/6/7 で得た scalar collapse、trace missing locus、repair frontier、trace curvature の witness を、protected invariant への faithfulness / nonfaithfulness として読む整理定理です。

tracking Issue は研究状態の正本なので、この PR では閉じません。

## 証明した定理

- `Formal.AG.Research.QualitySurface.ReadingAdequacy.reading_refinement_preserves_faithfulness`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.reading_refinement_preserves_faithfulness_on`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.supportSurface_refines_visibleSurface`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.traceLocusAware_refines_supportSurface`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.repairAware_refines_traceLocusAware`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.surfaceSupport_not_faithful_to_traceMissingLocus`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.surfaceSupport_not_faithful_to_exactRepairFrontier`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.traceLocusAware_faithful_to_repairFrontier_of_exact`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.same_surface_support_but_trace_locus_adequacy_gap`
- `Formal.AG.Research.QualitySurface.ReadingAdequacy.traceCurvature_surfaceSupport_not_pathOrderedRepairAdequate`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-reading-adequacy-lattice.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake build FormalAGResearch`
- [x] `lake env lean Formal/AG/Research/QualitySurface/ReadingAdequacy.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for reported declarations
- [x] private path scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した。tracking Issue のため `Closes` は使わない
- [x] Lean status を `proved-in-research` として候補カード / report に明記した
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
