### PR TITLE
研究: profile tuple integration を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -9,3 +9,4 @@ import Formal.AG.Research.QualitySurface.TraceCurvature
 import Formal.AG.Research.QualitySurface.ReadingAdequacy
 import Formal.AG.Research.QualitySurface.CodebaseTracePacket
 import Formal.AG.Research.QualitySurface.ProfileGridHolonomy
+import Formal.AG.Research.QualitySurface.ProfileTupleIntegration

--- a/Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean
+++ b/Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean
@@ -1,0 +1,454 @@
+import Formal.AG.Research.QualitySurface.CodebaseTracePacket
+import Formal.AG.Research.QualitySurface.ProfileGridHolonomy
+
+/-!
+Cycle 11 evidence for `G-aat-quality-surface-01`.
+
+This file fixes a finite profile-typed version of the central quality
+certificate tuple
+
+`Cert_A(p) = (sigma_p, omega_p, S_p, R_p, nu_p, T_p)`.
+
+The result is intentionally finite and relative to supplied trace data. It does
+not claim source extraction completeness, global quality, or a canonical
+promotion into `Formal/AG` proper.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace ProfileTupleIntegration
+
+open TraceLocus
+open StateSeparation
+
+abbrev TupleProfile :=
+  ProfileGridHolonomy.GridProfile
+
+abbrev endpointProfile : TupleProfile :=
+  ProfileGridHolonomy.highFine
+
+/-! ## Profile-typed certificate tuples -/
+
+/--
+A finite profile-typed certificate tuple.
+
+The field order follows the intended quality tuple:
+`(sigma_p, omega_p, S_p, R_p, nu_p, T_p)`.
+-/
+structure TupleCertificateAt (p : TupleProfile) where
+  gridCertificate : ProfileGridHolonomy.CertificateAt p
+  sigma : Nat
+  omega : ObligationKind
+  selectedSupport : Set LocusAtom
+  repairFrontier : Set LocusAtom
+  nu : StateVerdict
+  traceField : LocusAtom -> Option LocusTraceToken
+
+/-- Trace-locus projection of a profile-typed tuple. -/
+def toTraceLocusCertificate {p : TupleProfile}
+    (c : TupleCertificateAt p) : TraceLocusCertificate where
+  visibleScalarReading := c.sigma
+  verdict := c.nu
+  selectedSupport := c.selectedSupport
+  traceField := c.traceField
+  repairFrontier := c.repairFrontier
+  obligation := c.omega
+
+/-- Missing trace locus of a profile-typed tuple. -/
+def TupleTraceMissingLocus {p : TupleProfile}
+    (c : TupleCertificateAt p) : Set LocusAtom :=
+  fun atom => c.selectedSupport atom ∧ c.traceField atom = none
+
+/-- Exact repair regime for profile-typed tuples. -/
+def TupleRepairFrontierExact {p : TupleProfile}
+    (c : TupleCertificateAt p) : Prop :=
+  ∀ atom, c.repairFrontier atom ↔ TupleTraceMissingLocus c atom
+
+/-! ## Endpoint tuple witnesses -/
+
+/-- Endpoint tuple with complete trace coverage and no repair obligation. -/
+def fullEndpointTuple : TupleCertificateAt endpointProfile where
+  gridCertificate := ProfileGridHolonomy.lawFirstPath
+    ProfileGridHolonomy.seedAt
+  sigma := 4
+  omega := ObligationKind.none
+  selectedSupport := selectedSupport
+  repairFrontier := fun _ => False
+  nu := StateVerdict.acceptable
+  traceField := fullTraceField
+
+/-- Endpoint tuple with the same visible surface and a missing database trace. -/
+def traceMissingEndpointTuple : TupleCertificateAt endpointProfile where
+  gridCertificate := ProfileGridHolonomy.coverFirstPath
+    ProfileGridHolonomy.seedAt
+  sigma := 4
+  omega := ObligationKind.provideTrace
+  selectedSupport := selectedSupport
+  repairFrontier := databaseRepairFrontier
+  nu := StateVerdict.acceptable
+  traceField := partialTraceField
+
+/-! ## Projection and exactness -/
+
+/-- Tuple missing locus projects exactly to the trace-locus certificate. -/
+theorem tuple_missing_locus_projects_to_trace_missing
+    {p : TupleProfile} (c : TupleCertificateAt p) :
+    ∀ atom,
+      TraceMissingLocus (toTraceLocusCertificate c) atom ↔
+        TupleTraceMissingLocus c atom := by
+  intro atom
+  rfl
+
+/-- Tuple repair-frontier membership projects pointwise. -/
+theorem tuple_repair_projects_to_trace_repair
+    {p : TupleProfile} (c : TupleCertificateAt p) :
+    ∀ atom,
+      (toTraceLocusCertificate c).repairFrontier atom ↔
+        c.repairFrontier atom := by
+  intro atom
+  rfl
+
+/--
+Exact tuple repair frontier is preserved by projection to
+`TraceLocusCertificate`.
+-/
+theorem tupleExactRepair_projects_to_trace_exactRepair
+    {p : TupleProfile} (c : TupleCertificateAt p)
+    (hexact : TupleRepairFrontierExact c) :
+    ∀ atom,
+      (toTraceLocusCertificate c).repairFrontier atom ↔
+        TraceMissingLocus (toTraceLocusCertificate c) atom := by
+  intro atom
+  constructor
+  · intro hrepair
+    have hmissingTuple : TupleTraceMissingLocus c atom :=
+      (hexact atom).mp hrepair
+    exact (tuple_missing_locus_projects_to_trace_missing c atom).mpr
+      hmissingTuple
+  · intro hmissingTrace
+    have hmissingTuple : TupleTraceMissingLocus c atom :=
+      (tuple_missing_locus_projects_to_trace_missing c atom).mp
+        hmissingTrace
+    exact (hexact atom).mpr hmissingTuple
+
+/-! ## Readings of tuple certificates -/
+
+/-- Same selected support, stated pointwise to avoid extensionality assumptions. -/
+def SameTupleSupport {p : TupleProfile}
+    (c₁ c₂ : TupleCertificateAt p) : Prop :=
+  ∀ atom, c₁.selectedSupport atom ↔ c₂.selectedSupport atom
+
+/-- Same visible tuple surface: scalar, verdict, and selected support. -/
+def SameTupleVisibleSurface {p : TupleProfile}
+    (c₁ c₂ : TupleCertificateAt p) : Prop :=
+  c₁.sigma = c₂.sigma ∧ c₁.nu = c₂.nu ∧ SameTupleSupport c₁ c₂
+
+/-- Same tuple trace missing locus. -/
+def SameTupleTraceMissingLocus {p : TupleProfile}
+    (c₁ c₂ : TupleCertificateAt p) : Prop :=
+  ∀ atom, TupleTraceMissingLocus c₁ atom ↔ TupleTraceMissingLocus c₂ atom
+
+/-- Same tuple repair frontier. -/
+def SameTupleRepairFrontier {p : TupleProfile}
+    (c₁ c₂ : TupleCertificateAt p) : Prop :=
+  ∀ atom, c₁.repairFrontier atom ↔ c₂.repairFrontier atom
+
+/-- Same pointwise trace field before projection to a trace-locus certificate. -/
+def SameTupleTraceField {p : TupleProfile}
+    (c₁ c₂ : TupleCertificateAt p) : Prop :=
+  ∀ atom, c₁.traceField atom = c₂.traceField atom
+
+/-- Same protected tuple data before any trace-locus projection. -/
+def SameTupleProtectedData {p : TupleProfile}
+    (c₁ c₂ : TupleCertificateAt p) : Prop :=
+  c₁.omega = c₂.omega ∧
+    SameTupleRepairFrontier c₁ c₂ ∧
+    SameTupleTraceField c₁ c₂
+
+/-- Reading that keeps only the tuple visible surface. -/
+def visibleTupleSurfaceReading (p : TupleProfile) :
+    ReadingAdequacy.Reading (TupleCertificateAt p) where
+  Equivalent := fun c₁ c₂ => SameTupleVisibleSurface c₁ c₂
+
+/-- Reading that also keeps the tuple trace missing locus. -/
+def traceAwareTupleReading (p : TupleProfile) :
+    ReadingAdequacy.Reading (TupleCertificateAt p) where
+  Equivalent := fun c₁ c₂ =>
+    (visibleTupleSurfaceReading p).Equivalent c₁ c₂ ∧
+      SameTupleTraceMissingLocus c₁ c₂
+
+/-- Visible tuple agreement projects to the trace-locus support surface. -/
+theorem tuple_projects_visible_surface
+    {p : TupleProfile} {c₁ c₂ : TupleCertificateAt p}
+    (heq : SameTupleVisibleSurface c₁ c₂) :
+    ReadingAdequacy.supportSurfaceReading.Equivalent
+      (toTraceLocusCertificate c₁) (toTraceLocusCertificate c₂) := by
+  constructor
+  · exact ⟨heq.1, heq.2.1⟩
+  · exact heq.2.2
+
+/-- Trace-aware tuple agreement projects to trace-aware certificate agreement. -/
+theorem tuple_traceAware_projects_to_traceAware
+    {p : TupleProfile} {c₁ c₂ : TupleCertificateAt p}
+    (heq : (traceAwareTupleReading p).Equivalent c₁ c₂) :
+    ReadingAdequacy.traceLocusAwareReading.Equivalent
+      (toTraceLocusCertificate c₁) (toTraceLocusCertificate c₂) := by
+  constructor
+  · exact tuple_projects_visible_surface heq.1
+  · intro atom
+    exact Iff.trans
+      (tuple_missing_locus_projects_to_trace_missing c₁ atom)
+      (Iff.trans (heq.2 atom)
+        (Iff.symm
+          (tuple_missing_locus_projects_to_trace_missing c₂ atom)))
+
+/-! ## Endpoint facts -/
+
+/-- The endpoint tuples share the same visible tuple surface. -/
+theorem endpointTuple_visibleAgreement :
+    (visibleTupleSurfaceReading endpointProfile).Equivalent
+      fullEndpointTuple traceMissingEndpointTuple := by
+  constructor
+  · rfl
+  constructor
+  · rfl
+  · intro atom
+    constructor <;> intro _ <;> trivial
+
+/-- The endpoint tuples carry distinct typed grid certificates at the same profile. -/
+theorem endpointTuple_gridWitness_diff :
+    fullEndpointTuple.gridCertificate.val ≠
+      traceMissingEndpointTuple.gridCertificate.val := by
+  intro h
+  cases h
+
+/-- The complete endpoint tuple has trace coverage on selected support. -/
+theorem fullEndpoint_tuple_trace_available :
+    TraceTransport.TraceAvailableOn
+      fullEndpointTuple.selectedSupport fullEndpointTuple.traceField :=
+  fullTrace_available_on_support
+
+/-- The trace-missing endpoint tuple has a missing trace on selected support. -/
+theorem traceMissingEndpoint_tuple_trace_missing :
+    TraceTransport.TraceMissingOn
+      traceMissingEndpointTuple.selectedSupport
+      traceMissingEndpointTuple.traceField :=
+  partialTrace_missing_on_support
+
+/-- The complete endpoint tuple has no missing trace locus. -/
+theorem fullEndpoint_has_no_missing_locus :
+    ¬ ∃ atom, TupleTraceMissingLocus fullEndpointTuple atom :=
+  fullTrace_has_no_missing_locus
+
+/-- The trace-missing endpoint has the database atom in its missing locus. -/
+theorem traceMissingEndpoint_database_missing_locus :
+    TupleTraceMissingLocus traceMissingEndpointTuple LocusAtom.database :=
+  partialTrace_database_missing_locus
+
+/-- The trace-missing endpoint repair frontier is exactly its missing locus. -/
+theorem traceMissingEndpoint_repair_frontier_matches_missing_locus :
+    ∀ atom,
+      traceMissingEndpointTuple.repairFrontier atom ↔
+        TupleTraceMissingLocus traceMissingEndpointTuple atom :=
+  partialTrace_repair_frontier_matches_missing_locus
+
+/-- The complete endpoint has exact repair frontier. -/
+theorem fullEndpoint_repairFrontierExact :
+    TupleRepairFrontierExact fullEndpointTuple := by
+  intro atom
+  constructor
+  · intro hrepair
+    exact False.elim hrepair
+  · intro hmissing
+    exact fullEndpoint_has_no_missing_locus ⟨atom, hmissing⟩
+
+/-- The trace-missing endpoint has exact repair frontier. -/
+theorem traceMissingEndpoint_repairFrontierExact :
+    TupleRepairFrontierExact traceMissingEndpointTuple :=
+  traceMissingEndpoint_repair_frontier_matches_missing_locus
+
+/-- The complete endpoint does not put the database atom in its repair frontier. -/
+theorem fullEndpoint_no_database_repair :
+    ¬ fullEndpointTuple.repairFrontier LocusAtom.database :=
+  fullTrace_repair_frontier_excludes_database
+
+/-- The trace-missing endpoint forces the database repair frontier. -/
+theorem traceMissingEndpoint_forces_database_repair :
+    traceMissingEndpointTuple.repairFrontier LocusAtom.database :=
+  partialTrace_forces_database_repair
+
+/-- The endpoint tuples differ in the obstruction / obligation component. -/
+theorem endpointTuple_omega_diff :
+    fullEndpointTuple.omega ≠ traceMissingEndpointTuple.omega := by
+  intro h
+  cases h
+
+/-- The endpoint tuples do not have the same trace field before projection. -/
+theorem endpointTuple_traceField_diff :
+    ¬ SameTupleTraceField
+      fullEndpointTuple traceMissingEndpointTuple := by
+  intro hsame
+  have hdatabase := hsame LocusAtom.database
+  cases hdatabase
+
+/-- The endpoint tuples do not have the same protected tuple data. -/
+theorem endpointTuple_protectedData_diff :
+    ¬ SameTupleProtectedData
+      fullEndpointTuple traceMissingEndpointTuple := by
+  intro hsame
+  exact endpointTuple_omega_diff hsame.1
+
+/-- The endpoint tuples do not have the same trace missing locus. -/
+theorem endpointTuple_traceMissingLocus_diff :
+    ¬ SameTupleTraceMissingLocus
+      fullEndpointTuple traceMissingEndpointTuple := by
+  intro hsame
+  have hmissingFull : TupleTraceMissingLocus
+      fullEndpointTuple LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      traceMissingEndpoint_database_missing_locus
+  exact fullEndpoint_has_no_missing_locus
+    ⟨LocusAtom.database, hmissingFull⟩
+
+/-- The endpoint tuples do not have the same repair frontier. -/
+theorem endpointTuple_repairFrontier_diff :
+    ¬ SameTupleRepairFrontier
+      fullEndpointTuple traceMissingEndpointTuple := by
+  intro hsame
+  have hrepairFull :
+      fullEndpointTuple.repairFrontier LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      traceMissingEndpoint_forces_database_repair
+  exact fullEndpoint_no_database_repair hrepairFull
+
+/-! ## Tuple surface nonfaithfulness and exact trace-aware sufficiency -/
+
+/-- Visible tuple surface does not recover the tuple trace missing locus. -/
+theorem visibleTupleSurface_not_faithful_to_traceMissingLocus :
+    ¬ ReadingAdequacy.FaithfulToInvariant
+      (visibleTupleSurfaceReading endpointProfile)
+      (@SameTupleTraceMissingLocus endpointProfile) := by
+  intro hfaithful
+  have hsame :=
+    hfaithful fullEndpointTuple traceMissingEndpointTuple
+      endpointTuple_visibleAgreement
+  have hmissingFull : TupleTraceMissingLocus
+      fullEndpointTuple LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      traceMissingEndpoint_database_missing_locus
+  exact fullEndpoint_has_no_missing_locus
+    ⟨LocusAtom.database, hmissingFull⟩
+
+/-- Visible tuple surface does not recover the tuple repair frontier. -/
+theorem visibleTupleSurface_not_faithful_to_repairFrontier :
+    ¬ ReadingAdequacy.FaithfulToInvariant
+      (visibleTupleSurfaceReading endpointProfile)
+      (@SameTupleRepairFrontier endpointProfile) := by
+  intro hfaithful
+  have hsame :=
+    hfaithful fullEndpointTuple traceMissingEndpointTuple
+      endpointTuple_visibleAgreement
+  have hrepairFull :
+      fullEndpointTuple.repairFrontier LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      traceMissingEndpoint_forces_database_repair
+  exact fullEndpoint_no_database_repair hrepairFull
+
+/--
+In the exact trace-repair regime, a trace-aware tuple reading is faithful to
+the tuple repair frontier.
+-/
+theorem traceAwareTupleReading_faithful_to_repair_of_exact
+    (p : TupleProfile) :
+    ReadingAdequacy.FaithfulToInvariantOn
+      (@TupleRepairFrontierExact p)
+      (traceAwareTupleReading p)
+      (@SameTupleRepairFrontier p) := by
+  intro c₁ c₂ hexact₁ hexact₂ heq atom
+  have hmissingSame := heq.2 atom
+  constructor
+  · intro hrepair₁
+    have hmissing₁ : TupleTraceMissingLocus c₁ atom :=
+      (hexact₁ atom).mp hrepair₁
+    have hmissing₂ : TupleTraceMissingLocus c₂ atom :=
+      hmissingSame.mp hmissing₁
+    exact (hexact₂ atom).mpr hmissing₂
+  · intro hrepair₂
+    have hmissing₂ : TupleTraceMissingLocus c₂ atom :=
+      (hexact₂ atom).mp hrepair₂
+    have hmissing₁ : TupleTraceMissingLocus c₁ atom :=
+      hmissingSame.mpr hmissing₂
+    exact (hexact₁ atom).mpr hmissing₁
+
+/--
+Cycle-11 integrated witness: the same endpoint profile and visible tuple
+surface can hide different obstruction / trace / repair data. Projection to
+the earlier trace-locus certificate preserves the missing locus and exact
+repair frontier, while exact trace-aware tuple readings are repair-faithful.
+-/
+theorem same_surface_but_profile_tuple_diff :
+    (visibleTupleSurfaceReading endpointProfile).Equivalent
+      fullEndpointTuple traceMissingEndpointTuple ∧
+      fullEndpointTuple.gridCertificate.val ≠
+        traceMissingEndpointTuple.gridCertificate.val ∧
+      fullEndpointTuple.omega ≠ traceMissingEndpointTuple.omega ∧
+      ¬ SameTupleTraceField
+        fullEndpointTuple traceMissingEndpointTuple ∧
+      ¬ SameTupleProtectedData
+        fullEndpointTuple traceMissingEndpointTuple ∧
+      ¬ SameTupleTraceMissingLocus
+        fullEndpointTuple traceMissingEndpointTuple ∧
+      ¬ SameTupleRepairFrontier
+        fullEndpointTuple traceMissingEndpointTuple ∧
+      TupleRepairFrontierExact fullEndpointTuple ∧
+      TupleRepairFrontierExact traceMissingEndpointTuple ∧
+      (∀ atom,
+        (toTraceLocusCertificate traceMissingEndpointTuple).repairFrontier
+            atom ↔
+          TraceMissingLocus
+            (toTraceLocusCertificate traceMissingEndpointTuple) atom) ∧
+      TraceMissingLocus
+        (toTraceLocusCertificate traceMissingEndpointTuple)
+        LocusAtom.database ∧
+      ¬ TraceMissingLocus
+        (toTraceLocusCertificate fullEndpointTuple)
+        LocusAtom.database ∧
+      ¬ ReadingAdequacy.FaithfulToInvariant
+        (visibleTupleSurfaceReading endpointProfile)
+        (@SameTupleTraceMissingLocus endpointProfile) ∧
+      ¬ ReadingAdequacy.FaithfulToInvariant
+        (visibleTupleSurfaceReading endpointProfile)
+        (@SameTupleRepairFrontier endpointProfile) ∧
+      ReadingAdequacy.FaithfulToInvariantOn
+        (@TupleRepairFrontierExact endpointProfile)
+        (traceAwareTupleReading endpointProfile)
+        (@SameTupleRepairFrontier endpointProfile) := by
+  exact ⟨endpointTuple_visibleAgreement,
+    endpointTuple_gridWitness_diff,
+    endpointTuple_omega_diff,
+    endpointTuple_traceField_diff,
+    endpointTuple_protectedData_diff,
+    endpointTuple_traceMissingLocus_diff,
+    endpointTuple_repairFrontier_diff,
+    fullEndpoint_repairFrontierExact,
+    traceMissingEndpoint_repairFrontierExact,
+    tupleExactRepair_projects_to_trace_exactRepair
+      traceMissingEndpointTuple traceMissingEndpoint_repairFrontierExact,
+    (tuple_missing_locus_projects_to_trace_missing
+      traceMissingEndpointTuple LocusAtom.database).mpr
+      traceMissingEndpoint_database_missing_locus,
+    by
+      intro hmissingTrace
+      have hmissingTuple : TupleTraceMissingLocus
+          fullEndpointTuple LocusAtom.database :=
+        (tuple_missing_locus_projects_to_trace_missing
+          fullEndpointTuple LocusAtom.database).mp hmissingTrace
+      exact fullEndpoint_has_no_missing_locus
+        ⟨LocusAtom.database, hmissingTuple⟩,
+    visibleTupleSurface_not_faithful_to_traceMissingLocus,
+    visibleTupleSurface_not_faithful_to_repairFrontier,
+    traceAwareTupleReading_faithful_to_repair_of_exact endpointProfile⟩
+
+end ProfileTupleIntegration
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md
+++ b/research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md
@@ -1,0 +1,138 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: atom-supported-quality-geometry / quality-surface / certificate-transport / traceability / repair-potential
+expected_base_score: 55
+expected_evidence_multiplier: 2.0
+expected_final_score: 110
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle-11
+tags: [quality-surface, certificate-tuple, traceability, repair-frontier]
+created: 2026-06-20
+cycle: 11
+lean: Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean
+---
+
+# Profile-typed certificate tuple integration
+
+## 主張
+
+有限 profile 上で `Cert_A(p) = (sigma_p, omega_p, S_p, R_p, nu_p, T_p)` 型の
+profile-typed certificate tuple を固定する。tuple は visible scalar `sigma_p`、
+obstruction / obligation state `omega_p`、selected atom support `S_p`、repair frontier `R_p`、
+verdict `nu_p`、trace field `T_p` を同時に持つ。
+
+主張は、同じ visible projection `(sigma_p, nu_p, S_p)` を持つ二つの endpoint tuple が、
+protected tuple data `(omega_p, R_p, T_p)` で分岐しうること、tuple から trace-locus certificate への
+projection が missing locus と exact repair frontier を保存すること、かつ exact trace-repair regime では
+trace-missing locus を含む tuple reading が repair frontier に faithful になることである。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`。
+- cycle 5 の `StateSeparation.QualityCertificate`。
+- cycle 6 の `TraceLocus.TraceLocusCertificate`。
+- cycle 8 の `ReadingAdequacy.Reading` と exact trace-repair faithfulness。
+- cycle 9 の source-ref packet projection and exact repair preservation。
+- cycle 10 の typed profile grid endpoint witness。
+
+## 非自明性
+
+単なる tuple 定義ではなく、これまで別々に固定した state separation、trace locus、reading adequacy、
+source-ref packet、profile endpoint witness を、GOAL の中心語彙である
+`Cert_A(p) = (sigma_p, omega_p, S_p, R_p, nu_p, T_p)` へ戻す。Lean 側では
+visible tuple projection の非忠実性、trace-locus projection の保存、exact repair frontier に対する
+trace-aware tuple reading の faithful 性を同じ finite profile-typed object 上で同時に示す。
+
+## 数学的興味
+
+Quality Surface を「profile ごとの数値表」ではなく、profile fiber 上の certificate geometry として読むための
+中心対象を固定する。visible surface と protected tuple data の分離により、同じ surface point が異なる
+trace / repair geometry を持つ fold として現れることが明確になる。
+
+## GOAL への前進
+
+certificate tuple、traceability、repair potential、profile-typed endpoint reading を統合し、phase boundary criteria が
+要求する `Cert_A(p)` の意味を Lean-backed finite witness として与える。
+
+## SCORE 見込み
+
+- `score_reason`: cycles 5-10 の個別成果を GOAL の中心 certificate tuple に圧縮し、visible surface 非忠実性、trace-locus projection preservation、exact repair faithful reading を一つの finite profile-typed object 上で同時に示すため。G4 SCORE 監査は、新しい現象そのものより統合・圧縮価値が中心で、projection preservation が定義的に近いとして base score を 55 に減額した。
+- `dullness_risk`: tuple structure を定義するだけ、または既存 trace-locus theorem の名前替えだけなら低 SCORE であり、G2 で落とすべきである。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean` に `TupleCertificateAt`、`toTraceLocusCertificate`、`tuple_missing_locus_projects_to_trace_missing`、`tupleExactRepair_projects_to_trace_exactRepair`、`same_surface_but_profile_tuple_diff`、`traceAwareTupleReading_faithful_to_repair_of_exact` を証明する。
+
+## CS / SWE への帰結
+
+将来 tooling が表示する quality surface は、visible score、verdict、selected support だけでは repair frontier や trace gap を復元しない。
+一方で trace-missing locus を certificate tuple の reading に含めると、exact repair regime では repair frontier を安定に読む条件が得られる。
+この帰結は supplied trace data に相対化され、source extraction completeness や実コード全体の品質判定は主張しない。
+
+## 証明・根拠の見込み
+
+Research 配下に finite profile endpoint `endpointProfile` と `TupleCertificateAt p` を定義した。
+full endpoint tuple と trace-missing endpoint tuple は同じ `sigma`、`nu`、`S` を持つが、`omega`、`R`、`T`
+が異なる。tuple から `TraceLocus.TraceLocusCertificate` への射影を定義し、missing locus と repair frontier が
+pointwise に保存されることを示した。最後に `ReadingAdequacy.FaithfulToInvariantOn` を使い、
+exact trace-repair regime で trace-aware tuple reading が repair frontier に faithful であることを証明した。
+
+Lean declarations:
+
+- `tuple_projects_visible_surface`
+- `tuple_missing_locus_projects_to_trace_missing`
+- `tupleExactRepair_projects_to_trace_exactRepair`
+- `endpointTuple_gridWitness_diff`
+- `endpointTuple_traceField_diff`
+- `endpointTuple_protectedData_diff`
+- `visibleTupleSurface_not_faithful_to_traceMissingLocus`
+- `visibleTupleSurface_not_faithful_to_repairFrontier`
+- `traceAwareTupleReading_faithful_to_repair_of_exact`
+- `same_surface_but_profile_tuple_diff`
+
+visible_projection: `(sigma_p, nu_p, S_p)`
+
+protected_structure: `(omega_p, R_p, T_p, profile typing)`
+
+exactness_or_minimality_claim: `R_p` is exactly the trace-missing locus in the exact trace-repair regime.
+
+nonfaithfulness_or_failure_mode: the visible tuple surface cannot reconstruct trace missing locus or repair frontier.
+
+previous_cycle_delta: cycle 10 の grid witness をさらに大きくするのではなく、cycles 5-10 の protected data を `Cert_A(p)` 本体へ統合する。
+
+## 審判メモ
+
+- 厳密性: G2 A は `revise`。wrapper / rename risk を避けるため、profile typing、六成分 tuple、trace-locus projection、visible nonfaithfulness、exact repair faithful reading を同一 object 上で証明する必要がある。base score 期待値を 65 に下げ、主張を integration theorem に絞った。
+- 研究価値: G2 B は `accept`、base 65。surprise より compression / leverage / paper spine 化の価値が中心。
+- repo 全体価値: G2 C は `accept`、base 70。Research 配下の finite profile endpoint witness として扱い、canonical theory object への premature promotion を避ける。
+- G3 axiom / formalization audit: pass。追加 theorem を含む 10 declaration は axiom-free、形式化品質監査も pass。
+- G4 SCORE audit: `reduce`。base 55、multiplier 2.0、penalty 0、final 110。証拠不足ではなく、既存成果の統合・圧縮が中心であるため 65 から減額。
+
+## 証拠
+
+- Lean file: `Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean`
+- Evidence stage: `proved-in-research`
+- Build target: `lake env lean Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean`
+- Main theorem: `ProfileTupleIntegration.same_surface_but_profile_tuple_diff`
+- Axiom summary: `tuple_projects_visible_surface`、`tuple_missing_locus_projects_to_trace_missing`、`tupleExactRepair_projects_to_trace_exactRepair`、`endpointTuple_gridWitness_diff`、`endpointTuple_traceField_diff`、`endpointTuple_protectedData_diff`、`visibleTupleSurface_not_faithful_to_traceMissingLocus`、`visibleTupleSurface_not_faithful_to_repairFrontier`、`traceAwareTupleReading_faithful_to_repair_of_exact`、`same_surface_but_profile_tuple_diff` は `#print axioms` でいずれも axiom-free。
+- Formalization summary: `TupleCertificateAt p` が `ProfileGridHolonomy.CertificateAt p` を保持し、endpoint tuple は law-first / cover-first grid witness を同じ endpoint profile 上で運ぶ。主 theorem は visible agreement、grid witness divergence、projection 前の `omega` / `traceField` / protected data divergence、trace-locus projection、exact repair faithful reading を同時に述べる。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-measured-unmeasured-trace-missing.md`
+- `research/ideas/g-aat-quality-surface-01-finite-trace-locus-certificate.md`
+- `research/ideas/g-aat-quality-surface-01-reading-adequacy-lattice.md`
+- `research/ideas/g-aat-quality-surface-01-codebase-trace-packet.md`
+- `research/ideas/g-aat-quality-surface-01-profile-grid-holonomy.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 11 G1 候補として作成。
+- 2026-06-20: G2 A の `revise` を受け、expected score を 65 x 2.0 = 130 に下げ、同一 finite profile-typed object 上の projection / nonfaithfulness / exact repair faithful reading を必要証拠として明確化。
+- 2026-06-20: `Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean` で `TupleCertificateAt`、projection preservation、visible nonfaithfulness、exact trace-aware repair faithfulness、統合 witness theorem を追加。
+- 2026-06-20: G3 形式化監査の `revise` を受け、`TupleCertificateAt p` に `ProfileGridHolonomy.CertificateAt p` を保持させ、endpoint tuple が law-first / cover-first grid witness を運ぶこと、projection 前の trace field / protected data が分岐することを主 theorem に追加。
+- 2026-06-20: G3 再監査で axiom audit / formalization quality audit がいずれも pass。
+- 2026-06-20: G4 SCORE 監査で base 55、evidence multiplier 2.0、final SCORE 110 に確定。

