### PR TITLE
研究: finite square criterion を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -10,3 +10,4 @@ import Formal.AG.Research.QualitySurface.ReadingAdequacy
 import Formal.AG.Research.QualitySurface.CodebaseTracePacket
 import Formal.AG.Research.QualitySurface.ProfileGridHolonomy
 import Formal.AG.Research.QualitySurface.ProfileTupleIntegration
+import Formal.AG.Research.QualitySurface.FiniteSquareCriterion

--- a/Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean
+++ b/Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean
@@ -1,0 +1,276 @@
+import Formal.AG.Research.QualitySurface.ProfileTupleIntegration
+
+/-!
+Cycle 12 evidence for `G-aat-quality-surface-01`.
+
+This file extracts a finite-square reading criterion from the earlier
+profile-curvature witnesses. The criterion is relative to a chosen visible
+reading and a chosen protected invariant; it does not assert global flatness or
+source-observation completeness.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace FiniteSquareCriterion
+
+open TraceLocus
+
+universe u v
+
+/-! ## Generic finite-square path composites -/
+
+/-- A typed edge transport between two profile vertices. -/
+structure SquareEdgeTransport {Profile : Type u}
+    (CertificateAt : Profile -> Type v) (source target : Profile) where
+  map : CertificateAt source -> CertificateAt target
+
+/-- A finite square with four typed edge transports and one selected seed. -/
+structure FiniteSquare (Profile : Type u)
+    (CertificateAt : Profile -> Type v) where
+  lowerLeft : Profile
+  lowerRight : Profile
+  upperLeft : Profile
+  upperRight : Profile
+  seed : CertificateAt lowerLeft
+  lawBottom : SquareEdgeTransport CertificateAt lowerLeft lowerRight
+  coverRight : SquareEdgeTransport CertificateAt lowerRight upperRight
+  coverLeft : SquareEdgeTransport CertificateAt lowerLeft upperLeft
+  lawTop : SquareEdgeTransport CertificateAt upperLeft upperRight
+
+/-- A finite square remembers only the two typed path-composite endpoints. -/
+structure EndpointPair (Endpoint : Type u) where
+  lawFirst : Endpoint
+  coverFirst : Endpoint
+
+/-- The endpoint pair induced by the two path composites of a finite square. -/
+def endpointPairOfSquare {Profile : Type u} {CertificateAt : Profile -> Type v}
+    (square : FiniteSquare Profile CertificateAt) :
+    EndpointPair (CertificateAt square.upperRight) where
+  lawFirst := square.coverRight.map (square.lawBottom.map square.seed)
+  coverFirst := square.lawTop.map (square.coverLeft.map square.seed)
+
+/-- A visible reading and protected invariant chosen for one endpoint type. -/
+structure SquareReading (Endpoint : Type u) where
+  VisibleEquivalent : Endpoint -> Endpoint -> Prop
+  SameProtectedInvariant : Endpoint -> Endpoint -> Prop
+
+/-- The two endpoints are visibly flat for the selected reading. -/
+def VisibleFlat {Endpoint : Type u}
+    (reading : SquareReading Endpoint) (pair : EndpointPair Endpoint) : Prop :=
+  reading.VisibleEquivalent pair.lawFirst pair.coverFirst
+
+/-- The two endpoints have no holonomy for the selected protected invariant. -/
+def ProtectedInvariantFlat {Endpoint : Type u}
+    (reading : SquareReading Endpoint) (pair : EndpointPair Endpoint) : Prop :=
+  reading.SameProtectedInvariant pair.lawFirst pair.coverFirst
+
+/--
+Reading-curvature for a chosen protected invariant: the visible endpoint pair
+is flat, but the protected invariant is not.
+-/
+def ReadingCurved {Endpoint : Type u}
+    (reading : SquareReading Endpoint) (pair : EndpointPair Endpoint) : Prop :=
+  VisibleFlat reading pair ∧ ¬ ProtectedInvariantFlat reading pair
+
+/-- The visible reading is faithful to the chosen protected invariant. -/
+def VisibleFaithfulToProtected {Endpoint : Type u}
+    (reading : SquareReading Endpoint) : Prop :=
+  ∀ left right,
+    reading.VisibleEquivalent left right ->
+      reading.SameProtectedInvariant left right
+
+/-- A protected discrepancy together with visible flatness yields reading-curvature. -/
+theorem finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    {Endpoint : Type u} (reading : SquareReading Endpoint)
+    (pair : EndpointPair Endpoint)
+    (hvisible : VisibleFlat reading pair)
+    (hprotected : ¬ ProtectedInvariantFlat reading pair) :
+    ReadingCurved reading pair :=
+  ⟨hvisible, hprotected⟩
+
+/-- If the visible reading is faithful, visible flatness rules out holonomy. -/
+theorem finiteSquare_no_holonomy_of_faithful_reading
+    {Endpoint : Type u} (reading : SquareReading Endpoint)
+    (hfaithful : VisibleFaithfulToProtected reading)
+    (pair : EndpointPair Endpoint)
+    (hvisible : VisibleFlat reading pair) :
+    ProtectedInvariantFlat reading pair :=
+  hfaithful pair.lawFirst pair.coverFirst hvisible
+
+/-- A visibly flat square with protected discrepancy refutes visible faithfulness. -/
+theorem finiteSquare_not_faithful_of_curvature
+    {Endpoint : Type u} (reading : SquareReading Endpoint)
+    (pair : EndpointPair Endpoint)
+    (hcurved : ReadingCurved reading pair) :
+    ¬ VisibleFaithfulToProtected reading := by
+  intro hfaithful
+  exact hcurved.2
+    (finiteSquare_no_holonomy_of_faithful_reading
+      reading hfaithful pair hcurved.1)
+
+/-- The square-level version of the selected reading-curvature criterion. -/
+theorem finiteSquare_curvature_of_square_visible_protected_discrepancy
+    {Profile : Type u} {CertificateAt : Profile -> Type v}
+    (square : FiniteSquare Profile CertificateAt)
+    (reading : SquareReading (CertificateAt square.upperRight))
+    (hvisible : VisibleFlat reading (endpointPairOfSquare square))
+    (hprotected : ¬ ProtectedInvariantFlat reading (endpointPairOfSquare square)) :
+    ReadingCurved reading (endpointPairOfSquare square) :=
+  finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    reading (endpointPairOfSquare square) hvisible hprotected
+
+/-- For a faithful reading, a finite square has no protected holonomy. -/
+theorem finiteSquare_no_holonomy_of_square_faithful_reading
+    {Profile : Type u} {CertificateAt : Profile -> Type v}
+    (square : FiniteSquare Profile CertificateAt)
+    (reading : SquareReading (CertificateAt square.upperRight))
+    (hfaithful : VisibleFaithfulToProtected reading)
+    (hvisible : VisibleFlat reading (endpointPairOfSquare square)) :
+    ProtectedInvariantFlat reading (endpointPairOfSquare square) :=
+  finiteSquare_no_holonomy_of_faithful_reading
+    reading hfaithful (endpointPairOfSquare square) hvisible
+
+/-! ## Trace-curvature square as an instance -/
+
+abbrev TraceUpperRightEndpoint :=
+  TraceCurvature.CertificateAt TraceCurvature.TraceProfile.upperRight
+
+/-- The cycle-7 trace square as a generic finite square with typed transports. -/
+def traceCurvatureSquare :
+    FiniteSquare TraceCurvature.TraceProfile TraceCurvature.CertificateAt where
+  lowerLeft := TraceCurvature.TraceProfile.lowerLeft
+  lowerRight := TraceCurvature.TraceProfile.lowerRight
+  upperLeft := TraceCurvature.TraceProfile.upperLeft
+  upperRight := TraceCurvature.TraceProfile.upperRight
+  seed := TraceCurvature.seedAt
+  lawBottom := ⟨TraceCurvature.transportLawBottom.map⟩
+  coverRight := ⟨TraceCurvature.transportCoverRight.map⟩
+  coverLeft := ⟨TraceCurvature.transportCoverLeft.map⟩
+  lawTop := ⟨TraceCurvature.transportLawTop.map⟩
+
+/-- The two path-composite endpoints of the cycle-7 trace square. -/
+def traceCurvatureEndpointPair : EndpointPair TraceUpperRightEndpoint where
+  lawFirst := TraceCurvature.lawThenCover TraceCurvature.seedAt
+  coverFirst := TraceCurvature.coverThenLaw TraceCurvature.seedAt
+
+/-- The generic finite-square endpoints agree with the named trace path composites. -/
+theorem traceCurvature_endpointPairOfSquare :
+    (endpointPairOfSquare traceCurvatureSquare).lawFirst =
+        traceCurvatureEndpointPair.lawFirst ∧
+      (endpointPairOfSquare traceCurvatureSquare).coverFirst =
+        traceCurvatureEndpointPair.coverFirst :=
+  ⟨rfl, rfl⟩
+
+/-- Visible upper-right trace surface: scalar, verdict, and support. -/
+def SameTraceVisibleSurface
+    (left right : TraceUpperRightEndpoint) : Prop :=
+  TraceCurvature.scalarReading left.val =
+      TraceCurvature.scalarReading right.val ∧
+    TraceCurvature.verdict left.val =
+      TraceCurvature.verdict right.val ∧
+    TraceCurvature.support left.val =
+      TraceCurvature.support right.val
+
+/-- Same path-ordered trace missing locus. -/
+def SameTraceMissingInvariant
+    (left right : TraceUpperRightEndpoint) : Prop :=
+  ∀ atom,
+    TraceCurvature.traceMissingLocus left.val atom ↔
+      TraceCurvature.traceMissingLocus right.val atom
+
+/-- Same path-ordered repair frontier. -/
+def SameTraceRepairInvariant
+    (left right : TraceUpperRightEndpoint) : Prop :=
+  ∀ atom,
+    TraceCurvature.repairFrontier left.val atom ↔
+      TraceCurvature.repairFrontier right.val atom
+
+/-- Trace square reading with trace missing locus as protected invariant. -/
+def traceMissingSquareReading :
+    SquareReading TraceUpperRightEndpoint where
+  VisibleEquivalent := SameTraceVisibleSurface
+  SameProtectedInvariant := SameTraceMissingInvariant
+
+/-- Trace square reading with repair frontier as protected invariant. -/
+def traceRepairSquareReading :
+    SquareReading TraceUpperRightEndpoint where
+  VisibleEquivalent := SameTraceVisibleSurface
+  SameProtectedInvariant := SameTraceRepairInvariant
+
+/-- The two trace-square endpoints agree on the visible reading. -/
+theorem traceCurvature_visibleFlat :
+    VisibleFlat traceMissingSquareReading traceCurvatureEndpointPair :=
+  ⟨TraceCurvature.same_scalar_after_trace_paths,
+    TraceCurvature.same_verdict_after_trace_paths,
+    TraceCurvature.same_support_after_trace_paths⟩
+
+/-- The repair-frontier reading has the same visible-flat endpoint pair. -/
+theorem traceCurvature_repair_visibleFlat :
+    VisibleFlat traceRepairSquareReading traceCurvatureEndpointPair :=
+  traceCurvature_visibleFlat
+
+/-- The trace-square endpoints differ in trace missing locus. -/
+theorem traceCurvature_traceMissing_discrepancy :
+    ¬ ProtectedInvariantFlat
+      traceMissingSquareReading traceCurvatureEndpointPair := by
+  intro hsame
+  have hmissingLaw :
+      TraceCurvature.traceMissingLocus
+        (TraceCurvature.lawThenCover TraceCurvature.seedAt).val
+        LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      TraceLocus.partialTrace_database_missing_locus
+  exact TraceLocus.fullTrace_has_no_missing_locus
+    ⟨LocusAtom.database, hmissingLaw⟩
+
+/-- The trace-square endpoints differ in repair frontier. -/
+theorem traceCurvature_repairFrontier_discrepancy :
+    ¬ ProtectedInvariantFlat
+      traceRepairSquareReading traceCurvatureEndpointPair := by
+  intro hsame
+  have hrepairLaw :
+      TraceCurvature.repairFrontier
+        (TraceCurvature.lawThenCover TraceCurvature.seedAt).val
+        LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      TraceCurvature.coverThenLaw_forces_database_repair
+  exact TraceCurvature.lawThenCover_no_database_repair hrepairLaw
+
+/-- Cycle-7 trace square instantiates the trace-missing criterion. -/
+theorem traceCurvature_instantiates_traceMissingCriterion :
+    ReadingCurved traceMissingSquareReading traceCurvatureEndpointPair :=
+  finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    traceMissingSquareReading traceCurvatureEndpointPair
+    traceCurvature_visibleFlat traceCurvature_traceMissing_discrepancy
+
+/-- Cycle-7 trace square instantiates the repair-frontier criterion. -/
+theorem traceCurvature_instantiates_repairFrontierCriterion :
+    ReadingCurved traceRepairSquareReading traceCurvatureEndpointPair :=
+  finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    traceRepairSquareReading traceCurvatureEndpointPair
+    traceCurvature_repair_visibleFlat
+    traceCurvature_repairFrontier_discrepancy
+
+/--
+The trace square is visibly flat but reading-curved for both trace missing
+locus and repair frontier.
+-/
+theorem same_trace_surface_but_finiteSquareCriterion_curved :
+    VisibleFlat traceMissingSquareReading traceCurvatureEndpointPair ∧
+      ReadingCurved traceMissingSquareReading traceCurvatureEndpointPair ∧
+      ReadingCurved traceRepairSquareReading traceCurvatureEndpointPair ∧
+      ¬ VisibleFaithfulToProtected traceMissingSquareReading ∧
+      ¬ VisibleFaithfulToProtected traceRepairSquareReading := by
+  exact ⟨traceCurvature_visibleFlat,
+    traceCurvature_instantiates_traceMissingCriterion,
+    traceCurvature_instantiates_repairFrontierCriterion,
+    finiteSquare_not_faithful_of_curvature
+      traceMissingSquareReading traceCurvatureEndpointPair
+      traceCurvature_instantiates_traceMissingCriterion,
+    finiteSquare_not_faithful_of_curvature
+      traceRepairSquareReading traceCurvatureEndpointPair
+      traceCurvature_instantiates_repairFrontierCriterion⟩
+
+end FiniteSquareCriterion
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-square-protected-criterion.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-square-protected-criterion.md
@@ -1,0 +1,134 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: profile-curvature / certificate-transport / ridge-fold / invariance
+expected_base_score: 70
+expected_evidence_multiplier: 2.0
+expected_final_score: 140
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle-12
+tags: [profile-curvature, finite-square, reading, protected-invariant]
+created: 2026-06-20
+cycle: 12
+lean: Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean
+---
+
+# Arbitrary finite square protected-invariant curvature criterion
+
+## 主張
+
+任意の有限 profile square endpoint pair に対して、二つの typed path composite が visible reading では同値だが、
+chosen protected invariant では分岐するなら、その square はその protected invariant に関して reading-curved である。
+逆に、visible reading が protected invariant に faithful な square では、その invariant の path holonomy
+discrepancy は起きない。
+
+さらに、この criterion が cycle 7 の `TraceCurvature` finite square を instance として読むことを Lean で示す。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `research/GOALS.md` の `G-aat-quality-surface-01`。
+- cycle 3 の `ProfileCurvature.lean`。
+- cycle 7 の `TraceCurvature.lean`。
+- cycle 8 の `ReadingAdequacy.lean`。
+- cycle 10 の `ProfileGridHolonomy.lean`。
+- cycle 11 の `ProfileTupleIntegration.lean`。
+
+## 非自明性
+
+既存の finite witness を増やすのではなく、profile curvature を
+`visible reading agreement + protected invariant discrepancy` の criterion として切り出す。
+ただし theorem 自体が定義展開にならないように、generic endpoint-pair / path-composite framework、
+faithfulness obstruction、既存 trace-curvature witness への instance 化を同じ Lean file で示す。
+
+## 数学的興味
+
+Quality Surface 上の curvature は、単なる path の違いではなく、選んだ reading がどの protected invariant に
+faithful でないかとして読める。この形にすると、support antichain、trace missing locus、repair frontier、
+tuple protected data を同じ criterion で扱える。
+
+## GOAL への前進
+
+任意有限 square criterion frontier を進め、cycle 3/7/10 の witness を report / paper で使える判定形式へ整理する。
+
+## SCORE 見込み
+
+- `score_reason`: witness から criterion への移行で profile-curvature / certificate-transport / ridge-fold / invariance を統合するため。ただし G2 A/C は定義展開 risk を指摘したため、expected base は 70 に下げる。
+- `dullness_risk`: `Curved := discrepancy` と定義して即証明するだけなら低 SCORE。typed path composite framework、faithful reading では discrepancy が起きない方向、cycle 7 trace-curvature witness が criterion を満たす instance theorem が必要。
+- `proof_or_evidence_plan`: `Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean` に generic finite square endpoint pair、reading、protected invariant、faithfulness、curvature criterion を置く。cycle 7 の trace-curvature endpoint pair を instance として証明する。可能なら repair frontier instance も入れる。
+
+## CS / SWE への帰結
+
+visible endpoint surface が flat に見えても、protected invariant の path discrepancy があれば、quality surface は
+その reading に関して curved と判断する必要がある。これは tooling の endpoint-only view を full certificate
+geometry と誤読しないための有限判定基準になる。ただし source extraction completeness、global flatness、
+実コード全体の品質判定は主張しない。
+
+## 証明・根拠の見込み
+
+Lean では、generic square を「同じ target profile に入る二つの typed path composite endpoint」として相対化した。
+reading `R` と protected invariant equivalence `SameInvariant` を受け取り、
+`R.Equivalent left right` と `¬ SameInvariant left right` から reading-level curvature を得る。
+また `FaithfulToInvariant R SameInvariant` があればその discrepancy は不可能であることを示した。
+最後に `TraceCurvature.lawThenCover TraceCurvature.seedAt` と
+`TraceCurvature.coverThenLaw TraceCurvature.seedAt` を instance として入れ、
+trace missing locus / repair frontier discrepancy が criterion を満たすことを証明した。
+
+Lean declarations:
+
+- `finiteSquare_curvature_of_visible_agreement_protected_discrepancy`
+- `finiteSquare_no_holonomy_of_faithful_reading`
+- `finiteSquare_not_faithful_of_curvature`
+- `finiteSquare_curvature_of_square_visible_protected_discrepancy`
+- `finiteSquare_no_holonomy_of_square_faithful_reading`
+- `traceCurvature_endpointPairOfSquare`
+- `traceCurvature_instantiates_traceMissingCriterion`
+- `traceCurvature_instantiates_repairFrontierCriterion`
+- `same_trace_surface_but_finiteSquareCriterion_curved`
+
+visible_projection: scalar / verdict / support agreement.
+
+protected_structure: trace missing locus, repair frontier, support antichain, tuple protected data.
+
+exactness_or_minimality_claim: criterion is exact relative to the chosen reading and protected invariant.
+
+nonfaithfulness_or_failure_mode: visible reading can be flat while protected invariant has path discrepancy.
+
+previous_cycle_delta: cycle 11 の tuple endpoint witness から、再び finite profile square の criterion へ戻し、静的 tuple integration ではなく path curvature 判定を進める。
+
+## 審判メモ
+
+- 厳密性: G2 A は `revise`。現状の `Curved := visible agreement + protected discrepancy` は定義展開に近すぎるため、typed endpoint/path-composite framework、faithful no-holonomy theorem、trace missing / repair frontier instance が必須。
+- 研究価値: G2 B は `accept`、base 75。surprise は中程度だが compression / leverage / paper section potential は高い。
+- repo 全体価値: G2 C は `revise`、base 70。任意有限 square criterion frontier には合うが、wrapper 化を避けるため reusable finite-square API と cycle 7 instance が必要。
+- G3 axiom / formalization audit: pass。9 declaration は axiom-free。形式化品質監査も、generic `FiniteSquare` と typed edge transport 追加後に pass。
+- G4 SCORE audit: `confirm`。base 70、multiplier 2.0、penalty 0、final 140。generic finite-square/path-composite framework が wrapper risk を十分に下げたが、criterion-by-definition に近い面もあるため 70 を超えては評価しない。
+
+## 証拠
+
+- Lean file: `Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean`
+- Evidence stage: `proved-in-research`
+- Build target: `lake env lean Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean`
+- Main theorem: `FiniteSquareCriterion.same_trace_surface_but_finiteSquareCriterion_curved`
+- Axiom summary: `finiteSquare_curvature_of_visible_agreement_protected_discrepancy`、`finiteSquare_no_holonomy_of_faithful_reading`、`finiteSquare_not_faithful_of_curvature`、`finiteSquare_curvature_of_square_visible_protected_discrepancy`、`finiteSquare_no_holonomy_of_square_faithful_reading`、`traceCurvature_endpointPairOfSquare`、`traceCurvature_instantiates_traceMissingCriterion`、`traceCurvature_instantiates_repairFrontierCriterion`、`same_trace_surface_but_finiteSquareCriterion_curved` は `#print axioms` でいずれも axiom-free。
+- Formalization summary: `SquareEdgeTransport`、`FiniteSquare`、`endpointPairOfSquare` が四頂点、四つの typed edge transport、seed、二つの path composite endpoint を generic square data として保持する。`traceCurvatureSquare` と `traceCurvature_endpointPairOfSquare` により cycle 7 witness は generic square framework の instance として読める。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-profile-curvature-detector.md`
+- `research/ideas/g-aat-quality-surface-01-trace-curvature-detector.md`
+- `research/ideas/g-aat-quality-surface-01-profile-grid-holonomy.md`
+- `research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 12 G1 候補として作成。
+- 2026-06-20: G2 A/C の `revise` を受け、expected score を 70 x 2.0 = 140 に下げ、typed endpoint/path-composite framework、faithful no-holonomy theorem、cycle 7 trace-curvature instance を必要証拠として明確化。
+- 2026-06-20: `Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean` で generic endpoint pair、selected reading / protected invariant、faithful no-holonomy theorem、cycle 7 trace missing / repair frontier instance を追加。
+- 2026-06-20: G3 形式化監査の `revise` を受け、generic `FiniteSquare`、`SquareEdgeTransport`、`endpointPairOfSquare`、square-level curvature / no-holonomy theorem、cycle 7 trace square の generic square instance を追加。
+- 2026-06-20: G3 再監査で axiom audit / formalization quality audit がいずれも pass。
+- 2026-06-20: G4 SCORE 監査で base 70、evidence multiplier 2.0、final SCORE 140 に確定。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 1520
+- total SCORE: 1660
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -17,8 +17,9 @@
   - traceability / computability / quality-surface / repair-potential: 150
   - profile-curvature / quality-surface / certificate-transport / ridge-fold / traceability: 130
   - unification / atom-supported-quality-geometry / traceability / repair-potential: 110
