### PR TITLE
研究: source-ref exact visualization を追加

### DIFF
--- a/Formal/AG/Research.lean
+++ b/Formal/AG/Research.lean
@@ -22,3 +22,4 @@ import Formal.AG.Research.QualitySurface.GridHolonomyLocalization
 import Formal.AG.Research.QualitySurface.CodebaseTraceRepairTrajectory
 import Formal.AG.Research.QualitySurface.TupleHolonomyDefect
 import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket
+import Formal.AG.Research.QualitySurface.SourceRefExactVisualization

--- a/Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean
+++ b/Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean
@@ -1,0 +1,276 @@
+import Formal.AG.Research.QualitySurface.CodebaseTraceHolonomyPacket
+
+/-!
+Cycle 24 evidence for `G-aat-quality-surface-01`.
+
+This file separates lossy packet-to-tuple visualization from source-ref exact
+visualization.  The result is relative to supplied finite source-ref packets
+and the explicit packet-to-tuple bridge; it does not assert source extraction
+completeness, ArchMap correctness, a canonical packet extractor, arbitrary
+codebase traceability, or whole-codebase quality.
+-/
+
+namespace Formal.AG.Research
+namespace QualitySurface
+namespace SourceRefExactVisualizationCriterion
+
+open CodebaseTracePacket
+open CodebaseTraceHolonomyPacket
+open TraceLocus
+
+abbrev TupleProfile :=
+  SourceRefTupleBridge.TupleProfile
+
+abbrev TupleCertificateAt :=
+  ProfileTupleIntegration.TupleCertificateAt
+
+/-! ## Exact and lossy packet-to-tuple visualizations -/
+
+/-- Two source-ref packets have the same visible packet-induced tuple surface. -/
+def TupleVisibleVisualizationEquivalent {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) : Prop :=
+  (ProfileTupleIntegration.visibleTupleSurfaceReading p).Equivalent
+    (SourceRefTupleBridge.packetToTuple gridLeft left)
+    (SourceRefTupleBridge.packetToTuple gridRight right)
+
+/--
+Source-ref exact visualization: visible packet-induced tuple equivalence plus
+zero tuple holonomy.
+-/
+def SourceRefExactVisualization {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) : Prop :=
+  TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+    TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+
+/--
+Lossy packet-to-tuple visualization: the visible tuple surface agrees, but the
+underlying source-ref packet has protected holonomy.
+-/
+def LossyPacketToTupleVisualization {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) : Prop :=
+  TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+    HasSourceRefPacketHolonomyDefect left right
+
+/-! ## Packet zero-defect iff tuple zero-defect -/
+
+/-- Tuple zero holonomy reflects source-ref packet zero holonomy. -/
+theorem tupleZeroHolonomy_reflects_packetZeroHolonomy
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket}
+    (hzero :
+      TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+        (SourceRefTupleBridge.packetToTuple gridLeft left)
+        (SourceRefTupleBridge.packetToTuple gridRight right)) :
+    NoSourceRefPacketHolonomyDefect left right := by
+  exact ⟨hzero.1,
+    by
+      intro atom
+      have hrepair :=
+        hzero.2.1 (toLocusAtom atom)
+      change
+        left.repairFrontier (fromLocusAtom (toLocusAtom atom)) ↔
+          right.repairFrontier (fromLocusAtom (toLocusAtom atom)) at hrepair
+      simpa [SourceRefTupleBridge.from_to_locusAtom] using hrepair,
+    by
+      apply SourceRefTokenIdentityReflection.projectedTraceField_reflects_sourceRefTable
+      intro atom
+      exact hzero.2.2 atom⟩
+
+/--
+For packet-induced tuples, tuple zero holonomy is equivalent to packet zero
+holonomy.
+-/
+theorem packetTuple_zeroHolonomy_iff_packetZeroHolonomy
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) :
+    TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+        (SourceRefTupleBridge.packetToTuple gridLeft left)
+        (SourceRefTupleBridge.packetToTuple gridRight right) ↔
+      NoSourceRefPacketHolonomyDefect left right := by
+  constructor
+  · intro hzero
+    exact tupleZeroHolonomy_reflects_packetZeroHolonomy
+      gridLeft gridRight hzero
+  · intro hzero
+    exact noPacketHolonomy_projects_to_noTupleHolonomy
+      gridLeft gridRight hzero
+
+/--
+Source-ref exact visualization is equivalent to visible tuple equivalence plus
+packet zero holonomy.
+-/
+theorem sourceRefExactVisualization_iff_visible_packetZeroHolonomy
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    (left right : SourceRefPacket) :
+    SourceRefExactVisualization gridLeft gridRight left right ↔
+      TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+        NoSourceRefPacketHolonomyDefect left right := by
+  constructor
+  · intro hexact
+    exact ⟨hexact.1,
+      tupleZeroHolonomy_reflects_packetZeroHolonomy
+        gridLeft gridRight hexact.2⟩
+  · intro hpacket
+    exact ⟨hpacket.1,
+      noPacketHolonomy_projects_to_noTupleHolonomy
+        gridLeft gridRight hpacket.2⟩
+
+/-! ## Loss detection -/
+
+/-- Any packet component defect obstructs source-ref exact visualization. -/
+theorem packetHolonomyDefect_obstructs_sourceRefExactVisualization
+    {p : TupleProfile}
+    {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left right : SourceRefPacket}
+    {component : SourceRefPacketProtectedComponent}
+    (hdefect : SourceRefPacketHolonomyDefect left right component) :
+    ¬ SourceRefExactVisualization gridLeft gridRight left right := by
+  intro hexact
+  have hpacketZero :
+      NoSourceRefPacketHolonomyDefect left right :=
+    tupleZeroHolonomy_reflects_packetZeroHolonomy
+      gridLeft gridRight hexact.2
+  exact (sourceRefPacketHolonomyDefect_obstructs_noPacketHolonomy
+    hdefect) hpacketZero
+
+/-- A lossy visualization is not source-ref exact. -/
+theorem lossyVisualization_not_sourceRefExact
+    {p : TupleProfile}
+    {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+    {left right : SourceRefPacket}
+    (hlossy : LossyPacketToTupleVisualization gridLeft gridRight left right) :
+    ¬ SourceRefExactVisualization gridLeft gridRight left right := by
+  intro hexact
+  have hpacketZero :
+      NoSourceRefPacketHolonomyDefect left right :=
+    tupleZeroHolonomy_reflects_packetZeroHolonomy
+      gridLeft gridRight hexact.2
+  exact hlossy.2 hpacketZero
+
+/-- A source-ref table defect is detected as a tuple trace-field defect. -/
+theorem sourceRefTableDefect_detected_as_tupleTraceFieldDefect
+    {p : TupleProfile}
+    (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+    {left right : SourceRefPacket} {atom : CodeAtom}
+    (hdefect : SourceRefTableDefectAt left right atom) :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      (SourceRefTupleBridge.packetToTuple gridLeft left)
+      (SourceRefTupleBridge.packetToTuple gridRight right)
+      (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+        (toLocusAtom atom)) :=
+  sourceRefTableDefect_projects_to_tupleDefect
+    gridLeft gridRight hdefect
+
+/-! ## Full / partial packet instance -/
+
+/-- The full/partial packet pair is a concrete lossy visualization. -/
+theorem full_partial_packetTuple_lossyVisualization :
+    LossyPacketToTupleVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket partialPacket :=
+  ⟨SourceRefTupleBridge.full_partial_packetTuple_visible_equivalent,
+    full_partial_packet_hasHolonomyDefect⟩
+
+/-- The full/partial lossy visualization is not source-ref exact. -/
+theorem full_partial_packetTuple_not_sourceRefExact :
+    ¬ SourceRefExactVisualization
+      SourceRefTupleBridge.endpointGridCertificate
+      SourceRefTupleBridge.endpointGridCertificate
+      fullPacket partialPacket :=
+  lossyVisualization_not_sourceRefExact
+    full_partial_packetTuple_lossyVisualization
+
+/-- The full/partial source-ref table defect is visible as a tuple trace defect. -/
+theorem full_partial_packetTuple_traceFieldDefect_detected :
+    TupleHolonomyDefectInvariant.TupleHolonomyDefect
+      SourceRefTupleBridge.fullPacketEndpointTuple
+      SourceRefTupleBridge.partialPacketEndpointTuple
+      (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+        LocusAtom.database) :=
+  sourceRefTableDefect_detected_as_tupleTraceFieldDefect
+    SourceRefTupleBridge.endpointGridCertificate
+    SourceRefTupleBridge.endpointGridCertificate
+    full_partial_packet_storageSourceRefDefect
+
+/-! ## Theorem package -/
+
+/--
+Cycle-24 theorem package: packet-induced tuple zero holonomy is equivalent to
+packet zero holonomy.  Visible tuple visualization alone is lossy for the
+full/partial packet pair, while source-ref exactness detects packet component
+defects as tuple protected-data defects.
+-/
+theorem sourceRefExactVisualization_package :
+    (∀ {p : TupleProfile}
+      (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+      (left right : SourceRefPacket),
+      TupleHolonomyDefectInvariant.NoTupleHolonomyDefect
+          (SourceRefTupleBridge.packetToTuple gridLeft left)
+          (SourceRefTupleBridge.packetToTuple gridRight right) ↔
+        NoSourceRefPacketHolonomyDefect left right) ∧
+      (∀ {p : TupleProfile}
+        (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+        (left right : SourceRefPacket),
+        SourceRefExactVisualization gridLeft gridRight left right ↔
+          TupleVisibleVisualizationEquivalent gridLeft gridRight left right ∧
+            NoSourceRefPacketHolonomyDefect left right) ∧
+      LossyPacketToTupleVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      ¬ SourceRefExactVisualization
+        SourceRefTupleBridge.endpointGridCertificate
+        SourceRefTupleBridge.endpointGridCertificate
+        fullPacket partialPacket ∧
+      TupleHolonomyDefectInvariant.TupleHolonomyDefect
+        SourceRefTupleBridge.fullPacketEndpointTuple
+        SourceRefTupleBridge.partialPacketEndpointTuple
+        (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+          LocusAtom.database) ∧
+      (∀ {p : TupleProfile}
+        {gridLeft gridRight : ProfileGridHolonomy.CertificateAt p}
+        {left right : SourceRefPacket}
+        {component : SourceRefPacketProtectedComponent},
+        SourceRefPacketHolonomyDefect left right component ->
+          ¬ SourceRefExactVisualization gridLeft gridRight left right) ∧
+      (∀ {p : TupleProfile}
+        (gridLeft gridRight : ProfileGridHolonomy.CertificateAt p)
+        {left right : SourceRefPacket} {atom : CodeAtom},
+        SourceRefTableDefectAt left right atom ->
+          TupleHolonomyDefectInvariant.TupleHolonomyDefect
+            (SourceRefTupleBridge.packetToTuple gridLeft left)
+            (SourceRefTupleBridge.packetToTuple gridRight right)
+            (TupleHolonomyDefectInvariant.TupleProtectedComponent.traceField
+              (toLocusAtom atom))) := by
+  exact ⟨by
+    intro p gridLeft gridRight left right
+    exact packetTuple_zeroHolonomy_iff_packetZeroHolonomy
+      gridLeft gridRight left right,
+    by
+      intro p gridLeft gridRight left right
+      exact sourceRefExactVisualization_iff_visible_packetZeroHolonomy
+        gridLeft gridRight left right,
+    full_partial_packetTuple_lossyVisualization,
+    full_partial_packetTuple_not_sourceRefExact,
+    full_partial_packetTuple_traceFieldDefect_detected,
+    by
+      intro p gridLeft gridRight left right component hdefect
+      exact packetHolonomyDefect_obstructs_sourceRefExactVisualization
+        hdefect,
+    by
+      intro p gridLeft gridRight left right atom hdefect
+      exact sourceRefTableDefect_detected_as_tupleTraceFieldDefect
+        gridLeft gridRight hdefect⟩
+
+end SourceRefExactVisualizationCriterion
+end QualitySurface
+end Formal.AG.Research

--- a/research/ideas/g-aat-quality-surface-01-source-ref-exact-visualization.md
+++ b/research/ideas/g-aat-quality-surface-01-source-ref-exact-visualization.md
@@ -1,0 +1,161 @@
+---
+status: picked
+goal: G-aat-quality-surface-01
+candidate_type: bridge
+capability_category: traceability/certificate-transport/invariance/computability/quality-surface
+expected_base_score: 60
+expected_evidence_multiplier: 2.0
+expected_final_score: 120
+evidence_stage: proved-in-research
+origin: G-aat-quality-surface-01-cycle24
+tags:
+  - source-ref
+  - exact-visualization
+  - packet-to-tuple
+created: 2026-06-20
+---
+
+# Source-ref exactness detects lossy packet-to-tuple visualization
+
+## 主張
+
+packet-induced tuple visualization が source-ref exact であることを、visible tuple surface と tuple-level
+zero holonomy defect の組として定式化する。packet-to-tuple bridge では、tuple zero holonomy と packet
+zero holonomy が同値であり、visible tuple surface だけでは full / partial packet の source-ref packet
+holonomy を隠す。したがって source-ref exactness は lossy packet-to-tuple visualization を検出する条件である。
+
+主張は supplied finite source-ref packets、finite code atom vocabulary、explicit packet-to-tuple bridge、
+selected endpoint tuple に相対化する。source extraction completeness、ArchMap correctness、canonical
+packet extractor、任意 codebase traceability、実コード全体の品質判定は結論しない。
+
+## 候補種別
+
+`bridge`
+
+## 依拠
+
+- `Formal/AG/Research/QualitySurface/SourceRefTupleBridge.lean`
+- `Formal/AG/Research/QualitySurface/SourceRefTokenIdentityReflection.lean`
+- `Formal/AG/Research/QualitySurface/TupleHolonomyDefect.lean`
+- `Formal/AG/Research/QualitySurface/CodebaseTraceHolonomyPacket.lean`
+- `CodebaseTraceHolonomyPacket.NoSourceRefPacketHolonomyDefect`
+- `CodebaseTraceHolonomyPacket.SourceRefPacketHolonomyDefect`
+- `CodebaseTraceHolonomyPacket.noPacketHolonomy_projects_to_noTupleHolonomy`
+- `SourceRefTokenIdentityReflection.projectedTraceField_reflects_sourceRefTable`
+
+## 非自明性
+
+Cycle 23 は packet defect が tuple defect へ写ることを示した。この候補はそれを detector にし、
+packet-induced tuple の zero holonomy が packet-level zero holonomy と同値であることを示す。
+これにより、visible tuple surface が同じでも source-ref exactness を欠く visualization は lossy であると
+定理として判定できる。
+
+単なる Cycle 23 の再掲にしないため、次を required evidence にする。
+
+- `TupleVisibleVisualizationEquivalent` と `SourceRefExactVisualization`。
+- packet-induced tuple zero holonomy iff packet zero holonomy。
+- `LossyPacketToTupleVisualization` witness。
+- full / partial packet pair が visible tuple surface では一致するが source-ref exact visualization ではないこと。
+- packet component defect が source-ref exact visualization を阻害する theorem。
+- source-ref table defect は token identity reflection により tuple trace-field defect として検出されること。
+
+## 数学的興味
+
+可視化の exactness を「見た目が同じか」ではなく「source-ref protected data へ戻れるか」として定義する。
+これは Quality Surface の reading / projection がどこで hidden holonomy を落とすかを判定する基礎になる。
+
+## GOAL への前進
+
+traceability、certificate-transport、invariance、loss-aware visualization を接続し、finite codebase trace
+example を exact-vs-lossy reading の theorem として強化する。
+
+## SCORE 見込み
+
+- `score_reason`: G2-B は base 70 を認めたが、G2-A/C が Cycle 16/23 に近い immediate-corollary risk を
+  指摘したため、revised candidate は base 60 / final 120 に下げる。
+- `dullness_risk`: medium。`sourceRefOptionMap_eq_iff` や Cycle 23 projection theorem の再掲に落ちないよう、
+  zero-holonomy iff、lossy visualization witness、exactness obstruction theorem を required evidence にする。
+- `proof_or_evidence_plan`: `SourceRefExactVisualization.lean` に exact / lossy visualization relation、
+  zero-holonomy iff、full/partial lossy witness、component obstruction、package theorem を置く。
+
+## CS / SWE への帰結
+
+loss-aware visualization や drill-down report では、tuple visible surface だけでは source-ref packet holonomy を
+見落とす。source-ref exactness を要求すると、packet-level source-ref table / repair frontier の defect を
+tuple protected data の defect として検出できる。
+
+## 証明・根拠
+
+Lean proof は `Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean` に閉じた。
+`Formal/AG/Research.lean` はこの Research evidence file を import する。
+
+主要 theorem / declaration:
+
+- `TupleVisibleVisualizationEquivalent`
+- `SourceRefExactVisualization`
+- `LossyPacketToTupleVisualization`
+- `tupleZeroHolonomy_reflects_packetZeroHolonomy`
+- `packetTuple_zeroHolonomy_iff_packetZeroHolonomy`
+- `sourceRefExactVisualization_iff_visible_packetZeroHolonomy`
+- `packetHolonomyDefect_obstructs_sourceRefExactVisualization`
+- `lossyVisualization_not_sourceRefExact`
+- `sourceRefTableDefect_detected_as_tupleTraceFieldDefect`
+- `full_partial_packetTuple_lossyVisualization`
+- `full_partial_packetTuple_not_sourceRefExact`
+- `full_partial_packetTuple_traceFieldDefect_detected`
+- `sourceRefExactVisualization_package`
+
+固定された内容:
+
+- `SourceRefExactVisualization` は visible packet-induced tuple equivalence と tuple-level
+  `NoTupleHolonomyDefect` の組であり、packet zero defect を定義へ埋め込まない。
+- `packetTuple_zeroHolonomy_iff_packetZeroHolonomy` は、packet-induced tuple zero holonomy と packet-level
+  zero holonomy defect の同値を示す。
+- `tupleZeroHolonomy_reflects_packetZeroHolonomy` は、tuple trace-field equality から
+  `projectedTraceField_reflects_sourceRefTable` によって source-ref table equality を反射する。
+- `LossyPacketToTupleVisualization` と `full_partial_packetTuple_lossyVisualization` は、visible tuple surface は
+  一致するが packet holonomy defect が残る finite witness を固定する。
+- `packetHolonomyDefect_obstructs_sourceRefExactVisualization` は、任意 packet component defect が source-ref
+  exact visualization を阻害することを示す。
+- `sourceRefTableDefect_detected_as_tupleTraceFieldDefect` は、source-ref table defect が tuple trace-field
+  defect として検出されることを示す。
+
+検証:
+
+- `lake env lean Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`: pass。
+- `lake build FormalAGResearch`: pass。
+- `.tmp/source_ref_exact_visualization_axioms.lean` の `#print axioms`: listed declarations are all
+  `does not depend on any axioms`。`sorryAx`、`propext`、`Classical.choice`、`Quot.sound` は出ていない。
+- 対象 Lean file の `axiom` / `admit` / `sorry` / `unsafe` / `Classical` / `choice` / `propext` /
+  `Quot.sound` scan: no hits。
+- hidden / bidirectional Unicode scan: no hits。
+- G3 Lean 形式化品質監査: pass。`SourceRefExactVisualization` は tuple-zero 側の条件であり、
+  `packetTuple_zeroHolonomy_iff_packetZeroHolonomy` の逆向きは token identity reflection を使う。
+
+## 審判メモ
+
+- 厳密性: G2-A は初回 revise、base 60。`SourceRefExactVisualization` が packet zero defect を定義へ
+  埋め込むと tautological になるため、tuple zero holonomy 側で定義し、packet zero defect は theorem として
+  反射することを required evidence とした。
+- 厳密性再審判: G2-A は revised card / Lean proof を accept、base 60 / final 120。
+- 研究価値: G2-B は accept、base 70。exact-vs-lossy visualization criterion としての価値を認めた。
+- repo 全体価値: G2-C は accept、base 60。Cycle 13/16/22/23 に近いため score は抑えるが、
+  loss-aware visualization の report / paper seed として有効と判定した。
+- SCORE 監査: G4 は confirm、base 60 / evidence multiplier 2.0 / penalty 0 / final 120。
+
+## 関連
+
+- `research/ideas/g-aat-quality-surface-01-source-ref-tuple-bridge.md`
+- `research/ideas/g-aat-quality-surface-01-source-ref-packet-transport.md`
+- `research/ideas/g-aat-quality-surface-01-finite-codebase-trace-holonomy-packet.md`
+- `research/ideas/g-aat-quality-surface-01-tuple-holonomy-defect-invariant.md`
+- `research/reports/G-aat-quality-surface-01.md`
+
+## 進捗ログ
+
+- 2026-06-20: Cycle 24 candidate card 作成。
+- 2026-06-20: G2-A revise を反映し、`SourceRefExactVisualization` を packet zero defect ではなく
+  tuple zero holonomy 側で定義する方針に修正し、expected score を base 60 / final 120 に下げた。
+- 2026-06-20: `SourceRefExactVisualization.lean` を追加し、単体 Lean、`FormalAGResearch`、axiom harness、
+  G3 Lean 形式化品質監査を通した。
+- 2026-06-20: G4 SCORE 監査 confirm。report の Cycle 24 と Current SCORE を total 2920 に更新した。

--- a/research/reports/G-aat-quality-surface-01.md
+++ b/research/reports/G-aat-quality-surface-01.md
@@ -4,7 +4,7 @@
 
 ## Current SCORE
 
-- total SCORE: 2800
+- total SCORE: 2920
 - category scores:
   - obstruction / repair-potential / atom-supported-quality-geometry: 120
   - ridge-fold / atom-supported-quality-geometry / repair-potential / multi-axis-signature: 160
@@ -29,8 +29,9 @@
   - traceability / repair-potential / computability / quality-surface / certificate-transport: 120
   - profile-curvature / certificate-transport / invariance / obstruction / traceability: 120
   - traceability / profile-curvature / certificate-transport / computability / repair-potential: 120
+  - traceability / certificate-transport / invariance / computability / quality-surface: 120
 - evidence portfolio:
-  - proved-in-research: 23
+  - proved-in-research: 24
 
 ## Cycle 1: Minimal-support hitting theorem for local repair
 
@@ -1015,9 +1016,54 @@ tuple protected-data geometry に反映する。主張は supplied finite source
 explicit packet-to-tuple bridge、selected endpoint tuple に相対化され、source extraction completeness、
 ArchMap correctness、canonical packet extractor、任意 codebase traceability、実コード全体の品質判定は結論しない。
 
+## Cycle 24: Source-ref exactness detects lossy packet-to-tuple visualization
+
+```text
+candidate: Source-ref exactness detects lossy packet-to-tuple visualization
+candidate_type: bridge
+evidence_stage: proved-in-research
+base_score: 60
+evidence_multiplier: 2.0
+penalty: 0
+final_score: 120
+category: traceability/certificate-transport/invariance/computability/quality-surface
+goal_delta: visible tuple visualization と source-ref exact visualization を分離し、packet-induced tuple の zero holonomy と packet zero holonomy の同値により、lossy packet-to-tuple visualization を検出できる条件を固定した。
+project_value_delta: loss-aware visualization / drill-down report の paper seed として、visible equality だけでは hidden source-ref holonomy を落とすこと、source-ref exactness がそれを検出することを Lean-backed にした。
+formalization_quality: pass。`SourceRefExactVisualization`、tuple/packet zero-holonomy iff、lossy finite witness、component obstruction、source-ref table defect detection、package theorem が axiom-free / sorry-free で証明されている。
+open_questions: 任意 packet family、canonical extractor、実コード全体の traceability には拡張していない。次は repair/transport commutator、component defect composition、selected decomposition calculus が自然な frontier。
+```
+
+### Result
+
+`Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean` は、
+packet-induced tuple visualization の exact-vs-lossy 境界を定義する。
+`SourceRefExactVisualization` は visible packet-induced tuple equivalence と tuple-level
+`NoTupleHolonomyDefect` の組であり、packet zero defect を定義へ埋め込まない。
+
+Lean 証拠は次を固定する。
+
+- `TupleVisibleVisualizationEquivalent`: packet-induced tuples の visible surface equivalence。
+- `SourceRefExactVisualization`: visible tuple equivalence と tuple zero holonomy を持つ exact visualization。
+- `LossyPacketToTupleVisualization`: visible tuple surface は一致するが packet holonomy defect が残る visualization。
+- `tupleZeroHolonomy_reflects_packetZeroHolonomy`: tuple zero holonomy から packet zero holonomy を反射する。
+- `packetTuple_zeroHolonomy_iff_packetZeroHolonomy`: packet-induced tuple zero holonomy と packet zero holonomy は同値である。
+- `sourceRefExactVisualization_iff_visible_packetZeroHolonomy`: exact visualization は visible tuple equivalence と
+  packet zero holonomy の組と同値である。
+- `packetHolonomyDefect_obstructs_sourceRefExactVisualization`: packet component defect は exact visualization を阻害する。
+- `lossyVisualization_not_sourceRefExact`: lossy visualization は source-ref exact ではない。
+- `sourceRefTableDefect_detected_as_tupleTraceFieldDefect`: source-ref table defect は tuple trace-field defect として検出される。
+- `full_partial_packetTuple_lossyVisualization`: full / partial packet pair は concrete lossy visualization である。
+- `sourceRefExactVisualization_package`: zero-holonomy iff、exactness iff、lossy witness、component obstruction、
+  source-ref table defect detection を束ねる theorem package。
+
+この結果により、tuple visible surface だけを見る visualization は finite source-ref packet holonomy を隠すが、
+source-ref exactness を要求すれば hidden packet holonomy は tuple protected-data defect として検出される。
+主張は supplied finite source-ref packets、finite code atom vocabulary、explicit packet-to-tuple bridge、
+selected endpoint tuple に相対化され、source extraction completeness、ArchMap correctness、canonical packet
+extractor、任意 codebase traceability、実コード全体の品質判定は結論しない。
+
 ### Next Frontier
 
-現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 23 後の total SCORE は 2800 である。
-次に進める場合は、source-ref exactness detects lossy packet-to-tuple visualization、finite codebase trace holonomy
-packet の transport / repair commutator、component defect の合成則、または selected decomposition を越える
-grid localization calculus を狙う。
+現在の `research/GOALS.md` の SCORE threshold は 5000 であり、cycle 24 後の total SCORE は 2920 である。
+次に進める場合は、finite codebase trace holonomy packet の transport / repair commutator、component defect の合成則、
+または selected decomposition を越える grid localization calculus を狙う。


### PR DESCRIPTION
## 概要

Refs #2348

Cycle 24 として、packet-to-tuple visualization の exact-vs-lossy 境界を Lean evidence として追加しました。`SourceRefExactVisualization` は visible tuple surface と tuple zero holonomy で定義し、packet-induced tuple zero holonomy と packet-level zero holonomy が同値であることを証明しています。これにより、visible tuple surface だけでは hidden source-ref holonomy を落とす一方、source-ref exactness はそれを検出する、という reading 境界を固定しました。

G4 SCORE 監査は base 60 / multiplier 2.0 / penalty 0 / final 120 を confirm し、report の total SCORE を 2920 / 5000 に更新しています。この PR は tracking Issue を閉じません。threshold 未達のため、merge 後も research-loop は継続します。

## 証明した定理

- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.TupleVisibleVisualizationEquivalent`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.SourceRefExactVisualization`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.LossyPacketToTupleVisualization`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.tupleZeroHolonomy_reflects_packetZeroHolonomy`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.packetTuple_zeroHolonomy_iff_packetZeroHolonomy`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.sourceRefExactVisualization_iff_visible_packetZeroHolonomy`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.packetHolonomyDefect_obstructs_sourceRefExactVisualization`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.lossyVisualization_not_sourceRefExact`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.sourceRefTableDefect_detected_as_tupleTraceFieldDefect`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.full_partial_packetTuple_lossyVisualization`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.full_partial_packetTuple_traceFieldDefect_detected`
- `Formal.AG.Research.QualitySurface.SourceRefExactVisualizationCriterion.sourceRefExactVisualization_package`

## 編集したドキュメント

- `research/ideas/g-aat-quality-surface-01-source-ref-exact-visualization.md`
- `research/reports/G-aat-quality-surface-01.md`

## 実施したテスト

- [x] `lake env lean Formal/AG/Research/QualitySurface/SourceRefExactVisualization.lean`
- [x] `lake build FormalAGResearch`
- [x] `lake build`
- [x] `.tmp/source_ref_exact_visualization_axioms.lean` の主要 `#print axioms`: all no axioms
- [x] `git diff --check`
- [x] hidden / bidirectional Unicode scan
- [x] `axiom` / `admit` / `sorry` / `unsafe` / `Classical` / `choice` / `propext` / `Quot.sound` scan
- [ ] `cargo test --manifest-path tools/archsig/Cargo.toml`（ArchSig 変更なし）
- [ ] `cargo test --manifest-path tools/fieldsig/Cargo.toml`（FieldSig 変更なし）

## チェックリスト

- [x] 対象 Issue を `Refs #2348` 形式で本文に記載した（tracking Issue のため close しない）
- [x] Lean status を `proved-in-research` として明確にした
- [x] `docs` の研究主張と Lean status が矛盾していない
- [x] 明示的な相談なしに `axiom`, `admit`, `sorry`, `unsafe` を導入していない
- [x] Architecture Signature を単一スコアではなく多軸診断として扱っている
- [x] ArchSig と FieldSig の責務を混同していない
