### PR TITLE
研究ループ Cycle 19 の tuple transport component laws を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -17,3 +17,4 @@ import Formal.AG.Research.QualitySurface.SupportAntichainSquareCriterion
 import Formal.AG.Research.QualitySurface.SourceRefTokenIdentityReflection
 import Formal.AG.Research.QualitySurface.SourceRefPacketTransport
 import Formal.AG.Research.QualitySurface.TupleProtectedDataSquareCriterion
+import Formal.AG.Research.QualitySurface.TupleTransportComponentLaws

--- a/Formal/AG/Research/QualitySurface/TupleTransportComponentLaws.lean
+++ b/Formal/AG/Research/QualitySurface/TupleTransportComponentLaws.lean
@@ -1,0 +1,547 @@
+import Formal.AG.Research.QualitySurface.TupleTransportExactness
+
+/-!
+Cycle 19 evidence for `G-aat-quality-surface-01`.
+
+This file gives finite independence witnesses for tuple-transport component
+laws. The witnesses are relative to supplied finite tuple transports. They do
+not assert a global minimality classification, canonical tuple transport,
+source extraction completeness, ArchMap correctness, or whole-codebase
+traceability.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace TupleTransportComponentLaws
+
+open TraceLocus
+open StateSeparation
+open TupleTransportExactness
+
+abbrev EndpointTuple :=
+  ProfileTupleIntegration.TupleCertificateAt
+    ProfileTupleIntegration.endpointProfile
+
+/-! ## Readings preserved by the finite witnesses -/
+
+/-- Same scalar and verdict, without selected-support equality. -/
+def SameTupleScalarVerdict (left right : EndpointTuple) : Prop :=
+  left.sigma = right.sigma ∧ left.nu = right.nu
+
+/-- A transport preserves the full visible tuple surface. -/
+def PreservesVisibleTupleSurface
+    (τ : TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile) : Prop :=
+  ∀ c, ProfileTupleIntegration.SameTupleVisibleSurface c (τ.map c)
+
+/-- A transport preserves only scalar and verdict. -/
+def PreservesScalarVerdict
+    (τ : TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile) : Prop :=
+  ∀ c, SameTupleScalarVerdict c (τ.map c)
+
+/-! ## Component-editing transports -/
+
+/-- Erase the database trace token while leaving the other atoms unchanged. -/
+def eraseDatabaseTrace
+    (field : LocusAtom -> Option LocusTraceToken) :
+    LocusAtom -> Option LocusTraceToken
+  | LocusAtom.api => field LocusAtom.api
+  | LocusAtom.database => none
+  | LocusAtom.queue => field LocusAtom.queue
+
+/-- Fill the database trace token while leaving the other atoms unchanged. -/
+def fillDatabaseTrace
+    (field : LocusAtom -> Option LocusTraceToken) :
+    LocusAtom -> Option LocusTraceToken
+  | LocusAtom.api => field LocusAtom.api
+  | LocusAtom.database => some LocusTraceToken.refDatabase
+  | LocusAtom.queue => field LocusAtom.queue
+
+/-- Transport that creates an extra missing trace at the database atom. -/
+def traceErasingTransport :
+    TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile where
+  map := fun c =>
+    { gridCertificate := c.gridCertificate
+      sigma := c.sigma
+      omega := c.omega
+      selectedSupport := c.selectedSupport
+      repairFrontier := c.repairFrontier
+      nu := c.nu
+      traceField := eraseDatabaseTrace c.traceField }
+
+/-- Transport that fills a missing database trace token. -/
+def traceCreatingTransport :
+    TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile where
+  map := fun c =>
+    { gridCertificate := c.gridCertificate
+      sigma := c.sigma
+      omega := c.omega
+      selectedSupport := c.selectedSupport
+      repairFrontier := c.repairFrontier
+      nu := c.nu
+      traceField := fillDatabaseTrace c.traceField }
+
+/-- Transport that removes every repair frontier atom. -/
+def repairErasingTransport :
+    TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile where
+  map := fun c =>
+    { gridCertificate := c.gridCertificate
+      sigma := c.sigma
+      omega := c.omega
+      selectedSupport := c.selectedSupport
+      repairFrontier := fun _ => False
+      nu := c.nu
+      traceField := c.traceField }
+
+/-- Transport that adds the database atom to the repair frontier. -/
+def repairCreatingTransport :
+    TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile where
+  map := fun c =>
+    { gridCertificate := c.gridCertificate
+      sigma := c.sigma
+      omega := c.omega
+      selectedSupport := c.selectedSupport
+      repairFrontier := fun atom =>
+        c.repairFrontier atom ∨ atom = LocusAtom.database
+      nu := c.nu
+      traceField := c.traceField }
+
+/-- Transport that drops the selected support entirely. -/
+def supportDroppingTransport :
+    TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile where
+  map := fun c =>
+    { gridCertificate := c.gridCertificate
+      sigma := c.sigma
+      omega := c.omega
+      selectedSupport := fun _ => False
+      repairFrontier := c.repairFrontier
+      nu := c.nu
+      traceField := c.traceField }
+
+/-- Transport that expands the selected support to every finite locus atom. -/
+def supportExpandingTransport :
+    TupleTransport
+      ProfileTupleIntegration.endpointProfile
+      ProfileTupleIntegration.endpointProfile where
+  map := fun c =>
+    { gridCertificate := c.gridCertificate
+      sigma := c.sigma
+      omega := c.omega
+      selectedSupport := fun _ => True
+      repairFrontier := c.repairFrontier
+      nu := c.nu
+      traceField := c.traceField }
+
+/-- Endpoint tuple with empty support and a partial trace field. -/
+def emptySupportPartialEndpointTuple : EndpointTuple where
+  gridCertificate := ProfileGridHolonomy.coverFirstPath
+    ProfileGridHolonomy.seedAt
+  sigma := 4
+  omega := ObligationKind.none
+  selectedSupport := fun _ => False
+  repairFrontier := fun _ => False
+  nu := StateVerdict.acceptable
+  traceField := partialTraceField
+
+/-! ## Positive component laws retained by the witnesses -/
+
+theorem traceErasing_preserves_visibleTupleSurface :
+    PreservesVisibleTupleSurface traceErasingTransport := by
+  intro c
+  exact ⟨rfl, rfl, by
+    intro atom
+    rfl⟩
+
+theorem traceCreating_preserves_visibleTupleSurface :
+    PreservesVisibleTupleSurface traceCreatingTransport := by
+  intro c
+  exact ⟨rfl, rfl, by
+    intro atom
+    rfl⟩
+
+theorem repairErasing_preserves_visibleTupleSurface :
+    PreservesVisibleTupleSurface repairErasingTransport := by
+  intro c
+  exact ⟨rfl, rfl, by
+    intro atom
+    rfl⟩
+
+theorem repairCreating_preserves_visibleTupleSurface :
+    PreservesVisibleTupleSurface repairCreatingTransport := by
+  intro c
+  exact ⟨rfl, rfl, by
+    intro atom
+    rfl⟩
+
+theorem supportDropping_preserves_scalarVerdict :
+    PreservesScalarVerdict supportDroppingTransport := by
+  intro c
+  exact ⟨rfl, rfl⟩
+
+theorem supportExpanding_preserves_scalarVerdict :
+    PreservesScalarVerdict supportExpandingTransport := by
+  intro c
+  exact ⟨rfl, rfl⟩
+
+theorem traceErasing_support_laws :
+    PreservesTupleSupport traceErasingTransport ∧
+      ReflectsTupleSupport traceErasingTransport := by
+  exact ⟨by
+    intro c atom hsupport
+    exact hsupport,
+    by
+      intro c atom hsupport
+      exact hsupport⟩
+
+theorem traceCreating_support_laws :
+    PreservesTupleSupport traceCreatingTransport ∧
+      ReflectsTupleSupport traceCreatingTransport := by
+  exact ⟨by
+    intro c atom hsupport
+    exact hsupport,
+    by
+      intro c atom hsupport
+      exact hsupport⟩
+
+theorem repairErasing_support_laws :
+    PreservesTupleSupport repairErasingTransport ∧
+      ReflectsTupleSupport repairErasingTransport := by
+  exact ⟨by
+    intro c atom hsupport
+    exact hsupport,
+    by
+      intro c atom hsupport
+      exact hsupport⟩
+
+theorem repairCreating_support_laws :
+    PreservesTupleSupport repairCreatingTransport ∧
+      ReflectsTupleSupport repairCreatingTransport := by
+  exact ⟨by
+    intro c atom hsupport
+    exact hsupport,
+    by
+      intro c atom hsupport
+      exact hsupport⟩
+
+theorem traceErasing_preserves_traceNone :
+    PreservesTupleTraceNone traceErasingTransport := by
+  intro c atom htrace
+  cases atom with
+  | api => exact htrace
+  | database => rfl
+  | queue => exact htrace
+
+theorem traceCreating_reflects_traceNone :
+    ReflectsTupleTraceNone traceCreatingTransport := by
+  intro c atom htrace
+  cases atom with
+  | api => exact htrace
+  | database => cases htrace
+  | queue => exact htrace
+
+theorem repairErasing_trace_laws :
+    PreservesTupleTraceNone repairErasingTransport ∧
+      ReflectsTupleTraceNone repairErasingTransport := by
+  exact ⟨by
+    intro c atom htrace
+    exact htrace,
+    by
+      intro c atom htrace
+      exact htrace⟩
+
+theorem repairCreating_trace_laws :
+    PreservesTupleTraceNone repairCreatingTransport ∧
+      ReflectsTupleTraceNone repairCreatingTransport := by
+  exact ⟨by
+    intro c atom htrace
+    exact htrace,
+    by
+      intro c atom htrace
+      exact htrace⟩
+
+theorem supportDropping_trace_laws :
+    PreservesTupleTraceNone supportDroppingTransport ∧
+      ReflectsTupleTraceNone supportDroppingTransport := by
+  exact ⟨by
+    intro c atom htrace
+    exact htrace,
+    by
+      intro c atom htrace
+      exact htrace⟩
+
+theorem supportExpanding_trace_laws :
+    PreservesTupleTraceNone supportExpandingTransport ∧
+      ReflectsTupleTraceNone supportExpandingTransport := by
+  exact ⟨by
+    intro c atom htrace
+    exact htrace,
+    by
+      intro c atom htrace
+      exact htrace⟩
+
+theorem traceErasing_repair_laws :
+    PreservesTupleRepairFrontier traceErasingTransport ∧
+      ReflectsTupleRepairFrontier traceErasingTransport := by
+  exact ⟨by
+    intro c atom hrepair
+    exact hrepair,
+    by
+      intro c atom hrepair
+      exact hrepair⟩
+
+theorem traceCreating_repair_laws :
+    PreservesTupleRepairFrontier traceCreatingTransport ∧
+      ReflectsTupleRepairFrontier traceCreatingTransport := by
+  exact ⟨by
+    intro c atom hrepair
+    exact hrepair,
+    by
+      intro c atom hrepair
+      exact hrepair⟩
+
+theorem repairErasing_reflects_repairFrontier :
+    ReflectsTupleRepairFrontier repairErasingTransport := by
+  intro c atom hrepair
+  exact False.elim hrepair
+
+theorem repairCreating_preserves_repairFrontier :
+    PreservesTupleRepairFrontier repairCreatingTransport := by
+  intro c atom hrepair
+  exact Or.inl hrepair
+
+theorem supportDropping_repair_laws :
+    PreservesTupleRepairFrontier supportDroppingTransport ∧
+      ReflectsTupleRepairFrontier supportDroppingTransport := by
+  exact ⟨by
+    intro c atom hrepair
+    exact hrepair,
+    by
+      intro c atom hrepair
+      exact hrepair⟩
+
+theorem supportExpanding_repair_laws :
+    PreservesTupleRepairFrontier supportExpandingTransport ∧
+      ReflectsTupleRepairFrontier supportExpandingTransport := by
+  exact ⟨by
+    intro c atom hrepair
+    exact hrepair,
+    by
+      intro c atom hrepair
+      exact hrepair⟩
+
+theorem supportDropping_reflects_support :
+    ReflectsTupleSupport supportDroppingTransport := by
+  intro c atom hsupport
+  exact False.elim hsupport
+
+theorem supportExpanding_preserves_support :
+    PreservesTupleSupport supportExpandingTransport := by
+  intro c atom _hsupport
+  trivial
+
+/-! ## Component-law failures and exactness obstructions -/
+
+theorem traceNoneReflection_failure_obstructs_missingLocus_reflection :
+    ¬ ReflectsTupleTraceNone traceErasingTransport ∧
+      ¬ ReflectsTupleTraceMissingLocus traceErasingTransport := by
+  constructor
+  · intro hreflect
+    have htarget :
+        (traceErasingTransport.map
+          ProfileTupleIntegration.fullEndpointTuple).traceField
+          LocusAtom.database = none :=
+      rfl
+    have hsource :=
+      hreflect ProfileTupleIntegration.fullEndpointTuple
+        LocusAtom.database htarget
+    cases hsource
+  · intro hreflect
+    have htarget :
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          (traceErasingTransport.map
+            ProfileTupleIntegration.fullEndpointTuple)
+          LocusAtom.database :=
+      ⟨trivial, rfl⟩
+    have hsource :=
+      hreflect ProfileTupleIntegration.fullEndpointTuple
+        LocusAtom.database htarget
+    exact ProfileTupleIntegration.fullEndpoint_has_no_missing_locus
+      ⟨LocusAtom.database, hsource⟩
+
+theorem traceNonePreservation_failure_obstructs_missingLocus_preservation :
+    ¬ PreservesTupleTraceNone traceCreatingTransport ∧
+      ¬ PreservesTupleTraceMissingLocus traceCreatingTransport := by
+  constructor
+  · intro hpreserve
+    have htarget :=
+      hpreserve ProfileTupleIntegration.traceMissingEndpointTuple
+        LocusAtom.database rfl
+    cases htarget
+  · intro hpreserve
+    have hsource :
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          ProfileTupleIntegration.traceMissingEndpointTuple
+          LocusAtom.database :=
+      ProfileTupleIntegration.traceMissingEndpoint_database_missing_locus
+    have htarget :=
+      hpreserve ProfileTupleIntegration.traceMissingEndpointTuple
+        LocusAtom.database hsource
+    cases htarget.2
+
+theorem repairPreservation_failure_obstructs_exactRepair_preservation :
+    ¬ PreservesTupleRepairFrontier repairErasingTransport ∧
+      ¬ (∀ c : EndpointTuple,
+        ProfileTupleIntegration.TupleRepairFrontierExact c ->
+          ProfileTupleIntegration.TupleRepairFrontierExact
+            (repairErasingTransport.map c)) := by
+  constructor
+  · intro hpreserve
+    have htarget :=
+      hpreserve ProfileTupleIntegration.traceMissingEndpointTuple
+        LocusAtom.database
+        ProfileTupleIntegration.traceMissingEndpoint_forces_database_repair
+    exact htarget
+  · intro hpreserveExact
+    have htargetExact :=
+      hpreserveExact ProfileTupleIntegration.traceMissingEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpoint_repairFrontierExact
+    have hrepair :=
+      (htargetExact LocusAtom.database).mpr
+        ProfileTupleIntegration.traceMissingEndpoint_database_missing_locus
+    exact hrepair
+
+theorem repairReflection_failure_obstructs_exactRepair_preservation :
+    ¬ ReflectsTupleRepairFrontier repairCreatingTransport ∧
+      ¬ (∀ c : EndpointTuple,
+        ProfileTupleIntegration.TupleRepairFrontierExact c ->
+          ProfileTupleIntegration.TupleRepairFrontierExact
+            (repairCreatingTransport.map c)) := by
+  constructor
+  · intro hreflect
+    have hsource :=
+      hreflect ProfileTupleIntegration.fullEndpointTuple
+        LocusAtom.database (Or.inr rfl)
+    exact ProfileTupleIntegration.fullEndpoint_no_database_repair hsource
+  · intro hpreserveExact
+    have htargetExact :=
+      hpreserveExact ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.fullEndpoint_repairFrontierExact
+    have hmissingTarget :
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          (repairCreatingTransport.map ProfileTupleIntegration.fullEndpointTuple)
+          LocusAtom.database :=
+      (htargetExact LocusAtom.database).mp (Or.inr rfl)
+    cases hmissingTarget.2
+
+theorem supportPreservation_failure_obstructs_missingLocus_preservation :
+    ¬ PreservesTupleSupport supportDroppingTransport ∧
+      ¬ PreservesTupleTraceMissingLocus supportDroppingTransport := by
+  constructor
+  · intro hpreserve
+    have htarget :=
+      hpreserve ProfileTupleIntegration.fullEndpointTuple
+        LocusAtom.database trivial
+    exact htarget
+  · intro hpreserve
+    have htarget :=
+      hpreserve ProfileTupleIntegration.traceMissingEndpointTuple
+        LocusAtom.database
+        ProfileTupleIntegration.traceMissingEndpoint_database_missing_locus
+    exact htarget.1
+
+theorem emptySupportPartial_repairFrontierExact :
+    ProfileTupleIntegration.TupleRepairFrontierExact
+      emptySupportPartialEndpointTuple := by
+  intro atom
+  constructor
+  · intro hrepair
+    exact False.elim hrepair
+  · intro hmissing
+    exact False.elim hmissing.1
+
+theorem supportReflection_failure_obstructs_missingLocus_reflection :
+    ¬ ReflectsTupleSupport supportExpandingTransport ∧
+      ¬ ReflectsTupleTraceMissingLocus supportExpandingTransport := by
+  constructor
+  · intro hreflect
+    have hsource :=
+      hreflect emptySupportPartialEndpointTuple
+        LocusAtom.database trivial
+    exact hsource
+  · intro hreflectMissing
+    have htarget :
+        ProfileTupleIntegration.TupleTraceMissingLocus
+          (supportExpandingTransport.map emptySupportPartialEndpointTuple)
+          LocusAtom.database :=
+      ⟨trivial, rfl⟩
+    have hsource :=
+      hreflectMissing emptySupportPartialEndpointTuple
+        LocusAtom.database htarget
+    exact hsource.1
+
+/--
+Cycle-19 package: finite component-law failures are witnessed by supplied tuple
+transports. Trace and repair witnesses preserve the full visible tuple surface;
+support witnesses preserve only scalar/verdict because selected support is the
+law being varied.
+-/
+theorem tupleTransport_componentLaws_independence_package :
+    PreservesVisibleTupleSurface traceErasingTransport ∧
+      PreservesVisibleTupleSurface traceCreatingTransport ∧
+      PreservesVisibleTupleSurface repairErasingTransport ∧
+      PreservesVisibleTupleSurface repairCreatingTransport ∧
+      PreservesScalarVerdict supportDroppingTransport ∧
+      PreservesScalarVerdict supportExpandingTransport ∧
+      ¬ ReflectsTupleTraceNone traceErasingTransport ∧
+      ¬ ReflectsTupleTraceMissingLocus traceErasingTransport ∧
+      ¬ PreservesTupleTraceNone traceCreatingTransport ∧
+      ¬ PreservesTupleTraceMissingLocus traceCreatingTransport ∧
+      ¬ PreservesTupleRepairFrontier repairErasingTransport ∧
+      ¬ (∀ c : EndpointTuple,
+        ProfileTupleIntegration.TupleRepairFrontierExact c ->
+          ProfileTupleIntegration.TupleRepairFrontierExact
+            (repairErasingTransport.map c)) ∧
+      ¬ ReflectsTupleRepairFrontier repairCreatingTransport ∧
+      ¬ (∀ c : EndpointTuple,
+        ProfileTupleIntegration.TupleRepairFrontierExact c ->
+          ProfileTupleIntegration.TupleRepairFrontierExact
+            (repairCreatingTransport.map c)) ∧
+      ¬ PreservesTupleSupport supportDroppingTransport ∧
+      ¬ PreservesTupleTraceMissingLocus supportDroppingTransport ∧
+      ¬ ReflectsTupleSupport supportExpandingTransport ∧
+      ¬ ReflectsTupleTraceMissingLocus supportExpandingTransport := by
+  exact ⟨traceErasing_preserves_visibleTupleSurface,
+    traceCreating_preserves_visibleTupleSurface,
+    repairErasing_preserves_visibleTupleSurface,
+    repairCreating_preserves_visibleTupleSurface,
+    supportDropping_preserves_scalarVerdict,
+    supportExpanding_preserves_scalarVerdict,
+    traceNoneReflection_failure_obstructs_missingLocus_reflection.1,
+    traceNoneReflection_failure_obstructs_missingLocus_reflection.2,
+    traceNonePreservation_failure_obstructs_missingLocus_preservation.1,
+    traceNonePreservation_failure_obstructs_missingLocus_preservation.2,
+    repairPreservation_failure_obstructs_exactRepair_preservation.1,
+    repairPreservation_failure_obstructs_exactRepair_preservation.2,
+    repairReflection_failure_obstructs_exactRepair_preservation.1,
+    repairReflection_failure_obstructs_exactRepair_preservation.2,
+    supportPreservation_failure_obstructs_missingLocus_preservation.1,
+    supportPreservation_failure_obstructs_missingLocus_preservation.2,
+    supportReflection_failure_obstructs_missingLocus_reflection.1,
+    supportReflection_failure_obstructs_missingLocus_reflection.2⟩
+
+end TupleTransportComponentLaws
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-minimal-component-laws-lossless-tuple-transport.md
+++ b/research/ideas/g-aat-quality-surface-01-minimal-component-laws-lossless-tuple-transport.md
@@ -1,0 +1,149 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: orientation
+capability_category: certificate-transport/obstruction/invariance/repair-potential/traceability
+expected_base_score: 55
+expected_evidence_multiplier: 2.0
+expected_final_score: 110
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle19
+tags:
+  - tuple-transport
+  - component-laws
+  - obstruction
+created: 2026-06-20
+cycle: 19
+lean: proved
+---
+
+# Finite component-law independence witnesses for tuple transport
+
+## 主張
+
+Cycle 14 の `BidirectionalTupleTransport` は、tuple missing locus と exact repair frontier を
+lossless に運ぶための十分条件を与えた。この候補では逆向きに、support / trace-none /
+repair-frontier の保存・反映 law を component-wise に落とすと、missing locus または exact repair
+frontier が壊れる finite transport witness が存在することを示す。
+
+trace-none と repair-frontier の failure witnesses は selected support を保ち、Cycle 11 の
+visible tuple surface `(sigma, nu, selectedSupport)` を保つ。support preservation / reflection の
+failure witnesses は selected support 自体を変えるため、visible surface preserving とは呼ばず、
+より弱い scalar / verdict visible reading の下での support-law independence として分けて扱う。
+
+主張は supplied finite tuple transports と finite witnesses に相対化する。任意 transport に対する
+完全な必要十分分類、global minimality theorem、canonical global tuple transport、任意 profile
+change の exactness、source extraction completeness、ArchMap correctness、実コード全体の
+traceability は結論しない。
+
+## 候補種別
+
+`orientation`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/TupleTransportExactness.lean`
+- `Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean`
+- `tupleTransport_preserves_traceMissingLocus`
+- `tupleTransport_reflects_traceMissingLocus`
+- `tupleTransport_exactRepair_iff_of_bidirectional`
+- `lawFirstTupleTransport_lossless_boundary`
+
+## 非自明性
+
+Cycle 14 は component laws があれば exact repair frontier が不変になることを証明したが、
+どの law failure がどの protected exactness failure を生むかは未整理だった。この候補は十分条件を、
+有限反例群による obstruction calculus へ鋭くする。
+
+単なる既存 theorem の対偶ではなく、trace erasure、trace creation、repair erasure、repair creation、
+support loss / support expansion の具体 transport witness を分けて、各 component law の欠落が
+missing locus または exact repair frontier の lossless transport を壊すことを固定する。ただし
+support witness は visible tuple surface preserving claim から外す。
+
+## 数学的興味
+
+comparison map の exactness は「強い仮定を置けば保たれる」というだけではなく、どの component law を
+落とすと何が壊れるかという obstruction profile を持つ。これは quality certificate transport の
+境界を測るための最小反例 calculus になる。
+
+## GOAL への前進
+
+certificate-transport / obstruction / invariance / repair-potential を接続し、lossy tuple transport の
+失敗様式を finite witness として分類する。
+
+## SCORE 見込み
+
+- `score_reason`: G2-A/C は `minimal` と visible-preserving support-law claim を強すぎるとして revise。finite independence witnesses に絞り、base 55 / final 110 に下げる。
+- `dullness_risk`: medium。単なる theorem package 再掲ではなく、各 component law failure の witness と exactness failure の対応を明示する必要がある。
+- `proof_or_evidence_plan`: `TupleTransportComponentLaws.lean` に lossy transport witnesses と law-failure theorem を置いた。trace/repair witnesses では visible tuple surface preservation を示し、support witnesses では scalar/verdict-only preservation に限定した。最終 package は global minimality ではなく finite independence witness package とする。
+
+## CS / SWE への帰結
+
+quality tuple transport の UI / report が visible tuple surface を保っていても、support、trace-none、
+repair frontier の保存・反映 law を落とすと trace / repair exactness は壊れる。これは supplied finite
+transport 内の数学的 obstruction であり、実コード全体や tooling completeness の claim ではない。
+
+## 証明・根拠の見込み
+
+Lean proof は `Formal/AG/Research/QualitySurface/TupleTransportComponentLaws.lean` に閉じる。
+
+主要 theorem / declaration:
+
+- `SameTupleScalarVerdict`
+- `traceErasingTransport`
+- `traceCreatingTransport`
+- `repairErasingTransport`
+- `repairCreatingTransport`
+- `supportDroppingTransport`
+- `supportExpandingTransport`
+- `traceErasing_preserves_visibleTupleSurface`
+- `traceCreating_preserves_visibleTupleSurface`
+- `repairErasing_preserves_visibleTupleSurface`
+- `repairCreating_preserves_visibleTupleSurface`
+- `supportDropping_preserves_scalarVerdict`
+- `supportExpanding_preserves_scalarVerdict`
+- `traceNonePreservation_failure_obstructs_missingLocus_preservation`
+- `traceNoneReflection_failure_obstructs_missingLocus_reflection`
+- `repairPreservation_failure_obstructs_exactRepair_preservation`
+- `repairReflection_failure_obstructs_exactRepair_preservation`
+- `supportPreservation_failure_obstructs_missingLocus_preservation`
+- `supportReflection_failure_obstructs_missingLocus_reflection`
+- `tupleTransport_componentLaws_independence_package`
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/TupleTransportComponentLaws.lean` pass。
+- `lake build FormalAGResearch` pass。
+- `lake env lean .tmp/tuple_transport_component_laws_axioms.lean` pass。
+- reported declaration はすべて `does not depend on any axioms`。
+- changed-file scan で hidden / bidirectional Unicode と local path は no matches。
+
+## 審判メモ
+
+- 厳密性: G2-A は revise、base 55。`SameTupleVisibleSurface` は support を含むため、support-dropping / support-expanding を visible-preserving と呼ぶ claim は不整合。support cases は scalar/verdict-only reading へ分離し、global minimality は主張しないこと。
+- 研究価値: G2-B は accept、base 70。Cycle 14 の十分条件を obstruction calculus へ反転する価値を認めるが、component-law independence と visible-surface preservation の明示を要求。
+- repo 全体価値: G2-C は revise、base 65。repo 全体価値は高いが、`Minimal component laws` は完全最小性分類に読めるため、finite independence witness に絞ること。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-tuple-transport-exactness.md`
+- `research/ideas/g-aat-quality-surface-01-tuple-protected-data-square-criterion.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## G2 revise log
+
+- G2-A: 初回 revise、base 55。support-law cases を full visible tuple surface preserving と呼ぶ不整合と global minimality overclaim を指摘。修正後 accept、base 55。
+- G2-B: accept、base 70。Cycle 14 の十分条件を obstruction calculus へ反転する研究価値を認めた。
+- G2-C: 初回 revise、base 65。`Minimal component laws` は完全最小性分類に読めるため、finite independence witnesses に絞ることを要求。修正後 accept、base 55。
+
+## G3 監査
+
+- `TupleTransportComponentLaws.lean` は trace/repair witnesses の visible tuple surface preservation、support witnesses の scalar/verdict preservation、各 component-law failure と missing-locus / exact-repair failure を証明する。
+- G3 axiom audit: pass。target Lean、`FormalAGResearch`、axiom harness は pass。reported declaration はすべて axiom-free。
+- G3 formalization quality audit: pass。finite supplied witnesses、trace/repair visible-surface preservation、support scalar/verdict-only preservation、global minimality を主張しない境界が Lean statement に反映されている。
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 19 candidate card 作成。
+- 2026-06-20: G2-A/C revise を反映し、global minimality claim を外して finite independence witnesses に絞り、support-law cases を scalar/verdict-only reading へ分離した。
+- 2026-06-20: `TupleTransportComponentLaws.lean` added and verified locally.

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2210
+- total SCORE: 2320
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -24,8 +24,9 @@
   - traceability / invariance / atom-supported-quality-geometry: 90
   - traceability / certificate-transport / repair-potential / invariance: 90
   - quality-surface / profile-curvature / certificate-transport / traceability / repair-potential: 80