+  - profile-curvature / certificate-transport / ridge-fold / invariance: 140
 - evidence portfolio:
-  - proved-in-research: 11
+  - proved-in-research: 12
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -438,9 +439,55 @@ Lean 証拠は次を固定する。
 profile fiber 上の protected tuple geometry として読める。主張は supplied trace data と finite profile witness に
 相対化され、source extraction completeness、global flatness、実コード全体の品質判定、現行 tooling schema impact は結論しない。
 
+## Cycle 12: Arbitrary finite square protected-invariant curvature criterion
+
+```text
+candidate: Arbitrary finite square protected-invariant curvature criterion
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 70
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 140
+category: profile-curvature/certificate-transport/ridge-fold/invariance
+goal_delta: finite square profile-curvature criterion を typed path composites 上で再利用できる形にし、cycle 7 trace square を trace missing locus / repair frontier の instance として固定した。
+project_value_delta: finite witness 群を generic protected-invariant curvature criterion へつなぎ、report / paper で witness から判定基準へ移る節を支える。
+formalization_quality: pass。`SquareEdgeTransport`、`FiniteSquare`、`endpointPairOfSquare`、square-level curvature theorem、faithful no-holonomy theorem、cycle 7 trace missing / repair frontier instances が axiom-free / sorry-free で証明されている。
+open_questions: support antichain / tuple protected data への additional instance、grid-level flatness / holonomy criterion、non-definitional tuple transport theorem、source-ref packet と profile tuple の preservation/reflection。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean` は、有限 square を四頂点と四つの
+typed edge transport、および seed certificate からなる generic data として定義する。
+`endpointPairOfSquare` は law-first / cover-first の二つの path composite endpoint を取り出す。
+その endpoint pair に対して chosen visible reading と chosen protected invariant を与え、
+visible flatness と protected discrepancy を reading-curvature として読む。
+
+Lean 証拠は次を固定する。
+
+- `SquareEdgeTransport`: profile vertex 間の typed edge transport。
+- `FiniteSquare`: lower-left / lower-right / upper-left / upper-right、seed、四つの edge transport からなる finite square。
+- `endpointPairOfSquare`: finite square の二つの path composite endpoint。
+- `finiteSquare_curvature_of_visible_agreement_protected_discrepancy`: visible flat かつ protected invariant discrepancy があれば reading-curved である。
+- `finiteSquare_no_holonomy_of_faithful_reading`: visible reading が protected invariant に faithful なら protected holonomy discrepancy は起きない。
+- `finiteSquare_not_faithful_of_curvature`: reading-curved square は visible faithfulness を否定する。
+- `finiteSquare_curvature_of_square_visible_protected_discrepancy`: square data から直接 reading-curvature を読む。
+- `finiteSquare_no_holonomy_of_square_faithful_reading`: square data 上の faithful no-holonomy theorem。
+- `traceCurvatureSquare`: cycle 7 の trace-curvature witness を generic finite square として表す。
+- `traceCurvature_endpointPairOfSquare`: generic square endpoint pair が cycle 7 の named law-first / cover-first endpoints と一致する。
+- `traceCurvature_instantiates_traceMissingCriterion`: trace missing locus は finite-square criterion の instance である。
+- `traceCurvature_instantiates_repairFrontierCriterion`: repair frontier は finite-square criterion の instance である。
+- `same_trace_surface_but_finiteSquareCriterion_curved`: 同じ visible trace surface の下で、trace missing locus と repair frontier の両方が reading-curved である。
+
+この結果により、profile curvature は witness の列挙だけでなく、選んだ reading がどの protected invariant に
+faithful でないかを finite square の path composite で判定する形へ整理された。主張は selected reading /
+selected invariant / supplied finite evidence に相対化され、global flatness、source extraction completeness、
+実コード全体の品質判定、現行 tooling schema impact は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 11 後の total SCORE は 1520 である。
-次に進める場合は、任意有限 square criterion、profile tuple に沿う non-definitional transport theorem、
-source-ref packet と profile tuple の統合、grid-level flatness / holonomy criterion、または source-ref evidence を
-実 tooling artifact と同期する将来 surface を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 12 後の total SCORE は 1660 である。
+次に進める場合は、profile tuple に沿う non-definitional transport theorem、source-ref packet と profile tuple の
+preservation/reflection、grid-level flatness / holonomy criterion、または support antichain / tuple protected data の
+finite-square criterion instance を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

