### PR TITLE
研究ループ Cycle 17: source-ref packet transport

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -15,3 +15,4 @@ import Formal.AG.Research.QualitySurface.SourceRefTupleBridge
 import Formal.AG.Research.QualitySurface.TupleTransportExactness
 import Formal.AG.Research.QualitySurface.SupportAntichainSquareCriterion
 import Formal.AG.Research.QualitySurface.SourceRefTokenIdentityReflection
+import Formal.AG.Research.QualitySurface.SourceRefPacketTransport

--- a/Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean
+++ b/Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean
@@ -1,0 +1,305 @@
+import Formal.AG.Research.QualitySurface.SourceRefTokenIdentityReflection
+
+/-!
+Cycle 17 evidence for `G-aat-quality-surface-01`.
+
+This file treats an explicitly supplied source-ref packet update as a bounded
+transport law for packet-induced or aligned profile tuples. The transport is
+range-restricted to the supplied packets and alignment witnesses; it does not
+assert a global `TupleTransport`, a tuple-to-packet extractor, source
+extraction completeness, or ArchMap correctness.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SourceRefPacketTransport
+
+open TraceLocus
+
+abbrev TupleProfile :=
+  SourceRefTupleBridge.TupleProfile
+
+abbrev TupleCertificateAt :=
+  ProfileTupleIntegration.TupleCertificateAt
+
+/-! ## Packet update laws -/
+
+/-- A supplied comparison map between source-ref packets. -/
+structure PacketUpdate where
+  map : CodebaseTracePacket.SourceRefPacket ->
+    CodebaseTracePacket.SourceRefPacket
+
+/-- Packet update preserves code support. -/
+def PreservesCodeSupport (τ : PacketUpdate) : Prop :=
+  ∀ packet atom, packet.codeSupport atom -> (τ.map packet).codeSupport atom
+
+/-- Packet update reflects code support. -/
+def ReflectsCodeSupport (τ : PacketUpdate) : Prop :=
+  ∀ packet atom, (τ.map packet).codeSupport atom -> packet.codeSupport atom
+
+/-- Packet update preserves source-ref missing loci. -/
+def PreservesSourceRefMissingLocus (τ : PacketUpdate) : Prop :=
+  ∀ packet atom,
+    CodebaseTracePacket.SourceRefMissingLocus packet atom ->
+      CodebaseTracePacket.SourceRefMissingLocus (τ.map packet) atom
+
+/-- Packet update reflects source-ref missing loci. -/
+def ReflectsSourceRefMissingLocus (τ : PacketUpdate) : Prop :=
+  ∀ packet atom,
+    CodebaseTracePacket.SourceRefMissingLocus (τ.map packet) atom ->
+      CodebaseTracePacket.SourceRefMissingLocus packet atom
+
+/-- Packet update preserves repair-frontier membership. -/
+def PreservesSourceRefRepairFrontier (τ : PacketUpdate) : Prop :=
+  ∀ packet atom,
+    packet.repairFrontier atom -> (τ.map packet).repairFrontier atom
+
+/-- Packet update reflects repair-frontier membership. -/
+def ReflectsSourceRefRepairFrontier (τ : PacketUpdate) : Prop :=
+  ∀ packet atom,
+    (τ.map packet).repairFrontier atom -> packet.repairFrontier atom
+
+/-- Packet update preserves source-ref token identity pointwise. -/
+def PreservesSourceRefTable (τ : PacketUpdate) : Prop :=
+  ∀ packet atom,
+    (τ.map packet).sourceRefTable atom = packet.sourceRefTable atom
+
+/-- Bundled bidirectional laws for the packet update. -/
+structure BidirectionalSourceRefPacketTransport
+    (τ : PacketUpdate) : Prop where
+  preservesSupport : PreservesCodeSupport τ
+  reflectsSupport : ReflectsCodeSupport τ
+  preservesMissing : PreservesSourceRefMissingLocus τ
+  reflectsMissing : ReflectsSourceRefMissingLocus τ
+  preservesRepair : PreservesSourceRefRepairFrontier τ
+  reflectsRepair : ReflectsSourceRefRepairFrontier τ
+  preservesSourceRefTable : PreservesSourceRefTable τ
+
+/-! ## Packet-induced tuple transport -/
+
+/-- Packet update preserves tuple missing loci on `packetToTuple` images. -/
+theorem packetTransport_preserves_tupleMissingLocus
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    ∀ atom,
+      ProfileTupleIntegration.TupleTraceMissingLocus
+          (SourceRefTupleBridge.packetToTuple gridSource packet) atom ->
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)) atom := by
+  intro atom hmissing
+  have hsourceMissing :
+      CodebaseTracePacket.SourceRefMissingLocus packet
+        (CodebaseTracePacket.fromLocusAtom atom) :=
+    (SourceRefTupleBridge.sourceRefPacket_to_tuple_missingLocus
+      gridSource packet atom).mp hmissing
+  exact (SourceRefTupleBridge.sourceRefPacket_to_tuple_missingLocus
+    gridTarget (τ.map packet) atom).mpr
+    (hlaws.preservesMissing packet
+      (CodebaseTracePacket.fromLocusAtom atom) hsourceMissing)
+
+/-- Packet update reflects tuple missing loci on `packetToTuple` images. -/
+theorem packetTransport_reflects_tupleMissingLocus
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    ∀ atom,
+      ProfileTupleIntegration.TupleTraceMissingLocus
+          (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)) atom ->
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          (SourceRefTupleBridge.packetToTuple gridSource packet) atom := by
+  intro atom hmissing
+  have htargetMissing :
+      CodebaseTracePacket.SourceRefMissingLocus (τ.map packet)
+        (CodebaseTracePacket.fromLocusAtom atom) :=
+    (SourceRefTupleBridge.sourceRefPacket_to_tuple_missingLocus
+      gridTarget (τ.map packet) atom).mp hmissing
+  exact (SourceRefTupleBridge.sourceRefPacket_to_tuple_missingLocus
+    gridSource packet atom).mpr
+    (hlaws.reflectsMissing packet
+      (CodebaseTracePacket.fromLocusAtom atom) htargetMissing)
+
+/--
+Packet update makes tuple missing-locus membership invariant on
+`packetToTuple` images.
+-/
+theorem packetTransport_tupleMissingLocus_iff
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket)
+    (atom : LocusAtom) :
+    ProfileTupleIntegration.TupleTraceMissingLocus
+        (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)) atom ↔
+      ProfileTupleIntegration.TupleTraceMissingLocus
+        (SourceRefTupleBridge.packetToTuple gridSource packet) atom := by
+  constructor
+  · exact packetTransport_reflects_tupleMissingLocus
+      gridSource gridTarget τ hlaws packet atom
+  · exact packetTransport_preserves_tupleMissingLocus
+      gridSource gridTarget τ hlaws packet atom
+
+/-- Packet update preserves tuple repair-frontier membership on induced tuples. -/
+theorem packetTransport_preserves_tupleRepairFrontier
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    ∀ atom,
+      (SourceRefTupleBridge.packetToTuple gridSource packet).repairFrontier atom ->
+        (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)).repairFrontier atom := by
+  intro atom hrepair
+  exact hlaws.preservesRepair packet
+    (CodebaseTracePacket.fromLocusAtom atom) hrepair
+
+/-- Packet update reflects tuple repair-frontier membership on induced tuples. -/
+theorem packetTransport_reflects_tupleRepairFrontier
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    ∀ atom,
+      (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)).repairFrontier atom ->
+        (SourceRefTupleBridge.packetToTuple gridSource packet).repairFrontier atom := by
+  intro atom hrepair
+  exact hlaws.reflectsRepair packet
+    (CodebaseTracePacket.fromLocusAtom atom) hrepair
+
+/-- Packet update preserves and reflects exact repair on induced tuples. -/
+theorem sourceRefPacketTransport_exactRepair_iff
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    ProfileTupleIntegration.TupleRepairFrontierExact
+        (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)) ↔
+      ProfileTupleIntegration.TupleRepairFrontierExact
+        (SourceRefTupleBridge.packetToTuple gridSource packet) := by
+  constructor
+  · intro hexactTarget atom
+    constructor
+    · intro hrepairSource
+      have hrepairTarget :=
+        packetTransport_preserves_tupleRepairFrontier
+          gridSource gridTarget τ hlaws packet atom hrepairSource
+      exact packetTransport_reflects_tupleMissingLocus
+        gridSource gridTarget τ hlaws packet atom
+        ((hexactTarget atom).mp hrepairTarget)
+    · intro hmissingSource
+      have hmissingTarget :=
+        packetTransport_preserves_tupleMissingLocus
+          gridSource gridTarget τ hlaws packet atom hmissingSource
+      exact packetTransport_reflects_tupleRepairFrontier
+        gridSource gridTarget τ hlaws packet atom
+        ((hexactTarget atom).mpr hmissingTarget)
+  · intro hexactSource atom
+    constructor
+    · intro hrepairTarget
+      have hrepairSource :=
+        packetTransport_reflects_tupleRepairFrontier
+          gridSource gridTarget τ hlaws packet atom hrepairTarget
+      exact packetTransport_preserves_tupleMissingLocus
+        gridSource gridTarget τ hlaws packet atom
+        ((hexactSource atom).mp hrepairSource)
+    · intro hmissingTarget
+      have hmissingSource :=
+        packetTransport_reflects_tupleMissingLocus
+          gridSource gridTarget τ hlaws packet atom hmissingTarget
+      exact packetTransport_preserves_tupleRepairFrontier
+        gridSource gridTarget τ hlaws packet atom
+        ((hexactSource atom).mpr hmissingSource)
+
+/-! ## Source-ref token identity and aligned tuples -/
+
+/-- Packet update preserves projected tuple trace fields on induced tuples. -/
+theorem packetTransport_preserves_tupleTraceField
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    ∀ atom,
+      (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)).traceField atom =
+        (SourceRefTupleBridge.packetToTuple gridSource packet).traceField atom := by
+  intro atom
+  change
+    CodebaseTracePacket.projectedTraceField (τ.map packet) atom =
+      CodebaseTracePacket.projectedTraceField packet atom
+  exact SourceRefTokenIdentityReflection.sourceRefTable_preserves_projectedTraceField
+    (τ.map packet) packet
+    (by
+      intro codeAtom
+      exact hlaws.preservesSourceRefTable packet codeAtom)
+    atom
+
+/--
+For aligned source and target tuples, source-ref table preservation by the
+packet update is equivalent to equality of tuple trace fields.
+-/
+theorem sourceRefPacketTransport_traceField_identity_iff
+    {profileSource profileTarget : TupleProfile}
+    {packet : CodebaseTracePacket.SourceRefPacket}
+    {sourceTuple : TupleCertificateAt profileSource}
+    {targetTuple : TupleCertificateAt profileTarget}
+    (τ : PacketUpdate)
+    (hsourceAligned :
+      SourceRefTupleBridge.PacketTupleAligned packet sourceTuple)
+    (htargetAligned :
+      SourceRefTupleBridge.PacketTupleAligned (τ.map packet) targetTuple) :
+    (∀ atom, targetTuple.traceField atom = sourceTuple.traceField atom) ↔
+      ∀ atom, (τ.map packet).sourceRefTable atom = packet.sourceRefTable atom := by
+  calc
+    (∀ atom, targetTuple.traceField atom = sourceTuple.traceField atom) ↔
+        ∀ atom, (τ.map packet).sourceRefTable atom = packet.sourceRefTable atom :=
+      SourceRefTokenIdentityReflection.aligned_tupleTraceField_eq_iff_sourceRefTable
+        htargetAligned hsourceAligned
+
+/--
+Cycle-17 theorem package: bidirectional source-ref packet update laws give
+missing-locus invariance, exact-repair invariance, and trace-field identity
+for packet-induced or aligned profile tuples.
+-/
+theorem sourceRefPacketTransport_exactness_package
+    {profileSource profileTarget : TupleProfile}
+    (gridSource : ProfileGridHolonomy.CertificateAt profileSource)
+    (gridTarget : ProfileGridHolonomy.CertificateAt profileTarget)
+    (τ : PacketUpdate)
+    (hlaws : BidirectionalSourceRefPacketTransport τ)
+    (packet : CodebaseTracePacket.SourceRefPacket) :
+    (∀ atom,
+      ProfileTupleIntegration.TupleTraceMissingLocus
+          (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)) atom ↔
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          (SourceRefTupleBridge.packetToTuple gridSource packet) atom) ∧
+      (ProfileTupleIntegration.TupleRepairFrontierExact
+          (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)) ↔
+        ProfileTupleIntegration.TupleRepairFrontierExact
+          (SourceRefTupleBridge.packetToTuple gridSource packet)) ∧
+      (∀ atom,
+        (SourceRefTupleBridge.packetToTuple gridTarget (τ.map packet)).traceField atom =
+          (SourceRefTupleBridge.packetToTuple gridSource packet).traceField atom) := by
+  exact ⟨packetTransport_tupleMissingLocus_iff
+      gridSource gridTarget τ hlaws packet,
+    sourceRefPacketTransport_exactRepair_iff
+      gridSource gridTarget τ hlaws packet,
+    packetTransport_preserves_tupleTraceField
+      gridSource gridTarget τ hlaws packet⟩
+
+end SourceRefPacketTransport
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-source-ref-packet-transport.md
+++ b/research/ideas/g-aat-quality-surface-01-source-ref-packet-transport.md
@@ -1,0 +1,124 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: traceability/certificate-transport/repair-potential/invariance
+expected_base_score: 45
+expected_evidence_multiplier: 2.0
+expected_final_score: 90
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle17
+tags:
+  - source-ref
+  - tuple-transport
+  - exact-repair
+created: 2026-06-20
+cycle: 17
+lean: proved
+---
+
+# Source-ref packet updates induce exact tuple transports
+
+## 主張
+
+supplied source-ref packet update が code support、source-ref missing locus、repair frontier、
+source-ref token identity を保存・反映するなら、`packetToTuple` の像または `PacketTupleAligned`
+な tuple に限定して、tuple missing locus、exact repair frontier、tuple trace field identity を
+保存・反映する。
+
+主張は finite supplied source-ref packets、明示的な packet update law、明示的な grid-certificate
+map、`packetToTuple` の像または明示的 alignment witness に相対化する。canonical global tuple
+transport、任意 tuple から source-ref packet への extractor、source extraction completeness、
+ArchMap correctness、実コード全体の traceability、全 profile change の exactness は主張しない。
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SourceRefTupleBridge.lean`
+- `Formal/AG/Research/QualitySurface/TupleTransportExactness.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefTokenIdentityReflection.lean`
+- `PacketTupleAligned`
+- `sourceRefPacket_to_tuple_exactRepair_iff`
+- `tupleTransport_exactRepair_iff_of_bidirectional`
+- `aligned_tupleTraceField_eq_iff_sourceRefTable`
+
+## 非自明性
+
+Cycle 13 は single packet-to-tuple alignment、Cycle 14 は tuple transport exactness、Cycle 16 は
+token identity reflection をそれぞれ固定した。この候補はそれらを、source-ref artifact の update
+law から profile-typed tuple transport law を誘導する theorem として合成する。
+
+単なる theorem chaining ではなく、packet update の保存・反映条件を明示し、`packetToTuple` 像または
+aligned tuple に限定して missing / repair / trace-field identity を保存・反映する theorem package として
+まとめる。
+
+## 数学的興味
+
+source-ref artifact contract の変化を、profile-typed certificate geometry の transport として読める。
+これは traceability と certificate-transport を結ぶ bridge であり、source-ref 層の law が tuple 側の
+exact repair invariance を十分条件として与える。
+
+## GOAL への前進
+
+traceability / certificate-transport / repair-potential を接続し、supplied source-ref artifact の update
+を Quality Surface の exact tuple transport として扱う能力を追加する。
+
+## SCORE 見込み
+
+- `score_reason`: G2-B/C は base 60 を認めたが、G2-A は全域 `TupleTransport` 主張を強すぎるとして revise。range-restricted / aligned theorem に修正し、base 45 / final 90 とする。
+- `dullness_risk`: medium-high。既存 iff theorem の連鎖だけなら 45 未満。packet transport structure、bidirectional source-ref laws、aligned/range-restricted theorem package まで必要。
+- `proof_or_evidence_plan`: `SourceRefPacketTransport.lean` に packet update、bidirectional packet laws、`packetToTuple` 像の missing/exact repair preservation-reflection、aligned tuple の trace field identity iff、theorem package を置く。全域 `TupleTransport` は主張しない。
+
+## CS / SWE への帰結
+
+ArchMap / observation artifact が source-ref table を更新する場合、その update が source-ref missing
+locus、repair frontier、token identity を保存・反映する範囲では、packet-induced / aligned profile tuple
+側の exact repair frontier と trace field identity も lossless に transport できる。これは artifact
+contract 内の十分条件であり、source extraction completeness ではない。
+
+## 証明・根拠の見込み
+
+Lean proof は `Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean` に閉じる。
+
+主要 theorem:
+
+- `PacketUpdate`
+- `BidirectionalSourceRefPacketTransport`
+- `packetTransport_preserves_tupleMissingLocus`
+- `packetTransport_reflects_tupleMissingLocus`
+- `packetTransport_tupleMissingLocus_iff`
+- `packetTransport_preserves_tupleRepairFrontier`
+- `packetTransport_reflects_tupleRepairFrontier`
+- `sourceRefPacketTransport_exactRepair_iff`
+- `packetTransport_preserves_tupleTraceField`
+- `sourceRefPacketTransport_traceField_identity_iff`
+- `sourceRefPacketTransport_exactness_package`
+
+## 審判メモ
+
+- 厳密性: G2-A は revise。全域 `TupleTransport` は任意 tuple から source-ref packet へ戻す構造がないため強すぎる。`packetToTuple` 像または `PacketTupleAligned` tuple に限定すること。
+- 研究価値: G2-B は accept、base 60。source-ref artifact update を exact tuple transport 条件へ送る価値を認めた。
+- repo 全体価値: G2-C は accept、base 60。ただし仮定が強すぎる自明化を避け、bounded artifact contract に閉じることを要求。
+
+## G3 監査
+
+- `lake env lean Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean` pass。
+- `lake build FormalAGResearch` pass。
+- `lake env lean .tmp/source_ref_packet_transport_axioms.lean` pass。
+- reported declaration はすべて `does not depend on any axioms`。
+- local scan で `axiom` / `admit` / `sorry` / `unsafe`、不可視 Unicode、local path は no matches。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-tuple-bridge.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-token-identity-reflection.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 17 candidate card 作成。
+- 2026-06-20: G2-A revise を反映し、全域 `TupleTransport` 主張を避けて base 45 / final 90 に下げた。
+- 2026-06-20: `SourceRefPacketTransport.lean` added and verified.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2040
+- total SCORE: 2130
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -22,8 +22,9 @@
   - certificate-transport / invariance / repair-potential / traceability: 90
   - profile-curvature / atom-supported-quality-geometry / repair-potential / invariance: 80
   - traceability / invariance / atom-supported-quality-geometry: 90
+  - traceability / certificate-transport / repair-potential / invariance: 90
 - evidence portfolio:
-  - proved-in-research: 16
+  - proved-in-research: 17
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -664,6 +665,51 @@ global source-reference namespace injectivity、実コード全体の traceabili
 
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 16 後の total SCORE は 2040 である。
+## Cycle 17: Source-ref packet updates induce exact tuple transports
+
+```text
+candidate: Source-ref packet updates induce exact tuple transports
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 45
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 90
+category: traceability/certificate-transport/repair-potential/invariance
+goal_delta: Cycle 13 の packet-to-tuple bridge、Cycle 14 の tuple transport exactness、Cycle 16 の token identity reflection を、source-ref packet update law から packet-induced / aligned tuple transport exactness へ統合した。
+project_value_delta: supplied source-ref artifact update が missing locus、repair frontier、source-ref table identity を保存・反映する範囲で、packet-induced tuple の missing locus、exact repair、trace-field identity が lossless に運ばれることを固定した。
+formalization_quality: pass。`PacketUpdate`、`BidirectionalSourceRefPacketTransport`、packet-induced tuple missing-locus preservation/reflection、exact repair iff、aligned tuple trace-field identity iff、theorem package が axiom-free / sorry-free で証明されている。全域 `TupleTransport` は主張しない。
+open_questions: grid-level flatness / holonomy criterion、lossy tuple transport obstruction、tuple protected data finite-square criterion instance、source-ref exactness detects lossy packet-to-tuple visualization。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean` は、
+source-ref packet update を明示的な `PacketUpdate` として置く。更新 law は code support、
+source-ref missing locus、repair frontier、source-ref table identity の保存・反映を bundled
+`BidirectionalSourceRefPacketTransport` として持つ。
+
+Lean 証拠は次を固定する。
+
+- `PacketUpdate`: supplied source-ref packet update。
+- `BidirectionalSourceRefPacketTransport`: support / missing / repair / source-ref table identity の保存・反映 law。
+- `packetTransport_preserves_tupleMissingLocus`: packet update は `packetToTuple` 像の tuple missing locus を保存する。
+- `packetTransport_reflects_tupleMissingLocus`: packet update は `packetToTuple` 像の tuple missing locus を反映する。
+- `packetTransport_tupleMissingLocus_iff`: `packetToTuple` 像で missing locus membership は不変である。
+- `packetTransport_preserves_tupleRepairFrontier`: packet update は induced tuple repair frontier を保存する。
+- `packetTransport_reflects_tupleRepairFrontier`: packet update は induced tuple repair frontier を反映する。
+- `sourceRefPacketTransport_exactRepair_iff`: packet-induced tuples で exact repair frontier は同値である。
+- `packetTransport_preserves_tupleTraceField`: source-ref table identity preservation は induced tuple trace field を保存する。
+- `sourceRefPacketTransport_traceField_identity_iff`: aligned tuple witness の下で、tuple trace-field equality は source-ref table identity と同値である。
+- `sourceRefPacketTransport_exactness_package`: missing-locus invariance、exact-repair invariance、trace-field identity をまとめる theorem package。
+
+この結果により、source-ref artifact の bounded update law は、packet-induced / aligned profile tuple の
+exact transport law として読める。主張は supplied packets、explicit update law、`packetToTuple` の像、
+`PacketTupleAligned` witness に相対化され、canonical global `TupleTransport`、tuple-to-packet extractor、
+source extraction completeness、ArchMap correctness、全 profile change の exactness は結論しない。
+
+### Next Frontier
+
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 17 後の total SCORE は 2130 である。
 次に進める場合は、grid-level flatness / holonomy criterion、lossy tuple transport obstruction、
-tuple protected data finite-square criterion instance、または source-ref packet updates induced exact tuple transports を狙う。
+tuple protected data finite-square criterion instance、または source-ref exactness detects lossy packet-to-tuple visualization を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 Cycle 17 として、source-ref packet update から packet-induced / aligned profile tuple の exact transport 条件を導く Lean evidence を追加します。

G2-A の revise に従い、全域 `TupleTransport` は主張しません。主張は supplied packets、明示的な `PacketUpdate` law、`packetToTuple` の像、`PacketTupleAligned` witness に限定しています。

確定 SCORE:

```text
candidate: Source-ref packet updates induce exact tuple transports
candidate_type: bridge
base_score: 45
evidence_multiplier: 2.0
penalty: 0
final_score: 90
total_score_after_merge: 2130 / 5000
```

## 証明した定理

- `PacketUpdate`
- `BidirectionalSourceRefPacketTransport`
- `packetTransport_preserves_tupleMissingLocus`
- `packetTransport_reflects_tupleMissingLocus`
- `packetTransport_tupleMissingLocus_iff`
- `packetTransport_preserves_tupleRepairFrontier`
- `packetTransport_reflects_tupleRepairFrontier`
- `sourceRefPacketTransport_exactRepair_iff`
- `packetTransport_preserves_tupleTraceField`
- `sourceRefPacketTransport_traceField_identity_iff`
- `sourceRefPacketTransport_exactness_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-source-ref-packet-transport.md`
- `research/reports/G-aat-quality-surface-01.md`

保護対象の数学本文、`docs/note`、`research/GOALS.md` は編集していません。

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SourceRefPacketTransport.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/source_ref_packet_transport_axioms.lean`
- [x] `lake build`（既存の `Formal/Arch/Extension/FeatureExtensionExamples.lean:201,207` linter warning のみ）
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [x] local/private path scan

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（tracking Issue のため `Closes` しない）
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
