### PR TITLE
研究: finite codebase trace holonomy packet を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -21,3 +21,4 @@ import Formal.AG.Research.QualitySurface.TupleTransportComponentLaws
 import Formal.AG.Research.QualitySurface.GridHolonomyLocalization
 import Formal.AG.Research.QualitySurface.CodebaseTraceRepairTrajectory
 import Formal.AG.Research.QualitySurface.TupleHolonomyDefect
+import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket

--- a/Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean
+++ b/Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean
@@ -1,0 +1,395 @@
+import Formal.AG.Research.QualitySurface.SourceRefTokenIdentityReflection
+import Formal.AG.Research.QualitySurface.TupleHolonomyDefect
+
+/-!
+Cycle 23 evidence for `G-aat-quality-surface-01`.
+
+This file reads the supplied finite source-reference packets as a code-atom
+level holonomy carrier.  The claim is relative to the supplied packet pair,
+the finite code atom vocabulary, and the explicit packet-to-tuple bridge.  It
+does not assert source extraction completeness, ArchMap correctness, a
+canonical packet extractor, arbitrary codebase traceability, or whole-codebase
+quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace CodebaseTraceHolonomyPacket
+
+open CodebaseTracePacket
+open TraceLocus
+
+abbrev TupleProfile :=
+  SourceRefTupleBridge.TupleProfile
+
+abbrev TupleCertificateAt :=
+  ProfileTupleIntegration.TupleCertificateAt
+
+/-! ## Packet-level protected component defects -/
+
+/-- Protected source-ref packet component whose defect can carry holonomy. -/
+inductive SourceRefPacketProtectedComponent where
+  | obligation
+  | repairFrontier (atom : CodeAtom)
+  | sourceRefTable (atom : CodeAtom)
+  deriving DecidableEq
+
+/-- Same source-ref table, stated pointwise. -/
+def SameSourceRefTable (left right : SourceRefPacket) : Prop :=
+  ∀ atom, left.sourceRefTable atom = right.sourceRefTable atom
+
+/-- Same protected packet data: obligation, repair frontier, and source-ref table. -/
+def SameSourceRefPacketProtectedData
+    (left right : SourceRefPacket) : Prop :=
+  left.obligation = right.obligation ∧
+    SameCodebaseRepairFrontier left right ∧
+    SameSourceRefTable left right
+
+/-- Zero packet-level holonomy defect. -/
+def NoSourceRefPacketHolonomyDefect
+    (left right : SourceRefPacket) : Prop :=
+  left.obligation = right.obligation ∧
+    SameCodebaseRepairFrontier left right ∧
+    SameSourceRefTable left right
+
+/-- Nonzero packet-level protected-data defect. -/
+def HasSourceRefPacketHolonomyDefect
+    (left right : SourceRefPacket) : Prop :=
+  ¬ NoSourceRefPacketHolonomyDefect left right
+
+/-- Obligation component defect. -/
+def SourceRefObligationDefect
+    (left right : SourceRefPacket) : Prop :=
+  left.obligation ≠ right.obligation
+
+/-- Repair-frontier component defect at one code atom. -/
+def SourceRefRepairFrontierDefectAt
+    (left right : SourceRefPacket) (atom : CodeAtom) : Prop :=
+  ¬ (left.repairFrontier atom ↔ right.repairFrontier atom)
+
+/-- Source-ref table component defect at one code atom. -/
+def SourceRefTableDefectAt
+    (left right : SourceRefPacket) (atom : CodeAtom) : Prop :=
+  left.sourceRefTable atom ≠ right.sourceRefTable atom
+
+/-- Component-indexed packet holonomy defect. -/
+def SourceRefPacketHolonomyDefect
+    (left right : SourceRefPacket) :
+    SourceRefPacketProtectedComponent -> Prop
+  | .obligation => SourceRefObligationDefect left right
+  | .repairFrontier atom => SourceRefRepairFrontierDefectAt left right atom
+  | .sourceRefTable atom => SourceRefTableDefectAt left right atom
+
+/-- Zero packet defect is protected packet data agreement. -/
+theorem noSourceRefPacketHolonomyDefect_iff_protectedData
+    (left right : SourceRefPacket) :
+    NoSourceRefPacketHolonomyDefect left right ↔
+      SameSourceRefPacketProtectedData left right :=
+  Iff.rfl
+
+/-- Obligation disagreement obstructs zero packet defect. -/
+theorem sourceRefObligationDefect_obstructs_noPacketHolonomy
+    {left right : SourceRefPacket}
+    (hdefect : SourceRefObligationDefect left right) :
+    HasSourceRefPacketHolonomyDefect left right := by
+  intro hzero
+  exact hdefect hzero.1
+
+/-- Repair-frontier disagreement obstructs zero packet defect. -/
+theorem sourceRefRepairDefect_obstructs_noPacketHolonomy
+    {left right : SourceRefPacket} {atom : CodeAtom}
+    (hdefect : SourceRefRepairFrontierDefectAt left right atom) :
+    HasSourceRefPacketHolonomyDefect left right := by
+  intro hzero
+  exact hdefect (hzero.2.1 atom)
+
+/-- Source-ref table disagreement obstructs zero packet defect. -/
+theorem sourceRefTableDefect_obstructs_noPacketHolonomy
+    {left right : SourceRefPacket} {atom : CodeAtom}
+    (hdefect : SourceRefTableDefectAt left right atom) :
+    HasSourceRefPacketHolonomyDefect left right := by
+  intro hzero
+  exact hdefect (hzero.2.2 atom)
+
+/-- Any component-indexed packet defect obstructs zero packet defect. -/
+theorem sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+    {left right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hdefect : SourceRefPacketHolonomyDefect left right component) :
+    HasSourceRefPacketHolonomyDefect left right := by
+  cases component with
+  | obligation =>
+      exact sourceRefObligationDefect_obstructs_noPacketHolonomy hdefect
+  | repairFrontier atom =>
+      exact sourceRefRepairDefect_obstructs_noPacketHolonomy hdefect
+  | sourceRefTable atom =>
+      exact sourceRefTableDefect_obstructs_noPacketHolonomy hdefect
+
+/-! ## Full / partial packet holonomy witness -/
+
+/-- The selected full/partial packet pair is visibly flat. -/
+theorem full_partial_packet_visibleFlat :
+    supportSurfaceReading.Equivalent fullPacket partialPacket :=
+  full_partial_supportSurface_equivalent
+
+/-- Full and partial packets differ in obligation. -/
+theorem full_partial_packet_obligationDefect :
+    SourceRefObligationDefect fullPacket partialPacket := by
+  intro h
+  cases h
+
+/-- Full and partial packets differ in the storage repair-frontier component. -/
+theorem full_partial_packet_storageRepairDefect :
+    SourceRefRepairFrontierDefectAt fullPacket partialPacket CodeAtom.storage := by
+  intro hsame
+  have hrepairFull : fullPacket.repairFrontier CodeAtom.storage :=
+    hsame.mpr partialTrace_forces_storage_repair
+  exact fullTrace_repair_frontier_excludes_storage hrepairFull
+
+/-- Full and partial packets differ in the storage source-ref table component. -/
+theorem full_partial_packet_storageSourceRefDefect :
+    SourceRefTableDefectAt fullPacket partialPacket CodeAtom.storage := by
+  intro hsame
+  cases hsame
+
+/-- The full/partial packet pair has nonzero packet holonomy. -/
+theorem full_partial_packet_hasHolonomyDefect :
+    HasSourceRefPacketHolonomyDefect fullPacket partialPacket :=
+  sourceRefObligationDefect_obstructs_noPacketHolonomy
+    full_partial_packet_obligationDefect
+
+/-- Component-indexed obligation defect of the full/partial packet pair. -/
+theorem full_partial_packet_obligationComponentDefect :
+    SourceRefPacketHolonomyDefect fullPacket partialPacket
+      SourceRefPacketProtectedComponent.obligation :=
+  full_partial_packet_obligationDefect
+
+/-- Component-indexed storage repair-frontier defect. -/
+theorem full_partial_packet_storageRepairComponentDefect :
+    SourceRefPacketHolonomyDefect fullPacket partialPacket
+      (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) :=
+  full_partial_packet_storageRepairDefect
+
+/-- Component-indexed storage source-ref table defect. -/
+theorem full_partial_packet_storageSourceRefComponentDefect :
+    SourceRefPacketHolonomyDefect fullPacket partialPacket
+      (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) :=
+  full_partial_packet_storageSourceRefDefect
+
+/--
+The selected full/partial packet pair is visibly flat but has three protected
+packet component defects.
+-/
+theorem full_partial_packet_visibleFlat_componentDefects :
+    supportSurfaceReading.Equivalent fullPacket partialPacket ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        SourceRefPacketProtectedComponent.obligation ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+      HasSourceRefPacketHolonomyDefect fullPacket partialPacket :=
+  ⟨full_partial_packet_visibleFlat,
+    full_partial_packet_obligationComponentDefect,
+    full_partial_packet_storageRepairComponentDefect,
+    full_partial_packet_storageSourceRefComponentDefect,
+    full_partial_packet_hasHolonomyDefect⟩
+
+/-! ## Projection of packet holonomy to tuple holonomy -/
+
+/-- Packet protected component seen as a tuple protected component. -/
+def packetComponentToTupleComponent :
+    SourceRefPacketProtectedComponent ->
+      TupleHolonomyDefectInvariant.TupleProtectedComponent
+  | .obligation =>
+      TupleHolonomyDefectInvariant.TupleProtectedComponent.obligation
+  | .repairFrontier atom =>
+      TupleHolonomyDefectInvariant.TupleProtectedComponent.repairFrontier
+        (toLocusAtom atom)
+  | .sourceRefTable atom =>
+      TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+        (toLocusAtom atom)
+
+/-- Packet-level zero defect induces tuple-level zero defect. -/
+theorem noPacketHolonomy_projects_to_noTupleHolonomy
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    (hzero : NoSourceRefPacketHolonomyDefect left right) :
+    TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right) := by
+  exact ⟨hzero.1,
+    by
+      intro atom
+      exact hzero.2.1 (fromLocusAtom atom),
+    by
+      intro atom
+      change
+        projectedTraceField left atom =
+          projectedTraceField right atom
+      exact SourceRefTokenIdentityReflection.sourceRefTable_preserves_projectedTraceField
+        left right hzero.2.2 atom⟩
+
+/-- Obligation packet defect projects to tuple obligation defect. -/
+theorem sourceRefObligationDefect_projects_to_tupleDefect
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    (hdefect : SourceRefObligationDefect left right) :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      TupleHolonomyDefectInvariant.TupleProtectedComponent.obligation :=
+  hdefect
+
+/-- Repair-frontier packet defect projects to tuple repair-frontier defect. -/
+theorem sourceRefRepairDefect_projects_to_tupleDefect
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket} {atom : CodeAtom}
+    (hdefect : SourceRefRepairFrontierDefectAt left right atom) :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      (TupleHolonomyDefectInvariant.TupleProtectedComponent.repairFrontier
+        (toLocusAtom atom)) := by
+  intro hsame
+  have hsource :
+      left.repairFrontier atom ↔ right.repairFrontier atom := by
+    change
+      left.repairFrontier (fromLocusAtom (toLocusAtom atom)) ↔
+        right.repairFrontier (fromLocusAtom (toLocusAtom atom)) at hsame
+    simpa [SourceRefTupleBridge.from_to_locusAtom] using hsame
+  exact hdefect hsource
+
+/-- Source-ref table packet defect projects to tuple trace-field defect. -/
+theorem sourceRefTableDefect_projects_to_tupleDefect
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket} {atom : CodeAtom}
+    (hdefect : SourceRefTableDefectAt left right atom) :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+        (toLocusAtom atom)) := by
+  intro hsame
+  have hsource :
+      left.sourceRefTable atom = right.sourceRefTable atom :=
+    (SourceRefTokenIdentityReflection.sourceRefOptionMap_eq_iff
+      (left.sourceRefTable atom) (right.sourceRefTable atom)).mp
+      (by
+        change
+          Option.map sourceRefToTraceToken
+              (left.sourceRefTable (fromLocusAtom (toLocusAtom atom))) =
+            Option.map sourceRefToTraceToken
+              (right.sourceRefTable (fromLocusAtom (toLocusAtom atom))) at hsame
+        simpa [SourceRefTupleBridge.from_to_locusAtom] using hsame)
+  exact hdefect hsource
+
+/-- Any component-indexed packet defect projects to a tuple holonomy defect. -/
+theorem sourceRefPacketHolonomy_projects_to_tupleHolonomy
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hdefect : SourceRefPacketHolonomyDefect left right component) :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      (packetComponentToTupleComponent component) := by
+  cases component with
+  | obligation =>
+      exact sourceRefObligationDefect_projects_to_tupleDefect
+        gridLeft gridRight hdefect
+  | repairFrontier atom =>
+      exact sourceRefRepairDefect_projects_to_tupleDefect
+        gridLeft gridRight hdefect
+  | sourceRefTable atom =>
+      exact sourceRefTableDefect_projects_to_tupleDefect
+        gridLeft gridRight hdefect
+
+/-! ## Endpoint package -/
+
+/-- Full/partial packet holonomy projects to selected endpoint tuple holonomy. -/
+theorem full_partial_packetHolonomy_projects_to_endpointTupleHolonomy :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      SourceRefTupleBridge.fullPacketEndpointTuple
+      SourceRefTupleBridge.partialPacketEndpointTuple
+      (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+        LocusAtom.database) :=
+  sourceRefPacketHolonomy_projects_to_tupleHolonomy
+    SourceRefTupleBridge.endpointGridCertificate
+    SourceRefTupleBridge.endpointGridCertificate
+    full_partial_packet_storageSourceRefComponentDefect
+
+/-- The packet-level visible flatness induces endpoint tuple visible flatness. -/
+theorem full_partial_packetHolonomy_tupleVisibleFlat :
+    (ProfileTupleIntegration.visibleTupleSurfaceReading
+        SourceRefTupleBridge.endpointProfile).Equivalent
+      SourceRefTupleBridge.fullPacketEndpointTuple
+      SourceRefTupleBridge.partialPacketEndpointTuple :=
+  SourceRefTupleBridge.full_partial_packetTuple_visible_equivalent
+
+/--
+Cycle-23 theorem package: the finite full/partial source-ref packet pair is a
+visible-flat packet holonomy carrier, and its protected component defects
+project to tuple holonomy defects through the packet-to-tuple bridge.
+-/
+theorem finiteCodebaseTraceHolonomyPacket_package :
+    supportSurfaceReading.Equivalent fullPacket partialPacket ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        SourceRefPacketProtectedComponent.obligation ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        (SourceRefPacketProtectedComponent.repairFrontier CodeAtom.storage) ∧
+      SourceRefPacketHolonomyDefect fullPacket partialPacket
+        (SourceRefPacketProtectedComponent.sourceRefTable CodeAtom.storage) ∧
+      HasSourceRefPacketHolonomyDefect fullPacket partialPacket ∧
+      (ProfileTupleIntegration.visibleTupleSurfaceReading
+          SourceRefTupleBridge.endpointProfile).Equivalent
+        SourceRefTupleBridge.fullPacketEndpointTuple
+        SourceRefTupleBridge.partialPacketEndpointTuple ∧
+      TupleHolonomyDefectInvariant.TupleHolonomyDefect
+        SourceRefTupleBridge.fullPacketEndpointTuple
+        SourceRefTupleBridge.partialPacketEndpointTuple
+        TupleHolonomyDefectInvariant.TupleProtectedComponent.obligation ∧
+      TupleHolonomyDefectInvariant.TupleHolonomyDefect
+        SourceRefTupleBridge.fullPacketEndpointTuple
+        SourceRefTupleBridge.partialPacketEndpointTuple
+        (TupleHolonomyDefectInvariant.TupleProtectedComponent.repairFrontier
+          LocusAtom.database) ∧
+      TupleHolonomyDefectInvariant.TupleHolonomyDefect
+        SourceRefTupleBridge.fullPacketEndpointTuple
+        SourceRefTupleBridge.partialPacketEndpointTuple
+        (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+          LocusAtom.database) ∧
+      (NoSourceRefPacketHolonomyDefect fullPacket partialPacket ->
+        TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+          SourceRefTupleBridge.fullPacketEndpointTuple
+          SourceRefTupleBridge.partialPacketEndpointTuple) :=
+  ⟨full_partial_packet_visibleFlat,
+    full_partial_packet_obligationComponentDefect,
+    full_partial_packet_storageRepairComponentDefect,
+    full_partial_packet_storageSourceRefComponentDefect,
+    full_partial_packet_hasHolonomyDefect,
+    full_partial_packetHolonomy_tupleVisibleFlat,
+    sourceRefPacketHolonomy_projects_to_tupleHolonomy
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      full_partial_packet_obligationComponentDefect,
+    sourceRefPacketHolonomy_projects_to_tupleHolonomy
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      full_partial_packet_storageRepairComponentDefect,
+    full_partial_packetHolonomy_projects_to_endpointTupleHolonomy,
+    by
+      intro hzero
+      exact noPacketHolonomy_projects_to_noTupleHolonomy
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        hzero⟩
+
+end CodebaseTraceHolonomyPacket
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-finite-codebase-trace-holonomy-packet.md
+++ b/research/ideas/g-aat-quality-surface-01-finite-codebase-trace-holonomy-packet.md
@@ -1,0 +1,170 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: traceability/profile-curvature/certificate-transport/computability/repair-potential
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle23
+tags:
+  - source-ref
+  - holonomy-packet
+  - packet-to-tuple
+created: 2026-06-20
+---
+
+# Finite codebase trace holonomy packet
+
+## 主張
+
+supplied finite source-ref packet pair を code-atom level の holonomy packet として読み、visible packet
+surface は flat だが、obligation、storage repair frontier、storage source-ref table の protected
+component defect が非ゼロであることを固定する。さらに、packet-to-tuple bridge はこの source-ref packet
+holonomy を tuple holonomy defect へ反映する。
+
+主張は supplied finite source-ref packets、finite code atom vocabulary、explicit packet-to-tuple bridge、
+selected endpoint tuple に相対化する。source extraction completeness、ArchMap correctness、canonical
+packet extractor、任意 codebase traceability、実コード全体の品質判定は結論しない。
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/CodebaseTracePacket.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefTupleBridge.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefTokenIdentityReflection.lean`
+- `Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean`
+- `CodebaseTracePacket.fullPacket`
+- `CodebaseTracePacket.partialPacket`
+- `CodebaseTracePacket.full_partial_supportSurface_equivalent`
+- `SourceRefTupleBridge.packetToTuple`
+- `SourceRefTokenIdentityReflection.sourceRefOptionMap_eq_iff`
+- `TupleHolonomyDefectInvariant.TupleHolonomyDefect`
+
+## 非自明性
+
+Cycle 9 は source-ref packet の static missing / repair frontier witness を固定し、Cycle 13 は
+packet-to-tuple bridge を固定し、Cycle 22 は tuple protected-data defect invariant を固定した。
+この候補は、source-ref packet 自体に component-indexed holonomy defect surface を置き、その defect が
+tuple component defect へ写ることを theorem package として接続する。
+
+単なる full / partial packet witness の再掲にしないため、次を required evidence にする。
+
+- source-ref packet protected component index。
+- packet-level zero-defect criterion と component defect obstruction。
+- full / partial packet endpoint pair が visible-flat で、三つの packet component defect を持つこと。
+- source-ref repair frontier defect が tuple repair-frontier defect へ写る theorem。
+- source-ref table defect が tuple trace-field defect へ写る theorem。
+- packet-level zero defect が packet-induced tuple zero defect を保証する theorem。
+- finite witness package が visible packet flatness、tuple visible flatness、packet defect、tuple defect reflection を同時に持つこと。
+
+## 数学的興味
+
+finite codebase trace data を単なる observation artifact ではなく、Quality Surface 上の hidden holonomy
+carrier として読む。code atom level の protected packet defect と tuple protected-data defect の対応を
+固定することで、source-ref traceability と profile tuple geometry の間に explicit bridge を置く。
+
+## GOAL への前進
+
+finite codebase trace example、profile curvature、certificate transport、traceability、repair-potential を
+接続し、GOAL の phase boundary criteria にある finite example / trace example / curvature frontier を前進させる。
+
+## SCORE 見込み
+
+- `score_reason`: G2-B は base 75 を認めたが、G2-A/C が Cycle 9/13/16/21/22 近接による再包装リスクを指摘したため、
+  revised candidate は base 60 / final 120 に下げる。
+- `dullness_risk`: medium-high。full / partial packet の既存 theorem 再掲にしないため、packet protected
+  component、zero-defect criterion、component projection to tuple holonomy、finite package theorem を必須にする。
+- `proof_or_evidence_plan`: `CodebaseTraceHolonomyPacket.lean` に packet protected component、packet holonomy
+  defect、projection theorem、full/partial finite witness、package theorem を置く。
+
+## CS / SWE への帰結
+
+source-ref packet の visible surface が同じでも、repair frontier や source-ref table component defect が
+hidden holonomy として残る。packet-to-tuple visualization はその defect を tuple protected data に反映できるため、
+loss-aware visualization / drill-down report では code atom level の source-ref defect を保持すべき理由が明確になる。
+
+## 証明・根拠
+
+Lean proof は `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean` に閉じた。
+`Formal/AG/Research.lean` はこの Research evidence file を import する。
+
+主要 theorem / declaration:
+
+- `SourceRefPacketProtectedComponent`
+- `SameSourceRefTable`
+- `SameSourceRefPacketProtectedData`
+- `NoSourceRefPacketHolonomyDefect`
+- `HasSourceRefPacketHolonomyDefect`
+- `SourceRefPacketHolonomyDefect`
+- `noSourceRefPacketHolonomyDefect_iff_protectedData`
+- `sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy`
+- `full_partial_packet_visibleFlat_componentDefects`
+- `packetComponentToTupleComponent`
+- `noPacketHolonomy_projects_to_noTupleHolonomy`
+- `sourceRefObligationDefect_projects_to_tupleDefect`
+- `sourceRefRepairDefect_projects_to_tupleDefect`
+- `sourceRefTableDefect_projects_to_tupleDefect`
+- `sourceRefPacketHolonomy_projects_to_tupleHolonomy`
+- `full_partial_packetHolonomy_projects_to_endpointTupleHolonomy`
+- `finiteCodebaseTraceHolonomyPacket_package`
+
+固定された内容:
+
+- `SourceRefPacketProtectedComponent` は `obligation`、`repairFrontier atom`、`sourceRefTable atom` を持つ。
+- `NoSourceRefPacketHolonomyDefect` は packet protected data agreement と同値である。
+- `sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy` は、任意 packet component defect が zero defect を
+  阻害することを示す。
+- `full_partial_packet_visibleFlat_componentDefects` は、full / partial packet pair が visible packet surface で
+  flat だが、obligation、storage repair frontier、storage source-ref table の defect を持つことを示す。
+- `noPacketHolonomy_projects_to_noTupleHolonomy` は、packet-level zero defect が packet-induced tuple の
+  zero holonomy defect を保証することを示す。
+- `sourceRefRepairDefect_projects_to_tupleDefect` は、source-ref repair-frontier defect を tuple repair-frontier
+  defect へ写す。
+- `sourceRefTableDefect_projects_to_tupleDefect` は、`sourceRefOptionMap_eq_iff` を用いて source-ref table defect を
+  tuple trace-field defect へ写す。
+- `finiteCodebaseTraceHolonomyPacket_package` は visible packet flatness、packet component defects、
+  tuple visible flatness、tuple component defects、zero-defect projectionを束ねる。
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `.tmp/codebase_trace_holonomy_packet_axioms.lean` の `#print axioms`: listed declarations are all
+  `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は出ていない。
+- 対象 Lean file の `axiom` / `admit` / `sorry` / `unsafe` / `Classical` / `choice` / `propext` /
+  `Quot.sound` scan: no hits。
+- hidden / bidirectional Unicode scan: no hits。
+- G3 Lean 形式化品質監査: pass。`sourceRefTableDefect_projects_to_tupleDefect` は token identity reflection
+  を使っており、opaque contradiction ではない。
+
+## 審判メモ
+
+- 厳密性: G2-A は初回 revise、base 60。Cycle 9/13/22 の再包装に落ちないよう、packet-level component
+  defect calculus と tuple projection theorem を required evidence とした。
+- 厳密性再審判: G2-A は revised card / Lean proof を accept、base 60 / final 120。
+- 研究価値: G2-B は accept、base 75。source-ref packet を Quality Surface 上の hidden holonomy packet として
+  読む価値を認めた。
+- repo 全体価値: G2-C は accept、base 60。既存成果に近いため score は抑えるが、packet-level defect surface と
+  tuple-level reflection は report / paper seed として有効と判定した。
+- SCORE 監査: G4 は confirm、base 60 / evidence multiplier 2.0 / penalty 0 / final 120。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-packet.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-tuple-bridge.md`
+- `research/ideas/g-aat-quality-surface-01-codebase-trace-repair-trajectory.md`
+- `research/ideas/g-aat-quality-surface-01-tuple-holonomy-defect-invariant.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 23 candidate card 作成。
+- 2026-06-20: G2-A revise / G2-C accept base 60 を反映し、expected score を base 60 / final 120 に下げた。
+- 2026-06-20: `CodebaseTraceHolonomyPacket.lean` を追加し、単体 Lean、`FormalAGResearch`、axiom harness、
+  G3 Lean 形式化品質監査を通した。
+- 2026-06-20: G4 SCORE 監査 confirm。report の Cycle 23 と Current SCORE を total 2800 に更新した。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2680
+- total SCORE: 2800
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -28,8 +28,9 @@
   - profile-curvature / certificate-transport / invariance / computability / obstruction: 120
   - traceability / repair-potential / computability / quality-surface / certificate-transport: 120
   - profile-curvature / certificate-transport / invariance / obstruction / traceability: 120
+  - traceability / profile-curvature / certificate-transport / computability / repair-potential: 120
 - evidence portfolio:
-  - proved-in-research: 22
+  - proved-in-research: 23
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -962,8 +963,61 @@ Lean 証拠は次を固定する。
 任意 profile family の global classification、canonical transport、source extraction completeness、
 ArchMap correctness、実コード全体の traceability は結論しない。
 
+## Cycle 23: Finite codebase trace holonomy packet
+
+```text
+candidate: Finite codebase trace holonomy packet
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: traceability/profile-curvature/certificate-transport/computability/repair-potential
+goal_delta: finite source-ref packet を code-atom level holonomy carrier として固定し、visible-flat surface の背後に残る protected packet defects を tuple holonomy defects へ接続した。
+project_value_delta: source-ref traceability、repair frontier、tuple certificate geometry の橋を report / paper seed に載せられる形で追加した。
+formalization_quality: pass。`SourceRefPacketProtectedComponent`、packet-level component defect、zero-defect criterion、三 component defect witness、packet defect -> tuple defect projection、package theorem が axiom-free / sorry-free で証明されている。
+open_questions: 任意 packet family や canonical extractor への一般化は未主張。selected finite packet pair に相対化した成果として扱う。component defect の合成則、source-ref exactness detector、selected grid/path family への接続が残る。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean` は、
+Cycle 9 の full / partial source-ref packet pair を code-atom level の holonomy carrier として読む。
+visible packet surface は flat だが、protected packet data は obligation、storage repair frontier、
+storage source-ref table の三 component で分岐する。
+
+Lean 証拠は次を固定する。
+
+- `SourceRefPacketProtectedComponent`: packet holonomy を担う protected component。
+- `SameSourceRefTable` / `SameSourceRefPacketProtectedData`: packet protected data agreement。
+- `NoSourceRefPacketHolonomyDefect` / `HasSourceRefPacketHolonomyDefect`: packet-level zero / nonzero defect。
+- `SourceRefPacketHolonomyDefect`: component-indexed packet holonomy defect。
+- `noSourceRefPacketHolonomyDefect_iff_protectedData`: zero packet defect は protected packet data agreement と同値である。
+- `sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy`: 任意 packet component defect は zero packet defect を阻害する。
+- `full_partial_packet_visibleFlat_componentDefects`: full / partial packet pair は visible-flat だが三つの protected
+  packet component defect を持つ。
+- `packetComponentToTupleComponent`: packet protected component を tuple protected component へ読む map。
+- `noPacketHolonomy_projects_to_noTupleHolonomy`: packet-level zero defect は packet-induced tuple の zero holonomy
+  defect を保証する。
+- `sourceRefObligationDefect_projects_to_tupleDefect`: packet obligation defect は tuple obligation defect へ写る。
+- `sourceRefRepairDefect_projects_to_tupleDefect`: packet repair-frontier defect は tuple repair-frontier defect へ写る。
+- `sourceRefTableDefect_projects_to_tupleDefect`: packet source-ref table defect は、source-ref token identity reflection を
+  使って tuple trace-field defect へ写る。
+- `sourceRefPacketHolonomy_projects_to_tupleHolonomy`: 任意 component-indexed packet defect は対応する tuple
+  holonomy defect へ写る。
+- `finiteCodebaseTraceHolonomyPacket_package`: visible packet flatness、packet component defects、tuple visible
+  flatness、tuple component defects、zero-defect projection を束ねる theorem package。
+
+この結果により、finite source-ref packet は、visible surface では平坦でも protected source-ref data が
+hidden holonomy を担う finite codebase trace example として扱える。packet-to-tuple bridge はその defect を
+tuple protected-data geometry に反映する。主張は supplied finite source-ref packets、finite code atom vocabulary、
+explicit packet-to-tuple bridge、selected endpoint tuple に相対化され、source extraction completeness、
+ArchMap correctness、canonical packet extractor、任意 codebase traceability、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 22 後の total SCORE は 2680 である。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 23 後の total SCORE は 2800 である。
 次に進める場合は、source-ref exactness detects lossy packet-to-tuple visualization、finite codebase trace holonomy
-packet、component defect の合成則、または selected decomposition を越える grid localization calculus を狙う。
+packet の transport / repair commutator、component defect の合成則、または selected decomposition を越える
+grid localization calculus を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 23 として、finite source-ref packet を code-atom level の holonomy carrier として読む Lean evidence を追加しました。visible packet surface は flat でも、obligation / storage repair frontier / storage source-ref table の protected packet component defect が残り、それらが packet-to-tuple bridge を通じて tuple holonomy defect へ反映されることを証明しています。

G4 SCORE 監査は base 60 / multiplier 2.0 / penalty 0 / final 120 を confirm し、report の total SCORE を 2800 / 5000 に更新しています。この PR は tracking Issue を閉じません。threshold 未達のため、merge 後も research-loop は継続します。

## 証明した定理

- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.SourceRefPacketProtectedComponent`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.NoSourceRefPacketHolonomyDefect`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.SourceRefPacketHolonomyDefect`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.noSourceRefPacketHolonomyDefect_iff_protectedData`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.full_partial_packet_visibleFlat_componentDefects`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.noPacketHolonomy_projects_to_noTupleHolonomy`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.sourceRefObligationDefect_projects_to_tupleDefect`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.sourceRefRepairDefect_projects_to_tupleDefect`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.sourceRefTableDefect_projects_to_tupleDefect`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.sourceRefPacketHolonomy_projects_to_tupleHolonomy`
- `Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket.finiteCodebaseTraceHolonomyPacket_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-finite-codebase-trace-holonomy-packet.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `.tmp/codebase_trace_holonomy_packet_axioms.lean` の主要 `#print axioms`: all no axioms
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` / `Classical` / `choice` / `propext` / `Quot.sound` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（tracking Issue のため close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