+  - certificate-transport / obstruction / invariance / repair-potential / traceability: 110
 - evidence portfolio:
-  - proved-in-research: 18
+  - proved-in-research: 19
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -755,8 +756,56 @@ Lean 証拠は次を固定する。
 相対化され、canonical global tuple transport、任意 profile grid の flatness、source extraction completeness、
 ArchMap correctness、実コード全体の traceability、全 repair semantics は結論しない。
 
+## Cycle 19: Finite component-law independence witnesses for tuple transport
+
+```text
+candidate: Finite component-law independence witnesses for tuple transport
+candidate_type: orientation
+evidence_stage: proved-in-research
+base_score: 55
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 110
+category: certificate-transport/obstruction/invariance/repair-potential/traceability
+goal_delta: Cycle 14 の十分条件を逆向きの有限 obstruction witness 群へ変換し、support / trace-none / repair-frontier component law の欠落が missing locus または exact repair frontier を壊すことを固定した。
+project_value_delta: Research / Lean / paper seed に lossless tuple transport の境界を説明する finite obstruction calculus を追加した。global minimality、任意 transport 分類、tooling / source completeness には拡張しない。
+formalization_quality: pass。trace / repair witnesses は visible tuple surface preservation、support witnesses は scalar / verdict-only preservation に分離され、component-law failure と missing-locus / exact-repair failure が axiom-free / sorry-free で証明されている。
+open_questions: grid-level flatness / holonomy criterion、source-ref exactness detects lossy packet-to-tuple visualization、finite codebase trace example への接続、tuple holonomy defect invariant。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/TupleTransportComponentLaws.lean` は、
+Cycle 14 の `BidirectionalTupleTransport` の十分条件を、有限 component-law failure witness として
+逆向きに読む。trace / repair frontier を変える witnesses は Cycle 11 の visible tuple surface
+`(sigma, nu, selectedSupport)` を保つ。support を変える witnesses は selected support 自体を動かすため、
+visible tuple surface preserving とは呼ばず、scalar / verdict-only reading の下で分離する。
+
+Lean 証拠は次を固定する。
+
+- `SameTupleScalarVerdict`: support を含まない scalar / verdict-only reading。
+- `traceErasingTransport` / `traceCreatingTransport`: trace-none component law failure witnesses。
+- `repairErasingTransport` / `repairCreatingTransport`: repair-frontier component law failure witnesses。
+- `supportDroppingTransport` / `supportExpandingTransport`: support preservation / reflection failure witnesses。
+- `traceErasing_preserves_visibleTupleSurface` / `traceCreating_preserves_visibleTupleSurface`: trace witnesses は visible tuple surface を保つ。
+- `repairErasing_preserves_visibleTupleSurface` / `repairCreating_preserves_visibleTupleSurface`: repair witnesses は visible tuple surface を保つ。
+- `supportDropping_preserves_scalarVerdict` / `supportExpanding_preserves_scalarVerdict`: support witnesses は scalar / verdict を保つ。
+- `traceNoneReflection_failure_obstructs_missingLocus_reflection`: trace erasure は trace-none reflection と missing-locus reflection を壊す。
+- `traceNonePreservation_failure_obstructs_missingLocus_preservation`: trace creation は trace-none preservation と missing-locus preservation を壊す。
+- `repairPreservation_failure_obstructs_exactRepair_preservation`: repair erasure は repair preservation と exact repair preservation を壊す。
+- `repairReflection_failure_obstructs_exactRepair_preservation`: repair creation は repair reflection と exact repair preservation を壊す。
+- `supportPreservation_failure_obstructs_missingLocus_preservation`: support dropping は support preservation と missing-locus preservation を壊す。
+- `supportReflection_failure_obstructs_missingLocus_reflection`: support expansion は support reflection と missing-locus reflection を壊す。
+- `tupleTransport_componentLaws_independence_package`: visible / scalar-verdict preservation と component-law failure witnesses をまとめる theorem package。
+
+この結果により、tuple transport exactness は単なる sufficiency theorem ではなく、どの component law を
+落とすとどの protected exactness が壊れるかを有限 witness として持つ。主張は supplied finite tuple
+transports と selected witnesses に相対化され、complete necessity/sufficiency classification、
+global minimality theorem、canonical global tuple transport、source extraction completeness、ArchMap correctness、
+実コード全体の traceability は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 18 後の total SCORE は 2210 である。
-次に進める場合は、grid-level flatness / holonomy criterion、lossy tuple transport obstruction、
-source-ref exactness detects lossy packet-to-tuple visualization、または finite codebase trace example への接続を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 19 後の total SCORE は 2320 である。
+次に進める場合は、grid-level flatness / holonomy criterion、source-ref exactness detects lossy packet-to-tuple visualization、
+finite codebase trace example への接続、または tuple holonomy defect invariant を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 Cycle 19 として、tuple transport の component-law failure が missing locus / exact repair frontier を壊す有限 witness 群を追加しました。