--- a/research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md
+++ b/research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md
@@ -2,7 +2,7 @@
 status: picked
 goal: G-aat-quality-surface-01
 candidate_type: unification
-capability_category: atom-supported-quality-geometry / quality-surface / certificate-transport / traceability / repair-potential
+capability_category: unification / atom-supported-quality-geometry / traceability / repair-potential
 expected_base_score: 55
 expected_evidence_multiplier: 2.0
 expected_final_score: 110

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 1410
+- total SCORE: 1520
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -16,8 +16,9 @@
   - quality-surface / traceability / ridge-fold / repair-potential: 110
   - traceability / computability / quality-surface / repair-potential: 150
   - profile-curvature / quality-surface / certificate-transport / ridge-fold / traceability: 130
+  - unification / atom-supported-quality-geometry / traceability / repair-potential: 110
 - evidence portfolio:
-  - proved-in-research: 10
+  - proved-in-research: 11
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -395,8 +396,51 @@ Lean 証拠は次を固定する。
 として固定された。主張は finite witness に限定され、global flatness theorem、source extraction completeness、
 実コード全体の品質判定、現行 tooling schema impact は結論しない。
 
+## Cycle 11: Profile-typed certificate tuple integration
+
+```text
+candidate: Profile-typed certificate tuple integration
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 55
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 110
+category: unification/atom-supported-quality-geometry/traceability/repair-potential
+goal_delta: `Cert_A(p)` 六成分 tuple を finite profile-typed object として固定し、visible surface 非忠実性、trace-locus projection、exact repair frontier faithfulness を同一 witness 上にまとめた。
+project_value_delta: phase boundary が要求する certificate tuple の意味を Lean-backed witness として補強する。新しい不変量や curvature theorem ではなく、cycles 5-10 の成果を中心語彙へ圧縮する成果である。
+formalization_quality: pass。`TupleCertificateAt p`、grid witness を持つ endpoint tuple、trace-locus projection、projection 前の `omega` / `traceField` / protected data 分岐、visible tuple surface nonfaithfulness、exact trace-aware repair faithfulness が axiom-free / sorry-free で証明されている。
+open_questions: 任意有限 square criterion、profile tuple に沿う non-definitional transport theorem、source-ref packet との同一 tuple への統合、grid-level flatness / holonomy criterion。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean` は、有限 profile 上の
+`Cert_A(p) = (sigma_p, omega_p, S_p, R_p, nu_p, T_p)` 型 tuple を Research 配下に固定する。
+`TupleCertificateAt p` は `ProfileGridHolonomy.CertificateAt p` を保持し、cycle 10 の
+law-first / cover-first endpoint witness を同じ endpoint profile 上の tuple として読む。
+
+Lean 証拠は次を固定する。
+
+- `TupleCertificateAt`: profile witness と六成分 `(sigma, omega, S, R, nu, T)` を同時に持つ finite tuple。
+- `toTraceLocusCertificate`: tuple から trace-locus certificate への射影。
+- `tuple_missing_locus_projects_to_trace_missing`: tuple missing locus は射影先 trace missing locus と一致する。
+- `tupleExactRepair_projects_to_trace_exactRepair`: tuple-level exact repair frontier は射影先の exact repair frontier を与える。
+- `endpointTuple_gridWitness_diff`: 同じ endpoint profile 上で law-first / cover-first の typed grid witness は異なる。
+- `endpointTuple_traceField_diff`: projection 前の trace field は二つの endpoint tuple で異なる。
+- `endpointTuple_protectedData_diff`: projection 前の protected tuple data `(omega, R, T)` は二つの endpoint tuple で異なる。
+- `visibleTupleSurface_not_faithful_to_traceMissingLocus`: visible tuple surface は trace missing locus を復元しない。
+- `visibleTupleSurface_not_faithful_to_repairFrontier`: visible tuple surface は repair frontier を復元しない。
+- `traceAwareTupleReading_faithful_to_repair_of_exact`: exact trace-repair regime では trace-aware tuple reading が repair frontier に faithful である。
+- `same_surface_but_profile_tuple_diff`: 同じ visible tuple surface の下で、grid witness、obligation state、trace field、repair frontier が分岐する統合 witness。
+
+この結果により、Quality Surface の中心対象は、単なる scalar / verdict / support の表示ではなく、
+profile fiber 上の protected tuple geometry として読める。主張は supplied trace data と finite profile witness に
+相対化され、source extraction completeness、global flatness、実コード全体の品質判定、現行 tooling schema impact は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 10 後の total SCORE は 1410 である。
-次に進める場合は、任意有限 square criterion、profile-typed certificate tuple 全体への拡張、
-grid-level flatness / holonomy criterion、または source-ref evidence を実 tooling artifact と同期する将来 surface を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 11 後の total SCORE は 1520 である。
+次に進める場合は、任意有限 square criterion、profile tuple に沿う non-definitional transport theorem、
+source-ref packet と profile tuple の統合、grid-level flatness / holonomy criterion、または source-ref evidence を
+実 tooling artifact と同期する将来 surface を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` cycle 11 として、profile-typed certificate tuple integration を Research 配下に追加した。
`Cert_A(p) = (sigma_p, omega_p, S_p, R_p, nu_p, T_p)` 型の finite tuple を `TupleCertificateAt p` として固定し、cycle 10 の law-first / cover-first endpoint witness を同じ endpoint profile 上の tuple として読む。

G4 SCORE 監査は `reduce` で、base 55、evidence multiplier 2.0、final SCORE +110。total SCORE は 1520/5000 に更新した。

## 証明した定理

- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.tuple_projects_visible_surface`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.tuple_missing_locus_projects_to_trace_missing`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.tupleExactRepair_projects_to_trace_exactRepair`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.endpointTuple_gridWitness_diff`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.endpointTuple_traceField_diff`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.endpointTuple_protectedData_diff`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.visibleTupleSurface_not_faithful_to_traceMissingLocus`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.visibleTupleSurface_not_faithful_to_repairFrontier`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.traceAwareTupleReading_faithful_to_repair_of_exact`
- `Formal.AG.Research.QualitySurface.ProfileTupleIntegration.same_surface_but_profile_tuple_diff`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/profile_tuple_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（今回追加 Lean file は no match。Research 全体 scan は既存コメント文 `locality axiom says` のみ）
- [x] local/private path scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

※ tracking Issue #2348 は research-loop 状態の正本なので、この PR では閉じない。
