### PR TITLE
研究: tuple holonomy defect invariant を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -20,3 +20,4 @@ import Formal.AG.Research.QualitySurface.TupleProtectedDataSquareCriterion
 import Formal.AG.Research.QualitySurface.TupleTransportComponentLaws
 import Formal.AG.Research.QualitySurface.GridHolonomyLocalization
 import Formal.AG.Research.QualitySurface.CodebaseTraceRepairTrajectory
+import Formal.AG.Research.QualitySurface.TupleHolonomyDefect

--- a/Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean
+++ b/Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean
@@ -1,0 +1,560 @@
+import Formal.AG.Research.QualitySurface.TupleProtectedDataSquareCriterion
+import Formal.AG.Research.QualitySurface.TupleTransportExactness
+
+/-!
+Cycle 22 evidence for `G-aat-quality-surface-01`.
+
+This file factors hidden tuple holonomy into component defects of protected
+tuple data: obligation, repair frontier, and trace field. The results are
+relative to supplied finite tuple certificates and declared tuple transports;
+they do not assert a global profile classification, canonical transport,
+source extraction completeness, or whole-codebase traceability.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace TupleHolonomyDefectInvariant
+
+open TraceLocus
+
+abbrev TupleProfile :=
+  ProfileTupleIntegration.TupleProfile
+
+abbrev TupleCertificateAt :=
+  ProfileTupleIntegration.TupleCertificateAt
+
+/-! ## Same-profile tuple holonomy defects -/
+
+/-- Protected tuple component whose defect can carry hidden holonomy. -/
+inductive TupleProtectedComponent where
+  | obligation
+  | repairFrontier (atom : LocusAtom)
+  | traceField (atom : LocusAtom)
+  deriving DecidableEq
+
+/-- Zero tuple-holonomy defect inside one profile fiber. -/
+def NoTupleHolonomyDefect {p : TupleProfile}
+    (left right : TupleCertificateAt p) : Prop :=
+  left.omega = right.omega ∧
+    ProfileTupleIntegration.SameTupleRepairFrontier left right ∧
+    ProfileTupleIntegration.SameTupleTraceField left right
+
+/-- A nonzero protected-data defect inside one profile fiber. -/
+def HasTupleHolonomyDefect {p : TupleProfile}
+    (left right : TupleCertificateAt p) : Prop :=
+  ¬ NoTupleHolonomyDefect left right
+
+/-- Obligation component defect. -/
+def ObligationDefect {p : TupleProfile}
+    (left right : TupleCertificateAt p) : Prop :=
+  left.omega ≠ right.omega
+
+/-- Repair-frontier component defect at a selected atom. -/
+def RepairFrontierDefectAt {p : TupleProfile}
+    (left right : TupleCertificateAt p) (atom : LocusAtom) : Prop :=
+  ¬ (left.repairFrontier atom ↔ right.repairFrontier atom)
+
+/-- Trace-field component defect at a selected atom. -/
+def TraceFieldDefectAt {p : TupleProfile}
+    (left right : TupleCertificateAt p) (atom : LocusAtom) : Prop :=
+  left.traceField atom ≠ right.traceField atom
+
+/-- Component-indexed tuple holonomy defect. -/
+def TupleHolonomyDefect {p : TupleProfile}
+    (left right : TupleCertificateAt p) :
+    TupleProtectedComponent -> Prop
+  | .obligation => ObligationDefect left right
+  | .repairFrontier atom => RepairFrontierDefectAt left right atom
+  | .traceField atom => TraceFieldDefectAt left right atom
+
+/-- Zero component defect is exactly protected tuple data agreement. -/
+theorem noTupleHolonomyDefect_iff_protectedData
+    {p : TupleProfile} (left right : TupleCertificateAt p) :
+    NoTupleHolonomyDefect left right ↔
+      ProfileTupleIntegration.SameTupleProtectedData left right :=
+  Iff.rfl
+
+/-- Obligation disagreement obstructs zero tuple-holonomy defect. -/
+theorem obligationDefect_obstructs_noTupleHolonomyDefect
+    {p : TupleProfile} {left right : TupleCertificateAt p}
+    (hdefect : ObligationDefect left right) :
+    HasTupleHolonomyDefect left right := by
+  intro hzero
+  exact hdefect hzero.1
+
+/-- Repair-frontier disagreement at one atom obstructs zero defect. -/
+theorem repairFrontierDefect_obstructs_noTupleHolonomyDefect
+    {p : TupleProfile} {left right : TupleCertificateAt p}
+    {atom : LocusAtom}
+    (hdefect : RepairFrontierDefectAt left right atom) :
+    HasTupleHolonomyDefect left right := by
+  intro hzero
+  exact hdefect (hzero.2.1 atom)
+
+/-- Trace-field disagreement at one atom obstructs zero defect. -/
+theorem traceFieldDefect_obstructs_noTupleHolonomyDefect
+    {p : TupleProfile} {left right : TupleCertificateAt p}
+    {atom : LocusAtom}
+    (hdefect : TraceFieldDefectAt left right atom) :
+    HasTupleHolonomyDefect left right := by
+  intro hzero
+  exact hdefect (hzero.2.2 atom)
+
+/-- Any component-indexed tuple holonomy defect obstructs zero defect. -/
+theorem tupleHolonomyDefect_obstructs_noTupleHolonomyDefect
+    {p : TupleProfile} {left right : TupleCertificateAt p}
+    {component : TupleProtectedComponent}
+    (hdefect : TupleHolonomyDefect left right component) :
+    HasTupleHolonomyDefect left right := by
+  cases component with
+  | obligation =>
+      exact obligationDefect_obstructs_noTupleHolonomyDefect hdefect
+  | repairFrontier atom =>
+      exact repairFrontierDefect_obstructs_noTupleHolonomyDefect hdefect
+  | traceField atom =>
+      exact traceFieldDefect_obstructs_noTupleHolonomyDefect hdefect
+
+/-! ## Selected endpoint and square witnesses -/
+
+/-- The selected endpoint pair has a nonzero obligation defect. -/
+theorem endpointTuple_obligationDefect :
+    ObligationDefect
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple :=
+  ProfileTupleIntegration.endpointTuple_omega_diff
+
+/-- The selected endpoint pair has a database repair-frontier defect. -/
+theorem endpointTuple_databaseRepairDefect :
+    RepairFrontierDefectAt
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      LocusAtom.database := by
+  intro hsame
+  have hrepairFull :
+      ProfileTupleIntegration.fullEndpointTuple.repairFrontier
+          LocusAtom.database :=
+    hsame.mpr
+      ProfileTupleIntegration.traceMissingEndpoint_forces_database_repair
+  exact ProfileTupleIntegration.fullEndpoint_no_database_repair hrepairFull
+
+/-- The selected endpoint pair has a database trace-field defect. -/
+theorem endpointTuple_databaseTraceFieldDefect :
+    TraceFieldDefectAt
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      LocusAtom.database := by
+  intro hsame
+  cases hsame
+
+/-- The selected endpoint pair has nonzero tuple holonomy. -/
+theorem endpointTuple_hasTupleHolonomyDefect :
+    HasTupleHolonomyDefect
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple :=
+  obligationDefect_obstructs_noTupleHolonomyDefect
+    endpointTuple_obligationDefect
+
+/-- Component-indexed endpoint obligation defect. -/
+theorem endpointTuple_obligationComponentDefect :
+    TupleHolonomyDefect
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      TupleProtectedComponent.obligation :=
+  endpointTuple_obligationDefect
+
+/-- Component-indexed endpoint repair-frontier defect. -/
+theorem endpointTuple_databaseRepairComponentDefect :
+    TupleHolonomyDefect
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      (TupleProtectedComponent.repairFrontier LocusAtom.database) :=
+  endpointTuple_databaseRepairDefect
+
+/-- Component-indexed endpoint trace-field defect. -/
+theorem endpointTuple_databaseTraceFieldComponentDefect :
+    TupleHolonomyDefect
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple
+      (TupleProtectedComponent.traceField LocusAtom.database) :=
+  endpointTuple_databaseTraceFieldDefect
+
+/--
+The visible endpoint surface is flat, but all three protected tuple components
+exhibit a defect.
+-/
+theorem endpointTuple_visibleSurface_hides_componentDefects :
+    (ProfileTupleIntegration.visibleTupleSurfaceReading
+        ProfileTupleIntegration.endpointProfile).Equivalent
+      ProfileTupleIntegration.fullEndpointTuple
+      ProfileTupleIntegration.traceMissingEndpointTuple ∧
+      ObligationDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple ∧
+      RepairFrontierDefectAt
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        LocusAtom.database ∧
+      TraceFieldDefectAt
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        LocusAtom.database ∧
+      HasTupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple :=
+  ⟨ProfileTupleIntegration.endpointTuple_visibleAgreement,
+    endpointTuple_obligationDefect,
+    endpointTuple_databaseRepairDefect,
+    endpointTuple_databaseTraceFieldDefect,
+    endpointTuple_hasTupleHolonomyDefect⟩
+
+/--
+The visible endpoint surface is flat, but the component-indexed defect surface
+detects all three protected tuple components.
+-/
+theorem endpointTuple_visibleSurface_hides_indexedDefects :
+    (ProfileTupleIntegration.visibleTupleSurfaceReading
+        ProfileTupleIntegration.endpointProfile).Equivalent
+      ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple ∧
+        TupleHolonomyDefect
+          ProfileTupleIntegration.fullEndpointTuple
+          ProfileTupleIntegration.traceMissingEndpointTuple
+          TupleProtectedComponent.obligation ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        (TupleProtectedComponent.repairFrontier LocusAtom.database) ∧
+      TupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple
+        (TupleProtectedComponent.traceField LocusAtom.database) ∧
+      HasTupleHolonomyDefect
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple :=
+  ⟨ProfileTupleIntegration.endpointTuple_visibleAgreement,
+    endpointTuple_obligationComponentDefect,
+    endpointTuple_databaseRepairComponentDefect,
+    endpointTuple_databaseTraceFieldComponentDefect,
+    endpointTuple_hasTupleHolonomyDefect⟩
+
+/-- The selected tuple square has an obligation component defect. -/
+theorem tupleProtectedDataSquare_obligationDefect :
+    ObligationDefect
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst :=
+  TupleProtectedDataSquareCriterion.tupleProtectedData_omega_discrepancy
+
+/-- The selected tuple square has a database repair-frontier defect. -/
+theorem tupleProtectedDataSquare_databaseRepairDefect :
+    RepairFrontierDefectAt
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+      LocusAtom.database := by
+  exact endpointTuple_databaseRepairDefect
+
+/-- The selected tuple square has a database trace-field defect. -/
+theorem tupleProtectedDataSquare_databaseTraceFieldDefect :
+    TraceFieldDefectAt
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+      LocusAtom.database := by
+  exact endpointTuple_databaseTraceFieldDefect
+
+/-- Component-indexed selected square obligation defect. -/
+theorem tupleProtectedDataSquare_obligationComponentDefect :
+    TupleHolonomyDefect
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+      TupleProtectedComponent.obligation :=
+  tupleProtectedDataSquare_obligationDefect
+
+/-- Component-indexed selected square repair-frontier defect. -/
+theorem tupleProtectedDataSquare_databaseRepairComponentDefect :
+    TupleHolonomyDefect
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+      (TupleProtectedComponent.repairFrontier LocusAtom.database) :=
+  tupleProtectedDataSquare_databaseRepairDefect
+
+/-- Component-indexed selected square trace-field defect. -/
+theorem tupleProtectedDataSquare_databaseTraceFieldComponentDefect :
+    TupleHolonomyDefect
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+      TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+      (TupleProtectedComponent.traceField LocusAtom.database) :=
+  tupleProtectedDataSquare_databaseTraceFieldDefect
+
+/--
+The selected finite square is visibly flat while its component defects produce
+protected-data curvature.
+-/
+theorem tupleProtectedDataSquare_componentDefects_curve :
+    FiniteSquareCriterion.VisibleFlat
+        TupleProtectedDataSquareCriterion.tupleProtectedDataSquareReading
+        (FiniteSquareCriterion.endpointPairOfSquare
+          TupleProtectedDataSquareCriterion.tupleProtectedDataSquare) ∧
+      ObligationDefect
+        TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+        TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst ∧
+      RepairFrontierDefectAt
+        TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+        TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+        LocusAtom.database ∧
+      TraceFieldDefectAt
+        TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+        TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+        LocusAtom.database ∧
+      FiniteSquareCriterion.ReadingCurved
+        TupleProtectedDataSquareCriterion.tupleProtectedDataSquareReading
+        (FiniteSquareCriterion.endpointPairOfSquare
+          TupleProtectedDataSquareCriterion.tupleProtectedDataSquare) :=
+  ⟨TupleProtectedDataSquareCriterion.tupleProtectedData_square_visibleFlat,
+    tupleProtectedDataSquare_obligationDefect,
+    tupleProtectedDataSquare_databaseRepairDefect,
+    tupleProtectedDataSquare_databaseTraceFieldDefect,
+    TupleProtectedDataSquareCriterion.tupleProtectedData_instantiates_finiteSquareCriterion⟩
+
+/-! ## Cross-profile tuple holonomy defects -/
+
+/-- Zero tuple-holonomy defect across two profile fibers. -/
+def NoTupleHolonomyDefectAcross {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q) : Prop :=
+  source.omega = target.omega ∧
+    (∀ atom, source.repairFrontier atom ↔ target.repairFrontier atom) ∧
+    (∀ atom, source.traceField atom = target.traceField atom)
+
+/-- A nonzero protected-data defect across profile fibers. -/
+def HasTupleHolonomyDefectAcross {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q) : Prop :=
+  ¬ NoTupleHolonomyDefectAcross source target
+
+/-- Cross-profile obligation component defect. -/
+def ObligationDefectAcross {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q) : Prop :=
+  source.omega ≠ target.omega
+
+/-- Cross-profile repair-frontier component defect at one atom. -/
+def RepairFrontierDefectAcrossAt {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q)
+    (atom : LocusAtom) : Prop :=
+  ¬ (source.repairFrontier atom ↔ target.repairFrontier atom)
+
+/-- Cross-profile trace-field component defect at one atom. -/
+def TraceFieldDefectAcrossAt {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q)
+    (atom : LocusAtom) : Prop :=
+  source.traceField atom ≠ target.traceField atom
+
+/-- Component-indexed cross-profile tuple holonomy defect. -/
+def TupleHolonomyDefectAcross {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q) :
+    TupleProtectedComponent -> Prop
+  | .obligation => ObligationDefectAcross source target
+  | .repairFrontier atom => RepairFrontierDefectAcrossAt source target atom
+  | .traceField atom => TraceFieldDefectAcrossAt source target atom
+
+/-- Cross-profile zero defect is protected-data agreement across profiles. -/
+theorem noTupleHolonomyDefectAcross_iff_protectedDataAcross
+    {p q : TupleProfile}
+    (source : TupleCertificateAt p) (target : TupleCertificateAt q) :
+    NoTupleHolonomyDefectAcross source target ↔
+      TupleTransportExactness.SameTupleProtectedDataAcross source target :=
+  Iff.rfl
+
+/-- Cross-profile obligation disagreement obstructs zero defect. -/
+theorem obligationDefectAcross_obstructs_noTupleHolonomyDefectAcross
+    {p q : TupleProfile} {source : TupleCertificateAt p}
+    {target : TupleCertificateAt q}
+    (hdefect : ObligationDefectAcross source target) :
+    HasTupleHolonomyDefectAcross source target := by
+  intro hzero
+  exact hdefect hzero.1
+
+/-- Cross-profile repair-frontier disagreement obstructs zero defect. -/
+theorem repairFrontierDefectAcross_obstructs_noTupleHolonomyDefectAcross
+    {p q : TupleProfile} {source : TupleCertificateAt p}
+    {target : TupleCertificateAt q} {atom : LocusAtom}
+    (hdefect : RepairFrontierDefectAcrossAt source target atom) :
+    HasTupleHolonomyDefectAcross source target := by
+  intro hzero
+  exact hdefect (hzero.2.1 atom)
+
+/-- Cross-profile trace-field disagreement obstructs zero defect. -/
+theorem traceFieldDefectAcross_obstructs_noTupleHolonomyDefectAcross
+    {p q : TupleProfile} {source : TupleCertificateAt p}
+    {target : TupleCertificateAt q} {atom : LocusAtom}
+    (hdefect : TraceFieldDefectAcrossAt source target atom) :
+    HasTupleHolonomyDefectAcross source target := by
+  intro hzero
+  exact hdefect (hzero.2.2 atom)
+
+/-- Any component-indexed cross-profile defect obstructs zero defect. -/
+theorem tupleHolonomyDefectAcross_obstructs_noTupleHolonomyDefectAcross
+    {p q : TupleProfile} {source : TupleCertificateAt p}
+    {target : TupleCertificateAt q}
+    {component : TupleProtectedComponent}
+    (hdefect : TupleHolonomyDefectAcross source target component) :
+    HasTupleHolonomyDefectAcross source target := by
+  cases component with
+  | obligation =>
+      exact obligationDefectAcross_obstructs_noTupleHolonomyDefectAcross
+        hdefect
+  | repairFrontier atom =>
+      exact repairFrontierDefectAcross_obstructs_noTupleHolonomyDefectAcross
+        hdefect
+  | traceField atom =>
+      exact traceFieldDefectAcross_obstructs_noTupleHolonomyDefectAcross
+        hdefect
+
+/-- Grid-map tuple transports have zero cross-profile tuple-holonomy defect. -/
+theorem tupleTransportOfGridMap_noTupleHolonomyDefectAcross
+    {p q : TupleProfile}
+    (gridMap :
+      ProfileGridHolonomy.CertificateAt p ->
+        ProfileGridHolonomy.CertificateAt q)
+    (c : TupleCertificateAt p) :
+    NoTupleHolonomyDefectAcross c
+      ((TupleTransportExactness.tupleTransportOfGridMap gridMap).map c) :=
+  TupleTransportExactness.tupleTransportOfGridMap_preserves_protectedDataAcross
+    gridMap c
+
+/-- Any transported cross-profile defect obstructs protected-data preservation. -/
+theorem hasTupleHolonomyDefectAcross_obstructs_losslessTransport
+    {p q : TupleProfile}
+    (τ : TupleTransportExactness.TupleTransport p q)
+    {c : TupleCertificateAt p}
+    (hdefect : HasTupleHolonomyDefectAcross c (τ.map c)) :
+    ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ := by
+  exact TupleTransportExactness.protectedDataDivergence_obstructs_losslessTupleTransport
+    τ hdefect
+
+/-- Any transported component defect obstructs protected-data preservation. -/
+theorem tupleHolonomyDefectAcross_obstructs_losslessTransport
+    {p q : TupleProfile}
+    (τ : TupleTransportExactness.TupleTransport p q)
+    {c : TupleCertificateAt p}
+    {component : TupleProtectedComponent}
+    (hdefect : TupleHolonomyDefectAcross c (τ.map c) component) :
+    ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ :=
+  hasTupleHolonomyDefectAcross_obstructs_losslessTransport τ
+    (tupleHolonomyDefectAcross_obstructs_noTupleHolonomyDefectAcross
+      hdefect)
+
+/-- Cross-profile obligation defect obstructs protected-data preserving transport. -/
+theorem obligationDefectAcross_obstructs_losslessTransport
+    {p q : TupleProfile}
+    (τ : TupleTransportExactness.TupleTransport p q)
+    {c : TupleCertificateAt p}
+    (hdefect : ObligationDefectAcross c (τ.map c)) :
+    ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ :=
+  hasTupleHolonomyDefectAcross_obstructs_losslessTransport τ
+    (obligationDefectAcross_obstructs_noTupleHolonomyDefectAcross hdefect)
+
+/-- Cross-profile repair-frontier defect obstructs protected-data preserving transport. -/
+theorem repairFrontierDefectAcross_obstructs_losslessTransport
+    {p q : TupleProfile}
+    (τ : TupleTransportExactness.TupleTransport p q)
+    {c : TupleCertificateAt p} {atom : LocusAtom}
+    (hdefect : RepairFrontierDefectAcrossAt c (τ.map c) atom) :
+    ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ :=
+  hasTupleHolonomyDefectAcross_obstructs_losslessTransport τ
+    (repairFrontierDefectAcross_obstructs_noTupleHolonomyDefectAcross hdefect)
+
+/-- Cross-profile trace-field defect obstructs protected-data preserving transport. -/
+theorem traceFieldDefectAcross_obstructs_losslessTransport
+    {p q : TupleProfile}
+    (τ : TupleTransportExactness.TupleTransport p q)
+    {c : TupleCertificateAt p} {atom : LocusAtom}
+    (hdefect : TraceFieldDefectAcrossAt c (τ.map c) atom) :
+    ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ :=
+  hasTupleHolonomyDefectAcross_obstructs_losslessTransport τ
+    (traceFieldDefectAcross_obstructs_noTupleHolonomyDefectAcross hdefect)
+
+/-! ## Theorem package -/
+
+/--
+Cycle-22 theorem package: tuple protected-data holonomy decomposes into
+obligation, repair-frontier, and trace-field component defects. Zero defect is
+protected-data agreement, concrete endpoint/square witnesses have nonzero
+component defects, and cross-profile defects obstruct lossless tuple transport.
+-/
+theorem tupleHolonomyDefect_invariant_package :
+    (∀ {p : TupleProfile} (left right : TupleCertificateAt p),
+      NoTupleHolonomyDefect left right ↔
+        ProfileTupleIntegration.SameTupleProtectedData left right) ∧
+      ((ProfileTupleIntegration.visibleTupleSurfaceReading
+          ProfileTupleIntegration.endpointProfile).Equivalent
+        ProfileTupleIntegration.fullEndpointTuple
+        ProfileTupleIntegration.traceMissingEndpointTuple ∧
+        TupleHolonomyDefect
+          ProfileTupleIntegration.fullEndpointTuple
+          ProfileTupleIntegration.traceMissingEndpointTuple
+          TupleProtectedComponent.obligation ∧
+        TupleHolonomyDefect
+          ProfileTupleIntegration.fullEndpointTuple
+          ProfileTupleIntegration.traceMissingEndpointTuple
+          (TupleProtectedComponent.repairFrontier LocusAtom.database) ∧
+        TupleHolonomyDefect
+          ProfileTupleIntegration.fullEndpointTuple
+          ProfileTupleIntegration.traceMissingEndpointTuple
+          (TupleProtectedComponent.traceField LocusAtom.database) ∧
+        HasTupleHolonomyDefect
+          ProfileTupleIntegration.fullEndpointTuple
+          ProfileTupleIntegration.traceMissingEndpointTuple) ∧
+      (FiniteSquareCriterion.ReadingCurved
+        TupleProtectedDataSquareCriterion.tupleProtectedDataSquareReading
+        (FiniteSquareCriterion.endpointPairOfSquare
+          TupleProtectedDataSquareCriterion.tupleProtectedDataSquare) ∧
+        TupleHolonomyDefect
+          TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+          TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+          TupleProtectedComponent.obligation ∧
+        TupleHolonomyDefect
+          TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+          TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+          (TupleProtectedComponent.repairFrontier LocusAtom.database) ∧
+        TupleHolonomyDefect
+          TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.lawFirst
+          TupleProtectedDataSquareCriterion.tupleProtectedDataEndpointPair.coverFirst
+          (TupleProtectedComponent.traceField LocusAtom.database)) ∧
+      (∀ {p q : TupleProfile}
+        (τ : TupleTransportExactness.TupleTransport p q)
+        {c : TupleCertificateAt p},
+        HasTupleHolonomyDefectAcross c (τ.map c) ->
+          ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ) ∧
+      (∀ {p q : TupleProfile}
+        (τ : TupleTransportExactness.TupleTransport p q)
+        {c : TupleCertificateAt p}
+        {component : TupleProtectedComponent},
+        TupleHolonomyDefectAcross c (τ.map c) component ->
+          ¬ TupleTransportExactness.PreservesTupleProtectedDataAcross τ) ∧
+      (∀ {p q : TupleProfile}
+        (gridMap :
+          ProfileGridHolonomy.CertificateAt p ->
+            ProfileGridHolonomy.CertificateAt q)
+        (c : TupleCertificateAt p),
+        NoTupleHolonomyDefectAcross c
+          ((TupleTransportExactness.tupleTransportOfGridMap gridMap).map c)) := by
+  exact ⟨by
+    intro p left right
+    exact noTupleHolonomyDefect_iff_protectedData left right,
+    endpointTuple_visibleSurface_hides_indexedDefects,
+    ⟨TupleProtectedDataSquareCriterion.tupleProtectedData_instantiates_finiteSquareCriterion,
+      tupleProtectedDataSquare_obligationComponentDefect,
+      tupleProtectedDataSquare_databaseRepairComponentDefect,
+      tupleProtectedDataSquare_databaseTraceFieldComponentDefect⟩,
+    by
+      intro p q τ c hdefect
+      exact hasTupleHolonomyDefectAcross_obstructs_losslessTransport τ
+        hdefect,
+    by
+      intro p q τ c component hdefect
+      exact tupleHolonomyDefectAcross_obstructs_losslessTransport τ
+        hdefect,
+    by
+      intro p q gridMap c
+      exact tupleTransportOfGridMap_noTupleHolonomyDefectAcross gridMap c⟩
+
+end TupleHolonomyDefectInvariant
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-tuple-holonomy-defect-invariant.md
+++ b/research/ideas/g-aat-quality-surface-01-tuple-holonomy-defect-invariant.md
@@ -1,0 +1,170 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: unification
+capability_category: profile-curvature/certificate-transport/invariance/obstruction/traceability
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle22
+tags:
+  - tuple-holonomy
+  - defect-invariant
+  - protected-data
+created: 2026-06-20
+---
+
+# Tuple holonomy defect invariant for protected certificate data
+
+## 主張
+
+profile tuple certificate の protected data 差分を、obligation、repair frontier、trace field の
+component defect として分解する。zero tuple-holonomy defect は protected tuple data agreement と同値であり、
+visible tuple surface が flat に見える selected finite square でも、component defect が非ゼロなら
+protected-data holonomy は消えない。
+
+さらに、cross-profile transport についても zero defect across profiles を protected-data preserving
+transport と同値に読み、tuple transport が protected data を保存しない場合は component defect が
+lossless tuple transport を阻害することを theorem package として固定する。
+
+主張は selected finite tuple certificate、existing profile tuple fields、declared tuple transport に相対化する。
+任意 profile family の global classification、canonical transport、source extraction completeness、
+ArchMap correctness、実コード全体の traceability は結論しない。
+
+## 候補種別
+
+`unification`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/ProfileTupleIntegration.lean`
+- `Formal/AG/Research/QualitySurface/TupleProtectedDataSquareCriterion.lean`
+- `Formal/AG/Research/QualitySurface/TupleTransportExactness.lean`
+- `ProfileTupleIntegration.SameTupleProtectedData`
+- `ProfileTupleIntegration.endpointTuple_visibleAgreement`
+- `ProfileTupleIntegration.endpointTuple_omega_diff`
+- `ProfileTupleIntegration.endpointTuple_repairFrontier_diff`
+- `ProfileTupleIntegration.endpointTuple_traceField_diff`
+- `TupleTransportExactness.SameTupleProtectedDataAcross`
+- `TupleTransportExactness.protectedDataDivergence_obstructs_losslessTupleTransport`
+
+## 非自明性
+
+Cycle 11 は same visible tuple surface の背後で protected tuple data が違う witness を固定し、
+Cycle 18 は finite square criterion にその witness を接続した。この候補は、差分を単なる
+`¬ SameTupleProtectedData` として扱わず、obligation / repair frontier / trace field の component
+defect に分解し、zero-defect criterion と transport obstruction を同じ invariant surface に置く。
+
+単なる rename にしないため、次を required evidence にする。
+
+- no-defect iff protected tuple data agreement。
+- obligation defect、repair-frontier defect、trace-field defect がそれぞれ no-defect を阻害する。
+- selected endpoint pair で visible surface は一致するが、三つの component defect がすべて非ゼロである。
+- selected tuple square の curvature を component defect から読める。
+- cross-profile no-defect は `SameTupleProtectedDataAcross` と一致し、defect across transport は
+  protected-data-preserving transport を阻害する。
+
+## 数学的興味
+
+profile curvature を「protected tuple data が違う」という一枚岩の否定命題から、有限 component
+defect invariant へ分解する。これにより、Quality Surface の hidden holonomy をどの protected
+component が支えているかを theorem statement として参照できる。
+
+## GOAL への前進
+
+profile-curvature / certificate-transport / invariance / obstruction / traceability を接続し、
+tuple certificate geometry の holonomy を component-level invariant として扱えるようにする。
+
+## SCORE 見込み
+
+- `score_reason`: G2-B は base 75 を認めたが、G2-A/C が Cycle 11/18/14 の既存 witness と theorem に近い
+  rename risk を指摘したため、revised candidate は base 60 / final 120 に下げる。
+- `dullness_risk`: medium-high。`¬ SameTupleProtectedData` の再命名に落ちないよう、explicit component index、
+  component theorem、selected endpoint instantiation、finite-square curvature reading、cross-profile transport
+  obstruction を必須にする。
+- `proof_or_evidence_plan`: `TupleHolonomyDefect.lean` に component defect、no-defect criterion、
+  selected endpoint witness、selected square witness、transport obstruction theorem、package theorem を置く。
+
+## CS / SWE への帰結
+
+loss-aware visualization や drill-down report では、visible tuple surface が同じ場合でも、obligation /
+repair frontier / trace field のどの component defect が hidden holonomy を作っているかを保持できる。
+これは finite selected tuple certificate の数学的 witness であり、tooling completeness や実コード全体の
+traceability は主張しない。
+
+## 証明・根拠
+
+Lean proof は `Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean` に閉じた。
+`Formal/AG/Research.lean` はこの Research evidence file を import する。
+
+主要 theorem / declaration:
+
+- `TupleProtectedComponent`
+- `NoTupleHolonomyDefect`
+- `HasTupleHolonomyDefect`
+- `TupleHolonomyDefect`
+- `TupleHolonomyDefectAcross`
+- `noTupleHolonomyDefect_iff_protectedData`
+- `tupleHolonomyDefect_obstructs_noTupleHolonomyDefect`
+- `endpointTuple_visibleSurface_hides_indexedDefects`
+- `tupleProtectedDataSquare_componentDefects_curve`
+- `noTupleHolonomyDefectAcross_iff_protectedDataAcross`
+- `tupleHolonomyDefectAcross_obstructs_losslessTransport`
+- `tupleTransportOfGridMap_noTupleHolonomyDefectAcross`
+- `tupleHolonomyDefect_invariant_package`
+
+固定された内容:
+
+- `TupleProtectedComponent` は `obligation`、`repairFrontier atom`、`traceField atom` を component-indexed
+  defect surface として持つ。
+- `NoTupleHolonomyDefect` は same-profile protected tuple data agreement と同値であり、
+  `TupleHolonomyDefect` は各 component の nonzero defect を表す。
+- `tupleHolonomyDefect_obstructs_noTupleHolonomyDefect` は、任意 component defect が zero defect を
+  阻害することを示す。
+- `endpointTuple_visibleSurface_hides_indexedDefects` は、selected endpoint pair が visible tuple
+  surface では一致する一方、三つの protected component defect をすべて持つことを示す。
+- `tupleProtectedDataSquare_componentDefects_curve` は、selected finite square の visible flatness と
+  component defect を `ReadingCurved` に接続する。
+- `TupleHolonomyDefectAcross` と `tupleHolonomyDefectAcross_obstructs_losslessTransport` は、declared
+  tuple transport 上の component defect が protected-data-preserving transport を阻害することを示す。
+- `tupleTransportOfGridMap_noTupleHolonomyDefectAcross` は、grid-map tuple transport が protected data を
+  pointwise に運ぶため zero cross-profile defect を持つことを示す。
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `.tmp/tuple_holonomy_defect_axioms.lean` の `#print axioms`: listed declarations are all
+  `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は出ていない。
+- 対象 Lean file の `axiom` / `admit` / `sorry` / `unsafe` scan: no hits。
+- G3 Lean 形式化品質監査: pass。component-indexed defect、endpoint/square witness、cross-profile
+  transport obstruction により、単なる `¬ SameTupleProtectedData` の rename には留まらない。
+
+## 審判メモ
+
+- 厳密性: G2-A は初回 revise、base 60。`SameTupleProtectedData` は既に三成分の conjunction なので、
+  no-defect iff だけでは定義展開に近い。explicit `TupleProtectedComponent` と component-indexed
+  defect surface、endpoint/square/transport obstruction を required evidence とした。
+- 厳密性再審判: G2-A は revised card / Lean proof を accept、base 60 / final 120。
+- 研究価値: G2-B は初回 accept、base 75 / final 150。hidden protected tuple curvature を成分別に
+  追跡できる invariant にする価値を認めた。
+- repo 全体価値: G2-C は初回 revise、base 65。既存 Cycle 11/14/18 に近いため、candidate type の正規化と
+  score reduction、explicit defect interface を要求した。再審判では accept、base 60 / final 120。
+- SCORE 監査: G4 は confirm、base 60 / evidence multiplier 2.0 / penalty 0 / final 120。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-profile-tuple-integration.md`
+- `research/ideas/g-aat-quality-surface-01-tuple-transport-exactness.md`
+- `research/ideas/g-aat-quality-surface-01-tuple-protected-data-square-criterion.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 22 candidate card 作成。
+- 2026-06-20: G2-A/C revise を反映し、candidate type を `unification` に正規化し、
+  expected score を base 60 / final 120 へ下げ、explicit component index を required evidence に追加した。
+- 2026-06-20: `TupleHolonomyDefect.lean` を追加し、単体 Lean、`FormalAGResearch`、axiom harness、
+  G3 Lean 形式化品質監査を通した。
+- 2026-06-20: G4 SCORE 監査 confirm。report の Cycle 22 と Current SCORE を total 2680 に更新した。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2560
+- total SCORE: 2680
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -27,8 +27,9 @@
   - certificate-transport / obstruction / invariance / repair-potential / traceability: 110
   - profile-curvature / certificate-transport / invariance / computability / obstruction: 120
   - traceability / repair-potential / computability / quality-surface / certificate-transport: 120
+  - profile-curvature / certificate-transport / invariance / obstruction / traceability: 120
 - evidence portfolio:
-  - proved-in-research: 21
+  - proved-in-research: 22
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -910,8 +911,59 @@ declared pointwise repair action、source-ref missing locus、exact repair front
 実コード全体の repair reachability、source extraction completeness、ArchMap correctness、任意 codebase の
 repair planning、tooling completeness は結論しない。
 
+## Cycle 22: Tuple holonomy defect invariant for protected certificate data
+
+```text
+candidate: Tuple holonomy defect invariant for protected certificate data
+candidate_type: unification
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: profile-curvature/certificate-transport/invariance/obstruction/traceability
+goal_delta: protected tuple data holonomy を obligation / repair frontier / trace field の component defect invariant として分解し、visible-flat な selected square の hidden curvature と transport obstruction を同じ語彙で扱えるようにした。
+project_value_delta: Cycle 11/14/18 の tuple protected-data witness、transport exactness、finite-square curvature を report / paper 用の component-level invariant package に統合した。
+formalization_quality: pass。`TupleProtectedComponent`、same-profile / cross-profile component-indexed defect、zero-defect iff、endpoint/square witness、transport obstruction、package theorem が axiom-free / sorry-free で証明されている。
+open_questions: component defect の合成則、任意 selected grid/path family への holonomy defect calculus、source-ref packet/tuple visualization の lossy exactness detector との接続。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean` は、profile tuple certificate の
+protected data 差分を component-indexed defect として切り出す。component は `obligation`、
+`repairFrontier atom`、`traceField atom` であり、zero defect は protected tuple data agreement
+と同値である。
+
+Lean 証拠は次を固定する。
+
+- `TupleProtectedComponent`: hidden holonomy を担う protected tuple component。
+- `NoTupleHolonomyDefect` / `HasTupleHolonomyDefect`: same-profile の zero / nonzero defect。
+- `TupleHolonomyDefect`: same-profile component-indexed defect。
+- `noTupleHolonomyDefect_iff_protectedData`: zero defect は `SameTupleProtectedData` と同値である。
+- `tupleHolonomyDefect_obstructs_noTupleHolonomyDefect`: 任意 component defect は zero defect を阻害する。
+- `endpointTuple_visibleSurface_hides_indexedDefects`: selected endpoint pair は visible tuple surface で一致するが、
+  obligation、database repair frontier、database trace field の各 component defect を持つ。
+- `tupleProtectedDataSquare_componentDefects_curve`: selected finite square は visible-flat だが、
+  component defect を持ち、protected-data reading では curved である。
+- `NoTupleHolonomyDefectAcross` / `TupleHolonomyDefectAcross`: cross-profile zero / component defect。
+- `noTupleHolonomyDefectAcross_iff_protectedDataAcross`: cross-profile zero defect は
+  `SameTupleProtectedDataAcross` と同値である。
+- `tupleHolonomyDefectAcross_obstructs_losslessTransport`: transported component defect は
+  `PreservesTupleProtectedDataAcross` を阻害する。
+- `tupleTransportOfGridMap_noTupleHolonomyDefectAcross`: grid-map tuple transport は protected data を
+  pointwise に運ぶため zero cross-profile defect を持つ。
+- `tupleHolonomyDefect_invariant_package`: same-profile zero criterion、endpoint indexed defects、
+  selected square curvature、transport obstruction、grid-map zero-defect transport を束ねる theorem package。
+
+この結果により、tuple protected-data curvature は単なる `¬ SameTupleProtectedData` ではなく、
+どの protected component が hidden holonomy を支えているかを参照できる defect interface として扱える。
+主張は supplied finite tuple certificate、selected finite square、declared tuple transport に相対化され、
+任意 profile family の global classification、canonical transport、source extraction completeness、
+ArchMap correctness、実コード全体の traceability は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 21 後の total SCORE は 2560 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 22 後の total SCORE は 2680 である。
 次に進める場合は、source-ref exactness detects lossy packet-to-tuple visualization、finite codebase trace holonomy
-packet、tuple holonomy defect invariant、または selected decomposition を越える grid localization calculus を狙う。
+packet、component defect の合成則、または selected decomposition を越える grid localization calculus を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 22 として、protected tuple data の hidden holonomy を `obligation` / `repairFrontier atom` / `traceField atom` の component defect invariant に分解する Lean evidence を追加しました。G4 SCORE 監査は base 60 / multiplier 2.0 / penalty 0 / final 120 を confirm し、report の total SCORE を 2680 / 5000 に更新しています。

この PR は tracking Issue を閉じません。threshold 未達のため、merge 後も research-loop は継続します。

## 証明した定理

- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.TupleProtectedComponent`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.NoTupleHolonomyDefect`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.TupleHolonomyDefect`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.TupleHolonomyDefectAcross`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.noTupleHolonomyDefect_iff_protectedData`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.tupleHolonomyDefect_obstructs_noTupleHolonomyDefect`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.endpointTuple_visibleSurface_hides_indexedDefects`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.tupleProtectedDataSquare_componentDefects_curve`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.noTupleHolonomyDefectAcross_iff_protectedDataAcross`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.tupleHolonomyDefectAcross_obstructs_losslessTransport`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.tupleTransportOfGridMap_noTupleHolonomyDefectAcross`
- `Formal.AG.Research.QualitySurface.TupleHolonomyDefectInvariant.tupleHolonomyDefect_invariant_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-tuple-holonomy-defect-invariant.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `.tmp/tuple_holonomy_defect_axioms.lean` の主要 `#print axioms`: all no axioms
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（tracking Issue のため close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