`G-aat-quality-surface-01` cycle 12 として、finite square protected-invariant curvature criterion を Research 配下に追加した。
`SquareEdgeTransport`、`FiniteSquare`、`endpointPairOfSquare` により、四頂点と四つの typed edge transport から law-first / cover-first の endpoint pair を取り出し、chosen visible reading と protected invariant に相対化した curvature criterion を証明する。

G4 SCORE 監査は `confirm` で、base 70、evidence multiplier 2.0、final SCORE +140。total SCORE は 1660/5000 に更新した。

## 証明した定理

- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.finiteSquare_curvature_of_visible_agreement_protected_discrepancy`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.finiteSquare_no_holonomy_of_faithful_reading`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.finiteSquare_not_faithful_of_curvature`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.finiteSquare_curvature_of_square_visible_protected_discrepancy`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.finiteSquare_no_holonomy_of_square_faithful_reading`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.traceCurvature_endpointPairOfSquare`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.traceCurvature_instantiates_traceMissingCriterion`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.traceCurvature_instantiates_repairFrontierCriterion`
- `Formal.AG.Research.QualitySurface.FiniteSquareCriterion.same_trace_surface_but_finiteSquareCriterion_curved`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-finite-square-protected-criterion.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/finite_square_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean` linter warning 2件のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan（今回追加 Lean file は no match）
- [x] local/private path scan

## チェックリスト

- [ ] 対象 Issue を `Closes #N` 形式で本文に記載した
- [x] Lean status を `proved`, `defined only`, `future proof obligation`, `empirical hypothesis` のいずれかで明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

※ tracking Issue #2348 は research-loop 状態の正本なので、この PR では閉じない。