Cycle 14 の `BidirectionalTupleTransport` は十分条件でしたが、この PR では trace-none、repair-frontier、support の各 law failure を supplied finite transports として分離します。trace / repair witnesses は visible tuple surface を保ち、support witnesses は scalar / verdict-only preservation に限定します。

## 証明した定理

- `traceErasing_preserves_visibleTupleSurface`
- `traceCreating_preserves_visibleTupleSurface`
- `repairErasing_preserves_visibleTupleSurface`
- `repairCreating_preserves_visibleTupleSurface`
- `supportDropping_preserves_scalarVerdict`
- `supportExpanding_preserves_scalarVerdict`
- `traceNoneReflection_failure_obstructs_missingLocus_reflection`
- `traceNonePreservation_failure_obstructs_missingLocus_preservation`
- `repairPreservation_failure_obstructs_exactRepair_preservation`
- `repairReflection_failure_obstructs_exactRepair_preservation`
- `supportPreservation_failure_obstructs_missingLocus_preservation`
- `supportReflection_failure_obstructs_missingLocus_reflection`
- `tupleTransport_componentLaws_independence_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-minimal-component-laws-lossless-tuple-transport.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/TupleTransportComponentLaws.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake env lean .tmp/tuple_transport_component_laws_axioms.lean`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない

## 研究ループ SCORE

- candidate: Finite component-law independence witnesses for tuple transport
- candidate_type: orientation
- evidence_stage: proved-in-research
- base_score: 55
- evidence_multiplier: 2.0
- penalty: 0
- final_score: 110
- total_score_after_merge: 2320 / 5000
