### PR TITLE
研究ループ cycle 10: profile grid holonomy を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -8,3 +8,4 @@ import Formal.AG.Research.QualitySurface.TraceLocus
 import Formal.AG.Research.QualitySurface.TraceCurvature
 import Formal.AG.Research.QualitySurface.ReadingAdequacy
 import Formal.AG.Research.QualitySurface.CodebaseTracePacket
+import Formal.AG.Research.QualitySurface.ProfileGridHolonomy

--- a/Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean
+++ b/Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean
@@ -1,0 +1,492 @@
+import Formal.AG.Research.QualitySurface.TraceCurvature
+
+/-!
+Cycle 10 evidence for `G-aat-quality-surface-01`.
+
+This file records a finite `P_law x P_cover` 3x3 profile-grid witness. It does
+not claim a global flatness criterion. It only fixes one localized
+trace-curvature cell whose path-ordered trace / repair frontier survives as an
+endpoint holonomy discrepancy.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ProfileGridHolonomy
+
+open TraceLocus
+
+/-! ## The finite 3x3 profile grid -/
+
+/-- Law-coordinate levels in the finite profile grid. -/
+inductive LawLevel where
+  | low
+  | mid
+  | high
+  deriving DecidableEq, Fintype
+
+/-- Cover-coordinate levels in the finite profile grid. -/
+inductive CoverLevel where
+  | coarse
+  | middle
+  | fine
+  deriving DecidableEq, Fintype
+
+open LawLevel CoverLevel
+
+/-- A profile vertex in the `P_law x P_cover` grid. -/
+abbrev GridProfile :=
+  LawLevel × CoverLevel
+
+def lowCoarse : GridProfile := (low, coarse)
+def midCoarse : GridProfile := (mid, coarse)
+def midMiddle : GridProfile := (mid, middle)
+def highMiddle : GridProfile := (high, middle)
+def midFine : GridProfile := (mid, fine)
+def highFine : GridProfile := (high, fine)
+
+/-! ## Certificates carried by the two length-4 paths -/
+
+/--
+Named certificates on the finite grid.
+
+The two paths share the first two stages and then cross the localized upper
+right elementary cell in opposite orders.
+-/
+inductive GridCertificateName where
+  | seed
+  | sharedLawStage
+  | sharedCenter
+  | lawFirstHighMiddle
+  | coverFirstMidFine
+  | lawFirstEndpoint
+  | coverFirstEndpoint
+  deriving DecidableEq, Fintype
+
+open GridCertificateName
+
+/-- The common support used by every grid certificate. -/
+def gridSupport : Set LocusAtom :=
+  selectedSupport
+
+/-- Trace-complete field used outside the localized curvature endpoint. -/
+def gridFullTraceField : LocusAtom -> Option LocusTraceToken :=
+  fullTraceField
+
+/-- Trace-missing field used at the cover-first endpoint. -/
+def gridCurvedTraceField : LocusAtom -> Option LocusTraceToken :=
+  partialTraceField
+
+/-- The empty repair frontier for trace-complete certificates. -/
+def gridEmptyRepairFrontier : Set LocusAtom :=
+  fun _ => False
+
+/-- The database repair frontier for the path-ordered trace gap. -/
+def gridDatabaseRepairFrontier : Set LocusAtom :=
+  databaseRepairFrontier
+
+/-- Certificate tuple carried by a grid node on a selected path. -/
+structure GridTraceCertificate where
+  visibleScalarReading : Nat
+  verdict : StateSeparation.StateVerdict
+  support : Set LocusAtom
+  traceField : LocusAtom -> Option LocusTraceToken
+  repairFrontier : Set LocusAtom
+
+/-- The lower-left seed certificate. -/
+def seedTuple : GridTraceCertificate where
+  visibleScalarReading := 0
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridFullTraceField
+  repairFrontier := gridEmptyRepairFrontier
+
+/-- The first shared law step, still trace complete. -/
+def sharedLawStageTuple : GridTraceCertificate where
+  visibleScalarReading := 1
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridFullTraceField
+  repairFrontier := gridEmptyRepairFrontier
+
+/-- The shared center of the 3x3 grid, still trace complete. -/
+def sharedCenterTuple : GridTraceCertificate where
+  visibleScalarReading := 2
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridFullTraceField
+  repairFrontier := gridEmptyRepairFrontier
+
+/-- Law-first side of the localized upper-right cell. -/
+def lawFirstHighMiddleTuple : GridTraceCertificate where
+  visibleScalarReading := 3
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridFullTraceField
+  repairFrontier := gridEmptyRepairFrontier
+
+/-- Cover-first side of the localized upper-right cell. -/
+def coverFirstMidFineTuple : GridTraceCertificate where
+  visibleScalarReading := 3
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridFullTraceField
+  repairFrontier := gridEmptyRepairFrontier
+
+/-- Endpoint reached by taking law before cover in the localized cell. -/
+def lawFirstEndpointTuple : GridTraceCertificate where
+  visibleScalarReading := 4
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridFullTraceField
+  repairFrontier := gridEmptyRepairFrontier
+
+/-- Endpoint reached by taking cover before law in the localized cell. -/
+def coverFirstEndpointTuple : GridTraceCertificate where
+  visibleScalarReading := 4
+  verdict := StateSeparation.StateVerdict.acceptable
+  support := gridSupport
+  traceField := gridCurvedTraceField
+  repairFrontier := gridDatabaseRepairFrontier
+
+/-- Read the tuple carried by a named grid certificate. -/
+def gridTuple : GridCertificateName -> GridTraceCertificate
+  | seed => seedTuple
+  | sharedLawStage => sharedLawStageTuple
+  | sharedCenter => sharedCenterTuple
+  | lawFirstHighMiddle => lawFirstHighMiddleTuple
+  | coverFirstMidFine => coverFirstMidFineTuple
+  | lawFirstEndpoint => lawFirstEndpointTuple
+  | coverFirstEndpoint => coverFirstEndpointTuple
+
+/-- The grid vertex where each named certificate lives. -/
+def profileOf : GridCertificateName -> GridProfile
+  | seed => lowCoarse
+  | sharedLawStage => midCoarse
+  | sharedCenter => midMiddle
+  | lawFirstHighMiddle => highMiddle
+  | coverFirstMidFine => midFine
+  | lawFirstEndpoint => highFine
+  | coverFirstEndpoint => highFine
+
+/-- Certificates typed by the grid profile where they live. -/
+def CertificateAt (p : GridProfile) : Type :=
+  { c : GridCertificateName // profileOf c = p }
+
+/-- The selected lower-left certificate. -/
+def seedAt : CertificateAt lowCoarse :=
+  ⟨seed, rfl⟩
+
+/-! ## Typed grid edge transports and two length-4 paths -/
+
+/-- A typed edge transport on the finite grid. -/
+structure EdgeTransport (source target : GridProfile) where
+  map : CertificateAt source -> CertificateAt target
+
+/-- First common step: increase law from low to mid at coarse cover. -/
+def transportLawLowToMid :
+    EdgeTransport lowCoarse midCoarse where
+  map := fun _ => ⟨sharedLawStage, rfl⟩
+
+/-- Second common step: refine cover from coarse to middle at mid law. -/
+def transportCoverCoarseToMiddle :
+    EdgeTransport midCoarse midMiddle where
+  map := fun _ => ⟨sharedCenter, rfl⟩
+
+/-- Localized cell, law-first branch: increase law from mid to high. -/
+def transportLawMiddleToHigh :
+    EdgeTransport midMiddle highMiddle where
+  map := fun _ => ⟨lawFirstHighMiddle, rfl⟩
+
+/-- Localized cell, law-first branch: refine cover from middle to fine. -/
+def transportCoverMiddleToFineAfterLaw :
+    EdgeTransport highMiddle highFine where
+  map := fun _ => ⟨lawFirstEndpoint, rfl⟩
+
+/-- Localized cell, cover-first branch: refine cover from middle to fine. -/
+def transportCoverMiddleToFine :
+    EdgeTransport midMiddle midFine where
+  map := fun _ => ⟨coverFirstMidFine, rfl⟩
+
+/-- Localized cell, cover-first branch: increase law from mid to high. -/
+def transportLawMiddleToHighAfterCover :
+    EdgeTransport midFine highFine where
+  map := fun _ => ⟨coverFirstEndpoint, rfl⟩
+
+/-- The first shared intermediate vertex on both paths. -/
+def commonLawStage
+    (c : CertificateAt lowCoarse) : CertificateAt midCoarse :=
+  transportLawLowToMid.map c
+
+/-- The shared center vertex on both paths. -/
+def commonCenter
+    (c : CertificateAt lowCoarse) : CertificateAt midMiddle :=
+  transportCoverCoarseToMiddle.map (commonLawStage c)
+
+/-- The law-first path's fourth vertex, before the endpoint. -/
+def lawFirstBeforeEndpoint
+    (c : CertificateAt lowCoarse) : CertificateAt highMiddle :=
+  transportLawMiddleToHigh.map (commonCenter c)
+
+/-- The cover-first path's fourth vertex, before the endpoint. -/
+def coverFirstBeforeEndpoint
+    (c : CertificateAt lowCoarse) : CertificateAt midFine :=
+  transportCoverMiddleToFine.map (commonCenter c)
+
+/-- The length-4 path that takes law before cover in the localized cell. -/
+def lawFirstPath
+    (c : CertificateAt lowCoarse) : CertificateAt highFine :=
+  transportCoverMiddleToFineAfterLaw.map (lawFirstBeforeEndpoint c)
+
+/-- The length-4 path that takes cover before law in the localized cell. -/
+def coverFirstPath
+    (c : CertificateAt lowCoarse) : CertificateAt highFine :=
+  transportLawMiddleToHighAfterCover.map (coverFirstBeforeEndpoint c)
+
+/-- The law-first path uses the shared middle grid vertices and the high-middle vertex. -/
+theorem lawFirst_uses_middle_grid_vertices :
+    (commonLawStage seedAt).val = sharedLawStage ∧
+      (commonCenter seedAt).val = sharedCenter ∧
+      (lawFirstBeforeEndpoint seedAt).val = lawFirstHighMiddle ∧
+      (lawFirstPath seedAt).val = lawFirstEndpoint :=
+  ⟨rfl, rfl, rfl, rfl⟩
+
+/-- The cover-first path uses the shared middle grid vertices and the mid-fine vertex. -/
+theorem coverFirst_uses_middle_grid_vertices :
+    (commonLawStage seedAt).val = sharedLawStage ∧
+      (commonCenter seedAt).val = sharedCenter ∧
+      (coverFirstBeforeEndpoint seedAt).val = coverFirstMidFine ∧
+      (coverFirstPath seedAt).val = coverFirstEndpoint :=
+  ⟨rfl, rfl, rfl, rfl⟩
+
+/-- The law-first path reaches the high/fine endpoint. -/
+theorem lawFirst_path_endpoint :
+    (lawFirstPath seedAt).property = rfl :=
+  rfl
+
+/-- The cover-first path reaches the high/fine endpoint. -/
+theorem coverFirst_path_endpoint :
+    (coverFirstPath seedAt).property = rfl :=
+  rfl
+
+/-! ## Endpoint readings, trace loci, and repair frontiers -/
+
+/-- Visible scalar reading of a grid certificate. -/
+def scalarReading (c : GridCertificateName) : Nat :=
+  (gridTuple c).visibleScalarReading
+
+/-- Selected verdict of a grid certificate. -/
+def verdict (c : GridCertificateName) : StateSeparation.StateVerdict :=
+  (gridTuple c).verdict
+
+/-- Selected support of a grid certificate. -/
+def support (c : GridCertificateName) : Set LocusAtom :=
+  (gridTuple c).support
+
+/-- Trace missing locus of a grid certificate. -/
+def traceMissingLocus (c : GridCertificateName) : Set LocusAtom :=
+  fun atom => support c atom ∧ (gridTuple c).traceField atom = none
+
+/-- Repair frontier of a grid certificate. -/
+def repairFrontier (c : GridCertificateName) : Set LocusAtom :=
+  (gridTuple c).repairFrontier
+
+/-- Endpoint scalar, verdict, and support agree along the two length-4 paths. -/
+theorem gridHolonomy_visibleAgreement :
+    scalarReading (lawFirstPath seedAt).val =
+        scalarReading (coverFirstPath seedAt).val ∧
+      verdict (lawFirstPath seedAt).val =
+        verdict (coverFirstPath seedAt).val ∧
+      support (lawFirstPath seedAt).val =
+        support (coverFirstPath seedAt).val :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- The law-first endpoint remains trace complete. -/
+theorem lawFirst_trace_available_at_endpoint :
+    TraceTransport.TraceAvailableOn
+      (support (lawFirstPath seedAt).val)
+      (gridTuple (lawFirstPath seedAt).val).traceField :=
+  TraceLocus.fullTrace_available_on_support
+
+/-- The cover-first endpoint has a missing database trace. -/
+theorem coverFirst_trace_missing_at_endpoint :
+    TraceTransport.TraceMissingOn
+      (support (coverFirstPath seedAt).val)
+      (gridTuple (coverFirstPath seedAt).val).traceField :=
+  TraceLocus.partialTrace_missing_on_support
+
+/-- The law-first endpoint has no database repair frontier. -/
+theorem lawFirst_no_database_repair_at_endpoint :
+    ¬ repairFrontier (lawFirstPath seedAt).val LocusAtom.database :=
+  TraceLocus.fullTrace_repair_frontier_excludes_database
+
+/-- The cover-first endpoint forces the database repair frontier. -/
+theorem coverFirst_forces_database_repair_at_endpoint :
+    repairFrontier (coverFirstPath seedAt).val LocusAtom.database :=
+  TraceLocus.partialTrace_forces_database_repair
+
+/-- The cover-first endpoint repair frontier is exactly its missing trace locus. -/
+theorem coverFirst_repair_frontier_matches_missing_locus :
+    ∀ atom,
+      repairFrontier (coverFirstPath seedAt).val atom ↔
+        traceMissingLocus (coverFirstPath seedAt).val atom :=
+  TraceLocus.partialTrace_repair_frontier_matches_missing_locus
+
+/-! ## Localized curvature and surrounding preservation -/
+
+/--
+Surrounding steps in the 3x3 grid preserve the trace frontier; the trace gap is
+not introduced by the common prefix or by either branch before the endpoint.
+-/
+theorem surrounding_steps_preserve_trace_frontier :
+    TraceTransport.TraceAvailableOn
+        (support (commonLawStage seedAt).val)
+        (gridTuple (commonLawStage seedAt).val).traceField ∧
+      TraceTransport.TraceAvailableOn
+        (support (commonCenter seedAt).val)
+        (gridTuple (commonCenter seedAt).val).traceField ∧
+      TraceTransport.TraceAvailableOn
+        (support (lawFirstBeforeEndpoint seedAt).val)
+        (gridTuple (lawFirstBeforeEndpoint seedAt).val).traceField ∧
+      TraceTransport.TraceAvailableOn
+        (support (coverFirstBeforeEndpoint seedAt).val)
+        (gridTuple (coverFirstBeforeEndpoint seedAt).val).traceField ∧
+      TraceTransport.TraceAvailableOn
+        (support (lawFirstPath seedAt).val)
+        (gridTuple (lawFirstPath seedAt).val).traceField ∧
+      ¬ repairFrontier (commonLawStage seedAt).val LocusAtom.database ∧
+      ¬ repairFrontier (commonCenter seedAt).val LocusAtom.database ∧
+      ¬ repairFrontier (lawFirstBeforeEndpoint seedAt).val LocusAtom.database ∧
+      ¬ repairFrontier (coverFirstBeforeEndpoint seedAt).val LocusAtom.database ∧
+      ¬ repairFrontier (lawFirstPath seedAt).val LocusAtom.database := by
+  exact ⟨TraceLocus.fullTrace_available_on_support,
+    TraceLocus.fullTrace_available_on_support,
+    TraceLocus.fullTrace_available_on_support,
+    TraceLocus.fullTrace_available_on_support,
+    lawFirst_trace_available_at_endpoint,
+    TraceLocus.fullTrace_repair_frontier_excludes_database,
+    TraceLocus.fullTrace_repair_frontier_excludes_database,
+    TraceLocus.fullTrace_repair_frontier_excludes_database,
+    TraceLocus.fullTrace_repair_frontier_excludes_database,
+    lawFirst_no_database_repair_at_endpoint⟩
+
+/-- The localized upper-right elementary cell is trace-curved. -/
+def LocalizedCurvatureCell : Prop :=
+  scalarReading (lawFirstPath seedAt).val =
+      scalarReading (coverFirstPath seedAt).val ∧
+    verdict (lawFirstPath seedAt).val =
+      verdict (coverFirstPath seedAt).val ∧
+    support (lawFirstPath seedAt).val =
+      support (coverFirstPath seedAt).val ∧
+    TraceTransport.TraceAvailableOn
+      (support (lawFirstPath seedAt).val)
+      (gridTuple (lawFirstPath seedAt).val).traceField ∧
+    TraceTransport.TraceMissingOn
+      (support (coverFirstPath seedAt).val)
+      (gridTuple (coverFirstPath seedAt).val).traceField ∧
+    ¬ repairFrontier (lawFirstPath seedAt).val LocusAtom.database ∧
+    repairFrontier (coverFirstPath seedAt).val LocusAtom.database ∧
+    (∀ atom,
+      repairFrontier (coverFirstPath seedAt).val atom ↔
+        traceMissingLocus (coverFirstPath seedAt).val atom)
+
+/-- The localized upper-right cell generates the path-ordered trace discrepancy. -/
+theorem localized_curvature_cell :
+    LocalizedCurvatureCell := by
+  exact ⟨gridHolonomy_visibleAgreement.1,
+    gridHolonomy_visibleAgreement.2.1,
+    gridHolonomy_visibleAgreement.2.2,
+    lawFirst_trace_available_at_endpoint,
+    coverFirst_trace_missing_at_endpoint,
+    lawFirst_no_database_repair_at_endpoint,
+    coverFirst_forces_database_repair_at_endpoint,
+    coverFirst_repair_frontier_matches_missing_locus⟩
+
+/-! ## Endpoint-only reading is not path-holonomy faithful -/
+
+/-- Endpoint-surface faithfulness to the path-ordered trace missing locus. -/
+def EndpointSurfaceFaithfulToTraceLocus : Prop :=
+  ∀ c₁ c₂ : CertificateAt highFine,
+    scalarReading c₁.val = scalarReading c₂.val ->
+      verdict c₁.val = verdict c₂.val ->
+        support c₁.val = support c₂.val ->
+          ∀ atom,
+            traceMissingLocus c₁.val atom ↔ traceMissingLocus c₂.val atom
+
+/-- Endpoint-surface faithfulness to the path-ordered repair frontier. -/
+def EndpointSurfaceFaithfulToGridRepairFrontier : Prop :=
+  ∀ c₁ c₂ : CertificateAt highFine,
+    scalarReading c₁.val = scalarReading c₂.val ->
+      verdict c₁.val = verdict c₂.val ->
+        support c₁.val = support c₂.val ->
+          ∀ atom,
+            repairFrontier c₁.val atom ↔ repairFrontier c₂.val atom
+
+/-- Endpoint-only reading cannot recover the path-ordered trace locus. -/
+theorem endpointSurface_not_faithful_to_gridTraceLocus :
+    ¬ EndpointSurfaceFaithfulToTraceLocus := by
+  intro hfaithful
+  have hiff :=
+    hfaithful (lawFirstPath seedAt) (coverFirstPath seedAt)
+      rfl rfl rfl LocusAtom.database
+  have hmissingLawFirst :
+      traceMissingLocus (lawFirstPath seedAt).val LocusAtom.database :=
+    hiff.mpr TraceLocus.partialTrace_database_missing_locus
+  exact TraceLocus.fullTrace_has_no_missing_locus
+    ⟨LocusAtom.database, hmissingLawFirst⟩
+
+/-- Endpoint-only reading cannot recover the path-ordered repair frontier. -/
+theorem endpointSurface_not_faithful_to_gridRepairFrontier :
+    ¬ EndpointSurfaceFaithfulToGridRepairFrontier := by
+  intro hfaithful
+  have hiff :=
+    hfaithful (lawFirstPath seedAt) (coverFirstPath seedAt)
+      rfl rfl rfl LocusAtom.database
+  have hrepairLawFirst :
+      repairFrontier (lawFirstPath seedAt).val LocusAtom.database :=
+    hiff.mpr coverFirst_forces_database_repair_at_endpoint
+  exact lawFirst_no_database_repair_at_endpoint hrepairLawFirst
+
+/--
+Cycle-10 witness: a localized trace-curvature cell in a 3x3 grid survives as
+endpoint path holonomy, even though endpoint scalar, verdict, and support agree.
+-/
+theorem same_grid_surface_but_path_ordered_frontier_diff :
+    (commonLawStage seedAt).val = sharedLawStage ∧
+      (commonCenter seedAt).val = sharedCenter ∧
+      (lawFirstBeforeEndpoint seedAt).val = lawFirstHighMiddle ∧
+      (coverFirstBeforeEndpoint seedAt).val = coverFirstMidFine ∧
+      (lawFirstPath seedAt).val = lawFirstEndpoint ∧
+      (coverFirstPath seedAt).val = coverFirstEndpoint ∧
+      scalarReading (lawFirstPath seedAt).val =
+        scalarReading (coverFirstPath seedAt).val ∧
+      verdict (lawFirstPath seedAt).val =
+        verdict (coverFirstPath seedAt).val ∧
+      support (lawFirstPath seedAt).val =
+        support (coverFirstPath seedAt).val ∧
+      LocalizedCurvatureCell ∧
+      ¬ repairFrontier (lawFirstPath seedAt).val LocusAtom.database ∧
+      repairFrontier (coverFirstPath seedAt).val LocusAtom.database ∧
+      (∀ atom,
+        repairFrontier (coverFirstPath seedAt).val atom ↔
+          traceMissingLocus (coverFirstPath seedAt).val atom) ∧
+      ¬ EndpointSurfaceFaithfulToTraceLocus ∧
+      ¬ EndpointSurfaceFaithfulToGridRepairFrontier := by
+  exact ⟨lawFirst_uses_middle_grid_vertices.1,
+    lawFirst_uses_middle_grid_vertices.2.1,
+    lawFirst_uses_middle_grid_vertices.2.2.1,
+    coverFirst_uses_middle_grid_vertices.2.2.1,
+    lawFirst_uses_middle_grid_vertices.2.2.2,
+    coverFirst_uses_middle_grid_vertices.2.2.2,
+    gridHolonomy_visibleAgreement.1,
+    gridHolonomy_visibleAgreement.2.1,
+    gridHolonomy_visibleAgreement.2.2,
+    localized_curvature_cell,
+    lawFirst_no_database_repair_at_endpoint,
+    coverFirst_forces_database_repair_at_endpoint,
+    coverFirst_repair_frontier_matches_missing_locus,
+    endpointSurface_not_faithful_to_gridTraceLocus,
+    endpointSurface_not_faithful_to_gridRepairFrontier⟩
+
+end ProfileGridHolonomy
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-profile-grid-holonomy.md
+++ b/research/ideas/g-aat-quality-surface-01-profile-grid-holonomy.md
@@ -1,0 +1,174 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: computability
+capability_category: profile-curvature / quality-surface / certificate-transport / ridge-fold / traceability
+expected_base_score: 65
+expected_evidence_multiplier: 2.0
+expected_final_score: 130
+evidence_stage: proved-in-research
+origin: cycle-10
+tags: [quality-surface, profile-grid, holonomy, trace-curvature, repair-frontier]
+created: 2026-06-20
+cycle: 10
+lean: Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean
+---
+
+# Finite 3x3 profile grid holonomy witness
+
+## 主張
+
+有限 `P_law x P_cover` の 3x3 profile grid 上で、左下から右上へ向かう二つの monotone path を構成する。
+二つの path は endpoint の visible scalar、verdict、support では一致するが、path-ordered trace missing locus と
+exact repair frontier では分岐する。二つの path は 3x3 grid の中間 vertex を実際に通る length-4 path であり、
+差分を生む elementary trace-curvature cell と、差分を作らない surrounding preservation steps を区別する。
+
+これは全 square flat iff global flat の一般定理ではない。主張するのは、一つの elementary trace-curvature cell が
+3x3 grid 上の endpoint holonomy discrepancy として観測される finite witness である。
+
+## 候補種別
+
+`computability`
+
+## 依拠
+
+- `research/reports/G-aat-quality-surface-01.md` cycle 3, 7, 8, 9
+- `Formal/AG/Research/QualitySurface/ProfileCurvature.lean`
+- `Formal/AG/Research/QualitySurface/TraceCurvature.lean`
+- `Formal/AG/Research/QualitySurface/TraceLocus.lean`
+- `Formal/AG/Research/QualitySurface/ReadingAdequacy.lean`
+- `research/GOALS.md` の finite product poset `P_law x P_cover` 上の 3x3 profile grid frontier
+
+## 非自明性
+
+cycle 7 は単一 profile square の path-ordered trace curvature を固定した。cycle 10 はこれを 3x3 grid の
+path holonomy witness へ持ち上げる。ただし単に 2x2 square を隅へ埋めるのではなく、3x3 grid の lower-left から
+upper-right へ進む二つの length-4 monotone path、path の中間 vertex、周辺 preservation step、holonomy を生む
+localized elementary cell を Lean statement として明示する。endpoint の visible surface だけを読むと二つの path は
+同じに見えるが、grid path が運ぶ protected trace locus / exact repair frontier は一致しない。
+
+単なる 9 点の表ではなく、grid vertex、typed edge transport、二つの monotone path、visible endpoint agreement、
+path-ordered repair frontier discrepancy、endpoint-only reading nonfaithfulness を Lean theorem として固定する。
+
+## 数学的興味
+
+Quality Surface を profile ごとの値の一覧ではなく、有限 connection / holonomy を持つ certificate geometry として読める。
+局所的な trace-curvature cell が、大域 endpoint の reading では失われる path memory を作ることを示す。
+
+## GOAL への前進
+
+GOAL の frontier と phase boundary criteria に明示された finite profile grid を前進させる。profile-curvature、
+quality-surface、certificate-transport、ridge-fold、traceability の能力を同時に増やす。
+
+## SCORE 見込み
+
+- `score_reason`: 3x3 profile grid frontier に直接対応するが、cycle 7 の single-square result からの拡張なので revised base 65 を見込む。local curvature cell と surrounding preservation steps を明示できれば G2 を通す。
+- `dullness_risk`: 2x2 square を 3x3 に埋め直すだけなら dull。typed grid profile、length-4 paths、non-dummy intermediate vertices、localized curvature cell、surrounding preservation steps、endpoint holonomy discrepancy、nonfaithfulness theorem を主成果にする。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean` を追加し、law level / cover level の 3x3 grid、named grid certificates、typed edge transports、二つの monotone path を定義する。endpoint visible agreement、trace availability / missing、exact repair frontier、endpoint-only reading nonfaithfulness を axiom-free で証明する。
+
+## CS / SWE への帰結
+
+Quality Surface viewer や report が endpoint の scalar / verdict / support だけを表示すると、grid 内の path-ordered trace repair frontier を失う。
+profile grid を読む surface は、どの path で certificate を運んだか、どの local trace-curvature cell を通ったかを保持する必要がある。
+
+## 証明・根拠の見込み
+
+Lean では `LawLevel = low | mid | high`、`CoverLevel = coarse | mid | fine` として 3x3 grid vertex を置く。
+二つの monotone path は law steps を先に進める path と cover steps を先に進める path とする。両 path は右上で
+同じ visible scalar / verdict / support を持つ。一方は trace complete のまま、もう一方は database trace gap と
+exact repair frontier を持つ。endpoint-only reading はこの path-ordered repair frontier に faithful ではない。
+
+予定 theorem:
+
+- `lawFirst_path_endpoint`
+- `coverFirst_path_endpoint`
+- `lawFirst_uses_middle_grid_vertices`
+- `coverFirst_uses_middle_grid_vertices`
+- `localized_curvature_cell`
+- `surrounding_steps_preserve_trace_frontier`
+- `gridHolonomy_visibleAgreement`
+- `lawFirst_trace_available_at_endpoint`
+- `coverFirst_trace_missing_at_endpoint`
+- `coverFirst_repair_frontier_matches_missing_locus`
+- `endpointSurface_not_faithful_to_gridRepairFrontier`
+- `same_grid_surface_but_path_ordered_frontier_diff`
+
+## ループ必須フィールド
+
+```text
+score_reason: 3x3 profile grid frontier に直接対応し、single-square trace curvature を localized cell と endpoint holonomy witness へ持ち上げる。
+mathematical_interest: Quality Surface を有限 connection / holonomy を持つ certificate geometry として読む。
+goal_advancement: profile-curvature、quality-surface、certificate-transport、ridge-fold、traceability を同時に進める。
+dullness_risk: 9 点の手作業表だけなら dull。typed length-4 path、localized curvature cell、surrounding preservation step、endpoint holonomy discrepancy、nonfaithfulness theorem を主成果にする。
+proof_or_evidence_plan: ProfileGridHolonomy.lean で 3x3 grid profile、edge transports、二つの length-4 monotone path、localized curvature cell、trace / repair discrepancy を証明する。
+planned_theorem_names: lawFirst_uses_middle_grid_vertices, coverFirst_uses_middle_grid_vertices, localized_curvature_cell, surrounding_steps_preserve_trace_frontier, gridHolonomy_visibleAgreement, lawFirst_trace_available_at_endpoint, coverFirst_trace_missing_at_endpoint, coverFirst_repair_frontier_matches_missing_locus, endpointSurface_not_faithful_to_gridRepairFrontier, same_grid_surface_but_path_ordered_frontier_diff
+visible_projection: endpoint の scalar / verdict / support が一致しても path-ordered repair frontier は分岐する。
+protected_structure: typed grid profile、path-ordered trace locus、exact repair frontier、endpoint certificate。
+exactness_or_minimality_claim: cover-first endpoint の repair frontier は missing trace locus ちょうどである。
+nonfaithfulness_or_failure_mode: endpoint-only reading が grid path holonomy を復元できると読むこと。
+previous_cycle_delta: cycle 7 の single-square trace curvature と cycle 8/9 の protected reading / trace packet を 3x3 profile grid に接続する。
+```
+
+## visible_projection
+
+endpoint の scalar、verdict、support は二つの path で一致する。visible endpoint surface だけでは、どちらの path が
+trace gap と repair frontier を運んだかを復元できない。
+
+## protected_structure
+
+protected data は、typed grid profile、path-ordered trace field、trace missing locus、repair frontier、endpoint path identity である。
+
+## exactness_or_minimality_claim
+
+cover-first path の endpoint repair frontier は、endpoint の missing trace locus と一致する。一般 grid 全体の最小 holonomy
+判定は主張しない。
+
+## nonfaithfulness_or_failure_mode
+
+同じ endpoint visible surface を、同じ path-ordered trace / repair frontier と読むのが failure mode である。
+
+## previous_cycle_delta
+
+cycle 3 は support / repair の finite square curvature、cycle 7 は trace curvature cell、cycle 8 は reading adequacy、
+cycle 9 は supplied source-ref packet を固定した。cycle 10 は profile square の局所曲率を finite 3x3 grid 上の
+path holonomy として固定する。
+
+## 審判メモ
+
+- 厳密性: revise。cycle 7 の 2x2 square を 3x3 に埋め直すだけなら dull。length-4 typed path、non-dummy middle vertices、localized curvature cell、surrounding preservation steps が必要。base 65。
+- 研究価値: revise。3x3 frontier には合うが、surprise は中低。localization theorem / grid-level path memory を入れるなら base 65 で採れる。
+- repo 全体価値: accept。Lean / paper-report / website / tooling-design の将来 surface として有用。ただし `profile-grid holonomy witness` に限定し、global flatness や現行 tooling schema impact は主張しない。
+- revised G2: A/B/C すべて accept。base 65。G3 では typed 3x3 grid、length-4 paths、middle vertices、localized curvature cell、surrounding preservation steps、endpoint nonfaithfulness を必須 evidence とする。
+
+## G3 監査
+
+- build: `lake env lean Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean` pass、`lake build FormalAGResearch` pass。
+- axiom check: pass。主要 declaration はすべて `does not depend on any axioms`。
+- formalization quality audit: pass。typed 3x3 grid、length-4 paths、middle vertices、localized curvature cell、surrounding preservation steps、endpoint nonfaithfulness が Lean statement として分離されている。
+- theorem highlights: `lawFirst_uses_middle_grid_vertices`、`coverFirst_uses_middle_grid_vertices`、`surrounding_steps_preserve_trace_frontier`、`localized_curvature_cell`、`endpointSurface_not_faithful_to_gridRepairFrontier`、`same_grid_surface_but_path_ordered_frontier_diff`。
+
+## G4 SCORE 監査
+
+- score_verdict: `confirm`
+- base_score: 65
+- evidence_multiplier: 2.0
+- penalty: 0
+- final_score: 130
+- category: `profile-curvature / quality-surface / certificate-transport / ridge-fold / traceability`
+- goal_delta: finite product poset `P_law x P_cover` 上の 3x3 profile grid frontier を、localized curvature cell と endpoint holonomy discrepancy の Lean-proved finite witness として前進させる。
+- project_value_delta: report / paper / future visualization surface で、endpoint-only reading が path-ordered trace / repair frontier を失う理由を示す。
+- formalization_quality: pass。global flatness theorem、source extraction completeness、実コード品質判定、現行 tooling schema impact は主張しない。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-profile-curvature-detector.md`
+- `research/ideas/g-aat-quality-surface-01-trace-curvature-detector.md`
+- `research/ideas/g-aat-quality-surface-01-reading-adequacy-lattice.md`
+- `research/ideas/g-aat-quality-surface-01-codebase-trace-packet.md`
+
+## 進捗ログ
+
+- 2026-06-20: cycle 10 候補として作成。
+- 2026-06-20: G2-A/B の revise を受け、base 65 / final 130 に下げ、length-4 path、localized curvature cell、surrounding preservation steps を必須 evidence にした。
+- 2026-06-20: `ProfileGridHolonomy.lean` を追加し、単体型検査、`lake build FormalAGResearch`、G3 公理検査が pass。
+- 2026-06-20: G4 SCORE 監査が confirm。report Cycle 10 と total SCORE 1410 を更新。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 1280
+- total SCORE: 1410
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -15,8 +15,9 @@
   - traceability / profile-curvature / certificate-transport / repair-potential / ridge-fold: 170
   - quality-surface / traceability / ridge-fold / repair-potential: 110
   - traceability / computability / quality-surface / repair-potential: 150
+  - profile-curvature / quality-surface / certificate-transport / ridge-fold / traceability: 130
 - evidence portfolio:
-  - proved-in-research: 9
+  - proved-in-research: 10
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -354,8 +355,48 @@ Lean 証拠は次を固定する。
 供給済み source-ref evidence に相対化された packet geometry として固定された。visible scalar / verdict /
 support は source-ref trace frontier を復元しないため、loss-aware surface には packet-level drill-down が必要である。
 
+## Cycle 10: Finite 3x3 profile grid holonomy witness
+
+```text
+candidate: Finite 3x3 profile grid holonomy witness
+candidate_type: computability
+evidence_stage: proved-in-research
+base_score: 65
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 130
+category: profile-curvature/quality-surface/certificate-transport/ridge-fold/traceability
+goal_delta: 3x3 profile grid frontier を、localized curvature cell と endpoint holonomy discrepancy の Lean-proved finite witness として前進させる。
+project_value_delta: endpoint-only reading が path-ordered trace / repair frontier を失うことを、report / paper / future visualization surface で使える証拠にした。
+formalization_quality: pass/high。typed 3x3 grid、length-4 path、middle vertices、localized curvature cell、surrounding preservation steps、endpoint nonfaithfulness が axiom-free / sorry-free で証明されている。
+open_questions: 任意有限 square criterion、profile-typed certificate tuple 全体への統合、grid-level flatness / holonomy criterion、source-ref evidence を実 tooling artifact と同期する将来 surface。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean` は、`LawLevel x CoverLevel` による
+finite 3x3 profile grid を定義する。左下 `low/coarse` から右上 `high/fine` へ向かう二つの
+length-4 monotone path を typed `EdgeTransport` の合成として置く。二つの path は共通の middle vertex を通り、
+右上の localized elementary cell を law-first / cover-first の逆順で通過する。
+
+Lean 証拠は次を固定する。
+
+- `lawFirst_uses_middle_grid_vertices`: law-first path は shared middle vertices と high/middle vertex を通る。
+- `coverFirst_uses_middle_grid_vertices`: cover-first path は shared middle vertices と mid/fine vertex を通る。
+- `gridHolonomy_visibleAgreement`: endpoint の scalar、verdict、support は二つの path で一致する。
+- `surrounding_steps_preserve_trace_frontier`: common prefix と周辺 step は trace frontier を保存し、database repair frontier を作らない。
+- `localized_curvature_cell`: localized upper-right cell は trace-complete endpoint と trace-missing endpoint を分岐させる。
+- `coverFirst_repair_frontier_matches_missing_locus`: cover-first endpoint の repair frontier は missing trace locus と一致する。
+- `endpointSurface_not_faithful_to_gridTraceLocus`: endpoint-only reading は path-ordered trace missing locus を復元できない。
+- `endpointSurface_not_faithful_to_gridRepairFrontier`: endpoint-only reading は path-ordered repair frontier を復元できない。
+- `same_grid_surface_but_path_ordered_frontier_diff`: 3x3 grid の path memory は endpoint surface では失われる。
+
+この結果により、cycle 7 の single-square trace curvature は、3x3 profile grid 上の endpoint holonomy discrepancy
+として固定された。主張は finite witness に限定され、global flatness theorem、source extraction completeness、
+実コード全体の品質判定、現行 tooling schema impact は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 9 後の total SCORE は 1280 である。
-次に進める場合は、任意有限 square への一般化、profile-typed certificate tuple 全体への拡張、
-finite profile grid holonomy criterion、または source-ref evidence を実 tooling artifact と同期する将来 surface を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 10 後の total SCORE は 1410 である。
+次に進める場合は、任意有限 square criterion、profile-typed certificate tuple 全体への拡張、
+grid-level flatness / holonomy criterion、または source-ref evidence を実 tooling artifact と同期する将来 surface を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` の cycle 10 として、finite `P_law x P_cover` 3x3 profile grid の holonomy witness を追加します。
cycle 7 の single-square trace curvature を、typed 3x3 grid、length-4 monotone paths、localized curvature cell、surrounding preservation steps、endpoint-only nonfaithfulness として Lean research evidence に固定します。

## 証明した定理

- `ProfileGridHolonomy.lawFirst_uses_middle_grid_vertices`
- `ProfileGridHolonomy.coverFirst_uses_middle_grid_vertices`
- `ProfileGridHolonomy.gridHolonomy_visibleAgreement`
- `ProfileGridHolonomy.surrounding_steps_preserve_trace_frontier`
- `ProfileGridHolonomy.localized_curvature_cell`
- `ProfileGridHolonomy.coverFirst_repair_frontier_matches_missing_locus`
- `ProfileGridHolonomy.endpointSurface_not_faithful_to_gridTraceLocus`
- `ProfileGridHolonomy.endpointSurface_not_faithful_to_gridRepairFrontier`
- `ProfileGridHolonomy.same_grid_surface_but_path_ordered_frontier_diff`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-profile-grid-holonomy.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] `#print axioms` for cycle 10 main theorem set: no axioms

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

tracking issue は SCORE しきい値到達まで開いたままにするため、`Closes #2348` ではなく `Refs #2348` としています。
