### PR TITLE
研究ループ Cycle 15: support antichain square criterion

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -13,3 +13,4 @@ import Formal.AG.Research.QualitySurface.ProfileTupleIntegration
 import Formal.AG.Research.QualitySurface.FiniteSquareCriterion
 import Formal.AG.Research.QualitySurface.SourceRefTupleBridge
 import Formal.AG.Research.QualitySurface.TupleTransportExactness
+import Formal.AG.Research.QualitySurface.SupportAntichainSquareCriterion

--- a/Formal/AG/Research/QualitySurface/SupportAntichainSquareCriterion.lean
+++ b/Formal/AG/Research/QualitySurface/SupportAntichainSquareCriterion.lean
@@ -1,0 +1,202 @@
+import Formal.AG.Research.QualitySurface.FiniteSquareCriterion
+import Formal.AG.Research.QualitySurface.ProfileCurvature
+
+/-!
+Cycle 15 evidence for `G-aat-quality-surface-01`.
+
+This file instantiates the generic finite-square criterion with the
+support-antichain / repair-hitting data from the finite profile-curvature
+witness. The result is relative to the selected finite square and selected
+protected invariant; it does not assert global flatness or complete repair
+semantics.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SupportAntichainSquareCriterion
+
+/-! ## Profile-curvature square as a generic finite square -/
+
+abbrev SupportRepairEndpoint :=
+  ProfileCurvature.CertificateAt ProfileCurvature.SquareProfile.upperRight
+
+/-- Cycle-3 profile-curvature square as a generic finite square. -/
+def profileCurvatureSquare :
+    FiniteSquareCriterion.FiniteSquare ProfileCurvature.SquareProfile ProfileCurvature.CertificateAt where
+  lowerLeft := ProfileCurvature.SquareProfile.lowerLeft
+  lowerRight := ProfileCurvature.SquareProfile.lowerRight
+  upperLeft := ProfileCurvature.SquareProfile.upperLeft
+  upperRight := ProfileCurvature.SquareProfile.upperRight
+  seed := ProfileCurvature.seedAt
+  lawBottom := ⟨ProfileCurvature.transportLawBottom.map⟩
+  coverRight := ⟨ProfileCurvature.transportCoverRight.map⟩
+  coverLeft := ⟨ProfileCurvature.transportCoverLeft.map⟩
+  lawTop := ⟨ProfileCurvature.transportLawTop.map⟩
+
+/-- The named endpoint pair of the profile-curvature square. -/
+def profileCurvatureEndpointPair :
+    FiniteSquareCriterion.EndpointPair SupportRepairEndpoint where
+  lawFirst := ProfileCurvature.lawThenCover ProfileCurvature.seedAt
+  coverFirst := ProfileCurvature.coverThenLaw ProfileCurvature.seedAt
+
+/-- Generic finite-square endpoints agree with the named profile-curvature paths. -/
+theorem profileCurvature_endpointPairOfSquare :
+    (FiniteSquareCriterion.endpointPairOfSquare profileCurvatureSquare).lawFirst =
+        profileCurvatureEndpointPair.lawFirst ∧
+      (FiniteSquareCriterion.endpointPairOfSquare profileCurvatureSquare).coverFirst =
+        profileCurvatureEndpointPair.coverFirst :=
+  ⟨rfl, rfl⟩
+
+/-! ## Support-antichain / repair-hitting reading -/
+
+/-- Visible reading: scalar projection and verdict only. -/
+def SameScalarVerdictSurface
+    (left right : SupportRepairEndpoint) : Prop :=
+  ProfileCurvature.scalarReading left.val = ProfileCurvature.scalarReading right.val ∧
+    ProfileCurvature.verdict left.val = ProfileCurvature.verdict right.val
+
+/-- Same selected support-family antichain. -/
+def SameSupportFamilyInvariant
+    (left right : SupportRepairEndpoint) : Prop :=
+  ProfileCurvature.supportFamily left.val = ProfileCurvature.supportFamily right.val
+
+/-- Same repair hitting requirement. -/
+def SameRepairHittingInvariant
+    (left right : SupportRepairEndpoint) : Prop :=
+  ProfileCurvature.repairHittingNumber left.val = ProfileCurvature.repairHittingNumber right.val
+
+/-- Protected invariant: support family and repair hitting requirement together. -/
+def SameSupportRepairInvariant
+    (left right : SupportRepairEndpoint) : Prop :=
+  SameSupportFamilyInvariant left right ∧
+    SameRepairHittingInvariant left right
+
+/-- Square reading that hides support antichain and repair hitting data. -/
+def supportRepairSquareReading :
+    FiniteSquareCriterion.SquareReading SupportRepairEndpoint where
+  VisibleEquivalent := SameScalarVerdictSurface
+  SameProtectedInvariant := SameSupportRepairInvariant
+
+/-- The two endpoints agree on the visible scalar/verdict surface. -/
+theorem profileCurvature_supportRepair_visibleFlat :
+    FiniteSquareCriterion.VisibleFlat
+      supportRepairSquareReading profileCurvatureEndpointPair :=
+  ⟨ProfileCurvature.same_scalarReading_after_paths,
+    ProfileCurvature.same_verdict_after_paths⟩
+
+/-- The law-first endpoint has a nonempty support-family antichain. -/
+theorem lawFirst_supportFamily_nonempty_antichain :
+    ProfileCurvature.SupportFamilyNonempty
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.lawFirst.val) ∧
+      ProfileCurvature.SupportFamilyAntichain
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.lawFirst.val) :=
+  ⟨ProfileCurvature.lawThenCover_supportFamily_nonempty,
+    ProfileCurvature.lawThenCover_supportFamily_antichain⟩
+
+/-- The cover-first endpoint has a nonempty support-family antichain. -/
+theorem coverFirst_supportFamily_nonempty_antichain :
+    ProfileCurvature.SupportFamilyNonempty
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.coverFirst.val) ∧
+      ProfileCurvature.SupportFamilyAntichain
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.coverFirst.val) :=
+  ⟨ProfileCurvature.coverThenLaw_supportFamily_nonempty,
+    ProfileCurvature.coverThenLaw_supportFamily_antichain⟩
+
+/-- The two endpoints differ in selected support family. -/
+theorem profileCurvature_supportFamily_discrepancy :
+    ¬ SameSupportFamilyInvariant
+      profileCurvatureEndpointPair.lawFirst
+      profileCurvatureEndpointPair.coverFirst :=
+  ProfileCurvature.supportFamily_path_ne
+
+/-- The two endpoints differ in repair hitting requirement. -/
+theorem profileCurvature_repairHitting_discrepancy :
+    ¬ SameRepairHittingInvariant
+      profileCurvatureEndpointPair.lawFirst
+      profileCurvatureEndpointPair.coverFirst :=
+  ProfileCurvature.repairHittingNumber_path_ne
+
+/-- The two endpoints differ in the combined support/repair invariant. -/
+theorem profileCurvature_supportRepair_discrepancy :
+    ¬ FiniteSquareCriterion.ProtectedInvariantFlat
+      supportRepairSquareReading profileCurvatureEndpointPair := by
+  intro hsame
+  exact profileCurvature_supportFamily_discrepancy hsame.1
+
+/--
+Cycle-3 support antichain / repair-hitting witness instantiates the generic
+finite-square reading-curvature criterion.
+-/
+theorem profileCurvature_instantiates_supportAntichainCriterion :
+    FiniteSquareCriterion.ReadingCurved
+      supportRepairSquareReading profileCurvatureEndpointPair :=
+  FiniteSquareCriterion.finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    supportRepairSquareReading profileCurvatureEndpointPair
+    profileCurvature_supportRepair_visibleFlat
+    profileCurvature_supportRepair_discrepancy
+
+/-- The scalar/verdict visible reading is not faithful to support/repair data. -/
+theorem profileCurvature_no_visibleFaithfulness_for_supportRepair :
+    ¬ FiniteSquareCriterion.VisibleFaithfulToProtected supportRepairSquareReading :=
+  FiniteSquareCriterion.finiteSquare_not_faithful_of_curvature
+    supportRepairSquareReading profileCurvatureEndpointPair
+    profileCurvature_instantiates_supportAntichainCriterion
+
+/--
+The support/repair reading-curvature instance is compatible with the original
+cycle-3 `CurvatureCell` predicate.
+-/
+theorem profileCurvature_readingCurved_implies_curvatureCell
+    (hcurved :
+      FiniteSquareCriterion.ReadingCurved
+        supportRepairSquareReading profileCurvatureEndpointPair) :
+    ProfileCurvature.CurvatureCell ProfileCurvature.seedAt := by
+  intro hregular
+  have hprotected :
+      SameSupportRepairInvariant
+        profileCurvatureEndpointPair.lawFirst
+        profileCurvatureEndpointPair.coverFirst := by
+    exact ⟨hregular.2.2.1, hregular.2.2.2⟩
+  exact hcurved.2 hprotected
+
+/--
+Cycle-15 theorem package: the profile-curvature square is visibly flat for
+scalar/verdict, while its support-family antichain and repair hitting
+requirement form a protected finite-square curvature instance.
+-/
+theorem same_scalar_verdict_but_supportAntichainSquare_curved :
+    FiniteSquareCriterion.VisibleFlat
+        supportRepairSquareReading profileCurvatureEndpointPair ∧
+      ProfileCurvature.SupportFamilyNonempty
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.lawFirst.val) ∧
+      ProfileCurvature.SupportFamilyAntichain
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.lawFirst.val) ∧
+      ProfileCurvature.SupportFamilyNonempty
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.coverFirst.val) ∧
+      ProfileCurvature.SupportFamilyAntichain
+        (ProfileCurvature.supportFamily profileCurvatureEndpointPair.coverFirst.val) ∧
+      ¬ SameSupportFamilyInvariant
+        profileCurvatureEndpointPair.lawFirst
+        profileCurvatureEndpointPair.coverFirst ∧
+      ¬ SameRepairHittingInvariant
+        profileCurvatureEndpointPair.lawFirst
+        profileCurvatureEndpointPair.coverFirst ∧
+      FiniteSquareCriterion.ReadingCurved
+        supportRepairSquareReading profileCurvatureEndpointPair ∧
+      ProfileCurvature.CurvatureCell ProfileCurvature.seedAt ∧
+      ¬ FiniteSquareCriterion.VisibleFaithfulToProtected supportRepairSquareReading := by
+  exact ⟨profileCurvature_supportRepair_visibleFlat,
+    lawFirst_supportFamily_nonempty_antichain.1,
+    lawFirst_supportFamily_nonempty_antichain.2,
+    coverFirst_supportFamily_nonempty_antichain.1,
+    coverFirst_supportFamily_nonempty_antichain.2,
+    profileCurvature_supportFamily_discrepancy,
+    profileCurvature_repairHitting_discrepancy,
+    profileCurvature_instantiates_supportAntichainCriterion,
+    profileCurvature_readingCurved_implies_curvatureCell
+      profileCurvature_instantiates_supportAntichainCriterion,
+    profileCurvature_no_visibleFaithfulness_for_supportRepair⟩
+
+end SupportAntichainSquareCriterion
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-support-antichain-square-criterion.md
+++ b/research/ideas/g-aat-quality-surface-01-support-antichain-square-criterion.md
@@ -1,0 +1,118 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: profile-curvature/atom-supported-quality-geometry/repair-potential/invariance
+expected_base_score: 40
+expected_evidence_multiplier: 2.0
+expected_final_score: 80
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle15
+tags:
+  - finite-square
+  - support-antichain
+  - repair-hitting
+created: 2026-06-20
+cycle: 15
+lean: proved
+---
+
+# Support antichain finite-square curvature instance
+
+## 主張
+
+Cycle 3 の profile-curvature square は、Cycle 12 の generic
+`FiniteSquareCriterion` の support-antichain / repair-hitting instance として読める。
+visible reading を scalar / verdict に限定し、protected invariant を selected support
+family と repair hitting requirement に取ると、visible には flat でも protected data は
+curved である。
+
+主張は finite supplied square、selected reading、selected invariant に相対化する。新しい
+finite square witness、generic finite-square criterion、global flatness、global no-holonomy、
+source extraction completeness、ArchMap correctness、全 repair semantics は主張しない。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/ProfileCurvature.lean`
+- `Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean`
+- `supportFamily_path_ne`
+- `repairHittingNumber_path_ne`
+- `finiteSquare_curvature_of_visible_agreement_protected_discrepancy`
+
+## 非自明性
+
+Cycle 3 は concrete witness、Cycle 12 は generic criterion と trace instances を与えた。
+この候補は support family / repair hitting requirement を protected invariant として
+criterion に載せ、trace 以外の atom-supported repair geometry も generic criterion の
+正規 instance であることを固定する。
+
+## 数学的興味
+
+Quality Surface の scalar/verdict view が support antichain と repair potential を隠すことを、
+finite square curvature の selected invariant として読む。新現象ではなく、criterion 節を
+support-repair frontier へ閉じる整理である。
+
+## GOAL への前進
+
+profile-curvature / atom-supported-quality-geometry / repair-potential を generic finite-square
+criterion と接続する。
+
+## SCORE 見込み
+
+- `score_reason`: G2-A/B は base 45 cap、G2-C は base 40 妥当と判定。Cycle 3/12 の bridge instance なので base 40 / final 80 とする。
+- `dullness_risk`: medium-high。既存 witness と existing criterion の instance 化であり、新しい witness ではない。
+- `proof_or_evidence_plan`: `SupportAntichainSquareCriterion.lean` に `profileCurvatureSquare`、visible/protected reading、nonempty antichain evidence、support/repair discrepancy、generic criterion instance、旧 `CurvatureCell` への bridge theorem を置く。
+
+## CS / SWE への帰結
+
+Quality Surface の finite-square view で、scalar/verdict だけでは support family と repair hitting
+requirement を復元できないことを、trace-missing とは別の repair-potential invariant として表示できる。
+
+## 証明・根拠の見込み
+
+Lean proof は `Formal/AG/Research/QualitySurface/SupportAntichainSquareCriterion.lean` に閉じる。
+
+主要 theorem:
+
+- `profileCurvatureSquare`
+- `profileCurvature_endpointPairOfSquare`
+- `supportRepairSquareReading`
+- `profileCurvature_supportRepair_visibleFlat`
+- `lawFirst_supportFamily_nonempty_antichain`
+- `coverFirst_supportFamily_nonempty_antichain`
+- `profileCurvature_supportFamily_discrepancy`
+- `profileCurvature_repairHitting_discrepancy`
+- `profileCurvature_instantiates_supportAntichainCriterion`
+- `profileCurvature_no_visibleFaithfulness_for_supportRepair`
+- `profileCurvature_readingCurved_implies_curvatureCell`
+- `same_scalar_verdict_but_supportAntichainSquare_curved`
+
+## 審判メモ
+
+- 厳密性: `lake env lean` と axiom harness は pass。reported theorem は axiom-free。
+- 研究価値: closure / instance。G2-C に従い base 40 とする。
+- repo 全体価値: `Formal/AG/Research` と `research/` に閉じる。保護された数学本文、tooling schema、`Formal/AG` 本体は編集しない。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-profile-curvature-detector.md`
+- `research/ideas/g-aat-quality-surface-01-finite-square-protected-criterion.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## G2 revise log
+
+- G2-A: accept, base 45。visible scalar/verdict と protected support/repair を明示すれば許容。
+- G2-B: revise-to-accept, cap 45。旧 `CurvatureCell` との bridge があれば base 50 まで許容だが、過大評価は避ける。
+- G2-C: accept, base 40 妥当。Cycle 3/12 の connection closure なので 50+ は高すぎる。
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 15 candidate picked.
+- 2026-06-20: `SupportAntichainSquareCriterion.lean` added.
+- 2026-06-20: `lake env lean Formal/AG/Research/QualitySurface/SupportAntichainSquareCriterion.lean` pass.
+- 2026-06-20: `lake build FormalAGResearch` pass.
+- 2026-06-20: `lake env lean .tmp/support_antichain_square_axioms.lean` pass; reported theorem package is axiom-free.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 1870
+- total SCORE: 1950
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -20,8 +20,9 @@
   - profile-curvature / certificate-transport / ridge-fold / invariance: 140
   - traceability / atom-supported-quality-geometry / certificate-transport / quality-surface: 120
   - certificate-transport / invariance / repair-potential / traceability: 90
+  - profile-curvature / atom-supported-quality-geometry / repair-potential / invariance: 80
 - evidence portfolio:
-  - proved-in-research: 14
+  - proved-in-research: 15
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -575,9 +576,54 @@ component law によって exactness を運ぶ comparison map として扱える
 selected component laws に相対化され、任意 profile change の canonical transport、global flatness、source
 extraction completeness、ArchMap correctness、observation completeness、実コード全体の品質判定は結論しない。
 
+## Cycle 15: Support antichain finite-square curvature instance
+
+```text
+candidate: Support antichain finite-square curvature instance
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 40
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 80
+category: profile-curvature/atom-supported-quality-geometry/repair-potential/invariance
+goal_delta: Cycle 3 の support-antichain / repair-hitting witness を Cycle 12 の generic finite-square criterion の正式 instance として固定した。
+project_value_delta: trace missing / repair frontier 以外の atom-supported repair geometry も selected protected invariant として finite-square reading-curvature へ載ることを示した。
+formalization_quality: pass。`profileCurvatureSquare`、visible scalar/verdict reading、support/repair protected invariant、endpoint support-family antichain evidence、support and repair discrepancy、generic finite-square criterion instance、旧 `CurvatureCell` への bridge theorem が axiom-free / sorry-free で証明されている。
+open_questions: grid-level flatness / holonomy criterion、source-ref token identity の injective reflection、lossy tuple transport の obstruction criterion、tuple protected data の finite-square criterion instance。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SupportAntichainSquareCriterion.lean` は、
+Cycle 3 の profile-curvature square を Cycle 12 の `FiniteSquareCriterion.FiniteSquare` として読み直す。
+visible reading は scalar reading と verdict のみを保持し、protected invariant は selected support family と
+repair hitting requirement の組として置く。
+
+Lean 証拠は次を固定する。
+
+- `profileCurvatureSquare`: Cycle 3 の四辺 transport と seed を generic finite square として表す。
+- `profileCurvature_endpointPairOfSquare`: generic finite-square endpoints が named law-first / cover-first paths と一致する。
+- `SameScalarVerdictSurface`: scalar / verdict のみを保持する visible reading。
+- `SameSupportRepairInvariant`: support family と repair hitting requirement を保持する protected invariant。
+- `supportRepairSquareReading`: visible scalar/verdict と protected support/repair を組にした square reading。
+- `profileCurvature_supportRepair_visibleFlat`: 二つの endpoints は visible scalar/verdict では flat である。
+- `lawFirst_supportFamily_nonempty_antichain`: law-first endpoint の support family は nonempty antichain である。
+- `coverFirst_supportFamily_nonempty_antichain`: cover-first endpoint の support family は nonempty antichain である。
+- `profileCurvature_supportFamily_discrepancy`: endpoints は support family で分岐する。
+- `profileCurvature_repairHitting_discrepancy`: endpoints は repair hitting requirement で分岐する。
+- `profileCurvature_instantiates_supportAntichainCriterion`: support/repair protected invariant は generic finite-square criterion の reading-curved instance である。
+- `profileCurvature_no_visibleFaithfulness_for_supportRepair`: scalar/verdict visible reading は support/repair invariant に faithful ではない。
+- `profileCurvature_readingCurved_implies_curvatureCell`: finite-square reading-curvature は旧 Cycle 3 の `CurvatureCell` と整合する。
+- `same_scalar_verdict_but_supportAntichainSquare_curved`: visible flatness、support-family antichain evidence、support/repair discrepancy、reading-curvature、nonfaithfulness をまとめる theorem package。
+
+この結果により、Cycle 12 の finite-square criterion は trace data だけでなく、atom-supported support family と
+repair hitting requirement にも適用できることが固定された。主張は selected finite square / selected reading /
+selected invariant に相対化され、新しい finite square witness、generic criterion の新発見、global flatness、
+global no-holonomy、source extraction completeness、ArchMap correctness、全 repair semantics は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 14 後の total SCORE は 1870 である。
-次に進める場合は、grid-level flatness / holonomy criterion、support antichain / tuple protected data の
-finite-square criterion instance、source-ref token identity の injective reflection、または lossy tuple transport の
-obstruction criterion を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 15 後の total SCORE は 1950 である。
+次に進める場合は、grid-level flatness / holonomy criterion、source-ref token identity の injective reflection、
+lossy tuple transport の obstruction criterion、または tuple protected data の finite-square criterion instance を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

研究ループ `G-aat-quality-surface-01` の Cycle 15 として、Cycle 3 の support-antichain / repair-hitting witness を Cycle 12 の generic finite-square criterion の正式 instance として固定します。

主な設計判断:

- visible reading は scalar / verdict のみに限定します。
- protected invariant は selected support family と repair hitting requirement の組として扱います。
- 既存 witness と existing criterion の closure なので、G2-C に従い base 40 / final +80 として保守的に記録します。
- 新しい finite square witness、generic criterion の新発見、global flatness、global no-holonomy、source extraction completeness、ArchMap correctness、全 repair semantics は主張しません。

## 証明した定理

- `profileCurvature_endpointPairOfSquare`
- `profileCurvature_supportRepair_visibleFlat`
- `lawFirst_supportFamily_nonempty_antichain`
- `coverFirst_supportFamily_nonempty_antichain`
- `profileCurvature_supportFamily_discrepancy`
- `profileCurvature_repairHitting_discrepancy`
- `profileCurvature_supportRepair_discrepancy`
- `profileCurvature_instantiates_supportAntichainCriterion`
- `profileCurvature_no_visibleFaithfulness_for_supportRepair`
- `profileCurvature_readingCurved_implies_curvatureCell`
- `same_scalar_verdict_but_supportAntichainSquare_curved`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-support-antichain-square-criterion.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SupportAntichainSquareCriterion.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/support_antichain_square_axioms.lean`
- [x] `lake build`
  - 既存の unrelated linter warning: `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207`
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## SCORE

```text
base_score: 40
evidence_multiplier: 2.0
penalty: 0
final_score: 80
total_score: 1950
```

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（tracking Issue のため `Closes` しない）
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
