### PR TITLE
研究ループ Cycle 20 の grid holonomy 局所化を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -18,3 +18,4 @@ import Formal.AG.Research.QualitySurface.SourceRefTokenIdentityReflection
 import Formal.AG.Research.QualitySurface.SourceRefPacketTransport
 import Formal.AG.Research.QualitySurface.TupleProtectedDataSquareCriterion
 import Formal.AG.Research.QualitySurface.TupleTransportComponentLaws
+import Formal.AG.Research.QualitySurface.GridHolonomyLocalization

--- a/Formal/AG/Research/QualitySurface/GridHolonomyLocalization.lean
+++ b/Formal/AG/Research/QualitySurface/GridHolonomyLocalization.lean
@@ -1,0 +1,299 @@
+import Formal.AG.Research.QualitySurface.FiniteSquareCriterion
+import Formal.AG.Research.QualitySurface.ProfileGridHolonomy
+
+/-!
+Cycle 20 evidence for `G-aat-quality-surface-01`.
+
+This file localizes endpoint holonomy in the selected finite profile grid.  The
+result is deliberately relative to the supplied two-cell decomposition, selected
+visible reading, selected protected invariant, and shared-boundary compatibility.
+It does not assert global grid flatness, arbitrary path pasting, canonical
+transport, source extraction completeness, ArchMap correctness, or whole-codebase
+traceability.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace GridHolonomyLocalization
+
+open TraceLocus
+
+/-! ## Selected endpoint pair and readings -/
+
+/-- Endpoint type at the selected high/fine grid vertex. -/
+abbrev GridEndpoint :=
+  ProfileGridHolonomy.CertificateAt ProfileGridHolonomy.highFine
+
+/-- Endpoint pair used by the selected upper-right grid cell. -/
+abbrev GridCellEndpointPair :=
+  FiniteSquareCriterion.EndpointPair GridEndpoint
+
+/-- The selected upper-right cell endpoints, reached in the two path orders. -/
+def gridUpperRightCellPair : GridCellEndpointPair where
+  lawFirst := ProfileGridHolonomy.lawFirstPath ProfileGridHolonomy.seedAt
+  coverFirst := ProfileGridHolonomy.coverFirstPath ProfileGridHolonomy.seedAt
+
+/-- Visible grid surface: scalar, verdict, and selected support. -/
+def SameGridVisibleSurface (left right : GridEndpoint) : Prop :=
+  ProfileGridHolonomy.scalarReading left.val = ProfileGridHolonomy.scalarReading right.val ∧
+    ProfileGridHolonomy.verdict left.val = ProfileGridHolonomy.verdict right.val ∧
+    ProfileGridHolonomy.support left.val = ProfileGridHolonomy.support right.val
+
+/-- Protected invariant given by the path-ordered trace missing locus. -/
+def SameGridTraceMissingInvariant (left right : GridEndpoint) : Prop :=
+  ∀ atom,
+    ProfileGridHolonomy.traceMissingLocus left.val atom ↔
+      ProfileGridHolonomy.traceMissingLocus right.val atom
+
+/-- Protected invariant given by the path-ordered repair frontier. -/
+def SameGridRepairInvariant (left right : GridEndpoint) : Prop :=
+  ∀ atom,
+    ProfileGridHolonomy.repairFrontier left.val atom ↔
+      ProfileGridHolonomy.repairFrontier right.val atom
+
+/-- Grid reading that hides the trace missing locus behind the visible surface. -/
+def gridTraceCellReading :
+    FiniteSquareCriterion.SquareReading GridEndpoint where
+  VisibleEquivalent := SameGridVisibleSurface
+  SameProtectedInvariant := SameGridTraceMissingInvariant
+
+/-- Grid reading that hides the repair frontier behind the visible surface. -/
+def gridRepairCellReading :
+    FiniteSquareCriterion.SquareReading GridEndpoint where
+  VisibleEquivalent := SameGridVisibleSurface
+  SameProtectedInvariant := SameGridRepairInvariant
+
+/-! ## Selected two-cell decomposition boundary -/
+
+/--
+Shared-boundary compatibility for the supplied two-cell grid: the common prefix
+and the branch vertices before the endpoint are trace-complete and carry no
+database repair frontier.  The localized obstruction is therefore isolated at
+the selected upper-right cell endpoint.
+-/
+def SharedBoundaryProtectedCompatible : Prop :=
+  TraceTransport.TraceAvailableOn
+      (ProfileGridHolonomy.support (ProfileGridHolonomy.commonLawStage ProfileGridHolonomy.seedAt).val)
+      (ProfileGridHolonomy.gridTuple (ProfileGridHolonomy.commonLawStage ProfileGridHolonomy.seedAt).val).traceField ∧
+    TraceTransport.TraceAvailableOn
+      (ProfileGridHolonomy.support (ProfileGridHolonomy.commonCenter ProfileGridHolonomy.seedAt).val)
+      (ProfileGridHolonomy.gridTuple (ProfileGridHolonomy.commonCenter ProfileGridHolonomy.seedAt).val).traceField ∧
+    TraceTransport.TraceAvailableOn
+      (ProfileGridHolonomy.support (ProfileGridHolonomy.lawFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val)
+      (ProfileGridHolonomy.gridTuple (ProfileGridHolonomy.lawFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val).traceField ∧
+    TraceTransport.TraceAvailableOn
+      (ProfileGridHolonomy.support (ProfileGridHolonomy.coverFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val)
+      (ProfileGridHolonomy.gridTuple (ProfileGridHolonomy.coverFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val).traceField ∧
+    TraceTransport.TraceAvailableOn
+      (ProfileGridHolonomy.support (ProfileGridHolonomy.lawFirstPath ProfileGridHolonomy.seedAt).val)
+      (ProfileGridHolonomy.gridTuple (ProfileGridHolonomy.lawFirstPath ProfileGridHolonomy.seedAt).val).traceField ∧
+    ¬ ProfileGridHolonomy.repairFrontier (ProfileGridHolonomy.commonLawStage ProfileGridHolonomy.seedAt).val LocusAtom.database ∧
+    ¬ ProfileGridHolonomy.repairFrontier (ProfileGridHolonomy.commonCenter ProfileGridHolonomy.seedAt).val LocusAtom.database ∧
+    ¬ ProfileGridHolonomy.repairFrontier (ProfileGridHolonomy.lawFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val LocusAtom.database ∧
+    ¬ ProfileGridHolonomy.repairFrontier (ProfileGridHolonomy.coverFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val LocusAtom.database ∧
+    ¬ ProfileGridHolonomy.repairFrontier (ProfileGridHolonomy.lawFirstPath ProfileGridHolonomy.seedAt).val LocusAtom.database
+
+/--
+The selected two-cell decomposition remembers the shared prefix, the two
+intermediate branch vertices, the named endpoint pair, and the protected
+boundary compatibility that isolates the endpoint holonomy to the upper-right
+cell.
+-/
+structure SelectedTwoCellDecomposition where
+  commonLawStage_is_shared :
+    (ProfileGridHolonomy.commonLawStage ProfileGridHolonomy.seedAt).val =
+      ProfileGridHolonomy.GridCertificateName.sharedLawStage
+  commonCenter_is_shared :
+    (ProfileGridHolonomy.commonCenter ProfileGridHolonomy.seedAt).val =
+      ProfileGridHolonomy.GridCertificateName.sharedCenter
+  lawFirstBeforeEndpoint_is_highMiddle :
+    (ProfileGridHolonomy.lawFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val =
+      ProfileGridHolonomy.GridCertificateName.lawFirstHighMiddle
+  coverFirstBeforeEndpoint_is_midFine :
+    (ProfileGridHolonomy.coverFirstBeforeEndpoint ProfileGridHolonomy.seedAt).val =
+      ProfileGridHolonomy.GridCertificateName.coverFirstMidFine
+  lawFirstEndpoint_selected :
+    gridUpperRightCellPair.lawFirst = ProfileGridHolonomy.lawFirstPath ProfileGridHolonomy.seedAt
+  coverFirstEndpoint_selected :
+    gridUpperRightCellPair.coverFirst = ProfileGridHolonomy.coverFirstPath ProfileGridHolonomy.seedAt
+  sharedBoundaryCompatible : SharedBoundaryProtectedCompatible
+
+/-- The supplied grid witness carries the selected two-cell decomposition. -/
+theorem selectedTwoCellDecomposition_witness :
+    SelectedTwoCellDecomposition where
+  commonLawStage_is_shared := ProfileGridHolonomy.lawFirst_uses_middle_grid_vertices.1
+  commonCenter_is_shared := ProfileGridHolonomy.lawFirst_uses_middle_grid_vertices.2.1
+  lawFirstBeforeEndpoint_is_highMiddle :=
+    ProfileGridHolonomy.lawFirst_uses_middle_grid_vertices.2.2.1
+  coverFirstBeforeEndpoint_is_midFine :=
+    ProfileGridHolonomy.coverFirst_uses_middle_grid_vertices.2.2.1
+  lawFirstEndpoint_selected := rfl
+  coverFirstEndpoint_selected := rfl
+  sharedBoundaryCompatible := ProfileGridHolonomy.surrounding_steps_preserve_trace_frontier
+
+/-! ## Cellwise flatness and endpoint holonomy -/
+
+/-- All selected cells are visibly flat for a chosen reading. -/
+def AllSelectedCellsVisibleFlat
+    (reading : FiniteSquareCriterion.SquareReading GridEndpoint) : Prop :=
+  SharedBoundaryProtectedCompatible ∧
+    FiniteSquareCriterion.VisibleFlat reading gridUpperRightCellPair
+
+/-- All selected cells are protected-flat for a chosen protected invariant. -/
+def AllSelectedCellsProtectedFlat
+    (reading : FiniteSquareCriterion.SquareReading GridEndpoint) : Prop :=
+  SharedBoundaryProtectedCompatible ∧
+    FiniteSquareCriterion.ProtectedInvariantFlat reading gridUpperRightCellPair
+
+/--
+For the selected two-cell decomposition, cellwise protected flatness rules out
+endpoint protected holonomy for the chosen reading.
+-/
+theorem endpointProtectedFlat_of_allSelectedCellsFlat
+    (reading : FiniteSquareCriterion.SquareReading GridEndpoint)
+    (hflat : AllSelectedCellsProtectedFlat reading) :
+    FiniteSquareCriterion.ProtectedInvariantFlat reading gridUpperRightCellPair :=
+  hflat.2
+
+/-- Endpoint trace holonomy is failure of trace protected-flatness. -/
+def EndpointTraceHolonomy : Prop :=
+  ¬ FiniteSquareCriterion.ProtectedInvariantFlat gridTraceCellReading gridUpperRightCellPair
+
+/-- Endpoint repair holonomy is failure of repair protected-flatness. -/
+def EndpointRepairHolonomy : Prop :=
+  ¬ FiniteSquareCriterion.ProtectedInvariantFlat gridRepairCellReading gridUpperRightCellPair
+
+/-- The selected upper-right grid cell is visibly flat for trace reading. -/
+theorem gridUpperRightCell_visibleFlat :
+    FiniteSquareCriterion.VisibleFlat gridTraceCellReading gridUpperRightCellPair :=
+  ProfileGridHolonomy.gridHolonomy_visibleAgreement
+
+/-- The selected upper-right grid cell is visibly flat for repair reading. -/
+theorem gridUpperRightCell_repair_visibleFlat :
+    FiniteSquareCriterion.VisibleFlat gridRepairCellReading gridUpperRightCellPair :=
+  ProfileGridHolonomy.gridHolonomy_visibleAgreement
+
+/-- All selected cells are visibly flat for trace reading. -/
+theorem allSelectedCells_trace_visibleFlat :
+    AllSelectedCellsVisibleFlat gridTraceCellReading :=
+  ⟨ProfileGridHolonomy.surrounding_steps_preserve_trace_frontier,
+    gridUpperRightCell_visibleFlat⟩
+
+/-- All selected cells are visibly flat for repair reading. -/
+theorem allSelectedCells_repair_visibleFlat :
+    AllSelectedCellsVisibleFlat gridRepairCellReading :=
+  ⟨ProfileGridHolonomy.surrounding_steps_preserve_trace_frontier,
+    gridUpperRightCell_repair_visibleFlat⟩
+
+/-! ## Concrete endpoint discrepancies -/
+
+/-- The selected grid endpoints differ in trace missing locus. -/
+theorem gridUpperRightCell_traceDiscrepancy :
+    ¬ FiniteSquareCriterion.ProtectedInvariantFlat
+      gridTraceCellReading gridUpperRightCellPair := by
+  intro hsame
+  have hmissingLaw :
+      ProfileGridHolonomy.traceMissingLocus
+        gridUpperRightCellPair.lawFirst.val
+        LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      TraceLocus.partialTrace_database_missing_locus
+  exact TraceLocus.fullTrace_has_no_missing_locus
+    ⟨LocusAtom.database, hmissingLaw⟩
+
+/-- The selected grid endpoints differ in repair frontier. -/
+theorem gridUpperRightCell_repairDiscrepancy :
+    ¬ FiniteSquareCriterion.ProtectedInvariantFlat
+      gridRepairCellReading gridUpperRightCellPair := by
+  intro hsame
+  have hrepairLaw :
+      ProfileGridHolonomy.repairFrontier
+        gridUpperRightCellPair.lawFirst.val
+        LocusAtom.database :=
+    (hsame LocusAtom.database).mpr
+      ProfileGridHolonomy.coverFirst_forces_database_repair_at_endpoint
+  exact ProfileGridHolonomy.lawFirst_no_database_repair_at_endpoint hrepairLaw
+
+/-- The concrete endpoint trace holonomy of the selected grid. -/
+theorem gridUpperRightCell_endpointTraceHolonomy :
+    EndpointTraceHolonomy :=
+  gridUpperRightCell_traceDiscrepancy
+
+/-- The concrete endpoint repair holonomy of the selected grid. -/
+theorem gridUpperRightCell_endpointRepairHolonomy :
+    EndpointRepairHolonomy :=
+  gridUpperRightCell_repairDiscrepancy
+
+/-! ## Holonomy localization to a selected curved cell -/
+
+/--
+If the selected decomposition has visible-flat cells and endpoint trace holonomy,
+then a selected cell is trace-curved.
+-/
+theorem curvedCell_of_endpointTraceHolonomy
+    (hvisible : AllSelectedCellsVisibleFlat gridTraceCellReading)
+    (hholonomy : EndpointTraceHolonomy) :
+    FiniteSquareCriterion.ReadingCurved gridTraceCellReading gridUpperRightCellPair :=
+  FiniteSquareCriterion.finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    gridTraceCellReading gridUpperRightCellPair hvisible.2 hholonomy
+
+/--
+If the selected decomposition has visible-flat cells and endpoint repair
+holonomy, then a selected cell is repair-curved.
+-/
+theorem curvedCell_of_endpointRepairHolonomy
+    (hvisible : AllSelectedCellsVisibleFlat gridRepairCellReading)
+    (hholonomy : EndpointRepairHolonomy) :
+    FiniteSquareCriterion.ReadingCurved gridRepairCellReading gridUpperRightCellPair :=
+  FiniteSquareCriterion.finiteSquare_curvature_of_visible_agreement_protected_discrepancy
+    gridRepairCellReading gridUpperRightCellPair hvisible.2 hholonomy
+
+/-- The selected grid instantiates the trace holonomy localization criterion. -/
+theorem gridUpperRightCell_instantiates_traceCriterion :
+    FiniteSquareCriterion.ReadingCurved gridTraceCellReading gridUpperRightCellPair :=
+  curvedCell_of_endpointTraceHolonomy
+    allSelectedCells_trace_visibleFlat
+    gridUpperRightCell_endpointTraceHolonomy
+
+/-- The selected grid instantiates the repair holonomy localization criterion. -/
+theorem gridUpperRightCell_instantiates_repairCriterion :
+    FiniteSquareCriterion.ReadingCurved gridRepairCellReading gridUpperRightCellPair :=
+  curvedCell_of_endpointRepairHolonomy
+    allSelectedCells_repair_visibleFlat
+    gridUpperRightCell_endpointRepairHolonomy
+
+/--
+Cycle-20 theorem package: the selected two-cell grid decomposition has
+shared-boundary protected compatibility; all-cell protected flatness would
+remove endpoint holonomy; the actual endpoint holonomy localizes to the selected
+upper-right cell as trace and repair reading-curvature.
+-/
+theorem gridHolonomy_localization_package :
+    SelectedTwoCellDecomposition ∧
+      AllSelectedCellsVisibleFlat gridTraceCellReading ∧
+      AllSelectedCellsVisibleFlat gridRepairCellReading ∧
+      (AllSelectedCellsProtectedFlat gridTraceCellReading ->
+        FiniteSquareCriterion.ProtectedInvariantFlat
+          gridTraceCellReading gridUpperRightCellPair) ∧
+      (AllSelectedCellsProtectedFlat gridRepairCellReading ->
+        FiniteSquareCriterion.ProtectedInvariantFlat
+          gridRepairCellReading gridUpperRightCellPair) ∧
+      EndpointTraceHolonomy ∧
+      EndpointRepairHolonomy ∧
+      FiniteSquareCriterion.ReadingCurved gridTraceCellReading gridUpperRightCellPair ∧
+      FiniteSquareCriterion.ReadingCurved gridRepairCellReading gridUpperRightCellPair ∧
+      ProfileGridHolonomy.LocalizedCurvatureCell := by
+  exact ⟨selectedTwoCellDecomposition_witness,
+    allSelectedCells_trace_visibleFlat,
+    allSelectedCells_repair_visibleFlat,
+    endpointProtectedFlat_of_allSelectedCellsFlat gridTraceCellReading,
+    endpointProtectedFlat_of_allSelectedCellsFlat gridRepairCellReading,
+    gridUpperRightCell_endpointTraceHolonomy,
+    gridUpperRightCell_endpointRepairHolonomy,
+    gridUpperRightCell_instantiates_traceCriterion,
+    gridUpperRightCell_instantiates_repairCriterion,
+    ProfileGridHolonomy.localized_curvature_cell⟩
+
+end GridHolonomyLocalization
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-grid-holonomy-localization-criterion.md
+++ b/research/ideas/g-aat-quality-surface-01-grid-holonomy-localization-criterion.md
@@ -1,0 +1,155 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: closure
+capability_category: profile-curvature/certificate-transport/invariance/computability/obstruction
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle20
+tags:
+  - grid-holonomy
+  - finite-square
+  - localization
+created: 2026-06-20
+---
+
+# Grid-level flatness and holonomy localization criterion
+
+## 主張
+
+有限 profile grid 上の selected two-cell decomposition で endpoint holonomy が protected invariant に
+現れるなら、cellwise visible-flatness と shared-boundary compatibility の下で、その holonomy は
+少なくとも一つの selected elementary square の reading curvature として局所化できる。逆に、
+selected decomposition の各 cell が protected-flat であり、shared boundary が protected invariant を
+保って貼り合わされていれば、endpoint protected holonomy は消える。
+
+Cycle 10 の `ProfileGridHolonomy` は一つの 3x3 witness を固定し、Cycle 12 は単一 finite-square
+criterion を固定した。この候補は、selected two-cell path decomposition に限って、cellwise
+flatness と endpoint holonomy localization を Lean で接続する。
+
+主張は supplied finite grid、selected two-cell decomposition、selected visible reading、selected
+protected invariant、cellwise visible-flatness、shared-boundary protected compatibility に相対化する。
+任意 grid の global flatness theorem、任意 path family の pasting theorem、canonical profile transport、
+source extraction completeness、ArchMap correctness、実コード全体の traceability は結論しない。
+
+## 候補種別
+
+`closure`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/ProfileGridHolonomy.lean`
+- `Formal/AG/Research/QualitySurface/FiniteSquareCriterion.lean`
+- `Formal/AG/Research/QualitySurface/TupleProtectedDataSquareCriterion.lean`
+- `gridHolonomy_visibleAgreement`
+- `localized_curvature_cell`
+- `same_grid_surface_but_path_ordered_frontier_diff`
+- `finiteSquare_curvature_of_visible_agreement_protected_discrepancy`
+
+## 非自明性
+
+Cycle 10 は localized upper-right cell の具体 witness、Cycle 12 は一つの endpoint pair に対する
+generic criterion だった。この候補は endpoint-level holonomy を cell-level witness に戻し、selected
+two-cell decomposition で all-cell flatness が endpoint holonomy を消すことを示す。
+
+単なる Cycle 10 の再掲にしないため、cell endpoint pair、cell reading、shared-boundary compatibility、
+flatness-to-no-endpoint-holonomy、endpoint-holonomy-to-curved-cell の両方向を theorem package として固定する。
+
+## 数学的興味
+
+holonomy を「二つの path endpoint が違う」という現象から、「どの elementary cell が obstruction を
+支えるか」という局所化問題へ移す。これは Quality Surface の curvature を計算可能な cell-level
+obstruction として扱うための基礎になる。
+
+## GOAL への前進
+
+profile-curvature / certificate-transport / invariance / computability / obstruction を接続し、
+grid-level flatness / holonomy criterion frontier を前進させる。
+
+## SCORE 見込み
+
+- `score_reason`: G2-B/C は base 70 を認めたが、G2-A が selected decomposition の shared-boundary compatibility と cellwise visible-flatness を required evidence として要求したため、revised candidate は base 60 / final 120 に下げる。
+- `dullness_risk`: medium-high。Cycle 10 witness の再包装に落ちないよう、cellwise flatness sufficient condition と holonomy localization を明示する。
+- `proof_or_evidence_plan`: `GridHolonomyLocalization.lean` で selected cell reading、cell pair、shared-boundary compatibility、all-cell flatness predicate、endpoint protected-flatness theorem、curved-cell localization theorem、theorem package を証明済み。
+
+## CS / SWE への帰結
+
+grid endpoint の quality reading が同じでも protected data が違う場合、その差分を selected cell に
+戻せる。これは loss-aware visualization や repair planning で「どこを drill down すべきか」を
+数学的に扱う土台になる。ただし supplied finite grid の claim であり、tooling completeness ではない。
+
+## 証明・根拠
+
+Lean proof は `Formal/AG/Research/QualitySurface/GridHolonomyLocalization.lean` に閉じた。
+`Formal/AG/Research.lean` はこの Research evidence file を import する。
+
+主要 theorem / declaration:
+
+- `GridCellEndpointPair`
+- `gridUpperRightCellPair`
+- `gridTraceCellReading`
+- `gridRepairCellReading`
+- `SelectedTwoCellDecomposition`
+- `SharedBoundaryProtectedCompatible`
+- `gridUpperRightCell_visibleFlat`
+- `gridUpperRightCell_repair_visibleFlat`
+- `gridUpperRightCell_traceDiscrepancy`
+- `gridUpperRightCell_repairDiscrepancy`
+- `AllSelectedCellsProtectedFlat`
+- `AllSelectedCellsVisibleFlat`
+- `endpointProtectedFlat_of_allSelectedCellsFlat`
+- `curvedCell_of_endpointTraceHolonomy`
+- `curvedCell_of_endpointRepairHolonomy`
+- `gridUpperRightCell_instantiates_traceCriterion`
+- `gridUpperRightCell_instantiates_repairCriterion`
+- `gridHolonomy_localization_package`
+
+固定された内容:
+
+- `SharedBoundaryProtectedCompatible` は common prefix と branch endpoint 手前の trace-complete /
+  no-database-repair-frontier を明示する。
+- `SelectedTwoCellDecomposition` は shared prefix、二つの branch vertex、upper-right endpoint pair、
+  shared-boundary protected compatibility を束ねる。
+- `AllSelectedCellsVisibleFlat` と `AllSelectedCellsProtectedFlat` は selected decomposition に相対化した
+  visible-flat / protected-flat 条件である。
+- `endpointProtectedFlat_of_allSelectedCellsFlat` は selected cells が protected-flat なら endpoint
+  protected holonomy が消える sufficient condition を固定する。
+- `curvedCell_of_endpointTraceHolonomy` と `curvedCell_of_endpointRepairHolonomy` は、cellwise
+  visible-flatness と endpoint protected holonomy から selected upper-right cell の
+  `ReadingCurved` を返す。
+- `gridUpperRightCell_instantiates_traceCriterion` と `gridUpperRightCell_instantiates_repairCriterion`
+  は Cycle 10 の concrete grid witness を Cycle 12 の finite-square criterion に接続する。
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/GridHolonomyLocalization.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `.tmp/grid_holonomy_localization_axioms.lean` の `#print axioms`: listed declarations are all
+  `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は出ていない。
+- G3 公理検査: pass。
+- G3 Lean 形式化品質監査: pass。`endpointProtectedFlat_of_allSelectedCellsFlat` は package 内の
+  sufficient-condition 成分であり、非自明性は concrete discrepancy と endpoint-holonomy localization
+  theorem 側で固定されている。
+
+## 審判メモ
+
+- 厳密性: G2-A は revise、base 60。endpoint holonomy から reading-curved cell を出すには cellwise visible-flatness と shared-boundary protected compatibility が必要。単なる `localized_curvature_cell` 再掲を避けること。
+- 厳密性再審判: G2-A は revised card を accept、base 60。two-cell decomposition package と
+  endpoint-to-cell localization / all-cell-flatness-to-endpoint-flatness を Lean で弱めずに出すことを required evidence とした。
+- 研究価値: G2-B は accept、base 70。selected two-cell decomposition への相対化により完全 global theorem ではないが、grid-level frontier に直接効くと判定。
+- repo 全体価値: G2-C は accept、base 70。Lean / paper seed として価値は高いが、selected decomposition に閉じるため base 80 は過大。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-grid-holonomy.md`
+- `research/ideas/g-aat-quality-surface-01-finite-square-protected-criterion.md`
+- `research/ideas/g-aat-quality-surface-01-tuple-protected-data-square-criterion.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 20 candidate card 作成。
+- 2026-06-20: G2-A revise を反映し、cellwise visible-flatness と shared-boundary protected compatibility を required evidence に追加し、base 60 / final 120 に下げた。
+- 2026-06-20: G2-A 再審判 accept。`GridHolonomyLocalization.lean` を追加し、単体 Lean、`FormalAGResearch`、axiom harness、G3 公理検査、G3 Lean 形式化品質監査を通した。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2320
+- total SCORE: 2440
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -25,8 +25,9 @@
   - traceability / certificate-transport / repair-potential / invariance: 90
   - quality-surface / profile-curvature / certificate-transport / traceability / repair-potential: 80
   - certificate-transport / obstruction / invariance / repair-potential / traceability: 110
+  - profile-curvature / certificate-transport / invariance / computability / obstruction: 120
 - evidence portfolio:
-  - proved-in-research: 19
+  - proved-in-research: 20
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -804,8 +805,60 @@ transports と selected witnesses に相対化され、complete necessity/suffic
 global minimality theorem、canonical global tuple transport、source extraction completeness、ArchMap correctness、
 実コード全体の traceability は結論しない。
 
+## Cycle 20: Grid-level flatness and holonomy localization criterion
+
+```text
+candidate: Grid-level flatness and holonomy localization criterion
+candidate_type: closure
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: profile-curvature/certificate-transport/invariance/computability/obstruction
+goal_delta: selected two-cell decomposition 上で、endpoint holonomy を trace / repair protected invariant の selected cell reading-curvature へ局所化し、all-selected-cells protected-flat なら endpoint protected holonomy が消える sufficient condition を固定した。
+project_value_delta: Cycle 10 の 3x3 witness と Cycle 12 の finite-square criterion を、Lean-backed な grid-level localization package として接続し、report / paper の grid holonomy frontier を一段閉じた。
+formalization_quality: pass。`SharedBoundaryProtectedCompatible`、`SelectedTwoCellDecomposition`、cellwise visible / protected flatness、trace / repair endpoint holonomy、trace / repair localization theorem、package theorem が axiom-free / sorry-free で証明されている。
+open_questions: selected two-cell decomposition を越える任意 finite grid / path family の localization theorem、canonical global pasting なしで扱える decomposition calculus、source-ref exactness detects lossy packet-to-tuple visualization、finite codebase trace example への接続。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/GridHolonomyLocalization.lean` は、
+Cycle 10 の finite `P_law x P_cover` 3x3 grid witness と Cycle 12 の
+`FiniteSquareCriterion` を、selected two-cell decomposition 上の holonomy localization
+criterion として接続する。
+
+Lean 証拠は次を固定する。
+
+- `GridCellEndpointPair` / `gridUpperRightCellPair`: selected upper-right cell の two path endpoint pair。
+- `gridTraceCellReading` / `gridRepairCellReading`: visible surface の下に trace missing locus /
+  repair frontier を protected invariant として置く selected readings。
+- `SharedBoundaryProtectedCompatible`: common prefix と branch endpoint 手前が trace-complete で、
+  database repair frontier を持たないこと。
+- `SelectedTwoCellDecomposition`: shared prefix、二つの branch vertex、upper-right endpoint pair、
+  shared-boundary protected compatibility を束ねる selected decomposition。
+- `AllSelectedCellsVisibleFlat` / `AllSelectedCellsProtectedFlat`: selected decomposition に相対化した
+  cellwise visible / protected flatness。
+- `endpointProtectedFlat_of_allSelectedCellsFlat`: selected cells が protected-flat なら endpoint
+  protected holonomy が消える sufficient condition。
+- `gridUpperRightCell_traceDiscrepancy` / `gridUpperRightCell_repairDiscrepancy`: endpoint trace /
+  repair protected invariant の concrete discrepancy。
+- `curvedCell_of_endpointTraceHolonomy` / `curvedCell_of_endpointRepairHolonomy`: cellwise visible-flatness
+  と endpoint holonomy から selected cell の `ReadingCurved` を得る localization theorem。
+- `gridHolonomy_localization_package`: selected two-cell decomposition、visible-flatness、
+  endpoint-flatness sufficient condition、trace / repair endpoint holonomy、trace / repair
+  reading-curvature、Cycle 10 の localized curvature cell をまとめる theorem package。
+
+この結果により、endpoint の path-ordered holonomy は、supplied selected decomposition と
+shared-boundary compatibility の下で、少なくとも selected upper-right elementary cell の
+reading-curvature として局所化できる。主張は supplied finite grid、selected visible reading、
+selected protected invariant、selected two-cell decomposition に相対化され、任意 finite grid の
+global flatness、任意 path family の pasting theorem、canonical profile transport、source extraction
+completeness、ArchMap correctness、実コード全体の traceability は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 19 後の total SCORE は 2320 である。
-次に進める場合は、grid-level flatness / holonomy criterion、source-ref exactness detects lossy packet-to-tuple visualization、
-finite codebase trace example への接続、または tuple holonomy defect invariant を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 20 後の total SCORE は 2440 である。
+次に進める場合は、source-ref exactness detects lossy packet-to-tuple visualization、finite codebase trace example
+への接続、tuple holonomy defect invariant、または selected decomposition を越える grid localization calculus を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

G-aat-quality-surface-01 の Cycle 20 として、selected finite profile grid 上の endpoint holonomy を selected cell の reading-curvature へ局所化する Lean evidence を追加します。

Cycle 10 の `ProfileGridHolonomy` witness と Cycle 12 の `FiniteSquareCriterion` を接続し、shared-boundary protected compatibility、cellwise visible/protected flatness、endpoint trace / repair holonomy、trace / repair localization theorem を Research 側に閉じて固定しました。SCORE は G4 監査で +120 と確定し、report total は 2440 に更新しています。

## 証明した定理

- `SelectedTwoCellDecomposition`
- `SharedBoundaryProtectedCompatible`
- `endpointProtectedFlat_of_allSelectedCellsFlat`
- `curvedCell_of_endpointTraceHolonomy`
- `curvedCell_of_endpointRepairHolonomy`
- `gridUpperRightCell_instantiates_traceCriterion`
- `gridUpperRightCell_instantiates_repairCriterion`
- `gridHolonomy_localization_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-grid-holonomy-localization-criterion.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/GridHolonomyLocalization.lean`
- [x] `lake build FormalAGResearch`
- [x] `.tmp/grid_holonomy_localization_axioms.lean` の `#print axioms`
- [x] `lake build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（対象外: ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（対象外: FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を本文に記載した（研究 tracking Issue のため `Refs #2348`）
- [x] Lean status を `proved` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
